### PR TITLE
agents: forward prompt_cache_key on openai-completions when compat.supportsPromptCacheKey is set

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1639,6 +1639,110 @@ describe("openai transport stream", () => {
     expect(params).toHaveProperty("tool_choice", "required");
   });
 
+  it("does not emit prompt_cache_key on openai-completions by default", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek-v3",
+        name: "DeepSeek V3",
+        api: "openai-completions",
+        provider: "volcengine",
+        baseUrl: "https://ark.example/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 64000,
+        maxTokens: 4096,
+      } satisfies Model<"openai-completions">,
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      { sessionId: "sess-123" } as never,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
+  it("emits prompt_cache_key on openai-completions when compat.supportsPromptCacheKey=true and sessionId is set", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "qwen3-next",
+        name: "Qwen3 Next",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+        compat: { supportsPromptCacheKey: true },
+      } as never,
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      { sessionId: "sess-abc" } as never,
+    );
+    expect(params).toHaveProperty("prompt_cache_key", "sess-abc");
+  });
+
+  it("suppresses prompt_cache_key when cacheRetention is 'none' even with supportsPromptCacheKey=true", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "qwen3-next",
+        name: "Qwen3 Next",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+        compat: { supportsPromptCacheKey: true },
+      } as never,
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      { sessionId: "sess-abc", cacheRetention: "none" } as never,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
+  it("suppresses prompt_cache_key when sessionId is missing even with supportsPromptCacheKey=true", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "qwen3-next",
+        name: "Qwen3 Next",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+        compat: { supportsPromptCacheKey: true },
+      } as never,
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      undefined,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
+  it("does not emit prompt_cache_key when supportsPromptCacheKey is explicitly false", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek-v3",
+        name: "DeepSeek V3",
+        api: "openai-completions",
+        provider: "volcengine",
+        baseUrl: "https://ark.example/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 64000,
+        maxTokens: 4096,
+        compat: { supportsPromptCacheKey: false },
+      } as never,
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      { sessionId: "sess-xyz" } as never,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
   it("resets stopReason to stop when finish_reason is tool_calls but tool_calls array is empty", async () => {
     const model = {
       id: "nemotron-3-super",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1504,6 +1504,18 @@ export function buildOpenAICompletionsParams(
     stream: true,
     stream_options: { include_usage: true },
   };
+  // OpenAI-compatible providers (vLLM, SGLang, Chutes, etc.) that honor
+  // prompt_cache_key on the Completions path can opt in via
+  // compat.supportsPromptCacheKey. Default stays off to preserve the
+  // conservative behavior from #49877 / #48155 (some proxies reject unknown
+  // fields). Mirrors the Responses API emission in buildOpenAIResponsesParams.
+  if (
+    model.compat?.supportsPromptCacheKey === true &&
+    resolveCacheRetention(options?.cacheRetention) !== "none" &&
+    options?.sessionId
+  ) {
+    params.prompt_cache_key = options.sessionId;
+  }
   if (compat.supportsStore) {
     params.store = false;
   }


### PR DESCRIPTION
## Summary

Fixes #69272.

`buildOpenAICompletionsParams` never emitted `prompt_cache_key` on the
Completions path, so operators running OpenAI-compatible proxies (vLLM,
SGLang, Chutes, etc.) could not opt into stable prompt caching per session
the way `buildOpenAIResponsesParams` already does for the Responses API.

This change forwards `options.sessionId` as `prompt_cache_key` on the
Completions path under all three of the following conditions:

1. `model.compat.supportsPromptCacheKey === true` (explicit opt-in, defaults
   to the existing behavior — nothing emitted — when unset or false).
2. `resolveCacheRetention(options?.cacheRetention) !== "none"` (mirrors the
   Responses API gate at `src/agents/openai-transport-stream.ts:794`).
3. `options?.sessionId` is present.

Conservative default preserves #49877 / #48155 (Volcano Engine DeepSeek
rejects unknown fields) and the scope maintainers set in #67427.

## Why not covered by #67427

#67427 added `compat.supportsPromptCacheKey` to gate the Responses API
strip. That is the right mechanism, but it only affected Responses API
payloads. The Completions builder had no knob at all. This PR wires the
same flag through the second code path.

## Changes

- `src/agents/openai-transport-stream.ts` — added the conditional emit in
  `buildOpenAICompletionsParams` with an explanatory comment matching the
  Responses API emission.
- `src/agents/openai-transport-stream.test.ts` — 5 new tests covering:
  1. Default off (no `compat.supportsPromptCacheKey`, sessionId present) → not emitted
  2. `compat.supportsPromptCacheKey=true` + sessionId → emitted
  3. `compat.supportsPromptCacheKey=true` + `cacheRetention: "none"` → suppressed
  4. `compat.supportsPromptCacheKey=true` + no sessionId → suppressed
  5. `compat.supportsPromptCacheKey=false` → suppressed

## Scope

Nothing else touched:
- No new provider surface, no new compat field, no schema changes.
- No change to Responses API, Anthropic `cacheRetention`, or Gemini
  `cachedContents`.
- No change to tool assembly, system prompt shaping, or usage parsing.

## Test plan

- [x] `pnpm test src/agents/openai-transport-stream.test.ts` — 70/70 passed
- [x] `pnpm tsgo:core` — clean
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm lint` — clean (via committer `check:changed`)
- [x] `pnpm format` — clean
- [x] Import cycle checks — 0 cycles

AI-assisted: yes (Claude, under sk7n4k3d supervision).