### PR TITLE
fix: complete zsh positional wiki ingest paths

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -25,6 +25,22 @@ function createCompletionProgram(): Command {
     .argument("<path>", "Local file path to ingest")
     .option("--title <title>", "Override the source title");
 
+  const models = program.command("models").description("Model commands");
+  models
+    .command("set-profile")
+    .description("Set the auth profile")
+    .argument("<value>", "Auth profile ids (e.g. anthropic:default)");
+
+  const tags = program.command("tags").description("Tag commands");
+  tags.command("add").description("Add entries").argument("<entries...>", "Entries to add");
+
+  const maybe = program.command("maybe").description("Optional positional commands");
+  maybe
+    .command("take")
+    .description("Take optional values")
+    .argument("[first]", "First optional arg")
+    .argument("[second]", "Second optional arg");
+
   return program;
 }
 
@@ -44,6 +60,20 @@ describe("completion-cli", () => {
     expect(script).toContain("_openclaw_wiki_ingest()");
     expect(script).toContain('"1:Local file path to ingest:_files"');
     expect(script).toContain('"--title[Override the source title]"');
+  });
+
+  it("escapes zsh positional descriptions and keeps positional arity semantics", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("_openclaw_models_set_profile()");
+    expect(script).toContain('"1:Auth profile ids (e.g. anthropic\\:default):"');
+
+    expect(script).toContain("_openclaw_tags_add()");
+    expect(script).toContain('"*:Entries to add:"');
+
+    expect(script).toContain("_openclaw_maybe_take()");
+    expect(script).toContain('"1::First optional arg:"');
+    expect(script).toContain('"2::Second optional arg:"');
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -18,6 +18,13 @@ function createCompletionProgram(): Command {
   gateway.command("status").description("Show gateway status").option("--json", "JSON output");
   gateway.command("restart").description("Restart gateway");
 
+  const wiki = program.command("wiki").description("Wiki commands");
+  wiki
+    .command("ingest")
+    .description("Ingest a local file into the wiki sources folder")
+    .argument("<path>", "Local file path to ingest")
+    .option("--title <title>", "Override the source title");
+
   return program;
 }
 
@@ -29,6 +36,14 @@ describe("completion-cli", () => {
     expect(script).toContain("(status) _openclaw_gateway_status ;;");
     expect(script).toContain("(restart) _openclaw_gateway_restart ;;");
     expect(script).toContain("--force[Force the action]");
+  });
+
+  it("adds zsh positional file completion for nested leaf commands", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("_openclaw_wiki_ingest()");
+    expect(script).toContain('"1:Local file path to ingest:_files"');
+    expect(script).toContain('"--title[Override the source title]"');
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -189,6 +189,7 @@ function escapeZshDescription(value: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
     .replace(/'/g, "'\\''")
+    .replace(/:/g, "\\:")
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }
@@ -220,7 +221,13 @@ function generateZshPositionals(cmd: Command): string {
   return cmd.registeredArguments
     .map((arg, index) => {
       const description = escapeZshDescription(arg.description || arg.name());
-      const position = arg.variadic ? "*::" : arg.required ? `${index + 1}:` : "::";
+      const position = arg.variadic
+        ? arg.required
+          ? "*:"
+          : "*::"
+        : arg.required
+          ? `${index + 1}:`
+          : `${index + 1}::`;
       const action = generateZshArgumentAction(arg.name(), arg.description || "");
       return `"${position}${description}${action ? `:${action}` : ":"}"`;
     })
@@ -230,6 +237,8 @@ function generateZshPositionals(cmd: Command): string {
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
     .map((c) => {
+      // These specs are single-quoted in zsh, so keep the narrower inline escaping here
+      // instead of reusing escapeZshDescription, which would over-escape double quotes.
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -184,22 +184,45 @@ fi
   return script;
 }
 
+function escapeZshDescription(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "'\\''")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
 function generateZshArgs(cmd: Command): string {
   return (cmd.options || [])
     .map((opt) => {
       const flags = opt.flags.split(/[ ,|]+/);
       const name = flags.find((f) => f.startsWith("--")) || flags[0];
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
-      const desc = opt.description
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
+      const desc = escapeZshDescription(opt.description);
       if (short) {
         return `"(${name} ${short})"{${name},${short}}"[${desc}]"`;
       }
       return `"${name}[${desc}]"`;
+    })
+    .join(" \\\n    ");
+}
+
+function generateZshArgumentAction(argName: string, argDescription: string): string {
+  const hint = `${argName} ${argDescription}`.toLowerCase();
+  if (/\b(path|paths|file|files|dir|dirs|directory|directories|folder|folders)\b/.test(hint)) {
+    return "_files";
+  }
+  return "";
+}
+
+function generateZshPositionals(cmd: Command): string {
+  return cmd.registeredArguments
+    .map((arg, index) => {
+      const description = escapeZshDescription(arg.description || arg.name());
+      const position = arg.variadic ? "*::" : arg.required ? `${index + 1}:` : "::";
+      const action = generateZshArgumentAction(arg.name(), arg.description || "");
+      return `"${position}${description}${action ? `:${action}` : ":"}"`;
     })
     .join(" \\\n    ");
 }
@@ -254,10 +277,13 @@ ${funcName}() {
         continue;
       }
 
+      const positionalArgs = generateZshPositionals(cmd);
+      const zshSpecs = [generateZshArgs(cmd), positionalArgs].filter(Boolean).join(" \\\n    ");
+
       segments.push(`
 ${funcName}() {
   _arguments -C \\
-    ${generateZshArgs(cmd)}
+    ${zshSpecs}
 }
 `);
     }


### PR DESCRIPTION
## Summary

Teach the zsh completion generator to emit positional argument specs for leaf commands, including `_files` completion for path-like arguments. This restores tab completion for `openclaw wiki ingest <path>` without changing unrelated completion behavior.

## Changes

- add reusable escaping for zsh completion descriptions
- emit zsh positional argument specs from Commander registered arguments
- route path-like positional arguments to `_files`
- add a regression test covering `openclaw wiki ingest <path>`

## Testing

- `pnpm exec vitest run src/cli/completion-cli.test.ts src/cli/completion-cli.write-state.test.ts`

Fixes openclaw/openclaw#69293