### PR TITLE
fix: add pricing sanity checks to prevent cost inflation (#367)

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -241,4 +241,92 @@ describe("model-pricing-cache", () => {
       cacheWrite: 0,
     });
   });
+
+  it("rejects suspicious pricing values > $100/million to prevent cost inflation", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "test/suspicious-model" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    // Simulate corrupted pricing data (e.g., already in per-million format but treated as per-token)
+    const fetchImpl = withFetchPreconnect(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "test/suspicious-model",
+                pricing: {
+                  prompt: "0.0003", // This would be $300/million - suspicious!
+                  completion: "0.0009", // This would be $900/million - suspicious!
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    // Should reject suspicious pricing and use 0 instead
+    expect(
+      getCachedGatewayModelPricing({ provider: "test", model: "suspicious-model" }),
+    ).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  });
+
+  it("accepts valid pricing in typical LLM range", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "test/normal-model" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    // GPT-4 class pricing: ~$2.50/million input, ~$10/million output
+    const fetchImpl = withFetchPreconnect(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "test/normal-model",
+                pricing: {
+                  prompt: "0.0000025", // $2.50/million
+                  completion: "0.00001", // $10/million
+                  input_cache_read: "0.00000025", // $0.25/million
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    expect(
+      getCachedGatewayModelPricing({ provider: "test", model: "normal-model" }),
+    ).toEqual({
+      input: 2.5,
+      output: 10,
+      cacheRead: 0.25,
+      cacheWrite: 0,
+    });
+  });
 });

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -94,11 +94,35 @@ function parseNumberString(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function toPricePerMillion(value: number | null): number {
+function toPricePerMillion(value: number | null, context?: string): number {
   if (value === null || value < 0 || !Number.isFinite(value)) {
     return 0;
   }
-  return value * 1_000_000;
+  const result = value * 1_000_000;
+  
+  // Sanity check: reject pricing > $100/million as suspicious
+  // Typical LLM pricing: $0.10-$10/million for input, $0.30-$30/million for output
+  // Values >$100/million indicate corrupted data or format mismatch
+  if (result > 100) {
+    log.warn(
+      `Suspicious pricing detected${context ? ` (${context})` : ""}: ` +
+      `${value} per-token → ${result.toFixed(4)} per-million USD. ` +
+      `Expected range: $0.01-$100/million. Using 0 to avoid cost inflation.`,
+    );
+    return 0;
+  }
+  
+  // Also warn on unusually low pricing (< $0.0001/million) which might indicate
+  // the value was already in per-million format and got double-converted
+  if (result > 0 && result < 0.0001) {
+    log.warn(
+      `Unusually low pricing detected${context ? ` (${context})` : ""}: ` +
+      `${value} per-token → ${result} per-million USD. ` +
+      `Verify source format is per-token (not per-million).`,
+    );
+  }
+  
+  return result;
 }
 
 function parseOpenRouterPricing(value: unknown): CachedModelPricing | null {
@@ -112,10 +136,10 @@ function parseOpenRouterPricing(value: unknown): CachedModelPricing | null {
     return null;
   }
   return {
-    input: toPricePerMillion(prompt),
-    output: toPricePerMillion(completion),
-    cacheRead: toPricePerMillion(parseNumberString(pricing.input_cache_read)),
-    cacheWrite: toPricePerMillion(parseNumberString(pricing.input_cache_write)),
+    input: toPricePerMillion(prompt, "input"),
+    output: toPricePerMillion(completion, "output"),
+    cacheRead: toPricePerMillion(parseNumberString(pricing.input_cache_read), "cacheRead"),
+    cacheWrite: toPricePerMillion(parseNumberString(pricing.input_cache_write), "cacheWrite"),
   };
 }
 


### PR DESCRIPTION
## Summary

This PR adds defensive validation to prevent the pricing cache corruption issue reported in #367, where costs were being reported as 100-1000x higher than expected (e.g., $3120 for 2.3M tokens on gpt-5.4-mini instead of ~$1.73).

## Root Cause

As identified in the #367 investigation, the gateway pricing cache could contain corrupted values from:
- Previous bugs that double-converted prices
- Stale data persisted across gateway restarts  
- API response format changes

The cost calculation math itself is correct, but corrupted source data caused massive overcharges.

## Changes

### 1. Pricing Sanity Checks (model-pricing-cache.ts)

Added validation in `toPricePerMillion()` to:
- **Reject pricing >$100/million tokens** as suspicious (typical LLM pricing: $0.10-$10/million input, $0.30-$30/million output)
- **Warn on unusually low pricing (<$0.0001/million)** which might indicate double-conversion
- **Default to 0** for suspicious values to prevent cost inflation
- **Log warnings** with context to aid debugging

### 2. Tests (model-pricing-cache.test.ts)

Added two new test cases:
- `rejects suspicious pricing values > $100/million to prevent cost inflation`
- `accepts valid pricing in typical LLM range`

## Impact

- **Prevents future occurrences** of the $3120 bug
- **Defensive**: If corrupted data enters the cache again, it will be caught and rejected
- **Observable**: Warnings logged to help diagnose pricing data issues
- **Safe**: Defaults to 0 for suspicious values rather than using potentially inflated costs

## Testing

All existing tests pass. New tests verify:
- Suspicious pricing ($300-900/million) is rejected and returns 0
- Normal pricing ($2.50-10/million) is accepted and calculated correctly

## Follow-up Recommendations

1. Consider adding a CLI command to manually clear the pricing cache: `openclaw gateway clear-pricing-cache`
2. Monitor logs for pricing warnings after deployment
3. Consider cache invalidation strategy (TTL, version-based) to prevent stale data persistence

Fixes #367