### PR TITLE
Fix: Image tool fails with reasoning-capable vision models that return empty content

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,6 +1,11 @@
+import { Message } from "@mariozechner/pi-ai";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import {
+  extractAssistantText,
+  extractAssistantThinking,
+} from "../utils/pi-embedded-utils.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -124,4 +129,32 @@ export async function minimaxUnderstandImage(params: {
   }
 
   return content;
+}
+
+export function coerceImageAssistantText(params: {
+  message: Message;
+  provider: string;
+  model: string;
+}) {
+  const stop = params.message.stopReason;
+  const errorMessage = params.message.errorMessage?.trim();
+  if (stop === "error" || stop === "aborted") {
+    throw new Error(
+      `Image model failed (${params.provider}/${params.model})${
+        errorMessage ? `: ${errorMessage}` : ""
+      }`,
+    );
+  }
+  if (errorMessage) {
+    throw new Error(`Image model error (${params.provider}/${params.model}): ${errorMessage}`);
+  }
+
+  const text = extractAssistantText(params.message);
+  if (text.trim()) return text.trim();
+
+  // Fallback: reasoning models may return content in thinking blocks
+  const thinking = extractAssistantThinking(params.message);
+  if (thinking.trim()) return thinking.trim();
+
+  throw new Error(`Image model returned no text (${params.provider}/${params.model}).`);
 }


### PR DESCRIPTION
Added the missing `coerceImageAssistantText` function to `src/agents/minimax-vlm.ts` and updated it to include a fallback to `extractAssistantThinking()` when the assistant's text content is empty. This ensures that reasoning-capable vision models (like some OpenAI-compatible models) that return their response in `reasoning_content` (parsed as `thinking` blocks) are correctly handled instead of throwing an 'Image model returned no text' error. Also added the necessary imports for `Message`, `extractAssistantText`, and `extractAssistantThinking`.

Test: const mockMessage = {
  stopReason: 'stop',
  content: [{ type: 'thinking', thinking: 'This image contains a cat.' }]
};
const params = {
  message: mockMessage as any,
  provider: 'custom-openai',
  model: 'reasoning-vision-v1'
};
const result = coerceImageAssistantText(params);
if (result !== 'This image contains a cat.') {
  throw new Error('Fallback to thinking block failed');
}