### PR TITLE
fix(ui): hide async exec system events and heartbeat acks from chat transcript

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -1,10 +1,77 @@
 import { describe, expect, it } from "vitest";
 import {
   filterHeartbeatPairs,
+  isExecEventInjectionMessage,
   isHeartbeatOkResponse,
   isHeartbeatUserMessage,
 } from "./heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "./heartbeat.js";
+
+describe("isExecEventInjectionMessage", () => {
+  it("matches exec event injection user messages", () => {
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content:
+          "System (untrusted): [2026-04-19 15:04:47 PDT] Exec completed (rapid-or, code 0) :: hello\n\nRead HEARTBEAT.md if it exists.",
+      }),
+    ).toBe(true);
+
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-19 08:22:20 PDT] Exec failed (job-1, code 1) :: error\n\nAn async command failed.",
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content: "System (untrusted): [Mon 2026-04-19 15:04:47] Exec finished (deploy-abc, code 0)",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match regular user messages", () => {
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content: "run this shell command asynchronously: sleep 3 && echo hello",
+      }),
+    ).toBe(false);
+
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content: "Please reply HEARTBEAT_OK so I can test something.",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match assistant messages", () => {
+    expect(
+      isExecEventInjectionMessage({
+        role: "assistant",
+        content:
+          "System (untrusted): [2026-04-19 15:04:47 PDT] Exec completed (rapid-or, code 0) :: hello",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match messages without the exec prefix", () => {
+    expect(
+      isExecEventInjectionMessage({
+        role: "user",
+        content: "System (untrusted): [2026-04-19 15:04:47 PDT] Some other event",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -4,6 +4,13 @@ const HEARTBEAT_TASK_PROMPT_PREFIX =
   "Run the following periodic tasks (only those due based on their intervals):";
 const HEARTBEAT_TASK_PROMPT_ACK = "After completing all due tasks, reply HEARTBEAT_OK.";
 
+// Matches the "System (untrusted): [timestamp] Exec completed/failed/finished ..." prefix
+// written by the heartbeat runner when an async exec event is injected into the session.
+// This pattern is unique to heartbeat-injected user messages — real users cannot produce
+// the "System (untrusted):" prefix since inbound text sanitization rewrites it.
+const EXEC_INJECTION_PREFIX_RE =
+  /^System \(untrusted\): \[.+?\] Exec (completed|failed|finished)\b/i;
+
 function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
     return { text: content, hasNonTextContent: false };
@@ -31,6 +38,14 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
     .map((block) => block.text)
     .join("");
   return { text, hasNonTextContent };
+}
+
+export function isExecEventInjectionMessage(message: { role: string; content?: unknown }): boolean {
+  if (message.role !== "user") {
+    return false;
+  }
+  const { text } = resolveMessageText(message.content);
+  return EXEC_INJECTION_PREFIX_RE.test(text.trimStart());
 }
 
 export function isHeartbeatUserMessage(

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types/chat-types.ts";
 import { agentLogoUrl } from "../views/agents-utils.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
+import { stripHeartbeatToken } from "./heartbeat-client.ts";
 import {
   extractTextCached,
   extractThinkingCached,
@@ -1204,7 +1205,16 @@ function renderGroupedMessage(
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-  const markdown = markdownBase;
+  // Strip HEARTBEAT_OK token from assistant messages. For pure acks this yields null
+  // (message already hidden by shouldHideHistoryMessage, but this is a safety net).
+  // For relay messages like "Command finished...\n\nHEARTBEAT_OK" it strips only the token.
+  const markdown =
+    role === "assistant" && markdownBase
+      ? (() => {
+          const s = stripHeartbeatToken(markdownBase, { mode: "heartbeat", maxAckChars: 0 });
+          return s.shouldSkip ? null : s.didStrip ? s.text || null : markdownBase;
+        })()
+      : markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
 

--- a/ui/src/ui/chat/heartbeat-client.ts
+++ b/ui/src/ui/chat/heartbeat-client.ts
@@ -1,0 +1,151 @@
+/**
+ * Browser-safe heartbeat utilities for the Control UI.
+ *
+ * These are inlined here rather than importing from src/auto-reply/heartbeat.ts
+ * or src/auto-reply/heartbeat-filter.ts because those modules transitively import
+ * Node.js built-ins (fs, os, path via src/utils.ts) which are unavailable in the
+ * browser bundle.
+ */
+
+const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
+const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+
+// Matches the "System (untrusted): [timestamp] Exec completed/failed/finished ..." prefix
+// written by the heartbeat runner when an async exec event is injected into the session.
+// Real users cannot produce the "System (untrusted):" prefix — inbound sanitization rewrites it.
+const EXEC_INJECTION_PREFIX_RE =
+  /^System \(untrusted\): \[.+?\] Exec (completed|failed|finished)\b/i;
+
+function resolveContentText(content: unknown): { text: string; hasNonTextContent: boolean } {
+  if (typeof content === "string") {
+    return { text: content, hasNonTextContent: false };
+  }
+  if (!Array.isArray(content)) {
+    return { text: "", hasNonTextContent: content != null };
+  }
+  let hasNonTextContent = false;
+  const texts: string[] = [];
+  for (const block of content) {
+    if (typeof block !== "object" || block === null || !("type" in block)) {
+      hasNonTextContent = true;
+      continue;
+    }
+    const b = block as { type: unknown; text?: unknown };
+    if (b.type !== "text") {
+      hasNonTextContent = true;
+      continue;
+    }
+    if (typeof b.text !== "string") {
+      hasNonTextContent = true;
+      continue;
+    }
+    texts.push(b.text);
+  }
+  return { text: texts.join(""), hasNonTextContent };
+}
+
+export function isExecEventInjectionMessage(message: { role: string; content?: unknown }): boolean {
+  if (message.role !== "user") {
+    return false;
+  }
+  const { text } = resolveContentText(message.content);
+  return EXEC_INJECTION_PREFIX_RE.test(text.trimStart());
+}
+
+function stripMarkup(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/^[*`~_]+/, "")
+    .replace(/[*`~_]+$/, "");
+}
+
+function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
+  let text = raw.trim();
+  if (!text) {
+    return { text: "", didStrip: false };
+  }
+  if (!text.includes(HEARTBEAT_TOKEN)) {
+    return { text, didStrip: false };
+  }
+  let didStrip = false;
+  let changed = true;
+  const endRe = new RegExp(`${HEARTBEAT_TOKEN}[^\\w]{0,4}$`);
+  while (changed) {
+    changed = false;
+    const next = text.trim();
+    if (next.startsWith(HEARTBEAT_TOKEN)) {
+      text = next.slice(HEARTBEAT_TOKEN.length).trimStart();
+      didStrip = true;
+      changed = true;
+      continue;
+    }
+    if (endRe.test(next)) {
+      const idx = next.lastIndexOf(HEARTBEAT_TOKEN);
+      const before = next.slice(0, idx).trimEnd();
+      const after = next.slice(idx + HEARTBEAT_TOKEN.length).trimStart();
+      text = before ? `${before}${after}`.trimEnd() : "";
+      didStrip = true;
+      changed = true;
+    }
+  }
+  return { text: text.replace(/\s+/g, " ").trim(), didStrip };
+}
+
+export function stripHeartbeatToken(
+  raw: string | undefined,
+  opts: { mode?: "heartbeat" | "message"; maxAckChars?: number } = {},
+): { shouldSkip: boolean; text: string; didStrip: boolean } {
+  if (!raw) {
+    return { shouldSkip: true, text: "", didStrip: false };
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { shouldSkip: true, text: "", didStrip: false };
+  }
+  const maxAckChars =
+    typeof opts.maxAckChars === "number" && Number.isFinite(opts.maxAckChars)
+      ? Math.max(0, opts.maxAckChars)
+      : DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
+  const mode = opts.mode ?? "message";
+  const trimmedNormalized = stripMarkup(trimmed);
+  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
+  if (!hasToken) {
+    return { shouldSkip: false, text: trimmed, didStrip: false };
+  }
+  const strippedOriginal = stripTokenAtEdges(trimmed);
+  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
+  const picked =
+    strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  if (!picked.didStrip) {
+    return { shouldSkip: false, text: trimmed, didStrip: false };
+  }
+  if (!picked.text) {
+    return { shouldSkip: true, text: "", didStrip: true };
+  }
+  const rest = picked.text.trim();
+  if (mode === "heartbeat" && rest.length <= maxAckChars) {
+    return { shouldSkip: true, text: "", didStrip: true };
+  }
+  return { shouldSkip: false, text: rest, didStrip: true };
+}
+
+export function isHeartbeatOkResponse(
+  message: { role: string; content?: unknown },
+  ackMaxChars = 0,
+): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  const { text, hasNonTextContent } = resolveContentText(message.content);
+  if (hasNonTextContent) {
+    return false;
+  }
+  // Guard against false positives: absent or empty content is not a heartbeat ack.
+  // stripHeartbeatToken returns shouldSkip=true for empty strings, which would
+  // incorrectly hide legitimate assistant history entries with no content field.
+  if (!text) {
+    return false;
+  }
+  return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
+}

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,4 +1,5 @@
 import { resetToolStream } from "../app-tool-stream.ts";
+import { isExecEventInjectionMessage, isHeartbeatOkResponse } from "../chat/heartbeat-client.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { formatConnectError } from "../connect-error.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../gateway.ts";
@@ -72,7 +73,25 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
 }
 
 function shouldHideHistoryMessage(message: unknown): boolean {
-  return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+  if (isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message)) {
+    return true;
+  }
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as { role: string; content?: unknown };
+  // Hide heartbeat exec-event injection messages that leaked into the main session.
+  // These appear as user-role messages starting with "System (untrusted): [...] Exec completed..."
+  // and are internal runtime machinery, not real user messages.
+  if (isExecEventInjectionMessage(entry)) {
+    return true;
+  }
+  // Hide pure HEARTBEAT_OK assistant acks (ackMaxChars=0 means only empty-after-strip matches).
+  // Relay messages that happen to append HEARTBEAT_OK are handled by text stripping in the renderer.
+  if (isHeartbeatOkResponse(entry, 0)) {
+    return true;
+  }
+  return false;
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {


### PR DESCRIPTION
## Summary

- **Problem:** When an async exec command completes, the Control UI rendered two internal runtime messages as visible chat bubbles: (1) a fake "You" bubble containing `System (untrusted): [...] Exec completed...` and (2) a pure `HEARTBEAT_OK` assistant ack bubble.
- **Why it matters:** Users see confusing noise in their chat transcript — messages that look like they sent something they didn't, and cryptic ack tokens from the agent.
- **What changed:** Added detection for exec-event injection messages in `heartbeat-filter.ts`, created a browser-safe `heartbeat-client.ts` reimplementation for the UI bundle (avoids pulling in Node.js built-ins via `src/utils.ts`), extended `shouldHideHistoryMessage` in `chat.ts` to hide both message types, and added `HEARTBEAT_OK` stripping to the renderer in `grouped-render.ts`.
- **What did NOT change:** Heartbeat runner logic, exec runtime, delivery routing, session storage — this is display-layer only.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #68992
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** The heartbeat runner injects exec completion events as `user`-role messages directly into the session (prefixed `System (untrusted): [...] Exec completed...`). The Control UI had no filter for these, so they rendered as if the user had sent them. Similarly, pure `HEARTBEAT_OK` assistant acks had no stripping logic, so they appeared as assistant bubbles.
- **Missing detection / guardrail:** `shouldHideHistoryMessage` only filtered `isAssistantSilentReply` and synthetic transcript repair tool results — no awareness of heartbeat-injected user messages or HEARTBEAT_OK acks.
- **Contributing context:** The `System (untrusted):` prefix is unique to heartbeat-injected messages (inbound sanitization rewrites it for real user input), so it is a safe and reliable signal to filter on.

## Regression Test Plan

- Coverage level: [x] Unit test
- Target test: `src/auto-reply/heartbeat-filter.test.ts`
- Scenario: `isExecEventInjectionMessage` correctly matches all three exec event variants (`completed`, `failed`, `finished`), both string and array content, and does not match regular user messages or heartbeat prompts.
- Why this is the smallest reliable guardrail: directly tests the detection predicate at the source — the same function gating the hide decision in the UI.

## User-visible / Behavior Changes

- `System (untrusted): [...] Exec completed/failed/finished ...` messages no longer appear as user chat bubbles in the Control UI.
- Pure `HEARTBEAT_OK` assistant acks no longer appear as assistant chat bubbles.
- Relay messages that happen to append `HEARTBEAT_OK` (e.g. "Command finished... HEARTBEAT_OK") have the token stripped and show only the human-readable content.

## Diagram

```text
Before:
async exec completes → heartbeat injects user message → Control UI renders it as "You: System (untrusted): Exec completed..."
heartbeat agent acks  → Control UI renders it as assistant bubble: "HEARTBEAT_OK"

After:
async exec completes → heartbeat injects user message → hidden by shouldHideHistoryMessage
heartbeat agent acks  → hidden by shouldHideHistoryMessage / token stripped by renderer
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Arch Linux
- Model: gpt-5.4
- Integration/channel: Control UI (webchat)
- OpenClaw version: 2026.4.15 (041266a), Linux arm64

### Steps

1. Start a session in the Control UI
2. Send: `run this shell command asynchronously: sleep 3 && echo hello`
3. Wait for the exec to complete

### Expected

No `System (untrusted):` user bubble. No `HEARTBEAT_OK` assistant bubble.

### Actual (before fix)

A fake "You" bubble appears: `System (untrusted): [timestamp] Exec completed (session, code 0) :: hello`
A `HEARTBEAT_OK` assistant bubble may also appear.

## Evidence

- [x] Failing test/log before + passing after — 3 unit tests added to `heartbeat-filter.test.ts`
- [x] Screenshot/recording — see below

<!-- Before screenshot: System (untrusted) bubble visible as user message -->
-  Before the Fix you can see the internal message being leaked into the user message bubble
<img width="1377" height="692" alt="beforeFix" src="https://github.com/user-attachments/assets/a469a072-02b6-4e24-97f6-50d94c8d3c05" />

<!-- After screenshot: clean transcript, no injected bubbles -->

- After the fix you dont see that happening
<img width="1594" height="743" alt="afterFix" src="https://github.com/user-attachments/assets/eb8661aa-0401-41e3-a1fb-15446e8204d4" />

## Human Verification

- Verified: multiple async exec commands (instant, delayed, concurrent, failing) — no `System (untrusted)` user bubbles, no `HEARTBEAT_OK` assistant bubbles in any scenario
- Verified: relay messages with appended `HEARTBEAT_OK` show only the human-readable content
- Verified: `pnpm build && pnpm check && pnpm test` all green (798 tests, 68 test files)
- Did NOT verify: non-webchat channels (fix is UI display-layer only, does not affect channel delivery)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `EXEC_INJECTION_PREFIX_RE` pattern too broad — could accidentally hide legitimate user messages.
  - Mitigation: The `System (untrusted):` prefix is actively rewritten by inbound sanitization for real user input, so it cannot appear in genuine messages. Pattern is tightly anchored to that prefix plus a timestamp.
- Risk: Browser-safe `heartbeat-client.ts` drifts from `heartbeat-filter.ts` / `heartbeat.ts` source of truth.
  - Mitigation: The file has a prominent comment explaining why it exists and what it mirrors. The divergence is intentional and bounded — only the UI-needed subset is reimplemented.
