### PR TITLE
perf: memoize plugin loader alias maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Plugins/tests: reuse plugin loader alias and Jiti config resolution across repeated same-context loads, reducing import-heavy test overhead. (#69316) Thanks @amknight.
+
 ### Fixes
 
 - Cron/delivery: treat explicit `delivery.mode: "none"` runs as not requested even if the runner reports `delivered: false`, so no-delivery cron jobs no longer persist false delivery failures or errors. (#69285) Thanks @matsuri1987.

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -21,8 +21,18 @@ export function getCachedPluginJitiLoader(params: {
   tryNative?: boolean;
   cacheScopeKey?: string;
 }): PluginJitiLoader {
+  const jitiFilename = params.jitiFilename ?? params.modulePath;
+  if (params.cacheScopeKey) {
+    const scopedCacheKey = `${jitiFilename}::${params.cacheScopeKey}`;
+    const cached = params.cache.get(scopedCacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+  const hasAliasOverride = Boolean(params.aliasMap);
+  const hasTryNativeOverride = typeof params.tryNative === "boolean";
   const defaultConfig =
-    params.aliasMap || typeof params.tryNative === "boolean"
+    hasAliasOverride || hasTryNativeOverride
       ? resolvePluginLoaderJitiConfig({
           modulePath: params.modulePath,
           argv1: params.argvEntry ?? process.argv[1],
@@ -34,6 +44,11 @@ export function getCachedPluginJitiLoader(params: {
     ? {
         tryNative: params.tryNative ?? defaultConfig.tryNative,
         aliasMap: params.aliasMap ?? defaultConfig.aliasMap,
+        cacheKey:
+          !hasAliasOverride &&
+          (!hasTryNativeOverride || params.tryNative === defaultConfig.tryNative)
+            ? defaultConfig.cacheKey
+            : undefined,
       }
     : resolvePluginLoaderJitiConfig({
         modulePath: params.modulePath,
@@ -42,16 +57,18 @@ export function getCachedPluginJitiLoader(params: {
         ...(params.preferBuiltDist ? { preferBuiltDist: true } : {}),
       });
   const { tryNative, aliasMap } = resolved;
-  const cacheKey = createPluginLoaderJitiCacheKey({
-    tryNative,
-    aliasMap,
-  });
-  const scopedCacheKey = `${params.jitiFilename ?? params.modulePath}::${params.cacheScopeKey ?? cacheKey}`;
+  const cacheKey =
+    resolved.cacheKey ??
+    createPluginLoaderJitiCacheKey({
+      tryNative,
+      aliasMap,
+    });
+  const scopedCacheKey = `${jitiFilename}::${params.cacheScopeKey ?? cacheKey}`;
   const cached = params.cache.get(scopedCacheKey);
   if (cached) {
     return cached;
   }
-  const loader = (params.createLoader ?? createJiti)(params.jitiFilename ?? params.modulePath, {
+  const loader = (params.createLoader ?? createJiti)(jitiFilename, {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1128,6 +1128,56 @@ describe("buildPluginLoaderAliasMap memoization", () => {
     expect(a).not.toBe(b);
   });
 
+  it("does not reuse a public alias map after private qa aliases are enabled", () => {
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    const sourceQaRuntimePath = path.join(fixture.root, "src", "plugin-sdk", "qa-runtime.ts");
+    fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
+    fs.writeFileSync(sourceQaRuntimePath, "export const qaRuntime = true;\n", "utf-8");
+    const entry = writePluginEntry(fixture.root, bundledPluginFile("private-qa", "src/index.ts"));
+
+    const publicAliases = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined }, () =>
+      buildPluginLoaderAliasMap(entry),
+    );
+    const privateAliases = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1" }, () =>
+      buildPluginLoaderAliasMap(entry),
+    );
+
+    expect(publicAliases).not.toBe(privateAliases);
+    expect(publicAliases["openclaw/plugin-sdk/qa-runtime"]).toBeUndefined();
+    expect(fs.realpathSync(privateAliases["openclaw/plugin-sdk/qa-runtime"] ?? "")).toBe(
+      fs.realpathSync(sourceQaRuntimePath),
+    );
+  });
+
+  it("does not reuse a development alias map in production mode", () => {
+    const fixture = createPluginSdkAliasFixture();
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    const distRootAlias = path.join(fixture.root, "dist", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(sourceRootAlias, "module.exports = { source: true };\n", "utf-8");
+    fs.writeFileSync(distRootAlias, "module.exports = { dist: true };\n", "utf-8");
+    const entry = writePluginEntry(fixture.root, bundledPluginFile("env-mode", "src/index.ts"));
+
+    const developmentAliases = withEnv({ NODE_ENV: undefined }, () =>
+      buildPluginLoaderAliasMap(entry),
+    );
+    const productionAliases = withEnv({ NODE_ENV: "production" }, () =>
+      buildPluginLoaderAliasMap(entry),
+    );
+
+    expect(developmentAliases).not.toBe(productionAliases);
+    expect(fs.realpathSync(developmentAliases["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(sourceRootAlias),
+    );
+    expect(fs.realpathSync(productionAliases["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(distRootAlias),
+    );
+  });
+
   it("memoized result has identical content to a freshly computed map", () => {
     const fixture = createPluginSdkAliasFixture();
     fs.writeFileSync(

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1058,7 +1058,7 @@ export const syntheticRuntimeMarker = {
 });
 
 describe("buildPluginLoaderAliasMap memoization", () => {
-  it("returns the same object reference for identical inputs (jiti sentinel safety)", () => {
+  it("returns the same object reference for identical effective context", () => {
     const fixture = createPluginSdkAliasFixture();
     const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
     fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
@@ -1070,8 +1070,6 @@ describe("buildPluginLoaderAliasMap memoization", () => {
     const first = buildPluginLoaderAliasMap(sourcePluginEntry);
     const second = buildPluginLoaderAliasMap(sourcePluginEntry);
 
-    // Reference identity is critical: jiti's normalizeAliases uses a
-    // reference-identity sentinel to skip O(N²) re-processing.
     expect(second).toBe(first);
   });
 

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1056,3 +1056,95 @@ export const syntheticRuntimeMarker = {
     expect(resolved).toBe(expected === "dist" ? fixture.distFile : fixture.srcFile);
   });
 });
+
+describe("buildPluginLoaderAliasMap memoization", () => {
+  it("returns the same object reference for identical inputs (jiti sentinel safety)", () => {
+    const fixture = createPluginSdkAliasFixture();
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
+    const sourcePluginEntry = writePluginEntry(
+      fixture.root,
+      bundledPluginFile("memo-demo", "src/index.ts"),
+    );
+
+    const first = buildPluginLoaderAliasMap(sourcePluginEntry);
+    const second = buildPluginLoaderAliasMap(sourcePluginEntry);
+
+    // Reference identity is critical: jiti's normalizeAliases uses a
+    // reference-identity sentinel to skip O(N²) re-processing.
+    expect(second).toBe(first);
+  });
+
+  it("returns different references for different modulePath inputs", () => {
+    const fixtureA = createPluginSdkAliasFixture();
+    const fixtureB = createPluginSdkAliasFixture();
+    fs.writeFileSync(
+      path.join(fixtureA.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(fixtureB.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    const entryA = writePluginEntry(fixtureA.root, bundledPluginFile("a", "src/index.ts"));
+    const entryB = writePluginEntry(fixtureB.root, bundledPluginFile("b", "src/index.ts"));
+
+    const aliasA = buildPluginLoaderAliasMap(entryA);
+    const aliasB = buildPluginLoaderAliasMap(entryB);
+
+    expect(aliasA).not.toBe(aliasB);
+    expect(aliasA["openclaw/plugin-sdk"]).not.toBe(aliasB["openclaw/plugin-sdk"]);
+  });
+
+  it("returns different references when pluginSdkResolution differs", () => {
+    const fixture = createPluginSdkAliasFixture();
+    fs.writeFileSync(
+      path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    const entry = writePluginEntry(fixture.root, bundledPluginFile("res", "src/index.ts"));
+
+    const auto = buildPluginLoaderAliasMap(entry, undefined, undefined, "auto");
+    const dist = buildPluginLoaderAliasMap(entry, undefined, undefined, "dist");
+
+    expect(auto).not.toBe(dist);
+  });
+
+  it("returns different references when argv1 differs", () => {
+    const fixture = createPluginSdkAliasFixture();
+    fs.writeFileSync(
+      path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    const entry = writePluginEntry(fixture.root, bundledPluginFile("argv", "src/index.ts"));
+
+    const a = buildPluginLoaderAliasMap(entry, "/path/to/cli-a.mjs");
+    const b = buildPluginLoaderAliasMap(entry, "/path/to/cli-b.mjs");
+
+    expect(a).not.toBe(b);
+  });
+
+  it("memoized result has identical content to a freshly computed map", () => {
+    const fixture = createPluginSdkAliasFixture();
+    fs.writeFileSync(
+      path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    const entry = writePluginEntry(fixture.root, bundledPluginFile("eq", "src/index.ts"));
+
+    const first = buildPluginLoaderAliasMap(entry);
+    const second = buildPluginLoaderAliasMap(entry);
+
+    // Same reference (cache hit)
+    expect(second).toBe(first);
+    // Same content
+    expect(second).toEqual(first);
+    // Same key set
+    expect(Object.keys(second).toSorted()).toEqual(Object.keys(first).toSorted());
+  });
+});

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -430,12 +430,25 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
   return null;
 }
 
+// Memoize alias maps by inputs so the same object reference is returned for
+// identical parameters. jiti's `normalizeAliases` uses a reference-identity
+// sentinel (`if (e[pt]) return e`) to skip its O(N²) normalization — returning
+// the same object lets the sentinel fire on the 2nd+ call instead of repeating
+// the full cycle every time. See #68983.
+const aliasMapCache = new Map<string, Record<string, string>>();
+
 export function buildPluginLoaderAliasMap(
   modulePath: string,
   argv1: string | undefined = STARTUP_ARGV1,
   moduleUrl?: string,
   pluginSdkResolution: PluginSdkResolutionPreference = "auto",
 ): Record<string, string> {
+  const cacheKey = `${modulePath}\0${argv1 ?? ""}\0${moduleUrl ?? ""}\0${pluginSdkResolution}`;
+  const cached = aliasMapCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const pluginSdkAlias = resolvePluginSdkAliasFile({
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
@@ -445,7 +458,7 @@ export function buildPluginLoaderAliasMap(
     pluginSdkResolution,
   });
   const extensionApiAlias = resolveExtensionApiAlias({ modulePath, pluginSdkResolution });
-  return {
+  const result: Record<string, string> = {
     ...(extensionApiAlias
       ? { "openclaw/extension-api": normalizeJitiAliasTargetPath(extensionApiAlias) }
       : {}),
@@ -463,6 +476,8 @@ export function buildPluginLoaderAliasMap(
       ).map(([key, value]) => [key, normalizeJitiAliasTargetPath(value)]),
     ),
   };
+  aliasMapCache.set(cacheKey, result);
+  return result;
 }
 
 export function resolvePluginRuntimeModulePath(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -430,11 +430,9 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
   return null;
 }
 
-// Memoize alias maps by inputs so the same object reference is returned for
-// identical parameters. jiti's `normalizeAliases` uses a reference-identity
-// sentinel (`if (e[pt]) return e`) to skip its O(N²) normalization — returning
-// the same object lets the sentinel fire on the 2nd+ call instead of repeating
-// the full cycle every time. See #68983.
+// Memoize alias maps by effective resolution context so repeated loader setup
+// avoids rebuilding the same filesystem-derived map. Include cwd/env inputs
+// because the fallback root and private QA alias surfaces depend on them.
 const aliasMapCache = new Map<string, Record<string, string>>();
 
 function buildPluginLoaderAliasMapCacheKey(params: {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -437,13 +437,35 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
 // the full cycle every time. See #68983.
 const aliasMapCache = new Map<string, Record<string, string>>();
 
+function buildPluginLoaderAliasMapCacheKey(params: {
+  modulePath: string;
+  argv1?: string;
+  moduleUrl?: string;
+  pluginSdkResolution: PluginSdkResolutionPreference;
+}) {
+  return [
+    params.modulePath,
+    params.argv1 ?? "",
+    params.moduleUrl ?? "",
+    params.pluginSdkResolution,
+    process.cwd(),
+    process.env.NODE_ENV === "production" ? "production" : "non-production",
+    shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ? "private-qa" : "public",
+  ].join("\0");
+}
+
 export function buildPluginLoaderAliasMap(
   modulePath: string,
   argv1: string | undefined = STARTUP_ARGV1,
   moduleUrl?: string,
   pluginSdkResolution: PluginSdkResolutionPreference = "auto",
 ): Record<string, string> {
-  const cacheKey = `${modulePath}\0${argv1 ?? ""}\0${moduleUrl ?? ""}\0${pluginSdkResolution}`;
+  const cacheKey = buildPluginLoaderAliasMapCacheKey({
+    modulePath,
+    argv1,
+    moduleUrl,
+    pluginSdkResolution,
+  });
   const cached = aliasMapCache.get(cacheKey);
   if (cached) {
     return cached;

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -430,10 +430,35 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
   return null;
 }
 
-// Memoize alias maps by effective resolution context so repeated loader setup
-// avoids rebuilding the same filesystem-derived map. Include cwd/env inputs
-// because the fallback root and private QA alias surfaces depend on them.
+const MAX_PLUGIN_LOADER_ALIAS_CACHE_ENTRIES = 512;
+
+// Memoize loader alias/config by effective resolution context so repeated
+// loader setup avoids rebuilding the same filesystem-derived map and cache key.
+// Include cwd/env inputs because the fallback root and private QA alias
+// surfaces depend on them.
 const aliasMapCache = new Map<string, Record<string, string>>();
+const pluginLoaderJitiConfigCache = new Map<
+  string,
+  {
+    tryNative: boolean;
+    aliasMap: Record<string, string>;
+    cacheKey: string;
+  }
+>();
+
+function setBoundedCacheValue<T>(cache: Map<string, T>, key: string, value: T) {
+  if (cache.has(key)) {
+    cache.delete(key);
+  }
+  cache.set(key, value);
+  while (cache.size > MAX_PLUGIN_LOADER_ALIAS_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    cache.delete(oldestKey);
+  }
+}
 
 function buildPluginLoaderAliasMapCacheKey(params: {
   modulePath: string;
@@ -449,6 +474,23 @@ function buildPluginLoaderAliasMapCacheKey(params: {
     process.cwd(),
     process.env.NODE_ENV === "production" ? "production" : "non-production",
     shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ? "private-qa" : "public",
+  ].join("\0");
+}
+
+function buildPluginLoaderJitiConfigCacheKey(params: {
+  modulePath: string;
+  argv1?: string;
+  moduleUrl: string;
+  preferBuiltDist?: boolean;
+}) {
+  return [
+    buildPluginLoaderAliasMapCacheKey({
+      modulePath: params.modulePath,
+      argv1: params.argv1,
+      moduleUrl: params.moduleUrl,
+      pluginSdkResolution: "auto",
+    }),
+    params.preferBuiltDist === true ? "prefer-built-dist" : "default-dist",
   ].join("\0");
 }
 
@@ -496,7 +538,7 @@ export function buildPluginLoaderAliasMap(
       ).map(([key, value]) => [key, normalizeJitiAliasTargetPath(value)]),
     ),
   };
-  aliasMapCache.set(cacheKey, result);
+  setBoundedCacheValue(aliasMapCache, cacheKey, result);
   return result;
 }
 
@@ -610,12 +652,18 @@ export function resolvePluginLoaderJitiConfig(params: {
   aliasMap: Record<string, string>;
   cacheKey: string;
 } {
+  const configCacheKey = buildPluginLoaderJitiConfigCacheKey(params);
+  const cached = pluginLoaderJitiConfigCache.get(configCacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const tryNative = resolvePluginLoaderJitiTryNative(
     params.modulePath,
     params.preferBuiltDist ? { preferBuiltDist: true } : {},
   );
   const aliasMap = buildPluginLoaderAliasMap(params.modulePath, params.argv1, params.moduleUrl);
-  return {
+  const result = {
     tryNative,
     aliasMap,
     cacheKey: createPluginLoaderJitiCacheKey({
@@ -623,6 +671,8 @@ export function resolvePluginLoaderJitiConfig(params: {
       aliasMap,
     }),
   };
+  setBoundedCacheValue(pluginLoaderJitiConfigCache, configCacheKey, result);
+  return result;
 }
 
 export function isBundledPluginExtensionPath(params: {


### PR DESCRIPTION
## Summary
- memoize plugin loader alias maps by effective resolution context
- reuse the resolved Jiti loader config/cache key on hot loader-cache hits
- bound the loader alias/config caches to avoid unbounded growth on unique module paths
- keep cache keys sensitive to cwd, production mode, and private QA alias enablement

## Why
OpenClaw hits this in real plugin/channel loader paths. A cached Jiti loader hit still had to rebuild the plugin SDK alias map and stringify the alias map into a Jiti cache key before it could discover that the loader was already cached.

Reading local `jiti@2.6.1` source showed that this is not about reusing Jiti's internal alias sentinel across fresh `createJiti()` calls. Jiti normalizes aliases into its own internal object. The useful optimization is avoiding repeated OpenClaw alias/config resolution before returning an already-cached loader.

## Measurements
Local synthetic measurements on this machine; medians across repeated samples.

| Benchmark | main | first PR patch | refined PR |
| --- | ---: | ---: | ---: |
| `buildPluginLoaderAliasMap()` same module, 5,000 calls | 3676.79ms | 4.74ms | 4.74ms |
| `getCachedPluginJitiLoader()` same module, 5,000 calls | 13770.14ms | 1392.08ms | 41.71ms |
| `loadChannelPluginModule()` same module, 5,000 hot loads | 17174.67ms | 3791.66ms | 583.18ms |

## Tradeoff
This helps repeated same-context loader resolution: long-running processes, channel/package-state probes, runtime boundary loads, and import-heavy tests. It is not a broad cold-start win when every module path is unique. Unique paths still pay first-resolution cost, with cache entries capped to avoid retaining arbitrary module paths forever.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/plugins/sdk-alias.test.ts src/plugins/jiti-loader-cache.test.ts`
- `pnpm build`
- commit hook `pnpm check`
