### PR TITLE
docs(coding-agent): add "recovering from a destructive spawn" note

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -307,6 +307,42 @@ This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 
 
 ---
 
+## Recovering from a destructive spawn
+
+Spawned agents run with broad file access — that's the point. Occasionally
+they will delete, overwrite, or mangle files you didn't want touched. Before
+an off-leash spawn (Claude Code with `--permission-mode bypassPermissions`,
+Codex with `--yolo`, any PTY session with write access to the workspace),
+create a filesystem snapshot of the workdir so you can restore it in one
+command if things go sideways.
+
+One zero-dependency tool that does this via native Copy-on-Write (APFS
+`clonefile()` / Linux `FICLONE`) is [cowback](https://github.com/jinbowang1/cowback):
+
+```bash
+# One-time setup in the target project
+cd /path/to/project
+cowback on          # watches + auto-snapshots on file changes
+
+# Now spawn the agent as usual
+bash pty:true workdir:/path/to/project command:"codex --yolo exec 'your task'"
+# or: cd /path/to/project && claude --permission-mode bypassPermissions --print 'your task'
+
+# If the agent broke something:
+cowback undo        # preview → confirm → restore
+```
+
+Snapshots are ~millisecond / ~0-disk-cost on CoW-capable filesystems (APFS,
+BTRFS, XFS with reflink), so leaving protection on has negligible overhead.
+On other filesystems it falls back to a regular copy.
+
+The point isn't the specific tool — any snapshot/restore utility works. The
+point is: once you've passed `bypassPermissions` / `--yolo`, you've given up
+the interactive confirmation safety net. Have an undo button before you do
+that.
+
+---
+
 ## Learnings (Jan 2026)
 
 - **PTY is essential:** Coding agents are interactive terminal apps. Without `pty:true`, output breaks or agent hangs.

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -320,9 +320,10 @@ One zero-dependency tool that does this via native Copy-on-Write (APFS
 `clonefile()` / Linux `FICLONE`) is [cowback](https://github.com/jinbowang1/cowback):
 
 ```bash
-# One-time setup in the target project
+# Enable protection for this project (runs in background)
 cd /path/to/project
-cowback on          # watches + auto-snapshots on file changes
+cowback on          # auto-snapshots on file changes;
+                    # stays running until `cowback off` or reboot
 
 # Now spawn the agent as usual
 bash pty:true workdir:/path/to/project command:"codex --yolo exec 'your task'"


### PR DESCRIPTION
## What this does

Adds a short "Recovering from a destructive spawn" section to `skills/coding-agent/SKILL.md`, right before the `Learnings (Jan 2026)` appendix.

The skill today tells users to run agents with `bypassPermissions` (Claude Code) or PTY + `--yolo` (Codex) for throughput. That's the right call — but it means a misbehaving agent can delete or mangle files, and the current docs don't say what to do about it.

## Why add this here

- This skill's whole job is spawning off-leash coding agents
- "Off-leash" + broad file access is where rollback matters most
- Users running this skill are the first to hit the footgun

The new section covers the pattern (snapshot before spawn → restore on blow-up) and points at [cowback](https://github.com/jinbowang1/cowback) as one concrete zero-dependency implementation using native filesystem Copy-on-Write (APFS `clonefile()` / Linux `FICLONE`). Disclosure: I maintain cowback.

## Tone

The section is explicitly tool-agnostic — cowback is the example, not the prescription. The closing paragraph says "any snapshot/restore utility works" to stay general.

Happy to drop the specific reference if the maintainers prefer vendor-neutral wording; the pattern itself is the value. Also happy to point at an OpenClaw-native hook if one exists that fits better than a third-party wrapper.