### PR TITLE
fix(agents): enforce subagent envelope inheritance on ACP child sessions [AI-assisted]

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -152,7 +152,7 @@ vi.mock("./subagent-registry.js", () => ({
   countActiveRunsForSession: hoisted.countActiveRunsForSessionMock,
 }));
 
-vi.mock("../tasks/task-registry.js", () => ({
+vi.mock("../tasks/runtime-internal.js", () => ({
   listTasksForOwnerKey: hoisted.listTasksForOwnerKeyMock,
 }));
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -23,6 +23,14 @@ function createDefaultSpawnConfig(): OpenClawConfig {
       backend: "acpx",
       allowedAgents: ["codex"],
     },
+    agents: {
+      defaults: {
+        subagents: {
+          allowAgents: ["codex"],
+          maxSpawnDepth: 2,
+        },
+      },
+    },
     session: {
       mainKey: "main",
       scope: "per-sender",
@@ -704,7 +712,9 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
             maxSpawnDepth: 2,
           },
         },
@@ -734,22 +744,18 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
             maxSpawnDepth: 2,
           },
         },
       },
     });
-    hoisted.loadSessionStoreMock.mockReturnValueOnce({
-      "agent:main:subagent:flat-leaf": {
-        sessionId: "subagent-flat-leaf",
-        spawnDepth: 2,
-      },
-    });
 
     const result = await spawnAcpDirect(createSpawnRequest(), {
       ...createRequesterContext(),
-      agentSessionKey: "agent:main:subagent:flat-leaf",
+      agentSessionKey: "agent:main:subagent:parent:subagent:leaf",
     });
 
     const failed = expectFailedSpawn(result, "forbidden");
@@ -762,7 +768,9 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
             maxChildrenPerAgent: 1,
           },
         },
@@ -788,6 +796,7 @@ describe("spawnAcpDirect", () => {
         allowedAgents: ["codex", "writer"],
       },
       agents: {
+        ...hoisted.state.cfg.agents,
         list: [
           {
             id: "main",
@@ -1653,6 +1662,7 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           sandbox: { mode: "all" },
         },
       },
@@ -1754,6 +1764,7 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           heartbeat: {
             every: "30m",
             target: "last",
@@ -1837,6 +1848,7 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           heartbeat: {
             every: "30m",
             target: "discord",
@@ -1871,6 +1883,7 @@ describe("spawnAcpDirect", () => {
       },
       agents: {
         defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
           heartbeat: {
             every: "30m",
             target: "last",
@@ -1899,6 +1912,7 @@ describe("spawnAcpDirect", () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,
       agents: {
+        ...hoisted.state.cfg.agents,
         list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "research" }],
       },
     });
@@ -1923,6 +1937,7 @@ describe("spawnAcpDirect", () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,
       agents: {
+        ...hoisted.state.cfg.agents,
         list: [
           {
             id: "research",

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1972,6 +1972,75 @@ describe("spawnAcpDirect", () => {
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
   });
 
+  it("does not implicitly stream for ACP requester sessions inside a subagent envelope", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
+          heartbeat: {
+            every: "30m",
+            target: "last",
+          },
+        },
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReset().mockImplementation(() => {
+      const store: Record<
+        string,
+        {
+          sessionId: string;
+          updatedAt: number;
+          deliveryContext?: unknown;
+          spawnedBy?: string;
+          spawnDepth?: number;
+          subagentRole?: string;
+          subagentControlScope?: string;
+        }
+      > = {
+        "agent:main:acp:child": {
+          sessionId: "parent-sess-1",
+          updatedAt: Date.now(),
+          deliveryContext: {
+            channel: "discord",
+            to: "channel:parent-channel",
+            accountId: "default",
+          },
+          spawnedBy: "agent:main:subagent:parent",
+          spawnDepth: 2,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+        },
+      };
+      return new Proxy(store, {
+        get(target, prop) {
+          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+            return { sessionId: "sess-123", updatedAt: Date.now() };
+          }
+          return target[prop as keyof typeof target];
+        },
+      });
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:acp:child",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.mode).toBe("run");
+    expect(accepted.streamLogPath).toBeUndefined();
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
   it("does not implicitly stream when heartbeat target is not session-local", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -70,6 +70,7 @@ const hoisted = vi.hoisted(() => {
   const cleanupFailedAcpSpawnMock = vi.fn();
   const createRunningTaskRunMock = vi.fn();
   const countActiveRunsForSessionMock = vi.fn();
+  const listTasksForOwnerKeyMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -94,6 +95,7 @@ const hoisted = vi.hoisted(() => {
     cleanupFailedAcpSpawnMock,
     createRunningTaskRunMock,
     countActiveRunsForSessionMock,
+    listTasksForOwnerKeyMock,
     state,
   };
 });
@@ -148,6 +150,10 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
 
 vi.mock("./subagent-registry.js", () => ({
   countActiveRunsForSession: hoisted.countActiveRunsForSessionMock,
+}));
+
+vi.mock("../tasks/task-registry.js", () => ({
+  listTasksForOwnerKey: hoisted.listTasksForOwnerKeyMock,
 }));
 
 const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await import("./acp-spawn.js");
@@ -510,6 +516,7 @@ describe("spawnAcpDirect", () => {
     hoisted.cleanupFailedAcpSpawnMock.mockReset().mockResolvedValue(undefined);
     hoisted.createRunningTaskRunMock.mockReset().mockReturnValue(undefined);
     hoisted.countActiveRunsForSessionMock.mockReset().mockReturnValue(0);
+    hoisted.listTasksForOwnerKeyMock.mockReset().mockReturnValue([]);
 
     hoisted.callGatewayMock.mockReset();
     hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
@@ -782,6 +789,42 @@ describe("spawnAcpDirect", () => {
       ...createRequesterContext(),
       agentSessionKey: "agent:main:subagent:parent",
     });
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toContain("max active children");
+  });
+
+  it('counts streamTo="parent" ACP runs toward subagent child caps', async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
+          subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
+            maxChildrenPerAgent: 1,
+          },
+        },
+      },
+    });
+    hoisted.listTasksForOwnerKeyMock.mockReturnValueOnce([
+      {
+        runtime: "acp",
+        status: "running",
+        childSessionKey: "agent:codex:acp:existing-parent-stream",
+      },
+    ]);
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        streamTo: "parent",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
 
     const failed = expectFailedSpawn(result, "forbidden");
     expect(failed.errorCode).toBe("subagent_policy");

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -61,6 +61,7 @@ const hoisted = vi.hoisted(() => {
   });
   const cleanupFailedAcpSpawnMock = vi.fn();
   const createRunningTaskRunMock = vi.fn();
+  const countActiveRunsForSessionMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -84,6 +85,7 @@ const hoisted = vi.hoisted(() => {
     normalizeChannelIdMock,
     cleanupFailedAcpSpawnMock,
     createRunningTaskRunMock,
+    countActiveRunsForSessionMock,
     state,
   };
 });
@@ -110,6 +112,11 @@ vi.mock("../config/sessions/store.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
 }));
 
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: hoisted.loadSessionStoreMock,
+  resolveStorePath: hoisted.resolveStorePathMock,
+}));
+
 vi.mock("../config/sessions/transcript.js", () => ({
   resolveSessionTranscriptFile: hoisted.resolveSessionTranscriptFileMock,
 }));
@@ -129,6 +136,10 @@ vi.mock("../tasks/detached-task-runtime.js", () => ({
 vi.mock("./acp-spawn-parent-stream.js", () => ({
   resolveAcpSpawnStreamLogPath: hoisted.resolveAcpSpawnStreamLogPathMock,
   startAcpSpawnParentStreamRelay: hoisted.startAcpSpawnParentStreamRelayMock,
+}));
+
+vi.mock("./subagent-registry.js", () => ({
+  countActiveRunsForSession: hoisted.countActiveRunsForSessionMock,
 }));
 
 const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await import("./acp-spawn.js");
@@ -490,6 +501,7 @@ describe("spawnAcpDirect", () => {
     hoisted.getLoadedChannelPluginMock.mockReset().mockReturnValue(undefined);
     hoisted.cleanupFailedAcpSpawnMock.mockReset().mockResolvedValue(undefined);
     hoisted.createRunningTaskRunMock.mockReset().mockReturnValue(undefined);
+    hoisted.countActiveRunsForSessionMock.mockReset().mockReturnValue(0);
 
     hoisted.callGatewayMock.mockReset();
     hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
@@ -685,6 +697,125 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls).toHaveLength(2);
     expect(transcriptCalls[0]?.threadId).toBeUndefined();
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+  });
+
+  it("inherits subagent envelope fields onto ACP children", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          subagents: {
+            maxSpawnDepth: 2,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(createSpawnRequest(), {
+      ...createRequesterContext(),
+      agentSessionKey: "agent:main:subagent:parent",
+    });
+
+    const accepted = expectAcceptedSpawn(result);
+    const patchCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "sessions.patch");
+    expect(patchCall?.params).toMatchObject({
+      key: accepted.childSessionKey,
+      spawnedBy: "agent:main:subagent:parent",
+      spawnDepth: 2,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+    });
+  });
+
+  it("rejects ACP spawns that exceed subagent max depth", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          subagents: {
+            maxSpawnDepth: 2,
+          },
+        },
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValueOnce({
+      "agent:main:subagent:flat-leaf": {
+        sessionId: "subagent-flat-leaf",
+        spawnDepth: 2,
+      },
+    });
+
+    const result = await spawnAcpDirect(createSpawnRequest(), {
+      ...createRequesterContext(),
+      agentSessionKey: "agent:main:subagent:flat-leaf",
+    });
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toContain("current depth: 2, max: 2");
+  });
+
+  it("rejects ACP spawns that exceed subagent child caps", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          subagents: {
+            maxChildrenPerAgent: 1,
+          },
+        },
+      },
+    });
+    hoisted.countActiveRunsForSessionMock.mockReturnValueOnce(1);
+
+    const result = await spawnAcpDirect(createSpawnRequest(), {
+      ...createRequesterContext(),
+      agentSessionKey: "agent:main:subagent:parent",
+    });
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toContain("max active children");
+  });
+
+  it("rejects ACP spawns to agents outside the subagent allowlist", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex", "writer"],
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+          {
+            id: "writer",
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        agentId: "writer",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toContain("agentId is not allowed");
   });
 
   it("spawns Matrix thread-bound ACP sessions from top-level room targets", async () => {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -70,6 +70,7 @@ const hoisted = vi.hoisted(() => {
   const cleanupFailedAcpSpawnMock = vi.fn();
   const createRunningTaskRunMock = vi.fn();
   const countActiveRunsForSessionMock = vi.fn();
+  const getSubagentRunByChildSessionKeyMock = vi.fn();
   const listTasksForOwnerKeyMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
@@ -95,6 +96,7 @@ const hoisted = vi.hoisted(() => {
     cleanupFailedAcpSpawnMock,
     createRunningTaskRunMock,
     countActiveRunsForSessionMock,
+    getSubagentRunByChildSessionKeyMock,
     listTasksForOwnerKeyMock,
     state,
   };
@@ -150,6 +152,7 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
 
 vi.mock("./subagent-registry.js", () => ({
   countActiveRunsForSession: hoisted.countActiveRunsForSessionMock,
+  getSubagentRunByChildSessionKey: hoisted.getSubagentRunByChildSessionKeyMock,
 }));
 
 vi.mock("../tasks/runtime-internal.js", () => ({
@@ -516,6 +519,7 @@ describe("spawnAcpDirect", () => {
     hoisted.cleanupFailedAcpSpawnMock.mockReset().mockResolvedValue(undefined);
     hoisted.createRunningTaskRunMock.mockReset().mockReturnValue(undefined);
     hoisted.countActiveRunsForSessionMock.mockReset().mockReturnValue(0);
+    hoisted.getSubagentRunByChildSessionKeyMock.mockReset().mockReturnValue(null);
     hoisted.listTasksForOwnerKeyMock.mockReset().mockReturnValue([]);
 
     hoisted.callGatewayMock.mockReset();
@@ -853,6 +857,49 @@ describe("spawnAcpDirect", () => {
       {
         runtime: "acp",
         status: "queued",
+        childSessionKey: "agent:codex:acp:existing-parent-stream",
+      },
+    ]);
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        streamTo: "parent",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+  });
+
+  it("does not double-count ACP task rows for active registry-tracked ACP children", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
+          subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
+            maxChildrenPerAgent: 2,
+          },
+        },
+      },
+    });
+    hoisted.countActiveRunsForSessionMock.mockReturnValueOnce(1);
+    hoisted.getSubagentRunByChildSessionKeyMock.mockImplementationOnce((childSessionKey: string) =>
+      childSessionKey === "agent:codex:acp:existing-parent-stream"
+        ? {
+            childSessionKey,
+            createdAt: Date.now(),
+          }
+        : null,
+    );
+    hoisted.listTasksForOwnerKeyMock.mockReturnValueOnce([
+      {
+        runtime: "acp",
+        status: "running",
         childSessionKey: "agent:codex:acp:existing-parent-stream",
       },
     ]);

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -831,6 +831,45 @@ describe("spawnAcpDirect", () => {
     expect(failed.error).toContain("max active children");
   });
 
+  it("does not double-count duplicate ACP task rows for the same child session", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        defaults: {
+          ...hoisted.state.cfg.agents?.defaults,
+          subagents: {
+            ...hoisted.state.cfg.agents?.defaults?.subagents,
+            maxChildrenPerAgent: 2,
+          },
+        },
+      },
+    });
+    hoisted.listTasksForOwnerKeyMock.mockReturnValueOnce([
+      {
+        runtime: "acp",
+        status: "running",
+        childSessionKey: "agent:codex:acp:existing-parent-stream",
+      },
+      {
+        runtime: "acp",
+        status: "queued",
+        childSessionKey: "agent:codex:acp:existing-parent-stream",
+      },
+    ]);
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        streamTo: "parent",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+  });
+
   it("rejects ACP spawns to agents outside the subagent allowlist", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -33,6 +33,7 @@ import {
   resolveThreadBindingSpawnPolicy,
 } from "../channels/thread-bindings-policy.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
+import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store.js";
@@ -50,7 +51,6 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
@@ -75,6 +75,9 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
+import { isSubagentEnvelopeSession, resolveSubagentCapabilities } from "./subagent-capabilities.js";
+import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
+import { countActiveRunsForSession } from "./subagent-registry.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -117,6 +120,7 @@ export const ACP_SPAWN_ERROR_CODES = [
   "acp_disabled",
   "requester_session_required",
   "runtime_policy",
+  "subagent_policy",
   "thread_required",
   "target_agent_required",
   "agent_forbidden",
@@ -214,6 +218,15 @@ type AcpSpawnRequesterState = {
 type AcpSpawnStreamPlan = {
   implicitStreamToParent: boolean;
   effectiveStreamToParent: boolean;
+};
+
+type AcpSubagentEnvelopeState = {
+  childSessionPatch?: {
+    spawnDepth: number;
+    subagentRole: "orchestrator" | "leaf" | null;
+    subagentControlScope: "children" | "none";
+  };
+  error?: string;
 };
 
 type AcpSpawnBootstrapDeliveryPlan = {
@@ -662,7 +675,8 @@ function resolveAcpSpawnRequesterState(params: {
   const bindingService = getSessionBindingService();
   const requesterParsedSession = parseAgentSessionKey(params.parentSessionKey);
   const isSubagentSession =
-    Boolean(requesterParsedSession) && isSubagentSessionKey(params.parentSessionKey);
+    Boolean(requesterParsedSession) &&
+    isSubagentEnvelopeSession(params.parentSessionKey, { cfg: params.cfg });
   const hasActiveSubagentBinding =
     isSubagentSession && params.parentSessionKey
       ? bindingService
@@ -703,6 +717,84 @@ function resolveAcpSpawnRequesterState(params: {
       requesterGroupSpace: params.ctx.agentGroupSpace,
       requesterMemberRoleIds: params.ctx.agentMemberRoleIds,
     }),
+  };
+}
+
+function resolveAcpSubagentEnvelopeState(params: {
+  cfg: OpenClawConfig;
+  requesterSessionKey?: string;
+  targetAgentId: string;
+  requestedAgentId?: string;
+}): AcpSubagentEnvelopeState {
+  const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
+  if (!requesterSessionKey) {
+    return {};
+  }
+  if (!isSubagentEnvelopeSession(requesterSessionKey, { cfg: params.cfg })) {
+    return {};
+  }
+
+  const callerDepth = getSubagentDepthFromSessionStore(requesterSessionKey, {
+    cfg: params.cfg,
+  });
+  const maxSpawnDepth =
+    params.cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  if (callerDepth >= maxSpawnDepth) {
+    return {
+      error: `sessions_spawn is not allowed at this depth (current depth: ${callerDepth}, max: ${maxSpawnDepth})`,
+    };
+  }
+
+  const maxChildren = params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ?? 5;
+  const activeChildren = countActiveRunsForSession(requesterSessionKey);
+  if (activeChildren >= maxChildren) {
+    return {
+      error: `sessions_spawn has reached max active children for this session (${activeChildren}/${maxChildren})`,
+    };
+  }
+
+  const requesterAgentId = normalizeAgentId(parseAgentSessionKey(requesterSessionKey)?.agentId);
+  const requireAgentId =
+    resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.requireAgentId ??
+    params.cfg.agents?.defaults?.subagents?.requireAgentId ??
+    false;
+  if (requireAgentId && !params.requestedAgentId?.trim()) {
+    return {
+      error:
+        "sessions_spawn requires explicit agentId when requireAgentId is configured. Use agents_list to see allowed agent ids.",
+    };
+  }
+
+  if (params.targetAgentId !== requesterAgentId) {
+    const allowAgents =
+      resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ??
+      params.cfg.agents?.defaults?.subagents?.allowAgents ??
+      [];
+    const allowAny = allowAgents.some((value) => value.trim() === "*");
+    const normalizedTargetId = normalizeOptionalLowercaseString(params.targetAgentId) ?? "";
+    const allowSet = new Set(
+      allowAgents
+        .filter((value) => value.trim() && value.trim() !== "*")
+        .map((value) => normalizeOptionalLowercaseString(normalizeAgentId(value)) ?? ""),
+    );
+    if (!allowAny && !allowSet.has(normalizedTargetId)) {
+      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+      return {
+        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+      };
+    }
+  }
+
+  const childCapabilities = resolveSubagentCapabilities({
+    depth: callerDepth + 1,
+    maxSpawnDepth,
+  });
+  return {
+    childSessionPatch: {
+      spawnDepth: childCapabilities.depth,
+      subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
+      subagentControlScope: childCapabilities.controlScope,
+    },
   };
 }
 
@@ -1012,6 +1104,19 @@ export async function spawnAcpDirect(
     targetAgentId,
     ctx,
   });
+  const subagentEnvelopeState = resolveAcpSubagentEnvelopeState({
+    cfg,
+    requesterSessionKey: requesterInternalKey,
+    targetAgentId,
+    requestedAgentId: params.agentId,
+  });
+  if (subagentEnvelopeState.error) {
+    return createAcpSpawnFailure({
+      status: "forbidden",
+      errorCode: "subagent_policy",
+      error: subagentEnvelopeState.error,
+    });
+  }
   const { effectiveStreamToParent } = resolveAcpSpawnStreamPlan({
     spawnMode,
     requestThreadBinding,
@@ -1070,6 +1175,7 @@ export async function spawnAcpDirect(
       params: {
         key: sessionKey,
         spawnedBy: requesterInternalKey,
+        ...subagentEnvelopeState.childSessionPatch,
         ...(params.label ? { label: params.label } : {}),
       },
       timeoutMs: 10_000,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -54,6 +54,7 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
+  isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
@@ -722,11 +723,7 @@ function resolveAcpSpawnRequesterState(params: {
   const bindingService = getSessionBindingService();
   const requesterParsedSession = parseAgentSessionKey(params.parentSessionKey);
   const isSubagentSession =
-    Boolean(requesterParsedSession) &&
-    isSubagentEnvelopeSession(params.parentSessionKey, {
-      cfg: params.cfg,
-      store: params.subagentStore,
-    });
+    Boolean(requesterParsedSession) && isSubagentSessionKey(params.parentSessionKey);
   const hasActiveSubagentBinding =
     isSubagentSession && params.parentSessionKey
       ? bindingService

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -63,6 +63,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
+import { listTasksForOwnerKey } from "../tasks/task-registry.js";
 import {
   deliveryContextFromSession,
   formatConversationTarget,
@@ -78,7 +79,12 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
-import { isSubagentEnvelopeSession, resolveSubagentCapabilities } from "./subagent-capabilities.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilities,
+  resolveSubagentCapabilityStore,
+  type SessionCapabilityStore,
+} from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession } from "./subagent-registry.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
@@ -231,6 +237,37 @@ type AcpSubagentEnvelopeState = {
   };
   error?: string;
 };
+
+function isActiveTaskStatus(status: string | undefined): boolean {
+  return status === "queued" || status === "running";
+}
+
+function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): number {
+  const normalizedOwnerKey = normalizeOptionalString(ownerKey);
+  if (!normalizedOwnerKey) {
+    return 0;
+  }
+  const tasks = listTasksForOwnerKey(normalizedOwnerKey);
+  const trackedChildSessionKeys = new Set(
+    tasks
+      .filter(
+        (task) =>
+          task.runtime === "subagent" &&
+          isActiveTaskStatus(task.status) &&
+          normalizeOptionalString(task.childSessionKey),
+      )
+      .map((task) => normalizeOptionalString(task.childSessionKey) as string),
+  );
+  return tasks.filter((task) => {
+    const childSessionKey = normalizeOptionalString(task.childSessionKey);
+    return (
+      task.runtime === "acp" &&
+      isActiveTaskStatus(task.status) &&
+      Boolean(childSessionKey) &&
+      !trackedChildSessionKeys.has(childSessionKey)
+    );
+  }).length;
+}
 
 type AcpSpawnBootstrapDeliveryPlan = {
   useInlineDelivery: boolean;
@@ -674,12 +711,16 @@ function resolveAcpSpawnRequesterState(params: {
   parentSessionKey?: string;
   targetAgentId: string;
   ctx: SpawnAcpContext;
+  subagentStore?: SessionCapabilityStore;
 }): AcpSpawnRequesterState {
   const bindingService = getSessionBindingService();
   const requesterParsedSession = parseAgentSessionKey(params.parentSessionKey);
   const isSubagentSession =
     Boolean(requesterParsedSession) &&
-    isSubagentEnvelopeSession(params.parentSessionKey, { cfg: params.cfg });
+    isSubagentEnvelopeSession(params.parentSessionKey, {
+      cfg: params.cfg,
+      store: params.subagentStore,
+    });
   const hasActiveSubagentBinding =
     isSubagentSession && params.parentSessionKey
       ? bindingService
@@ -728,12 +769,18 @@ function resolveAcpSubagentEnvelopeState(params: {
   requesterSessionKey?: string;
   targetAgentId: string;
   requestedAgentId?: string;
+  subagentStore?: SessionCapabilityStore;
 }): AcpSubagentEnvelopeState {
   const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
   if (!requesterSessionKey) {
     return {};
   }
-  if (!isSubagentEnvelopeSession(requesterSessionKey, { cfg: params.cfg })) {
+  if (
+    !isSubagentEnvelopeSession(requesterSessionKey, {
+      cfg: params.cfg,
+      store: params.subagentStore,
+    })
+  ) {
     return {};
   }
 
@@ -751,7 +798,9 @@ function resolveAcpSubagentEnvelopeState(params: {
   const maxChildren =
     params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
     DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT;
-  const activeChildren = countActiveRunsForSession(requesterSessionKey);
+  const activeChildren =
+    countActiveRunsForSession(requesterSessionKey) +
+    countUntrackedActiveAcpRunsForOwner(requesterSessionKey);
   if (activeChildren >= maxChildren) {
     return {
       error: `sessions_spawn has reached max active children for this session (${activeChildren}/${maxChildren})`,
@@ -1103,17 +1152,22 @@ export async function spawnAcpDirect(
       error: agentPolicyError.message,
     });
   }
+  const subagentStore = resolveSubagentCapabilityStore(parentSessionKey, {
+    cfg,
+  });
   const requesterState = resolveAcpSpawnRequesterState({
     cfg,
     parentSessionKey,
     targetAgentId,
     ctx,
+    subagentStore,
   });
   const subagentEnvelopeState = resolveAcpSubagentEnvelopeState({
     cfg,
     requesterSessionKey: requesterInternalKey,
     targetAgentId,
     requestedAgentId: params.agentId,
+    subagentStore,
   });
   if (subagentEnvelopeState.error) {
     return createAcpSpawnFailure({

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -263,7 +263,7 @@ function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): numb
     return (
       task.runtime === "acp" &&
       isActiveTaskStatus(task.status) &&
-      Boolean(childSessionKey) &&
+      childSessionKey !== undefined &&
       !trackedChildSessionKeys.has(childSessionKey)
     );
   }).length;

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -86,7 +86,7 @@ import {
   type SessionCapabilityStore,
 } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import { countActiveRunsForSession } from "./subagent-registry.js";
+import { countActiveRunsForSession, getSubagentRunByChildSessionKey } from "./subagent-registry.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -261,9 +261,12 @@ function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): numb
   const activeAcpChildSessionKeys = new Set(
     tasks.flatMap((task) => {
       const childSessionKey = normalizeOptionalString(task.childSessionKey);
+      const trackedRun = childSessionKey ? getSubagentRunByChildSessionKey(childSessionKey) : null;
+      const hasActiveRegistryRun = Boolean(trackedRun && typeof trackedRun.endedAt !== "number");
       return task.runtime === "acp" &&
         isActiveTaskStatus(task.status) &&
         childSessionKey !== undefined &&
+        !hasActiveRegistryRun &&
         !trackedChildSessionKeys.has(childSessionKey)
         ? [childSessionKey]
         : [];

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -33,7 +33,10 @@ import {
   resolveThreadBindingSpawnPolicy,
 } from "../channels/thread-bindings-policy.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
+import {
+  DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
+  DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
+} from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store.js";
@@ -745,7 +748,9 @@ function resolveAcpSubagentEnvelopeState(params: {
     };
   }
 
-  const maxChildren = params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ?? 5;
+  const maxChildren =
+    params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
+    DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT;
   const activeChildren = countActiveRunsForSession(requesterSessionKey);
   if (activeChildren >= maxChildren) {
     return {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -63,7 +63,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
-import { listTasksForOwnerKey } from "../tasks/task-registry.js";
+import { listTasksForOwnerKey } from "../tasks/runtime-internal.js";
 import {
   deliveryContextFromSession,
   formatConversationTarget,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -258,15 +258,18 @@ function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): numb
       )
       .map((task) => normalizeOptionalString(task.childSessionKey) as string),
   );
-  return tasks.filter((task) => {
-    const childSessionKey = normalizeOptionalString(task.childSessionKey);
-    return (
-      task.runtime === "acp" &&
-      isActiveTaskStatus(task.status) &&
-      childSessionKey !== undefined &&
-      !trackedChildSessionKeys.has(childSessionKey)
-    );
-  }).length;
+  const activeAcpChildSessionKeys = new Set(
+    tasks.flatMap((task) => {
+      const childSessionKey = normalizeOptionalString(task.childSessionKey);
+      return task.runtime === "acp" &&
+        isActiveTaskStatus(task.status) &&
+        childSessionKey !== undefined &&
+        !trackedChildSessionKeys.has(childSessionKey)
+        ? [childSessionKey]
+        : [];
+    }),
+  );
+  return activeAcpChildSessionKeys.size;
 }
 
 type AcpSpawnBootstrapDeliveryPlan = {

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -6,7 +6,10 @@ import {
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,
 } from "../pi-tools.policy.js";
-import { isSubagentEnvelopeSession } from "../subagent-capabilities.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../subagent-capabilities.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -133,9 +136,18 @@ export function applyFinalEffectiveToolPolicy(
     providerProfilePolicy,
     providerProfileAlsoAllow,
   );
+  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
+    cfg: params.config,
+  });
   const subagentPolicy =
-    params.sessionKey && isSubagentEnvelopeSession(params.sessionKey, { cfg: params.config })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
+    params.sessionKey &&
+    isSubagentEnvelopeSession(params.sessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey, {
+          store: subagentStore,
+        })
       : undefined;
   const ownerFiltered = applyOwnerOnlyToolPolicy(
     params.bundledTools,

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -1,12 +1,12 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getPluginToolMeta } from "../../plugins/tools.js";
-import { isSubagentSessionKey } from "../../routing/session-key.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupContextFromSessionKey,
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,
 } from "../pi-tools.policy.js";
+import { isSubagentEnvelopeSession } from "../subagent-capabilities.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -134,7 +134,7 @@ export function applyFinalEffectiveToolPolicy(
     providerProfileAlsoAllow,
   );
   const subagentPolicy =
-    isSubagentSessionKey(params.sessionKey) && params.sessionKey
+    params.sessionKey && isSubagentEnvelopeSession(params.sessionKey, { cfg: params.config })
       ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
       : undefined;
   const ownerFiltered = applyOwnerOnlyToolPolicy(

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -252,6 +252,9 @@ describe("createOpenClawCodingTools", () => {
               sessionId: "session-acp-child",
               updatedAt: Date.now(),
               spawnedBy: "agent:main:subagent:parent",
+              spawnDepth: 2,
+              subagentRole: "leaf",
+              subagentControlScope: "none",
             },
             "agent:main:acp:plain": {
               sessionId: "session-acp-plain",
@@ -285,7 +288,7 @@ describe("createOpenClawCodingTools", () => {
         "utf-8",
       );
 
-      const restrictedTools = createOpenClawCodingTools({
+      const persistedEnvelopeTools = createOpenClawCodingTools({
         sessionKey: "agent:main:acp:child",
         config: {
           session: {
@@ -300,13 +303,13 @@ describe("createOpenClawCodingTools", () => {
           },
         },
       });
-      const restrictedNames = new Set(restrictedTools.map((tool) => tool.name));
-      expect(restrictedNames.has("sessions_spawn")).toBe(false);
-      expect(restrictedNames.has("sessions_list")).toBe(false);
-      expect(restrictedNames.has("sessions_history")).toBe(false);
-      expect(restrictedNames.has("subagents")).toBe(false);
+      const persistedEnvelopeNames = new Set(persistedEnvelopeTools.map((tool) => tool.name));
+      expect(persistedEnvelopeNames.has("sessions_spawn")).toBe(false);
+      expect(persistedEnvelopeNames.has("sessions_list")).toBe(false);
+      expect(persistedEnvelopeNames.has("sessions_history")).toBe(false);
+      expect(persistedEnvelopeNames.has("subagents")).toBe(false);
 
-      const plainTools = createOpenClawCodingTools({
+      const restrictedTools = createOpenClawCodingTools({
         sessionKey: "agent:main:acp:plain",
         config: {
           session: {
@@ -321,11 +324,11 @@ describe("createOpenClawCodingTools", () => {
           },
         },
       });
-      const plainNames = new Set(plainTools.map((tool) => tool.name));
-      expect(plainNames.has("sessions_spawn")).toBe(true);
-      expect(plainNames.has("subagents")).toBe(true);
+      const restrictedNames = new Set(restrictedTools.map((tool) => tool.name));
+      expect(restrictedNames.has("sessions_spawn")).toBe(true);
+      expect(restrictedNames.has("subagents")).toBe(true);
 
-      const crossAgentTools = createOpenClawCodingTools({
+      const ancestryTools = createOpenClawCodingTools({
         sessionKey: "agent:writer:acp:child",
         config: {
           session: {
@@ -340,11 +343,11 @@ describe("createOpenClawCodingTools", () => {
           },
         },
       });
-      const crossAgentNames = new Set(crossAgentTools.map((tool) => tool.name));
-      expect(crossAgentNames.has("sessions_spawn")).toBe(false);
-      expect(crossAgentNames.has("sessions_list")).toBe(false);
-      expect(crossAgentNames.has("sessions_history")).toBe(false);
-      expect(crossAgentNames.has("subagents")).toBe(false);
+      const ancestryNames = new Set(ancestryTools.map((tool) => tool.name));
+      expect(ancestryNames.has("sessions_spawn")).toBe(false);
+      expect(ancestryNames.has("sessions_list")).toBe(false);
+      expect(ancestryNames.has("sessions_history")).toBe(false);
+      expect(ancestryNames.has("subagents")).toBe(false);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -238,6 +238,76 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("applies subagent tool policy to ACP children spawned under a subagent envelope", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-subagent-policy-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      const storePath = storeTemplate.replaceAll("{agentId}", "main");
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:main:acp:child": {
+              sessionId: "session-acp-child",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:subagent:parent",
+            },
+            "agent:main:acp:plain": {
+              sessionId: "session-acp-plain",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const restrictedTools = createOpenClawCodingTools({
+        sessionKey: "agent:main:acp:child",
+        config: {
+          session: {
+            store: storeTemplate,
+          },
+          agents: {
+            defaults: {
+              subagents: {
+                maxSpawnDepth: 2,
+              },
+            },
+          },
+        },
+      });
+      const restrictedNames = new Set(restrictedTools.map((tool) => tool.name));
+      expect(restrictedNames.has("sessions_spawn")).toBe(false);
+      expect(restrictedNames.has("sessions_list")).toBe(false);
+      expect(restrictedNames.has("sessions_history")).toBe(false);
+      expect(restrictedNames.has("subagents")).toBe(false);
+
+      const plainTools = createOpenClawCodingTools({
+        sessionKey: "agent:main:acp:plain",
+        config: {
+          session: {
+            store: storeTemplate,
+          },
+          agents: {
+            defaults: {
+              subagents: {
+                maxSpawnDepth: 2,
+              },
+            },
+          },
+        },
+      });
+      const plainNames = new Set(plainTools.map((tool) => tool.name));
+      expect(plainNames.has("sessions_spawn")).toBe(true);
+      expect(plainNames.has("subagents")).toBe(true);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("supports allow-only sub-agent tool policy", () => {
     const tools = createOpenClawCodingTools({
       sessionKey: "agent:main:subagent:test",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -353,6 +353,68 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("applies leaf tool policy for cross-agent subagent sessions when spawnDepth is missing", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cross-agent-subagent-"));
+    try {
+      const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
+      const mainStorePath = storeTemplate.replaceAll("{agentId}", "main");
+      const writerStorePath = storeTemplate.replaceAll("{agentId}", "writer");
+      await fs.writeFile(
+        mainStorePath,
+        JSON.stringify(
+          {
+            "agent:main:subagent:parent": {
+              sessionId: "session-main-parent",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(
+        writerStorePath,
+        JSON.stringify(
+          {
+            "agent:writer:subagent:child": {
+              sessionId: "session-writer-child",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:subagent:parent",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const tools = createOpenClawCodingTools({
+        sessionKey: "agent:writer:subagent:child",
+        config: {
+          session: {
+            store: storeTemplate,
+          },
+          agents: {
+            defaults: {
+              subagents: {
+                maxSpawnDepth: 2,
+              },
+            },
+          },
+        },
+      });
+      const names = new Set(tools.map((tool) => tool.name));
+      expect(names.has("sessions_spawn")).toBe(false);
+      expect(names.has("sessions_list")).toBe(false);
+      expect(names.has("sessions_history")).toBe(false);
+      expect(names.has("subagents")).toBe(false);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("supports allow-only sub-agent tool policy", () => {
     const tools = createOpenClawCodingTools({
       sessionKey: "agent:main:subagent:test",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -242,9 +242,10 @@ describe("createOpenClawCodingTools", () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-subagent-policy-"));
     try {
       const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
-      const storePath = storeTemplate.replaceAll("{agentId}", "main");
+      const mainStorePath = storeTemplate.replaceAll("{agentId}", "main");
+      const writerStorePath = storeTemplate.replaceAll("{agentId}", "writer");
       await fs.writeFile(
-        storePath,
+        mainStorePath,
         JSON.stringify(
           {
             "agent:main:acp:child": {
@@ -256,6 +257,26 @@ describe("createOpenClawCodingTools", () => {
               sessionId: "session-acp-plain",
               updatedAt: Date.now(),
               spawnedBy: "agent:main:main",
+            },
+            "agent:main:acp:parent": {
+              sessionId: "session-acp-parent",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:subagent:parent",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      await fs.writeFile(
+        writerStorePath,
+        JSON.stringify(
+          {
+            "agent:writer:acp:child": {
+              sessionId: "session-acp-cross-agent-child",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:acp:parent",
             },
           },
           null,
@@ -303,6 +324,27 @@ describe("createOpenClawCodingTools", () => {
       const plainNames = new Set(plainTools.map((tool) => tool.name));
       expect(plainNames.has("sessions_spawn")).toBe(true);
       expect(plainNames.has("subagents")).toBe(true);
+
+      const crossAgentTools = createOpenClawCodingTools({
+        sessionKey: "agent:writer:acp:child",
+        config: {
+          session: {
+            store: storeTemplate,
+          },
+          agents: {
+            defaults: {
+              subagents: {
+                maxSpawnDepth: 2,
+              },
+            },
+          },
+        },
+      });
+      const crossAgentNames = new Set(crossAgentTools.map((tool) => tool.name));
+      expect(crossAgentNames.has("sessions_spawn")).toBe(false);
+      expect(crossAgentNames.has("sessions_list")).toBe(false);
+      expect(crossAgentNames.has("sessions_history")).toBe(false);
+      expect(crossAgentNames.has("subagents")).toBe(false);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -19,7 +19,9 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox.js";
 import {
+  resolveSubagentCapabilityStore,
   resolveStoredSubagentCapabilities,
+  type SessionCapabilityStore,
   type SubagentSessionRole,
 } from "./subagent-capabilities.js";
 import { isToolAllowedByPolicies, isToolAllowedByPolicyName } from "./tool-policy-match.js";
@@ -100,9 +102,19 @@ export function resolveSubagentToolPolicy(cfg?: OpenClawConfig, depth?: number):
 export function resolveSubagentToolPolicyForSession(
   cfg: OpenClawConfig | undefined,
   sessionKey: string,
+  opts?: {
+    store?: SessionCapabilityStore;
+  },
 ): SandboxToolPolicy {
   const configured = cfg?.tools?.subagents?.tools;
-  const capabilities = resolveStoredSubagentCapabilities(sessionKey, { cfg });
+  const store = resolveSubagentCapabilityStore(sessionKey, {
+    cfg,
+    store: opts?.store,
+  });
+  const capabilities = resolveStoredSubagentCapabilities(sessionKey, {
+    cfg,
+    store,
+  });
   const allow = Array.isArray(configured?.allow) ? configured.allow : undefined;
   const alsoAllow = Array.isArray(configured?.alsoAllow) ? configured.alsoAllow : undefined;
   const explicitAllow = new Set(

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -48,7 +48,10 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
-import { isSubagentEnvelopeSession } from "./subagent-capabilities.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "./subagent-capabilities.js";
 import {
   EXEC_TOOL_DISPLAY_SUMMARY,
   PROCESS_TOOL_DISPLAY_SUMMARY,
@@ -395,9 +398,18 @@ export function createOpenClawCodingTools(options?: {
   // Fallback to agentId if no sessionKey is available (e.g. legacy or global contexts).
   const scopeKey =
     options?.exec?.scopeKey ?? options?.sessionKey ?? (agentId ? `agent:${agentId}` : undefined);
+  const subagentStore = resolveSubagentCapabilityStore(options?.sessionKey, {
+    cfg: options?.config,
+  });
   const subagentPolicy =
-    options?.sessionKey && isSubagentEnvelopeSession(options.sessionKey, { cfg: options.config })
-      ? resolveSubagentToolPolicyForSession(options.config, options.sessionKey)
+    options?.sessionKey &&
+    isSubagentEnvelopeSession(options.sessionKey, {
+      cfg: options.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(options.config, options.sessionKey, {
+          store: subagentStore,
+        })
       : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -5,7 +5,6 @@ import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -49,6 +48,7 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import { isSubagentEnvelopeSession } from "./subagent-capabilities.js";
 import {
   EXEC_TOOL_DISPLAY_SUMMARY,
   PROCESS_TOOL_DISPLAY_SUMMARY,
@@ -396,7 +396,7 @@ export function createOpenClawCodingTools(options?: {
   const scopeKey =
     options?.exec?.scopeKey ?? options?.sessionKey ?? (agentId ? `agent:${agentId}` : undefined);
   const subagentPolicy =
-    isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
+    options?.sessionKey && isSubagentEnvelopeSession(options.sessionKey, { cfg: options.config })
       ? resolveSubagentToolPolicyForSession(options.config, options.sessionKey)
       : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -261,9 +261,10 @@ export function resolveStoredSubagentCapabilities(
         store,
       })
     : undefined;
+  const depthStore = opts?.cfg && isAcpSessionKey(normalizedSessionKey) ? undefined : store;
   const depth = getSubagentDepthFromSessionStore(normalizedSessionKey, {
     cfg: opts?.cfg,
-    store,
+    store: depthStore,
   });
   if (!isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, store, entry })) {
     return resolveSubagentCapabilities({ depth, maxSpawnDepth });

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -40,6 +40,16 @@ function shouldInspectStoredSubagentEnvelope(sessionKey: string): boolean {
   return isSubagentSessionKey(sessionKey) || isAcpSessionKey(sessionKey);
 }
 
+function isSameAgentSessionStore(leftSessionKey: string, rightSessionKey: string): boolean {
+  const leftAgentId = normalizeOptionalLowercaseString(
+    parseAgentSessionKey(leftSessionKey)?.agentId,
+  );
+  const rightAgentId = normalizeOptionalLowercaseString(
+    parseAgentSessionKey(rightSessionKey)?.agentId,
+  );
+  return Boolean(leftAgentId) && leftAgentId === rightAgentId;
+}
+
 function readSessionStore(storePath: string): Record<string, SessionCapabilityEntry> {
   try {
     return loadSessionStore(storePath);
@@ -183,11 +193,14 @@ function isStoredSubagentEnvelopeSession(
   if (!spawnedBy) {
     return false;
   }
+  const parentStore = isSameAgentSessionStore(normalizedSessionKey, spawnedBy)
+    ? params.store
+    : undefined;
   return isStoredSubagentEnvelopeSession(
     {
       sessionKey: spawnedBy,
       cfg: params.cfg,
-      store: params.store,
+      store: parentStore,
     },
     visited,
   );

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -261,7 +261,7 @@ export function resolveStoredSubagentCapabilities(
         store,
       })
     : undefined;
-  const depthStore = opts?.cfg && isAcpSessionKey(normalizedSessionKey) ? undefined : store;
+  const depthStore = opts?.cfg && typeof entry?.spawnDepth !== "number" ? undefined : store;
   const depth = getSubagentDepthFromSessionStore(normalizedSessionKey, {
     cfg: opts?.cfg,
     store: depthStore,

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -16,13 +16,15 @@ export type SubagentSessionRole = (typeof SUBAGENT_SESSION_ROLES)[number];
 export const SUBAGENT_CONTROL_SCOPES = ["children", "none"] as const;
 export type SubagentControlScope = (typeof SUBAGENT_CONTROL_SCOPES)[number];
 
-type SessionCapabilityEntry = {
+export type SessionCapabilityEntry = {
   sessionId?: unknown;
   spawnDepth?: unknown;
   subagentRole?: unknown;
   subagentControlScope?: unknown;
   spawnedBy?: unknown;
 };
+
+export type SessionCapabilityStore = Record<string, SessionCapabilityEntry>;
 
 function normalizeSubagentRole(value: unknown): SubagentSessionRole | undefined {
   const trimmed = normalizeOptionalLowercaseString(value);
@@ -34,6 +36,10 @@ function normalizeSubagentControlScope(value: unknown): SubagentControlScope | u
   return SUBAGENT_CONTROL_SCOPES.find((entry) => entry === trimmed);
 }
 
+function shouldInspectStoredSubagentEnvelope(sessionKey: string): boolean {
+  return isSubagentSessionKey(sessionKey) || isAcpSessionKey(sessionKey);
+}
+
 function readSessionStore(storePath: string): Record<string, SessionCapabilityEntry> {
   try {
     return loadSessionStore(storePath);
@@ -43,7 +49,7 @@ function readSessionStore(storePath: string): Record<string, SessionCapabilityEn
 }
 
 function findEntryBySessionId(
-  store: Record<string, SessionCapabilityEntry>,
+  store: SessionCapabilityStore,
   sessionId: string,
 ): SessionCapabilityEntry | undefined {
   const normalizedSessionId = normalizeSubagentSessionKey(sessionId);
@@ -62,7 +68,7 @@ function findEntryBySessionId(
 function resolveSessionCapabilityEntry(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
-  store?: Record<string, SessionCapabilityEntry>;
+  store?: SessionCapabilityStore;
 }): SessionCapabilityEntry | undefined {
   if (params.store) {
     return params.store[params.sessionKey] ?? findEntryBySessionId(params.store, params.sessionKey);
@@ -77,6 +83,31 @@ function resolveSessionCapabilityEntry(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: parsed.agentId });
   const store = readSessionStore(storePath);
   return store[params.sessionKey] ?? findEntryBySessionId(store, params.sessionKey);
+}
+
+export function resolveSubagentCapabilityStore(
+  sessionKey: string | undefined | null,
+  opts?: {
+    cfg?: OpenClawConfig;
+    store?: SessionCapabilityStore;
+  },
+): SessionCapabilityStore | undefined {
+  const normalizedSessionKey = normalizeSubagentSessionKey(sessionKey);
+  if (!normalizedSessionKey) {
+    return opts?.store;
+  }
+  if (opts?.store) {
+    return opts.store;
+  }
+  if (!opts?.cfg || !shouldInspectStoredSubagentEnvelope(normalizedSessionKey)) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(normalizedSessionKey);
+  if (!parsed?.agentId) {
+    return undefined;
+  }
+  const storePath = resolveStorePath(opts.cfg.session?.store, { agentId: parsed.agentId });
+  return readSessionStore(storePath);
 }
 
 export function resolveSubagentRoleForDepth(params: {
@@ -116,7 +147,7 @@ function isStoredSubagentEnvelopeSession(
   params: {
     sessionKey: string;
     cfg?: OpenClawConfig;
-    store?: Record<string, SessionCapabilityEntry>;
+    store?: SessionCapabilityStore;
     entry?: SessionCapabilityEntry;
   },
   visited = new Set<string>(),
@@ -166,7 +197,7 @@ export function isSubagentEnvelopeSession(
   sessionKey: string | undefined | null,
   opts?: {
     cfg?: OpenClawConfig;
-    store?: Record<string, SessionCapabilityEntry>;
+    store?: SessionCapabilityStore;
     entry?: SessionCapabilityEntry;
   },
 ): boolean {
@@ -174,10 +205,17 @@ export function isSubagentEnvelopeSession(
   if (!normalizedSessionKey) {
     return false;
   }
+  if (isSubagentSessionKey(normalizedSessionKey)) {
+    return true;
+  }
+  if (!isAcpSessionKey(normalizedSessionKey)) {
+    return false;
+  }
+  const store = resolveSubagentCapabilityStore(normalizedSessionKey, opts);
   return isStoredSubagentEnvelopeSession({
     sessionKey: normalizedSessionKey,
     cfg: opts?.cfg,
-    store: opts?.store,
+    store,
     entry: opts?.entry,
   });
 }
@@ -186,27 +224,35 @@ export function resolveStoredSubagentCapabilities(
   sessionKey: string | undefined | null,
   opts?: {
     cfg?: OpenClawConfig;
-    store?: Record<string, SessionCapabilityEntry>;
+    store?: SessionCapabilityStore;
   },
 ) {
   const normalizedSessionKey = normalizeSubagentSessionKey(sessionKey);
   const maxSpawnDepth =
     opts?.cfg?.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  if (!normalizedSessionKey) {
+    return resolveSubagentCapabilities({ depth: 0, maxSpawnDepth });
+  }
+  if (!shouldInspectStoredSubagentEnvelope(normalizedSessionKey)) {
+    const depth = getSubagentDepthFromSessionStore(normalizedSessionKey, {
+      cfg: opts?.cfg,
+      store: opts?.store,
+    });
+    return resolveSubagentCapabilities({ depth, maxSpawnDepth });
+  }
+  const store = resolveSubagentCapabilityStore(normalizedSessionKey, opts);
   const entry = normalizedSessionKey
     ? resolveSessionCapabilityEntry({
         sessionKey: normalizedSessionKey,
         cfg: opts?.cfg,
-        store: opts?.store,
+        store,
       })
     : undefined;
   const depth = getSubagentDepthFromSessionStore(normalizedSessionKey, {
     cfg: opts?.cfg,
-    store: opts?.store,
+    store,
   });
-  if (
-    !normalizedSessionKey ||
-    !isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, entry })
-  ) {
+  if (!isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, store, entry })) {
     return resolveSubagentCapabilities({ depth, maxSpawnDepth });
   }
   const storedRole = normalizeSubagentRole(entry?.subagentRole);

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -1,7 +1,11 @@
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  isAcpSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { normalizeSubagentSessionKey } from "./subagent-session-key.js";
@@ -17,6 +21,7 @@ type SessionCapabilityEntry = {
   spawnDepth?: unknown;
   subagentRole?: unknown;
   subagentControlScope?: unknown;
+  spawnedBy?: unknown;
 };
 
 function normalizeSubagentRole(value: unknown): SubagentSessionRole | undefined {
@@ -107,6 +112,71 @@ export function resolveSubagentCapabilities(params: { depth: number; maxSpawnDep
   };
 }
 
+function isStoredSubagentEnvelopeSession(
+  params: {
+    sessionKey: string;
+    cfg?: OpenClawConfig;
+    store?: Record<string, SessionCapabilityEntry>;
+  },
+  visited = new Set<string>(),
+): boolean {
+  const normalizedSessionKey = normalizeSubagentSessionKey(params.sessionKey);
+  if (!normalizedSessionKey || visited.has(normalizedSessionKey)) {
+    return false;
+  }
+  visited.add(normalizedSessionKey);
+
+  if (isSubagentSessionKey(normalizedSessionKey)) {
+    return true;
+  }
+  if (!isAcpSessionKey(normalizedSessionKey)) {
+    return false;
+  }
+
+  const entry = resolveSessionCapabilityEntry({
+    sessionKey: normalizedSessionKey,
+    cfg: params.cfg,
+    store: params.store,
+  });
+  if (
+    normalizeSubagentRole(entry?.subagentRole) ||
+    normalizeSubagentControlScope(entry?.subagentControlScope)
+  ) {
+    return true;
+  }
+
+  const spawnedBy = normalizeSubagentSessionKey(entry?.spawnedBy);
+  if (!spawnedBy) {
+    return false;
+  }
+  return isStoredSubagentEnvelopeSession(
+    {
+      sessionKey: spawnedBy,
+      cfg: params.cfg,
+      store: params.store,
+    },
+    visited,
+  );
+}
+
+export function isSubagentEnvelopeSession(
+  sessionKey: string | undefined | null,
+  opts?: {
+    cfg?: OpenClawConfig;
+    store?: Record<string, SessionCapabilityEntry>;
+  },
+): boolean {
+  const normalizedSessionKey = normalizeSubagentSessionKey(sessionKey);
+  if (!normalizedSessionKey) {
+    return false;
+  }
+  return isStoredSubagentEnvelopeSession({
+    sessionKey: normalizedSessionKey,
+    cfg: opts?.cfg,
+    store: opts?.store,
+  });
+}
+
 export function resolveStoredSubagentCapabilities(
   sessionKey: string | undefined | null,
   opts?: {
@@ -117,18 +187,20 @@ export function resolveStoredSubagentCapabilities(
   const normalizedSessionKey = normalizeSubagentSessionKey(sessionKey);
   const maxSpawnDepth =
     opts?.cfg?.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  const entry = normalizedSessionKey
+    ? resolveSessionCapabilityEntry({
+        sessionKey: normalizedSessionKey,
+        cfg: opts?.cfg,
+        store: opts?.store,
+      })
+    : undefined;
   const depth = getSubagentDepthFromSessionStore(normalizedSessionKey, {
     cfg: opts?.cfg,
     store: opts?.store,
   });
-  if (!normalizedSessionKey || !isSubagentSessionKey(normalizedSessionKey)) {
+  if (!normalizedSessionKey || !isSubagentEnvelopeSession(normalizedSessionKey, opts)) {
     return resolveSubagentCapabilities({ depth, maxSpawnDepth });
   }
-  const entry = resolveSessionCapabilityEntry({
-    sessionKey: normalizedSessionKey,
-    cfg: opts?.cfg,
-    store: opts?.store,
-  });
   const storedRole = normalizeSubagentRole(entry?.subagentRole);
   const storedControlScope = normalizeSubagentControlScope(entry?.subagentControlScope);
   const fallback = resolveSubagentCapabilities({ depth, maxSpawnDepth });

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -117,6 +117,7 @@ function isStoredSubagentEnvelopeSession(
     sessionKey: string;
     cfg?: OpenClawConfig;
     store?: Record<string, SessionCapabilityEntry>;
+    entry?: SessionCapabilityEntry;
   },
   visited = new Set<string>(),
 ): boolean {
@@ -133,11 +134,13 @@ function isStoredSubagentEnvelopeSession(
     return false;
   }
 
-  const entry = resolveSessionCapabilityEntry({
-    sessionKey: normalizedSessionKey,
-    cfg: params.cfg,
-    store: params.store,
-  });
+  const entry =
+    params.entry ??
+    resolveSessionCapabilityEntry({
+      sessionKey: normalizedSessionKey,
+      cfg: params.cfg,
+      store: params.store,
+    });
   if (
     normalizeSubagentRole(entry?.subagentRole) ||
     normalizeSubagentControlScope(entry?.subagentControlScope)
@@ -164,6 +167,7 @@ export function isSubagentEnvelopeSession(
   opts?: {
     cfg?: OpenClawConfig;
     store?: Record<string, SessionCapabilityEntry>;
+    entry?: SessionCapabilityEntry;
   },
 ): boolean {
   const normalizedSessionKey = normalizeSubagentSessionKey(sessionKey);
@@ -174,6 +178,7 @@ export function isSubagentEnvelopeSession(
     sessionKey: normalizedSessionKey,
     cfg: opts?.cfg,
     store: opts?.store,
+    entry: opts?.entry,
   });
 }
 
@@ -198,7 +203,10 @@ export function resolveStoredSubagentCapabilities(
     cfg: opts?.cfg,
     store: opts?.store,
   });
-  if (!normalizedSessionKey || !isSubagentEnvelopeSession(normalizedSessionKey, opts)) {
+  if (
+    !normalizedSessionKey ||
+    !isSubagentEnvelopeSession(normalizedSessionKey, { ...opts, entry })
+  ) {
     return resolveSubagentCapabilities({ depth, maxSpawnDepth });
   }
   const storedRole = normalizeSubagentRole(entry?.subagentRole);

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -1,5 +1,8 @@
 export { formatThinkingLevels, normalizeThinkLevel } from "../auto-reply/thinking.js";
-export { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
+export {
+  DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
+  DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
+} from "../config/agent-limits.js";
 export { loadConfig } from "../config/config.js";
 export { mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
 export { callGateway } from "../gateway/call.js";

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -159,6 +159,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
       params.emitSessionLifecycleEventMock?.(...args),
     formatThinkingLevels: (levels: string[]) => levels.join(", "),
     normalizeThinkLevel: (level: unknown) => normalizeOptionalString(level),
+    DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT: 5,
     DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH: 3,
     ADMIN_SCOPE: "operator.admin",
     AGENT_LANE_SUBAGENT: "subagent",

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -36,6 +36,7 @@ import {
 import {
   ADMIN_SCOPE,
   AGENT_LANE_SUBAGENT,
+  DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
   buildSubagentSystemPrompt,
   callGateway,
@@ -436,7 +437,8 @@ export async function spawnSubagentDirect(
     };
   }
 
-  const maxChildren = cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ?? 5;
+  const maxChildren =
+    cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ?? DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT;
   const activeChildren = countActiveRunsForSession(requesterInternalKey);
   if (activeChildren >= maxChildren) {
     return {

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -29,7 +29,15 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "list", "--json"]);
 
-    expect(buildPluginSnapshotReport).toHaveBeenCalledWith();
+    expect(buildPluginSnapshotReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+        }),
+      }),
+    );
 
     expect(JSON.parse(runtimeLogs[0] ?? "null")).toEqual({
       workspaceDir: "/workspace",

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -16,6 +16,7 @@ import {
   buildPluginSnapshotReport,
   formatPluginCompatibilityNotice,
 } from "../plugins/status.js";
+import type { PluginLogger } from "../plugins/types.js";
 import {
   resolveUninstallChannelConfigKeys,
   resolveUninstallDirectoryTarget,
@@ -64,6 +65,13 @@ export type PluginUninstallOptions = {
   keepConfig?: boolean;
   force?: boolean;
   dryRun?: boolean;
+};
+
+const quietPluginJsonLogger: PluginLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
 };
 
 function formatInspectSection(title: string, lines: string[]): string[] {
@@ -144,7 +152,9 @@ export function registerPluginsCli(program: Command) {
     .option("--enabled", "Only show enabled plugins", false)
     .option("--verbose", "Show detailed entries", false)
     .action((opts: PluginsListOptions) => {
-      const report = buildPluginSnapshotReport();
+      const report = buildPluginSnapshotReport(
+        opts.json ? { logger: quietPluginJsonLogger } : undefined,
+      );
       const list = opts.enabled
         ? report.plugins.filter((p) => p.status === "loaded")
         : report.plugins;
@@ -246,7 +256,10 @@ export function registerPluginsCli(program: Command) {
     .option("--json", "Print JSON")
     .action((id: string | undefined, opts: PluginInspectOptions) => {
       const cfg = loadConfig();
-      const report = buildPluginDiagnosticsReport({ config: cfg });
+      const report = buildPluginDiagnosticsReport({
+        config: cfg,
+        ...(opts.json ? { logger: quietPluginJsonLogger } : {}),
+      });
       if (opts.all) {
         if (id) {
           defaultRuntime.error("Pass either a plugin id or --all, not both.");
@@ -254,6 +267,7 @@ export function registerPluginsCli(program: Command) {
         }
         const inspectAll = buildAllPluginInspectReports({
           config: cfg,
+          ...(opts.json ? { logger: quietPluginJsonLogger } : {}),
           report,
         });
         const inspectAllWithInstall = inspectAll.map((inspect) => ({
@@ -322,6 +336,7 @@ export function registerPluginsCli(program: Command) {
       const inspect = buildPluginInspectReport({
         id,
         config: cfg,
+        ...(opts.json ? { logger: quietPluginJsonLogger } : {}),
         report,
       });
       if (!inspect) {

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -5,7 +5,10 @@ import {
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,
 } from "../agents/pi-tools.policy.js";
-import { isSubagentEnvelopeSession } from "../agents/subagent-capabilities.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../agents/subagent-capabilities.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -61,8 +64,16 @@ export function resolveGatewayScopedTools(params: {
     messageProvider: params.messageProvider,
     accountId: params.accountId ?? null,
   });
-  const subagentPolicy = isSubagentEnvelopeSession(params.sessionKey, { cfg: params.cfg })
-    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey)
+  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
+    cfg: params.cfg,
+  });
+  const subagentPolicy = isSubagentEnvelopeSession(params.sessionKey, {
+    cfg: params.cfg,
+    store: subagentStore,
+  })
+    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey, {
+        store: subagentStore,
+      })
     : undefined;
   const workspaceDir = resolveAgentWorkspaceDir(
     params.cfg,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -3,8 +3,9 @@ import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
-  resolveSubagentToolPolicy,
+  resolveSubagentToolPolicyForSession,
 } from "../agents/pi-tools.policy.js";
+import { isSubagentEnvelopeSession } from "../agents/subagent-capabilities.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -18,7 +19,6 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 
 export type GatewayScopedToolSurface = "http" | "loopback";
@@ -61,8 +61,8 @@ export function resolveGatewayScopedTools(params: {
     messageProvider: params.messageProvider,
     accountId: params.accountId ?? null,
   });
-  const subagentPolicy = isSubagentSessionKey(params.sessionKey)
-    ? resolveSubagentToolPolicy(params.cfg)
+  const subagentPolicy = isSubagentEnvelopeSession(params.sessionKey, { cfg: params.cfg })
+    ? resolveSubagentToolPolicyForSession(params.cfg, params.sessionKey)
     : undefined;
   const workspaceDir = resolveAgentWorkspaceDir(
     params.cfg,

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -79,6 +79,29 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
     );
   });
 
+  it("forwards an explicit logger through metadata snapshots", () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    loadPluginMetadataRegistrySnapshot({
+      config: { plugins: {} },
+      logger,
+      workspaceDir: "/workspace",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: { plugins: {} },
+        logger,
+        workspaceDir: "/workspace",
+        mode: "validate",
+      }),
+    );
+  });
+
   it("preserves explicit empty plugin scopes on metadata snapshots", () => {
     loadPluginMetadataRegistrySnapshot({
       config: { plugins: {} },

--- a/src/plugins/runtime/metadata-registry-loader.ts
+++ b/src/plugins/runtime/metadata-registry-loader.ts
@@ -2,12 +2,14 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasExplicitPluginIdScope } from "../plugin-scope.js";
 import type { PluginRegistry } from "../registry.js";
+import type { PluginLogger } from "../types.js";
 import { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } from "./load-context.js";
 
 export function loadPluginMetadataRegistrySnapshot(options?: {
   config?: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
   workspaceDir?: string;
   onlyPluginIds?: string[];
   loadModules?: boolean;

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -111,6 +111,7 @@ function expectPluginLoaderCall(params: {
   autoEnabledReasons?: Record<string, string[]>;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: unknown;
   loadModules?: boolean;
 }) {
   expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
@@ -124,6 +125,7 @@ function expectPluginLoaderCall(params: {
         : {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.env ? { env: params.env } : {}),
+      ...(params.logger !== undefined ? { logger: params.logger } : {}),
       ...(params.loadModules !== undefined ? { loadModules: params.loadModules } : {}),
     }),
   );
@@ -134,6 +136,7 @@ function expectMetadataSnapshotLoaderCall(params: {
   activationSourceConfig?: unknown;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: unknown;
   loadModules?: boolean;
 }) {
   expect(loadPluginMetadataRegistrySnapshotMock).toHaveBeenCalledWith(
@@ -144,6 +147,7 @@ function expectMetadataSnapshotLoaderCall(params: {
         : {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.env ? { env: params.env } : {}),
+      ...(params.logger !== undefined ? { logger: params.logger } : {}),
       ...(params.loadModules !== undefined ? { loadModules: params.loadModules } : {}),
     }),
   );
@@ -363,6 +367,27 @@ describe("plugin status reports", () => {
       config: {},
       workspaceDir: "/workspace",
       env,
+      loadModules: false,
+    });
+  });
+
+  it("forwards an explicit logger to plugin loading", () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    buildPluginSnapshotReport({
+      config: {},
+      logger,
+      workspaceDir: "/workspace",
+    });
+
+    expectMetadataSnapshotLoaderCall({
+      config: {},
+      logger,
+      workspaceDir: "/workspace",
       loadModules: false,
     });
   });

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -195,6 +195,7 @@ function buildPluginReport(
         activationSourceConfig: rawConfig,
         workspaceDir,
         env: params?.env,
+        logger: params?.logger,
         loadModules: false,
       });
   const importedPluginIds = new Set([

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -26,7 +26,7 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
 import { loadPluginMetadataRegistrySnapshot } from "./runtime/metadata-registry-loader.js";
-import type { PluginHookName } from "./types.js";
+import type { PluginHookName, PluginLogger } from "./types.js";
 
 export type PluginStatusReport = PluginRegistry & {
   workspaceDir?: string;
@@ -134,6 +134,7 @@ type PluginReportParams = {
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
 };
 
 function buildPluginReport(
@@ -143,6 +144,7 @@ function buildPluginReport(
   const baseContext = resolvePluginRuntimeLoadContext({
     config: params?.config ?? loadConfig(),
     env: params?.env,
+    logger: params?.logger,
     workspaceDir: params?.workspaceDir,
   });
   const workspaceDir = baseContext.workspaceDir ?? resolveDefaultAgentWorkspaceDir();
@@ -230,18 +232,21 @@ export function buildPluginInspectReport(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginInspectReport | null {
   const rawConfig = params.config ?? loadConfig();
   const config = resolvePluginRuntimeLoadContext({
     config: rawConfig,
     env: params.env,
+    logger: params.logger,
     workspaceDir: params.workspaceDir,
   }).config;
   const report =
     params.report ??
     buildPluginDiagnosticsReport({
       config: rawConfig,
+      logger: params.logger,
       workspaceDir: params.workspaceDir,
       env: params.env,
     });
@@ -355,6 +360,7 @@ export function buildAllPluginInspectReports(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginInspectReport[] {
   const rawConfig = params?.config ?? loadConfig();
@@ -362,6 +368,7 @@ export function buildAllPluginInspectReports(params?: {
     params?.report ??
     buildPluginDiagnosticsReport({
       config: rawConfig,
+      logger: params?.logger,
       workspaceDir: params?.workspaceDir,
       env: params?.env,
     });
@@ -371,6 +378,7 @@ export function buildAllPluginInspectReports(params?: {
       buildPluginInspectReport({
         id: plugin.id,
         config: rawConfig,
+        logger: params?.logger,
         report,
       }),
     )
@@ -381,6 +389,7 @@ export function buildPluginCompatibilityWarnings(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
   report?: PluginStatusReport;
 }): string[] {
   return buildPluginCompatibilityNotices(params).map(formatPluginCompatibilityNotice);
@@ -390,6 +399,7 @@ export function buildPluginCompatibilityNotices(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginCompatibilityNotice[] {
   return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);


### PR DESCRIPTION
## Summary

- **Problem:** ACP child sessions (`agent:{id}:acp:{uuid}`) were not recognized as subagent-envelope sessions by `isSubagentSessionKey`, so subagent tool policy, spawn-depth caps, per-parent child caps, and the `subagents.allowAgents` target allowlist were all skipped for ACP children spawned from within a subagent envelope.
- **Why it matters:** A restricted subagent could spawn an ACP child and regain access to tools blocked by the subagent deny list (e.g. `sessions_send`, `agents_list`), and bypass depth/child/allowlist caps — all while still running inside the same trusted gateway.
- **What changed:** Introduced `isSubagentEnvelopeSession` (replacing bare `isSubagentSessionKey` in three tool-policy call sites) to transitively detect ACP sessions parented by a subagent envelope via the `spawnedBy` chain. Added `resolveAcpSubagentEnvelopeState` to run depth, child-count, and `allowAgents` checks on the ACP spawn path and patch `spawnDepth`/`subagentRole`/`subagentControlScope` onto the child session record. Extracted `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` constant.
- **What did NOT change:** No changes to `isSubagentSessionKey` itself, ACP approval/allowlist classification, sandbox inheritance, per-sender authorization checks, or `acp.allowedAgents` default behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `isSubagentSessionKey` matches only keys with a `subagent:` rest segment. ACP child keys use `acp:{uuid}` and fell through, so `pi-tools.ts`, `effective-tool-policy.ts`, and `gateway/tool-resolution.ts` all skipped `resolveSubagentToolPolicyForSession` for them. The ACP spawn path in `acp-spawn.ts` also never ran the depth/child/allowAgents guards from `subagent-spawn.ts`.
- Missing detection / guardrail: No classification check or spawn-time guard for the ACP child case — the subagent path and ACP path shared no common enforcement point.
- Contributing context: Same inheritance-drift pattern as prior sandbox inheritance fixes — same ACP spawn call site, different boundary (subagent envelope rather than sandbox).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/agents/acp-spawn.test.ts`, `src/agents/pi-tools.create-openclaw-coding-tools.test.ts`
- Scenario the test should lock in: ACP children spawned from a subagent session receive the subagent tool policy and are rejected when depth/child/allowAgents caps are exceeded.
- Why this is the smallest reliable guardrail: The spawn path and tool-policy gate are both exercised directly; no runtime or channel infrastructure required.
- Existing test that already covers this (if any): None — new cases added.

## User-visible / Behavior Changes

- ACP children spawned from within a subagent envelope now inherit the subagent tool deny list. This is a restriction tightening, not a new permission.
- `subagents.maxSpawnDepth`, `subagents.maxChildrenPerAgent`, and `subagents.allowAgents` now apply to ACP spawns from subagent sessions (previously they applied only to `runtime="subagent"` spawns).
- `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` is now an exported constant (default value unchanged: `5`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — tool deny lists now also apply to ACP child sessions parented by a subagent envelope. This restricts the tool surface for that session class; it does not expand it.
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime: Node 22
- Model/provider: N/A (unit tests only)
- Integration/channel: N/A

### Steps

1. `pnpm install`
2. `pnpm test src/agents/acp-spawn.test.ts`
3. `pnpm test src/agents/pi-tools.create-openclaw-coding-tools.test.ts`
4. `pnpm tsgo:prod`

### Expected

- All new test cases pass: depth rejection, child-cap rejection, allowAgents rejection, envelope field inheritance, ACP-child tool policy restriction.

### Actual

- All tests pass on branch HEAD.

## Evidence

- [x] Failing test/log before + passing after — four new `acp-spawn.test.ts` cases and one new `pi-tools` integration case, all green on branch.

## Human Verification (required)

> ⚠️ AI-assisted PR — generated by OpenAI Codex, reviewed by Claude Code. No human runtime verification was performed.

- Verified scenarios: Static analysis and unit test review confirm the three tool-policy call sites and the spawn-time gate are consistent with each other and with the prior subagent-spawn path.
- Edge cases checked: Non-subagent ACP sessions (plain ACP, not under a subagent envelope) are unaffected — `isSubagentEnvelopeSession` returns false for them and the spawn-time gate exits early.
- What you did **not** verify: Live gateway session, end-to-end channel round-trip, macOS app smoke.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — restriction tightening only; no API or config surface removed.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: ACP children of subagents that previously had unrestricted tool access will now receive the deny list. Operators relying (intentionally or not) on the old behavior may see tool calls blocked.
  - Mitigation: The change matches the documented contract for subagent envelopes. No operator-visible config change is required. The fix aligns ACP spawn with `runtime="subagent"` spawn behavior.