### PR TITLE
fix: sync auth token to state after gateway hello for media preview URLs

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -273,6 +273,13 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.lastErrorCode = null;
       host.hello = hello;
       applySnapshot(host, hello);
+      // Sync auth token to state so resolveAssistantAttachmentAuthToken can access it
+      // for media preview URLs (requires Bearer token on the media endpoint).
+      if (host.settings.token) {
+        applySettings(host as unknown as Parameters<typeof applySettings>[0], {
+          {...host.settings}
+        });
+      }
       // Reset orphaned chat run state from before disconnect.
       // Any in-flight run's final event was lost during the disconnect window.
       host.chatRunId = null;


### PR DESCRIPTION
## Problem

In the webchat Control UI, locally generated images (e.g. from the image generation tool) fail to display with the error **"Attachment unavailable"**, even though the files exist in allowed directories.

## Root Cause

The gateway `/__openclaw__/assistant-media` endpoint requires Bearer token authentication (gateway auth mode: `token`). The webchat client correctly sent the token during the WebSocket handshake to establish the connection.

However, `resolveAssistantAttachmentAuthToken()` reads the token from `state.settings.token` (the UI app state), which is a **different object** from `host.settings.token` (the gateway connection object). After the WebSocket connection is established via `onHello`, the token was **never synced** to `state.settings`.

As a result, when the UI constructs media preview URLs (`/__openclaw__/assistant-media?source=...`), no Bearer token was included, causing the gateway to return 401 Unauthorized.

## Fix

After `applySnapshot(host, hello)` in the `onHello` callback, sync `host.settings.token` to `state.settings.token` via `applySettings()`.

```diff
  host.hello = hello;
  applySnapshot(host, hello);
+ if (host.settings.token) {
+   applySettings(host as unknown as Parameters<typeof applySettings>[0], {
+     ...host.settings,
+     token: host.settings.token,
+   });
+ }
```

## Testing

1. Open webchat and connect to a gateway with auth mode `token`
2. Generate an image via the image generation tool
3. Observe the image is now correctly rendered inline (instead of "Attachment unavailable")