### PR TITLE
fix: resolve openrouter model alias redirects in provider response

### DIFF
--- a/extensions/openrouter/stream.test.ts
+++ b/extensions/openrouter/stream.test.ts
@@ -1,0 +1,119 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { wrapOpenRouterProviderStream } from "./stream.js";
+
+describe("wrapOpenRouterProviderStream", () => {
+  it("keeps assistant messages pinned to the configured OpenRouter alias", async () => {
+    const baseStreamFn: StreamFn = (model) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "hi" }],
+            api: model.api,
+            provider: model.provider,
+            model: "deepseek/deepseek-chat-v3-20260117",
+            usage: {
+              input: 0,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 1,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: Date.now(),
+          },
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapOpenRouterProviderStream({
+      streamFn: baseStreamFn,
+      modelId: "deepseek/deepseek-v3.2",
+      thinkingLevel: "adaptive",
+      extraParams: undefined,
+    } as never)!;
+
+    const stream = wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "deepseek/deepseek-v3.2",
+      } as never,
+      { messages: [] },
+      {},
+    );
+
+    const events = [] as Array<Record<string, unknown>>;
+    for await (const event of stream) {
+      events.push(event as Record<string, unknown>);
+    }
+    const result = await stream.result();
+
+    expect((events[0]?.message as { model?: string }).model).toBe("deepseek/deepseek-v3.2");
+    expect(result?.model).toBe("deepseek/deepseek-v3.2");
+  });
+
+  it("normalizes error events to the configured alias too", async () => {
+    const baseStreamFn: StreamFn = (model) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: {
+            role: "assistant",
+            content: [],
+            api: model.api,
+            provider: model.provider,
+            model: "anthropic/claude-4.5-sonnet-20250929",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "error",
+            errorMessage: "boom",
+            timestamp: Date.now(),
+          },
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapOpenRouterProviderStream({
+      streamFn: baseStreamFn,
+      modelId: "anthropic/claude-sonnet-4.5",
+      thinkingLevel: "adaptive",
+      extraParams: undefined,
+    } as never)!;
+
+    const stream = wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4.5",
+      } as never,
+      { messages: [] },
+      {},
+    );
+
+    const events = [] as Array<Record<string, unknown>>;
+    for await (const event of stream) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect((events[0]?.error as { model?: string }).model).toBe("anthropic/claude-sonnet-4.5");
+  });
+});

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -1,6 +1,8 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { OPENROUTER_THINKING_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
+import { wrapStreamObjectEvents } from "../../src/agents/pi-embedded-runner/run/stream-wrapper.js";
 
 function injectOpenRouterRouting(
   baseStreamFn: StreamFn | undefined,
@@ -27,6 +29,36 @@ function injectOpenRouterRouting(
     );
 }
 
+function normalizeOpenRouterAssistantMessage(
+  message: unknown,
+  model: { provider: string; id: string },
+): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const assistant = message as { provider?: unknown; model?: unknown };
+  assistant.provider = model.provider;
+  assistant.model = model.id;
+}
+
+function createOpenRouterAliasStableStream(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const stream = underlying(model, context, options);
+    const originalResult = stream.result.bind(stream);
+    stream.result = async () => {
+      const message = await originalResult();
+      normalizeOpenRouterAssistantMessage(message, model);
+      return message;
+    };
+    return wrapStreamObjectEvents(stream, (event) => {
+      normalizeOpenRouterAssistantMessage(event.partial, model);
+      normalizeOpenRouterAssistantMessage(event.message, model);
+      normalizeOpenRouterAssistantMessage(event.error, model);
+    });
+  };
+}
+
 export function wrapOpenRouterProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | null | undefined {
@@ -38,13 +70,10 @@ export function wrapOpenRouterProviderStream(
     ? injectOpenRouterRouting(ctx.streamFn, providerRouting)
     : ctx.streamFn;
   const wrapStreamFn = OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn ?? undefined;
-  if (!wrapStreamFn) {
-    return routedStreamFn;
-  }
-  return (
-    wrapStreamFn({
+  const wrappedStreamFn =
+    wrapStreamFn?.({
       ...ctx,
       streamFn: routedStreamFn,
-    }) ?? undefined
-  );
+    }) ?? routedStreamFn;
+  return createOpenRouterAliasStableStream(wrappedStreamFn);
 }


### PR DESCRIPTION
## Summary
- keep OpenRouter assistant stream messages pinned to the configured model alias instead of the provider-returned redirected id
- normalize done/error stream events and final stream results so downstream payload assembly does not lose the resolved model
- add regression coverage for redirected OpenRouter aliases on success and error paths

## Testing
- pnpm test -- --run extensions/openrouter/stream.test.ts src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts

Closes #69507