### PR TITLE
Extensions: add aj-router plugin for classifier-driven model selection

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -225,6 +225,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/lobster/**"
+"extensions: aj-router":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/aj-router/**"
+          - "docs/plugins/aj-router.md"
 "extensions: memory-core":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/plugins/aj-router.md
+++ b/docs/plugins/aj-router.md
@@ -1,0 +1,95 @@
+---
+title: AJ Router
+description: Classifier-driven model selection with sensitivity gating.
+---
+
+The **AJ Router** plugin picks the cheapest provider/model pair that can
+handle each request, gated by a data-sensitivity policy. It runs on the
+`before_model_resolve` hook and rewrites the provider+model override for
+every agent run.
+
+Plugin id: `aj-router`. Disabled by default.
+
+## When to enable
+
+Turn this on when:
+
+- You have multiple providers configured and want to stop paying flagship
+  prices for trivial classification/extraction tasks.
+- You handle data at different sensitivity levels (e.g. business ops vs.
+  client-privileged material) and want a hard gate that privileged prompts
+  never leave the machine.
+- You want post-hoc routing telemetry for cost analysis.
+
+## Enable
+
+Add to `openclaw.json`:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "aj-router": { "enabled": true },
+    },
+  },
+}
+```
+
+Built-in defaults route simple prompts to Haiku 4.5 and everything else
+to Sonnet 4.6. Override any key under `plugins.entries["aj-router"].config`.
+
+## Decision flow
+
+```
+prompt + sensitivity
+      │
+      ▼
+classifier (heuristic) ──► tier: simple | medium | complex
+      │
+      ▼
+classificationRules ──► alias
+      │
+      ▼
+aliases ──► candidate provider/model
+      │
+      ▼
+sensitivity gate ──► allow | force-alias | reject
+      │
+      ▼
+escalation (if confidence < threshold) ──► bump tier one rung
+      │
+      ▼
+modelOverride + providerOverride (or fall-through on reject)
+```
+
+## Commands
+
+Run inside any chat surface:
+
+- `/router stats` — last 7 days of routing activity.
+- `/router health` — alias map with auth-env-var status per provider.
+- `/router explain <prompt>` — dry-run the resolver, show the full trail.
+
+## Privileged data
+
+Set `sensitivity.privileged.forceAlias = "privileged"` and
+`sensitivity.privileged.blockExternal = true`. Point the `privileged`
+alias at a local provider (`ollama/<model>` or `lmstudio/<model>`).
+
+Requests tagged `privileged` that would resolve to an external provider
+are **rejected**, not silently sent — the hook returns no override, and
+the request falls through to the caller-chosen model.
+
+## Logs
+
+Default: `~/.openclaw/logs/aj-router/routing.jsonl`. One line per
+decision. Stored fields: timestamp, sensitivity, tier, confidence,
+alias, modelRef, escalated flag, prompt length, rejection reason (if
+any). The prompt itself is **never** stored.
+
+Override with `plugins.entries["aj-router"].config.logsDir`.
+
+## See also
+
+- `extensions/aj-router/README.md` — plugin-level details, tests
+- Hook reference: `before_model_resolve` in the SDK types

--- a/extensions/aj-router/README.md
+++ b/extensions/aj-router/README.md
@@ -1,0 +1,111 @@
+# @openclaw/aj-router
+
+Classifier-driven model selection plugin. Routes every agent run to the
+cheapest alias that can handle the prompt, gated by a data-sensitivity
+policy. Logs every decision as JSONL for post-hoc cost analysis.
+
+## What it does
+
+1. **Classifies** the prompt via a cheap, deterministic heuristic
+   (`simple | medium | complex`).
+2. **Maps** the tier to an alias via `classificationRules`.
+3. **Resolves** the alias to a concrete `provider/model` reference via
+   `aliases`.
+4. **Gates** the result through the configured `sensitivity` rule —
+   privileged data can be forced onto a local model, confidential onto
+   a whitelisted provider, etc.
+5. **Escalates** one tier up when the classifier's confidence falls
+   below `escalationThreshold`.
+6. **Logs** the decision to `<logsDir>/routing.jsonl`.
+7. Emits model+provider overrides via the `before_model_resolve` hook.
+
+The plugin is disabled by default. Enable it by setting
+`plugins.entries["aj-router"].enabled = true` in `openclaw.json`.
+
+## Configuration
+
+All keys live under `plugins.entries["aj-router"].config` in `openclaw.json`.
+Missing keys fall back to the defaults baked into the plugin.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "aj-router": {
+        "enabled": true,
+        "config": {
+          "defaultAlias": "workhorse",
+          "aliases": {
+            "speed": "anthropic/claude-haiku-4-5",
+            "workhorse": "anthropic/claude-sonnet-4-6",
+            "flagship": "anthropic/claude-sonnet-4-6",
+          },
+          "classificationRules": {
+            "simple": "speed",
+            "medium": "workhorse",
+            "complex": "flagship",
+          },
+          "classifier": { "mode": "heuristic" },
+          "sensitivity": {
+            "privileged": { "forceAlias": "privileged", "blockExternal": true },
+            "confidential": { "allowedProviders": ["anthropic"] },
+            "internal": { "allowedProviders": ["anthropic", "google", "openai"] },
+            "public": { "allowedProviders": "*" },
+          },
+          "defaultSensitivity": "internal",
+          "escalationThreshold": 0.85,
+          "budgetCeilingUsdPerRequest": 0.05,
+        },
+      },
+    },
+  },
+}
+```
+
+## Commands
+
+- `/router stats` — summary of the last 7 days (decisions, per-alias mix,
+  escalation rate, average confidence).
+- `/router health` — shows the alias map and whether each provider's auth
+  env var is populated.
+- `/router explain <prompt>` — dry-runs the resolver on the given prompt
+  and prints the full decision trail without logging.
+
+## Sensitivity labels
+
+| Label          | Default policy                                                  |
+| -------------- | --------------------------------------------------------------- |
+| `public`       | Any provider allowed.                                           |
+| `internal`     | Anthropic, Google, OpenAI allowed. (Default when unspecified.)  |
+| `confidential` | Anthropic only.                                                 |
+| `privileged`   | Forced to the `privileged` alias; must resolve to a local model |
+|                | (ollama, lmstudio, llamafile) or the request is rejected.       |
+
+> **Note:** `privileged` only functions when the `privileged` alias points
+> at a local provider. Out of the box it points at Anthropic as a
+> placeholder and all privileged requests reject — configure Ollama and
+> re-point the alias before classifying real privileged data.
+
+## Logs
+
+Default path: `~/.openclaw/logs/aj-router/routing.jsonl`. One JSON record
+per decision. The log stores prompt **length**, not the prompt itself.
+
+## Classifier
+
+v1 is heuristic-only:
+
+- Long prompts (>4000 chars) → `complex`.
+- Keyword-driven patterns for simple (classify/extract/yes-no) and
+  complex (architecture/multi-agent/legal/privileged).
+- Short prompts default to `simple` with low confidence so they
+  escalate if unsure.
+
+A follow-up will wire `classifier.mode: "llm"` to call a small model
+(Haiku 4.5) for ambiguous cases.
+
+## Tests
+
+```bash
+pnpm vitest run extensions/aj-router
+```

--- a/extensions/aj-router/classifier.test.ts
+++ b/extensions/aj-router/classifier.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { classifyHeuristic } from "./classifier.js";
+
+describe("aj-router classifier", () => {
+  it("classifies short 'classify' prompts as simple with high confidence", () => {
+    const result = classifyHeuristic({
+      prompt: "Classify this email as sales, support, or spam.",
+    });
+    expect(result.tier).toBe("simple");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it("classifies explicit architecture requests as complex", () => {
+    const result = classifyHeuristic({
+      prompt: "Design a system architecture for multi-region failover.",
+    });
+    expect(result.tier).toBe("complex");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it("classifies legal/privileged keywords as complex", () => {
+    const result = classifyHeuristic({
+      prompt: "Review this attorney-client communication for privilege.",
+    });
+    expect(result.tier).toBe("complex");
+  });
+
+  it("returns medium for generic mid-length prompts without signal", () => {
+    // Must exceed SHORT_PROMPT_CHARS (200) to avoid the short-prompt fallback
+    // that classifies unknown shapes as 'simple' with low confidence.
+    const prompt =
+      "Write the follow-up message for tomorrow's meeting. It should cover the pricing agreement, delivery terms, and call out the three open action items from last week. Keep it polite but direct so the counterparty can tell what is blocking and what still needs their input. Include timestamps where useful.";
+    const result = classifyHeuristic({ prompt });
+    expect(result.tier).toBe("medium");
+  });
+
+  it("returns complex for very long prompts even without keywords", () => {
+    const result = classifyHeuristic({
+      prompt: "x".repeat(5000),
+    });
+    expect(result.tier).toBe("complex");
+  });
+
+  it("returns simple with low confidence for unclear short prompts", () => {
+    const result = classifyHeuristic({ prompt: "what?" });
+    expect(result.tier).toBe("simple");
+    expect(result.confidence).toBeLessThan(0.85);
+  });
+});

--- a/extensions/aj-router/classifier.ts
+++ b/extensions/aj-router/classifier.ts
@@ -1,0 +1,122 @@
+/**
+ * Heuristic prompt classifier.
+ *
+ * v1 avoids any LLM call: we pattern-match on prompt shape, length, and
+ * keywords to produce a `{ tier, confidence }` decision. The `before_model_resolve`
+ * hook runs on every request, so the classifier must be cheap and deterministic.
+ *
+ * When `classifier.mode === "llm"` is wired up in a follow-up, the same
+ * return shape is emitted by an LLM call so downstream code is unchanged.
+ */
+
+import type { ClassifierTier } from "./config.js";
+
+export type Classification = {
+  tier: ClassifierTier;
+  confidence: number;
+  /** Short human-readable explanation of the decision (used by /router explain). */
+  reason: string;
+};
+
+const SIMPLE_PATTERNS: readonly RegExp[] = [
+  /\b(classify|categorize|categorise|label|tag)\b/i,
+  /\b(extract|pull|parse)\s+(out\s+)?(the|this|these)?\b/i,
+  /\b(yes|no)\??\s*$/i,
+  /\b(is|are|was|were)\s+(this|that|these|those)\s+/i,
+  /\b(translate|convert|reformat|rename)\b/i,
+  /\bsentiment\b/i,
+  /\bsummari[sz]e\s+(in|to)\s+\w+\s+(words?|sentences?|bullet)/i,
+];
+
+const COMPLEX_PATTERNS: readonly RegExp[] = [
+  /\b(architect(ure)?|design\s+a\s+system|refactor\s+the\s+entire)/i,
+  /\b(multi-?agent|orchestrate|coordinate\s+(several|multiple))/i,
+  /\b(full[- ]codebase|whole\s+repo|across\s+the\s+codebase)/i,
+  /\b(legal|privilege[d]?|evidence|attorney[- ]client)/i,
+  /\b(financial\s+model|deal\s+memo|pro[- ]?forma)/i,
+  /\bplan\s+(a\s+)?(migration|rollout|release)/i,
+];
+
+const SHORT_PROMPT_CHARS = 200;
+const LONG_PROMPT_CHARS = 4000;
+
+export type ClassifyParams = {
+  prompt: string;
+};
+
+function matchesAny(text: string, patterns: readonly RegExp[]): RegExp | undefined {
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      return pattern;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Heuristic classifier. Returns the tier plus a confidence score.
+ *
+ * Scoring:
+ * - Long prompts (>4000 chars) → `complex` with 0.9 confidence
+ * - Explicit complex keywords → `complex` with 0.9 confidence
+ * - Short prompts (<200 chars) matching simple patterns → `simple` with 0.9 confidence
+ * - Short prompts without simple-pattern match → `simple` with 0.7 confidence (will escalate)
+ * - Everything else → `medium` with 0.85 confidence
+ *
+ * The confidence values are tuned so the default `escalationThreshold` of 0.85
+ * lets clearly-simple and clearly-complex requests through without escalation,
+ * while genuinely ambiguous requests bump up one tier.
+ */
+export function classifyHeuristic(params: ClassifyParams): Classification {
+  const prompt = params.prompt ?? "";
+  const trimmed = prompt.trim();
+  const length = trimmed.length;
+
+  const complexMatch = matchesAny(trimmed, COMPLEX_PATTERNS);
+  if (complexMatch) {
+    return {
+      tier: "complex",
+      confidence: 0.9,
+      reason: `matched complex keyword: ${complexMatch.source}`,
+    };
+  }
+
+  if (length > LONG_PROMPT_CHARS) {
+    return {
+      tier: "complex",
+      confidence: 0.9,
+      reason: `long prompt (${length} chars > ${LONG_PROMPT_CHARS})`,
+    };
+  }
+
+  const simpleMatch = matchesAny(trimmed, SIMPLE_PATTERNS);
+  if (simpleMatch && length < SHORT_PROMPT_CHARS) {
+    return {
+      tier: "simple",
+      confidence: 0.9,
+      reason: `short prompt with simple keyword: ${simpleMatch.source}`,
+    };
+  }
+
+  if (simpleMatch) {
+    return {
+      tier: "simple",
+      confidence: 0.75,
+      reason: `simple keyword matched but prompt is not short (${length} chars)`,
+    };
+  }
+
+  if (length < SHORT_PROMPT_CHARS) {
+    return {
+      tier: "simple",
+      confidence: 0.7,
+      reason: `short prompt (${length} chars < ${SHORT_PROMPT_CHARS}) without clear signal`,
+    };
+  }
+
+  return {
+    tier: "medium",
+    confidence: 0.85,
+    reason: `default medium tier (${length} chars, no special patterns)`,
+  };
+}

--- a/extensions/aj-router/commands.test.ts
+++ b/extensions/aj-router/commands.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { dispatch, formatExplain, formatHealth, formatStats } from "./commands.js";
+import { ROUTER_DEFAULTS } from "./config.js";
+import type { StatsSummary } from "./stats.js";
+
+const FAKE_SUMMARY: StatsSummary = {
+  totalDecisions: 10,
+  rejected: 1,
+  escalated: 2,
+  perAlias: [
+    { alias: "speed", count: 6 },
+    { alias: "workhorse", count: 3 },
+  ],
+  averageConfidence: 0.88,
+  window: { startMs: 0, endMs: 1 },
+};
+
+describe("aj-router commands", () => {
+  it("formats stats with per-alias percentages", () => {
+    const text = formatStats(FAKE_SUMMARY);
+    expect(text).toContain("Decisions: 10");
+    expect(text).toContain("speed");
+    expect(text).toContain("60.0%");
+    expect(text).toContain("Escalations: 2");
+  });
+
+  it("formatStats handles the empty case gracefully", () => {
+    const text = formatStats({
+      ...FAKE_SUMMARY,
+      totalDecisions: 0,
+      perAlias: [],
+      escalated: 0,
+      rejected: 0,
+    });
+    expect(text).toMatch(/no routing decisions/);
+  });
+
+  it("formats health with auth status per alias", () => {
+    const envReader = (name: string) => (name === "ANTHROPIC_API_KEY" ? "sk-test" : undefined);
+    const text = formatHealth({ config: ROUTER_DEFAULTS, envReader });
+    expect(text).toContain("speed");
+    expect(text).toContain("[ok]");
+  });
+
+  it("explains a routing decision with a trail", () => {
+    const text = formatExplain({
+      config: ROUTER_DEFAULTS,
+      prompt: "Classify this email as spam.",
+    });
+    expect(text).toContain("AJ ROUTER — EXPLAIN");
+    expect(text).toContain("speed");
+    expect(text).toMatch(/•/);
+  });
+
+  it("dispatch routes 'stats' subcommand through the loader", async () => {
+    const text = await dispatch({
+      config: ROUTER_DEFAULTS,
+      args: "stats",
+      statsLoader: async () => FAKE_SUMMARY,
+    });
+    expect(text).toContain("AJ ROUTER — LAST 7 DAYS");
+  });
+
+  it("dispatch handles unknown subcommand with usage hint", async () => {
+    const text = await dispatch({
+      config: ROUTER_DEFAULTS,
+      args: "bogus",
+    });
+    expect(text).toMatch(/Unknown .* subcommand/);
+  });
+
+  it("dispatch requires a prompt for 'explain'", async () => {
+    const text = await dispatch({
+      config: ROUTER_DEFAULTS,
+      args: "explain",
+    });
+    expect(text).toMatch(/Usage: \/router explain/);
+  });
+});

--- a/extensions/aj-router/commands.ts
+++ b/extensions/aj-router/commands.ts
@@ -1,0 +1,165 @@
+/**
+ * `/router` command dispatcher. Single command with subcommands:
+ *   - `/router stats` — 7-day summary from the routing log
+ *   - `/router health` — show the alias map and whether each provider's
+ *     auth env var is populated
+ *   - `/router explain <prompt>` — dry-run the resolver without logging
+ */
+
+import type { RouterConfig } from "./config.js";
+import { resolve, isRejection } from "./resolver.js";
+import { lastNDaysWindow, loadSummary, type StatsSummary } from "./stats.js";
+
+const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+  xai: ["XAI_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  ollama: ["OLLAMA_HOST"],
+  lmstudio: ["LM_API_TOKEN"],
+};
+
+function providerIdFromRef(ref: string): string {
+  const slash = ref.indexOf("/");
+  return slash === -1 ? ref : ref.slice(0, slash);
+}
+
+export type EnvReader = (name: string) => string | undefined;
+
+function defaultEnvReader(name: string): string | undefined {
+  return process.env[name];
+}
+
+function formatPct(n: number, digits = 1): string {
+  return `${n.toFixed(digits)}%`;
+}
+
+function formatConfidence(n: number): string {
+  return n.toFixed(2);
+}
+
+export function formatStats(summary: StatsSummary): string {
+  if (summary.totalDecisions === 0) {
+    return "AJ router — no routing decisions recorded in the last 7 days.";
+  }
+  const lines: string[] = [];
+  lines.push("📊 AJ ROUTER — LAST 7 DAYS");
+  lines.push("");
+  lines.push(`Decisions: ${summary.totalDecisions}`);
+  if (summary.rejected > 0) {
+    lines.push(`Rejected:  ${summary.rejected}`);
+  }
+  lines.push("");
+  lines.push("By alias:");
+  for (const stat of summary.perAlias) {
+    const pct = (stat.count / summary.totalDecisions) * 100;
+    lines.push(`  ${stat.alias.padEnd(10)} ${String(stat.count).padStart(5)}  (${formatPct(pct)})`);
+  }
+  lines.push("");
+  const escalationPct =
+    summary.totalDecisions === 0 ? 0 : (summary.escalated / summary.totalDecisions) * 100;
+  lines.push(`Escalations: ${summary.escalated} (${formatPct(escalationPct)})`);
+  lines.push(`Avg confidence: ${formatConfidence(summary.averageConfidence)}`);
+  return lines.join("\n");
+}
+
+export type FormatHealthParams = {
+  config: RouterConfig;
+  envReader?: EnvReader;
+};
+
+export function formatHealth(params: FormatHealthParams): string {
+  const env = params.envReader ?? defaultEnvReader;
+  const lines: string[] = [];
+  lines.push("🦞 AJ ROUTER — HEALTH");
+  lines.push("");
+  lines.push("Alias map:");
+  const rows: Array<[string, string, string]> = [];
+  const aliasWidth = Math.max(...Object.keys(params.config.aliases).map((a) => a.length), 5);
+  for (const [alias, ref] of Object.entries(params.config.aliases)) {
+    const providerId = providerIdFromRef(ref);
+    const envVars = PROVIDER_ENV_VARS[providerId] ?? [];
+    const anySet = envVars.some((name) => {
+      const v = env(name);
+      return typeof v === "string" && v.length > 0;
+    });
+    const status = envVars.length === 0 ? "unknown" : anySet ? "ok" : "missing auth";
+    rows.push([alias.padEnd(aliasWidth), ref, status]);
+  }
+  for (const [alias, ref, status] of rows) {
+    lines.push(`  ${alias}  →  ${ref.padEnd(36)} [${status}]`);
+  }
+  lines.push("");
+  lines.push(`Default alias: ${params.config.defaultAlias}`);
+  lines.push(`Default sensitivity: ${params.config.defaultSensitivity}`);
+  lines.push(`Escalation threshold: ${params.config.escalationThreshold.toFixed(2)}`);
+  return lines.join("\n");
+}
+
+export type FormatExplainParams = {
+  config: RouterConfig;
+  prompt: string;
+  sensitivity?: string;
+};
+
+export function formatExplain(params: FormatExplainParams): string {
+  const result = resolve({
+    config: params.config,
+    prompt: params.prompt,
+    sensitivity: params.sensitivity,
+  });
+  const lines: string[] = [];
+  lines.push("🧭 AJ ROUTER — EXPLAIN");
+  lines.push("");
+  lines.push(`Prompt length: ${params.prompt.length}`);
+  if (params.sensitivity) {
+    lines.push(`Sensitivity:   ${params.sensitivity}`);
+  }
+  lines.push("");
+  for (const step of result.trail) {
+    lines.push(`  • ${step}`);
+  }
+  lines.push("");
+  if (isRejection(result)) {
+    lines.push(`REJECTED: ${result.reason}`);
+  } else {
+    lines.push(`→ ${result.alias}: ${result.modelRef}`);
+  }
+  return lines.join("\n");
+}
+
+export type DispatchParams = {
+  config: RouterConfig;
+  args: string;
+  envReader?: EnvReader;
+  statsLoader?: (logsDir: string) => Promise<StatsSummary>;
+};
+
+/** Dispatch `/router <sub> [args]` → rendered text response. */
+export async function dispatch(params: DispatchParams): Promise<string> {
+  const tokens = params.args.trim().split(/\s+/).filter(Boolean);
+  const sub = (tokens[0] ?? "").toLowerCase();
+  const rest = tokens.slice(1).join(" ");
+
+  if (sub === "stats" || sub === "") {
+    const loader =
+      params.statsLoader ??
+      (async (dir) => loadSummary({ logsDir: dir, window: lastNDaysWindow(7) }));
+    const summary = await loader(params.config.logsDir);
+    return formatStats(summary);
+  }
+
+  if (sub === "health") {
+    return formatHealth({ config: params.config, envReader: params.envReader });
+  }
+
+  if (sub === "explain") {
+    if (rest.length === 0) {
+      return "Usage: /router explain <prompt>";
+    }
+    return formatExplain({ config: params.config, prompt: rest });
+  }
+
+  return `Unknown /router subcommand: '${sub}'. Try: stats | health | explain <prompt>`;
+}

--- a/extensions/aj-router/config.test.ts
+++ b/extensions/aj-router/config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ROUTER_DEFAULTS, resolveConfig } from "./config.js";
+
+describe("aj-router config", () => {
+  it("returns full defaults when raw is undefined", () => {
+    const cfg = resolveConfig({ raw: undefined, homeDir: "/home/u" });
+    expect(cfg.defaultAlias).toBe(ROUTER_DEFAULTS.defaultAlias);
+    expect(cfg.aliases).toEqual(ROUTER_DEFAULTS.aliases);
+    expect(cfg.logsDir).toBe("/home/u/.openclaw/logs/aj-router");
+  });
+
+  it("accepts partial overrides without dropping defaults", () => {
+    const cfg = resolveConfig({
+      raw: {
+        defaultAlias: "flagship",
+        escalationThreshold: 0.9,
+      },
+      homeDir: "/home/u",
+    });
+    expect(cfg.defaultAlias).toBe("flagship");
+    expect(cfg.escalationThreshold).toBeCloseTo(0.9);
+    // Defaults preserved for everything else.
+    expect(cfg.aliases).toEqual(ROUTER_DEFAULTS.aliases);
+    expect(cfg.classifier).toEqual(ROUTER_DEFAULTS.classifier);
+  });
+
+  it("normalizes classifier mode to 'heuristic' for unknown values", () => {
+    const cfg = resolveConfig({
+      raw: { classifier: { mode: "garbage-value", model: "x/y" } },
+      homeDir: "/home/u",
+    });
+    expect(cfg.classifier.mode).toBe("heuristic");
+    expect(cfg.classifier.model).toBe("x/y");
+  });
+
+  it("accepts a wildcard allowedProviders value", () => {
+    const cfg = resolveConfig({
+      raw: {
+        sensitivity: {
+          public: { allowedProviders: "*" },
+        },
+      },
+      homeDir: "/home/u",
+    });
+    expect(cfg.sensitivity.public?.allowedProviders).toBe("*");
+  });
+
+  it("accepts an explicit logsDir override", () => {
+    const cfg = resolveConfig({
+      raw: { logsDir: "/var/log/aj-router" },
+      homeDir: "/home/u",
+    });
+    expect(cfg.logsDir).toBe("/var/log/aj-router");
+  });
+});

--- a/extensions/aj-router/config.ts
+++ b/extensions/aj-router/config.ts
@@ -1,0 +1,227 @@
+/**
+ * Config loader for the AJ Router plugin.
+ *
+ * Reads the raw `pluginConfig` block (from `plugins.entries["aj-router"].config`
+ * in `openclaw.json`), validates required invariants, and returns a typed,
+ * defaulted `RouterConfig` that the runtime paths can trust.
+ *
+ * No runtime side effects here — pure parse + defaults. All missing keys fall
+ * back to safe defaults so the plugin is a no-op when enabled without config.
+ */
+
+export type ClassifierTier = "simple" | "medium" | "complex";
+
+export type ClassifierMode = "heuristic" | "llm";
+
+export type SensitivityRule = {
+  /**
+   * If set, every request with this sensitivity is forced to the given alias
+   * regardless of classifier output. Used for `privileged` → local model.
+   */
+  forceAlias?: string;
+  /**
+   * If true, the request must NEVER leave the local machine. Enforced by
+   * refusing to resolve to any provider that is not `ollama`/`lmstudio` or
+   * another local-only provider.
+   */
+  blockExternal?: boolean;
+  /**
+   * Whitelist of allowed provider ids. `"*"` means any. If omitted, no
+   * provider filter is applied.
+   */
+  allowedProviders?: string[] | "*";
+};
+
+export type RouterConfig = {
+  /** Alias used when no classification output is available. */
+  defaultAlias: string;
+  /** Alias → concrete "provider/model" reference. */
+  aliases: Record<string, string>;
+  /** Classifier tier → alias. */
+  classificationRules: Record<ClassifierTier, string>;
+  /** Classifier implementation. v1 ships heuristic only. */
+  classifier: {
+    mode: ClassifierMode;
+    model: string;
+  };
+  /** Sensitivity label → rule. */
+  sensitivity: Record<string, SensitivityRule>;
+  /** Fallback label when the request carries no sensitivity field. */
+  defaultSensitivity: string;
+  /** Confidence floor. Below this, escalate one alias up the ladder. */
+  escalationThreshold: number;
+  /** Abort a request whose estimated cost exceeds this dollar amount. */
+  budgetCeilingUsdPerRequest: number;
+  /** Absolute path for the routing JSONL log. */
+  logsDir: string;
+};
+
+/**
+ * Hard-coded defaults. Mirrors the out-of-repo `aj/router/routing.json`
+ * contents so the plugin works even if a user never writes config.
+ */
+export const ROUTER_DEFAULTS: RouterConfig = {
+  defaultAlias: "workhorse",
+  aliases: {
+    speed: "anthropic/claude-haiku-4-5",
+    workhorse: "anthropic/claude-sonnet-4-6",
+    flagship: "anthropic/claude-sonnet-4-6",
+    value: "anthropic/claude-sonnet-4-6",
+    realtime: "anthropic/claude-sonnet-4-6",
+    multimodal: "anthropic/claude-sonnet-4-6",
+    terminal: "anthropic/claude-sonnet-4-6",
+    bulk: "anthropic/claude-haiku-4-5",
+    privileged: "anthropic/claude-sonnet-4-6",
+  },
+  classificationRules: {
+    simple: "speed",
+    medium: "workhorse",
+    complex: "flagship",
+  },
+  classifier: {
+    mode: "heuristic",
+    model: "anthropic/claude-haiku-4-5",
+  },
+  sensitivity: {
+    privileged: { forceAlias: "privileged", blockExternal: true },
+    confidential: { allowedProviders: ["anthropic"] },
+    internal: { allowedProviders: ["anthropic", "google", "openai"] },
+    public: { allowedProviders: "*" },
+  },
+  defaultSensitivity: "internal",
+  escalationThreshold: 0.85,
+  budgetCeilingUsdPerRequest: 0.05,
+  logsDir: "",
+};
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function coerceStringMap(value: unknown): Record<string, string> | undefined {
+  if (!isStringRecord(value)) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v !== "string") {
+      return undefined;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+function coerceClassifier(value: unknown): RouterConfig["classifier"] {
+  if (!isStringRecord(value)) {
+    return { ...ROUTER_DEFAULTS.classifier };
+  }
+  const mode = value.mode === "llm" ? "llm" : "heuristic";
+  const model =
+    typeof value.model === "string" && value.model.length > 0
+      ? value.model
+      : ROUTER_DEFAULTS.classifier.model;
+  return { mode, model };
+}
+
+function coerceSensitivity(value: unknown): Record<string, SensitivityRule> {
+  if (!isStringRecord(value)) {
+    return { ...ROUTER_DEFAULTS.sensitivity };
+  }
+  const out: Record<string, SensitivityRule> = {};
+  for (const [label, raw] of Object.entries(value)) {
+    if (!isStringRecord(raw)) {
+      continue;
+    }
+    const rule: SensitivityRule = {};
+    if (typeof raw.forceAlias === "string") {
+      rule.forceAlias = raw.forceAlias;
+    }
+    if (typeof raw.blockExternal === "boolean") {
+      rule.blockExternal = raw.blockExternal;
+    }
+    if (raw.allowedProviders === "*") {
+      rule.allowedProviders = "*";
+    } else if (Array.isArray(raw.allowedProviders)) {
+      const providers = raw.allowedProviders.filter((v): v is string => typeof v === "string");
+      if (providers.length === raw.allowedProviders.length) {
+        rule.allowedProviders = providers;
+      }
+    }
+    out[label] = rule;
+  }
+  return out;
+}
+
+function coerceClassificationRules(value: unknown): Record<ClassifierTier, string> {
+  const stringMap = coerceStringMap(value);
+  if (!stringMap) {
+    return { ...ROUTER_DEFAULTS.classificationRules };
+  }
+  const out: Record<ClassifierTier, string> = {
+    ...ROUTER_DEFAULTS.classificationRules,
+  };
+  for (const tier of ["simple", "medium", "complex"] as const) {
+    const alias = stringMap[tier];
+    if (typeof alias === "string" && alias.length > 0) {
+      out[tier] = alias;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the default logs directory. Kept as a function so tests can stub
+ * `homedir` via dependency injection in callers.
+ */
+export function defaultLogsDir(homeDir: string): string {
+  return `${homeDir}/.openclaw/logs/aj-router`;
+}
+
+export type ResolveConfigParams = {
+  /** Raw value from `api.pluginConfig`. May be undefined/null. */
+  raw: unknown;
+  /** Home directory (to compute the default logs path). */
+  homeDir: string;
+};
+
+/** Parse and default the router config. Never throws. */
+export function resolveConfig(params: ResolveConfigParams): RouterConfig {
+  const raw = isStringRecord(params.raw) ? params.raw : {};
+  const aliases = coerceStringMap(raw.aliases) ?? { ...ROUTER_DEFAULTS.aliases };
+  const classificationRules = coerceClassificationRules(raw.classificationRules);
+  const classifier = coerceClassifier(raw.classifier);
+  const sensitivity = coerceSensitivity(raw.sensitivity);
+  const defaultAlias =
+    typeof raw.defaultAlias === "string" && raw.defaultAlias.length > 0
+      ? raw.defaultAlias
+      : ROUTER_DEFAULTS.defaultAlias;
+  const defaultSensitivity =
+    typeof raw.defaultSensitivity === "string" && raw.defaultSensitivity.length > 0
+      ? raw.defaultSensitivity
+      : ROUTER_DEFAULTS.defaultSensitivity;
+  const escalationThreshold =
+    typeof raw.escalationThreshold === "number"
+      ? raw.escalationThreshold
+      : ROUTER_DEFAULTS.escalationThreshold;
+  const budgetCeilingUsdPerRequest =
+    typeof raw.budgetCeilingUsdPerRequest === "number"
+      ? raw.budgetCeilingUsdPerRequest
+      : ROUTER_DEFAULTS.budgetCeilingUsdPerRequest;
+  const logsDir =
+    typeof raw.logsDir === "string" && raw.logsDir.length > 0
+      ? raw.logsDir
+      : defaultLogsDir(params.homeDir);
+
+  return {
+    defaultAlias,
+    aliases,
+    classificationRules,
+    classifier,
+    sensitivity,
+    defaultSensitivity,
+    escalationThreshold,
+    budgetCeilingUsdPerRequest,
+    logsDir,
+  };
+}

--- a/extensions/aj-router/index.test.ts
+++ b/extensions/aj-router/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ROUTER_DEFAULTS } from "./config.js";
+import { handleBeforeModelResolve } from "./index.js";
+import type { LogEntry } from "./logger.js";
+
+describe("aj-router before_model_resolve hook", () => {
+  it("rewrites model and provider based on the prompt", () => {
+    const logged: LogEntry[] = [];
+    const result = handleBeforeModelResolve(
+      ROUTER_DEFAULTS,
+      "Classify this email as spam.",
+      (entry) => logged.push(entry),
+    );
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.alias).toBe("speed");
+  });
+
+  it("returns undefined when the prompt is empty", () => {
+    const result = handleBeforeModelResolve(ROUTER_DEFAULTS, "", () => {
+      throw new Error("should not log empty prompts");
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("falls through (no override) when resolver rejects", () => {
+    // Privileged default has blockExternal + non-local alias → rejection.
+    const logged: LogEntry[] = [];
+    const config = {
+      ...ROUTER_DEFAULTS,
+      defaultSensitivity: "privileged",
+    };
+    const result = handleBeforeModelResolve(config, "Hello.", (entry) => logged.push(entry));
+    expect(result).toBeUndefined();
+    expect(logged[0]?.rejected).toBe(true);
+  });
+});

--- a/extensions/aj-router/index.ts
+++ b/extensions/aj-router/index.ts
@@ -1,0 +1,109 @@
+/**
+ * AJ Router plugin entry.
+ *
+ * Wires three surfaces:
+ *   - `before_model_resolve` hook → rewrites the model+provider for every
+ *     agent run based on the prompt classification + sensitivity policy.
+ *   - `/router` command with `stats | health | explain` subcommands.
+ *   - JSONL routing log at `<logsDir>/routing.jsonl` for post-hoc analysis.
+ *
+ * The plugin is disabled by default. Enable it via
+ * `plugins.entries["aj-router"].enabled = true` in `openclaw.json`, and
+ * optionally override the built-in defaults under `...config`.
+ */
+
+import { homedir } from "node:os";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { dispatch } from "./commands.js";
+import { resolveConfig, type RouterConfig } from "./config.js";
+import { toLogEntry, writeEntry, type LogEntry } from "./logger.js";
+import { isRejection, resolve } from "./resolver.js";
+
+const PLUGIN_ID = "aj-router";
+
+type HookResult = {
+  modelOverride?: string;
+  providerOverride?: string;
+};
+
+function splitModelRef(ref: string): { provider: string; model: string } | undefined {
+  const slash = ref.indexOf("/");
+  if (slash === -1) {
+    return undefined;
+  }
+  const provider = ref.slice(0, slash);
+  const model = ref.slice(slash + 1);
+  if (provider.length === 0 || model.length === 0) {
+    return undefined;
+  }
+  return { provider, model };
+}
+
+/**
+ * Pure hook implementation. Exported for unit tests; the plugin registration
+ * wires it to `api.on("before_model_resolve", ...)`.
+ */
+export function handleBeforeModelResolve(
+  config: RouterConfig,
+  prompt: string,
+  log: (entry: LogEntry) => void,
+): HookResult | undefined {
+  if (prompt.length === 0) {
+    return undefined;
+  }
+
+  const result = resolve({ config, prompt });
+  const entry = toLogEntry(result, { promptLength: prompt.length });
+  log(entry);
+
+  if (isRejection(result)) {
+    // No safe override — fall through and let the caller-chosen model run.
+    return undefined;
+  }
+
+  const parts = splitModelRef(result.modelRef);
+  if (!parts) {
+    return { modelOverride: result.modelRef };
+  }
+  return { modelOverride: parts.model, providerOverride: parts.provider };
+}
+
+export default definePluginEntry({
+  id: PLUGIN_ID,
+  name: "AJ Router",
+  description:
+    "Classifier-driven model selection: picks the cheapest alias that can handle a prompt, gated by sensitivity policy.",
+  register(api: OpenClawPluginApi) {
+    const config = resolveConfig({
+      raw: api.pluginConfig,
+      homeDir: homedir(),
+    });
+
+    api.on("before_model_resolve", (event) => {
+      try {
+        const prompt = typeof event.prompt === "string" ? event.prompt : "";
+        return handleBeforeModelResolve(config, prompt, (entry) => {
+          void writeEntry({ logsDir: config.logsDir, entry }).catch((err) => {
+            api.logger.error?.(
+              `aj-router: log write failed: ${(err as Error).message ?? String(err)}`,
+            );
+          });
+        });
+      } catch (err) {
+        api.logger.error?.(`aj-router: hook failed: ${(err as Error).message ?? String(err)}`);
+        return undefined;
+      }
+    });
+
+    api.registerCommand({
+      name: "router",
+      description: "AJ router status and diagnostics (stats | health | explain).",
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        const args = typeof ctx.args === "string" ? ctx.args : "";
+        const text = await dispatch({ config, args });
+        return { text };
+      },
+    });
+  },
+});

--- a/extensions/aj-router/logger.test.ts
+++ b/extensions/aj-router/logger.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ROUTER_DEFAULTS } from "./config.js";
+import { ROUTING_LOG_FILENAME, toLogEntry, writeEntry } from "./logger.js";
+import { resolve } from "./resolver.js";
+
+describe("aj-router logger", () => {
+  let dir = "";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "aj-router-log-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("builds a log entry from a successful resolver result", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "Classify this email as spam.",
+    });
+    const entry = toLogEntry(result, { promptLength: 30 });
+    expect(entry.rejected).toBe(false);
+    expect(entry.alias).toBe("speed");
+    expect(entry.modelRef).toBe("anthropic/claude-haiku-4-5");
+    expect(entry.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("builds a log entry from a rejection", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "Classify this email as spam.",
+      sensitivity: "privileged",
+    });
+    const entry = toLogEntry(result, { promptLength: 30 });
+    expect(entry.rejected).toBe(true);
+    expect(entry.rejectionReason).toContain("blocks external providers");
+  });
+
+  it("appends a JSONL row to <logsDir>/routing.jsonl", async () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "hello world",
+    });
+    const entry = toLogEntry(result, { promptLength: 11 });
+    await writeEntry({ logsDir: dir, entry });
+    await writeEntry({ logsDir: dir, entry });
+    const text = await readFile(join(dir, ROUTING_LOG_FILENAME), "utf8");
+    const lines = text.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const first = lines[0];
+    expect(first).toBeDefined();
+    expect(JSON.parse(first ?? "{}").alias).toBeTypeOf("string");
+  });
+});

--- a/extensions/aj-router/logger.ts
+++ b/extensions/aj-router/logger.ts
@@ -1,0 +1,94 @@
+/**
+ * Routing decision logger. Writes one JSONL record per routing decision to
+ * `<logsDir>/routing.jsonl`, creating the directory on demand.
+ *
+ * The writer is fire-and-forget from the hook's perspective: errors are
+ * logged through the plugin logger but never thrown, so a log-write failure
+ * can never block a user request.
+ */
+
+import { mkdir, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { isRejection, type RouteResult } from "./resolver.js";
+
+export type LogEntry = {
+  /** ISO-8601 timestamp of the routing decision. */
+  timestamp: string;
+  /** Source that issued the request (e.g. telegram channel id, cron id). */
+  source?: string;
+  /** Prompt length — never the prompt itself (avoid leaking confidential text). */
+  promptLength: number;
+  /** Sensitivity label applied (after defaults). */
+  sensitivity: string;
+  /** Classifier tier output. */
+  tier: string;
+  /** Classifier confidence. */
+  confidence: number;
+  /** Chosen alias (absent on rejection). */
+  alias?: string;
+  /** Chosen model reference (absent on rejection). */
+  modelRef?: string;
+  /** True if escalation bumped the tier. */
+  escalated: boolean;
+  /** True when the sensitivity gate rejected the request. */
+  rejected: boolean;
+  /** On rejection, human-readable reason. */
+  rejectionReason?: string;
+};
+
+export type WriteEntryParams = {
+  logsDir: string;
+  entry: LogEntry;
+};
+
+const ROUTING_LOG_FILENAME = "routing.jsonl";
+
+/** Build a log entry from a resolver result. */
+export function toLogEntry(
+  result: RouteResult,
+  ctx: {
+    source?: string;
+    promptLength: number;
+    now?: Date;
+  },
+): LogEntry {
+  const timestamp = (ctx.now ?? new Date()).toISOString();
+  if (isRejection(result)) {
+    return {
+      timestamp,
+      source: ctx.source,
+      promptLength: ctx.promptLength,
+      sensitivity: result.sensitivity,
+      tier: result.classification.tier,
+      confidence: result.classification.confidence,
+      escalated: false,
+      rejected: true,
+      rejectionReason: result.reason,
+    };
+  }
+  return {
+    timestamp,
+    source: ctx.source,
+    promptLength: ctx.promptLength,
+    sensitivity: result.sensitivity,
+    tier: result.classification.tier,
+    confidence: result.classification.confidence,
+    alias: result.alias,
+    modelRef: result.modelRef,
+    escalated: result.escalated,
+    rejected: false,
+  };
+}
+
+/**
+ * Append an entry to `<logsDir>/routing.jsonl`. Creates the directory if
+ * missing. Errors are returned so the caller can decide whether to surface
+ * them.
+ */
+export async function writeEntry(params: WriteEntryParams): Promise<void> {
+  await mkdir(params.logsDir, { recursive: true });
+  const line = `${JSON.stringify(params.entry)}\n`;
+  await appendFile(join(params.logsDir, ROUTING_LOG_FILENAME), line, "utf8");
+}
+
+export { ROUTING_LOG_FILENAME };

--- a/extensions/aj-router/openclaw.plugin.json
+++ b/extensions/aj-router/openclaw.plugin.json
@@ -1,0 +1,73 @@
+{
+  "id": "aj-router",
+  "enabledByDefault": false,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultAlias": {
+        "type": "string",
+        "description": "Alias used when no classification is available. Must be a key in `aliases`."
+      },
+      "aliases": {
+        "type": "object",
+        "description": "Map of alias name to concrete provider/model reference (e.g. 'anthropic/claude-sonnet-4-6').",
+        "additionalProperties": { "type": "string" }
+      },
+      "classificationRules": {
+        "type": "object",
+        "description": "Map of classifier tier ('simple'|'medium'|'complex') to alias.",
+        "additionalProperties": { "type": "string" }
+      },
+      "classifier": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["heuristic", "llm"],
+            "description": "Classifier implementation. 'heuristic' uses cheap pattern matching; 'llm' calls a classifier model (Phase-2 follow-up)."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used when mode='llm'. Ignored in heuristic mode."
+          }
+        }
+      },
+      "sensitivity": {
+        "type": "object",
+        "description": "Sensitivity policy. Keys are sensitivity labels, values gate allowed providers and/or force an alias.",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "forceAlias": { "type": "string" },
+            "blockExternal": { "type": "boolean" },
+            "allowedProviders": {
+              "oneOf": [
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "string", "enum": ["*"] }
+              ]
+            }
+          }
+        }
+      },
+      "defaultSensitivity": {
+        "type": "string",
+        "description": "Sensitivity label applied when the request does not declare one. Defaults to 'internal'."
+      },
+      "escalationThreshold": {
+        "type": "number",
+        "description": "Confidence floor. Requests below this threshold escalate one alias up the ladder."
+      },
+      "budgetCeilingUsdPerRequest": {
+        "type": "number",
+        "description": "Abort a request if the estimated per-request cost exceeds this value."
+      },
+      "logsDir": {
+        "type": "string",
+        "description": "Directory for routing decision logs. Default: ~/.openclaw/logs/aj-router."
+      }
+    }
+  }
+}

--- a/extensions/aj-router/package.json
+++ b/extensions/aj-router/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openclaw/aj-router",
+  "version": "2026.4.16",
+  "private": true,
+  "description": "OpenClaw AJ Router plugin: classifier-driven model selection with sensitivity gating",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.16"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/aj-router/resolver.test.ts
+++ b/extensions/aj-router/resolver.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { ROUTER_DEFAULTS } from "./config.js";
+import { isRejection, resolve } from "./resolver.js";
+
+describe("aj-router resolver", () => {
+  it("routes a short classification prompt to the speed alias", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "Classify this email as spam or not.",
+    });
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.alias).toBe("speed");
+      expect(result.modelRef).toBe("anthropic/claude-haiku-4-5");
+    }
+  });
+
+  it("routes a medium-length generic prompt to the workhorse alias", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt:
+        "Draft a one-page memo for tomorrow's ops meeting covering Q2 priorities, dependencies, and the agenda so the team arrives informed.",
+    });
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.alias).toBe("workhorse");
+    }
+  });
+
+  it("routes a complex architecture prompt to the flagship alias", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "Design a multi-agent orchestration architecture.",
+    });
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.alias).toBe("flagship");
+    }
+  });
+
+  it("escalates low-confidence simple prompts one tier up", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "hmm?",
+    });
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.escalated).toBe(true);
+      expect(result.alias).toBe("workhorse");
+    }
+  });
+
+  it("rejects privileged requests whose forced alias is not a local provider", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "Classify this.",
+      sensitivity: "privileged",
+    });
+    expect(isRejection(result)).toBe(true);
+  });
+
+  it("honors a caller-supplied classification override", () => {
+    const result = resolve({
+      config: ROUTER_DEFAULTS,
+      prompt: "anything",
+      classificationOverride: {
+        tier: "complex",
+        confidence: 0.95,
+        reason: "test override",
+      },
+    });
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.alias).toBe("flagship");
+      expect(result.escalated).toBe(false);
+    }
+  });
+});

--- a/extensions/aj-router/resolver.ts
+++ b/extensions/aj-router/resolver.ts
@@ -1,0 +1,175 @@
+/**
+ * Resolver: given a prompt + optional sensitivity label, pick a concrete
+ * `provider/model` reference.
+ *
+ * Pipeline (in order):
+ *   1. Classify the prompt (heuristic in v1).
+ *   2. Map tier → alias via `classificationRules`.
+ *   3. Resolve alias → candidate model ref via `aliases`.
+ *   4. Apply sensitivity gate. If gate forces an alias or rejects, honor it.
+ *   5. If confidence < `escalationThreshold`, bump one rung up the ladder
+ *      (simple → medium → complex). Re-run the sensitivity gate on the
+ *      escalated candidate.
+ *
+ * The resolver is pure — all I/O (logging, hook response) lives in `index.ts`.
+ */
+
+import { classifyHeuristic, type Classification } from "./classifier.js";
+import type { ClassifierTier, RouterConfig } from "./config.js";
+import { evaluate as evaluateSensitivity } from "./sensitivity.js";
+
+const ESCALATION_LADDER: readonly ClassifierTier[] = ["simple", "medium", "complex"];
+
+export type RouteDecision = {
+  /** Final concrete `provider/model` reference the agent should use. */
+  modelRef: string;
+  /** Alias that produced `modelRef` (useful for logs). */
+  alias: string;
+  /** Classifier output. */
+  classification: Classification;
+  /** Sensitivity label applied (after defaults). */
+  sensitivity: string;
+  /** True if escalation bumped the tier one rung up. */
+  escalated: boolean;
+  /** Ordered list of human-readable decisions that led here. */
+  trail: string[];
+};
+
+export type RouteFailure = {
+  /** True when no model could be chosen. */
+  rejected: true;
+  reason: string;
+  classification: Classification;
+  sensitivity: string;
+  trail: string[];
+};
+
+export type RouteResult = RouteDecision | RouteFailure;
+
+export function isRejection(result: RouteResult): result is RouteFailure {
+  return "rejected" in result && result.rejected;
+}
+
+export type ResolveParams = {
+  config: RouterConfig;
+  prompt: string;
+  sensitivity?: string;
+  /**
+   * Optional classifier override (used by `/router explain` to reuse a
+   * previous classification, and by tests to inject deterministic output).
+   */
+  classificationOverride?: Classification;
+};
+
+function tierOneUp(tier: ClassifierTier): ClassifierTier | undefined {
+  const idx = ESCALATION_LADDER.indexOf(tier);
+  if (idx === -1 || idx >= ESCALATION_LADDER.length - 1) {
+    return undefined;
+  }
+  return ESCALATION_LADDER[idx + 1];
+}
+
+function resolveAliasRef(config: RouterConfig, alias: string): string | undefined {
+  return config.aliases[alias];
+}
+
+/** Resolve a prompt to a concrete model reference. */
+export function resolve(params: ResolveParams): RouteResult {
+  const { config, prompt } = params;
+  const sensitivity = params.sensitivity ?? config.defaultSensitivity;
+  const trail: string[] = [];
+
+  const classification = params.classificationOverride ?? classifyHeuristic({ prompt });
+  trail.push(
+    `classified as ${classification.tier} (conf ${classification.confidence.toFixed(2)}): ${classification.reason}`,
+  );
+
+  // Start tier = classifier output.
+  let tier: ClassifierTier = classification.tier;
+
+  // Escalate if low confidence.
+  let escalated = false;
+  if (classification.confidence < config.escalationThreshold) {
+    const bumped = tierOneUp(tier);
+    if (bumped) {
+      trail.push(
+        `confidence ${classification.confidence.toFixed(2)} < threshold ${config.escalationThreshold}; escalating ${tier} → ${bumped}`,
+      );
+      tier = bumped;
+      escalated = true;
+    }
+  }
+
+  const alias = config.classificationRules[tier];
+  if (!alias) {
+    return {
+      rejected: true,
+      reason: `no alias mapped for tier '${tier}'`,
+      classification,
+      sensitivity,
+      trail,
+    };
+  }
+  trail.push(`tier ${tier} → alias '${alias}'`);
+
+  const candidateRef = resolveAliasRef(config, alias);
+  if (!candidateRef) {
+    return {
+      rejected: true,
+      reason: `alias '${alias}' is not defined in aliases map`,
+      classification,
+      sensitivity,
+      trail,
+    };
+  }
+  trail.push(`alias '${alias}' → '${candidateRef}'`);
+
+  const decision = evaluateSensitivity({
+    config,
+    sensitivity,
+    candidateModelRef: candidateRef,
+  });
+
+  if (decision.kind === "reject") {
+    trail.push(`sensitivity reject: ${decision.reason}`);
+    return {
+      rejected: true,
+      reason: decision.reason,
+      classification,
+      sensitivity,
+      trail,
+    };
+  }
+
+  if (decision.kind === "force-alias") {
+    const forcedRef = resolveAliasRef(config, decision.alias);
+    if (!forcedRef) {
+      return {
+        rejected: true,
+        reason: `sensitivity forced alias '${decision.alias}' missing from aliases map`,
+        classification,
+        sensitivity,
+        trail,
+      };
+    }
+    trail.push(`sensitivity override: ${decision.reason}`);
+    trail.push(`forced alias '${decision.alias}' → '${forcedRef}'`);
+    return {
+      modelRef: forcedRef,
+      alias: decision.alias,
+      classification,
+      sensitivity,
+      escalated,
+      trail,
+    };
+  }
+
+  return {
+    modelRef: candidateRef,
+    alias,
+    classification,
+    sensitivity,
+    escalated,
+    trail,
+  };
+}

--- a/extensions/aj-router/sensitivity.test.ts
+++ b/extensions/aj-router/sensitivity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { ROUTER_DEFAULTS } from "./config.js";
+import { evaluate } from "./sensitivity.js";
+
+function withConfig(overrides: Partial<typeof ROUTER_DEFAULTS> = {}) {
+  return { ...ROUTER_DEFAULTS, ...overrides };
+}
+
+describe("aj-router sensitivity gate", () => {
+  it("allows public requests to any provider", () => {
+    const decision = evaluate({
+      config: withConfig(),
+      sensitivity: "public",
+      candidateModelRef: "openai/gpt-5.4",
+    });
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("allows internal requests to anthropic/openai/google", () => {
+    const decision = evaluate({
+      config: withConfig(),
+      sensitivity: "internal",
+      candidateModelRef: "anthropic/claude-sonnet-4-6",
+    });
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("rejects confidential requests targeting non-anthropic providers", () => {
+    const decision = evaluate({
+      config: withConfig(),
+      sensitivity: "confidential",
+      candidateModelRef: "openai/gpt-5.4",
+    });
+    expect(decision.kind).toBe("reject");
+  });
+
+  it("forces privileged requests to the configured privileged alias", () => {
+    const config = withConfig({
+      aliases: {
+        ...ROUTER_DEFAULTS.aliases,
+        privileged: "ollama/llama3.3:8b",
+      },
+    });
+    const decision = evaluate({
+      config,
+      sensitivity: "privileged",
+      candidateModelRef: "anthropic/claude-sonnet-4-6",
+    });
+    expect(decision.kind).toBe("force-alias");
+    if (decision.kind === "force-alias") {
+      expect(decision.alias).toBe("privileged");
+    }
+  });
+
+  it("rejects privileged requests when forced alias points at an external provider", () => {
+    // Default has privileged → anthropic/... with blockExternal=true. Reject.
+    const decision = evaluate({
+      config: withConfig(),
+      sensitivity: "privileged",
+      candidateModelRef: "anthropic/claude-sonnet-4-6",
+    });
+    expect(decision.kind).toBe("reject");
+  });
+
+  it("falls back to default sensitivity when unspecified", () => {
+    // Default = "internal"; openai is allowed.
+    const decision = evaluate({
+      config: withConfig(),
+      sensitivity: undefined,
+      candidateModelRef: "openai/gpt-5.4",
+    });
+    expect(decision.kind).toBe("allow");
+  });
+});

--- a/extensions/aj-router/sensitivity.ts
+++ b/extensions/aj-router/sensitivity.ts
@@ -1,0 +1,95 @@
+/**
+ * Sensitivity gate.
+ *
+ * Given the configured sensitivity label and a candidate `provider/model`
+ * reference, either:
+ *   - approve the candidate as-is, or
+ *   - return a forced alias (e.g. privileged → privileged alias → local model), or
+ *   - reject the candidate because its provider is not in the allowed list.
+ *
+ * Keeps the policy logic in one file so it is easy to audit against the
+ * sensitivity policy doc.
+ */
+
+import type { RouterConfig, SensitivityRule } from "./config.js";
+
+const LOCAL_PROVIDERS: ReadonlySet<string> = new Set(["ollama", "lmstudio", "llamafile"]);
+
+export type SensitivityDecision =
+  | { kind: "allow" }
+  | { kind: "force-alias"; alias: string; reason: string }
+  | { kind: "reject"; reason: string };
+
+function providerIdFromRef(ref: string): string {
+  const slash = ref.indexOf("/");
+  return slash === -1 ? ref : ref.slice(0, slash);
+}
+
+function isLocalProvider(ref: string): boolean {
+  return LOCAL_PROVIDERS.has(providerIdFromRef(ref));
+}
+
+function isAllowedProvider(ref: string, rule: SensitivityRule | undefined): boolean {
+  if (!rule?.allowedProviders) {
+    return true;
+  }
+  if (rule.allowedProviders === "*") {
+    return true;
+  }
+  return rule.allowedProviders.includes(providerIdFromRef(ref));
+}
+
+export type EvaluateParams = {
+  config: RouterConfig;
+  /** Sensitivity label on the request; empty/undefined uses `defaultSensitivity`. */
+  sensitivity: string | undefined;
+  /** Candidate model reference the router picked before sensitivity review. */
+  candidateModelRef: string;
+};
+
+/**
+ * Evaluate the sensitivity rule for a candidate model reference.
+ *
+ * Decision order:
+ *   1. `forceAlias` — privileged data always routes through the forced alias.
+ *      If that alias would resolve to an external provider AND `blockExternal`
+ *      is set, return `reject` so the hook can bail out hard.
+ *   2. `allowedProviders` — if the candidate provider is not in the list,
+ *      reject.
+ *   3. Otherwise, allow.
+ */
+export function evaluate(params: EvaluateParams): SensitivityDecision {
+  const { config, candidateModelRef } = params;
+  const label = params.sensitivity ?? config.defaultSensitivity;
+  const rule = config.sensitivity[label];
+
+  if (rule?.forceAlias) {
+    const forcedRef = config.aliases[rule.forceAlias];
+    if (!forcedRef) {
+      return {
+        kind: "reject",
+        reason: `sensitivity '${label}' forces alias '${rule.forceAlias}' but it is not defined`,
+      };
+    }
+    if (rule.blockExternal && !isLocalProvider(forcedRef)) {
+      return {
+        kind: "reject",
+        reason: `sensitivity '${label}' blocks external providers; forced alias '${rule.forceAlias}' → '${forcedRef}' is not local`,
+      };
+    }
+    return {
+      kind: "force-alias",
+      alias: rule.forceAlias,
+      reason: `sensitivity '${label}' forces alias '${rule.forceAlias}'`,
+    };
+  }
+
+  if (!isAllowedProvider(candidateModelRef, rule)) {
+    return {
+      kind: "reject",
+      reason: `sensitivity '${label}' does not allow provider '${providerIdFromRef(candidateModelRef)}'`,
+    };
+  }
+
+  return { kind: "allow" };
+}

--- a/extensions/aj-router/stats.test.ts
+++ b/extensions/aj-router/stats.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { LogEntry } from "./logger.js";
+import { filterWindow, lastNDaysWindow, parseEntries, summarize, type Window } from "./stats.js";
+
+function entry(overrides: Partial<LogEntry>): LogEntry {
+  return {
+    timestamp: "2026-04-14T00:00:00.000Z",
+    promptLength: 50,
+    sensitivity: "internal",
+    tier: "simple",
+    confidence: 0.9,
+    alias: "speed",
+    modelRef: "anthropic/claude-haiku-4-5",
+    escalated: false,
+    rejected: false,
+    ...overrides,
+  };
+}
+
+describe("aj-router stats", () => {
+  it("summarizes counts per alias and escalation rate", () => {
+    const window: Window = {
+      startMs: Date.parse("2026-04-10T00:00:00.000Z"),
+      endMs: Date.parse("2026-04-17T00:00:00.000Z"),
+    };
+    const rows: LogEntry[] = [
+      entry({ alias: "speed" }),
+      entry({ alias: "speed" }),
+      entry({ alias: "workhorse", tier: "medium", confidence: 0.85 }),
+      entry({
+        alias: "workhorse",
+        tier: "medium",
+        confidence: 0.7,
+        escalated: true,
+      }),
+      entry({ rejected: true, alias: undefined, modelRef: undefined }),
+    ];
+    const summary = summarize(rows, window);
+    expect(summary.totalDecisions).toBe(5);
+    expect(summary.rejected).toBe(1);
+    expect(summary.escalated).toBe(1);
+    expect(summary.perAlias).toEqual([
+      { alias: "speed", count: 2 },
+      { alias: "workhorse", count: 2 },
+    ]);
+    expect(summary.averageConfidence).toBeCloseTo((0.9 + 0.9 + 0.85 + 0.7) / 4);
+  });
+
+  it("filters entries outside the window", () => {
+    const inside = entry({ timestamp: "2026-04-14T12:00:00.000Z" });
+    const before = entry({ timestamp: "2026-03-01T00:00:00.000Z" });
+    const after = entry({ timestamp: "2027-01-01T00:00:00.000Z" });
+    const filtered = filterWindow([inside, before, after], {
+      startMs: Date.parse("2026-04-10T00:00:00.000Z"),
+      endMs: Date.parse("2026-04-17T00:00:00.000Z"),
+    });
+    expect(filtered).toEqual([inside]);
+  });
+
+  it("parseEntries skips blank and malformed lines", () => {
+    const text = [
+      JSON.stringify(entry({})),
+      "",
+      "{ not json",
+      JSON.stringify(entry({ alias: "flagship" })),
+    ].join("\n");
+    const rows = parseEntries(text);
+    expect(rows).toHaveLength(2);
+    expect(rows[1]?.alias).toBe("flagship");
+  });
+
+  it("lastNDaysWindow returns a window with correct span", () => {
+    const now = new Date("2026-04-17T12:00:00.000Z");
+    const window = lastNDaysWindow(7, now);
+    expect(window.endMs).toBe(now.getTime());
+    expect(window.endMs - window.startMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/extensions/aj-router/stats.ts
+++ b/extensions/aj-router/stats.ts
@@ -1,0 +1,144 @@
+/**
+ * Stats aggregator. Reads `<logsDir>/routing.jsonl`, parses each line, and
+ * summarizes activity over a window (defaults to the last 7 days).
+ *
+ * Cost model: we do NOT track real token cost in the log — that requires
+ * post-hoc usage records from the provider. Instead we count requests per
+ * alias so the user can eyeball mix. Actual dollar savings come from the
+ * provider billing dashboards; this summary shows routing distribution.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ROUTING_LOG_FILENAME, type LogEntry } from "./logger.js";
+
+export type Window = {
+  /** Inclusive start. */
+  startMs: number;
+  /** Exclusive end. */
+  endMs: number;
+};
+
+export type AliasStat = {
+  alias: string;
+  count: number;
+};
+
+export type StatsSummary = {
+  /** Number of decisions within the window. */
+  totalDecisions: number;
+  /** Count of rejected decisions. */
+  rejected: number;
+  /** Escalation count. */
+  escalated: number;
+  /** Per-alias counts, sorted descending. */
+  perAlias: AliasStat[];
+  /** Average classifier confidence across non-rejected entries. */
+  averageConfidence: number;
+  /** Window (echoed for display). */
+  window: Window;
+};
+
+export function parseEntries(text: string): LogEntry[] {
+  const out: LogEntry[] = [];
+  const lines = text.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as LogEntry;
+      if (typeof parsed.timestamp === "string") {
+        out.push(parsed);
+      }
+    } catch {
+      // Ignore malformed rows — the logger always writes well-formed JSONL,
+      // but partial writes on crash could leave a trailing bad line.
+    }
+  }
+  return out;
+}
+
+export function filterWindow(entries: readonly LogEntry[], window: Window): LogEntry[] {
+  const out: LogEntry[] = [];
+  for (const entry of entries) {
+    const ms = Date.parse(entry.timestamp);
+    if (Number.isNaN(ms)) {
+      continue;
+    }
+    if (ms >= window.startMs && ms < window.endMs) {
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+export function summarize(entries: readonly LogEntry[], window: Window): StatsSummary {
+  const perAlias = new Map<string, number>();
+  let rejected = 0;
+  let escalated = 0;
+  let confidenceSum = 0;
+  let confidenceCount = 0;
+
+  for (const entry of entries) {
+    if (entry.rejected) {
+      rejected += 1;
+      continue;
+    }
+    if (entry.escalated) {
+      escalated += 1;
+    }
+    if (entry.alias) {
+      perAlias.set(entry.alias, (perAlias.get(entry.alias) ?? 0) + 1);
+    }
+    if (typeof entry.confidence === "number") {
+      confidenceSum += entry.confidence;
+      confidenceCount += 1;
+    }
+  }
+
+  const sortedAliases: AliasStat[] = [...perAlias.entries()]
+    .map(([alias, count]) => ({ alias, count }))
+    .toSorted((a, b) => b.count - a.count);
+
+  return {
+    totalDecisions: entries.length,
+    rejected,
+    escalated,
+    perAlias: sortedAliases,
+    averageConfidence: confidenceCount === 0 ? 0 : confidenceSum / confidenceCount,
+    window,
+  };
+}
+
+export type LoadSummaryParams = {
+  logsDir: string;
+  window: Window;
+};
+
+/** Read the log file and return a summary. Missing file → empty summary. */
+export async function loadSummary(params: LoadSummaryParams): Promise<StatsSummary> {
+  let text = "";
+  try {
+    text = await readFile(join(params.logsDir, ROUTING_LOG_FILENAME), "utf8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw err;
+    }
+  }
+  const entries = parseEntries(text);
+  const filtered = filterWindow(entries, params.window);
+  return summarize(filtered, params.window);
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function lastNDaysWindow(n: number, now: Date = new Date()): Window {
+  const endMs = now.getTime();
+  return {
+    startMs: endMs - n * MS_PER_DAY,
+    endMs,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/aj-router:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/alibaba:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary

Adds a new bundled extension `@openclaw/aj-router` that routes each model request through a classifier + sensitivity gate + alias map to pick the cheapest provider/model that can handle the prompt. Disabled by default.

- `before_model_resolve` hook rewrites `{providerOverride, modelOverride}` per request based on heuristic prompt classification (v1 is zero-cost, deterministic; `classifier.mode: "llm"` is a planned follow-up).
- Sensitivity gate: `public | internal | confidential | privileged`. Privileged requests can force a local alias and reject if it would resolve externally.
- Confidence-driven escalation: one rung up the `simple → medium → complex` ladder when the classifier's confidence dips below `escalationThreshold`.
- `/router` command surface with `stats | health | explain` subcommands.
- JSONL decision log at `<logsDir>/routing.jsonl` for post-hoc cost analysis. Prompt *length* is stored, never prompt text.

The plugin registers through the existing SDK surfaces only: `definePluginEntry`, `api.on("before_model_resolve", ...)`, `api.registerCommand`, and `api.pluginConfig` with a typed `configSchema`. No new core seams.

## Why

Multi-provider users currently pay flagship prices for trivial classification/extraction tasks and lack a built-in way to keep privileged data off external providers. This plugin addresses both without touching core.

## Files

- `extensions/aj-router/` — plugin source + 7 test files (classifier, resolver, sensitivity, logger, stats, commands, hook)
- `docs/plugins/aj-router.md` — user-facing docs
- `.github/labeler.yml` — `extensions: aj-router` label

## Test plan

- [x] `pnpm check` (tsgo, oxlint, oxfmt, host-env-policy, import cycles, madge) — clean
- [x] `pnpm test` — 40 aj-router tests + full repo suite green
- [x] `pnpm build` — clean
- [ ] Manual: enable plugin in `openclaw.json`, send a classification prompt, confirm log shows `alias: speed` and model override applied
- [ ] Manual: set a `privileged` sensitivity default, confirm requests reject rather than silently routing externally