### PR TITLE
auto-reply: suppress reasoning-prefaced silent replies

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  isReasoningPrefacedSilentReply,
+  isSilentReplyPayloadText,
   isSilentReplyPrefixText,
   isSilentReplyText,
   startsWithSilentToken,
@@ -133,5 +135,88 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+});
+
+describe("isReasoningPrefacedSilentReply", () => {
+  it("classifies reasoning preamble + trailing NO_REPLY as silent", () => {
+    const text =
+      "think\n" +
+      "The user's message is from Aftermath in the #general channel.\n" +
+      "The message is a self-promotional advertisement.\n" +
+      "Silence is the required action.\n" +
+      "Therefore, I should output NO_REPLY.NO_REPLY";
+    expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+  });
+
+  it("classifies single trailing NO_REPLY with reasoning preamble as silent", () => {
+    const text = "think\nThe user is saying hello. I will not reply.\nNO_REPLY";
+    expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+  });
+
+  it("accepts other reasoning heading words", () => {
+    for (const heading of ["thinking", "thought", "reasoning", "analysis"]) {
+      const text = `${heading}\nUser asked a trivial question.\nNO_REPLY`;
+      expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+    }
+  });
+
+  it("accepts reasoning heading with trailing colon", () => {
+    expect(isReasoningPrefacedSilentReply("thinking:\nSome analysis.\nNO_REPLY")).toBe(true);
+  });
+
+  it("collapses doubled trailing NO_REPLY forms with inner punctuation", () => {
+    // The exact observed pattern from the bug report.
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY.NO_REPLY")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY NO_REPLY")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY. NO_REPLY")).toBe(true);
+  });
+
+  it("preserves #19537 — substantive replies ending with NO_REPLY are not silent", () => {
+    const substantive = "Here is the answer you asked for.\n\nNO_REPLY";
+    expect(isReasoningPrefacedSilentReply(substantive)).toBe(false);
+  });
+
+  it("returns false when message does not end with the silent token", () => {
+    expect(isReasoningPrefacedSilentReply("think\nbody\nactual reply")).toBe(false);
+  });
+
+  it("returns false for plain substantive text without reasoning preamble", () => {
+    expect(isReasoningPrefacedSilentReply("I should reply to this. NO_REPLY")).toBe(false);
+  });
+
+  it("returns false for empty or whitespace-only input", () => {
+    expect(isReasoningPrefacedSilentReply("")).toBe(false);
+    expect(isReasoningPrefacedSilentReply(undefined)).toBe(false);
+    expect(isReasoningPrefacedSilentReply("   ")).toBe(false);
+  });
+
+  it("returns true when only the silent token remains after trimming", () => {
+    expect(isReasoningPrefacedSilentReply("  NO_REPLY  ")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("NO_REPLY.NO_REPLY")).toBe(true);
+  });
+
+  it("does not match when reasoning heading is followed inline by prose on same line", () => {
+    // A bare heading must be on its own line; inline "think the answer is X" is
+    // natural language and should not be suppressed.
+    expect(isReasoningPrefacedSilentReply("think the answer is yes\nNO_REPLY")).toBe(false);
+  });
+});
+
+describe("isSilentReplyPayloadText integration", () => {
+  it("returns true for reasoning-prefaced silent replies", () => {
+    expect(isSilentReplyPayloadText("think\nanalysis goes here\nNO_REPLY.NO_REPLY")).toBe(true);
+  });
+
+  it("still returns true for exact token", () => {
+    expect(isSilentReplyPayloadText("NO_REPLY")).toBe(true);
+  });
+
+  it("still returns true for JSON action envelope", () => {
+    expect(isSilentReplyPayloadText('{"action":"NO_REPLY"}')).toBe(true);
+  });
+
+  it("still returns false for substantive replies ending with NO_REPLY (#19537)", () => {
+    expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -29,6 +29,25 @@ function getSilentTrailingRegex(token: string): RegExp {
   return regex;
 }
 
+const silentReasoningTrailingRegexByToken = new Map<string, RegExp>();
+
+function getSilentReasoningTrailingRegex(token: string): RegExp {
+  const cached = silentReasoningTrailingRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  // Dedicated, more tolerant trailing match for the reasoning-prefaced silent
+  // reply check: allows whitespace, asterisks, or common sentence punctuation
+  // to precede the trailing token so concluding model prose like
+  // "Therefore, I should output NO_REPLY.NO_REPLY" collapses cleanly. Kept
+  // separate from `getSilentTrailingRegex` to preserve the long-standing
+  // `stripSilentToken("interject.NO_REPLY")` no-op contract.
+  const regex = new RegExp(`(?:^|[\\s.:;,!?*]+)${escaped}\\s*$`, "i");
+  silentReasoningTrailingRegexByToken.set(token, regex);
+  return regex;
+}
+
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -75,7 +94,11 @@ export function isSilentReplyPayloadText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
 ): boolean {
-  return isSilentReplyText(text, token) || isSilentReplyEnvelopeText(text, token);
+  return (
+    isSilentReplyText(text, token) ||
+    isSilentReplyEnvelopeText(text, token) ||
+    isReasoningPrefacedSilentReply(text, token)
+  );
 }
 
 /**
@@ -85,6 +108,70 @@ export function isSilentReplyPayloadText(
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
   return text.replace(getSilentTrailingRegex(token), "").trim();
+}
+
+function stripTrailingSilentTokensTolerant(text: string, token: string): string {
+  const regex = getSilentReasoningTrailingRegex(token);
+  let current = text;
+  // Iterate so doubled/tripled trailing forms (for example
+  // "NO_REPLY.NO_REPLY" or "NO_REPLY NO_REPLY") collapse cleanly. Capped at 8
+  // iterations — in practice the loop exits after 1-3 passes.
+  for (let i = 0; i < 8; i++) {
+    const next = current.replace(regex, "").trim();
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+  return current;
+}
+
+// Matches a bare reasoning preamble at the start of the message: a word like
+// "think", "thinking", "thought", "reasoning", or "analysis" on its own line
+// (optionally followed by a colon) with nothing else on that line. Reasoning
+// models occasionally leak their chain-of-thought as plain text content when
+// structured thinking stream events are not produced; those messages must not
+// be treated as substantive replies when they are followed by a silent-reply
+// sentinel like NO_REPLY. The proper XML-tag stripper in
+// src/shared/text/reasoning-tags.ts cannot catch this form because there are
+// no tags to match.
+const BARE_REASONING_PREAMBLE_RE =
+  /^\s*(?:think(?:ing)?|thought|reasoning|analysis)\s*:?\s*(?:\r?\n|$)/i;
+
+/**
+ * Whether `text` is a reasoning-prefaced silent reply — a message that ends
+ * with the silent-reply token and whose preceding content is a bare reasoning
+ * preamble (not substantive user-visible content).
+ *
+ * Preserves the #19537 semantics: substantive replies that happen to end with
+ * NO_REPLY are still delivered. Only messages where the non-token content is
+ * a reasoning preamble are suppressed.
+ */
+export function isReasoningPrefacedSilentReply(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  // Use the tolerant trailing strip so concluding model prose like
+  // "...I should output NO_REPLY.NO_REPLY" collapses even with inner
+  // punctuation between doubled tokens.
+  const withoutToken = stripTrailingSilentTokensTolerant(trimmed, token);
+  // Must actually end with the silent token (stripping changed the text).
+  if (withoutToken === trimmed) {
+    return false;
+  }
+  // All content was silent tokens → nothing left to classify.
+  if (!withoutToken) {
+    return true;
+  }
+  // The remaining content must start with a bare reasoning preamble.
+  return BARE_REASONING_PREAMBLE_RE.test(withoutToken);
 }
 
 const silentLeadingRegexByToken = new Map<string, RegExp>();


### PR DESCRIPTION
## Summary

- Suppress messages where the model's reply is a bare reasoning preamble (a word like `think`, `thinking`, `thought`, `reasoning`, or `analysis` on its own line) followed by the `NO_REPLY` sentinel, instead of delivering the chain-of-thought verbatim to users.
- Collapse doubled trailing tokens such as `NO_REPLY.NO_REPLY` (observed with Gemini 3.x) inside the new check, while keeping the existing `stripSilentToken` contract unchanged.
- Preserve the #19537 semantics: substantive replies that happen to end with `NO_REPLY` are still delivered.

Closes #69470.

## Problem

When a reasoning-prone model emits its chain-of-thought as plain text content (not via structured `thinking_*` stream events or `<thinking>` XML tags) and concludes with the silent-reply sentinel, `isSilentReplyPayloadText` returns `false` and the whole message — reasoning plus `NO_REPLY` — is delivered to the messaging channel.

Observed Discord output:

```
think
The user's message is from "Aftermath" in the #general channel.
The channel topic is: "Topics of general interest around PDD. No advertisement or soliciting."
...
Therefore, I should output NO_REPLY.NO_REPLY
```

The proper XML tag stripper in `src/shared/text/reasoning-tags.ts` cannot catch this form — there are no tags — and `stripSilentToken` intentionally leaves `interject.NO_REPLY`-style glued suffixes alone (per existing test at `src/auto-reply/tokens.test.ts:64`).

## Fix

All changes localized to `src/auto-reply/tokens.ts`:

1. New `isReasoningPrefacedSilentReply(text, token)` returns `true` when the message ends with the silent token and the preceding content is a bare reasoning preamble.
2. Included in `isSilentReplyPayloadText`, so the single channel-agnostic gate at `src/auto-reply/reply/reply-directives.ts:34` catches the leak for every channel.
3. Private `stripTrailingSilentTokensTolerant` helper with its own regex (`getSilentReasoningTrailingRegex`) iterates to collapse doubled trailing tokens separated by punctuation. Kept out of the public `stripSilentToken` path so no other caller behavior shifts.

## Test plan

- `pnpm test src/auto-reply/tokens.test.ts` — 38 tests pass (16 new).
- `pnpm test src/auto-reply` — 1086 tests pass.
- Covers: reasoning-prefaced messages, all supported heading words, trailing-colon headings, doubled `NO_REPLY.NO_REPLY`, preserves #19537 substantive replies, rejects inline "think the answer is X" natural language, handles whitespace-only and undefined inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)