### PR TITLE
fix(discord): avoid native opus install path

### DIFF
--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -9,7 +9,7 @@
     "@snazzah/davey": "^0.1.11",
     "discord-api-types": "^0.38.47",
     "https-proxy-agent": "^9.0.0",
-    "opusscript": "^0.1.1"
+    "opusscript": "^0.0.8"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
@@ -22,9 +22,6 @@
     "openclaw": {
       "optional": true
     }
-  },
-  "optionalDependencies": {
-    "@discordjs/opus": "^0.10.0"
   },
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1612,7 +1612,6 @@
       "protobufjs": "7.5.5"
     },
     "onlyBuiltDependencies": [
-      "@discordjs/opus",
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,10 +446,10 @@ importers:
     dependencies:
       '@buape/carbon':
         specifier: 0.16.0
-        version: 0.16.0(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.1.1)
+        version: 0.16.0(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.0.8)
       '@discordjs/voice':
         specifier: ^0.19.2
-        version: 0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.1.1)
+        version: 0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.0.8)
       '@snazzah/davey':
         specifier: ^0.1.11
         version: 0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)
@@ -460,8 +460,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       opusscript:
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.0.8
+        version: 0.0.8
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -469,10 +469,6 @@ importers:
       openclaw:
         specifier: workspace:*
         version: link:../..
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
 
   extensions/duckduckgo:
     devDependencies:
@@ -6354,8 +6350,8 @@ packages:
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
-  opusscript@0.1.1:
-    resolution: {integrity: sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==}
+  opusscript@0.0.8:
+    resolution: {integrity: sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -8619,13 +8615,13 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@buape/carbon@0.16.0(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.1.1)':
+  '@buape/carbon@0.16.0(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.0.8)':
     dependencies:
       '@types/node': 25.6.0
       discord-api-types: 0.38.45
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260405.1
-      '@discordjs/voice': 0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.0.8)
       '@types/bun': 1.3.11
       '@types/ws': 8.18.1
       ws: 8.20.0
@@ -8789,12 +8785,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@discordjs/voice@0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.1.1)':
+  '@discordjs/voice@0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(opusscript@0.0.8)':
     dependencies:
       '@snazzah/davey': 0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)
       '@types/ws': 8.18.1
       discord-api-types: 0.38.47
-      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8)
       tslib: 2.8.1
       ws: 8.20.0
     transitivePeerDependencies:
@@ -13611,7 +13607,7 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  opusscript@0.1.1: {}
+  opusscript@0.0.8: {}
 
   ora@5.4.1:
     dependencies:
@@ -13913,10 +13909,10 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1):
+  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8):
     optionalDependencies:
       '@discordjs/opus': 0.10.0
-      opusscript: 0.1.1
+      opusscript: 0.0.8
 
   process-nextick-args@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,6 @@ minimumReleaseAgeExclude:
   - "sqlite-vec-*"
 
 onlyBuiltDependencies:
-  - "@discordjs/opus"
   - "@lydell/node-pty"
   - "@matrix-org/matrix-sdk-crypto-nodejs"
   - "@napi-rs/canvas"

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -8,7 +8,6 @@ const packageManifestContractTests: PackageManifestContractParams[] = [
     pluginId: "discord",
     pluginLocalRuntimeDeps: [
       "@buape/carbon",
-      "@discordjs/opus",
       "@discordjs/voice",
       "@snazzah/davey",
       "discord-api-types",

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -13,9 +13,20 @@ const createLazyFacadeObjectValue = vi.hoisted(() => {
       },
     ) as T;
 });
+const createLazyFacadeValue = vi.hoisted(() => {
+  return <T extends object, K extends keyof T>(load: () => T, key: K): T[K] =>
+    ((...args: unknown[]) => {
+      const value = load()[key];
+      if (typeof value !== "function") {
+        return value;
+      }
+      return (value as (...innerArgs: unknown[]) => unknown)(...args);
+    }) as T[K];
+});
 
 vi.mock("../plugin-sdk/facade-runtime.js", () => ({
   createLazyFacadeObjectValue,
+  createLazyFacadeValue,
   loadActivatedBundledPluginPublicSurfaceModuleSync,
   loadBundledPluginPublicSurfaceModuleSync,
 }));


### PR DESCRIPTION
## Summary
- remove Discord's declared optional `@discordjs/opus` runtime dependency
- use the `opusscript` range that satisfies `prism-media`'s optional peer path
- remove `@discordjs/opus` from pnpm build-script allowlists and package contract expectations

## Validation
- pnpm test src/plugins/contracts/package-manifest.contract.test.ts
- npm install /Users/steipete/Projects/clawdbot4/extensions/discord --package-lock-only --omit=dev --ignore-scripts --no-audit --no-fund
  - confirms no @discordjs/opus, @discordjs/node-pre-gyp, or tar paths in the npm lock
