### PR TITLE
fix(config/io): preserve symlinked config by writing through realpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Context engine/plugins: stop rejecting third-party context engines whose `info.id` differs from the registered plugin slot id. The strict-match contract added in 2026.4.14 broke `lossless-claw` and other plugins whose internal engine id does not equal the slot id they are registered under, producing repeated `info.id must match registered id` lane failures on every turn. Fixes #66601. (#66678) Thanks @GodsBoy.
 - Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 - Security/dotenv: block all `OPENCLAW_*` keys from untrusted workspace `.env` files so workspace-local env loading fails closed for new runtime-control variables instead of silently inheriting them. (#473)
+- Config/io: resolve the config path through `fs.promises.realpath` before the atomic temp-file+rename write, so user-managed symlinks at `~/.openclaw/openclaw.json` (git-tracked workspace config, dotfiles, Nix, Chezmoi layouts documented in TOOLS.md) are written through to their target file instead of being clobbered with a freshly created regular file on every config touch. Addresses the symlink-clobber half of #69396; the companion SecretRef-plaintext-serialization bug is tracked separately. [AI-assisted]
 
 ## 2026.4.20
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1580,7 +1580,19 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       // If reading the current file fails, write cfg as-is (no env restoration)
     }
 
-    const dir = path.dirname(configPath);
+    // Resolve the real path so atomic rename replaces the target of any
+    // user-managed symlink (git-tracked workspace config, dotfiles, etc.)
+    // instead of clobbering the symlink itself. realpath fails when the
+    // config does not yet exist, so fall back to the raw path.
+    let realConfigPath = configPath;
+    if (snapshot.exists) {
+      try {
+        realConfigPath = await deps.fs.promises.realpath(configPath);
+      } catch {
+        realConfigPath = configPath;
+      }
+    }
+    const dir = path.dirname(realConfigPath);
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
     await tightenStateDirPermissionsIfNeeded({
       configPath,
@@ -1730,13 +1742,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
 
       try {
-        await deps.fs.promises.rename(tmp, configPath);
+        await deps.fs.promises.rename(tmp, realConfigPath);
       } catch (err) {
         const code = (err as { code?: string }).code;
         // Windows doesn't reliably support atomic replace via rename when dest exists.
         if (code === "EPERM" || code === "EEXIST") {
-          await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+          await deps.fs.promises.copyFile(tmp, realConfigPath);
+          await deps.fs.promises.chmod(realConfigPath, 0o600).catch(() => {
             // best-effort
           });
           await deps.fs.promises.unlink(tmp).catch(() => {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -287,6 +287,47 @@ describe("config io write", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "preserves a symlinked config by writing through to its realpath target (#69396)",
+    async () => {
+      // Users who keep their config under version control commonly symlink
+      // ~/.openclaw/openclaw.json to a workspace file (see TOOLS.md). Before
+      // this fix, atomic rename replaced the symlink with a regular file,
+      // breaking dotfiles/Nix/Chezmoi deployments and forcing users to keep
+      // re-creating the symlink after every config touch.
+      await withSuiteHome(async (home) => {
+        const workspaceDir = path.join(home, "workspace", "config");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        const realTarget = path.join(workspaceDir, "openclaw.json");
+        await fs.writeFile(
+          realTarget,
+          `${JSON.stringify({ gateway: { mode: "local", port: 18789 } }, null, 2)}\n`,
+          "utf-8",
+        );
+
+        const stateDir = path.join(home, ".openclaw");
+        await fs.mkdir(stateDir, { recursive: true });
+        const configPath = path.join(stateDir, "openclaw.json");
+        await fs.symlink(realTarget, configPath);
+
+        const io = createFastConfigIO(home);
+        await io.writeConfigFile({ gateway: { mode: "local", port: 27890 } });
+
+        const symlinkStat = await fs.lstat(configPath);
+        expect(symlinkStat.isSymbolicLink()).toBe(true);
+
+        const targetStat = await fs.stat(configPath);
+        const realTargetStat = await fs.stat(realTarget);
+        expect(targetStat.ino).toBe(realTargetStat.ino);
+
+        const persistedFromTarget = JSON.parse(await fs.readFile(realTarget, "utf-8")) as {
+          gateway?: { port?: number };
+        };
+        expect(persistedFromTarget.gateway?.port).toBe(27890);
+      });
+    },
+  );
+
   it("writes disabled plugin entries without requiring plugin config", async () => {
     mockLoadPluginManifestRegistry.mockReturnValue({
       diagnostics: [],


### PR DESCRIPTION
## Summary

Partial fix for #69396. The config writer does an atomic temp-file + `rename` into `configPath`, which **replaces the symlink with a regular file** on every config touch — `openclaw update`, `meta.lastTouchedAt` bump on restart, `config.patch`, etc. This breaks the workspace-template deployment pattern documented in `TOOLS.md` (symlink \`~/.openclaw/openclaw.json\` → a git-tracked file under \`workspace/config/\`) and causes the runtime file to silently diverge from the user's source of truth.

## Fix

Resolve the config path via \`fs.promises.realpath\` when the file already exists, then use that resolved path as both the temp-file parent directory and the rename / copy-fallback / chmod target. Rename stays atomic (same filesystem as the real file) while writing *through* the symlink instead of replacing it.

The raw \`configPath\` is intentionally still passed to:
- audit logs (so the user-visible path is what's recorded)
- backup rotation (\`.bak\` files live next to the symlink, the visible location)
- \`tightenStateDirPermissionsIfNeeded\` (which intentionally checks the state-dir, not the symlink target)

## Test plan

- [x] New regression test in \`src/config/io.write-config.test.ts\` gated on \`process.platform !== \"win32\"\`:
  - Creates \`~/workspace/config/openclaw.json\` as the real file
  - Symlinks \`~/.openclaw/openclaw.json\` → that real file
  - Writes a config change
  - Asserts \`lstat\` still reports a symbolic link, \`stat\` inode matches the real target, and the new port landed in the target file
- [x] \`pnpm test src/config/io.write-config.test.ts\` — 9/9 pass
- [x] Full \`src/config/io.*\` lane — 57/57 pass

## Scope

This PR addresses **only the symlink-clobber half of #69396**. The companion SecretRef → plaintext serialization bug (the secrets ending up in the regular file after the clobber) is a deeper change in \`resolvePersistCandidateForWrite\` and wants its own focused PR — I'd rather not bundle the two. Happy to take that one next if the fix direction here looks right.

## Notes

- No behavior change when \`~/.openclaw/openclaw.json\` is a regular file (\`realpath\` returns the same path).
- First-write case (no config yet) is unaffected — \`realpath\` is only consulted when \`snapshot.exists\` is true.
- Windows path unchanged (test is gated; \`realpath\` on Windows works but the atomic-rename fallback already handles dest-exists via \`copyFile\`).