### PR TITLE
tasks: add detached task recovery hook before markLost

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4ec700ac180b7eca81ca48885bc7f645dbf5016e2438e44678f4c206eed4b643  plugin-sdk-api-baseline.json
-ff0d1541e7220c67d97444304568285303e423770bd6af6227afdf470bf233cc  plugin-sdk-api-baseline.jsonl
+c1d52cab340bc37d6750de609ba565598cbfc883291786092b0bfebec9d0c926  plugin-sdk-api-baseline.json
+d03fa4539c6a2f0a138da3c658543315ad56648c3fd375591d09253d5db09298  plugin-sdk-api-baseline.jsonl

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -531,7 +531,7 @@ export async function tasksMaintenanceCommand(
 
   runtime.log(
     info(
-      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.pruned} prune`,
+      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.recovered} recovered · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.pruned} prune`,
     ),
   );
   runtime.log(

--- a/src/tasks/detached-task-runtime-contract.ts
+++ b/src/tasks/detached-task-runtime-contract.ts
@@ -97,6 +97,17 @@ export type DetachedTaskCancelResult = {
   task?: TaskRecord;
 };
 
+export type DetachedTaskRecoveryAttemptParams = {
+  taskId: string;
+  runtime: TaskRuntime;
+  task: TaskRecord;
+  now: number;
+};
+
+export type DetachedTaskRecoveryAttemptResult = {
+  recovered: boolean;
+};
+
 export type DetachedTaskLifecycleRuntime = {
   createQueuedTaskRun: (params: DetachedTaskCreateParams) => TaskRecord;
   createRunningTaskRun: (params: DetachedRunningTaskCreateParams) => TaskRecord;
@@ -112,11 +123,13 @@ export type DetachedTaskLifecycleRuntime = {
   cancelDetachedTaskRunById: (
     params: DetachedTaskCancelParams,
   ) => Promise<DetachedTaskCancelResult>;
-  onBeforeMarkLost?: (params: {
-    taskId: string;
-    runtime: TaskRuntime;
-    task: TaskRecord;
-  }) => { recovered: boolean } | Promise<{ recovered: boolean }>;
+  /**
+   * Give a registered detached runtime one last chance to recover a stale task
+   * before core marks it lost during maintenance.
+   */
+  tryRecoverTaskBeforeMarkLost?: (
+    params: DetachedTaskRecoveryAttemptParams,
+  ) => DetachedTaskRecoveryAttemptResult | Promise<DetachedTaskRecoveryAttemptResult>;
 };
 
 export type DetachedTaskLifecycleRuntimeRegistration = {

--- a/src/tasks/detached-task-runtime-contract.ts
+++ b/src/tasks/detached-task-runtime-contract.ts
@@ -112,6 +112,11 @@ export type DetachedTaskLifecycleRuntime = {
   cancelDetachedTaskRunById: (
     params: DetachedTaskCancelParams,
   ) => Promise<DetachedTaskCancelResult>;
+  onBeforeMarkLost?: (params: {
+    taskId: string;
+    runtime: TaskRuntime;
+    task: TaskRecord;
+  }) => { recovered: boolean } | Promise<{ recovered: boolean }>;
 };
 
 export type DetachedTaskLifecycleRuntimeRegistration = {

--- a/src/tasks/detached-task-runtime.test.ts
+++ b/src/tasks/detached-task-runtime.test.ts
@@ -7,13 +7,13 @@ import {
   failTaskRunByRunId,
   getDetachedTaskLifecycleRuntime,
   getDetachedTaskLifecycleRuntimeRegistration,
-  onBeforeMarkLost,
   registerDetachedTaskRuntime,
   recordTaskRunProgressByRunId,
   resetDetachedTaskLifecycleRuntimeForTests,
   setDetachedTaskLifecycleRuntime,
   setDetachedTaskDeliveryStatusByRunId,
   startTaskRunByRunId,
+  tryRecoverTaskBeforeMarkLost,
 } from "./detached-task-runtime.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
@@ -166,17 +166,18 @@ describe("detached-task-runtime", () => {
     expect(getDetachedTaskLifecycleRuntime()).toBe(runtime);
   });
 
-  describe("onBeforeMarkLost", () => {
+  describe("tryRecoverTaskBeforeMarkLost", () => {
     it("returns recovered when hook returns recovered true", async () => {
       const task = createFakeTaskRecord({ taskId: "task-recover", runtime: "subagent" });
       setDetachedTaskLifecycleRuntime({
         ...getDetachedTaskLifecycleRuntime(),
-        onBeforeMarkLost: vi.fn(() => ({ recovered: true })),
+        tryRecoverTaskBeforeMarkLost: vi.fn(() => ({ recovered: true })),
       });
-      const result = await onBeforeMarkLost({
+      const result = await tryRecoverTaskBeforeMarkLost({
         taskId: task.taskId,
         runtime: task.runtime,
         task,
+        now: 123,
       });
       expect(result).toEqual({ recovered: true });
     });
@@ -185,22 +186,24 @@ describe("detached-task-runtime", () => {
       const task = createFakeTaskRecord({ taskId: "task-no-recover", runtime: "cron" });
       setDetachedTaskLifecycleRuntime({
         ...getDetachedTaskLifecycleRuntime(),
-        onBeforeMarkLost: vi.fn(() => ({ recovered: false })),
+        tryRecoverTaskBeforeMarkLost: vi.fn(() => ({ recovered: false })),
       });
-      const result = await onBeforeMarkLost({
+      const result = await tryRecoverTaskBeforeMarkLost({
         taskId: task.taskId,
         runtime: task.runtime,
         task,
+        now: 456,
       });
       expect(result).toEqual({ recovered: false });
     });
 
     it("returns not recovered when hook is not provided", async () => {
       const task = createFakeTaskRecord({ taskId: "task-no-hook", runtime: "cli" });
-      const result = await onBeforeMarkLost({
+      const result = await tryRecoverTaskBeforeMarkLost({
         taskId: task.taskId,
         runtime: task.runtime,
         task,
+        now: 789,
       });
       expect(result).toEqual({ recovered: false });
     });
@@ -209,20 +212,62 @@ describe("detached-task-runtime", () => {
       const task = createFakeTaskRecord({ taskId: "task-throw", runtime: "acp" });
       setDetachedTaskLifecycleRuntime({
         ...getDetachedTaskLifecycleRuntime(),
-        onBeforeMarkLost: vi.fn(() => {
+        tryRecoverTaskBeforeMarkLost: vi.fn(() => {
           throw new Error("plugin crashed");
         }),
       });
-      const result = await onBeforeMarkLost({
+      const result = await tryRecoverTaskBeforeMarkLost({
         taskId: task.taskId,
         runtime: task.runtime,
         task,
+        now: 1_000,
       });
       expect(result).toEqual({ recovered: false });
       expect(mockLogWarn).toHaveBeenCalledWith(
-        "onBeforeMarkLost hook threw, proceeding with markTaskLost",
-        expect.objectContaining({ taskId: "task-throw", runtime: "acp" }),
+        "Detached task recovery hook threw, proceeding with markTaskLost",
+        expect.objectContaining({ taskId: "task-throw", runtime: "acp", elapsedMs: 0 }),
       );
+    });
+
+    it("returns not recovered and logs warning when hook returns invalid result", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-invalid", runtime: "cron" });
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        tryRecoverTaskBeforeMarkLost: vi.fn(() => ({ nope: true }) as never),
+      });
+      const result = await tryRecoverTaskBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+        now: 2_000,
+      });
+      expect(result).toEqual({ recovered: false });
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        "Detached task recovery hook returned invalid result, proceeding with markTaskLost",
+        expect.objectContaining({ taskId: "task-invalid", runtime: "cron" }),
+      );
+    });
+
+    it("logs when the recovery hook is slow", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-slow", runtime: "subagent" });
+      const dateNowSpy = vi.spyOn(Date, "now");
+      dateNowSpy.mockReturnValueOnce(10_000).mockReturnValueOnce(16_000);
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        tryRecoverTaskBeforeMarkLost: vi.fn(async () => ({ recovered: true })),
+      });
+      const result = await tryRecoverTaskBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+        now: 3_000,
+      });
+      expect(result).toEqual({ recovered: true });
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        "Detached task recovery hook was slow",
+        expect.objectContaining({ taskId: "task-slow", runtime: "subagent", elapsedMs: 6_000 }),
+      );
+      dateNowSpy.mockRestore();
     });
   });
 });

--- a/src/tasks/detached-task-runtime.test.ts
+++ b/src/tasks/detached-task-runtime.test.ts
@@ -17,6 +17,24 @@ import {
 } from "./detached-task-runtime.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
+const { mockLogWarn } = vi.hoisted(() => ({
+  mockLogWarn: vi.fn(),
+}));
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    subsystem: "tasks/detached-runtime",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockLogWarn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
 function createFakeTaskRecord(overrides?: Partial<TaskRecord>): TaskRecord {
   return {
     taskId: "task-fake",
@@ -37,6 +55,7 @@ function createFakeTaskRecord(overrides?: Partial<TaskRecord>): TaskRecord {
 describe("detached-task-runtime", () => {
   afterEach(() => {
     resetDetachedTaskLifecycleRuntimeForTests();
+    mockLogWarn.mockClear();
   });
 
   it("dispatches lifecycle operations through the installed runtime", async () => {
@@ -200,6 +219,10 @@ describe("detached-task-runtime", () => {
         task,
       });
       expect(result).toEqual({ recovered: false });
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        "onBeforeMarkLost hook threw, proceeding with markTaskLost",
+        expect.objectContaining({ taskId: "task-throw", runtime: "acp" }),
+      );
     });
   });
 });

--- a/src/tasks/detached-task-runtime.test.ts
+++ b/src/tasks/detached-task-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   failTaskRunByRunId,
   getDetachedTaskLifecycleRuntime,
   getDetachedTaskLifecycleRuntimeRegistration,
+  onBeforeMarkLost,
   registerDetachedTaskRuntime,
   recordTaskRunProgressByRunId,
   resetDetachedTaskLifecycleRuntimeForTests,
@@ -144,5 +145,61 @@ describe("detached-task-runtime", () => {
       runtime,
     });
     expect(getDetachedTaskLifecycleRuntime()).toBe(runtime);
+  });
+
+  describe("onBeforeMarkLost", () => {
+    it("returns recovered when hook returns recovered true", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-recover", runtime: "subagent" });
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        onBeforeMarkLost: vi.fn(() => ({ recovered: true })),
+      });
+      const result = await onBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+      });
+      expect(result).toEqual({ recovered: true });
+    });
+
+    it("returns not recovered when hook returns recovered false", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-no-recover", runtime: "cron" });
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        onBeforeMarkLost: vi.fn(() => ({ recovered: false })),
+      });
+      const result = await onBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+      });
+      expect(result).toEqual({ recovered: false });
+    });
+
+    it("returns not recovered when hook is not provided", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-no-hook", runtime: "cli" });
+      const result = await onBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+      });
+      expect(result).toEqual({ recovered: false });
+    });
+
+    it("returns not recovered and logs warning when hook throws", async () => {
+      const task = createFakeTaskRecord({ taskId: "task-throw", runtime: "acp" });
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        onBeforeMarkLost: vi.fn(() => {
+          throw new Error("plugin crashed");
+        }),
+      });
+      const result = await onBeforeMarkLost({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        task,
+      });
+      expect(result).toEqual({ recovered: false });
+    });
   });
 });

--- a/src/tasks/detached-task-runtime.ts
+++ b/src/tasks/detached-task-runtime.ts
@@ -1,5 +1,7 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type {
+  DetachedTaskRecoveryAttemptParams,
+  DetachedTaskRecoveryAttemptResult,
   DetachedTaskLifecycleRuntime,
   DetachedTaskLifecycleRuntimeRegistration,
 } from "./detached-task-runtime-contract.js";
@@ -19,9 +21,9 @@ import {
   setDetachedTaskDeliveryStatusByRunId as setDetachedTaskDeliveryStatusByRunIdFromExecutor,
   startTaskRunByRunId as startTaskRunByRunIdFromExecutor,
 } from "./task-executor.js";
-import type { TaskRecord, TaskRuntime } from "./task-registry.types.js";
 
 const log = createSubsystemLogger("tasks/detached-runtime");
+const DETACHED_TASK_RECOVERY_WARN_MS = 5_000;
 
 export type { DetachedTaskLifecycleRuntime, DetachedTaskLifecycleRuntimeRegistration };
 
@@ -109,25 +111,38 @@ export function cancelDetachedTaskRunById(
   return getDetachedTaskLifecycleRuntime().cancelDetachedTaskRunById(...args);
 }
 
-export async function onBeforeMarkLost(params: {
-  taskId: string;
-  runtime: TaskRuntime;
-  task: TaskRecord;
-}): Promise<{ recovered: boolean }> {
-  const hook = getDetachedTaskLifecycleRuntime().onBeforeMarkLost;
+export async function tryRecoverTaskBeforeMarkLost(
+  params: DetachedTaskRecoveryAttemptParams,
+): Promise<DetachedTaskRecoveryAttemptResult> {
+  const hook = getDetachedTaskLifecycleRuntime().tryRecoverTaskBeforeMarkLost;
   if (!hook) {
     return { recovered: false };
   }
+  const startedAt = Date.now();
   try {
     const result = await hook(params);
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= DETACHED_TASK_RECOVERY_WARN_MS) {
+      log.warn("Detached task recovery hook was slow", {
+        taskId: params.taskId,
+        runtime: params.runtime,
+        elapsedMs,
+      });
+    }
     if (result && typeof result.recovered === "boolean") {
       return result;
     }
-    return { recovered: false };
-  } catch (err) {
-    log.warn("onBeforeMarkLost hook threw, proceeding with markTaskLost", {
+    log.warn("Detached task recovery hook returned invalid result, proceeding with markTaskLost", {
       taskId: params.taskId,
       runtime: params.runtime,
+      result,
+    });
+    return { recovered: false };
+  } catch (err) {
+    log.warn("Detached task recovery hook threw, proceeding with markTaskLost", {
+      taskId: params.taskId,
+      runtime: params.runtime,
+      elapsedMs: Date.now() - startedAt,
       error: err,
     });
     return { recovered: false };

--- a/src/tasks/detached-task-runtime.ts
+++ b/src/tasks/detached-task-runtime.ts
@@ -119,7 +119,11 @@ export async function onBeforeMarkLost(params: {
     return { recovered: false };
   }
   try {
-    return await hook(params);
+    const result = await hook(params);
+    if (result && typeof result.recovered === "boolean") {
+      return result;
+    }
+    return { recovered: false };
   } catch (err) {
     log.warn("onBeforeMarkLost hook threw, proceeding with markTaskLost", {
       taskId: params.taskId,

--- a/src/tasks/detached-task-runtime.ts
+++ b/src/tasks/detached-task-runtime.ts
@@ -1,3 +1,4 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type {
   DetachedTaskLifecycleRuntime,
   DetachedTaskLifecycleRuntimeRegistration,
@@ -18,6 +19,9 @@ import {
   setDetachedTaskDeliveryStatusByRunId as setDetachedTaskDeliveryStatusByRunIdFromExecutor,
   startTaskRunByRunId as startTaskRunByRunIdFromExecutor,
 } from "./task-executor.js";
+import type { TaskRecord, TaskRuntime } from "./task-registry.types.js";
+
+const log = createSubsystemLogger("tasks/detached-runtime");
 
 export type { DetachedTaskLifecycleRuntime, DetachedTaskLifecycleRuntimeRegistration };
 
@@ -103,4 +107,25 @@ export function cancelDetachedTaskRunById(
   ...args: Parameters<DetachedTaskLifecycleRuntime["cancelDetachedTaskRunById"]>
 ): ReturnType<DetachedTaskLifecycleRuntime["cancelDetachedTaskRunById"]> {
   return getDetachedTaskLifecycleRuntime().cancelDetachedTaskRunById(...args);
+}
+
+export async function onBeforeMarkLost(params: {
+  taskId: string;
+  runtime: TaskRuntime;
+  task: TaskRecord;
+}): Promise<{ recovered: boolean }> {
+  const hook = getDetachedTaskLifecycleRuntime().onBeforeMarkLost;
+  if (!hook) {
+    return { recovered: false };
+  }
+  try {
+    return await hook(params);
+  } catch (err) {
+    log.warn("onBeforeMarkLost hook threw, proceeding with markTaskLost", {
+      taskId: params.taskId,
+      runtime: params.runtime,
+      error: err,
+    });
+    return { recovered: false };
+  }
 }

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -8,6 +8,7 @@ import {
   getDetachedTaskLifecycleRuntime,
 } from "./detached-task-runtime.js";
 import {
+  previewTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
   runTaskRegistryMaintenance,
   setTaskRegistryMaintenanceRuntimeForTests,
@@ -204,7 +205,7 @@ describe("task-registry maintenance issue #60299", () => {
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
   });
 
-  it("skips markTaskLost and counts recovered when onBeforeMarkLost hook recovers a stale task", async () => {
+  it("skips markTaskLost and counts recovered when recovery hook recovers a stale task", async () => {
     const task = makeStaleTask({
       runtime: "cron",
       sourceId: "cron-job-recovered",
@@ -215,13 +216,23 @@ describe("task-registry maintenance issue #60299", () => {
       tasks: [task],
     });
 
+    const recoveryHook = vi.fn(() => ({ recovered: true }));
     setDetachedTaskLifecycleRuntime({
       ...getDetachedTaskLifecycleRuntime(),
-      onBeforeMarkLost: vi.fn(() => ({ recovered: true })),
+      tryRecoverTaskBeforeMarkLost: recoveryHook,
     });
 
+    expect(previewTaskRegistryMaintenance()).toMatchObject({ reconciled: 1, recovered: 0 });
     const result = await runTaskRegistryMaintenance();
     expect(result).toMatchObject({ reconciled: 0, recovered: 1 });
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+    expect(recoveryHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.taskId,
+        runtime: "cron",
+        task: expect.objectContaining({ taskId: task.taskId }),
+        now: expect.any(Number),
+      }),
+    );
   });
 });

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
+import {
+  resetDetachedTaskLifecycleRuntimeForTests,
+  setDetachedTaskLifecycleRuntime,
+  getDetachedTaskLifecycleRuntime,
+} from "./detached-task-runtime.js";
 import {
   resetTaskRegistryMaintenanceRuntimeForTests,
   runTaskRegistryMaintenance,
@@ -38,6 +43,7 @@ type TaskRegistryMaintenanceRuntime = Parameters<
 afterEach(() => {
   stopTaskRegistryMaintenanceForTests();
   resetTaskRegistryMaintenanceRuntimeForTests();
+  resetDetachedTaskLifecycleRuntimeForTests();
 });
 
 function createTaskRegistryMaintenanceHarness(params: {
@@ -195,6 +201,27 @@ describe("task-registry maintenance issue #60299", () => {
     });
 
     expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+  });
+
+  it("skips markTaskLost and counts recovered when onBeforeMarkLost hook recovers a stale task", async () => {
+    const task = makeStaleTask({
+      runtime: "cron",
+      sourceId: "cron-job-recovered",
+      childSessionKey: undefined,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+    });
+
+    setDetachedTaskLifecycleRuntime({
+      ...getDetachedTaskLifecycleRuntime(),
+      onBeforeMarkLost: vi.fn(() => ({ recovered: true })),
+    });
+
+    const result = await runTaskRegistryMaintenance();
+    expect(result).toMatchObject({ reconciled: 0, recovered: 1 });
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
   });
 });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -5,7 +5,7 @@ import { getAgentRunContext } from "../infra/agent-events.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { deriveSessionChatType } from "../sessions/session-chat-type.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { onBeforeMarkLost } from "./detached-task-runtime.js";
+import { tryRecoverTaskBeforeMarkLost } from "./detached-task-runtime.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -252,7 +252,7 @@ export function reconcileTaskLookupToken(token: string): TaskRecord | undefined 
   return task ? reconcileTaskRecordForOperatorInspection(task) : undefined;
 }
 
-// Preview is synchronous and cannot call the async onBeforeMarkLost hook,
+// Preview is synchronous and cannot call the async detached-task recovery hook,
 // so recovered tasks are counted under reconciled here. The real sweep
 // in runTaskRegistryMaintenance splits them into reconciled vs recovered.
 export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
@@ -312,10 +312,11 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       continue;
     }
     if (shouldMarkLost(current, now)) {
-      const recovery = await onBeforeMarkLost({
+      const recovery = await tryRecoverTaskBeforeMarkLost({
         taskId: current.taskId,
         runtime: current.runtime,
         task: current,
+        now,
       });
       const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
       if (!freshAfterHook || !shouldMarkLost(freshAfterHook, now)) {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -252,6 +252,9 @@ export function reconcileTaskLookupToken(token: string): TaskRecord | undefined 
   return task ? reconcileTaskRecordForOperatorInspection(task) : undefined;
 }
 
+// Preview is synchronous and cannot call the async onBeforeMarkLost hook,
+// so recovered tasks are counted under reconciled here. The real sweep
+// in runTaskRegistryMaintenance splits them into reconciled vs recovered.
 export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const now = Date.now();
@@ -314,18 +317,23 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
         runtime: current.runtime,
         task: current,
       });
-      if (recovery.recovered) {
-        const fresh = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
-        if (fresh && isActiveTask(fresh)) {
-          recovered += 1;
-        }
+      const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
+      if (!freshAfterHook || !shouldMarkLost(freshAfterHook, now)) {
         processed += 1;
         if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
           await yieldToEventLoop();
         }
         continue;
       }
-      const next = markTaskLost(current, now);
+      if (recovery.recovered) {
+        recovered += 1;
+        processed += 1;
+        if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+          await yieldToEventLoop();
+        }
+        continue;
+      }
+      const next = markTaskLost(freshAfterHook, now);
       if (next.status === "lost") {
         reconciled += 1;
       }

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -5,6 +5,7 @@ import { getAgentRunContext } from "../infra/agent-events.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { deriveSessionChatType } from "../sessions/session-chat-type.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { onBeforeMarkLost } from "./detached-task-runtime.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -77,6 +78,7 @@ let taskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime =
 
 export type TaskRegistryMaintenanceSummary = {
   reconciled: number;
+  recovered: number;
   cleanupStamped: number;
   pruned: number;
 };
@@ -269,7 +271,7 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
       cleanupStamped += 1;
     }
   }
-  return { reconciled, cleanupStamped, pruned };
+  return { reconciled, recovered: 0, cleanupStamped, pruned };
 }
 
 /**
@@ -296,6 +298,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const now = Date.now();
   let reconciled = 0;
+  let recovered = 0;
   let cleanupStamped = 0;
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
@@ -306,6 +309,22 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       continue;
     }
     if (shouldMarkLost(current, now)) {
+      const recovery = await onBeforeMarkLost({
+        taskId: current.taskId,
+        runtime: current.runtime,
+        task: current,
+      });
+      if (recovery.recovered) {
+        const fresh = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
+        if (fresh && isActiveTask(fresh)) {
+          recovered += 1;
+        }
+        processed += 1;
+        if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+          await yieldToEventLoop();
+        }
+        continue;
+      }
       const next = markTaskLost(current, now);
       if (next.status === "lost") {
         reconciled += 1;
@@ -341,7 +360,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       await yieldToEventLoop();
     }
   }
-  return { reconciled, cleanupStamped, pruned };
+  return { reconciled, recovered, cleanupStamped, pruned };
 }
 
 export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummary> {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1328,6 +1328,7 @@ describe("task-registry", () => {
 
       expect(await runTaskRegistryMaintenance()).toEqual({
         reconciled: 1,
+        recovered: 0,
         cleanupStamped: 0,
         pruned: 0,
       });
@@ -1363,6 +1364,7 @@ describe("task-registry", () => {
 
       expect(await sweepTaskRegistry()).toEqual({
         reconciled: 0,
+        recovered: 0,
         cleanupStamped: 0,
         pruned: 1,
       });
@@ -1406,12 +1408,14 @@ describe("task-registry", () => {
 
       expect(previewTaskRegistryMaintenance()).toEqual({
         reconciled: 0,
+        recovered: 0,
         cleanupStamped: 1,
         pruned: 0,
       });
 
       expect(await runTaskRegistryMaintenance()).toEqual({
         reconciled: 0,
+        recovered: 0,
         cleanupStamped: 1,
         pruned: 0,
       });
@@ -1530,6 +1534,7 @@ describe("task-registry", () => {
 
     expect(await runTaskRegistryMaintenance()).toEqual({
       reconciled: 0,
+      recovered: 0,
       cleanupStamped: 0,
       pruned: 0,
     });
@@ -1570,6 +1575,7 @@ describe("task-registry", () => {
 
     expect(await sweepTaskRegistry()).toEqual({
       reconciled: 0,
+      recovered: 0,
       cleanupStamped: 0,
       pruned: 0,
     });


### PR DESCRIPTION
## Context

I'm building a plugin that wraps subagent execution in a durable job queue: crash recovery, retry with backoff, timeout enforcement. The `DetachedTaskLifecycleRuntime` seam (#68886) and plugin registration contract (#68915) give me most of what I need. The one remaining gap is stale-task recovery after a gateway restart: the maintenance sweep can find running tasks whose backing sessions are gone and mark them `lost` before a durable executor has a chance to re-spawn them.

This PR adds one small recovery seam so a registered detached runtime can say "I can recover this task" before core marks it lost.

## What this PR does

Adds an optional `tryRecoverTaskBeforeMarkLost?` hook to `DetachedTaskLifecycleRuntime` in `src/tasks/detached-task-runtime-contract.ts`.

When `runTaskRegistryMaintenance()` is about to mark a stale running task as `lost`, it now:

- calls `tryRecoverTaskBeforeMarkLost({ taskId, runtime, task, now })`
- if the hook returns `{ recovered: true }`, skips `markTaskLost()` and increments a `recovered` counter
- if the hook returns `{ recovered: false }`, proceeds normally
- if the hook is absent, preserves existing behavior
- if the hook throws or returns an invalid shape, logs a warning and proceeds normally
- if the hook is slow, logs a warning so maintenance stalls are visible

After the async hook returns, the sweep re-reads the task and re-checks `shouldMarkLost(...)` before marking it lost, so concurrent completion or recovery wins.

## Why optional

`cancelDetachedTaskRunById` is required because every detached executor needs cancel. Recovery before `markLost` is advisory and only matters for executors with durable recovery state. Keeping it optional preserves current behavior for existing runtimes and test doubles.

## Scope

- adds one optional recovery hook to the detached runtime contract
- adds one dispatch wrapper with invalid-return, throw, and slow-hook logging
- wires the maintenance sweep through that seam
- threads `recovered` through `TaskRegistryMaintenanceSummary` and CLI output
- updates the public Plugin SDK baseline hash because this is a real exported surface change
- adds regression coverage for:
  - recovered / not recovered / no hook
  - throw fallback
  - invalid return fallback
  - slow-hook warning
  - stale task recovered in real maintenance while preview still reports it under `reconciled`

## Test plan

Validated on `mb-server` against head `2de191988a5f0f3065b4ccb48a4ffff97a67ae41`:

- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/tasks/detached-task-runtime.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts src/tasks/task-executor.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm plugin-sdk:api:check`

## Notes

Preview/operator inspection remains intentionally synchronous. It cannot call the async recovery hook, so recoverable stale tasks still count under `reconciled` in preview until the real sweep runs and either recovers or marks them lost.