### PR TITLE
fix(sessions): snapshot estimatedCostUsd to mirror token snapshot semantics

### DIFF
--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -131,8 +131,10 @@ export async function updateSessionStoreAfterAgentRun(params: {
     next.cacheRead = usage.cacheRead ?? 0;
     next.cacheWrite = usage.cacheWrite ?? 0;
     if (runEstimatedCostUsd !== undefined) {
-      next.estimatedCostUsd =
-        (resolveNonNegativeNumber(entry.estimatedCostUsd) ?? 0) + runEstimatedCostUsd;
+      // Snapshot — mirror the token fields above.  `runEstimatedCostUsd` is
+      // derived from `usage` which is the run-cumulative usage; accumulating
+      // would compound the cost for a single run.
+      next.estimatedCostUsd = runEstimatedCostUsd;
     }
   } else if (
     typeof entry.totalTokens === "number" &&

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -132,7 +132,6 @@ export async function persistSessionUsageUpdate(params: {
             providerUsed: params.providerUsed ?? entry.modelProvider,
             modelUsed: params.modelUsed ?? entry.model,
           });
-          const existingEstimatedCostUsd = resolveNonNegativeNumber(entry.estimatedCostUsd) ?? 0;
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
@@ -150,7 +149,12 @@ export async function persistSessionUsageUpdate(params: {
             patch.cacheWrite = cacheUsage?.cacheWrite ?? 0;
           }
           if (runEstimatedCostUsd !== undefined) {
-            patch.estimatedCostUsd = existingEstimatedCostUsd + runEstimatedCostUsd;
+            // Snapshot, mirroring the token fields above.  `runEstimatedCostUsd`
+            // is derived from `params.usage` which is the run-cumulative usage;
+            // this handler is invoked from several call sites per run, so
+            // accumulating would compound the cost for a single run (#53734
+            // underreports, this path overreports by the same mechanism).
+            patch.estimatedCostUsd = runEstimatedCostUsd;
           } else if (entry.estimatedCostUsd !== undefined) {
             patch.estimatedCostUsd = entry.estimatedCostUsd;
           }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -597,9 +597,10 @@ async function finalizeCronRun(params: {
     prepared.cronSession.sessionEntry.cacheRead = usage.cacheRead ?? 0;
     prepared.cronSession.sessionEntry.cacheWrite = usage.cacheWrite ?? 0;
     if (runEstimatedCostUsd !== undefined) {
-      prepared.cronSession.sessionEntry.estimatedCostUsd =
-        (resolveNonNegativeNumber(prepared.cronSession.sessionEntry.estimatedCostUsd) ?? 0) +
-        runEstimatedCostUsd;
+      // Snapshot — mirror the token fields above.  `runEstimatedCostUsd` is
+      // derived from `usage` which is the run-cumulative usage; accumulating
+      // would compound the cost for a single run.
+      prepared.cronSession.sessionEntry.estimatedCostUsd = runEstimatedCostUsd;
     }
     telemetry = {
       model: modelUsed,


### PR DESCRIPTION
## Summary

- **Problem:** `sessions.json.estimatedCostUsd` is inflated 1×–72× over real OpenRouter cost because three persist sites snapshot tokens but accumulate cost. The same run-cumulative `usage` object is handled multiple times per run, so tokens converge to the correct total while cost compounds.
- **Why it matters:** Every consumer of `sessions.json.estimatedCostUsd` — session cost summaries, per-model/day usage, budget enforcement, plugin telemetry — is silently overreporting. Observed peak on live sessions: 72.59× (`ee4a3bb3`: $3.378 reported vs $0.047 JSONL-ground-truth).
- **What changed:** One-line fix at each of the three persist sites — replace `existingCost + runCost` with just `runCost` — mirroring the token-field semantics already in place. Explanatory comment added next to each edit.
- **What did NOT change:** The cost math (`estimateSessionRunCostUsd`) is untouched; it is already correct (single-turn Claude sessions consistently show ratio = 1.00× on live data, proving the write path — not the math — is the defect). No changes to `SessionEntry` shape, `mergeSessionEntry`, pricing config, or any public API surface.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Closes #69347
- Related #53734 (the underreporting counterpart: `toNormalizedUsage()` discards accumulated input/cache tokens)
- Related #62954 (heartbeat turn overwriting persisted fields — one of the extra call paths that multiplies this defect)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** Three persist handlers (`persistSessionUsageUpdate`, `updateSessionStoreAfterAgentRun`, and the cron-session persist path in `isolated-agent/run.ts`) all use the pattern `next.estimatedCostUsd = (existing ?? 0) + runEstimatedCostUsd`, where `runEstimatedCostUsd = estimateSessionRunCostUsd(usage, ...)` and `usage` is already the run-cumulative usage object. Tokens in the same handlers use `next.inputTokens = usage.input` (snapshot). Because these handlers are called multiple times per run (agent-command finalize, auto-reply followup, agent-runner main path, heartbeat/reply fallback transitions), the token snapshot converges to the correct final value while the cost accumulates `existingCost + cost(cumulative_usage)` once per call.
- **Missing detection / guardrail:** No invariant test asserts `sessions.json.estimatedCostUsd ≤ 1.05 × Σ(JSONL usage.cost.total)` per session. A system-level test at that boundary would have caught this within the first multi-persist session after merge.
- **Contributing context:** PR #67490 (`fix(agents): persist cli transcript turns`) and the broader set of heartbeat/persist refactors have multiplied the number of call sites that invoke these handlers per run. The underlying write path was already asymmetric; the extra call sites amplified the defect.

## Regression Test Plan

- **Coverage level that should have caught this:**
  - [x] Seam / integration test
- **Target test or file:** a new seam test around `persistSessionUsageUpdate` / `updateSessionStoreAfterAgentRun` that invokes the handler twice with the same run-cumulative `usage` object and asserts the resulting `estimatedCostUsd` equals `runEstimatedCostUsd` (idempotent), not `2 × runEstimatedCostUsd`.
- **Scenario the test should lock in:** multiple persist calls per run produce a single snapshot, not an accumulated total. Equivalent assertion for the cron path in `src/cron/isolated-agent/run.ts`.
- **Why this is the smallest reliable guardrail:** the bug is at the write boundary of `SessionEntry`; a handler-level seam test captures the invariant without needing a full agent run.
- **Existing test that already covers this (if any):** None. `src/auto-reply/reply/commands-session-usage.test.ts` tests the slash-command layer (`handleUsageCommand`), not the persist layer.
- **If no new test is added, why not:** I have not added upstream tests in this PR to keep it minimal and reviewable; happy to follow up with a seam test once the fix is accepted. Downstream, a system-level invariant test (`sessions.json.estimatedCostUsd ≤ 1.05 × Σ(JSONL usage.cost.total)` per session, currently `xfail`) is in place and will flip to `xpass` automatically once this patch ships.

## User-visible / Behavior Changes

- `sessions.json.estimatedCostUsd` values written by this version correctly reflect the run-cumulative cost (parity with token snapshots). Historical values written by prior versions remain inflated until the host application overwrites or recomputes them.

## Diagram

```text
Before (bug):
  run N call site 1: estimatedCostUsd += cost(usage_run_N)   -> 1x runCost
  run N call site 2: estimatedCostUsd += cost(usage_run_N)   -> 2x runCost
  run N call site 3: estimatedCostUsd += cost(usage_run_N)   -> 3x runCost
  (heartbeat transitions can add more)
  Observed live inflation: up to 72.59x

After (fix):
  run N call site *: estimatedCostUsd  = cost(usage_run_N)   -> 1x runCost (snapshot)
  (same semantics tokens already use; handler is idempotent on the same usage)
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Docker)
- Runtime/container: Docker container on VPS
- Model/provider: openrouter -> {z-ai, anthropic, google} (model-agnostic, reproduced on several)
- Integration/channel: agent sessions running inside the gateway
- Relevant config: default `openclaw.json`, no exotic overrides

### Steps

1. Run OpenClaw 2026.4.15 with any multi-turn agent session (auto-reply enabled, heartbeats present).
2. After the session completes, read `${OPENCLAW_DIR}/agents/<agent>/sessions/sessions.json` for that session's `estimatedCostUsd`.
3. Sum `usage.cost.total` across every `type=message`, `role=assistant` line in `${OPENCLAW_DIR}/agents/<agent>/sessions/<sessionId>.jsonl`.

### Expected

- `sessions.json.estimatedCostUsd ≈ Σ(JSONL usage.cost.total)` — same snapshot semantics as `inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`.

### Actual

- Ratio is 1×–72× depending on persist-call count per run. Live sample (2026-04-20, 93 sessions scanned):

| sessionId | sessions.json | JSONL sum | ratio |
|-----------|--------------:|----------:|------:|
| `ee4a3bb3` | $3.378 | $0.047 | **72.59×** |
| `7c9db1d2` | $0.309 | $0.007 | **42.80×** |
| `f3b2742e` | $5.727 | $0.153 | **37.52×** |
| `ed17328f` | $2.672 | $0.083 | **32.21×** |
| `2157016e` | $0.610 | $0.046 | **13.14×** |

## Evidence

- [x] Trace/log snippets (the ratio table above, scanned programmatically across 93 live sessions on VPS)

Reproducible scan script:

```python
import json, os, glob
BASE = "/data/.openclaw/agents"
for agent_dir in sorted(glob.glob(os.path.join(BASE, "*"))):
    sess_json_path = os.path.join(agent_dir, "sessions", "sessions.json")
    if not os.path.isfile(sess_json_path): continue
    with open(sess_json_path) as f: sessions = json.load(f)
    for key, entry in sessions.items():
        est = entry.get("estimatedCostUsd")
        if not isinstance(est, (int, float)) or est <= 0.05: continue
        sid = entry.get("sessionId") or entry.get("id")
        jsonl_path = os.path.join(agent_dir, "sessions", f"{sid}.jsonl")
        if not os.path.isfile(jsonl_path): continue
        jsonl_cost = 0.0
        with open(jsonl_path) as f:
            for line in f:
                try: e = json.loads(line)
                except: continue
                if e.get("type") != "message": continue
                m = e.get("message") or {}
                if m.get("role") != "assistant": continue
                c = ((m.get("usage") or {}).get("cost") or {}).get("total")
                if c: jsonl_cost += float(c)
        if jsonl_cost > 0:
            print(f"{sid[:8]} est={est:.3f} jsonl={jsonl_cost:.3f} ratio={est/jsonl_cost:.2f}x")
```

## Human Verification

- **Verified scenarios:**
  - Read the three source sites and confirmed the same asymmetric pattern in each; the fix is identical across sites.
  - Scanned 93 live sessions on a VPS running 2026.4.15, confirmed 10 offenders with ratio > 1.05×, peak 72.59×.
  - Confirmed single-turn Claude Sonnet sessions (N=87) show ratio = 1.00×, proving `estimateSessionRunCostUsd` is correct — only the write path is broken.
  - Confirmed tokens in `sessions.json` already behave correctly under the snapshot pattern (e.g. `f22ae56a`: `inputTokens=29174` matches JSONL per-turn sum `24917+737+2547+913+60=29174`).
- **Edge cases checked:** Sessions with no usage; sessions with `runEstimatedCostUsd === undefined` (falls through to previous branch, unchanged by this PR); compaction resets handled by the established overwrite semantics of `mergeSessionEntry`, which remain consistent under snapshot cost.
- **What you did not verify:** Did not run the upstream vitest suite locally after the edit (comments are the only surrounding changes; the one-line replacements are semantically identical to the adjacent token handling). Happy to add that plus a seam test per the Regression Test Plan if maintainers prefer.

## Review Conversations

- [x] I will resolve any bot review conversations I address in this PR.

## Compatibility / Migration

- Backward compatible? `Yes` (values already read via existing accessors; the field meaning is now "run cost" — the documented intent — rather than "compounded cost"; no schema or API change)
- Config/env changes? `No`
- Migration needed? `No`. Historical sessions retain inflated stored values until the host application chooses to recompute or overwrite them; new sessions will be correct from the first persist call after deploy.

## Risks and Mitigations

- **Risk:** A session with multiple *independent* agent runs (e.g. compaction that resets `usage`) previously retained a compounded total across runs; under snapshot semantics it now reflects only the latest run's cost. 
  - **Mitigation:** This matches the behavior `inputTokens`/`outputTokens` already have in the same handlers — the token fields are snapshots and don't carry across independent runs either. Downstream accumulation (daily totals, per-model usage) is computed from JSONL transcripts via `costUsage` summaries, not from this per-session field; that path is unaffected.
