### PR TITLE
fix(infra/net): propagate global stream timeout onto pinned http/1.1 dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: raise the outbound `/api/v1/message/text` send timeout default from 10s to 30s, and add a configurable `channels.bluebubbles.sendTimeoutMs` (also per-account) so macOS 26 setups where Private API iMessage sends stall for 60+ seconds no longer silently lose messages at the 10s abort. Probes, chat lookups, and health checks keep the shorter 10s default. Fixes #67486. (#69193) Thanks @omarshahine.
 - Context engine/plugins: stop rejecting third-party context engines whose `info.id` differs from the registered plugin slot id. The strict-match contract added in 2026.4.14 broke `lossless-claw` and other plugins whose internal engine id does not equal the slot id they are registered under, producing repeated `info.id must match registered id` lane failures on every turn. Fixes #66601. (#66678) Thanks @GodsBoy.
 - Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
+- Infra/net: propagate the configured global undici stream timeout onto pinned HTTP/1.1 dispatchers built by `createHttp1Agent` / `createHttp1EnvHttpProxyAgent` (SSRF-guarded fetch flows, per-request Agents). Slow local providers — Ollama, embedded runners — no longer fall back to undici's default 5-minute `headersTimeout` while waiting for first-token latency. Fixes #69390. [AI-assisted]
 
 ## 2026.4.20
 

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -72,6 +72,7 @@ import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 let DEFAULT_UNDICI_STREAM_TIMEOUT_MS: typeof import("./undici-global-dispatcher.js").DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
 let ensureGlobalUndiciEnvProxyDispatcher: typeof import("./undici-global-dispatcher.js").ensureGlobalUndiciEnvProxyDispatcher;
 let ensureGlobalUndiciStreamTimeouts: typeof import("./undici-global-dispatcher.js").ensureGlobalUndiciStreamTimeouts;
+let getEffectiveUndiciStreamTimeoutMs: typeof import("./undici-global-dispatcher.js").getEffectiveUndiciStreamTimeoutMs;
 let resetGlobalUndiciStreamTimeoutsForTests: typeof import("./undici-global-dispatcher.js").resetGlobalUndiciStreamTimeoutsForTests;
 
 describe("ensureGlobalUndiciStreamTimeouts", () => {
@@ -80,6 +81,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
       ensureGlobalUndiciEnvProxyDispatcher,
       ensureGlobalUndiciStreamTimeouts,
+      getEffectiveUndiciStreamTimeoutMs,
       resetGlobalUndiciStreamTimeoutsForTests,
     } = await import("./undici-global-dispatcher.js"));
   });
@@ -170,6 +172,29 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
     });
+  });
+
+  it("exposes the last applied stream timeout via getEffectiveUndiciStreamTimeoutMs (#69390)", () => {
+    // Pinned dispatchers built outside the global scope (SSRF-guarded fetch
+    // flows, per-request Agents) need the effective stream timeout to avoid
+    // falling back to undici's 300_000 ms headers timeout on slow local
+    // providers like Ollama.
+    expect(getEffectiveUndiciStreamTimeoutMs()).toBeNull();
+
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 900_000 });
+    expect(getEffectiveUndiciStreamTimeoutMs()).toBe(900_000);
+
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_800_000 });
+    expect(getEffectiveUndiciStreamTimeoutMs()).toBe(1_800_000);
+  });
+
+  it("leaves getEffectiveUndiciStreamTimeoutMs untouched when dispatcher kind is unsupported (#69390)", () => {
+    setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
+
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 900_000 });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(getEffectiveUndiciStreamTimeoutMs()).toBeNull();
   });
 });
 

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -9,6 +9,17 @@ const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
 
 let lastAppliedTimeoutKey: string | null = null;
 let lastAppliedProxyBootstrap = false;
+let lastAppliedTimeoutMs: number | null = null;
+
+/**
+ * Return the last applied stream timeout in milliseconds, or null if no
+ * explicit timeout has been configured yet. Pinned dispatchers built outside
+ * the global scope (for example SSRF-guarded fetch flows) should apply this
+ * value when the caller has not set its own `headersTimeout`/`bodyTimeout`.
+ */
+export function getEffectiveUndiciStreamTimeoutMs(): number | null {
+  return lastAppliedTimeoutMs;
+}
 
 type DispatcherKind = "agent" | "env-proxy" | "unsupported";
 
@@ -144,6 +155,7 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
       );
     }
     lastAppliedTimeoutKey = nextKey;
+    lastAppliedTimeoutMs = timeoutMs;
   } catch {
     // Best-effort hardening only.
   }
@@ -152,4 +164,5 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {
   lastAppliedTimeoutKey = null;
   lastAppliedProxyBootstrap = false;
+  lastAppliedTimeoutMs = null;
 }

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { Agent, EnvHttpProxyAgent } = vi.hoisted(() => {
+  class Agent {
+    constructor(public readonly options?: Record<string, unknown>) {}
+  }
+  class EnvHttpProxyAgent {
+    constructor(public readonly options?: Record<string, unknown>) {}
+  }
+  return { Agent, EnvHttpProxyAgent };
+});
+
+vi.mock("./undici-global-dispatcher.js", () => ({
+  getEffectiveUndiciStreamTimeoutMs: vi.fn(() => null as number | null),
+}));
+
+import { getEffectiveUndiciStreamTimeoutMs } from "./undici-global-dispatcher.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  TEST_UNDICI_RUNTIME_DEPS_KEY,
+} from "./undici-runtime.js";
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+    Agent,
+    EnvHttpProxyAgent,
+    FormData: undefined,
+    ProxyAgent: class {
+      constructor(public readonly url: string) {}
+    },
+    fetch: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
+  vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(null);
+});
+
+describe("createHttp1Agent", () => {
+  it("does not inject timeouts when no effective stream timeout has been configured (#69390)", () => {
+    vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(null);
+
+    const agent = createHttp1Agent() as unknown as { options?: Record<string, unknown> };
+
+    expect(agent.options?.headersTimeout).toBeUndefined();
+    expect(agent.options?.bodyTimeout).toBeUndefined();
+    expect(agent.options?.allowH2).toBe(false);
+  });
+
+  it("mirrors the effective stream timeout onto pinned dispatchers when unset (#69390)", () => {
+    // SSRF-guarded fetches create per-request pinned Agents that do not
+    // inherit the global dispatcher timeouts; without this plumbing slow
+    // Ollama streams still hit undici's default 300_000 ms headers timeout.
+    vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(1_800_000);
+
+    const agent = createHttp1Agent() as unknown as { options?: Record<string, unknown> };
+
+    expect(agent.options?.headersTimeout).toBe(1_800_000);
+    expect(agent.options?.bodyTimeout).toBe(1_800_000);
+    expect(agent.options?.allowH2).toBe(false);
+  });
+
+  it("preserves caller-provided timeouts over the effective stream timeout (#69390)", () => {
+    vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(1_800_000);
+
+    const agent = createHttp1Agent({
+      headersTimeout: 10_000,
+      bodyTimeout: 20_000,
+    } as Parameters<typeof createHttp1Agent>[0]) as unknown as {
+      options?: Record<string, unknown>;
+    };
+
+    expect(agent.options?.headersTimeout).toBe(10_000);
+    expect(agent.options?.bodyTimeout).toBe(20_000);
+  });
+
+  it("injects only the missing half of the timeout pair (#69390)", () => {
+    vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(1_800_000);
+
+    const agent = createHttp1Agent({ headersTimeout: 5_000 } as Parameters<
+      typeof createHttp1Agent
+    >[0]) as unknown as { options?: Record<string, unknown> };
+
+    expect(agent.options?.headersTimeout).toBe(5_000);
+    expect(agent.options?.bodyTimeout).toBe(1_800_000);
+  });
+});
+
+describe("createHttp1EnvHttpProxyAgent", () => {
+  it("mirrors the effective stream timeout onto env-proxy pinned dispatchers (#69390)", () => {
+    vi.mocked(getEffectiveUndiciStreamTimeoutMs).mockReturnValue(900_000);
+
+    const agent = createHttp1EnvHttpProxyAgent() as unknown as {
+      options?: Record<string, unknown>;
+    };
+
+    expect(agent.options?.headersTimeout).toBe(900_000);
+    expect(agent.options?.bodyTimeout).toBe(900_000);
+    expect(agent.options?.allowH2).toBe(false);
+  });
+});

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { getEffectiveUndiciStreamTimeoutMs } from "./undici-global-dispatcher.js";
 
 export const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
 
@@ -65,16 +66,56 @@ function withHttp1OnlyDispatcherOptions<T extends object | undefined>(
   } as (T extends object ? T : Record<never, never>) & { allowH2: false };
 }
 
+/**
+ * Pinned dispatchers (SSRF-guarded flows, per-request Agents) do not inherit
+ * the global dispatcher's `headersTimeout`/`bodyTimeout`, so by default they
+ * fall back to undici's 300 000 ms headers timeout. Mirror the effective
+ * global stream timeout onto pinned options when the caller has not provided
+ * explicit values, so slow local providers (Ollama, embedded runners) honor
+ * the same run-level timeout ceiling as the global dispatcher. (#69390)
+ */
+function withEffectiveStreamTimeouts<T extends Record<string, unknown> | undefined>(
+  options?: T,
+): T {
+  const effective = getEffectiveUndiciStreamTimeoutMs();
+  if (effective === null) {
+    return options as T;
+  }
+  const hasHeadersTimeout =
+    options && Object.prototype.hasOwnProperty.call(options, "headersTimeout");
+  const hasBodyTimeout = options && Object.prototype.hasOwnProperty.call(options, "bodyTimeout");
+  if (hasHeadersTimeout && hasBodyTimeout) {
+    return options as T;
+  }
+  return {
+    ...options,
+    ...(hasHeadersTimeout ? {} : { headersTimeout: effective }),
+    ...(hasBodyTimeout ? {} : { bodyTimeout: effective }),
+  } as T;
+}
+
 export function createHttp1Agent(options?: UndiciAgentOptions): import("undici").Agent {
   const { Agent } = loadUndiciRuntimeDeps();
-  return new Agent(withHttp1OnlyDispatcherOptions(options));
+  return new Agent(
+    withHttp1OnlyDispatcherOptions(
+      withEffectiveStreamTimeouts(options as Record<string, unknown> | undefined) as
+        | UndiciAgentOptions
+        | undefined,
+    ),
+  );
 }
 
 export function createHttp1EnvHttpProxyAgent(
   options?: UndiciEnvHttpProxyAgentOptions,
 ): import("undici").EnvHttpProxyAgent {
   const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
-  return new EnvHttpProxyAgent(withHttp1OnlyDispatcherOptions(options));
+  return new EnvHttpProxyAgent(
+    withHttp1OnlyDispatcherOptions(
+      withEffectiveStreamTimeouts(options as Record<string, unknown> | undefined) as
+        | UndiciEnvHttpProxyAgentOptions
+        | undefined,
+    ),
+  );
 }
 
 export function createHttp1ProxyAgent(


### PR DESCRIPTION
## Summary

Fixes #69390. On 2026.4.15, slow local Ollama runs still failed at ~5 minutes with `Headers Timeout Error` even after increasing OpenClaw timeouts. The Ollama chat stream path routes through `fetchWithSsrFGuard`, which builds **per-request pinned** undici `Agent` / `EnvHttpProxyAgent` dispatchers via `createHttp1Agent` / `createHttp1EnvHttpProxyAgent`. Those pinned dispatchers do **not** inherit the global dispatcher's `headersTimeout` / `bodyTimeout`, so they fell back to undici's default `headersTimeout = 300_000 ms` while waiting for the first token.

The 2026.4.15 fix (b4bbf06816) correctly wired the configured timeout onto the **global** dispatcher via `ensureGlobalUndiciStreamTimeouts({ timeoutMs })`, but SSRF-guarded flows bypass that global entirely.

## Fix

1. `ensureGlobalUndiciStreamTimeouts` now also records the last applied timeout in a module-level `lastAppliedTimeoutMs`, exposed via a new getter `getEffectiveUndiciStreamTimeoutMs()` (returns `null` when no explicit timeout has been configured yet).
2. `createHttp1Agent` and `createHttp1EnvHttpProxyAgent` now call a `withEffectiveStreamTimeouts(...)` helper that mirrors that effective value onto pinned dispatcher options **only when the caller has not already set `headersTimeout`/`bodyTimeout`** (per-field, via `hasOwnProperty`).
3. `createHttp1ProxyAgent` is intentionally **not** touched — explicit proxy routing keeps its existing semantics.

Net result: once the user configures a longer embedded-agent run timeout, slow Ollama first-token latency is honored end-to-end instead of silently capping at 5 minutes.

## Test plan

- [x] Added `src/infra/net/undici-runtime.test.ts` (new) — 5 cases covering:
  - no injection when effective is `null`
  - mirrors effective timeout onto pinned `Agent` / `EnvHttpProxyAgent`
  - caller-provided timeouts win over effective
  - only the missing half of the pair is injected
  - `allowH2: false` is preserved throughout
- [x] Extended `src/infra/net/undici-global-dispatcher.test.ts` — getter exposes last applied value; leaves it `null` when dispatcher kind is unsupported.
- [x] `FAST_COMMIT=1 pnpm test src/infra/net` — 7 test files, 93 tests all pass.
- [x] Typecheck clean.

## Notes

- No behavior change for callers that already pass explicit `headersTimeout`/`bodyTimeout` (e.g. short SSRF-guard connect probes).
- Default remains `DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000`, so until `ensureGlobalUndiciStreamTimeouts` has been called the getter returns `null` and pinned dispatchers keep undici's defaults — zero regression risk for non-embedded paths.
- Changelog entry added under Unreleased → Fixes, tagged `[AI-assisted]`.