### PR TITLE
update: skip package install when already on target version (#69412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Update/CLI: short-circuit `openclaw update` on package installs when the running version already matches the resolved channel target, so idempotent runs no longer invoke the global package manager for a no-op reinstall. Explicit `--tag` still reinstalls. (#69412) [AI-assisted]
 - fix(security): block MINIMAX_API_HOST workspace env injection and remove env-driven URL routing [AI-assisted]. (#67300) Thanks @pgondhi987.
 - Cron/delivery: treat explicit `delivery.mode: "none"` runs as not requested even if the runner reports `delivered: false`, so no-delivery cron jobs no longer persist false delivery failures or errors. (#69285) Thanks @matsuri1987.
 - Plugins/install: repair active and default-enabled bundled plugin runtime dependencies before import in packaged installs, so bundled Discord, WhatsApp, Slack, Telegram, and provider plugins work without putting their dependency trees in core.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -720,6 +720,83 @@ describe("update-cli", () => {
     );
   });
 
+  it("skips package install when the running version already matches the target (#69412)", async () => {
+    const tempDir = createCaseDir("openclaw-update-idempotent");
+    mockPackageInstallStatus(tempDir);
+    readPackageVersion.mockResolvedValue("2026.4.20");
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.20",
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalledWith(
+      expect.arrayContaining(["npm", "i", "-g"]),
+      expect.any(Object),
+    );
+    expect(runDaemonInstall).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.some((line) => line.includes("Already on 2026.4.20"))).toBe(true);
+  });
+
+  it("emits structured JSON when skipping an already-latest package install (#69412)", async () => {
+    const tempDir = createCaseDir("openclaw-update-idempotent-json");
+    mockPackageInstallStatus(tempDir);
+    readPackageVersion.mockResolvedValue("2026.4.20");
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.20",
+    });
+
+    await updateCommand({ yes: true, json: true });
+
+    expect(runCommandWithTimeout).not.toHaveBeenCalledWith(
+      expect.arrayContaining(["npm", "i", "-g"]),
+      expect.any(Object),
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    const payloads = vi.mocked(defaultRuntime.writeJson).mock.calls.map((call) => call[0]);
+    const skipped = payloads.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as { status?: string }).status === "skipped" &&
+        (entry as { reason?: string }).reason === "already-on-target",
+    );
+    expect(skipped).toMatchObject({
+      status: "skipped",
+      reason: "already-on-target",
+      mode: "package",
+      currentVersion: "2026.4.20",
+      targetVersion: "2026.4.20",
+    });
+  });
+
+  it("still installs when --tag is passed even if versions match (#69412)", async () => {
+    const tempDir = createCaseDir("openclaw-update-idempotent-explicit-tag");
+    mockPackageInstallStatus(tempDir);
+    readPackageVersion.mockResolvedValue("2026.4.20");
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.20",
+    });
+    vi.mocked(fetchNpmTagVersion).mockResolvedValue({
+      version: "2026.4.20",
+      tag: "latest",
+    });
+
+    await updateCommand({ yes: true, tag: "2026.4.20" });
+
+    expect(runCommandWithTimeout).toHaveBeenCalledWith(
+      ["npm", "i", "-g", "openclaw@2026.4.20", "--no-fund", "--no-audit", "--loglevel=error"],
+      expect.any(Object),
+    );
+  });
+
   it("blocks package updates when the target requires a newer Node runtime", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1043,6 +1043,46 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     }
   }
 
+  // Short-circuit the install when the running version already matches the
+  // resolved target. Without this the command invokes the full package
+  // manager install (npm/pnpm/bun) every time, which can take tens of
+  // seconds even when nothing would change (#69412).
+  if (
+    updateInstallKind === "package" &&
+    !switchToPackage &&
+    !switchToGit &&
+    !explicitTag &&
+    canResolveRegistryVersionForPackageTarget(tag) &&
+    currentVersion !== null &&
+    targetVersion !== null &&
+    compareSemverStrings(currentVersion, targetVersion) === 0
+  ) {
+    if (opts.json) {
+      defaultRuntime.writeJson({
+        status: "skipped",
+        reason: "already-on-target",
+        mode: "package",
+        root,
+        installKind,
+        channel,
+        tag,
+        currentVersion,
+        targetVersion,
+      });
+    } else {
+      defaultRuntime.log(
+        theme.success(`Already on ${currentVersion} (${channel}). Nothing to update.`),
+      );
+      defaultRuntime.log(
+        theme.muted(
+          `Use \`openclaw update --tag <version>\` to reinstall or pin a specific release.`,
+        ),
+      );
+    }
+    defaultRuntime.exit(0);
+    return;
+  }
+
   const showProgress = !opts.json && process.stdout.isTTY;
   if (!opts.json) {
     defaultRuntime.log(theme.heading("Updating OpenClaw..."));


### PR DESCRIPTION
## Summary

Fixes #69412. When `openclaw update` runs on a package install and the running version already matches the resolved channel target, the command short-circuits before invoking the global package manager. Without this guard, `npm i -g openclaw@latest` (or the pnpm/bun equivalent) is executed even when the install would be a no-op, which takes 20-60 seconds, triggers network traffic, and occasionally rewrites `node_modules` with no user-visible change.

### Behavior

- Package-mode runs where `currentVersion === targetVersion`, no `--tag`, no install-kind switch, and the tag is registry-resolvable → log `Already on <version> (<channel>). Nothing to update.` and exit 0.
- `--json` output emits `{ status: "skipped", reason: "already-on-target", mode: "package", currentVersion, targetVersion, channel, tag, installKind, root }`.
- `--tag <version>` always reinstalls (same behavior as before, so operators who want to force a reinstall still can).
- Git installs, mode switches (`switchToGit`/`switchToPackage`), and non-registry specs fall through to the existing flow unchanged.

### Implementation

- `src/cli/update-cli/update-command.ts`: early-exit block inserted after the package runtime preflight, before the "Updating OpenClaw…" header. Gated on `updateInstallKind === "package" && !switchToPackage && !switchToGit && !explicitTag && canResolveRegistryVersionForPackageTarget(tag)` with a `compareSemverStrings` equality check.
- `src/cli/update-cli.test.ts`: three regression cases — text mode short-circuit, JSON mode payload shape, explicit `--tag` still reinstalls.
- `CHANGELOG.md`: entry under Unreleased → Fixes.

### Verification

- `pnpm test src/cli/update-cli.test.ts` → 49 passing (3 new).
- `pnpm check:changed` → green for this diff; pre-existing failures on `extensions/browser/src/browser/chrome.internal.test.ts` (Chrome not installed in sandbox) and `test/ui.presenter-next-run.test.ts` (French locale) are unrelated.

## Test plan

- [x] Unit: `pnpm test src/cli/update-cli.test.ts`
- [x] Typecheck + lint via `pnpm check:changed` on touched files
- [ ] Manual: `openclaw update` while already on `@latest` → expect `Already on <v>...` and exit 0 without calling npm
- [ ] Manual: `openclaw update --json` same scenario → expect structured `status:"skipped"` payload
- [ ] Manual: `openclaw update --tag <current-version>` → still reinstalls

*Disclosure: this patch was drafted with AI assistance; manual review applied.*