### PR TITLE
Control UI: reduce unnecessary gateway churn and prevent stale index caching

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -368,6 +368,20 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves control-ui index with no-store cache headers", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const getRes = runControlUiRequest({ url: "/", method: "GET", rootPath: tmp });
+        expect(getRes.handled).toBe(true);
+        expect(getRes.res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+
+        const headRes = runControlUiRequest({ url: "/", method: "HEAD", rootPath: tmp });
+        expect(headRes.handled).toBe(true);
+        expect(headRes.res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+      },
+    });
+  });
+
   it("includes CSP hash for inline scripts in index.html", async () => {
     const scriptContent = "(function(){ var x = 1; })();";
     const html = `<html><head><script>${scriptContent}</script></head><body></body></html>\n`;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -468,12 +468,16 @@ export function handleControlUiAvatarRequest(
   }
 }
 
+function controlUiCacheControlForPath(filePath: string): string {
+  return path.basename(filePath).toLowerCase() === "index.html"
+    ? "no-store"
+    : "no-cache";
+}
+
 function setStaticFileHeaders(res: ServerResponse, filePath: string) {
   const ext = path.extname(filePath).toLowerCase();
   res.setHeader("Content-Type", contentTypeForExt(ext));
-  // Static UI should never be cached aggressively while iterating; allow the
-  // browser to revalidate.
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", controlUiCacheControlForPath(filePath));
 }
 
 function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) {
@@ -490,7 +494,7 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
     );
   }
   res.setHeader("Content-Type", "text/html; charset=utf-8");
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", "no-store");
   res.end(body);
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -50,6 +50,7 @@ export type ChatHost = {
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
+export const CHAT_SESSIONS_LIMIT = 200;
 
 export function isChatBusy(host: ChatHost) {
   return host.chatSending || Boolean(host.chatRunId);
@@ -454,8 +455,8 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
   await Promise.all([
     loadChatHistory(host as unknown as ChatState),
     loadSessions(host as unknown as SessionsState, {
-      activeMinutes: 0,
-      limit: 0,
+      activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+      limit: CHAT_SESSIONS_LIMIT,
       includeGlobal: true,
       includeUnknown: true,
     }),

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -5,6 +5,8 @@ import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts"
 import type { GatewayHelloOk } from "./gateway.ts";
 
 const loadChatHistoryMock = vi.hoisted(() => vi.fn(async () => undefined));
+const loadNodesMock = vi.hoisted(() => vi.fn(async () => undefined));
+const loadDevicesMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;
@@ -91,6 +93,22 @@ vi.mock("./controllers/chat.ts", async (importOriginal) => {
   return {
     ...actual,
     loadChatHistory: loadChatHistoryMock,
+  };
+});
+
+vi.mock("./controllers/nodes.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./controllers/nodes.ts")>();
+  return {
+    ...actual,
+    loadNodes: loadNodesMock,
+  };
+});
+
+vi.mock("./controllers/devices.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./controllers/devices.ts")>();
+  return {
+    ...actual,
+    loadDevices: loadDevicesMock,
   };
 });
 
@@ -192,6 +210,32 @@ describe("connectGateway", () => {
   beforeEach(() => {
     gatewayClientInstances.length = 0;
     loadChatHistoryMock.mockClear();
+    loadNodesMock.mockClear();
+    loadDevicesMock.mockClear();
+  });
+
+  it("skips node and device loading on hello outside the nodes tab", () => {
+    const { host, client } = connectHostGateway();
+    host.tab = "overview";
+
+    client.emitHello();
+
+    expect(loadNodesMock).not.toHaveBeenCalled();
+    expect(loadDevicesMock).not.toHaveBeenCalled();
+  });
+
+  it("loads node and device data via tab refresh for the nodes tab", async () => {
+    const { host, client } = connectHostGateway();
+    host.tab = "nodes";
+
+    client.emitHello();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadNodesMock).toHaveBeenCalledTimes(1);
+    expect(loadNodesMock).toHaveBeenCalledWith(host);
+    expect(loadDevicesMock).toHaveBeenCalledTimes(1);
+    expect(loadDevicesMock).toHaveBeenCalledWith(host);
   });
 
   it("ignores stale client onGap callbacks after reconnect", () => {

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -114,7 +114,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     vi.useRealTimers();
   });
 
-  it("debounces session reloads when the gateway pushes sessions.changed events", () => {
+  it("debounces session reloads on overview and sessions tabs", () => {
     vi.useFakeTimers();
     loadSessionsMock.mockReset();
     const host = createHost();
@@ -138,6 +138,24 @@ describe("handleGatewayEvent sessions.changed", () => {
     vi.advanceTimersByTime(1);
     expect(loadSessionsMock).toHaveBeenCalledTimes(1);
     expect(loadSessionsMock).toHaveBeenCalledWith(host);
+    expect(host.sessionsChangedReloadTimer).toBeNull();
+  });
+
+  it("ignores sessions.changed reloads on chat tab", () => {
+    vi.useFakeTimers();
+    loadSessionsMock.mockReset();
+    const host = createHost();
+    host.tab = "chat";
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: "agent:main:main", reason: "patch" },
+      seq: 1,
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
     expect(host.sessionsChangedReloadTimer).toBeNull();
   });
 });

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const loadSessionsMock = vi.fn();
 const loadChatHistoryMock = vi.fn();
@@ -102,6 +102,7 @@ function createHost() {
     sessionKey: "main",
     chatRunId: null,
     refreshSessionsAfterChat: new Set<string>(),
+    sessionsChangedReloadTimer: null,
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
@@ -109,7 +110,12 @@ function createHost() {
 }
 
 describe("handleGatewayEvent sessions.changed", () => {
-  it("reloads sessions when the gateway pushes a sessions.changed event", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces session reloads when the gateway pushes sessions.changed events", () => {
+    vi.useFakeTimers();
     loadSessionsMock.mockReset();
     const host = createHost();
 
@@ -119,9 +125,20 @@ describe("handleGatewayEvent sessions.changed", () => {
       payload: { sessionKey: "agent:main:main", reason: "patch" },
       seq: 1,
     });
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: "agent:main:main", reason: "patch" },
+      seq: 2,
+    });
 
+    expect(loadSessionsMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(749);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
     expect(loadSessionsMock).toHaveBeenCalledTimes(1);
     expect(loadSessionsMock).toHaveBeenCalledWith(host);
+    expect(host.sessionsChangedReloadTimer).toBeNull();
   });
 });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -293,8 +293,6 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       void loadAssistantIdentity(host as unknown as AssistantIdentityState);
       void loadAgents(host as unknown as AgentsState);
       void loadHealthState(host as unknown as HealthState);
-      void loadNodes(host as unknown as NodesState, { quiet: true });
-      void loadDevices(host as unknown as DevicesState, { quiet: true });
       void refreshActiveTab(host as unknown as Parameters<typeof refreshActiveTab>[0]);
     },
     onClose: ({ code, reason, error }) => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -93,6 +93,7 @@ type GatewayHost = {
   sessionKey: string;
   chatRunId: string | null;
   refreshSessionsAfterChat: Set<string>;
+  sessionsChangedReloadTimer: number | null;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
@@ -398,6 +399,16 @@ function handleTerminalChatEvent(
   return false;
 }
 
+function scheduleSessionsReload(host: GatewayHost, delayMs = 750) {
+  if (host.sessionsChangedReloadTimer != null) {
+    return;
+  }
+  host.sessionsChangedReloadTimer = window.setTimeout(() => {
+    host.sessionsChangedReloadTimer = null;
+    void loadSessions(host as unknown as SessionsState);
+  }, delayMs);
+}
+
 function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | undefined) {
   if (payload?.sessionKey) {
     setLastActiveSessionKey(
@@ -529,7 +540,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   }
 
   if (evt.event === "sessions.changed") {
-    void loadSessions(host as unknown as SessionsState);
+    scheduleSessionsReload(host);
     return;
   }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -399,8 +399,12 @@ function handleTerminalChatEvent(
   return false;
 }
 
+function shouldReloadSessionsForEvent(host: GatewayHost): boolean {
+  return host.tab === "overview" || host.tab === "sessions";
+}
+
 function scheduleSessionsReload(host: GatewayHost, delayMs = 750) {
-  if (host.sessionsChangedReloadTimer != null) {
+  if (!shouldReloadSessionsForEvent(host) || host.sessionsChangedReloadTimer != null) {
     return;
   }
   host.sessionsChangedReloadTimer = window.setTimeout(() => {

--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { applySettingsFromUrlMock, connectGatewayMock, loadBootstrapMock } = vi.hoisted(() => ({
+const {
+  applySettingsFromUrlMock,
+  connectGatewayMock,
+  loadBootstrapMock,
+  startNodesPollingMock,
+} = vi.hoisted(() => ({
   applySettingsFromUrlMock: vi.fn(),
   connectGatewayMock: vi.fn(),
   loadBootstrapMock: vi.fn(),
+  startNodesPollingMock: vi.fn(),
 }));
 
 vi.mock("./app-gateway.ts", () => ({
@@ -25,7 +31,7 @@ vi.mock("./app-settings.ts", () => ({
 
 vi.mock("./app-polling.ts", () => ({
   startLogsPolling: vi.fn(),
-  startNodesPolling: vi.fn(),
+  startNodesPolling: startNodesPollingMock,
   stopLogsPolling: vi.fn(),
   stopNodesPolling: vi.fn(),
   startDebugPolling: vi.fn(),
@@ -70,6 +76,7 @@ describe("handleConnected", () => {
     applySettingsFromUrlMock.mockReset();
     connectGatewayMock.mockReset();
     loadBootstrapMock.mockReset();
+    startNodesPollingMock.mockReset();
   });
 
   it("waits for bootstrap load before first gateway connect", async () => {
@@ -121,5 +128,17 @@ describe("handleConnected", () => {
     expect(applySettingsFromUrlMock.mock.invocationCallOrder[0]).toBeLessThan(
       loadBootstrapMock.mock.invocationCallOrder[0],
     );
+  });
+
+  it("starts node polling only when the active tab is nodes", () => {
+    loadBootstrapMock.mockResolvedValue(undefined);
+    const host = createHost();
+
+    handleConnected(host as never);
+    expect(startNodesPollingMock).not.toHaveBeenCalled();
+
+    host.tab = "nodes";
+    handleConnected(host as never);
+    expect(startNodesPollingMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -68,6 +68,7 @@ function createHost() {
     logsEntries: [],
     popStateHandler: vi.fn(),
     topbarObserver: null,
+    sessionsChangedReloadTimer: null,
   };
 }
 

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -23,13 +23,16 @@ function createHost() {
     logsEntries: [],
     popStateHandler: vi.fn(),
     topbarObserver: { disconnect: vi.fn() } as unknown as ResizeObserver,
+    sessionsChangedReloadTimer: null,
   };
 }
 
 describe("handleDisconnected", () => {
   it("stops and clears gateway client on teardown", () => {
     const removeSpy = vi.spyOn(window, "removeEventListener").mockImplementation(() => undefined);
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     const host = createHost();
+    host.sessionsChangedReloadTimer = 123 as unknown as number;
     const disconnectSpy = (
       host.topbarObserver as unknown as { disconnect: ReturnType<typeof vi.fn> }
     ).disconnect;
@@ -42,6 +45,9 @@ describe("handleDisconnected", () => {
     expect(host.connected).toBe(false);
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(host.topbarObserver).toBeNull();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
+    expect(host.sessionsChangedReloadTimer).toBeNull();
     removeSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
   });
 });

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -42,6 +42,7 @@ type LifecycleHost = {
   logsEntries: unknown[];
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
+  sessionsChangedReloadTimer: number | null;
 };
 
 export function handleConnected(host: LifecycleHost) {
@@ -79,6 +80,10 @@ export function handleDisconnected(host: LifecycleHost) {
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
+  if (host.sessionsChangedReloadTimer != null) {
+    clearTimeout(host.sessionsChangedReloadTimer);
+    host.sessionsChangedReloadTimer = null;
+  }
   host.client?.stop();
   host.client = null;
   host.connected = false;

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -58,7 +58,9 @@ export function handleConnected(host: LifecycleHost) {
     }
     connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   });
-  startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+  if (host.tab === "nodes") {
+    startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+  }
   if (host.tab === "logs") {
     startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
   }

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -16,10 +16,12 @@ export function startNodesPolling(host: PollingHost) {
   if (host.nodesPollInterval != null) {
     return;
   }
-  host.nodesPollInterval = window.setInterval(
-    () => void loadNodes(host as unknown as NodesState, { quiet: true }),
-    5000,
-  );
+  host.nodesPollInterval = window.setInterval(() => {
+    if (host.tab !== "nodes") {
+      return;
+    }
+    void loadNodes(host as unknown as NodesState, { quiet: true });
+  }, 5000);
 }
 
 export function stopNodesPolling(host: PollingHost) {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -14,6 +14,8 @@ const {
 }));
 
 vi.mock("./app-chat.ts", () => ({
+  CHAT_SESSIONS_ACTIVE_MINUTES: 120,
+  CHAT_SESSIONS_LIMIT: 200,
   refreshChat: refreshChatMock,
   refreshChatAvatar: refreshChatAvatarMock,
 }));
@@ -530,8 +532,8 @@ describe("switchChatSession", () => {
     });
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
     expect(loadSessionsMock).toHaveBeenCalledWith(state, {
-      activeMinutes: 0,
-      limit: 0,
+      activeMinutes: 120,
+      limit: 200,
       includeGlobal: true,
       includeUnknown: true,
     });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,11 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
+import {
+  CHAT_SESSIONS_ACTIVE_MINUTES,
+  CHAT_SESSIONS_LIMIT,
+  refreshChat,
+  refreshChatAvatar,
+} from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import {
@@ -526,8 +531,8 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
 
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
-    activeMinutes: 0,
-    limit: 0,
+    activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+    limit: CHAT_SESSIONS_LIMIT,
     includeGlobal: true,
     includeUnknown: true,
   });

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -60,6 +60,7 @@ type SettingsHost = {
   basePath: string;
   themeMedia: MediaQueryList | null;
   themeMediaHandler: ((event: MediaQueryListEvent) => void) | null;
+  nodesPollInterval: number | null;
   logsPollInterval: number | null;
   debugPollInterval: number | null;
   pendingGatewayUrl?: string | null;
@@ -157,6 +158,7 @@ const createHost = (tab: Tab): SettingsHost => ({
   basePath: "",
   themeMedia: null,
   themeMediaHandler: null,
+  nodesPollInterval: null,
   logsPollInterval: null,
   debugPollInterval: null,
   pendingGatewayUrl: null,
@@ -190,11 +192,24 @@ describe("setTabFromRoute", () => {
     vi.unstubAllGlobals();
   });
 
+  it("starts and stops node polling based on the tab", () => {
+    const host = createHost("chat");
+
+    setTabFromRoute(host, "nodes");
+    expect(host.nodesPollInterval).not.toBeNull();
+    expect(host.logsPollInterval).toBeNull();
+    expect(host.debugPollInterval).toBeNull();
+
+    setTabFromRoute(host, "chat");
+    expect(host.nodesPollInterval).toBeNull();
+  });
+
   it("starts and stops log polling based on the tab", () => {
     const host = createHost("chat");
 
     setTabFromRoute(host, "logs");
     expect(host.logsPollInterval).not.toBeNull();
+    expect(host.nodesPollInterval).toBeNull();
     expect(host.debugPollInterval).toBeNull();
 
     setTabFromRoute(host, "chat");
@@ -206,6 +221,7 @@ describe("setTabFromRoute", () => {
 
     setTabFromRoute(host, "debug");
     expect(host.debugPollInterval).not.toBeNull();
+    expect(host.nodesPollInterval).toBeNull();
     expect(host.logsPollInterval).toBeNull();
 
     setTabFromRoute(host, "chat");

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -4,6 +4,8 @@ import { refreshChat } from "./app-chat.ts";
 import {
   startLogsPolling,
   stopLogsPolling,
+  startNodesPolling,
+  stopNodesPolling,
   startDebugPolling,
   stopDebugPolling,
 } from "./app-polling.ts";
@@ -511,6 +513,9 @@ function applyTabSelection(
   if (next === "chat") {
     host.chatHasAutoScrolled = false;
   }
+  (next === "nodes" ? startNodesPolling : stopNodesPolling)(
+    host as unknown as Parameters<typeof startNodesPolling>[0],
+  );
   (next === "logs" ? startLogsPolling : stopLogsPolling)(
     host as unknown as Parameters<typeof startLogsPolling>[0],
   );

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -512,6 +512,7 @@ export class OpenClawApp extends LitElement {
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
   private debugPollInterval: number | null = null;
+  sessionsChangedReloadTimer: number | null = null;
   private logsScrollFrame: number | null = null;
   private toolStreamById = new Map<string, ToolStreamEntry>();
   private toolStreamOrder: string[] = [];


### PR DESCRIPTION
## Summary

This PR packages the local Control UI slowness fixes that materially reduced gateway churn during investigation, plus one small server-side hardening for stale bundle rollouts.

### Included fixes

- bound chat/session refresh to a recent slice instead of an effectively unbounded session universe
  - `activeMinutes: 120`
  - `limit: 200`
- scope node polling to the Nodes tab instead of starting globally on connect
- debounce `sessions.changed` reloads
- avoid reloading sessions for `sessions.changed` while on Chat
- skip eager `node.list` / `device.pair.list` preloads outside the Nodes flow
- serve Control UI `index.html` with `Cache-Control: no-store` so browsers fetch fresh bundle references after rollouts

## Why

In local runtime evidence, the biggest proven slowness driver was Control UI itself:

- repeated `sessions.list` refreshes from chat/session UI state
- global `node.list` polling even when Nodes was not open
- immediate session reloads on every `sessions.changed` push
- connect-time node/device preloads that were unnecessary for non-Nodes views
- stale browser tabs continuing to hold onto older bundle behavior after rollouts

These changes are intentionally small and reversible. They reduce control-plane load without changing the overall product model.

## Validation

Run on an isolated branch based on `origin/main`:

- `pnpm test -- --run src/gateway/control-ui.http.test.ts`
- `pnpm --dir ui test -- src/ui/app-gateway.node.test.ts src/ui/app-gateway.sessions.node.test.ts src/ui/app-lifecycle.node.test.ts src/ui/app-lifecycle-connect.node.test.ts src/ui/app-settings.test.ts src/ui/app-render.helpers.node.test.ts src/ui/app-chat.test.ts`
- `pnpm --dir ui build`

Observed locally after rollout:

- gateway health remained OK
- stale high-churn Control UI behavior disappeared after reload/reconnect
- watchdog timeout noise stayed quiet under the newer runtime budget

## Notes

- This branch intentionally excludes unrelated local Canvas work by being rebuilt cleanly from `origin/main`.
- One unrelated dirty local file (`ui/src/ui/views/chat.ts`) was left out on purpose.
