### PR TITLE
perf(slack): narrow runtime-setter specifier to avoid loading 284KB barrel

### DIFF
--- a/extensions/slack/index.ts
+++ b/extensions/slack/index.ts
@@ -26,7 +26,7 @@ export default defineBundledChannelEntry({
     exportName: "channelSecrets",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setSlackRuntime",
   },
   accountInspect: {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -14,7 +14,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.ts",
+      "./runtime-setter-api.ts"
     ],
     "setupEntry": "./setup-entry.ts",
     "channel": {

--- a/extensions/slack/runtime-setter-api.ts
+++ b/extensions/slack/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Narrow entry point for setSlackRuntime — avoids pulling in the full
+// runtime-api barrel (284KB, 29 chunks) during plugin register().
+export { setSlackRuntime } from "./src/runtime.js";


### PR DESCRIPTION
## Summary

The slack extension's `BundledChannelEntryContract` pointed its `runtime` specifier at `./runtime-api.js` — a barrel module that re-exports the full slack runtime surface (29 chunks, ~284KB). The framework calls `setChannelRuntime` synchronously during `register()`, so this barrel was loaded on every gateway startup just to obtain the 23-line `setSlackRuntime` setter function.

This PR adds a narrow `runtime-setter-api.ts` entry point that re-exports only `setSlackRuntime`, and points the contract at it. The full runtime-api tree is still loaded — but only when an actual slack message arrives, not during `register()`.

### Changes

- **New:** `extensions/slack/runtime-setter-api.ts` — 3 lines, re-exports `setSlackRuntime` only
- **Modified:** `extensions/slack/index.ts` — point `runtime.specifier` at the new narrow entry
- **Modified:** `extensions/slack/package.json` — add the new entry to the `openclaw.extensions` bundle list

### Profiling

Built into a production-style `dist/`. Measured via per-plugin profiler and gateway ready time on macOS, Node v24.

| Asset loaded by `register()` | Before | After |
|---|---|---|
| `runtime-setter-api.js` (or `runtime-api.js`) tree size | 29 files, ~284KB | 2 files, ~0.5KB |
| Slack module tree loaded at register time | full runtime surface | only the runtime store |

(Per-extension benefits are partial — the dominant slack startup cost remains `loadChannelPlugin()` which is being addressed separately by the framework-level lazy registration work in #65444. This PR removes one of the redundant module loads.)

### Related work

- #69316 (Phase 1A) — memoize `buildPluginLoaderAliasMap` to enable jiti sentinel reuse (cross-cutting framework fix; complements this PR)
- #68983 — startup regression caused by repeated jiti normalizeAliases
- #65444 — lazy-load channel plugins (the broader fix that would make this kind of per-extension narrowing unnecessary)

### Pattern

Same pattern Peter has been applying to other modules:
- `805481c176` perf: narrow bonjour and sqlite runtime type surfaces
- `a0919685be` perf: narrow local llama type surface
- `346aa0ed47` perf: narrow HTML parser type surface
- `1f71137d1e` perf: narrow PDF extractor type surface

Could be applied to other channel extensions (telegram, whatsapp, discord) that also have heavy `runtime-api` barrels.