### PR TITLE
Fix: Image tool fails with reasoning-capable vision models that return empty content

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,6 +1,11 @@
 import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import {
+  extractAssistantText,
+  extractAssistantThinking,
+  type AssistantMessage,
+} from "../utils/pi-embedded-utils.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -124,4 +129,34 @@ export async function minimaxUnderstandImage(params: {
   }
 
   return content;
+}
+
+export function coerceImageAssistantText(params: {
+  message: AssistantMessage;
+  provider: string;
+  model: string;
+}): string {
+  const stop = params.message.stopReason;
+  const errorMessage = params.message.errorMessage?.trim();
+  if (stop === "error" || stop === "aborted") {
+    throw new Error(
+      `Image model execution failed (${params.provider}/${params.model}): ${stop}${
+        errorMessage ? ` (${errorMessage})` : ""
+      }`,
+    );
+  }
+  if (errorMessage) {
+    throw new Error(
+      `Image model returned error (${params.provider}/${params.model}): ${errorMessage}`,
+    );
+  }
+
+  const text = extractAssistantText(params.message);
+  if (text.trim()) return text.trim();
+
+  // Fallback: reasoning models may return content in thinking blocks
+  const thinking = extractAssistantThinking(params.message);
+  if (thinking.trim()) return thinking.trim();
+
+  throw new Error(`Image model returned no text (${params.provider}/${params.model}).`);
 }


### PR DESCRIPTION
The issue was that `coerceImageAssistantText` only extracted content from text blocks. For vision models with reasoning enabled, the actual response text often resides in 'thinking' blocks (mapped from `reasoning_content`) while the standard 'content' array is empty. I updated `coerceImageAssistantText` in `src/agents/minimax-vlm.ts` to fall back to `extractAssistantThinking` if no text is found, and added the necessary imports and the missing function logic to support this fix.

Test: Configure a vision model with `reasoning: true` that returns its output in `reasoning_content`. Verify that `coerceImageAssistantText` successfully extracts this content via `extractAssistantThinking` instead of throwing an error when the standard `text` content is empty.