### PR TITLE
fix(cli): add positional argument completion for zsh leaf commands

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -219,6 +219,29 @@ function generateZshSubcmdList(cmd: Command): string {
   return `"1: :_values 'command' ${list}"`;
 }
 
+function generateZshPositionalArgs(cmd: Command): string {
+  const args = (cmd as unknown as { _args?: Array<{ name: string; description?: () => string; required: boolean; variadic: boolean }> })._args
+    ?? (cmd as unknown as { registeredArguments?: Array<{ name: string; description?: () => string; required: boolean; variadic: boolean }> }).registeredArguments;
+  if (!args || args.length === 0) {
+    return "";
+  }
+  return args
+    .map((arg, i) => {
+      const n = i + 1;
+      const desc = (arg.description?.() ?? arg.name)
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/'/g, "'\\''")
+        .replace(/\[/g, "\\[")
+        .replace(/\]/g, "\\]");
+      if (arg.variadic) {
+        return `${n}:${desc}:_files`;
+      }
+      return `${n}:${desc}:_files`;
+    })
+    .join(" \\\n    ");
+}
+
 function generateZshSubcommands(program: Command, prefix: string): string {
   const segments: string[] = [];
 
@@ -257,7 +280,8 @@ ${funcName}() {
       segments.push(`
 ${funcName}() {
   _arguments -C \\
-    ${generateZshArgs(cmd)}
+    ${generateZshArgs(cmd)} \\
+    ${generateZshPositionalArgs(cmd)}
 }
 `);
     }


### PR DESCRIPTION
## Summary

Zsh completion for leaf commands (e.g. `openclaw wiki ingest`) was missing positional argument specs, so `<Tab>` did not trigger file-path completion for commands that accept file arguments.

Root cause: `generateZshSubcommands` only emitted `_arguments` with option flags (`generateZshArgs`) for leaf commands — it never included `"N:description:_files"` lines for registered `.argument()` definitions.

## Changes

- Added `generateZshPositionalArgs(cmd)` helper that reads argument metadata from Commander.js internal `_args` / `registeredArguments` (with fallback between the two for version compatibility) and emits zsh positional argument completion specs (`"1:markdown file:_files"` style).
- Wired the new helper into the leaf command template so positional args are now included in `_arguments` calls.

## Fix

Closes #69293

## Notes

- Uses `_files` action for all positional arguments since the vast majority of openclaw leaf-command args are file paths (ingest, export, import, etc.). Commands with non-file positional args (if any) would need a more sophisticated mapper in a follow-up.
- Defensive: returns empty string when no args are registered, so existing behavior is preserved for commands without positional arguments.