### PR TITLE
fix(agents): strip antml thinking tags in streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,7 @@ Docs: https://docs.openclaw.ai
 - CLI backends: compact OpenClaw transcripts after over-budget CLI turns and reseed fresh CLI sessions from the compacted transcript instead of stale external resume state. Fixes #68329. (#71916) Thanks @obviyus.
 - Telegram: keep default tool progress messages visible when answer preview streaming is disabled. (#71825) Thanks @VACInc.
 - Configure/models: clear deselected model fallbacks when updating the model picker allowlist, including provider-scoped setup flows. (#71596) Thanks @rubencu.
+- Agents/streaming: strip namespaced `<antml:thinking>` reasoning tags from streamed assistant replies before user-visible text is emitted. (#69288) Thanks @xialonglee.
 
 ## 2026.4.24
 

--- a/src/agents/pi-embedded-subscribe.e2e-harness.ts
+++ b/src/agents/pi-embedded-subscribe.e2e-harness.ts
@@ -13,6 +13,7 @@ export const THINKING_TAG_CASES = [
   { tag: "thinking", open: "<thinking>", close: "</thinking>" },
   { tag: "thought", open: "<thought>", close: "</thought>" },
   { tag: "antthinking", open: "<antthinking>", close: "</antthinking>" },
+  { tag: "antml:thinking", open: "<antml:thinking>", close: "</antml:thinking>" },
 ] as const;
 
 export function createStubSessionHarness(): {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -36,7 +36,8 @@ import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.t
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
-const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+const THINKING_TAG_SCAN_RE =
+  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
 const log = createSubsystemLogger("agent/embedded");
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -33,11 +33,13 @@ import type {
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+  THINKING_TAG_SCAN_RE,
+} from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
-const THINKING_TAG_SCAN_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
 const log = createSubsystemLogger("agent/embedded");
 
@@ -516,7 +518,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const inlineStateStart = state.inlineCode ?? createInlineCodeState();
     const codeSpans = buildCodeSpanIndex(text, inlineStateStart);
 
-    // 1. Handle <think> blocks (stateful, strip content inside)
     let processed = "";
     THINKING_TAG_SCAN_RE.lastIndex = 0;
     let lastIndex = 0;
@@ -538,7 +539,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     state.thinking = inThinking;
 
-    // 2. Handle <final> blocks (stateful, strip content OUTSIDE)
     // If enforcement is disabled, we still strip the tags themselves to prevent
     // hallucinations (e.g. Minimax copying the style) from leaking, but we
     // do not enforce buffering/extraction logic.

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -806,6 +806,20 @@ describe("promoteThinkingTagsToBlocks", () => {
     expect(types).toContain("text");
   });
 
+  it("splits antml namespaced thinking tags into thinking blocks", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "<antml:thinking>hidden</antml:thinking>Visible" }],
+      timestamp: Date.now(),
+    });
+
+    promoteThinkingTagsToBlocks(msg);
+    expect(msg.content).toEqual([
+      { type: "thinking", thinking: "hidden" },
+      { type: "text", text: "Visible" },
+    ]);
+  });
+
   it("does not crash on undefined content entries", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -181,6 +181,25 @@ type ThinkTaggedSplitBlock =
   | { type: "thinking"; thinking: string }
   | { type: "text"; text: string };
 
+const THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)`;
+const THINKING_TAG_OPEN_RE = new RegExp(String.raw`<\s*${THINKING_TAG_NAME_PATTERN}\s*>`, "i");
+const THINKING_TAG_CLOSE_RE = new RegExp(
+  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  "i",
+);
+const THINKING_TAG_OPEN_GLOBAL_RE = new RegExp(
+  String.raw`<\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  "gi",
+);
+const THINKING_TAG_CLOSE_GLOBAL_RE = new RegExp(
+  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  "gi",
+);
+export const THINKING_TAG_SCAN_RE = new RegExp(
+  String.raw`<\s*(\/?)\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  "gi",
+);
+
 export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] | null {
   const trimmedStart = text.trimStart();
   // Avoid false positives: only treat it as structured thinking when it begins
@@ -189,16 +208,13 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
   if (!trimmedStart.startsWith("<")) {
     return null;
   }
-  const openRe = /<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/i;
-  const closeRe = /<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/i;
-  if (!openRe.test(trimmedStart)) {
+  if (!THINKING_TAG_OPEN_RE.test(trimmedStart)) {
     return null;
   }
-  if (!closeRe.test(text)) {
+  if (!THINKING_TAG_CLOSE_RE.test(text)) {
     return null;
   }
 
-  const scanRe = /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
   let inThinking = false;
   let cursor = 0;
   let thinkingStart = 0;
@@ -218,7 +234,7 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
     blocks.push({ type: "thinking", thinking: cleaned });
   };
 
-  for (const match of text.matchAll(scanRe)) {
+  for (const match of text.matchAll(THINKING_TAG_SCAN_RE)) {
     const index = match.index ?? 0;
     const isClose = match[1]?.includes("/") ?? false;
 
@@ -299,11 +315,10 @@ export function extractThinkingFromTaggedText(text: string): string {
   if (!text) {
     return "";
   }
-  const scanRe = /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
   let result = "";
   let lastIndex = 0;
   let inThinking = false;
-  for (const match of text.matchAll(scanRe)) {
+  for (const match of text.matchAll(THINKING_TAG_SCAN_RE)) {
     const idx = match.index ?? 0;
     if (inThinking) {
       result += text.slice(lastIndex, idx);
@@ -324,13 +339,11 @@ export function extractThinkingFromTaggedStream(text: string): string {
     return closed;
   }
 
-  const openRe = /<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
-  const closeRe = /<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
-  const openMatches = [...text.matchAll(openRe)];
+  const openMatches = [...text.matchAll(THINKING_TAG_OPEN_GLOBAL_RE)];
   if (openMatches.length === 0) {
     return "";
   }
-  const closeMatches = [...text.matchAll(closeRe)];
+  const closeMatches = [...text.matchAll(THINKING_TAG_CLOSE_GLOBAL_RE)];
   const lastOpen = openMatches[openMatches.length - 1];
   const lastClose = closeMatches[closeMatches.length - 1];
   if (lastClose && (lastClose.index ?? -1) > (lastOpen.index ?? -1)) {

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -189,8 +189,8 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
   if (!trimmedStart.startsWith("<")) {
     return null;
   }
-  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
-  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/i;
+  const openRe = /<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/i;
+  const closeRe = /<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/i;
   if (!openRe.test(trimmedStart)) {
     return null;
   }
@@ -198,7 +198,7 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
     return null;
   }
 
-  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  const scanRe = /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
   let inThinking = false;
   let cursor = 0;
   let thinkingStart = 0;
@@ -299,7 +299,7 @@ export function extractThinkingFromTaggedText(text: string): string {
   if (!text) {
     return "";
   }
-  const scanRe = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  const scanRe = /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
   let result = "";
   let lastIndex = 0;
   let inThinking = false;
@@ -324,8 +324,8 @@ export function extractThinkingFromTaggedStream(text: string): string {
     return closed;
   }
 
-  const openRe = /<\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
-  const closeRe = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  const openRe = /<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
+  const closeRe = /<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
   const openMatches = [...text.matchAll(openRe)];
   if (openMatches.length === 0) {
     return "";


### PR DESCRIPTION
## Summary
- Fix reasoning-tag filtering in streaming paths to recognize namespaced tags like `<antml:thinking>...</antml:thinking>`.
- Align streaming tag parsing with existing final-text sanitization behavior so reasoning text is consistently hidden from channel output.
- Extend shared thinking-tag test cases and add regression coverage for namespaced thinking blocks.
- fix #69235

## Why
Some Sonnet/Opus responses can emit namespaced reasoning tags (`antml:thinking`).  
Final extraction already handled this, but streaming/block-reply parsing did not fully match the same tag shape, which could leak reasoning text to channels (e.g. Slack) after final content.

## Test Plan
- `pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts -t "<antml:thinking>"`
- `pnpm test src/agents/pi-embedded-utils.test.ts -t "splits antml namespaced thinking tags into thinking blocks"`
- Existing repo hook checks on changed files passed during commit.