### PR TITLE
fix: keep isolated cron agentTurn runs from dropping visible answers

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -69,6 +69,49 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
   });
 
+  it("treats blank streamed assistant text as unavailable and keeps the final answer", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["   "],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "google",
+          model: "gemini-3-flash-preview",
+          content: [
+            {
+              type: "text",
+              text: "Need inspect.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_commentary",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "text",
+              text: "Done.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_final",
+                phase: "final_answer",
+              }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-incomplete-turn-blank-streamed-text",
+    });
+
+    expect(result.payloads).toEqual([{ text: "Done." }]);
+    expect(result.meta.finalAssistantVisibleText).toBe("Done.");
+  });
+
   it("uses explicit agentId without a session key before surfacing the strict-agentic blocked state", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1643,11 +1643,18 @@ export async function runEmbeddedPiAgent(
             toolMediaUrls: attempt.toolMediaUrls,
             toolAudioAsVoice: attempt.toolAudioAsVoice,
           });
+          const visibleAnswerFallbackPayloads =
+            !payloadsWithToolMedia?.length && finalAssistantVisibleText
+              ? [{ text: finalAssistantVisibleText }]
+              : undefined;
+          const effectivePayloads = payloadsWithToolMedia?.length
+            ? payloadsWithToolMedia
+            : visibleAnswerFallbackPayloads;
 
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
+          if (timedOut && !timedOutDuringCompaction && !effectivePayloads?.length) {
             const timeoutText = idleTimedOut
               ? "The model did not produce a response before the LLM idle timeout. " +
                 "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
@@ -1692,7 +1699,7 @@ export async function runEmbeddedPiAgent(
             };
           }
 
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
+          const payloadCount = effectivePayloads?.length ?? 0;
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
@@ -1995,7 +2002,7 @@ export async function runEmbeddedPiAgent(
             livenessState,
           });
           return {
-            payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
+            payloads: effectivePayloads,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -65,6 +65,38 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Done.");
   });
 
+  it("falls back to final-answer assistant text when streamed text is blank", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["   "],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Need inspect.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_commentary",
+              phase: "commentary",
+            }),
+          },
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
   it("suppresses exec tool errors when verbose mode is off", () => {
     expectNoPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -270,10 +270,11 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  const streamedAnswerTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
+    : (streamedAnswerTexts.length
+        ? streamedAnswerTexts
         : fallbackAnswerText
           ? [fallbackAnswerText]
           : []

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -597,6 +597,88 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
+  it("preserves optimistic local user messages missing from server history", async () => {
+    const optimisticMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 123,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [optimisticMessage],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([optimisticMessage]);
+  });
+
+  it("drops an optimistic local user message once matching server history arrives", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 456,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage]);
+  });
+
+  it("keeps extra optimistic duplicates until the server catches up", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 456,
+    };
+    const pendingDuplicate = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 789,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "same text" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+        pendingDuplicate,
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage, pendingDuplicate]);
+  });
+
   it("keeps a user message even if it matches the synthetic repair text", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -16,6 +16,7 @@ const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
+const LOCAL_ONLY_MESSAGE_FLAG = "__optimistic";
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
 function beginChatHistoryRequest(state: ChatState): number {
@@ -73,6 +74,67 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
 
 function shouldHideHistoryMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isOptimisticLocalMessage(message: unknown): message is Record<string, unknown> {
+  return isRecord(message) && message[LOCAL_ONLY_MESSAGE_FLAG] === true;
+}
+
+function toVisibleChatHistory(messages: unknown[]): unknown[] {
+  return messages.filter((message) => !shouldHideHistoryMessage(message));
+}
+
+function messageSignature(message: unknown): string | null {
+  if (!isRecord(message)) {
+    return null;
+  }
+  const role = normalizeLowercaseStringOrEmpty(message.role);
+  if (!role) {
+    return null;
+  }
+  const text = extractText(message);
+  const content = "content" in message ? JSON.stringify(message.content) : "";
+  return `${role}:${text ?? ""}:${content}`;
+}
+
+function mergeHistoryWithOptimisticMessages(
+  serverMessages: unknown[],
+  localMessages: unknown[],
+): unknown[] {
+  const optimisticLocals = localMessages.filter(isOptimisticLocalMessage);
+  if (optimisticLocals.length === 0) {
+    return serverMessages;
+  }
+
+  const serverSignatureCounts = new Map<string, number>();
+  for (const message of serverMessages) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      continue;
+    }
+    serverSignatureCounts.set(signature, (serverSignatureCounts.get(signature) ?? 0) + 1);
+  }
+
+  const preservedOptimisticMessages: unknown[] = [];
+  for (const message of optimisticLocals) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      preservedOptimisticMessages.push(message);
+      continue;
+    }
+    const remaining = serverSignatureCounts.get(signature) ?? 0;
+    if (remaining > 0) {
+      serverSignatureCounts.set(signature, remaining - 1);
+      continue;
+    }
+    preservedOptimisticMessages.push(message);
+  }
+
+  return [...serverMessages, ...preservedOptimisticMessages];
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
@@ -177,7 +239,8 @@ export async function loadChatHistory(state: ChatState) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    const visibleMessages = toVisibleChatHistory(messages);
+    state.chatMessages = mergeHistoryWithOptimisticMessages(visibleMessages, state.chatMessages);
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -328,6 +391,7 @@ export async function sendChatMessage(
       role: "user",
       content: contentBlocks,
       timestamp: now,
+      [LOCAL_ONLY_MESSAGE_FLAG]: true,
     },
   ];
 


### PR DESCRIPTION
## Summary
Fixes #69360.

## Problem
Isolated cron `agentTurn` runs could finish successfully but still be marked as `Agent couldn't generate a response`. In the failing runs, the model stopped normally and `finalAssistantVisibleText` was present, but `payloads=0` sent execution down the incomplete-turn error path.

## Root cause
Two closely related cases could leave the embedded runner with no outbound payloads even though a visible final answer existed:
- blank streamed assistant text (`assistantTexts` contained only whitespace) blocked the payload builder from falling back to the assistant's signed `final_answer` content
- downstream callers relied on payload count alone, so a recovered `finalAssistantVisibleText` was still treated as an incomplete turn when no payloads were built

## Fix
- ignore blank streamed assistant text when building reply payloads, so we fall back to the assistant's final visible answer
- in `runEmbeddedPiAgent`, synthesize a minimal text payload from `finalAssistantVisibleText` when payload construction still returns nothing
- use that effective payload set for incomplete-turn and timeout handling

## Tests
- added a payload builder test covering blank streamed text with a signed `final_answer` fallback
- added an embedded runner test covering the same end-to-end shape so the run returns `Done.` instead of the incomplete-turn error
- ran:
  - `CI=1 pnpm vitest run src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
