### PR TITLE
fix(gateway): block silent pairing scope self-approval

### DIFF
--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -113,7 +113,57 @@ async function expectRejectedScopeUpgradeAttempt({
   expect(paired?.tokens?.operator?.token).toBe(token);
 }
 
+async function openPairingWatcherSession(port: number): Promise<WebSocket> {
+  const watcher = await issueOperatorToken({
+    name: "silent-scope-upgrade-watcher",
+    approvedScopes: ["operator.admin"],
+    tokenScopes: ["operator.pairing"],
+    clientId: GATEWAY_CLIENT_NAMES.TEST,
+    clientMode: GATEWAY_CLIENT_MODES.TEST,
+  });
+  const ws = await openTrackedWs(port);
+  await connectOk(ws, {
+    skipDefaultAuth: true,
+    deviceToken: watcher.token,
+    deviceIdentityPath: watcher.identityPath,
+    scopes: ["operator.pairing"],
+  });
+  return ws;
+}
+
 describe("gateway silent scope-upgrade reconnect", () => {
+  test("does not silently self-approve admin scopes for first-time shared-auth pairing", async () => {
+    const started = await startServerWithClient("secret");
+    const loaded = loadDeviceIdentity("silent-first-pairing-admin-scope");
+    let firstPairingAttemptWs: WebSocket | undefined;
+
+    try {
+      firstPairingAttemptWs = await openTrackedWs(started.port);
+      const firstAttempt = await connectReq(firstPairingAttemptWs, {
+        token: "secret",
+        deviceIdentityPath: loaded.identityPath,
+        scopes: ["operator.admin"],
+      });
+      expect(firstAttempt.ok).toBe(false);
+      expect(firstAttempt.error?.message).toBe("pairing required: device is not approved yet");
+
+      const pending = await devicePairingModule.listDevicePairing();
+      expect(pending.pending).toHaveLength(1);
+      expect(pending.pending[0]?.deviceId).toBe(loaded.identity.deviceId);
+      expect(pending.pending[0]?.publicKey).toBe(loaded.publicKey);
+      expect(pending.pending[0]?.scopes).toEqual(["operator.admin"]);
+      expect(pending.pending[0]?.silent).toBe(true);
+
+      const paired = await getPairedDevice(loaded.identity.deviceId);
+      expect(paired).toBeNull();
+    } finally {
+      firstPairingAttemptWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
   test("does not silently widen a read-scoped paired device to admin on shared-auth reconnect", async () => {
     const started = await startServerWithClient("secret");
     const paired = await issueOperatorToken({
@@ -128,8 +178,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
     let postAttemptDeviceTokenWs: WebSocket | undefined;
 
     try {
-      watcherWs = await openTrackedWs(started.port);
-      await connectOk(watcherWs, { scopes: ["operator.admin"] });
+      watcherWs = await openPairingWatcherSession(started.port);
       const requestedEvent = onceMessage(
         watcherWs,
         (obj) => obj.type === "event" && obj.event === "device.pair.requested",
@@ -183,8 +232,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
     let backendReconnectWs: WebSocket | undefined;
 
     try {
-      watcherWs = await openTrackedWs(started.port);
-      await connectOk(watcherWs, { scopes: ["operator.admin"] });
+      watcherWs = await openPairingWatcherSession(started.port);
       const requestedEvent = onceMessage(
         watcherWs,
         (obj) => obj.type === "event" && obj.event === "device.pair.requested",
@@ -255,6 +303,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
       const res = await connectReq(ws, {
         token: "secret",
         deviceIdentityPath: loaded.identityPath,
+        scopes: [],
       });
       expect(res.ok).toBe(true);
 

--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import * as devicePairingModule from "../infra/device-pairing.js";
-import { getPairedDevice } from "../infra/device-pairing.js";
+import { getPairedDevice, LOCAL_SILENT_OPERATOR_SCOPES } from "../infra/device-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   issueOperatorToken,
@@ -132,32 +132,44 @@ async function openPairingWatcherSession(port: number): Promise<WebSocket> {
 }
 
 describe("gateway silent scope-upgrade reconnect", () => {
-  test("does not silently self-approve admin scopes for first-time shared-auth pairing", async () => {
+  test("first local shared-auth pairing keeps the session alive but bounds the issued device token", async () => {
     const started = await startServerWithClient("secret");
-    const loaded = loadDeviceIdentity("silent-first-pairing-admin-scope");
-    let firstPairingAttemptWs: WebSocket | undefined;
+    const loaded = loadDeviceIdentity("silent-local-first-pair-bounded");
+    let ws: WebSocket | undefined;
 
     try {
-      firstPairingAttemptWs = await openTrackedWs(started.port);
-      const firstAttempt = await connectReq(firstPairingAttemptWs, {
+      ws = await openTrackedWs(started.port);
+      const res = await connectReq(ws, {
         token: "secret",
         deviceIdentityPath: loaded.identityPath,
-        scopes: ["operator.admin"],
       });
-      expect(firstAttempt.ok).toBe(false);
-      expect(firstAttempt.error?.message).toBe("pairing required: device is not approved yet");
+      expect(res.ok).toBe(true);
 
-      const pending = await devicePairingModule.listDevicePairing();
-      expect(pending.pending).toHaveLength(1);
-      expect(pending.pending[0]?.deviceId).toBe(loaded.identity.deviceId);
-      expect(pending.pending[0]?.publicKey).toBe(loaded.publicKey);
-      expect(pending.pending[0]?.scopes).toEqual(["operator.admin"]);
-      expect(pending.pending[0]?.silent).toBe(true);
+      const payload = res.payload as
+        | {
+            type?: string;
+            auth?: { deviceToken?: string; scopes?: string[] };
+            snapshot?: {
+              configPath?: string;
+              stateDir?: string;
+              authMode?: string;
+            };
+          }
+        | undefined;
+      expect(payload?.type).toBe("hello-ok");
+      expect(payload?.auth?.scopes).toEqual([...LOCAL_SILENT_OPERATOR_SCOPES]);
+      expect(typeof payload?.auth?.deviceToken).toBe("string");
+      expect(typeof payload?.snapshot?.configPath).toBe("string");
+      expect((payload?.snapshot?.configPath ?? "").length).toBeGreaterThan(0);
+      expect(typeof payload?.snapshot?.stateDir).toBe("string");
+      expect((payload?.snapshot?.stateDir ?? "").length).toBeGreaterThan(0);
+      expect(payload?.snapshot?.authMode).toBe("token");
 
       const paired = await getPairedDevice(loaded.identity.deviceId);
-      expect(paired).toBeNull();
+      expect(paired?.approvedScopes).toEqual([...LOCAL_SILENT_OPERATOR_SCOPES]);
+      expect(paired?.tokens?.operator?.scopes).toEqual([...LOCAL_SILENT_OPERATOR_SCOPES]);
     } finally {
-      firstPairingAttemptWs?.close();
+      ws?.close();
       started.ws.close();
       await started.server.close();
       started.envSnapshot.restore();
@@ -276,25 +288,17 @@ describe("gateway silent scope-upgrade reconnect", () => {
     const loaded = loadDeviceIdentity("silent-reconnect-race");
     let ws: WebSocket | undefined;
 
-    const approveOriginal = devicePairingModule.approveDevicePairing;
+    const approveOriginal = devicePairingModule.approveSilentLocalOperatorDevicePairing;
     let simulatedRace = false;
-    const forwardApprove = async (requestId: string, optionsOrBaseDir?: unknown) => {
-      if (optionsOrBaseDir && typeof optionsOrBaseDir === "object") {
-        return await approveOriginal(
-          requestId,
-          optionsOrBaseDir as { callerScopes?: readonly string[] },
-        );
-      }
-      return await approveOriginal(requestId);
-    };
+    const forwardApprove = async (requestId: string) => await approveOriginal(requestId);
     const approveSpy = vi
-      .spyOn(devicePairingModule, "approveDevicePairing")
-      .mockImplementation(async (requestId: string, optionsOrBaseDir?: unknown) => {
+      .spyOn(devicePairingModule, "approveSilentLocalOperatorDevicePairing")
+      .mockImplementation(async (requestId: string) => {
         if (simulatedRace) {
-          return await forwardApprove(requestId, optionsOrBaseDir);
+          return await forwardApprove(requestId);
         }
         simulatedRace = true;
-        await forwardApprove(requestId, optionsOrBaseDir);
+        await forwardApprove(requestId);
         return null;
       });
 
@@ -303,7 +307,6 @@ describe("gateway silent scope-upgrade reconnect", () => {
       const res = await connectReq(ws, {
         token: "secret",
         deviceIdentityPath: loaded.identityPath,
-        scopes: [],
       });
       expect(res.ok).toBe(true);
 
@@ -325,7 +328,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
     let ws: WebSocket | undefined;
 
     const approveSpy = vi
-      .spyOn(devicePairingModule, "approveDevicePairing")
+      .spyOn(devicePairingModule, "approveSilentLocalOperatorDevicePairing")
       .mockImplementation(async (requestId: string) => {
         await devicePairingModule.rejectDevicePairing(requestId);
         return null;
@@ -337,9 +340,8 @@ describe("gateway silent scope-upgrade reconnect", () => {
         started.ws,
         (obj) => obj.type === "event" && obj.event === "device.pair.requested",
         300,
-      )
-        .then((event) => ({ ok: true as const, event }))
-        .catch((error: unknown) => ({ ok: false as const, error }));
+      );
+      const requestedEventTimeout = expect(requestedEvent).rejects.toThrow("timeout");
 
       ws = await openTrackedWs(started.port);
       const res = await connectReq(ws, {
@@ -352,13 +354,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
       expect(
         (res.error?.details as { requestId?: unknown; code?: string } | undefined)?.requestId,
       ).toBeUndefined();
-      const requested = await requestedEvent;
-      expect(requested.ok).toBe(false);
-      if (requested.ok) {
-        throw new Error("expected pairing request watcher to time out");
-      }
-      expect(requested.error).toBeInstanceOf(Error);
-      expect((requested.error as Error).message).toContain("timeout");
+      await requestedEventTimeout;
 
       const pending = await devicePairingModule.listDevicePairing();
       expect(pending.pending).toEqual([]);
@@ -378,7 +374,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
     let replacementRequestId = "";
 
     const approveSpy = vi
-      .spyOn(devicePairingModule, "approveDevicePairing")
+      .spyOn(devicePairingModule, "approveSilentLocalOperatorDevicePairing")
       .mockImplementation(async (_requestId: string) => {
         const replacement = await devicePairingModule.requestDevicePairing({
           deviceId: loaded.identity.deviceId,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -926,6 +926,14 @@ export function attachGatewayWsMessageHandler(params: {
             const bootstrapProfileForSilentApproval = allowSilentBootstrapPairing
               ? boundBootstrapProfile
               : null;
+            const pairedScopeBaseline =
+              existingPairedDevice && existingPairedDevice.publicKey === devicePublicKey
+                ? Array.isArray(existingPairedDevice.approvedScopes)
+                  ? existingPairedDevice.approvedScopes
+                  : Array.isArray(existingPairedDevice.scopes)
+                    ? existingPairedDevice.scopes
+                    : []
+                : [];
             const bootstrapPairingRoles = bootstrapProfileForSilentApproval
               ? Array.from(new Set([role, ...bootstrapProfileForSilentApproval.roles]))
               : undefined;
@@ -964,7 +972,7 @@ export function attachGatewayWsMessageHandler(params: {
                     bootstrapProfileForSilentApproval,
                   )
                 : await approveDevicePairing(pairing.request.requestId, {
-                    callerScopes: scopes,
+                    callerScopes: pairedScopeBaseline,
                   });
               if (approved?.status === "approved") {
                 if (bootstrapProfileForSilentApproval) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -16,9 +16,12 @@ import {
 import {
   approveBootstrapDevicePairing,
   approveDevicePairing,
+  approveSilentLocalOperatorDevicePairing,
+  type ApproveDevicePairingResult,
   ensureDeviceToken,
   getPairedDevice,
   hasEffectivePairedDeviceRole,
+  LOCAL_SILENT_OPERATOR_SCOPES,
   listApprovedPairedDeviceRoles,
   listDevicePairing,
   listEffectivePairedDeviceRoles,
@@ -822,6 +825,7 @@ export function attachGatewayWsMessageHandler(params: {
           trustedProxyAuthOk,
           resolvedAuth.mode,
         );
+        let issuedDeviceTokenScopes = scopes;
         if (device && devicePublicKey) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {
@@ -894,6 +898,14 @@ export function attachGatewayWsMessageHandler(params: {
                 allowedScopes: pairedScopes,
               });
             };
+            const pairingStateAllowsSilentLocalSession = (
+              pairedCandidate: Awaited<ReturnType<typeof getPairedDevice>>,
+            ): boolean => {
+              if (!pairedCandidate || pairedCandidate.publicKey !== devicePublicKey) {
+                return false;
+              }
+              return hasEffectivePairedDeviceRole(pairedCandidate, role);
+            };
             if (
               boundBootstrapProfile === null &&
               authMethod === "bootstrap-token" &&
@@ -926,14 +938,6 @@ export function attachGatewayWsMessageHandler(params: {
             const bootstrapProfileForSilentApproval = allowSilentBootstrapPairing
               ? boundBootstrapProfile
               : null;
-            const pairedScopeBaseline =
-              existingPairedDevice && existingPairedDevice.publicKey === devicePublicKey
-                ? Array.isArray(existingPairedDevice.approvedScopes)
-                  ? existingPairedDevice.approvedScopes
-                  : Array.isArray(existingPairedDevice.scopes)
-                    ? existingPairedDevice.scopes
-                    : []
-                : [];
             const bootstrapPairingRoles = bootstrapProfileForSilentApproval
               ? Array.from(new Set([role, ...bootstrapProfileForSilentApproval.roles]))
               : undefined;
@@ -948,7 +952,7 @@ export function attachGatewayWsMessageHandler(params: {
                   : allowSilentLocalPairing || allowSilentBootstrapPairing,
             });
             const context = buildRequestContext();
-            let approved: Awaited<ReturnType<typeof approveDevicePairing>> | undefined;
+            let approved: ApproveDevicePairingResult | undefined;
             let resolvedByConcurrentApproval = false;
             let recoveryRequestId: string | undefined = pairing.request.requestId;
             const resolveLivePendingRequestId = async (): Promise<string | undefined> => {
@@ -971,10 +975,15 @@ export function attachGatewayWsMessageHandler(params: {
                     pairing.request.requestId,
                     bootstrapProfileForSilentApproval,
                   )
-                : await approveDevicePairing(pairing.request.requestId, {
-                    callerScopes: pairedScopeBaseline,
-                  });
+                : role === "operator"
+                  ? await approveSilentLocalOperatorDevicePairing(pairing.request.requestId)
+                  : await approveDevicePairing(pairing.request.requestId, {
+                      callerScopes: scopes,
+                    });
               if (approved?.status === "approved") {
+                if (!bootstrapProfileForSilentApproval && role === "operator") {
+                  issuedDeviceTokenScopes = [...LOCAL_SILENT_OPERATOR_SCOPES];
+                }
                 if (bootstrapProfileForSilentApproval) {
                   handoffBootstrapProfile = bootstrapProfileForSilentApproval;
                 }
@@ -992,9 +1001,13 @@ export function attachGatewayWsMessageHandler(params: {
                   { dropIfSlow: true },
                 );
               } else {
-                resolvedByConcurrentApproval = pairingStateAllowsRequestedAccess(
-                  await getPairedDevice(device.id),
-                );
+                const pairedCandidate = await getPairedDevice(device.id);
+                resolvedByConcurrentApproval =
+                  !bootstrapProfileForSilentApproval &&
+                  reason === "not-paired" &&
+                  role === "operator"
+                    ? pairingStateAllowsSilentLocalSession(pairedCandidate)
+                    : pairingStateAllowsRequestedAccess(pairedCandidate);
                 let requestStillPending = false;
                 if (!resolvedByConcurrentApproval) {
                   recoveryRequestId = await resolveLivePendingRequestId();
@@ -1152,7 +1165,7 @@ export function attachGatewayWsMessageHandler(params: {
         }
 
         const deviceToken = device
-          ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
+          ? await ensureDeviceToken({ deviceId: device.id, role, scopes: issuedDeviceTokenScopes })
           : null;
         const bootstrapDeviceTokens: Array<{
           deviceToken: string;

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -113,6 +113,14 @@ export type ApproveDevicePairingResult =
   | DevicePairingForbiddenResult
   | null;
 
+export const LOCAL_SILENT_OPERATOR_SCOPES = [
+  "operator.approvals",
+  "operator.pairing",
+  "operator.read",
+  "operator.talk.secrets",
+  "operator.write",
+] as const;
+
 type DevicePairingStateFile = {
   pendingById: Record<string, DevicePairingPendingRequest>;
   pairedByDeviceId: Record<string, PairedDevice>;
@@ -638,6 +646,88 @@ export async function approveDevicePairing(
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, baseDir);
     return { status: "approved", requestId, device };
+  });
+}
+
+async function approveProfileDevicePairing(params: {
+  requestId: string;
+  approvedRoles: readonly string[];
+  approvedScopes: readonly string[];
+  baseDir?: string;
+}): Promise<ApproveDevicePairingResult> {
+  const approvedRoles = mergeRoles(Array.from(params.approvedRoles)) ?? [];
+  const approvedScopes = normalizeDeviceAuthScopes(Array.from(params.approvedScopes));
+  return await withLock(async () => {
+    const state = await loadState(params.baseDir);
+    const pending = state.pendingById[params.requestId];
+    if (!pending) {
+      return null;
+    }
+    const requestedRoles = resolveRequestedRoles(pending);
+    const missingRole = requestedRoles.find((role) => !approvedRoles.includes(role));
+    if (missingRole) {
+      return { status: "forbidden", reason: "bootstrap-role-not-allowed", role: missingRole };
+    }
+    // Silent local pairing is compatibility UX, not scope approval. Persist the
+    // server-owned profile and ignore any broader operator scopes in the request.
+    const now = Date.now();
+    const existing = state.pairedByDeviceId[pending.deviceId];
+    const roles = mergeRoles(
+      existing?.roles,
+      existing?.role,
+      pending.roles,
+      pending.role,
+      approvedRoles,
+    );
+    const nextApprovedScopes = mergeScopes(
+      existing?.approvedScopes ?? existing?.scopes,
+      approvedScopes,
+    );
+    const tokens = existing?.tokens ? { ...existing.tokens } : {};
+    for (const roleForToken of approvedRoles) {
+      const existingToken = tokens[roleForToken];
+      tokens[roleForToken] = buildDeviceAuthToken({
+        role: roleForToken,
+        scopes: resolveRoleScopedDeviceTokenScopes(roleForToken, nextApprovedScopes),
+        existing: existingToken,
+        now,
+        ...(existingToken ? { rotatedAtMs: now } : {}),
+      });
+    }
+
+    const device: PairedDevice = {
+      deviceId: pending.deviceId,
+      publicKey: pending.publicKey,
+      displayName: pending.displayName,
+      platform: pending.platform,
+      deviceFamily: pending.deviceFamily,
+      clientId: pending.clientId,
+      clientMode: pending.clientMode,
+      role: pending.role,
+      roles,
+      scopes: nextApprovedScopes,
+      approvedScopes: nextApprovedScopes,
+      remoteIp: pending.remoteIp,
+      tokens,
+      createdAtMs: existing?.createdAtMs ?? now,
+      approvedAtMs: now,
+    };
+    delete state.pendingById[params.requestId];
+    state.pairedByDeviceId[device.deviceId] = device;
+    await persistState(state, params.baseDir);
+    return { status: "approved", requestId: params.requestId, device };
+  });
+}
+
+export async function approveSilentLocalOperatorDevicePairing(
+  requestId: string,
+  baseDir?: string,
+): Promise<ApproveDevicePairingResult> {
+  return await approveProfileDevicePairing({
+    requestId,
+    approvedRoles: [OPERATOR_ROLE],
+    approvedScopes: LOCAL_SILENT_OPERATOR_SCOPES,
+    baseDir,
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: silent local shared-auth pairing used the client-requested scopes as the approval baseline, so a first-time local operator pairing could silently self-approve elevated scopes such as `operator.admin`.
- Why it matters: this let a local/shared-auth client persist broader operator scopes into the paired device record and minted device token without any explicit approval.
- What changed: silent local operator pairing now uses a server-owned bounded scope profile (`LOCAL_SILENT_OPERATOR_SCOPES`) instead of the client-requested scopes, while non-operator silent pairing paths keep their existing behavior.
- What did NOT change (scope boundary): bootstrap-profile silent approvals are unchanged, explicit pairing approval flows are unchanged, and first-time local pairing still succeeds for the bounded operator baseline.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the silent local pairing path forwarded `connectParams.scopes` into `approveDevicePairing` as `callerScopes`, so the device could effectively approve its own requested operator scopes.
- Missing detection / guardrail: regression coverage existed for reconnect scope widening, but not for the first local shared-auth pairing path where the session should stay alive while the issued token is bounded.
- Contributing context (if known): the repository already had a correct bounded-profile approach for this path, but that behavior was reverted and the self-approval path came back.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts`
- Scenario the test should lock in: first local shared-auth operator pairings should connect successfully but only receive the bounded local silent operator scope baseline; reconnects must not silently widen beyond already-approved scopes.
- Why this is the smallest reliable guardrail: the bug lives in the WebSocket handshake/pairing/token-mint seam, not in a pure helper.
- Existing test that already covers this (if any): the same file already covered reconnect scope-upgrade regressions for paired devices.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- First-time local shared-auth operator pairings still connect silently, but the paired record and issued device token are bounded to `LOCAL_SILENT_OPERATOR_SCOPES` rather than the client-requested operator scopes.
- Subsequent reconnects still require explicit approval for scope widening beyond the approved baseline.

## Diagram (if applicable)

```text
Before:
[local shared-auth operator connect requests operator.admin]
  -> [silent pairing uses requested scopes as callerScopes]
  -> [pairing approved]
  -> [device token minted with operator.admin]

After:
[local shared-auth operator connect requests operator.admin]
  -> [silent pairing applies server-owned bounded operator scope profile]
  -> [pairing approved for bounded baseline]
  -> [device token minted with bounded scopes only]
  -> [later widening still requires explicit approval]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: this narrows the scopes that can be silently persisted during first-time local operator pairing, preventing self-approved admin escalation while preserving the intended bounded local onboarding flow.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node.js / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket handshake
- Relevant config (redacted): shared-auth token flow in gateway test helpers

### Steps

1. Start the gateway test server with shared-auth enabled.
2. Attempt a first-time local operator pairing over WebSocket from a new device identity.
3. Request elevated scopes such as `operator.admin`.
4. Reconnect from an already paired device and attempt to widen scopes beyond the approved baseline.

### Expected

- First-time local operator pairing succeeds, but the issued token is limited to the bounded local silent operator scope profile.
- Reconnect scope widening beyond the approved baseline remains pending for explicit approval.

### Actual

- With this patch, the first local pairing no longer self-approves the client-requested admin scopes, and reconnect scope widening still fails closed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts src/gateway/session-message-events.test.ts` and confirmed both the security regression and the CI-reported first-pairing regression are covered and pass; ran `pnpm check` successfully before the follow-up commit.
- Edge cases checked: first-time local shared-auth operator pairing, paired-device reconnect scope upgrade, backend reconnect scope upgrade, node silent pairing behavior, and the existing concurrent approval/rejection race tests.
- What you did **not** verify: a manual live exploit outside the test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: local onboarding behavior changes if a client expected its requested operator scopes to be silently granted on first pair.
  - Mitigation: the intended bounded local onboarding path is preserved, and explicit approval remains available for broader scopes.

## AI Assistance

- AI-assisted: Codex
- Testing degree: fully tested
- I understand what the code does: Yes
