### PR TITLE
github-copilot: expand default model list with Opus 4.7, 4.5, Haiku 4.5, Gemini 2.5 Pro

### DIFF
--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -8,9 +8,13 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
+  "claude-opus-4.7",
   "claude-opus-4.6",
+  "claude-opus-4.5",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
+  "claude-haiku-4.5",
+  "gemini-2.5-pro",
   "gpt-4o",
   "gpt-4.1",
   "gpt-4.1-mini",

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -75,6 +75,22 @@ describe("github-copilot model defaults", () => {
       expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.5");
     });
 
+    it("includes claude-opus-4.7", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.7");
+    });
+
+    it("includes claude-opus-4.5", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.5");
+    });
+
+    it("includes claude-haiku-4.5", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-haiku-4.5");
+    });
+
+    it("includes gemini-2.5-pro", () => {
+      expect(getDefaultCopilotModelIds()).toContain("gemini-2.5-pro");
+    });
+
     it("returns a mutable copy", () => {
       const a = getDefaultCopilotModelIds();
       const b = getDefaultCopilotModelIds();


### PR DESCRIPTION
## Summary

Fixes #69241.

The GitHub Copilot provider's default model list was missing several models that Copilot actually serves today. Adding:

- `claude-opus-4.7` (latest Anthropic Opus, top of list for default preference)
- `claude-opus-4.5`
- `claude-haiku-4.5`
- `gemini-2.5-pro`

Ordering: Opus variants first (newest to oldest), then Sonnet, then Haiku, then Gemini, then OpenAI. Keeps deterministic order (matters for prompt cache stability — see `CLAUDE.md` Prompt Cache Stability section; the list is consumed as a `readonly` tuple and returned as a mutable copy via `getDefaultCopilotModelIds()`).

The provider boundary rule is honored: no core changes, all provider-local in `extensions/github-copilot/`. As the existing comment notes, if a given model isn't available for a user's plan/org Copilot returns an error and users remove it from their config — this PR just widens the default surface so current Copilot tenants see working models.

## Test plan

- [x] `pnpm test extensions/github-copilot/models.test.ts` — 25/25 pass (4 new `it(...)` blocks mirror the existing pattern for `claude-sonnet-4.6` / `claude-sonnet-4.5`)
- [x] `pnpm format` — clean
- [x] `pnpm lint extensions/github-copilot/...` — 0 warnings, 0 errors
- [x] `pnpm tsgo:extensions` — green

## Notes

- Marked as AI-assisted per CONTRIBUTING.md.
- Touches only `extensions/github-copilot/models-defaults.ts` and the colocated test; no core / SDK / manifest changes.

🤖 AI-assisted