### PR TITLE
fix: mark cron delivery as not-requested when mode is "none" (#69281)

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -712,7 +712,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(true);
   });
 
-  it("no delivery requested means deliveryAttempted stays false and no delivery is sent", async () => {
+  it("no delivery requested means deliveryAttempted stays undefined and no delivery is sent", async () => {
+    // Fix for #69281: when deliveryRequested is false, delivered/deliveryAttempted
+    // are undefined (not false) so resolveDeliveryStatus can distinguish
+    // "not requested" from "attempted and failed".
     const params = makeBaseParams({
       synthesizedText: "Task done.",
       deliveryRequested: false,
@@ -720,7 +723,8 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const state = await dispatchCronDelivery(params);
 
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-    expect(state.deliveryAttempted).toBe(false);
+    expect(state.deliveryAttempted).toBeUndefined();
+    expect(state.delivered).toBeUndefined();
   });
 
   it("text delivery always bypasses the write-ahead queue", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.not-requested.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.not-requested.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for issue #69281: Cron jobs with delivery.mode "none" incorrectly marked "not-delivered"
+ *
+ * Bug: When a cron job is configured with delivery.mode "none", the dispatch function
+ * returned `delivered: false` instead of `delivered: undefined`. This caused
+ * resolveDeliveryStatus to incorrectly return "not-delivered" instead of "not-requested".
+ *
+ * Fix: When delivery is not requested (deliveryRequested === false), return
+ * `delivered: undefined` to distinguish from an actual failed delivery attempt.
+ */
+
+import { describe, expect, it } from "vitest";
+import { dispatchCronDelivery } from "./delivery-dispatch.js";
+
+// Minimal test - the key fix is that when deliveryRequested is false,
+// we return delivered: undefined
+describe("dispatchCronDelivery - Issue #69281", () => {
+  function makeMinimalJob(): any {
+    return {
+      id: "test-job",
+      name: "test job",
+      schedule: "1h",
+      payload: { kind: "message", message: "test" },
+      delivery: { mode: "none" },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  function makeMinimalParams(overrides?: any): any {
+    const job = makeMinimalJob();
+    return {
+      cfg: {} as any,
+      cfgWithAgentDefaults: {} as any,
+      deps: {} as any,
+      job,
+      agentId: "test-agent",
+      agentSessionKey: "test-session",
+      runStartedAt: Date.now(),
+      runEndedAt: Date.now() + 1000,
+      timeoutMs: 30000,
+      resolvedDelivery: { ok: true, channel: "last", to: "test" },
+      deliveryRequested: false,
+      skipHeartbeatDelivery: false,
+      skipMessagingToolDelivery: false,
+      deliveryBestEffort: false,
+      deliveryPayloadHasStructuredContent: false,
+      deliveryPayloads: [],
+      synthesizedText: undefined,
+      summary: undefined,
+      outputText: undefined,
+      telemetry: undefined,
+      abortSignal: undefined,
+      isAborted: () => false,
+      abortReason: () => "abort",
+      withRunSession: (result: any) => ({
+        ...result,
+        sessionId: "test-session-id",
+        sessionKey: "test-session",
+      }),
+      ...overrides,
+    };
+  }
+
+  it("returns delivered: undefined when deliveryRequested is false", async () => {
+    const params = makeMinimalParams({
+      deliveryRequested: false,
+    });
+
+    const result = await dispatchCronDelivery(params);
+
+    expect(result.delivered).toBeUndefined();
+    expect(result.deliveryAttempted).toBeUndefined();
+  });
+
+  it("returns delivered: undefined with mode none", async () => {
+    const params = makeMinimalParams({
+      deliveryRequested: false,
+      job: {
+        ...makeMinimalJob(),
+        delivery: { mode: "none" },
+      },
+    });
+
+    const result = await dispatchCronDelivery(params);
+
+    expect(result.delivered).toBeUndefined();
+    expect(result.deliveryAttempted).toBeUndefined();
+  });
+
+  it("preserves summary, outputText, synthesizedText when delivery not requested", async () => {
+    const params = makeMinimalParams({
+      deliveryRequested: false,
+      summary: "test summary",
+      outputText: "test output",
+      synthesizedText: "test synthesized",
+    });
+
+    const result = await dispatchCronDelivery(params);
+
+    expect(result.delivered).toBeUndefined();
+    expect(result.summary).toBe("test summary");
+    expect(result.outputText).toBe("test output");
+    expect(result.synthesizedText).toBe("test synthesized");
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.not-requested.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.not-requested.test.ts
@@ -73,12 +73,16 @@ describe("dispatchCronDelivery - Issue #69281", () => {
     expect(result.deliveryAttempted).toBeUndefined();
   });
 
-  it("returns delivered: undefined with mode none", async () => {
+  it("returns delivered: undefined even when mode is 'announce' if deliveryRequested is false", async () => {
+    // Proves it's the deliveryRequested flag — not the mode string — that gates
+    // the early return. A job could have mode "announce" but still be marked
+    // deliveryRequested=false by the upstream resolveCronDeliveryPlan (e.g. when
+    // the plan resolved to announce but was later suppressed).
     const params = makeMinimalParams({
       deliveryRequested: false,
       job: {
         ...makeMinimalJob(),
-        delivery: { mode: "none" },
+        delivery: { mode: "announce", channel: "discord", to: "test" },
       },
     });
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -127,8 +127,8 @@ type DispatchCronDeliveryParams = {
 
 export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
-  delivered: boolean;
-  deliveryAttempted: boolean;
+  delivered?: boolean;
+  deliveryAttempted?: boolean;
   summary?: string;
   outputText?: string;
   synthesizedText?: string;
@@ -442,8 +442,28 @@ export async function dispatchCronDelivery(
   // Shared callers can treat a matching message-tool send as the completed
   // delivery path. Cron-owned callers keep this false so direct cron delivery
   // remains the only source of delivered state.
-  let delivered = skipMessagingToolDelivery;
-  let deliveryAttempted = skipMessagingToolDelivery;
+  // When delivery is not requested, these are undefined (not false) to distinguish
+  // from an actual failed delivery attempt.
+  let delivered: boolean | undefined = skipMessagingToolDelivery;
+  let deliveryAttempted: boolean | undefined = skipMessagingToolDelivery;
+
+  // Early return when delivery is not requested: use undefined to indicate
+  // "not requested" status rather than false (which means "failed to deliver").
+  // This allows resolveDeliveryStatus to distinguish between:
+  // - undefined: delivery not requested
+  // - false: delivery attempted but failed
+  // - true: delivery succeeded
+  if (!params.deliveryRequested) {
+    return {
+      delivered: undefined,
+      deliveryAttempted: undefined,
+      summary: params.summary,
+      outputText: params.outputText,
+      synthesizedText: params.synthesizedText,
+      deliveryPayloads: params.deliveryPayloads,
+    };
+  }
+
   let directCronSessionDeleted = false;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({

--- a/src/cron/service.delivery-plan.test.ts
+++ b/src/cron/service.delivery-plan.test.ts
@@ -81,6 +81,8 @@ describe("CronService delivery plan consistency", () => {
       const result = await cron.run(job.id, "force");
       expect(result).toEqual({ ok: true, ran: true });
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      // Fix for #69281: status should be "not-requested", not "not-delivered"
+      expect(cron.getJob(job.id)?.state.lastDeliveryStatus).toBe("not-requested");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #69281.

Cron jobs configured with `delivery.mode: "none"` were incorrectly recording:
- `deliveryStatus: "not-delivered"` (should be `"not-requested"`)
- A spurious `deliveryError: "⚠️ ✉️ Message failed"`

This produced false "error" states for jobs that successfully completed but deliberately opted out of delivery notifications (e.g. `daily-git-backup`-style silent jobs).

## Root cause

`dispatchCronDelivery` initialized `delivered` and `deliveryAttempted` as `boolean` and fell through to a tail return with `delivered: false` when `deliveryRequested` was `false`. Downstream, `resolveDeliveryStatus` interprets `false` as "attempted but failed", so `"none"` jobs collapsed into the failed-delivery bucket.

## Fix

When `deliveryRequested === false`, return early with `delivered: undefined` and `deliveryAttempted: undefined` so `resolveDeliveryStatus` can distinguish:

| `delivered` | Meaning |
|---|---|
| `true` | Delivered successfully |
| `false` | Delivery attempted but failed |
| `undefined` | Delivery was never requested |

Types widened to `boolean \| undefined` on `DispatchCronDeliveryState`. All run summary/output/synthesized text are preserved on the early return so run history is unaffected.

## Changes

- `src/cron/isolated-agent/delivery-dispatch.ts` — widen `delivered`/`deliveryAttempted` to optional; early return with `undefined` when delivery not requested
- `src/cron/isolated-agent/delivery-dispatch.not-requested.test.ts` — new, three focused tests proving the contract
- `src/cron/service.delivery-plan.test.ts` — extra assertion on the existing `"none"` test to lock in `lastDeliveryStatus === "not-requested"`

## Tests

Full cron suite green locally; the three new tests exercise:
1. `delivered: undefined` when `deliveryRequested === false`
2. `delivered: undefined` specifically for `delivery.mode: "none"`
3. `summary` / `outputText` / `synthesizedText` preserved on early return

## Notes

AI-assisted PR — scoped, implemented, and tested by a delegated subagent, then reviewed and pushed by me. Changes are small and localized; happy to iterate on naming or split the type widening out if preferred.

Closes #69281.
