### PR TITLE
fix(gateway): classify loopback shared-secret clients as local for pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/pairing: treat loopback shared-secret node-host, TUI, and gateway clients as local for pairing decisions, so trusted local tools no longer reconnect as remote clients and fail with `pairing required`. (#69431) Thanks @SARAMALI15792.
 - Telegram/status reactions: honor `messages.removeAckAfterReply` when lifecycle status reactions are enabled, clearing or restoring the reaction after success/error using the configured hold timings. (#68067) Thanks @poiskgit.
 - Telegram/polling: raise the default polling watchdog threshold from 90s to 120s and add configurable `channels.telegram.pollingStallThresholdMs` (also per-account) so long-running Telegram work gets more room before polling is treated as stalled. (#57737) Thanks @Vitalcheffe.
 - Telegram/polling: bound the persisted-offset confirmation `getUpdates` probe with a client-side timeout so a zombie socket cannot hang polling recovery before the runner watchdog starts. (#50368) Thanks @boticlaw.

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -548,4 +548,25 @@ describe("handshake auth helpers", () => {
       }),
     ).toBe(false);
   });
+
+  it("prefers cli_container_local over shared_secret_loopback_local for CLI clients", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+      },
+    } as ConnectParams;
+    expect(
+      resolvePairingLocality({
+        connectParams,
+        isLocalClient: false,
+        requestHost: "127.0.0.1:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe("cli_container_local");
+  });
 });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -322,7 +322,7 @@ describe("handshake auth helpers", () => {
     ).toBe("remote");
   });
 
-  it("keeps non-CLI clients remote when only the Docker CLI fallback conditions match", () => {
+  it("classifies non-CLI Docker-published loopback clients as shared_secret_loopback_local when auth is token/password", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -340,7 +340,7 @@ describe("handshake auth helpers", () => {
         sharedAuthOk: true,
         authMethod: "token",
       }),
-    ).toBe("remote");
+    ).toBe("shared_secret_loopback_local");
   });
 
   it("skips backend self-pairing only for direct-local backend clients", () => {
@@ -438,6 +438,113 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
         authMethod: "token",
+      }),
+    ).toBe(false);
+  });
+
+  it("classifies non-CLI loopback + shared-secret clients as shared_secret_loopback_local", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.NODE_HOST,
+        mode: GATEWAY_CLIENT_MODES.NODE,
+      },
+    } as ConnectParams;
+    expect(
+      resolvePairingLocality({
+        connectParams,
+        isLocalClient: false,
+        requestHost: "127.0.0.1:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe("shared_secret_loopback_local");
+  });
+
+  it("keeps non-CLI loopback clients remote without shared-secret auth", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.NODE_HOST,
+        mode: GATEWAY_CLIENT_MODES.NODE,
+      },
+    } as ConnectParams;
+    const base = {
+      connectParams,
+      isLocalClient: false,
+      requestHost: "127.0.0.1:18789",
+      remoteAddress: "127.0.0.1",
+      hasProxyHeaders: false,
+      hasBrowserOriginHeader: false,
+    } as const;
+
+    expect(
+      resolvePairingLocality({
+        ...base,
+        sharedAuthOk: false,
+        authMethod: "token",
+      }),
+    ).toBe("remote");
+    expect(
+      resolvePairingLocality({
+        ...base,
+        sharedAuthOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe("remote");
+    expect(
+      resolvePairingLocality({
+        ...base,
+        remoteAddress: "192.168.1.10",
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe("remote");
+    expect(
+      resolvePairingLocality({
+        ...base,
+        hasProxyHeaders: true,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe("remote");
+    expect(
+      resolvePairingLocality({
+        ...base,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe("remote");
+  });
+
+  it("allows silent scope-upgrade for shared_secret_loopback_local", () => {
+    expect(
+      shouldAllowSilentLocalPairing({
+        locality: "shared_secret_loopback_local",
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "scope-upgrade",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAllowSilentLocalPairing({
+        locality: "shared_secret_loopback_local",
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "role-upgrade",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAllowSilentLocalPairing({
+        locality: "shared_secret_loopback_local",
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "metadata-upgrade",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -20,6 +20,7 @@ export type PairingLocalityKind =
   | "direct_local"
   | "cli_container_local"
   | "browser_container_local"
+  | "shared_secret_loopback_local"
   | "remote";
 
 export type HandshakeBrowserSecurityContext = {
@@ -111,6 +112,26 @@ function isCliContainerLocalEquivalent(params: {
   );
 }
 
+function isSharedSecretLoopbackLocalEquivalent(params: {
+  requestHost?: string;
+  remoteAddress?: string;
+  hasProxyHeaders: boolean;
+  hasBrowserOriginHeader: boolean;
+  sharedAuthOk: boolean;
+  authMethod: GatewayAuthResult["method"];
+}): boolean {
+  const usesSharedSecretAuth =
+    params.authMethod === "token" || params.authMethod === "password";
+  return (
+    params.sharedAuthOk &&
+    usesSharedSecretAuth &&
+    !params.hasProxyHeaders &&
+    !params.hasBrowserOriginHeader &&
+    isLoopbackAddress(params.remoteAddress) &&
+    isPrivateOrLoopbackHost(resolveHostName(params.requestHost))
+  );
+}
+
 function resolveOriginHost(origin?: string): string {
   const trimmed = origin?.trim();
   if (!trimmed) {
@@ -189,6 +210,18 @@ export function resolvePairingLocality(params: {
     })
   ) {
     return "cli_container_local";
+  }
+  if (
+    isSharedSecretLoopbackLocalEquivalent({
+      requestHost: params.requestHost,
+      remoteAddress: params.remoteAddress,
+      hasProxyHeaders: params.hasProxyHeaders,
+      hasBrowserOriginHeader: params.hasBrowserOriginHeader,
+      sharedAuthOk: params.sharedAuthOk,
+      authMethod: params.authMethod,
+    })
+  ) {
+    return "shared_secret_loopback_local";
   }
   return "remote";
 }


### PR DESCRIPTION
## Summary

- **Problem:** Internal tools (node-host cron scheduler, TUI, gateway-client backend) connecting from loopback with valid shared-secret auth are classified as `remote` by `resolvePairingLocality()`, causing `close(1008, "pairing required")` on scope-upgrade with no recovery path.
- **Why it matters:** Users cannot use internal tools that require scope upgrades — the gateway silently kills the connection and no approval UI exists for scope-upgrade.
- **What changed:** Added new `PairingLocalityKind` variant `"shared_secret_loopback_local"` with gate function `isSharedSecretLoopbackLocalEquivalent` in `handshake-auth-helpers.ts`. Any loopback-origin connection with valid shared-secret (token/password), no proxy headers, and no browser origin header now classifies as local for pairing purposes.
- **What did NOT change (scope boundary):** No changes to `message-handler.ts`, error messages, pending persistence, Control UI, or silent-pairing policy. `shouldAllowSilentLocalPairing` already uses `locality !== "remote"` — the new kind passes automatically.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69397
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolvePairingLocality()` only recognized three local shapes: `direct_local`, `browser_container_local` (Control UI), and `cli_container_local` (CLI clients). Internal tools using `NODE_HOST`, `GATEWAY_CLIENT`, or `TUI` client IDs fell through to `"remote"` despite connecting from loopback with valid shared-secret auth.
- **Missing detection / guardrail:** No catch-all gate for loopback + shared-secret clients beyond CLI and Control UI.
- **Contributing context:** The gate functions were designed when only CLI and Control UI needed loopback classification. As internal tools (cron scheduler, TUI) were added, they inherited the `remote` fallback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- **Scenario the test should lock in:** NODE_HOST client + loopback + token auth → `"shared_secret_loopback_local"` (not `"remote"`)
- **Why this is the smallest reliable guardrail:** The gate function is pure logic with no I/O — unit tests cover all decision paths exhaustively.
- **Existing test that already covers this:** None existed. Added 4 new tests + updated 1 existing test.

## User-visible / Behavior Changes

- Internal tools (node-host cron, TUI, gateway-client backend) connecting from loopback with valid token/password auth will now silently auto-approve scope-upgrade, role-upgrade, and not-paired pairing requests instead of being disconnected with `1008 "pairing required"`.

## Diagram (if applicable)

```text
Before:
[node-host loopback+token] -> resolvePairingLocality -> "remote" -> close(1008, "pairing required")

After:
[node-host loopback+token] -> resolvePairingLocality -> "shared_secret_loopback_local" -> silent pairing approved
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — locality only affects the approval path, not authentication. Connections must still pass `sharedAuthOk` before locality is evaluated.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node.js via pnpm
- Model/provider: N/A (gateway infrastructure)
- Integration/channel: N/A

### Steps

1. Start gateway with token auth configured
2. Connect node-host runner from loopback (127.0.0.1) with valid token
3. Trigger scope-upgrade on the connection

### Expected

- Connection silently auto-approves scope-upgrade (same as CLI clients)

### Actual

- Before fix: Connection closed with `1008 "pairing required"`
- After fix: Scope-upgrade silently approved

## Evidence

- [x] Failing test/log before + passing after
- 19/19 unit tests pass including:
  - `classifies non-CLI loopback + shared-secret clients as shared_secret_loopback_local`
  - `keeps non-CLI loopback clients remote without shared-secret auth` (5 negative cases)
  - `allows silent scope-upgrade for shared_secret_loopback_local`
  - `prefers cli_container_local over shared_secret_loopback_local for CLI clients`

## Human Verification (required)

- **Verified scenarios:** All 19 unit tests pass (vitest verbose). Type safety confirmed via successful test compilation. Spec compliance review + code quality review both approved.
- **Edge cases checked:** Non-loopback remote (192.168.1.10 → remote), proxy headers (→ remote), browser origin (→ remote), device-token auth (→ remote), sharedAuthOk=false (→ remote), CLI precedence preserved.
- **What you did not verify:** Full `pnpm check` / `pnpm build` (OOM on local machine — CI will validate). E2E with live gateway connection.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Broadening locality classification could silently upgrade scopes for clients that previously failed.
  - **Mitigation:** Gate requires all 5 conditions simultaneously: `sharedAuthOk` + shared-secret auth method (token/password) + no proxy headers + no browser origin + loopback address + private/loopback host. Remote attackers cannot satisfy these conditions. The existing reason allowlist (not-paired, scope-upgrade, role-upgrade only — not metadata) is preserved unchanged.