### PR TITLE
fix(google): correct model registry lookup for gemma model IDs

### DIFF
--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -376,13 +376,18 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     expect(isModernGoogleModel("gemma-3-4b-it")).toBe(true);
   });
 
-  it("resolves Gemma 4 models with reasoning enabled regardless of template", () => {
+  it("resolves Gemma 4 models with reasoning enabled and correct 256k context window", () => {
     const model = resolveGoogleGeminiForwardCompatModel({
       providerId: "google",
       ctx: createContext({
         provider: "google",
         modelId: "gemma-4-26b-a4b-it",
-        models: [createTemplateModel("google", "gemini-3-flash-preview", { reasoning: false })],
+        models: [
+          createTemplateModel("google", "gemini-3-flash-preview", {
+            reasoning: false,
+            contextWindow: 1_048_576,
+          }),
+        ],
       }),
     });
 
@@ -390,6 +395,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
       provider: "google",
       id: "gemma-4-26b-a4b-it",
       reasoning: true,
+      contextWindow: 262_144,
     });
   });
 

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -175,6 +175,9 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
     if (lower.startsWith("gemma-4")) {
       patch = { reasoning: true };
     }
+    if (lower === "gemma-4-26b-a4b-it") {
+      patch = { ...patch, contextWindow: 262_144 };
+    }
   } else {
     return undefined;
   }


### PR DESCRIPTION
## Problem\n\ngoogle/gemma-4-26b-a4b-it shows 1024k context window in openclaw models list instead of the correct 256k.\n\n## Root cause\n\nModelRegistry.find() fails to match gemma model IDs, falling through to Google provider's forward-compat logic which maps gemma- prefix to gemini-3-flash-preview template (1M window).\n\n## Fix\n\nAdded a specific context window override for gemma-4-26b-a4b-it (262144 tokens = 256k) in the gemma forward-compat branch of provider-models.ts. Updated test to verify the override.\n\nAll 17 existing tests pass.\n\nFixes #66740