### PR TITLE
fix(microsoft-tts): emit ogg/opus for voice-note targets so WhatsApp auto-replies play as native voice notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Microsoft/TTS: default the Edge/Microsoft speech provider to `ogg-48khz-16bit-mono-opus` when the TTS dispatcher requests a voice-note target (WhatsApp, Telegram, Discord, Matrix, Feishu) so auto-TTS replies play as native voice notes instead of MP3 attachments WhatsApp cannot render. Explicit `messages.tts.providers.microsoft.outputFormat` overrides still win. (#69435)
 - Telegram/status reactions: honor `messages.removeAckAfterReply` when lifecycle status reactions are enabled, clearing or restoring the reaction after success/error using the configured hold timings. (#68067) Thanks @poiskgit.
 - Telegram/polling: raise the default polling watchdog threshold from 90s to 120s and add configurable `channels.telegram.pollingStallThresholdMs` (also per-account) so long-running Telegram work gets more room before polling is treated as stalled. (#57737) Thanks @Vitalcheffe.
 - Telegram/polling: bound the persisted-offset confirmation `getUpdates` probe with a client-side timeout so a zombie socket cannot hang polling recovery before the runner watchdog starts. (#50368) Thanks @boticlaw.

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -303,7 +303,7 @@ Then run:
 - `providers.microsoft.enabled`: allow Microsoft speech usage (default `true`; no API key).
 - `providers.microsoft.voice`: Microsoft neural voice name (e.g. `en-US-MichelleNeural`).
 - `providers.microsoft.lang`: language code (e.g. `en-US`).
-- `providers.microsoft.outputFormat`: Microsoft output format (e.g. `audio-24khz-48kbitrate-mono-mp3`).
+- `providers.microsoft.outputFormat`: Microsoft output format (e.g. `audio-24khz-48kbitrate-mono-mp3`). When omitted, OpenClaw selects per channel: `ogg-48khz-16bit-mono-opus` for native voice-note channels and `audio-24khz-48kbitrate-mono-mp3` otherwise.
   - See Microsoft Speech output formats for valid values; not all formats are supported by the bundled Edge-backed transport.
 - `providers.microsoft.rate` / `providers.microsoft.pitch` / `providers.microsoft.volume`: percent strings (e.g. `+10%`, `-5%`).
 - `providers.microsoft.saveSubtitles`: write JSON subtitles alongside the audio file.
@@ -397,12 +397,12 @@ These override `messages.tts.*` for that host.
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **MiniMax**: MP3 (`speech-2.8-hd` model, 32kHz sample rate). Voice-note format not natively supported; use OpenAI or ElevenLabs for guaranteed Opus voice messages.
 - **Google Gemini**: Gemini API TTS returns raw 24kHz PCM. OpenClaw wraps it as WAV for audio attachments and returns PCM directly for Talk/telephony. Native Opus voice-note format is not supported by this path.
-- **Microsoft**: uses `microsoft.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
+- **Microsoft**: defaults to `ogg-48khz-16bit-mono-opus` for voice-note channels (Feishu/Matrix/Telegram/WhatsApp/Discord) and `audio-24khz-48kbitrate-mono-mp3` for other channels. Set `microsoft.outputFormat` to pin a single format.
   - The bundled transport accepts an `outputFormat`, but not all formats are available from the service.
   - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus).
-  - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
-    guaranteed Opus voice messages.
-  - If the configured Microsoft output format fails, OpenClaw retries with MP3.
+  - Telegram `sendVoice` accepts OGG/MP3/M4A; WhatsApp requires OGG/Opus for
+    native voice-note playback, which the default now provides.
+  - If the selected Microsoft output format fails, OpenClaw retries with MP3.
 
 OpenAI/ElevenLabs output formats are fixed per channel (see above).
 

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -247,4 +247,71 @@ describe("buildMicrosoftSpeechProvider", () => {
       }),
     );
   });
+
+  it("uses ogg/opus output for voice-note targets when no format is configured", async () => {
+    const provider = buildMicrosoftSpeechProvider();
+    const edgeSpy = vi.spyOn(ttsModule, "edgeTTS").mockImplementation(async ({ outputPath }) => {
+      writeFileSync(outputPath, Buffer.from([0x4f, 0x67, 0x67, 0x53]));
+    });
+
+    const result = await provider.synthesize({
+      text: "Hello WhatsApp voice note",
+      cfg: TEST_CFG,
+      providerConfig: {
+        enabled: true,
+        voice: "en-US-MichelleNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        outputFormatConfigured: false,
+        saveSubtitles: false,
+      },
+      providerOverrides: {},
+      timeoutMs: 1000,
+      target: "voice-note",
+    });
+
+    expect(edgeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          outputFormat: "ogg-48khz-16bit-mono-opus",
+        }),
+      }),
+    );
+    expect(result.outputFormat).toBe("ogg-48khz-16bit-mono-opus");
+    expect(result.fileExtension).toBe(".ogg");
+    expect(result.voiceCompatible).toBe(true);
+  });
+
+  it("preserves an explicitly configured mp3 outputFormat for voice-note targets", async () => {
+    const provider = buildMicrosoftSpeechProvider();
+    const edgeSpy = vi.spyOn(ttsModule, "edgeTTS").mockImplementation(async ({ outputPath }) => {
+      writeFileSync(outputPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    });
+
+    const result = await provider.synthesize({
+      text: "Hello voice note",
+      cfg: TEST_CFG,
+      providerConfig: {
+        enabled: true,
+        voice: "en-US-MichelleNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        outputFormatConfigured: true,
+        saveSubtitles: false,
+      },
+      providerOverrides: {},
+      timeoutMs: 1000,
+      target: "voice-note",
+    });
+
+    expect(edgeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        }),
+      }),
+    );
+    expect(result.outputFormat).toBe("audio-24khz-48kbitrate-mono-mp3");
+    expect(result.fileExtension).toBe(".mp3");
+  });
 });

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -210,7 +210,10 @@ export function buildMicrosoftSpeechProvider(): SpeechProviderPlugin {
           : { lang: trimToUndefined(talkProviderConfig.languageCode) }),
         ...(trimToUndefined(talkProviderConfig.outputFormat) == null
           ? {}
-          : { outputFormat: trimToUndefined(talkProviderConfig.outputFormat) }),
+          : {
+              outputFormat: trimToUndefined(talkProviderConfig.outputFormat),
+              outputFormatConfigured: true,
+            }),
         ...(trimToUndefined(talkProviderConfig.pitch) == null
           ? {}
           : { pitch: trimToUndefined(talkProviderConfig.pitch) }),

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -22,6 +22,22 @@ import { edgeTTS, inferEdgeExtension } from "./tts.js";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const VOICE_NOTE_EDGE_OUTPUT_FORMAT = "ogg-48khz-16bit-mono-opus";
+
+function resolveMicrosoftOutputFormat(params: {
+  configuredFormat: string;
+  outputFormatConfigured: boolean;
+  overrideFormat: string | undefined;
+  target: "audio-file" | "voice-note";
+}): string {
+  if (params.overrideFormat) {
+    return params.overrideFormat;
+  }
+  if (params.outputFormatConfigured) {
+    return params.configuredFormat;
+  }
+  return params.target === "voice-note" ? VOICE_NOTE_EDGE_OUTPUT_FORMAT : params.configuredFormat;
+}
 
 type MicrosoftProviderConfig = {
   enabled: boolean;
@@ -230,8 +246,12 @@ export function buildMicrosoftSpeechProvider(): SpeechProviderPlugin {
       const overrideVoice = trimToUndefined(req.providerOverrides?.voice);
       let voice = overrideVoice ?? config.voice;
       let lang = config.lang;
-      let outputFormat =
-        trimToUndefined(req.providerOverrides?.outputFormat) ?? config.outputFormat;
+      let outputFormat = resolveMicrosoftOutputFormat({
+        configuredFormat: config.outputFormat,
+        outputFormatConfigured: config.outputFormatConfigured,
+        overrideFormat: trimToUndefined(req.providerOverrides?.outputFormat),
+        target: req.target,
+      });
       const fallbackOutputFormat =
         outputFormat !== DEFAULT_EDGE_OUTPUT_FORMAT ? DEFAULT_EDGE_OUTPUT_FORMAT : undefined;
 


### PR DESCRIPTION
## Summary

WhatsApp TTS auto-replies from the Microsoft (Edge) speech provider were
arriving as plain MP3 attachments instead of native voice notes. This PR
makes the Microsoft provider honor the `target: \"voice-note\"` hint that
the TTS dispatcher already passes for voice-note-capable channels
(WhatsApp, Telegram, Feishu, Matrix, Discord) and produce
`ogg-48khz-16bit-mono-opus` when no explicit override is configured.

Fixes #69435.

## Root cause

`extensions/speech-core/src/tts.ts` already picks
`target: \"voice-note\"` for WhatsApp and other native voice-note channels,
and `extensions/whatsapp/src/send.ts` rewrites `audio/ogg` to
`audio/ogg; codecs=opus` for PTT sends. Other providers (OpenAI,
ElevenLabs) switch to Opus for that target. The Microsoft provider in
`extensions/microsoft/speech-provider.ts` ignored `req.target` entirely
and always used its MP3 default (`audio-24khz-48kbitrate-mono-mp3`).
WhatsApp rejects MP3 as a voice note, so the audio was sent as a regular
audio attachment even though the channel was ready to upgrade to PTT.

## Fix

Add a narrow `resolveMicrosoftOutputFormat` helper that prefers:

1. a request-level `providerOverrides.outputFormat`, then
2. an explicit `messages.tts.providers.microsoft.outputFormat` from user
   config, then
3. `ogg-48khz-16bit-mono-opus` when `req.target === \"voice-note\"`, else
4. the existing MP3 default for `audio-file` targets.

`inferEdgeExtension` maps the new format to `.ogg`, which
`isVoiceCompatibleAudio` already treats as voice-compatible, so the
dispatcher correctly emits `audioAsVoice: true` and WhatsApp sends a
real voice note.

The MP3 fallback on synthesis error is preserved.

## Why it is safe

- No config-surface changes: `DEFAULT_EDGE_OUTPUT_FORMAT` is unchanged
  and `getResolvedSpeechProviderConfig(\"microsoft\")` still resolves to
  the MP3 default. The contract test
  (`src/plugins/contracts/tts.contract.test.ts` \u2192 \"resolveEdgeOutputFormat\")
  still passes unchanged.
- Explicit operator overrides win: users who set
  `messages.tts.providers.microsoft.outputFormat` keep that exact value
  for all targets, including voice-note.
- Non voice-note targets (`audio-file` for Slack, Mattermost, Webhooks,
  SMS, etc.) keep the existing MP3 default.
- The new Opus format is already documented by Microsoft Speech output
  formats and is accepted by the bundled `node-edge-tts` transport (it
  simply passes `outputFormat` through to the service).
- Behavior matches what the OpenAI and ElevenLabs speech providers
  already do for the same `target: \"voice-note\"` hint.

## Security / runtime controls unchanged

- No changes to tool policy, sandbox, SSRF policy, gateway auth, plugin
  trust, or operator-trusted config paths.
- No changes to prompt text, system prompt, or model-driven behavior.
  The new branch is a deterministic format selection based on the
  channel-derived `target` value computed by the TTS dispatcher before
  any model output, not on model-controlled text.
- No new capabilities, no new network destinations, no new credentials.

## Tests

Added focused unit cases in
`extensions/microsoft/speech-provider.test.ts`:

- voice-note target with no configured format \u2192 Edge is called with
  `ogg-48khz-16bit-mono-opus`, result reports `.ogg` extension and
  `voiceCompatible: true`.
- voice-note target with an explicitly configured MP3 format \u2192
  operator override wins, Edge is called with the configured MP3 format.

### Exact tests run

- `pnpm test extensions/microsoft` \u2192 2 files / 15 tests pass
- `pnpm test extensions/microsoft/speech-provider.test.ts extensions/speech-core/src/tts.test.ts` \u2192 passes
- `pnpm test src/plugins/contracts/tts.contract.test.ts` \u2192 41 tests pass
- `pnpm check:changed --staged` on the touched files passes conflict-marker and lint for my files; the only failing lanes are the pre-existing `extensions/qa-lab/src/providers/aimock/server.ts` TypeScript and lint errors on `main` (missing `@copilotkit/aimock` types and derived `no-redundant-type-constituents` lints). They reproduce on clean `main` and are unrelated to this change.
- `pnpm exec oxlint extensions/microsoft/speech-provider.ts extensions/microsoft/speech-provider.test.ts` \u2192 0 warnings / 0 errors
- `pnpm exec oxfmt` on the touched files applied

### Testing scope

- AI-assisted, lightly tested locally (unit + contract suites above; no
  live Edge network call in this sweep).

## Docs

- `docs/tools/tts.md`: updated the Microsoft output-format notes and the
  \"Output formats (fixed)\" section to describe the new channel-aware
  default.
- `CHANGELOG.md`: added an entry under `## Unreleased` \u2192 `### Fixes`.


Made with [Cursor](https://cursor.com)