### PR TITLE
daemon: honor OPENCLAW_WRAPPER in LaunchAgent ProgramArguments (#69400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Plugins/tests: reuse plugin loader alias and Jiti config resolution across repeated same-context loads, reducing import-heavy test overhead. (#69316) Thanks @amknight.
+- Daemon/LaunchAgent: honor `OPENCLAW_WRAPPER` when it points at an existing file so `ProgramArguments` resolution delegates to secrets-manager wrappers (Doppler/SOPS/1Password CLI) instead of spawning node/bun directly, without requiring manual plist repatching after reinstalls. Unset or invalid paths keep the existing Node/Bun entrypoint resolution. (#69400) [AI-assisted]
 
 ### Fixes
 

--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -8,6 +8,7 @@ const childProcessMocks = vi.hoisted(() => ({
 const fsMocks = vi.hoisted(() => ({
   access: vi.fn(),
   realpath: vi.fn(),
+  stat: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", async () => {
@@ -18,9 +19,11 @@ vi.mock("node:fs/promises", async () => {
       ...actual,
       access: fsMocks.access,
       realpath: fsMocks.realpath,
+      stat: fsMocks.stat,
     },
     access: fsMocks.access,
     realpath: fsMocks.realpath,
+    stat: fsMocks.stat,
   };
 });
 
@@ -150,6 +153,84 @@ describe("resolveGatewayProgramArguments", () => {
       "--port",
       "18789",
     ]);
+  });
+
+  it("honors OPENCLAW_WRAPPER when it points at an existing file (#69400)", async () => {
+    const wrapperPath = path.resolve("/usr/local/bin/openclaw-doppler");
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+    fsMocks.stat.mockResolvedValue({ isFile: () => true } as never);
+    const previous = process.env.OPENCLAW_WRAPPER;
+    process.env.OPENCLAW_WRAPPER = wrapperPath;
+    try {
+      const result = await resolveGatewayProgramArguments({ port: 18789 });
+      expect(result.programArguments).toEqual([wrapperPath, "gateway", "--port", "18789"]);
+      expect(result.workingDirectory).toBeUndefined();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_WRAPPER;
+      } else {
+        process.env.OPENCLAW_WRAPPER = previous;
+      }
+    }
+  });
+
+  it("ignores OPENCLAW_WRAPPER when the path does not exist (#69400)", async () => {
+    const wrapperPath = path.resolve("/usr/local/bin/missing-wrapper");
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    const indexPath = path.resolve("/opt/openclaw/dist/index.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+    fsMocks.stat.mockRejectedValue(new Error("ENOENT"));
+    const previous = process.env.OPENCLAW_WRAPPER;
+    process.env.OPENCLAW_WRAPPER = wrapperPath;
+    try {
+      const result = await resolveGatewayProgramArguments({ port: 18789 });
+      expect(result.programArguments).toEqual([
+        process.execPath,
+        indexPath,
+        "gateway",
+        "--port",
+        "18789",
+      ]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_WRAPPER;
+      } else {
+        process.env.OPENCLAW_WRAPPER = previous;
+      }
+    }
+  });
+
+  it("ignores OPENCLAW_WRAPPER when the path is not a file (#69400)", async () => {
+    const wrapperPath = path.resolve("/etc");
+    const entryPath = path.resolve("/opt/openclaw/dist/entry.js");
+    const indexPath = path.resolve("/opt/openclaw/dist/index.js");
+    process.argv = ["node", entryPath];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+    fsMocks.stat.mockResolvedValue({ isFile: () => false } as never);
+    const previous = process.env.OPENCLAW_WRAPPER;
+    process.env.OPENCLAW_WRAPPER = wrapperPath;
+    try {
+      const result = await resolveGatewayProgramArguments({ port: 18789 });
+      expect(result.programArguments).toEqual([
+        process.execPath,
+        indexPath,
+        "gateway",
+        "--port",
+        "18789",
+      ]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_WRAPPER;
+      } else {
+        process.env.OPENCLAW_WRAPPER = previous;
+      }
+    }
   });
 
   it("uses src/entry.ts for bun dev mode", async () => {

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -177,12 +177,39 @@ async function resolveBinaryPath(binary: string): Promise<string> {
   }
 }
 
+const WRAPPER_ENV_KEY = "OPENCLAW_WRAPPER";
+
+async function resolveWrapperProgramArgs(
+  params: { args: string[] },
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<GatewayProgramArgs | null> {
+  const raw = env[WRAPPER_ENV_KEY]?.trim();
+  if (!raw) {
+    return null;
+  }
+  const resolved = path.resolve(raw);
+  try {
+    const stat = await fs.stat(resolved);
+    if (!stat.isFile()) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return { programArguments: [resolved, ...params.args] };
+}
+
 async function resolveCliProgramArguments(params: {
   args: string[];
   dev?: boolean;
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
+  const wrapperOverride = await resolveWrapperProgramArgs(params);
+  if (wrapperOverride) {
+    return wrapperOverride;
+  }
+
   const execPath = process.execPath;
   const runtime = params.runtime ?? "auto";
 


### PR DESCRIPTION
Fixes #69400.

### Summary
Teach `resolveCliProgramArguments` (the helper that builds macOS LaunchAgent / systemd `ProgramArguments` for `openclaw gateway` and `openclaw node run` services) to honor an `OPENCLAW_WRAPPER` environment variable. When set to an existing regular file, the resolver emits `[<wrapper>, <gateway|node args...>]` instead of `[<node|bun>, <cli-entrypoint>, <args...>]`, so secrets-manager shims (Doppler, SOPS, 1Password CLI, sudo/run-as helpers) survive `openclaw update` / reinstall without manually repatching the generated plist.

Unset or invalid paths (missing file, directory, socket, etc.) transparently fall back to the existing Node/Bun entrypoint resolution, so this is a strict opt-in.

### Why
Operators using a launchd service plus a secrets-wrapper binary currently have to re-edit `/Library/LaunchAgents/ai.openclaw.gateway.plist` after every upgrade because `openclaw service install` regenerates `ProgramArguments` from `resolveCliProgramArguments` and drops the wrapper shim. See the reproduction in #69400.

### Implementation
- `src/daemon/program-args.ts`: add `WRAPPER_ENV_KEY = "OPENCLAW_WRAPPER"` plus `resolveWrapperProgramArgs(params, env)`. It trims the env value, resolves the absolute path, `fs.stat`s it, verifies `isFile()`, and only then returns the shortened `programArguments`. Any failure (unset/empty env, missing path, non-file) returns `null` and the existing resolver runs.
- `resolveCliProgramArguments` calls the wrapper resolver before any runtime/dev-mode branch. All existing runtime preferences (`auto`, `node`, `bun`, `dev`) remain unchanged when the wrapper is not active.
- `src/daemon/program-args.test.ts`: three regression tests (honor wrapper, ignore when missing, ignore when not a file), gated by `process.env.OPENCLAW_WRAPPER` within `try/finally` so they don't leak state. Added `fsMocks.stat` to the existing `vi.hoisted` mock pattern.

### Operator example
```xml
<!-- ~/Library/LaunchAgents/ai.openclaw.gateway.plist -->
<key>EnvironmentVariables</key>
<dict>
  <key>OPENCLAW_WRAPPER</key>
  <string>/opt/homebrew/bin/openclaw-doppler</string>
</dict>
```
`openclaw service install` (and any subsequent `openclaw update`) will now keep emitting `ProgramArguments = [/opt/homebrew/bin/openclaw-doppler, gateway, --port, 18789]`.

### Verification
- `pnpm test src/daemon/program-args.test.ts` → 9/9 (6 pre-existing + 3 new).
- Full `pnpm tsgo:all` hits pre-existing failures in `src/security/skill-scanner.test.ts` on `origin/main`, unrelated to this change (verified by stashing and rerunning on bare upstream).

### Notes
- Backwards compatible: no existing plist/systemd unit is rewritten; the feature only kicks in when the env var is explicitly set by the operator.
- The wrapper is expected to `exec` the real node/bun + CLI entry with the args it receives. This PR deliberately doesn't prescribe the wrapper contents — that's operator territory.
- AI-assisted contribution.