### PR TITLE
test(auto-reply): guard non-ACP reset reply (#69290)

### DIFF
--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -284,4 +284,33 @@ describe("handleCommands reset hooks", () => {
       }),
     );
   });
+
+  it("does not send the ACP reset reply when bound session key is non-ACP", async () => {
+    // resolveBoundAcpThreadSessionKey may return a non-ACP key because it
+    // calls resolveEffectiveResetTargetSessionKey with allowNonAcpBindingSessionKey: true.
+    // The ACP reply branch must stay gated behind isAcpSessionKey (regression guard for #69290).
+    resetMocks.resolveBoundAcpThreadSessionKey.mockReturnValue(
+      "agent:system-architect:telegram:direct:6689123501",
+    );
+    const params = buildResetParams(
+      "/new",
+      {
+        commands: { text: true },
+        channels: { telegram: { allowFrom: ["*"] } },
+      } as OpenClawConfig,
+      {
+        Provider: "telegram",
+        Surface: "telegram",
+        CommandSource: "native",
+      },
+    );
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "new" }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: [#69290](https://github.com/openclaw/openclaw/issues/69290) reports that `/new` and `/reset` reply `✅ ACP session reset in place.` for non-ACP sessions.
- Why it matters: the source on `main` (and `v2026.4.15`) already guards the ACP reply branch behind `isAcpSessionKey()`, so the reported symptom is not reproducible from a source read. However, the existing tests only exercise `resolveBoundAcpThreadSessionKey` returning `undefined` or an actual ACP-shaped key. The *non-ACP* return path — which exists because `resolveBoundAcpThreadSessionKey` passes `allowNonAcpBindingSessionKey: true` to `resolveEffectiveResetTargetSessionKey` — is not asserted anywhere.
- What changed: one new Vitest case in `src/auto-reply/reply/commands-reset-hooks.test.ts` locking in the guard: when `resolveBoundAcpThreadSessionKey` returns a non-ACP key (e.g. `agent:system-architect:telegram:direct:…`), `maybeHandleResetCommand` must not call `resetConfiguredBindingTargetInPlace`, must not emit the `✅ ACP session reset in place.` reply, and must fall through to the generic reset-hooks path.
- What did NOT change (scope boundary): no production code touched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

Closest match: a regression-guard test with no production change. If maintainers prefer to close as "already fixed, no test churn needed", feel free — the analysis on #69290 hopefully still helps triage.

## Scope (select all touched areas)

- [x] Integrations *(Auto-reply command handling — reset command)*

## Linked Issue/PR

- Closes #
- Related #69290
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — source already guards the ACP reply with `isAcpSessionKey`. The reported symptom does not reproduce on current `main` / `v2026.4.15`. See comment on #69290 for details.

- Root cause: N/A (already guarded)
- Missing detection / guardrail: no test locked in the non-ACP return path of `resolveBoundAcpThreadSessionKey` — a future refactor could silently regress the gate.
- Contributing context (if known): `resolveBoundAcpThreadSessionKey` calls `resolveEffectiveResetTargetSessionKey({ ..., allowNonAcpBindingSessionKey: true })`, so the caller *must* re-check `isAcpSessionKey` before taking any ACP-specific branch; that invariant was only covered by the happy-path tests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/reply/commands-reset-hooks.test.ts`
- Scenario the test should lock in: `resolveBoundAcpThreadSessionKey` returns a non-ACP session key → `maybeHandleResetCommand` does not reach the ACP reset path and does not reply with `✅ ACP session reset in place.`; falls through to the generic reset-hooks path.
- Why this is the smallest reliable guardrail: unit-level mocks of `resolveBoundAcpThreadSessionKey` and `resetConfiguredBindingTargetInPlace` exactly exercise the gate, no gateway/channel setup required.
- Existing test that already covers this (if any): no — existing cases only cover `undefined` or a real ACP-shaped key.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.2.0, arm64)
- Runtime/container: Node 22, pnpm 10.33
- Model/provider: N/A
- Integration/channel (if any): Telegram / ACP path
- Relevant config (redacted): N/A

### Steps

1. `pnpm install`
2. `pnpm test src/auto-reply/reply/commands-reset-hooks.test.ts`

### Expected

- All 6 tests pass, including the new `"does not send the ACP reset reply when bound session key is non-ACP"` case.

### Actual

- 6 passed / 6 total, 585ms locally.

## Evidence

- [x] Failing test/log before + passing after *(new test is additive; fails if the `isAcpSessionKey` gate is removed)*

```
Test Files  1 passed (1)
     Tests  6 passed (6)
  Duration  585ms
```

## Human Verification (required)

- Verified scenarios: ran `pnpm test src/auto-reply/reply/commands-reset-hooks.test.ts` locally (passes 6/6). Manually removed the `isAcpSessionKey(boundAcpSessionKey)` check in `commands-reset.ts` to confirm the new case fails, then restored.
- Edge cases checked: confirmed the non-ACP key shape (`agent:<id>:telegram:direct:<num>`) is what `isAcpSessionKey` classifies as `false`.
- What you did **not** verify: did not run the full `pnpm test` / `pnpm check` / `pnpm build` lanes — scope is test-only so I kept the local loop narrow; happy to run full lanes if a maintainer asks.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: test-only PR may be closed per contributor policy if seen as unnecessary.
  - Mitigation: single small test, narrowly scoped; close-safe.