### PR TITLE
fix(slack): preserve thread anchors over internal reply ids

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -430,6 +430,30 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text" });
   });
 
+  it("ignores non-Slack replyToId when threadId is available for sendText", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text-thread" });
+    const sendText = requireSlackSendText();
+
+    const result = await sendText({
+      cfg,
+      to: "C123",
+      text: "hello",
+      accountId: "default",
+      replyToId: "msg-internal-1",
+      threadId: "1712345678.123456",
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        threadTs: "1712345678.123456",
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-text-thread" });
+  });
+
   it("prefers replyToId over threadId for sendMedia", async () => {
     const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
     const sendMedia = requireSlackSendMedia();
@@ -454,6 +478,36 @@ describe("slackPlugin outbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-media" });
+  });
+
+  it("falls back to auto-thread resolution when replyToId is not a Slack ts", () => {
+    const autoThreadId = slackPlugin.threading?.resolveAutoThreadId?.({
+      cfg,
+      accountId: "default",
+      to: "channel:C123",
+      toolContext: {
+        currentChannelId: "C123",
+        currentThreadTs: "1712345678.123456",
+        replyToMode: "all",
+      },
+      replyToId: "msg-internal-1",
+    });
+
+    expect(autoThreadId).toBe("1712345678.123456");
+  });
+
+  it("falls back to threadId in reply transport when replyToId is not a Slack ts", () => {
+    const transport = slackPlugin.threading?.resolveReplyTransport?.({
+      cfg,
+      accountId: "default",
+      threadId: "1712345678.123456",
+      replyToId: "msg-internal-1",
+    });
+
+    expect(transport).toEqual({
+      replyToId: "1712345678.123456",
+      threadId: null,
+    });
   });
 
   it("forwards mediaLocalRoots for sendMedia", async () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -61,6 +61,7 @@ import {
   slackConfigAdapter,
 } from "./shared.js";
 import { parseSlackTarget } from "./target-parsing.js";
+import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
 
 // Lazy SDK loaders. The dynamic import is hidden behind a string-literal
@@ -167,7 +168,6 @@ let slackSendRuntimePromise: Promise<typeof import("./send.runtime.js")> | undef
 let slackProbeModulePromise: Promise<typeof import("./probe.js")> | undefined;
 let slackMonitorModulePromise: Promise<typeof import("./monitor.js")> | undefined;
 let slackDirectoryLiveModulePromise: Promise<typeof import("./directory-live.js")> | undefined;
-const SLACK_THREAD_TS_PATTERN = /^\d+\.\d+$/;
 
 const loadSlackDirectoryConfigModule = createLazyRuntimeModule(
   () => import("./directory-config.js"),
@@ -200,27 +200,6 @@ async function loadSlackMonitorModule() {
 async function loadSlackDirectoryLiveModule() {
   slackDirectoryLiveModulePromise ??= import("./directory-live.js");
   return await slackDirectoryLiveModulePromise;
-}
-
-function normalizeSlackThreadTsCandidate(value?: string | number | null): string | undefined {
-  const normalized =
-    typeof value === "number"
-      ? normalizeOptionalString(String(value))
-      : normalizeOptionalString(value);
-  if (!normalized) {
-    return undefined;
-  }
-  return SLACK_THREAD_TS_PATTERN.test(normalized) ? normalized : undefined;
-}
-
-function resolveSlackThreadTsValue(params: {
-  replyToId?: string | number | null;
-  threadId?: string | number | null;
-}): string | undefined {
-  return (
-    normalizeSlackThreadTsCandidate(params.replyToId) ??
-    (params.threadId != null ? normalizeOptionalString(String(params.threadId)) : undefined)
-  );
 }
 
 async function resolveSlackSendContext(params: {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -167,6 +167,7 @@ let slackSendRuntimePromise: Promise<typeof import("./send.runtime.js")> | undef
 let slackProbeModulePromise: Promise<typeof import("./probe.js")> | undefined;
 let slackMonitorModulePromise: Promise<typeof import("./monitor.js")> | undefined;
 let slackDirectoryLiveModulePromise: Promise<typeof import("./directory-live.js")> | undefined;
+const SLACK_THREAD_TS_PATTERN = /^\d+\.\d+$/;
 
 const loadSlackDirectoryConfigModule = createLazyRuntimeModule(
   () => import("./directory-config.js"),
@@ -201,6 +202,27 @@ async function loadSlackDirectoryLiveModule() {
   return await slackDirectoryLiveModulePromise;
 }
 
+function normalizeSlackThreadTsCandidate(value?: string | number | null): string | undefined {
+  const normalized =
+    typeof value === "number"
+      ? normalizeOptionalString(String(value))
+      : normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  return SLACK_THREAD_TS_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+function resolveSlackThreadTsValue(params: {
+  replyToId?: string | number | null;
+  threadId?: string | number | null;
+}): string | undefined {
+  return (
+    normalizeSlackThreadTsCandidate(params.replyToId) ??
+    (params.threadId != null ? normalizeOptionalString(String(params.threadId)) : undefined)
+  );
+}
+
 async function resolveSlackSendContext(params: {
   cfg: Parameters<typeof resolveSlackAccount>[0]["cfg"];
   accountId?: string;
@@ -218,7 +240,7 @@ async function resolveSlackSendContext(params: {
   const token = getTokenForOperation(account, "write");
   const botToken = account.botToken?.trim();
   const tokenOverride = token && token !== botToken ? token : undefined;
-  const threadTsValue = params.replyToId ?? params.threadId;
+  const threadTsValue = resolveSlackThreadTsValue(params);
   return { send, threadTsValue, tokenOverride };
 }
 
@@ -608,14 +630,14 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
     allowExplicitReplyTagsWhenOff: false,
     buildToolContext: (params) => buildSlackThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
-      replyToId
+      normalizeSlackThreadTsCandidate(replyToId)
         ? undefined
         : resolveSlackAutoThreadId({
             to,
             toolContext,
           }),
     resolveReplyTransport: ({ threadId, replyToId }) => ({
-      replyToId: replyToId ?? (threadId != null && threadId !== "" ? String(threadId) : undefined),
+      replyToId: resolveSlackThreadTsValue({ replyToId, threadId }),
       threadId: null,
     }),
   },
@@ -669,7 +691,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         });
         return await send(to, text, {
           cfg,
-          threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
+          threadTs: threadTsValue,
           accountId: accountId ?? undefined,
           ...(tokenOverride ? { token: tokenOverride } : {}),
         });
@@ -696,7 +718,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
           cfg,
           mediaUrl,
           mediaLocalRoots,
-          threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
+          threadTs: threadTsValue,
           accountId: accountId ?? undefined,
           ...(tokenOverride ? { token: tokenOverride } : {}),
         });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -201,4 +201,45 @@ describe("slackOutbound", () => {
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-final" });
   });
+
+  it("sends a top-level payload when threadId is missing", async () => {
+    sendMessageSlackMock.mockResolvedValue({ messageId: "m-final" });
+
+    const result = await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "final text",
+        channelData: {
+          slack: {
+            blocks: [
+              {
+                type: "section",
+                text: { type: "plain_text", text: "Block body" },
+              },
+            ],
+          },
+        },
+      },
+      accountId: "default",
+      replyToId: "msg-internal-1",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "final text",
+      expect.objectContaining({
+        cfg,
+        threadTs: undefined,
+        blocks: [
+          {
+            type: "section",
+            text: { type: "plain_text", text: "Block body" },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-final" });
+  });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -1,18 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
-const hasHooksMock = vi.hoisted(() => vi.fn());
-const runMessageSendingMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMessageSlackMock(...args),
-}));
-
-vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
-  getGlobalHookRunner: () => ({
-    hasHooks: (...args: unknown[]) => hasHooksMock(...args),
-    runMessageSending: (...args: unknown[]) => runMessageSendingMock(...args),
-  }),
 }));
 
 let slackOutbound: typeof import("./outbound-adapter.js").slackOutbound;
@@ -30,9 +21,6 @@ describe("slackOutbound", () => {
 
   beforeEach(() => {
     sendMessageSlackMock.mockReset();
-    hasHooksMock.mockReset();
-    runMessageSendingMock.mockReset();
-    hasHooksMock.mockReturnValue(false);
   });
 
   it("sends payload media first, then finalizes with blocks", async () => {
@@ -127,9 +115,8 @@ describe("slackOutbound", () => {
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-blocks" });
   });
-  it("cancels sendMedia when message_sending hooks block it", async () => {
-    hasHooksMock.mockReturnValue(true);
-    runMessageSendingMock.mockResolvedValue({ cancel: true });
+  it("sends media with a normalized threadTs", async () => {
+    sendMessageSlackMock.mockResolvedValue({ messageId: "m-media" });
 
     const result = await slackOutbound.sendMedia!({
       cfg,
@@ -140,24 +127,16 @@ describe("slackOutbound", () => {
       replyToId: "1712000000.000001",
     });
 
-    expect(runMessageSendingMock).toHaveBeenCalledWith(
-      {
-        to: "C123",
-        content: "caption",
-        metadata: {
-          threadTs: "1712000000.000001",
-          channelId: "C123",
-          mediaUrl: "https://example.com/image.png",
-        },
-      },
-      { channelId: "slack", accountId: "default" },
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "caption",
+      expect.objectContaining({
+        cfg,
+        mediaUrl: "https://example.com/image.png",
+        threadTs: "1712000000.000001",
+      }),
     );
-    expect(sendMessageSlackMock).not.toHaveBeenCalled();
-    expect(result).toMatchObject({
-      channel: "slack",
-      messageId: "cancelled-by-hook",
-      meta: { cancelled: true },
-    });
+    expect(result).toEqual({ channel: "slack", messageId: "m-media" });
   });
 
   it("ignores non-Slack replyToId on sendPayload when threadId is available", async () => {

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
+const hasHooksMock = vi.hoisted(() => vi.fn());
+const runMessageSendingMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMessageSlackMock(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: (...args: unknown[]) => hasHooksMock(...args),
+    runMessageSending: (...args: unknown[]) => runMessageSendingMock(...args),
+  }),
 }));
 
 let slackOutbound: typeof import("./outbound-adapter.js").slackOutbound;
@@ -21,6 +30,9 @@ describe("slackOutbound", () => {
 
   beforeEach(() => {
     sendMessageSlackMock.mockReset();
+    hasHooksMock.mockReset();
+    runMessageSendingMock.mockReset();
+    hasHooksMock.mockReturnValue(false);
   });
 
   it("sends payload media first, then finalizes with blocks", async () => {
@@ -114,5 +126,79 @@ describe("slackOutbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-blocks" });
+  });
+  it("cancels sendMedia when message_sending hooks block it", async () => {
+    hasHooksMock.mockReturnValue(true);
+    runMessageSendingMock.mockResolvedValue({ cancel: true });
+
+    const result = await slackOutbound.sendMedia!({
+      cfg,
+      to: "C123",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+      replyToId: "1712000000.000001",
+    });
+
+    expect(runMessageSendingMock).toHaveBeenCalledWith(
+      {
+        to: "C123",
+        content: "caption",
+        metadata: {
+          threadTs: "1712000000.000001",
+          channelId: "C123",
+          mediaUrl: "https://example.com/image.png",
+        },
+      },
+      { channelId: "slack", accountId: "default" },
+    );
+    expect(sendMessageSlackMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      channel: "slack",
+      messageId: "cancelled-by-hook",
+      meta: { cancelled: true },
+    });
+  });
+
+  it("ignores non-Slack replyToId on sendPayload when threadId is available", async () => {
+    sendMessageSlackMock.mockResolvedValue({ messageId: "m-final" });
+
+    const result = await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "final text",
+        channelData: {
+          slack: {
+            blocks: [
+              {
+                type: "section",
+                text: { type: "plain_text", text: "Block body" },
+              },
+            ],
+          },
+        },
+      },
+      accountId: "default",
+      replyToId: "msg-internal-1",
+      threadId: "1712345678.123456",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "final text",
+      expect.objectContaining({
+        cfg,
+        threadTs: "1712345678.123456",
+        blocks: [
+          {
+            type: "section",
+            text: { type: "plain_text", text: "Block body" },
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-final" });
   });
 });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -12,14 +12,12 @@ import {
   resolveOutboundSendDep,
   type OutboundIdentity,
 } from "openclaw/plugin-sdk/outbound-runtime";
-import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequenceAndFinalize,
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { resolveSlackAccount } from "./accounts.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
@@ -65,40 +63,6 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
-async function applySlackMessageSendingHooks(params: {
-  cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
-  to: string;
-  text: string;
-  threadTs?: string;
-  accountId?: string;
-  mediaUrl?: string;
-}): Promise<{ cancelled: boolean; text: string }> {
-  const hookRunner = getGlobalHookRunner();
-  if (!hookRunner?.hasHooks("message_sending")) {
-    return { cancelled: false, text: params.text };
-  }
-  const account = resolveSlackAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
-  const hookResult = await hookRunner.runMessageSending(
-    {
-      to: params.to,
-      content: params.text,
-      metadata: {
-        threadTs: params.threadTs,
-        channelId: params.to,
-        ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
-      },
-    },
-    { channelId: "slack", accountId: account.accountId },
-  );
-  if (hookResult?.cancel) {
-    return { cancelled: true, text: params.text };
-  }
-  return { cancelled: false, text: hookResult?.content ?? params.text };
-}
-
 async function sendSlackOutboundMessage(params: {
   cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
   to: string;
@@ -124,23 +88,8 @@ async function sendSlackOutboundMessage(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
   });
-  const hookResult = await applySlackMessageSendingHooks({
-    cfg: params.cfg,
-    to: params.to,
-    text: params.text,
-    threadTs,
-    mediaUrl: params.mediaUrl,
-    accountId: params.accountId ?? undefined,
-  });
-  if (hookResult.cancelled) {
-    return {
-      messageId: "cancelled-by-hook",
-      channelId: params.to,
-      meta: { cancelled: true },
-    };
-  }
   const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const result = await send(params.to, hookResult.text, {
+  const result = await send(params.to, params.text, {
     cfg: params.cfg,
     threadTs,
     accountId: params.accountId ?? undefined,

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -12,12 +12,14 @@ import {
   resolveOutboundSendDep,
   type OutboundIdentity,
 } from "openclaw/plugin-sdk/outbound-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequenceAndFinalize,
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { resolveSlackAccount } from "./accounts.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
@@ -27,6 +29,7 @@ import {
 import { compileSlackInteractiveReplies } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import type { SlackSendIdentity } from "./send.js";
+import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
 const SLACK_MAX_BLOCKS = 50;
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
@@ -62,6 +65,40 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
+async function applySlackMessageSendingHooks(params: {
+  cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
+  to: string;
+  text: string;
+  threadTs?: string;
+  accountId?: string;
+  mediaUrl?: string;
+}): Promise<{ cancelled: boolean; text: string }> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("message_sending")) {
+    return { cancelled: false, text: params.text };
+  }
+  const account = resolveSlackAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const hookResult = await hookRunner.runMessageSending(
+    {
+      to: params.to,
+      content: params.text,
+      metadata: {
+        threadTs: params.threadTs,
+        channelId: params.to,
+        ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
+      },
+    },
+    { channelId: "slack", accountId: account.accountId },
+  );
+  if (hookResult?.cancel) {
+    return { cancelled: true, text: params.text };
+  }
+  return { cancelled: false, text: hookResult?.content ?? params.text };
+}
+
 async function sendSlackOutboundMessage(params: {
   cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
   to: string;
@@ -83,10 +120,29 @@ async function sendSlackOutboundMessage(params: {
   const send =
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
     (await loadSlackSendRuntime()).sendMessageSlack;
-  const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const result = await send(params.to, params.text, {
+  const threadTs = resolveSlackThreadTsValue({
+    replyToId: params.replyToId,
+    threadId: params.threadId,
+  });
+  const hookResult = await applySlackMessageSendingHooks({
     cfg: params.cfg,
-    threadTs: params.replyToId ?? (params.threadId != null ? String(params.threadId) : undefined),
+    to: params.to,
+    text: params.text,
+    threadTs,
+    mediaUrl: params.mediaUrl,
+    accountId: params.accountId ?? undefined,
+  });
+  if (hookResult.cancelled) {
+    return {
+      messageId: "cancelled-by-hook",
+      channelId: params.to,
+      meta: { cancelled: true },
+    };
+  }
+  const slackIdentity = resolveSlackSendIdentity(params.identity);
+  const result = await send(params.to, hookResult.text, {
+    cfg: params.cfg,
+    threadTs,
     accountId: params.accountId ?? undefined,
     ...(params.mediaUrl
       ? {

--- a/extensions/slack/src/thread-ts.ts
+++ b/extensions/slack/src/thread-ts.ts
@@ -1,0 +1,26 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+
+const SLACK_THREAD_TS_PATTERN = /^\d+\.\d+$/;
+
+export function normalizeSlackThreadTsCandidate(
+  value?: string | number | null,
+): string | undefined {
+  const normalized =
+    typeof value === "number"
+      ? normalizeOptionalString(String(value))
+      : normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  return SLACK_THREAD_TS_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+export function resolveSlackThreadTsValue(params: {
+  replyToId?: string | number | null;
+  threadId?: string | number | null;
+}): string | undefined {
+  return (
+    normalizeSlackThreadTsCandidate(params.replyToId) ??
+    (params.threadId != null ? normalizeOptionalString(String(params.threadId)) : undefined)
+  );
+}

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { slackPlugin } from "../../../extensions/slack/api.js";
 import type {
   ChannelMessagingAdapter,
   ChannelPlugin,
@@ -59,12 +60,12 @@ const slackMessaging: ChannelMessagingAdapter = {
   },
 };
 
-const slackThreading: ChannelThreadingAdapter = {
-  resolveReplyTransport: ({ threadId, replyToId }) => ({
-    replyToId: replyToId ?? (threadId != null && threadId !== "" ? String(threadId) : undefined),
-    threadId: null,
-  }),
-};
+const slackThreading = (() => {
+  if (!slackPlugin.threading) {
+    throw new Error("slack threading unavailable");
+  }
+  return slackPlugin.threading satisfies ChannelThreadingAdapter;
+})();
 
 const mattermostThreading: ChannelThreadingAdapter = {
   resolveReplyTransport: ({ threadId, replyToId }) => ({
@@ -446,6 +447,21 @@ describe("routeReply", () => {
     expectLastDelivery({
       channel: "slack",
       replyToId: "1710000000.9999",
+      threadId: null,
+    });
+  });
+
+  it("prefers Slack threadId over a non-Slack replyToId when routing", async () => {
+    await routeReply({
+      payload: { text: "hi", replyToId: "msg-internal-1" },
+      channel: "slack",
+      to: "channel:C123",
+      threadId: "1712345678.123456",
+      cfg: {} as never,
+    });
+    expectLastDelivery({
+      channel: "slack",
+      replyToId: "1712345678.123456",
       threadId: null,
     });
   });

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { slackPlugin } from "../../../extensions/slack/api.js";
 import type {
   ChannelMessagingAdapter,
   ChannelPlugin,
@@ -60,12 +59,17 @@ const slackMessaging: ChannelMessagingAdapter = {
   },
 };
 
-const slackThreading = (() => {
-  if (!slackPlugin.threading) {
-    throw new Error("slack threading unavailable");
-  }
-  return slackPlugin.threading satisfies ChannelThreadingAdapter;
-})();
+function resolveSlackThreadTsCandidate(value?: string | number | null): string | undefined {
+  const normalized = typeof value === "number" ? String(value).trim() : value?.trim();
+  return normalized && /^\d+\.\d+$/.test(normalized) ? normalized : undefined;
+}
+
+const slackThreading: ChannelThreadingAdapter = {
+  resolveReplyTransport: ({ threadId, replyToId }) => ({
+    replyToId: resolveSlackThreadTsCandidate(replyToId) ?? resolveSlackThreadTsCandidate(threadId),
+    threadId: null,
+  }),
+};
 
 const mattermostThreading: ChannelThreadingAdapter = {
   resolveReplyTransport: ({ threadId, replyToId }) => ({


### PR DESCRIPTION
## Summary
- validate Slack `replyToId` values before treating them as `thread_ts`
- fall back to the known `threadId` anchor when `replyToId` is an internal OpenClaw message id
- add regression coverage for the send path plus Slack threading transport helpers

## Root cause
Slack-specific reply routing accepted any non-empty `replyToId` as a thread reference. In resumed turns triggered by internal events, `[[reply_to_current]]` could resolve to an internal OpenClaw message id instead of a real Slack `thread_ts`, which then overrode the valid Slack thread anchor and leaked the reply to channel root.

## Validation
- `pnpm test extensions/slack/src/channel.test.ts`
- `pnpm test extensions/slack/src/threading.test.ts`
- `pnpm check`

Closes #68790.
