### PR TITLE
fix(tui): increase token chunking limit and preserve code-like fragments

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -300,7 +300,9 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("preserves code-like tokens (dots and parens) to avoid breaking code snippets", () => {
-    const input = "user.has_opted_out?('work_break_notifications')";
+    // Must be > 128 chars to trigger LONG_TOKEN_RE and the isCopySensitiveToken path.
+    const segment = "user.has_opted_out?('work_break_notifications')";
+    const input = segment.repeat(4); // 188 chars, contains dots and parens
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -289,14 +289,21 @@ describe("sanitizeRenderableText", () => {
   function expectTokenWidthUnderLimit(input: string) {
     const sanitized = sanitizeRenderableText(input);
     const longestSegment = Math.max(...sanitized.split(/\s+/).map((segment) => segment.length));
-    expect(longestSegment).toBeLessThanOrEqual(32);
+    expect(longestSegment).toBeLessThanOrEqual(128);
   }
 
   it.each([
-    { label: "very long", input: "a".repeat(140) },
-    { label: "moderately long", input: "b".repeat(90) },
+    { label: "very long", input: "a".repeat(300) },
+    { label: "moderately long", input: "b".repeat(150) },
   ])("breaks $label unbroken tokens to protect narrow terminals", ({ input }) => {
     expectTokenWidthUnderLimit(input);
+  });
+
+  it("preserves code-like tokens (dots and parens) to avoid breaking code snippets", () => {
+    const input = "user.has_opted_out?('work_break_notifications')";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
   });
 
   it("preserves long filesystem paths verbatim for copy safety", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -5,9 +5,9 @@ import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
-const MAX_TOKEN_CHARS = 32;
-const LONG_TOKEN_RE = /\S{33,}/g;
-const LONG_TOKEN_TEST_RE = /\S{33,}/;
+const MAX_TOKEN_CHARS = 128;
+const LONG_TOKEN_RE = /\S{129,}/g;
+const LONG_TOKEN_TEST_RE = /\S{129,}/;
 const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
@@ -80,6 +80,11 @@ function isCopySensitiveToken(token: string): boolean {
     return true;
   }
   if (token.includes("_") && FILE_LIKE_RE.test(token)) {
+    return true;
+  }
+
+  // Preserve code-like fragments (containing dots, parentheses, or brackets)
+  if (token.includes(".") || token.includes("(") || token.includes(")") || token.includes("[") || token.includes("]")) {
     return true;
   }
 


### PR DESCRIPTION
The TUI currently chunks any non-whitespace sequence longer than 32 characters by injecting a space. This is intended to protect narrow terminals from layout issues but causes corruption in many common code snippets (e.g. Ruby method chains, long variable names).

This PR:
1. Increases the limit from 32 to 128 characters.
3. Updates the 'copy-sensitive' heuristic to preserve tokens containing code-specific characters like dots and parentheses.
4. Updates tests to reflect these changes.
5. Validated with existing test suite.