### PR TITLE
fix(gateway): enforce allowRequestSessionKey gate on template-rendered mapping sessionKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(gateway): enforce allowRequestSessionKey gate on template-rendered mapping sessionKeys. (#69381) Thanks @pgondhi987.
 - OpenAI/Responses: resolve `/think` levels against each GPT model's supported reasoning efforts so `/think off` no longer becomes high reasoning or sends unsupported `reasoning.effort: "none"` payloads.
 - Lobster/TaskFlow: allow managed approval resumes to use `approvalId` without a resume token, and persist that id in approval wait state. (#69559) Thanks @kirkluokun.
 - Plugins/startup: install bundled runtime dependencies into each plugin's own runtime directory, reuse source-checkout repair caches after rebuilds, and log only packages that were actually installed so repeated Gateway starts stay quiet once deps are present.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -3193,8 +3193,8 @@ See [Multiple Gateways](/gateway/multiple-gateways).
     path: "/hooks",
     maxBodyBytes: 262144,
     defaultSessionKey: "hook:ingress",
-    allowRequestSessionKey: false,
-    allowedSessionKeyPrefixes: ["hook:"],
+    allowRequestSessionKey: true,
+    allowedSessionKeyPrefixes: ["hook:", "hook:gmail:"],
     allowedAgentIds: ["hooks", "main"],
     presets: ["gmail"],
     transformsDir: "~/.openclaw/hooks/transforms",
@@ -3225,6 +3225,7 @@ Validation and safety notes:
 - `hooks.token` must be **distinct** from `gateway.auth.token`; reusing the Gateway token is rejected.
 - `hooks.path` cannot be `/`; use a dedicated subpath such as `/hooks`.
 - If `hooks.allowRequestSessionKey=true`, constrain `hooks.allowedSessionKeyPrefixes` (for example `["hook:"]`).
+- If a mapping or preset uses a templated `sessionKey`, set `hooks.allowedSessionKeyPrefixes` and `hooks.allowRequestSessionKey=true`. Static mapping keys do not require that opt-in.
 
 **Endpoints:**
 
@@ -3232,6 +3233,7 @@ Validation and safety notes:
 - `POST /hooks/agent` → `{ message, name?, agentId?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
   - `sessionKey` from request payload is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`).
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
+  - Template-rendered mapping `sessionKey` values are treated as externally supplied and also require `hooks.allowRequestSessionKey=true`.
 
 <Accordion title="Mapping details">
 
@@ -3243,14 +3245,18 @@ Validation and safety notes:
 - `agentId` routes to a specific agent; unknown IDs fall back to default.
 - `allowedAgentIds`: restricts explicit routing (`*` or omitted = allow all, `[]` = deny all).
 - `defaultSessionKey`: optional fixed session key for hook agent runs without explicit `sessionKey`.
-- `allowRequestSessionKey`: allow `/hooks/agent` callers to set `sessionKey` (default: `false`).
-- `allowedSessionKeyPrefixes`: optional prefix allowlist for explicit `sessionKey` values (request + mapping), e.g. `["hook:"]`.
+- `allowRequestSessionKey`: allow `/hooks/agent` callers and template-driven mapping session keys to set `sessionKey` (default: `false`).
+- `allowedSessionKeyPrefixes`: optional prefix allowlist for explicit `sessionKey` values (request + mapping), e.g. `["hook:"]`. It becomes required when any mapping or preset uses a templated `sessionKey`.
 - `deliver: true` sends final reply to a channel; `channel` defaults to `last`.
 - `model` overrides LLM for this hook run (must be allowed if model catalog is set).
 
 </Accordion>
 
 ### Gmail integration
+
+- The built-in Gmail preset uses `sessionKey: "hook:gmail:{{messages[0].id}}"`.
+- If you keep that per-message routing, set `hooks.allowRequestSessionKey: true` and constrain `hooks.allowedSessionKeyPrefixes` to match the Gmail namespace, for example `["hook:", "hook:gmail:"]`.
+- If you need `hooks.allowRequestSessionKey: false`, override the preset with a static `sessionKey` instead of the templated default.
 
 ```json5
 {

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -309,6 +309,95 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("treats empty transform session keys as absent for source tracking", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-sessionkey-empty-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(transformsRoot, "transform.mjs"),
+      [
+        "export default () => ({",
+        '  kind: "agent",',
+        '  message: "Transformed",',
+        '  sessionKey: "",',
+        '  sessionKeySource: "templated",',
+        "});",
+      ].join("\n"),
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            sessionKey: "hook:gmail:{{messages[0].subject}}",
+            transform: { module: "transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("");
+      expect(result.action.sessionKeySource).toBeUndefined();
+    }
+  });
+
+  it("defaults invalid transform session key source metadata to templated", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-sessionkey-invalid-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(transformsRoot, "transform.mjs"),
+      [
+        "export default () => ({",
+        '  kind: "agent",',
+        '  message: "Transformed",',
+        '  sessionKey: "hook:gmail:from-transform",',
+        '  sessionKeySource: "bogus",',
+        "});",
+      ].join("\n"),
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            transform: { module: "transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:from-transform");
+      expect(result.action.sessionKeySource).toBe("templated");
+    }
+  });
+
   it("rejects transform module traversal outside transformsDir", () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -220,6 +220,95 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("treats transform-provided session keys as templated by default", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-sessionkey-xform-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(transformsRoot, "transform.mjs"),
+      [
+        "export default ({ payload }) => ({",
+        '  kind: "agent",',
+        '  message: "Transformed",',
+        "  sessionKey: `hook:gmail:${payload.subject}`,",
+        "});",
+      ].join("\n"),
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            sessionKey: "hook:gmail:static",
+            transform: { module: "transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: { subject: "external" },
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:external");
+      expect(result.action.sessionKeySource).toBe("templated");
+    }
+  });
+
+  it("uses transform-provided static session key source metadata", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-sessionkey-static-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(transformsRoot, "transform.mjs"),
+      [
+        "export default () => ({",
+        '  kind: "agent",',
+        '  message: "Transformed",',
+        '  sessionKey: "hook:gmail:fixed",',
+        '  sessionKeySource: "static",',
+        "});",
+      ].join("\n"),
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            sessionKey: "hook:gmail:{{messages[0].subject}}",
+            transform: { module: "transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:fixed");
+      expect(result.action.sessionKeySource).toBe("static");
+    }
+  });
+
   it("rejects transform module traversal outside transformsDir", () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -144,6 +144,44 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("marks template-derived session keys as templated", async () => {
+    const result = await applyGmailMappings({
+      mappings: [
+        {
+          id: "templated-session-key",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "hook:gmail:{{messages[0].subject}}",
+        },
+      ],
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:Hello");
+      expect(result.action.sessionKeySource).toBe("templated");
+    }
+  });
+
+  it("marks literal session keys as static", async () => {
+    const result = await applyGmailMappings({
+      mappings: [
+        {
+          id: "static-session-key",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "hook:gmail:static",
+        },
+      ],
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:static");
+      expect(result.action.sessionKeySource).toBe("static");
+    }
+  });
+
   it("runs transform module", async () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -62,6 +62,8 @@ export type HookAction =
       timeoutSeconds?: number;
     };
 
+export type HookSessionKeyTemplateSource = "static" | "templated";
+
 export type HookMappingResult =
   | { ok: true; action: HookAction }
   | { ok: true; action: null; skipped: true }
@@ -93,6 +95,7 @@ type HookTransformResult = Partial<{
   wakeMode: "now" | "next-heartbeat";
   name: string;
   sessionKey: string;
+  sessionKeySource: HookSessionKeyTemplateSource;
   deliver: boolean;
   allowUnsafeExternalContent: boolean;
   channel: HookMessageChannel;
@@ -264,7 +267,7 @@ function buildActionFromMapping(
       agentId: mapping.agentId,
       wakeMode: mapping.wakeMode ?? "now",
       sessionKey: renderOptional(mapping.sessionKey, ctx),
-      sessionKeySource: getTemplatedSessionKeySource(mapping.sessionKey),
+      sessionKeySource: getSessionKeyTemplateSource(mapping.sessionKey),
       deliver: mapping.deliver,
       allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
       channel: mapping.channel,
@@ -303,7 +306,7 @@ function mergeAction(
     name: override.name ?? baseAgent?.name,
     agentId: override.agentId ?? baseAgent?.agentId,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
-    sessionKeySource: baseAgent?.sessionKeySource,
+    sessionKeySource: resolveMergedSessionKeySource(baseAgent, override),
     deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:
       typeof override.allowUnsafeExternalContent === "boolean"
@@ -330,16 +333,26 @@ function validateAction(action: HookAction): HookMappingResult {
   return { ok: true, action };
 }
 
-function getTemplatedSessionKeySource(
+function getSessionKeyTemplateSource(
   sessionKeyTemplate: string | undefined,
-): "static" | "templated" | undefined {
+): HookSessionKeyTemplateSource | undefined {
   if (!normalizeOptionalString(sessionKeyTemplate)) {
     return undefined;
   }
-  return hasTemplateExpressions(sessionKeyTemplate) ? "templated" : "static";
+  return hasHookTemplateExpressions(sessionKeyTemplate) ? "templated" : "static";
 }
 
-function hasTemplateExpressions(template: string): boolean {
+function resolveMergedSessionKeySource(
+  baseAgent: Extract<HookAction, { kind: "agent" }> | undefined,
+  override: Exclude<HookTransformResult, null>,
+): HookSessionKeyTemplateSource | undefined {
+  if (typeof override.sessionKey === "string") {
+    return override.sessionKeySource ?? "templated";
+  }
+  return baseAgent?.sessionKeySource;
+}
+
+export function hasHookTemplateExpressions(template: string): boolean {
   return /\{\{\s*[^}]+\s*\}\}/.test(template);
 }
 

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { CONFIG_PATH } from "../config/paths.js";
+import { resolveConfigPathCandidate } from "../config/paths.js";
 import type { HookMappingConfig, HooksConfig } from "../config/types.hooks.js";
 import { importFileModule, resolveFunctionModuleExport } from "../hooks/module-loader.js";
 import { normalizeOptionalString, readStringValue } from "../shared/string-coerce.js";
@@ -139,7 +139,7 @@ export function resolveHookMappings(
     return [];
   }
 
-  const configDir = path.resolve(opts?.configDir ?? path.dirname(CONFIG_PATH));
+  const configDir = path.resolve(opts?.configDir ?? path.dirname(resolveConfigPathCandidate()));
   const transformsRootDir = path.join(configDir, "hooks", "transforms");
   const transformsDir = resolveOptionalContainedPath(
     transformsRootDir,

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -350,6 +350,8 @@ function resolveMergedSessionKeySource(
   if (typeof override.sessionKey === "string") {
     const normalizedSessionKey = normalizeOptionalString(override.sessionKey);
     if (!normalizedSessionKey) {
+      // Empty transform overrides behave like an absent sessionKey and fall
+      // through to the default/generated key path later in hook dispatch.
       return undefined;
     }
     return override.sessionKeySource === "static" ? "static" : "templated";

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -52,6 +52,7 @@ export type HookAction =
       agentId?: string;
       wakeMode: "now" | "next-heartbeat";
       sessionKey?: string;
+      sessionKeySource?: "static" | "templated";
       deliver?: boolean;
       allowUnsafeExternalContent?: boolean;
       channel?: HookMessageChannel;
@@ -263,6 +264,7 @@ function buildActionFromMapping(
       agentId: mapping.agentId,
       wakeMode: mapping.wakeMode ?? "now",
       sessionKey: renderOptional(mapping.sessionKey, ctx),
+      sessionKeySource: getTemplatedSessionKeySource(mapping.sessionKey),
       deliver: mapping.deliver,
       allowUnsafeExternalContent: mapping.allowUnsafeExternalContent,
       channel: mapping.channel,
@@ -301,6 +303,7 @@ function mergeAction(
     name: override.name ?? baseAgent?.name,
     agentId: override.agentId ?? baseAgent?.agentId,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
+    sessionKeySource: baseAgent?.sessionKeySource,
     deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:
       typeof override.allowUnsafeExternalContent === "boolean"
@@ -325,6 +328,19 @@ function validateAction(action: HookAction): HookMappingResult {
     return { ok: false, error: "hook mapping requires message" };
   }
   return { ok: true, action };
+}
+
+function getTemplatedSessionKeySource(
+  sessionKeyTemplate: string | undefined,
+): "static" | "templated" | undefined {
+  if (!normalizeOptionalString(sessionKeyTemplate)) {
+    return undefined;
+  }
+  return hasTemplateExpressions(sessionKeyTemplate) ? "templated" : "static";
+}
+
+function hasTemplateExpressions(template: string): boolean {
+  return /\{\{\s*[^}]+\s*\}\}/.test(template);
 }
 
 async function loadTransform(transform: HookMappingTransformResolved): Promise<HookTransformFn> {

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -336,10 +336,11 @@ function validateAction(action: HookAction): HookMappingResult {
 function getSessionKeyTemplateSource(
   sessionKeyTemplate: string | undefined,
 ): HookSessionKeyTemplateSource | undefined {
-  if (!normalizeOptionalString(sessionKeyTemplate)) {
+  const normalizedTemplate = normalizeOptionalString(sessionKeyTemplate);
+  if (!normalizedTemplate) {
     return undefined;
   }
-  return hasHookTemplateExpressions(sessionKeyTemplate) ? "templated" : "static";
+  return hasHookTemplateExpressions(normalizedTemplate) ? "templated" : "static";
 }
 
 function resolveMergedSessionKeySource(

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -348,7 +348,11 @@ function resolveMergedSessionKeySource(
   override: Exclude<HookTransformResult, null>,
 ): HookSessionKeyTemplateSource | undefined {
   if (typeof override.sessionKey === "string") {
-    return override.sessionKeySource ?? "templated";
+    const normalizedSessionKey = normalizeOptionalString(override.sessionKey);
+    if (!normalizedSessionKey) {
+      return undefined;
+    }
+    return override.sessionKeySource === "static" ? "static" : "templated";
   }
   return baseAgent?.sessionKeySource;
 }

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -433,6 +433,30 @@ describe("gateway hooks helpers", () => {
       } as OpenClawConfig),
     ).not.toThrow();
   });
+
+  test("resolveHooksConfig allows a static catch-all mapping to shadow a later templated mapping", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              action: "agent",
+              messageTemplate: "catch-all",
+              sessionKey: "hook:static",
+            },
+            {
+              match: { path: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey: "hook:gmail:{{messages[0].id}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -397,6 +397,7 @@ describe("gateway hooks helpers", () => {
         hooks: {
           enabled: true,
           token: "secret",
+          allowRequestSessionKey: true,
           mappings: [
             {
               match: { path: "gmail" },
@@ -408,7 +409,7 @@ describe("gateway hooks helpers", () => {
         },
       } as OpenClawConfig),
     ).toThrow(
-      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates",
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
     );
   });
 });

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -476,6 +476,56 @@ describe("gateway hooks helpers", () => {
       } as OpenClawConfig),
     ).not.toThrow();
   });
+
+  test("resolveHooksConfig treats '/' match.path as a catch-all for shadowing", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "/" },
+              action: "agent",
+              messageTemplate: "catch-all",
+              sessionKey: "hook:static",
+            },
+            {
+              match: { path: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey: "hook:gmail:{{messages[0].id}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
+
+  test("resolveHooksConfig treats empty match.source as a wildcard for shadowing", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "gmail", source: "" },
+              action: "agent",
+              messageTemplate: "catch-all source",
+              sessionKey: "hook:static",
+            },
+            {
+              match: { path: "gmail", source: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey: "hook:gmail:{{messages[0].id}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -457,6 +457,25 @@ describe("gateway hooks helpers", () => {
       } as OpenClawConfig),
     ).not.toThrow();
   });
+
+  test("resolveHooksConfig ignores templated session keys on wake mappings", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "wake" },
+              action: "wake",
+              textTemplate: "ping",
+              sessionKey: "hook:wake:{{payload.id}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -288,7 +288,7 @@ describe("gateway hooks helpers", () => {
       hooks: {
         enabled: true,
         token: "secret",
-        allowedSessionKeyPrefixes: ["hook:gmail:"],
+        allowedSessionKeyPrefixes: ["hook:", "hook:gmail:"],
       },
     } as OpenClawConfig;
     const resolved = resolveHooksConfig(cfg);
@@ -310,7 +310,7 @@ describe("gateway hooks helpers", () => {
       hooks: {
         enabled: true,
         token: "secret",
-        allowedSessionKeyPrefixes: ["hook:gmail:"],
+        allowedSessionKeyPrefixes: ["hook:", "hook:gmail:"],
       },
     } as OpenClawConfig;
     const resolved = resolveHooksConfig(cfg);

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -277,10 +277,54 @@ describe("gateway hooks helpers", () => {
 
     const allowed = resolveHookSessionKey({
       hooksConfig: resolved,
-      source: "mapping",
+      source: "mapping-static",
       sessionKey: "hook:gmail:1",
     });
     expect(allowed).toEqual({ ok: true, value: "hook:gmail:1" });
+  });
+
+  test("resolveHookSessionKey blocks templated mapping sessionKey when request overrides are disabled", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowedSessionKeyPrefixes: ["hook:gmail:"],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+
+    const denied = resolveHookSessionKey({
+      hooksConfig: resolved,
+      source: "mapping-templated",
+      sessionKey: "hook:gmail:attacker",
+    });
+    expect(denied.ok).toBe(false);
+  });
+
+  test("resolveHookSessionKey still allows static mapping sessionKey when request overrides are disabled", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowedSessionKeyPrefixes: ["hook:gmail:"],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+
+    const allowed = resolveHookSessionKey({
+      hooksConfig: resolved,
+      source: "mapping-static",
+      sessionKey: "hook:gmail:fixed",
+    });
+    expect(allowed).toEqual({ ok: true, value: "hook:gmail:fixed" });
   });
 
   test("resolveHookSessionKey uses defaultSessionKey when request key is absent", () => {
@@ -344,6 +388,27 @@ describe("gateway hooks helpers", () => {
       } as OpenClawConfig),
     ).toThrow(
       "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset",
+    );
+  });
+
+  test("resolveHooksConfig requires prefixes for templated mapping session keys", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey: "hook:gmail:{{messages[0].id}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).toThrow(
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates",
     );
   });
 });

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -412,6 +412,27 @@ describe("gateway hooks helpers", () => {
       "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
     );
   });
+
+  test("resolveHooksConfig allows a static explicit mapping to shadow the templated gmail preset", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          allowRequestSessionKey: false,
+          presets: ["gmail"],
+          mappings: [
+            {
+              match: { path: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey: "hook:gmail:static",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -373,10 +373,10 @@ function isHookMappingShadowed(
   earlierMappings: HookMappingResolved[],
 ): boolean {
   return earlierMappings.some((earlier) => {
-    if (earlier.matchPath !== undefined && earlier.matchPath !== mapping.matchPath) {
+    if (earlier.matchPath && earlier.matchPath !== mapping.matchPath) {
       return false;
     }
-    return earlier.matchSource === undefined || earlier.matchSource === mapping.matchSource;
+    return !earlier.matchSource || earlier.matchSource === mapping.matchSource;
   });
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -88,10 +88,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
       "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset",
     );
   }
-  if (
-    mappings.some((mapping) => hasTemplatedHookSessionKey(mapping.sessionKey)) &&
-    !allowedSessionKeyPrefixes
-  ) {
+  if (hasEffectiveTemplatedHookSessionKeyMapping(mappings) && !allowedSessionKeyPrefixes) {
     throw new Error(
       "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
     );
@@ -355,6 +352,32 @@ export function resolveHookSessionKey(params: {
 
 function hasTemplatedHookSessionKey(sessionKey: string | undefined): boolean {
   return typeof sessionKey === "string" && hasHookTemplateExpressions(sessionKey);
+}
+
+function hasEffectiveTemplatedHookSessionKeyMapping(mappings: HookMappingResolved[]): boolean {
+  const effectiveMappings: HookMappingResolved[] = [];
+  for (const mapping of mappings) {
+    if (isHookMappingShadowed(mapping, effectiveMappings)) {
+      continue;
+    }
+    effectiveMappings.push(mapping);
+    if (hasTemplatedHookSessionKey(mapping.sessionKey)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isHookMappingShadowed(
+  mapping: HookMappingResolved,
+  earlierMappings: HookMappingResolved[],
+): boolean {
+  return earlierMappings.some((earlier) => {
+    if (earlier.matchPath !== mapping.matchPath) {
+      return false;
+    }
+    return earlier.matchSource === undefined || earlier.matchSource === mapping.matchSource;
+  });
 }
 
 export function normalizeHookDispatchSessionKey(params: {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -373,7 +373,7 @@ function isHookMappingShadowed(
   earlierMappings: HookMappingResolved[],
 ): boolean {
   return earlierMappings.some((earlier) => {
-    if (earlier.matchPath !== mapping.matchPath) {
+    if (earlier.matchPath !== undefined && earlier.matchPath !== mapping.matchPath) {
       return false;
     }
     return earlier.matchSource === undefined || earlier.matchSource === mapping.matchSource;

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -93,7 +93,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     !allowedSessionKeyPrefixes
   ) {
     throw new Error(
-      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates",
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
     );
   }
   return {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -361,7 +361,7 @@ function hasEffectiveTemplatedHookSessionKeyMapping(mappings: HookMappingResolve
       continue;
     }
     effectiveMappings.push(mapping);
-    if (hasTemplatedHookSessionKey(mapping.sessionKey)) {
+    if (mapping.action === "agent" && hasTemplatedHookSessionKey(mapping.sessionKey)) {
       return true;
     }
   }

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -40,6 +40,8 @@ export type HookSessionPolicyResolved = {
   allowedSessionKeyPrefixes?: string[];
 };
 
+export type HookSessionKeySource = "request" | "mapping-static" | "mapping-templated";
+
 export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | null {
   if (cfg.hooks?.enabled !== true) {
     return null;
@@ -80,6 +82,14 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   ) {
     throw new Error(
       "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset",
+    );
+  }
+  if (
+    mappings.some((mapping) => hasTemplatedHookSessionKey(mapping.sessionKey)) &&
+    !allowedSessionKeyPrefixes
+  ) {
+    throw new Error(
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates",
     );
   }
   return {
@@ -301,19 +311,22 @@ export function isHookAgentAllowed(
 
 export const getHookAgentPolicyError = () => "agentId is not allowed by hooks.allowedAgentIds";
 export const getHookSessionKeyRequestPolicyError = () =>
-  "sessionKey is disabled for external /hooks/agent payloads; set hooks.allowRequestSessionKey=true to enable";
+  "sessionKey is disabled for externally supplied hook payload values; set hooks.allowRequestSessionKey=true to enable";
 export const getHookSessionKeyPrefixError = (prefixes: string[]) =>
   `sessionKey must start with one of: ${prefixes.join(", ")}`;
 
 export function resolveHookSessionKey(params: {
   hooksConfig: HooksConfigResolved;
-  source: "request" | "mapping";
+  source: HookSessionKeySource;
   sessionKey?: string;
   idFactory?: () => string;
 }): { ok: true; value: string } | { ok: false; error: string } {
   const requested = resolveSessionKey(params.sessionKey);
   if (requested) {
-    if (params.source === "request" && !params.hooksConfig.sessionPolicy.allowRequestSessionKey) {
+    if (
+      (params.source === "request" || params.source === "mapping-templated") &&
+      !params.hooksConfig.sessionPolicy.allowRequestSessionKey
+    ) {
       return { ok: false, error: getHookSessionKeyRequestPolicyError() };
     }
     const allowedPrefixes = params.hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
@@ -334,6 +347,10 @@ export function resolveHookSessionKey(params: {
     return { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) };
   }
   return { ok: true, value: generated };
+}
+
+function hasTemplatedHookSessionKey(sessionKey: string | undefined): boolean {
+  return typeof sessionKey === "string" && /\{\{\s*[^}]+\s*\}\}/.test(sessionKey);
 }
 
 export function normalizeHookDispatchSessionKey(params: {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -11,7 +11,11 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
-import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
+import {
+  hasHookTemplateExpressions,
+  type HookMappingResolved,
+  resolveHookMappings,
+} from "./hooks-mapping.js";
 import { resolveAllowedAgentIds } from "./hooks-policy.js";
 import type { HookMessageChannel } from "./hooks.types.js";
 
@@ -350,7 +354,7 @@ export function resolveHookSessionKey(params: {
 }
 
 function hasTemplatedHookSessionKey(sessionKey: string | undefined): boolean {
-  return typeof sessionKey === "string" && /\{\{\s*[^}]+\s*\}\}/.test(sessionKey);
+  return typeof sessionKey === "string" && hasHookTemplateExpressions(sessionKey);
 }
 
 export function normalizeHookDispatchSessionKey(params: {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -757,7 +757,10 @@ export function createHooksRequestHandler(
           }
           const sessionKey = resolveHookSessionKey({
             hooksConfig,
-            source: "mapping",
+            source:
+              mapped.action.sessionKeySource === "templated"
+                ? "mapping-templated"
+                : "mapping-static",
             sessionKey: mapped.action.sessionKey,
           });
           if (!sessionKey.ok) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -758,9 +758,7 @@ export function createHooksRequestHandler(
           const sessionKey = resolveHookSessionKey({
             hooksConfig,
             source:
-              mapped.action.sessionKeySource === "templated"
-                ? "mapping-templated"
-                : "mapping-static",
+              mapped.action.sessionKeySource === "static" ? "mapping-static" : "mapping-templated",
             sessionKey: mapped.action.sessionKey,
           });
           if (!sessionKey.ok) {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import {
@@ -124,6 +125,14 @@ async function expectHookAgentSessionRouting(params: {
   expect(routedCall?.job?.agentId).toBe("hooks");
   expect(routedCall?.sessionKey).toBe(params.expectedSessionKey);
   drainSystemEvents(resolveMainKey());
+}
+
+async function writeHookTransformModule(moduleName: string, source: string): Promise<void> {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  expect(configPath).toBeTruthy();
+  const transformsDir = path.join(path.dirname(configPath!), "hooks", "transforms");
+  await fs.mkdir(transformsDir, { recursive: true });
+  await fs.writeFile(path.join(transformsDir, moduleName), source, "utf-8");
 }
 
 describe("gateway server hooks", () => {
@@ -393,6 +402,89 @@ describe("gateway server hooks", () => {
 
       const mappedBadPrefix = await postHook(port, "/hooks/mapped-bad", { subject: "hello" });
       expect(mappedBadPrefix.status).toBe(400);
+    });
+  });
+
+  test("enforces templated vs static mapping session keys on /hooks/<mapping>", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowedSessionKeyPrefixes: ["hook:", "hook:gmail:"],
+      mappings: [
+        {
+          match: { path: "mapped-templated" },
+          action: "agent",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          sessionKey: "hook:gmail:{{payload.id}}",
+        },
+        {
+          match: { path: "mapped-static" },
+          action: "agent",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          sessionKey: "hook:gmail:fixed",
+        },
+      ],
+    };
+
+    await withGatewayServer(async ({ port }) => {
+      const templated = await postHook(port, "/hooks/mapped-templated", {
+        subject: "hello",
+        id: "42",
+      });
+      expect(templated.status).toBe(400);
+      const templatedBody = (await templated.json()) as { error?: string };
+      expect(templatedBody.error).toContain("hooks.allowRequestSessionKey");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+
+      mockIsolatedRunOkOnce();
+      const staticMapped = await postHook(port, "/hooks/mapped-static", {
+        subject: "hello",
+      });
+      expect(staticMapped.status).toBe(200);
+      await waitForSystemEvent();
+      const staticCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { sessionKey?: string }
+        | undefined;
+      expect(staticCall?.sessionKey).toBe("hook:gmail:fixed");
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("treats malformed transform sessionKeySource as templated on /hooks/<mapping>", async () => {
+    await writeHookTransformModule(
+      "mapped-invalid-session-key-source.mjs",
+      [
+        "export default () => ({",
+        '  kind: "agent",',
+        '  message: "Mapped: from transform",',
+        '  sessionKey: "hook:gmail:from-transform",',
+        '  sessionKeySource: "bogus",',
+        "});",
+      ].join("\n"),
+    );
+
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowedSessionKeyPrefixes: ["hook:", "hook:gmail:"],
+      mappings: [
+        {
+          match: { path: "mapped-invalid-session-key-source" },
+          action: "agent",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          transform: { module: "mapped-invalid-session-key-source.mjs" },
+        },
+      ],
+    };
+
+    await withGatewayServer(async ({ port }) => {
+      const response = await postHook(port, "/hooks/mapped-invalid-session-key-source", {
+        subject: "hello",
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toContain("hooks.allowRequestSessionKey");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** Hook mappings that use `{{…}}` template expressions in their `sessionKey` (e.g. the built-in `gmail` preset with `sessionKey: \"hook:gmail:{{messages[0].id}}\"`) render attacker-controlled webhook payload values into the session key, then pass that value to `resolveHookSessionKey()` with `source: \"mapping\"`. The `allowRequestSessionKey` gate only checked `source === \"request\"`, so the mapping path was silently exempt.
- **Why it matters:** An operator who disabled `allowRequestSessionKey` (the secure default) believed they were preventing external callers from steering session routing. Template-rendered mapping keys bypassed that control entirely — a hook-token holder could route the dispatched message into any session their payload value could produce.
- **What changed:** `HookAction` gains `sessionKeySource: \"static\" | \"templated\"`; `HookTransformResult` gains the same field; `resolveHookSessionKey`'s `source` type expands to `\"mapping-static\" | \"mapping-templated\"`; the `allowRequestSessionKey` gate now also fires on `mapping-templated`; `resolveMergedSessionKeySource` handles transform overrides with a safe `\"templated\"` default; `resolveHooksConfig` throws if a mapping uses a templated `sessionKey` without `allowedSessionKeyPrefixes`; the shared `hasHookTemplateExpressions` utility eliminates the regex duplication.
- **What did NOT change:** Static operator-provided mapping keys (`sessionKey: \"hook:gmail:fixed\"`) are unaffected and continue to bypass the gate as before.

> 🤖 AI-assisted PR — generated by OpenAI Codex, reviewed by Claude.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveHookSessionKey()` was introduced with a `source: \"request\" | \"mapping\"` discriminator, but the `allowRequestSessionKey` gate was only wired to `source === \"request\"`. The `\"mapping\"` branch renders external webhook data through `renderOptional(mapping.sessionKey, ctx)` before reaching that function, making the distinction security-relevant, not just semantic.
- Missing detection / guardrail: No test covered the mapping path with `allowRequestSessionKey=false`; no config-time validation required `allowedSessionKeyPrefixes` when template expressions were present.
- Contributing context (if known): The original mapping branch was treated as operator-controlled. Once template expressions referencing `payload.*` were added, that assumption no longer held.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/gateway/hooks.test.ts`, `src/gateway/hooks-mapping.test.ts`
- Scenario the test should lock in: (1) `mapping-templated` source is blocked by `resolveHookSessionKey` when `allowRequestSessionKey=false`; (2) `mapping-static` is not blocked; (3) transform-provided `sessionKey` without explicit `sessionKeySource` defaults to `\"templated\"`; (4) transform-provided `sessionKey` with `sessionKeySource: \"static\"` is respected; (5) `resolveHooksConfig` throws when a templated mapping key is present but `allowedSessionKeyPrefixes` is absent.
- Why this is the smallest reliable guardrail: Each test directly exercises one decision point in the gate chain without a live gateway.
- Existing test that already covers this (if any): None — the pre-existing mapping-path test used `source: \"mapping\"` which is now renamed.

## User-visible / Behavior Changes

- **New config-time error:** `resolveHooksConfig` throws `\"hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates\"` if any mapping (or preset) has a template-driven `sessionKey` but `allowedSessionKeyPrefixes` is unset. Operators who use the `gmail` preset or write custom template-bearing session keys must now also set `allowedSessionKeyPrefixes`.
- **Tightened runtime gate:** Mappings with template-rendered session keys now require `allowRequestSessionKey: true`, same as request-supplied keys. Operators who run those mappings with the default `allowRequestSessionKey: false` will get a 400 error until they either set `allowRequestSessionKey: true` or supply a static `sessionKey`.
- Static mapping session keys and auto-generated session keys are unaffected.

## Diagram (if applicable)

```text
Before:
[webhook POST] -> renderOptional(sessionKey, ctx) -> resolveHookSessionKey(source:"mapping") -> gate skipped -> dispatch

After (templated key):
[webhook POST] -> renderOptional(sessionKey, ctx) -> resolveHookSessionKey(source:"mapping-templated") -> gate fires -> 400 if allowRequestSessionKey=false

After (static key):
[webhook POST] -> resolveHookSessionKey(source:"mapping-static") -> gate skipped -> dispatch (unchanged)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (CI), Darwin arm64 (local review)
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel: Gateway hooks (`/hooks/<mapping>`)
- Relevant config (redacted): `hooks.enabled=true`, `hooks.token=<secret>`, `hooks.presets=[\"gmail\"]`, `hooks.allowRequestSessionKey=false`

### Steps

1. Configure a gateway with `hooks.presets: [\"gmail\"]` and `hooks.allowRequestSessionKey: false` (the default).
2. POST a crafted webhook payload to `/hooks/gmail` with an attacker-chosen `messages[0].id`.
3. Observe the dispatched session key.

### Expected

- Gateway rejects the request with a 400 indicating session key is disabled, or requires `allowedSessionKeyPrefixes` to be set at startup.

### Actual (before fix)

- Gateway accepts the request and dispatches to the attacker-chosen session key.

## Evidence

- [x] Failing test/log before + passing after — new tests in `hooks.test.ts` and `hooks-mapping.test.ts` cover all five scenarios; the `source: \"mapping\"` → `source: \"mapping-static\"` rename in the existing passing test confirms the old neutral path still works.

## Human Verification (required)

- Verified scenarios: Codex-generated fix; code reviewed by Claude. All five new test cases exercise distinct gate-chain decision points. Transform-override merge logic (`resolveMergedSessionKeySource`) verified to default to `\"templated\"` when `sessionKeySource` is absent.
- Edge cases checked: Transform sets static `sessionKey` explicitly; transform sets dynamic `sessionKey` without declaring source; no-transform path (returns base directly); `allowedSessionKeyPrefixes` both set and unset.
- What you did **not** verify: Live gateway round-trip against a real Gmail Pub/Sub push endpoint.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? No — see User-visible / Behavior Changes above.
- Config/env changes? Yes — `allowedSessionKeyPrefixes` is now required when template session keys are used.
- Migration needed? Yes — operators using `hooks.presets: [\"gmail\"]` or custom template session keys must add `allowedSessionKeyPrefixes` to their hooks config. Operators who also want to retain template-driven routing must additionally set `allowRequestSessionKey: true`.
- If yes, exact upgrade steps:
  1. Add `hooks.allowedSessionKeyPrefixes: [\"hook:gmail:\"]` (or the relevant prefix) to your hooks config.
  2. If you need template-driven session routing, also set `hooks.allowRequestSessionKey: true`.

## Risks and Mitigations

- Risk: Operators using the `gmail` preset will see a startup error until they add `allowedSessionKeyPrefixes`.
  - Mitigation: Error message is actionable and names the required field. Static-key mappings and auto-generated keys are unaffected.
- Risk: Operators who legitimately rely on template-rendered session keys for routing (e.g. per-thread isolation) will additionally need `allowRequestSessionKey: true`.
  - Mitigation: The combination of `allowedSessionKeyPrefixes` + `allowRequestSessionKey: true` preserves the existing routing capability while constraining it to the declared prefix namespace.