### PR TITLE
fix(tasks): clamp createdAt to startedAt on task creation (#69229)

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -338,6 +338,7 @@ describe("task-registry", () => {
         startedAt: futureStartedAt,
       });
       expect(futureStart.createdAt).toBeLessThan(futureStartedAt);
+      expect(futureStart.createdAt).toBeGreaterThanOrEqual(before);
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -277,6 +277,70 @@ describe("task-registry", () => {
     });
   });
 
+  it("clamps createdAt to startedAt when a task is registered in a started state (#69229)", async () => {
+    // Regression: callers (e.g. pi-embedded subagent tools) capture
+    // `startedAt = Date.now()` at tool-call time, then later call
+    // createTaskRecord(). A naive `createdAt = Date.now()` inside the registry
+    // lands after `startedAt`, breaking the createdAt <= startedAt invariant
+    // that `task-registry.audit` relies on and producing false-positive
+    // `inconsistent_timestamps` warnings for the majority of tasks.
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const startedAt = Date.now() - 5_000;
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-clamp-createdat",
+        task: "measure",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt,
+      });
+
+      expect(task.startedAt).toBe(startedAt);
+      expect(task.createdAt).toBe(startedAt);
+      expect(task.createdAt).toBeLessThanOrEqual(task.startedAt ?? Number.POSITIVE_INFINITY);
+    });
+  });
+
+  it("keeps createdAt at now when startedAt is omitted or in the future", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const before = Date.now();
+      const queued = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-no-startedat",
+        task: "queued",
+        status: "queued",
+        deliveryStatus: "not_applicable",
+      });
+      expect(queued.createdAt).toBeGreaterThanOrEqual(before);
+
+      const futureStartedAt = Date.now() + 60_000;
+      const futureStart = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-future-startedat",
+        task: "future",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: futureStartedAt,
+      });
+      expect(futureStart.createdAt).toBeLessThan(futureStartedAt);
+    });
+  });
+
   it("ignores late agent events for operator-cancelled tasks", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1453,6 +1453,12 @@ export function createTaskRecord(params: {
     scopeKind,
   });
   const lastEventAt = params.lastEventAt ?? params.startedAt ?? now;
+  // Callers capture `startedAt` at tool-call time (Date.now()) and register the
+  // task a moment later, so a naive `createdAt = now` can land after `startedAt`
+  // and violate the createdAt <= startedAt invariant that audit relies on.
+  // Clamp to startedAt when it is already in the past to keep the invariant true.
+  const createdAt =
+    typeof params.startedAt === "number" && params.startedAt < now ? params.startedAt : now;
   const record: TaskRecord = {
     taskId,
     runtime: params.runtime,
@@ -1471,7 +1477,7 @@ export function createTaskRecord(params: {
     status,
     deliveryStatus,
     notifyPolicy,
-    createdAt: now,
+    createdAt,
     startedAt: params.startedAt,
     lastEventAt,
     cleanupAfter: params.cleanupAfter,


### PR DESCRIPTION
## Summary

- Problem: `openclaw tasks audit` reports `inconsistent_timestamps` / "startedAt is earlier than createdAt" on the majority of tasks (succeeded/failed/timed_out/running), making audit output noisy ([#69229](https://github.com/openclaw/openclaw/issues/69229)).
- Why it matters: callers capture `startedAt = Date.now()` at tool-call time and register the task a measurable moment later inside `createTaskRecord()`. The registry currently sets `createdAt = Date.now()` at registration time, so `startedAt < createdAt` is architecturally expected and the audit invariant is always broken.
- What changed: `createTaskRecord` now clamps `createdAt` to `params.startedAt` when the supplied `startedAt` is in the past, preserving the `createdAt <= startedAt` invariant audit assumes. When `startedAt` is absent or in the future, `createdAt = Date.now()` is kept.
- What did NOT change (scope boundary): audit code (`task-registry.audit.ts`) is unchanged. No data-model or persisted-schema changes. `TaskFlow` audit (`task-flow-registry.audit.ts`) is out of scope — its "updatedAt/endedAt vs createdAt" checks have a different root cause.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] API / contracts *(tasks registry invariants)*

## Linked Issue/PR

- Closes #69229
- Related: #69247 (competing PR taking a jitter-tolerance approach on the audit side), #69273 (closed by the PR-quota bot; same jitter-tolerance direction)
- [x] This PR fixes a bug or regression

## Root Cause

Tool runners capture `startedAt = Date.now()` at tool-call initiation (e.g. `pi-embedded-subscribe.handlers.tools.ts:579`). Registry record creation happens a bounded time later inside `createTaskRecord()` (`src/tasks/task-registry.ts:1440`), where a naive `createdAt = Date.now()` lands after `startedAt`. Because `task-registry.audit.ts:50` reads the invariant `startedAt >= createdAt`, every task registered in `running` state with a caller-provided `startedAt` is flagged.

- Root cause: creation-time timestamp ordering — `createdAt` is the registry record's wall-clock time, not the task's logical creation time, and the audit invariant treats it as the latter.
- Missing detection / guardrail: no unit test asserted the `createdAt <= startedAt` invariant at registry-creation time; the audit test suite only exercised artificially-shaped fixtures.
- Contributing context: the symptom was first analyzed in [#69273](https://github.com/openclaw/openclaw/pull/69273) by @Bartok9 (closed for PR-quota reasons, not technical rejection). This PR takes the **root-cause** route (clamp at creation) instead of widening the audit's tolerance band.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/tasks/task-registry.test.ts`
- Scenario the test should lock in:
  1. `createTaskRecord({ status: "running", startedAt: Date.now() - 5_000 })` results in `task.createdAt === startedAt` and `createdAt <= startedAt`.
  2. `createTaskRecord({ status: "queued" })` (no `startedAt`) keeps `createdAt ≈ Date.now()` (guards against over-reach).
  3. `createTaskRecord({ startedAt: Date.now() + 60_000 })` (future) keeps `createdAt = Date.now()` (guards against clamping forward).
- Why this is the smallest reliable guardrail: asserts the invariant at the exact place it was being broken, with minimal fixture setup.
- Existing test that already covers this: none — 44 existing `task-registry.test.ts` cases all passed before and after this change, but none asserted the invariant itself.
- If no new test is added, why not: N/A — two new cases added.

## User-visible / Behavior Changes

- `openclaw tasks audit` no longer emits `inconsistent_timestamps / startedAt is earlier than createdAt` findings for newly-created tasks. Existing records persisted before this change may still show the warning until they age out of retention; see the note under **Compatibility** below.
- `task.createdAt` for new `running`-state tasks may be up to a few ms–seconds earlier than before (equal to the caller-supplied `startedAt` when that is in the past). Orderings and cleanup retention that read `createdAt` are unaffected in practice because `endedAt` / `lastEventAt` are the primary reference points (see `task-status.ts:25`, `task-registry.ts:1493`, `task-registry.maintenance.ts:107`).

## Diagram

```text
Before:
  tool-call t0  -> startedAt = t0
  …(registration lag)…
  createTaskRecord t1 -> createdAt = t1  (t1 > t0)
  audit: startedAt < createdAt  ->  FALSE POSITIVE

After:
  tool-call t0  -> startedAt = t0
  …(registration lag)…
  createTaskRecord t1 -> createdAt = min(t1, t0) = t0
  audit: startedAt < createdAt  ->  clean
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.2.0 (Darwin arm64)
- Runtime/container: Node 22, pnpm 10.33, Vitest 4.1.4
- Model/provider: N/A
- Integration/channel (if any): N/A (tasks subsystem)

### Steps

1. `pnpm install`
2. `pnpm test src/tasks/task-registry.audit.test.ts src/tasks/task-registry.test.ts`
3. `pnpm test 'src/tasks/**/*.test.ts'` (full task suite)

### Expected

- New regression tests pass.
- All existing task tests remain green.

### Actual

```
# scoped
Test Files  1 passed (1)   # task-registry.audit.test.ts (3/3)
Test Files  1 passed (1)   # task-registry.test.ts (44/44 -> 46/46)

# full task suite
Test Files  11 passed (11)
     Tests  106 passed (106)
```

## Evidence

- [x] Failing test/log before + passing after *(new test asserts invariant; reverting the clamp makes it fail immediately)*

## Human Verification (required)

- Verified scenarios: ran scoped tests (`task-registry.audit.test.ts`, `task-registry.test.ts`) and the full `src/tasks/**` Vitest lane locally — all green. Manually reverted the clamp to confirm the new test fails, then restored.
- Edge cases checked: `startedAt` absent, `startedAt` in the future, `startedAt` equal to `Date.now()`. Confirmed no other createdAt-writing path in `src/tasks` needs the same treatment (audit/maintenance/ordering reads are fallback-safe; see grep summary in PR thread).
- What you did **not** verify: full repo `pnpm check` / `pnpm test` / `pnpm build`. The change is scoped to `src/tasks` and does not touch lazy-loading, bundled-plugin boundaries, or published surfaces; happy to run wider lanes if a maintainer asks.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — existing persisted task records with `createdAt > startedAt` will continue to trigger audit findings until they age out of retention. Because those records are pre-fix artifacts, a one-shot doctor migration or audit jitter band is a reasonable follow-up but is intentionally out of scope for this PR.

## Risks and Mitigations

- Risk: `task.createdAt` semantics shift slightly from "record-creation wall-clock" to "task-logical-start wall-clock" for `running`-state registrations.
  - Mitigation: only pulled backward (never forward), only when `startedAt` is in the past, and never when `startedAt` is absent — so existing callers that read `createdAt` for staleness / cleanup still see a monotonic, non-future value.
- Risk: competing PR #69247 proposes a jitter-tolerance band in audit instead.
  - Mitigation: the two approaches are complementary — this PR eliminates new false positives at source; a small audit-side tolerance (if maintainers still want one) would then only cover legacy records. Happy to defer to whichever direction maintainers prefer, or to combine.