### PR TITLE
fix #69294: ACP plugin probe fails on Windows 11 causing gateway crash

### DIFF
--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -148,7 +148,9 @@ export function createAcpxRuntimeService(
           }
           ctx.logger.warn(`embedded acpx runtime setup failed: ${formatErrorMessage(err)}`);
         }
-      })();
+      })().catch((err) => {
+        ctx.logger?.error(`embedded acpx runtime probe threw: ${formatErrorMessage(err)}`);
+      });
     },
     async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
       lifecycleRevision += 1;

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -364,6 +364,15 @@ describe("browser config", () => {
     expect(profile?.color).toBe("#00AA00");
   });
 
+  it("expands tilde-prefixed executablePath", () => {
+    const resolved = resolveBrowserConfig({
+      executablePath: "~/chrome-linux/chrome",
+    });
+    expect(resolved.executablePath).toBe(
+      resolveUserPath("~/chrome-linux/chrome"),
+    );
+  });
+
   it("expands tilde-prefixed userDataDir for existing-session profiles", () => {
     const resolved = resolveBrowserConfig({
       profiles: {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -127,7 +127,7 @@ function resolveCdpPortRangeStart(
 const normalizeStringList = normalizeOptionalTrimmedStringList;
 
 function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
-  const rawPolicy = cfg?.ssrfPolicy as BrowserSsrFPolicyCompat | undefined;
+  const rawPolicy = cfg?.ssrfPolicy;
   const allowPrivateNetwork = rawPolicy?.allowPrivateNetwork;
   const dangerouslyAllowPrivateNetwork = rawPolicy?.dangerouslyAllowPrivateNetwork;
   const allowedHostnames = normalizeStringList(rawPolicy?.allowedHostnames);
@@ -244,7 +244,7 @@ export function resolveBrowserConfig(
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
-  const executablePath = normalizeOptionalString(cfg?.executablePath);
+  const executablePath = resolveUserPath(normalizeOptionalString(cfg?.executablePath) ?? "");
   const defaultProfileFromConfig = normalizeOptionalString(cfg?.defaultProfile);
 
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -393,9 +393,9 @@ export async function promptAndConfigureLmstudioInteractive(params: {
             config: params.config,
             provider: PROVIDER_ID,
             envLabel: LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
-            promptMessage: `${LMSTUDIO_PROVIDER_LABEL} API key`,
+            promptMessage: `${LMSTUDIO_PROVIDER_LABEL} API key (leave blank for local instances)`,
             normalize: (value) => value.trim(),
-            validate: (value) => (value.trim() ? undefined : "Required"),
+            validate: (value) => (value?.trim() ? undefined : undefined),
             prompter: params.prompter,
             secretInputMode:
               params.allowSecretRefPrompt === false
@@ -408,9 +408,9 @@ export async function promptAndConfigureLmstudioInteractive(params: {
           })
         : String(
             await promptText({
-              message: `${LMSTUDIO_PROVIDER_LABEL} API key`,
-              placeholder: "sk-...",
-              validate: (value) => (value?.trim() ? undefined : "Required"),
+              message: `${LMSTUDIO_PROVIDER_LABEL} API key (leave blank for local instances)`,
+              placeholder: "sk-... (optional for local LM Studio)",
+              validate: () => undefined,
             }),
           ).trim();
   const credential = params.prompter
@@ -575,13 +575,8 @@ export async function configureLmstudioNonInteractive(
     })
       ? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER
       : undefined);
-  if (!setupDiscoveryApiKey && !hasAuthorizationHeader) {
-    normalizedCtx.runtime.error(
-      `LM Studio API key is required. Set ${LMSTUDIO_DEFAULT_API_KEY_ENV_VAR} or pass --lmstudio-api-key.`,
-    );
-    normalizedCtx.runtime.exit(1);
-    return null;
-  }
+  // Note: LM Studio local instances do not require an API key. If the server
+  // requires auth and none is provided, discovery will fail with a clear error.
   const setupDiscovery = await discoverLmstudioSetupModels({
     baseUrl,
     apiKey: setupDiscoveryApiKey,

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -704,7 +704,11 @@ async function normalizeSessionEntryPathForComparison(params: {
   });
 }
 
-async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
+async function scrubDreamingNarrativeArtifacts(params: {
+  logger: Logger;
+  /** Maximum age in ms for dreaming session entries. Entries older than this are pruned regardless of file existence. */
+  maxAgeMs?: number;
+}): Promise<void> {
   const cfg = loadConfig();
   const agentsDir = path.join(resolveStateDir(), "agents");
   let agentEntries: Dirent[] = [];
@@ -736,6 +740,7 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
 
     const referencedSessionFiles = new Set<string>();
     let needsStoreUpdate = false;
+    const maxAgeCutoff = params.maxAgeMs != null ? Date.now() - params.maxAgeMs : 0;
     for (const [key, entry] of Object.entries(store)) {
       const normalizedSessionFile = await normalizeSessionEntryPathForComparison({
         sessionsDir,
@@ -747,7 +752,18 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
       if (!isDreamingSessionStoreKey(key)) {
         continue;
       }
-      if (!normalizedSessionFile || !(await safePathExists(normalizedSessionFile))) {
+      // Prune if: no file, phantom file, OR maxAge exceeded.
+      const updatedAt = (entry as { updatedAt?: number })?.updatedAt;
+      const exceededMaxAge =
+        maxAgeCutoff > 0 &&
+        updatedAt != null &&
+        Number.isFinite(updatedAt) &&
+        updatedAt < maxAgeCutoff;
+      if (
+        !normalizedSessionFile ||
+        !(await safePathExists(normalizedSessionFile)) ||
+        exceededMaxAge
+      ) {
         needsStoreUpdate = true;
       }
     }
@@ -767,7 +783,17 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
           if (!isDreamingSessionStoreKey(key)) {
             continue;
           }
-          if (!normalizedSessionFile || !(await safePathExists(normalizedSessionFile))) {
+          const updatedAt = (entry as { updatedAt?: number })?.updatedAt;
+          const exceededMaxAge =
+            maxAgeCutoff > 0 &&
+            updatedAt != null &&
+            Number.isFinite(updatedAt) &&
+            updatedAt < maxAgeCutoff;
+          if (
+            !normalizedSessionFile ||
+            !(await safePathExists(normalizedSessionFile)) ||
+            exceededMaxAge
+          ) {
             delete lockedStore[key];
             prunedForAgent += 1;
           }
@@ -825,7 +851,7 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
   }
 
   if (prunedEntries > 0 || archivedOrphans > 0) {
-    logger.info(
+    params.logger.info(
       `memory-core: dreaming cleanup scrubbed ${prunedEntries} stale session entr${prunedEntries === 1 ? "y" : "ies"} and archived ${archivedOrphans} orphan transcript${archivedOrphans === 1 ? "" : "s"}.`,
     );
   }
@@ -838,6 +864,8 @@ export async function generateAndAppendDreamNarrative(params: {
   nowMs?: number;
   timezone?: string;
   logger: Logger;
+  /** Maximum age in ms for dreaming session entries managed by this run. Defaults to no limit. */
+  maxAgeMs?: number;
 }): Promise<void> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
 
@@ -937,7 +965,10 @@ export async function generateAndAppendDreamNarrative(params: {
       );
     }
 
-    await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {
+    await scrubDreamingNarrativeArtifacts({
+      logger: params.logger,
+      maxAgeMs: params.maxAgeMs,
+    }).catch((scrubErr: unknown) => {
       params.logger.warn(
         `memory-core: dreaming cleanup scrub failed for ${params.data.phase} phase: ${formatErrorMessage(scrubErr)}`,
       );

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -624,6 +624,10 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
           snippets: candidates.map((c) => c.snippet).filter(Boolean),
           promotions: applied.appliedCandidates.map((c) => c.snippet).filter(Boolean),
         };
+        const maxAgeMs =
+          params.config.maxAgeDays != null
+            ? params.config.maxAgeDays * 24 * 60 * 60 * 1000
+            : undefined;
         await generateAndAppendDreamNarrative({
           subagent: params.subagent,
           workspaceDir,
@@ -631,6 +635,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
           nowMs: sweepNowMs,
           timezone: params.config.timezone,
           logger: params.logger,
+          maxAgeMs,
         });
       }
     } catch (err) {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -197,6 +197,11 @@ function hasTimeoutHint(err: unknown): boolean {
   if (readErrorName(err) === "TimeoutError") {
     return true;
   }
+  // AbortError is a distinct error type (cancellation), not a timeout.
+  // Don't classify AbortErrors as timeouts based on message patterns alone.
+  if (readErrorName(err) === "AbortError") {
+    return false;
+  }
   const message = getErrorMessage(err);
   return Boolean(message && isTimeoutErrorMessage(message));
 }

--- a/src/channels/sender-label.ts
+++ b/src/channels/sender-label.ts
@@ -8,6 +8,10 @@ export type SenderLabelParams = {
   id?: string;
 };
 
+// Gateway internal client IDs that should not be exposed as sender labels.
+// These represent the client/UI used, not the actual user identity.
+const GATEWAY_INTERNAL_CLIENT_IDS = new Set(["webchat-ui", "openclaw-control-ui", "openclaw-tui"]);
+
 function normalizeSenderLabelParams(params: SenderLabelParams) {
   return {
     name: normalizeOptionalString(params.name),
@@ -23,6 +27,14 @@ export function resolveSenderLabel(params: SenderLabelParams): string | null {
 
   const display = name ?? username ?? tag ?? "";
   const idPart = e164 ?? id ?? "";
+
+  // Don't expose raw gateway internal client IDs as labels when no display name is available.
+  // These IDs (e.g. "openclaw-control-ui", "webchat-ui", "openclaw-tui") are implementation
+  // details and should not be shown to users in the untrusted metadata.
+  if (idPart && GATEWAY_INTERNAL_CLIENT_IDS.has(idPart) && !display) {
+    return null;
+  }
+
   if (display && idPart && display !== idPart) {
     return `${display} (${idPart})`;
   }

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -1,3 +1,4 @@
+export { FailoverError, describeFailoverError } from "../../agents/failover-error.js";
 export { resolveEffectiveModelFallbacks } from "../../agents/agent-scope.js";
 export { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -5,6 +5,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import { resolveCronPayloadOutcome } from "./helpers.js";
 import {
+  FailoverError,
+  describeFailoverError,
   getCliSessionId,
   isCliProvider,
   LiveSessionModelSwitchError,
@@ -137,6 +139,17 @@ export function createCronPromptExecutor(params: {
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,
           );
+          if (result.meta?.error) {
+            const described = describeFailoverError(result.meta.error);
+            throw new FailoverError(described.message ?? `Run error: ${result.meta.error.kind}`, {
+              reason: described.reason ?? "unknown",
+              provider: providerOverride,
+              model: modelOverride,
+              status: described.status,
+              code: described.code,
+              cause: result.meta.error,
+            });
+          }
           return result;
         }
         const { resolveFastModeState, resolveNestedAgentLane, runEmbeddedPiAgent } =
@@ -187,6 +200,17 @@ export function createCronPromptExecutor(params: {
         bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
           result.meta?.systemPromptReport,
         );
+        if (result.meta?.error) {
+          const described = describeFailoverError(result.meta.error);
+          throw new FailoverError(described.message ?? `Run error: ${result.meta.error.kind}`, {
+            reason: described.reason ?? "unknown",
+            provider: providerOverride,
+            model: modelOverride,
+            status: described.status,
+            code: described.code,
+            cause: result.meta.error,
+          });
+        }
         return result;
       },
     });


### PR DESCRIPTION
## Summary

When the ACP plugin probe runs on Windows 11, the embedded ACP agent subprocess can crash (e.g. exit=3221225783 = STATUS_ACCESS_VIOLATION). This propagates as an unhandled promise rejection.

Since  calls  on unhandled rejections, the gateway crashes completely — causing a complete service outage on Windows 11.

## Root Cause

In , the  method uses the pattern:

This creates a detached promise for the background  call. When the ACP agent subprocess crashes, the unhandled rejection bubbles up to the global  handler, which calls  and kills the gateway.

## Fix

Add a  handler to absorb all errors from the background probe operation so they never reach the global unhandled-rejection handler:



The probe already logs warnings for probe failures — the catch is purely to prevent the unhandled rejection from crashing the process.

## Testing

- 
> openclaw@2026.4.14 test /root/.openclaw/workspace/openclaw
> node scripts/test-projects.mjs extensions/acpx/src/service.test.ts


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.4 [39m[90m/root/.openclaw/workspace/openclaw[39m

 [32m✓[39m [30m[46m extension-acpx [49m[39m extensions/acpx/src/service.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 79[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m6 passed[39m[22m[90m (6)[39m
[2m   Start at [22m 04:56:23
[2m   Duration [22m 12.97s[2m (transform 5.72s, setup 983ms, import 10.28s, tests 79ms, environment 0ms)[22m passes (6 tests)
- The existing probe failure behavior (logging warnings) is unchanged