### PR TITLE
fix(tui): arm streaming watchdog on every delta, not only visible ones

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -298,15 +298,18 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
     }
     if (evt.state === "delta") {
+      // Arm watchdog and mark streaming on every delta, even when the visible
+      // text hasn't changed yet (e.g. first commentary-only or tool-call delta).
+      // Without this, the watchdog never fires and the status bar stays stale.
+      setActivityStatus("streaming");
+      if (state.activeChatRunId === evt.runId) {
+        armStreamingWatchdog(evt.runId);
+      }
       const displayText = streamAssembler.ingestDelta(evt.runId, evt.message, state.showThinking);
       if (!displayText) {
         return;
       }
       chatLog.updateAssistant(displayText, evt.runId);
-      setActivityStatus("streaming");
-      if (state.activeChatRunId === evt.runId) {
-        armStreamingWatchdog(evt.runId);
-      }
     }
     if (evt.state === "final") {
       const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;


### PR DESCRIPTION
## Summary

- When `ingestDelta` returns `null` (no visible change yet — first commentary-only delta, tool-call delta, or unchanged content), the handler returned early, skipping `setActivityStatus("streaming")` and `armStreamingWatchdog`
- If every delta during a run returned `null` (common when phase filtering drops all content), the streaming watchdog was never armed and the status bar stayed stuck on `"idle"` while the run was active
- Move `setActivityStatus` and `armStreamingWatchdog` before the null check so both fire on every received delta, regardless of visible output

## Root cause

```typescript
// before
if (!displayText) {
  return;  // ← skipped setActivityStatus + armStreamingWatchdog
}
chatLog.updateAssistant(displayText, evt.runId);
setActivityStatus("streaming");  // ← never reached on null delta
armStreamingWatchdog(evt.runId); // ← never reached on null delta
```

The `tui.requestRender()` at the end of `handleChatEvent` is intentionally still skipped on null deltas (no visual change), so render pressure is unchanged.

## Affected issues

Fixes #34513, #40824

## Test plan

- [ ] Status bar shows `streaming` immediately when a run starts, even if first visible text arrives after a delay
- [ ] 30s watchdog fires and resets status when backend drops a run silently mid-stream
- [ ] `pnpm test src/tui/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)