### PR TITLE
fix: support per-model provider extraParams

### DIFF
--- a/src/agents/minimax-docs.test.ts
+++ b/src/agents/minimax-docs.test.ts
@@ -8,13 +8,25 @@ import {
 } from "../plugin-sdk/minimax.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
+const testingDoc = fs.readFileSync(path.join(repoRoot, "docs/help/testing.md"), "utf8");
 const testingLiveDoc = fs.readFileSync(path.join(repoRoot, "docs/help/testing-live.md"), "utf8");
+const faqDoc = fs.readFileSync(path.join(repoRoot, "docs/help/faq.md"), "utf8");
+const faqModelsDoc = fs.readFileSync(path.join(repoRoot, "docs/help/faq-models.md"), "utf8");
 const minimaxDoc = fs.readFileSync(path.join(repoRoot, "docs/providers/minimax.md"), "utf8");
 
 describe("MiniMax docs sync", () => {
   it("keeps the live-testing guide on the current MiniMax default", () => {
+    expect(testingDoc).toContain("[Testing — live suites](/help/testing-live)");
     expect(testingLiveDoc).toContain("MiniMax M2.7");
     expect(testingLiveDoc).toContain(MINIMAX_DEFAULT_MODEL_REF);
+  });
+
+  it("keeps the FAQ troubleshooting model ids aligned", () => {
+    expect(faqDoc).toContain("[Models FAQ](/help/faq-models)");
+    expect(faqModelsDoc).toContain(`Unknown model: ${MINIMAX_DEFAULT_MODEL_REF}`);
+    for (const modelRef of MINIMAX_TEXT_MODEL_REFS.slice(3)) {
+      expect(faqModelsDoc).toContain(modelRef);
+    }
   });
 
   it("keeps the provider doc aligned with shared MiniMax ids", () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -284,6 +284,7 @@ import {
   applyExtraParamsToAgent,
   resolveAgentTransportOverride,
   resolveExplicitSettingsTransport,
+  resolveModelConfigExtraParams,
   resolvePreparedExtraParams,
 } from "./pi-embedded-runner/extra-params.js";
 import { createGoogleThinkingPayloadWrapper } from "./pi-embedded-runner/google-stream-wrappers.js";
@@ -2099,6 +2100,99 @@ describe("applyExtraParamsToAgent", () => {
     expect(Object.hasOwn(effectiveExtraParams, "__proto__")).toBe(false);
     expect(Object.hasOwn(effectiveExtraParams, "constructor")).toBe(false);
     expect(Object.hasOwn(effectiveExtraParams, "prototype")).toBe(false);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it("merges model-level extraParams before runtime overrides", () => {
+    const effectiveExtraParams = resolvePreparedExtraParams({
+      cfg: undefined,
+      provider: "openrouter",
+      modelId: "google/gemma-3-27b-it",
+      modelExtraParams: {
+        reasoning: { max_tokens: 0 },
+        temperature: 0.1,
+      },
+      extraParamsOverride: {
+        temperature: 0.3,
+      },
+    });
+
+    expect(effectiveExtraParams.reasoning).toEqual({ max_tokens: 0 });
+    expect(effectiveExtraParams.temperature).toBe(0.3);
+  });
+
+  it("keeps model-level cached content alias precedence over defaults", () => {
+    const effectiveExtraParams = resolvePreparedExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/google/gemma-3-27b-it": {
+                params: {
+                  cachedContent: "from-default",
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolvePreparedExtraParams>[0]["cfg"],
+      provider: "openrouter",
+      modelId: "google/gemma-3-27b-it",
+      modelExtraParams: {
+        cached_content: "from-model",
+      },
+    });
+
+    expect(effectiveExtraParams.cachedContent).toBe("from-model");
+    expect(effectiveExtraParams.cached_content).toBeUndefined();
+  });
+
+  it("keeps model-level service tier alias precedence over defaults", () => {
+    const effectiveExtraParams = resolvePreparedExtraParams({
+      cfg: undefined,
+      provider: "openai",
+      modelId: "gpt-5",
+      resolvedExtraParams: {
+        serviceTier: "auto",
+      },
+      modelExtraParams: {
+        service_tier: "priority",
+      },
+    });
+
+    expect(effectiveExtraParams.serviceTier).toBe("priority");
+    expect(effectiveExtraParams.service_tier).toBeUndefined();
+  });
+
+  it("keeps model-level fast mode alias precedence over defaults", () => {
+    const effectiveExtraParams = resolvePreparedExtraParams({
+      cfg: undefined,
+      provider: "openai",
+      modelId: "gpt-5",
+      resolvedExtraParams: {
+        fastMode: false,
+      },
+      modelExtraParams: {
+        fast_mode: true,
+      },
+    });
+
+    expect(effectiveExtraParams.fastMode).toBe(true);
+    expect(effectiveExtraParams.fast_mode).toBeUndefined();
+  });
+
+  it("reads sanitized model-level extraParams from runtime model objects", () => {
+    const resolved = resolveModelConfigExtraParams({
+      id: "google/gemma-3-27b-it",
+      extraParams: {
+        __proto__: { polluted: true },
+        reasoning: { max_tokens: 0 },
+      },
+    });
+
+    expect(resolved).toEqual({
+      reasoning: { max_tokens: 0 },
+    });
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
   });
 

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -98,6 +98,9 @@ export const resolveAgentTransportOverrideMock: Mock<(params?: unknown) => strin
 export const resolveSandboxContextMock = vi.fn(async () => null);
 export const maybeCompactAgentHarnessSessionMock: Mock<(params?: unknown) => Promise<unknown>> =
   vi.fn(async () => undefined);
+export const resolveModelConfigExtraParamsMock: Mock<
+  (model?: unknown) => Record<string, unknown> | undefined
+> = vi.fn(() => undefined);
 
 export function resetCompactSessionStateMocks(): void {
   sanitizeSessionHistoryMock.mockReset();
@@ -138,6 +141,8 @@ export function resetCompactSessionStateMocks(): void {
   resolveSandboxContextMock.mockResolvedValue(null);
   maybeCompactAgentHarnessSessionMock.mockReset();
   maybeCompactAgentHarnessSessionMock.mockResolvedValue(undefined);
+  resolveModelConfigExtraParamsMock.mockReset();
+  resolveModelConfigExtraParamsMock.mockReturnValue(undefined);
 }
 
 export function resetCompactHooksHarnessMocks(): void {
@@ -390,6 +395,7 @@ export async function loadCompactHooksHarness(): Promise<{
   vi.doMock("./extra-params.js", () => ({
     applyExtraParamsToAgent: applyExtraParamsToAgentMock,
     resolveAgentTransportOverride: resolveAgentTransportOverrideMock,
+    resolveModelConfigExtraParams: resolveModelConfigExtraParamsMock,
   }));
 
   vi.doMock("./tool-split.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -182,10 +182,12 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
-      config: undefined,
-      workspaceDir: "/tmp/workspace",
-    });
+    expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: undefined,
+        workspaceDir: expect.stringMatching(/[\\/]tmp[\\/]workspace$/),
+      }),
+    );
   });
 
   it("forwards gateway subagent binding opt-in during compaction bootstrap", async () => {
@@ -205,11 +207,13 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       allowGatewaySubagentBinding: true,
     });
 
-    expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
-      config: undefined,
-      workspaceDir: "/tmp/workspace",
-      allowGatewaySubagentBinding: true,
-    });
+    expect(ensureRuntimePluginsLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: undefined,
+        workspaceDir: expect.stringMatching(/[\\/]tmp[\\/]workspace$/),
+        allowGatewaySubagentBinding: true,
+      }),
+    );
   });
 
   it("uses sandboxSessionKey only for compaction sandbox resolution", async () => {
@@ -224,7 +228,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(resolveSandboxContextMock).toHaveBeenCalledWith({
       config: undefined,
       sessionKey: "agent:main:telegram:default:direct:12345",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: expect.stringMatching(/[\\/]tmp[\\/]workspace$/),
     });
   });
 
@@ -282,6 +286,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         api: "responses",
       }),
       "/tmp/workspace",
+      undefined,
     );
   });
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -110,7 +110,7 @@ import {
 } from "./compaction-safety-timeout.js";
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
-import { applyExtraParamsToAgent } from "./extra-params.js";
+import { applyExtraParamsToAgent, resolveModelConfigExtraParams } from "./extra-params.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { log } from "./logger.js";
 import { hardenManualCompactionBoundary } from "./manual-compaction-boundary.js";
@@ -213,6 +213,7 @@ function prepareCompactionSessionAgent(params: {
     params.effectiveWorkspace,
     params.effectiveModel,
     params.agentDir,
+    resolveModelConfigExtraParams(params.effectiveModel),
   );
 }
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -135,6 +135,7 @@ export function resolvePreparedExtraParams(params: {
   modelId: string;
   agentDir?: string;
   workspaceDir?: string;
+  modelExtraParams?: Record<string, unknown>;
   extraParamsOverride?: Record<string, unknown>;
   thinkingLevel?: ThinkLevel;
   agentId?: string;
@@ -158,19 +159,48 @@ export function resolvePreparedExtraParams(params: {
           ),
         )
       : undefined;
+  const modelExtraParams = sanitizeExtraParamsRecord(params.modelExtraParams);
   const merged = {
     ...sanitizeExtraParamsRecord(resolvedExtraParams),
+    ...modelExtraParams,
     ...override,
   };
-  const resolvedCachedContent = resolveAliasedParamValue(
-    [resolvedExtraParams, override],
-    "cached_content",
-    "cachedContent",
-  );
-  if (resolvedCachedContent !== undefined) {
-    merged.cachedContent = resolvedCachedContent;
-    delete merged.cached_content;
-  }
+  const aliasSources = [resolvedExtraParams, modelExtraParams, override];
+  applyAliasedParamCanonicalization({
+    merged,
+    sources: aliasSources,
+    snakeCaseKey: "cached_content",
+    camelCaseKey: "cachedContent",
+    canonicalKey: "cachedContent",
+  });
+  applyAliasedParamCanonicalization({
+    merged,
+    sources: aliasSources,
+    snakeCaseKey: "service_tier",
+    camelCaseKey: "serviceTier",
+    canonicalKey: "serviceTier",
+  });
+  applyAliasedParamCanonicalization({
+    merged,
+    sources: aliasSources,
+    snakeCaseKey: "fast_mode",
+    camelCaseKey: "fastMode",
+    canonicalKey: "fastMode",
+  });
+  applyAliasedParamCanonicalization({
+    merged,
+    sources: aliasSources,
+    snakeCaseKey: "text_verbosity",
+    camelCaseKey: "textVerbosity",
+    canonicalKey: "text_verbosity",
+  });
+  applyAliasedParamCanonicalization({
+    merged,
+    sources: aliasSources,
+    snakeCaseKey: "parallel_tool_calls",
+    camelCaseKey: "parallelToolCalls",
+    canonicalKey: "parallel_tool_calls",
+  });
   const prepared =
     providerRuntimeDeps.prepareProviderExtraParams({
       provider: params.provider,
@@ -216,6 +246,19 @@ function sanitizeExtraParamsRecord(
       ([key]) => key !== "__proto__" && key !== "prototype" && key !== "constructor",
     ),
   );
+}
+
+export function resolveModelConfigExtraParams(
+  model: unknown,
+): Record<string, unknown> | undefined {
+  if (!model || typeof model !== "object" || Array.isArray(model)) {
+    return undefined;
+  }
+  const rawExtraParams = (model as { extraParams?: unknown }).extraParams;
+  if (!rawExtraParams || typeof rawExtraParams !== "object" || Array.isArray(rawExtraParams)) {
+    return undefined;
+  }
+  return sanitizeExtraParamsRecord(rawExtraParams as Record<string, unknown>);
 }
 
 function shouldApplyDefaultOpenAIGptRuntimeParams(params: {
@@ -371,6 +414,30 @@ function resolveAliasedParamValue(
   return seen ? resolved : undefined;
 }
 
+function applyAliasedParamCanonicalization(params: {
+  merged: Record<string, unknown>;
+  sources: Array<Record<string, unknown> | undefined>;
+  snakeCaseKey: string;
+  camelCaseKey: string;
+  canonicalKey: string;
+}): void {
+  const resolvedValue = resolveAliasedParamValue(
+    params.sources,
+    params.snakeCaseKey,
+    params.camelCaseKey,
+  );
+  if (resolvedValue === undefined) {
+    return;
+  }
+  params.merged[params.canonicalKey] = resolvedValue;
+  if (params.snakeCaseKey !== params.canonicalKey) {
+    delete params.merged[params.snakeCaseKey];
+  }
+  if (params.camelCaseKey !== params.canonicalKey) {
+    delete params.merged[params.camelCaseKey];
+  }
+}
+
 function createParallelToolCallsWrapper(
   baseStreamFn: StreamFn | undefined,
   enabled: boolean,
@@ -493,8 +560,20 @@ export function applyExtraParamsToAgent(
   workspaceDir?: string,
   model?: ProviderRuntimeModel,
   agentDir?: string,
+  modelExtraParamsOrResolvedTransport?: Record<string, unknown> | SupportedTransport,
   resolvedTransport?: SupportedTransport,
 ): { effectiveExtraParams: Record<string, unknown> } {
+  const modelExtraParams =
+    modelExtraParamsOrResolvedTransport &&
+    typeof modelExtraParamsOrResolvedTransport === "object" &&
+    !Array.isArray(modelExtraParamsOrResolvedTransport)
+      ? modelExtraParamsOrResolvedTransport
+      : undefined;
+  const effectiveResolvedTransport =
+    resolvedTransport ??
+    (typeof modelExtraParamsOrResolvedTransport === "string"
+      ? modelExtraParamsOrResolvedTransport
+      : undefined);
   const resolvedExtraParams = resolveExtraParams({
     cfg,
     provider,
@@ -511,6 +590,7 @@ export function applyExtraParamsToAgent(
     cfg,
     provider,
     modelId,
+    modelExtraParams,
     extraParamsOverride,
     thinkingLevel,
     agentId,
@@ -518,7 +598,7 @@ export function applyExtraParamsToAgent(
     workspaceDir,
     resolvedExtraParams,
     model,
-    resolvedTransport,
+    resolvedTransport: effectiveResolvedTransport,
   });
   const wrapperContext: ApplyExtraParamsContext = {
     agent,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -395,6 +395,40 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("propagates extraParams from matching configured fallback model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                extraParams: {
+                  reasoning: { max_tokens: 128 },
+                },
+              },
+              {
+                ...makeModel("model-b"),
+                extraParams: {
+                  reasoning: { max_tokens: 512 },
+                  service_tier: "priority",
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
+
+    expect((result.model as { extraParams?: unknown } | undefined)?.extraParams).toEqual({
+      reasoning: { max_tokens: 512 },
+      service_tier: "priority",
+    });
+  });
+
   it("propagates image input capability from matching configured fallback model", () => {
     const cfg = {
       models: {
@@ -1483,6 +1517,9 @@ describe("resolveModel", () => {
                 input: ["text"],
                 contextWindow: 256000,
                 maxTokens: 32000,
+                extraParams: {
+                  fast_mode: true,
+                },
               },
             ],
           },
@@ -1508,6 +1545,9 @@ describe("resolveModel", () => {
         "X-Proxy-Auth": "token-123",
       },
     );
+    expect((result.model as { extraParams?: unknown } | undefined)?.extraParams).toEqual({
+      fast_mode: true,
+    });
   });
 
   it("resolves github-copilot Claude dynamic models to anthropic-messages by default", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -397,6 +397,7 @@ function applyConfiguredProviderOverrides(params: {
       contextTokens: metadataOverrideModel?.contextTokens ?? discoveredModel.contextTokens,
       maxTokens: metadataOverrideModel?.maxTokens ?? discoveredModel.maxTokens,
       headers: requestConfig.headers,
+      extraParams: configuredModel?.extraParams,
       compat: metadataOverrideModel?.compat ?? discoveredModel.compat,
     },
     providerRequest,
@@ -604,6 +605,7 @@ function resolveConfiguredFallbackModel(params: {
           providerConfig?.models?.[0]?.maxTokens ??
           DEFAULT_CONTEXT_TOKENS,
         headers: requestConfig.headers,
+        extraParams: configuredModel?.extraParams,
       } as Model<Api>,
       providerRequest,
     ),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -147,6 +147,7 @@ import {
   applyExtraParamsToAgent,
   resolveAgentTransportOverride,
   resolveExplicitSettingsTransport,
+  resolveModelConfigExtraParams,
 } from "../extra-params.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
@@ -1428,6 +1429,7 @@ export async function runEmbeddedAttempt(
         effectiveWorkspace,
         params.model,
         agentDir,
+        resolveModelConfigExtraParams(params.model),
         resolveExplicitSettingsTransport({
           settingsManager,
           sessionTransport: activeSession.agent.transport,

--- a/src/config/config.secrets-schema.test.ts
+++ b/src/config/config.secrets-schema.test.ts
@@ -156,6 +156,31 @@ describe("config secret refs schema", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts provider model extraParams objects", () => {
+    const result = validateConfigObjectRaw({
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            models: [
+              {
+                id: "google/gemma-3-27b-it",
+                name: "Gemma 3 27B IT",
+                extraParams: {
+                  reasoning: {
+                    max_tokens: 0,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("accepts model provider header SecretRef values", () => {
     const result = validateConfigObjectRaw({
       models: {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2844,6 +2844,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           type: "string",
                         },
                       },
+                      extraParams: {
+                        type: "object",
+                        propertyNames: {
+                          type: "string",
+                        },
+                        additionalProperties: {},
+                      },
                       compat: {
                         type: "object",
                         properties: {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -107,6 +107,11 @@ export type ModelDefinitionConfig = {
   contextTokens?: number;
   maxTokens: number;
   headers?: Record<string, string>;
+  /**
+   * Provider-specific request body fields merged into model calls.
+   * Use this for per-model vendor options that OpenClaw does not model explicitly.
+   */
+  extraParams?: Record<string, unknown>;
   compat?: ModelCompatConfig;
   metadataSource?: "models-add";
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -304,6 +304,8 @@ const ConfiguredModelProviderRequestSchema = z
   .strict()
   .optional();
 
+const ModelExtraParamsSchema = z.record(z.string(), z.unknown()).optional();
+
 export const ModelDefinitionSchema = z
   .object({
     id: z.string().min(1),
@@ -338,6 +340,7 @@ export const ModelDefinitionSchema = z
     contextTokens: z.number().int().positive().optional(),
     maxTokens: z.number().positive().optional(),
     headers: z.record(z.string(), z.string()).optional(),
+    extraParams: ModelExtraParamsSchema,
     compat: ModelCompatSchema,
     metadataSource: z.literal("models-add").optional(),
   })


### PR DESCRIPTION
## Summary

- Problem: `openclaw.json` rejected per-model provider-specific fields (for example `reasoning.max_tokens`), so users could not configure provider-native request options at model granularity.
- Why it matters: Providers like OpenRouter expose important controls (including disabling reasoning/thought blocks) that could not be passed through, blocking valid production configs.
- What changed: Added `models.providers.*.models[*].extraParams` to config types/schema, then merged model-level `extraParams` into runtime effective request params (with runtime overrides still taking precedence) in both normal run and compaction paths.
- What did NOT change (scope boundary): No provider-specific hardcoded logic for new keys; no change to existing `agents.defaults.models[*].params` semantics; no UI or docs changes in this PR.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69075
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Model definition schema/types were strict and did not allow provider-specific per-model request-body passthrough fields.
- Missing detection / guardrail: No contract test asserted acceptance + runtime merge behavior for per-model provider extra params.
- Contributing context (if known): Runtime already had an extra-params pipeline, but only config-default/runtime override sources were wired; model metadata source was missing.

## Regression Test Plan (if applicable)


- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/config/config.secrets-schema.test.ts`
  - `src/agents/pi-embedded-runner-extraparams.test.ts`
- Scenario the test should lock in:
  - Config accepts `models.providers.*.models[*].extraParams`.
  - Runtime merges model `extraParams` into effective request params with override precedence and sanitization.
- Why this is the smallest reliable guardrail: It validates both contract acceptance and runtime merge logic without requiring live provider calls.
- Existing test that already covers this (if any): N/A (new targeted coverage added).
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Users can now set provider-specific per-model request fields via `models.providers.<provider>.models[].extraParams`.
- These fields are merged into runtime request params for that model.
- Runtime/call-site overrides still take precedence over model-level values.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A


## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

- Add extraParams under a provider model entry in config.
- Validate/load config and run targeted tests.
- Confirm schema acceptance and runtime merge behavior via tests.


### Expected

- Config accepts per-model extraParams.
- Runtime includes model-level params in effective provider request params.


### Actual

Matches expected (targeted tests pass).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)


- Verified scenarios:
  - Reviewed schema/type acceptance for model extraParams.
  - Verified runtime merge path for model-level params + precedence behavior in tests.
- Edge cases checked:
  - Sanitization of prototype-pollution keys in model extra params.
  - Runtime override precedence over model-level value.
- What you did not verify:
  - Manual live provider call against OpenRouter in this PR. 

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.


## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A


## Risks and Mitigations

None

- Risk:
  - Mitigation:
