### PR TITLE
fix(tui): preserve hyphen-separated tokens from line-wrap splitting

### DIFF
--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -79,7 +79,7 @@ function isCopySensitiveToken(token: string): boolean {
   if (token.includes("/") || token.includes("\\")) {
     return true;
   }
-  if (token.includes("_") && FILE_LIKE_RE.test(token)) {
+  if ((token.includes("_") || token.includes("-")) && FILE_LIKE_RE.test(token)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

- `normalizeLongTokenForDisplay` splits tokens ≥33 chars with spaces to prevent terminal overflow
- `isCopySensitiveToken` only guarded underscore-separated names; hyphenated identifiers like `my-long-package-name-component` were split at arbitrary byte offsets, injecting spurious spaces inside code blocks at line-wrap positions
- Add `token.includes("-")` to the `FILE_LIKE_RE` guard so hyphen-separated tokens are preserved exactly alongside underscore-separated ones

## Root cause

```typescript
// before — only underscore-separated names were protected
if (token.includes("_") && FILE_LIKE_RE.test(token)) {
  return true;
}

// after — hyphens covered too
if ((token.includes("_") || token.includes("-")) && FILE_LIKE_RE.test(token)) {
  return true;
}
```

`FILE_LIKE_RE` is `/^[a-zA-Z0-9._-]+$/` — it already matches hyphenated tokens, the guard just wasn't checking for them.

## Affected issues

Fixes #48432

## Test plan

- [ ] `some-long-package-name-with-many-segments` (≥33 chars) renders without injected spaces in TUI code blocks
- [ ] Paths/URLs/credentials still split-protected as before
- [ ] `pnpm test src/tui/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)