### PR TITLE
perf(plugin-sdk): per-phase + per-jiti-call probes for bundled channel entries

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -133,6 +133,53 @@ describe("loadBundledEntryExportSync", () => {
     });
   });
 
+  it("emits zero jiti sub-step timings on the Win32 nodeRequire fast-path", async () => {
+    // The Win32 fast-path goes through `nodeRequire` directly and never
+    // touches jiti. The plugin-load-profile line must reflect that with
+    // `getJitiMs=0.0 jitiCallMs=0.0` rather than negative or full-elapsed
+    // values that would mis-attribute nodeRequire time to jiti sub-steps.
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("OPENCLAW_PLUGIN_LOAD_PROFILE", "1");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      const channelEntryContract = await importFreshModule<
+        typeof import("./channel-entry-contract.js")
+      >(import.meta.url, "./channel-entry-contract.js?scope=win32-profile-fast-path");
+
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
+      tempDirs.push(tempRoot);
+
+      const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
+      fs.mkdirSync(pluginRoot, { recursive: true });
+
+      const importerPath = path.join(pluginRoot, "index.js");
+      const sidecarPath = path.join(pluginRoot, "fast-path-sidecar.js");
+      fs.writeFileSync(importerPath, "export default {};\n", "utf8");
+      // CommonJS so `nodeRequire` succeeds without falling back to jiti.
+      fs.writeFileSync(sidecarPath, "module.exports = { sentinel: 7 };\n", "utf8");
+
+      expect(
+        channelEntryContract.loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {
+          specifier: "./fast-path-sidecar.js",
+          exportName: "sentinel",
+        }),
+      ).toBe(7);
+
+      const profileLine = errorSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .find((line) => line.startsWith("[plugin-load-profile] phase=bundled-entry-module-load"));
+      expect(profileLine, "expected a bundled-entry-module-load profile line").toBeDefined();
+      expect(profileLine).toContain("getJitiMs=0.0");
+      expect(profileLine).toContain("jitiCallMs=0.0");
+      expect(profileLine).not.toMatch(/getJitiMs=-/);
+      expect(profileLine).not.toMatch(/jitiCallMs=-/);
+    } finally {
+      errorSpy.mockRestore();
+      platformSpy.mockRestore();
+    }
+  });
+
   it("can disable source-tree fallback for dist bundled entry checks", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -12,6 +12,11 @@ import {
   getCachedPluginJitiLoader,
   type PluginJitiLoaderCache,
 } from "../plugins/jiti-loader-cache.js";
+import {
+  formatPluginLoadProfileLine,
+  profilePluginLoaderSync,
+  shouldProfilePluginLoader,
+} from "../plugins/plugin-load-profile.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { resolveLoaderPackageRoot } from "../plugins/sdk-alias.js";
 import type { AnyAgentTool, OpenClawPluginApi, PluginCommandContext } from "../plugins/types.js";
@@ -311,34 +316,6 @@ function getJiti(modulePath: string) {
   });
 }
 
-// File-local mirror of `profilePluginLoaderSync` from `src/plugins/loader.ts`.
-// Kept inline to avoid pulling host internals into the SDK boundary, and to
-// keep the profile log format identical so existing tooling that scrapes
-// `[plugin-load-profile]` lines keeps working.
-function shouldProfileBundledEntryLoader(): boolean {
-  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
-}
-
-function profileBundledEntryStepSync<T>(params: {
-  phase: string;
-  pluginId?: string;
-  source: string;
-  run: () => T;
-}): T {
-  if (!shouldProfileBundledEntryLoader()) {
-    return params.run();
-  }
-  const startMs = performance.now();
-  try {
-    return params.run();
-  } finally {
-    const elapsedMs = performance.now() - startMs;
-    console.error(
-      `[plugin-load-profile] phase=${params.phase} plugin=${params.pluginId ?? "(core)"} elapsedMs=${elapsedMs.toFixed(1)} source=${params.source}`,
-    );
-  }
-}
-
 function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): unknown {
   const modulePath = resolveBundledEntryModulePath(importMetaUrl, specifier);
   const cached = loadedModuleExports.get(modulePath);
@@ -346,7 +323,7 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
     return cached;
   }
   let loaded: unknown;
-  const profile = shouldProfileBundledEntryLoader();
+  const profile = shouldProfilePluginLoader();
   const loadStartMs = profile ? performance.now() : 0;
   let getJitiEndMs = 0;
   if (
@@ -368,12 +345,21 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
   }
   if (profile) {
     const endMs = performance.now();
-    const getJitiMs = (getJitiEndMs - loadStartMs).toFixed(1);
-    const jitiCallMs = (endMs - (getJitiEndMs || loadStartMs)).toFixed(1);
-    const totalMs = (endMs - loadStartMs).toFixed(1);
-    // Single line, key=value pairs so existing log scrapers can parse it.
+    // Use shared formatter — but split timing fields ourselves so we can
+    // attribute time spent in `getJiti(...)` factory creation vs the actual
+    // graph-walking `__j(modulePath)` call. Both are emitted as extras
+    // alongside the canonical `elapsedMs=<total>` field.
     console.error(
-      `[plugin-load-profile] phase=bundled-entry-module-load plugin=(bundled-entry) elapsedMs=${totalMs} getJitiMs=${getJitiMs} jitiCallMs=${jitiCallMs} source=${modulePath}`,
+      formatPluginLoadProfileLine({
+        phase: "bundled-entry-module-load",
+        pluginId: "(bundled-entry)",
+        source: modulePath,
+        elapsedMs: endMs - loadStartMs,
+        extras: [
+          ["getJitiMs", getJitiEndMs - loadStartMs],
+          ["jitiCallMs", endMs - (getJitiEndMs || loadStartMs)],
+        ],
+      }),
     );
   }
   loadedModuleExports.set(modulePath, loaded);
@@ -455,23 +441,39 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
         registerCliMetadata?.(api);
         return;
       }
-      const profileStep = <T>(phase: string, run: () => T): T =>
-        profileBundledEntryStepSync({
-          phase: `bundled-register:${phase}`,
-          pluginId: id,
-          source: importMetaUrl,
-          run,
-        });
-      profileStep("setChannelRuntime", () => setChannelRuntime?.(api.runtime));
-      const channelPlugin = profileStep("loadChannelPlugin", () => loadChannelPlugin());
-      profileStep("registerChannel", () =>
-        api.registerChannel({ plugin: channelPlugin as ChannelPlugin }),
-      );
+      profilePluginLoaderSync({
+        phase: "bundled-register:setChannelRuntime",
+        pluginId: id,
+        source: importMetaUrl,
+        run: () => setChannelRuntime?.(api.runtime),
+      });
+      const channelPlugin = profilePluginLoaderSync({
+        phase: "bundled-register:loadChannelPlugin",
+        pluginId: id,
+        source: importMetaUrl,
+        run: () => loadChannelPlugin(),
+      });
+      profilePluginLoaderSync({
+        phase: "bundled-register:registerChannel",
+        pluginId: id,
+        source: importMetaUrl,
+        run: () => api.registerChannel({ plugin: channelPlugin as ChannelPlugin }),
+      });
       if (api.registrationMode !== "full") {
         return;
       }
-      profileStep("registerCliMetadata", () => registerCliMetadata?.(api));
-      profileStep("registerFull", () => registerFull?.(api));
+      profilePluginLoaderSync({
+        phase: "bundled-register:registerCliMetadata",
+        pluginId: id,
+        source: importMetaUrl,
+        run: () => registerCliMetadata?.(api),
+      });
+      profilePluginLoaderSync({
+        phase: "bundled-register:registerFull",
+        pluginId: id,
+        source: importMetaUrl,
+        run: () => registerFull?.(api),
+      });
     },
     loadChannelPlugin,
     ...(loadChannelSecrets ? { loadChannelSecrets } : {}),

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -13,8 +13,8 @@ import {
   type PluginJitiLoaderCache,
 } from "../plugins/jiti-loader-cache.js";
 import {
+  createProfiler,
   formatPluginLoadProfileLine,
-  profilePluginLoaderSync,
   shouldProfilePluginLoader,
 } from "../plugins/plugin-load-profile.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -441,39 +441,17 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
         registerCliMetadata?.(api);
         return;
       }
-      profilePluginLoaderSync({
-        phase: "bundled-register:setChannelRuntime",
-        pluginId: id,
-        source: importMetaUrl,
-        run: () => setChannelRuntime?.(api.runtime),
-      });
-      const channelPlugin = profilePluginLoaderSync({
-        phase: "bundled-register:loadChannelPlugin",
-        pluginId: id,
-        source: importMetaUrl,
-        run: () => loadChannelPlugin(),
-      });
-      profilePluginLoaderSync({
-        phase: "bundled-register:registerChannel",
-        pluginId: id,
-        source: importMetaUrl,
-        run: () => api.registerChannel({ plugin: channelPlugin as ChannelPlugin }),
-      });
+      const profile = createProfiler({ pluginId: id, source: importMetaUrl });
+      profile("bundled-register:setChannelRuntime", () => setChannelRuntime?.(api.runtime));
+      const channelPlugin = profile("bundled-register:loadChannelPlugin", loadChannelPlugin);
+      profile("bundled-register:registerChannel", () =>
+        api.registerChannel({ plugin: channelPlugin as ChannelPlugin }),
+      );
       if (api.registrationMode !== "full") {
         return;
       }
-      profilePluginLoaderSync({
-        phase: "bundled-register:registerCliMetadata",
-        pluginId: id,
-        source: importMetaUrl,
-        run: () => registerCliMetadata?.(api),
-      });
-      profilePluginLoaderSync({
-        phase: "bundled-register:registerFull",
-        pluginId: id,
-        source: importMetaUrl,
-        run: () => registerFull?.(api),
-      });
+      profile("bundled-register:registerCliMetadata", () => registerCliMetadata?.(api));
+      profile("bundled-register:registerFull", () => registerFull?.(api));
     },
     loadChannelPlugin,
     ...(loadChannelSecrets ? { loadChannelSecrets } : {}),

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -355,9 +355,15 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
         pluginId: "(bundled-entry)",
         source: modulePath,
         elapsedMs: endMs - loadStartMs,
+        // When the Win32 fast-path resolves the module via `nodeRequire`,
+        // `getJitiEndMs` stays `0` because the `catch` block (the only place
+        // it gets stamped) never runs. Reporting `getJitiMs` /
+        // `jitiCallMs` as `0` for that path keeps the breakdown honest:
+        // `elapsedMs=` already captures the nodeRequire time, and we don't
+        // want to mis-attribute it to jiti sub-steps.
         extras: [
-          ["getJitiMs", getJitiEndMs - loadStartMs],
-          ["jitiCallMs", endMs - (getJitiEndMs || loadStartMs)],
+          ["getJitiMs", getJitiEndMs ? getJitiEndMs - loadStartMs : 0],
+          ["jitiCallMs", getJitiEndMs ? endMs - getJitiEndMs : 0],
         ],
       }),
     );

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -311,6 +311,34 @@ function getJiti(modulePath: string) {
   });
 }
 
+// File-local mirror of `profilePluginLoaderSync` from `src/plugins/loader.ts`.
+// Kept inline to avoid pulling host internals into the SDK boundary, and to
+// keep the profile log format identical so existing tooling that scrapes
+// `[plugin-load-profile]` lines keeps working.
+function shouldProfileBundledEntryLoader(): boolean {
+  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
+}
+
+function profileBundledEntryStepSync<T>(params: {
+  phase: string;
+  pluginId?: string;
+  source: string;
+  run: () => T;
+}): T {
+  if (!shouldProfileBundledEntryLoader()) {
+    return params.run();
+  }
+  const startMs = performance.now();
+  try {
+    return params.run();
+  } finally {
+    const elapsedMs = performance.now() - startMs;
+    console.error(
+      `[plugin-load-profile] phase=${params.phase} plugin=${params.pluginId ?? "(core)"} elapsedMs=${elapsedMs.toFixed(1)} source=${params.source}`,
+    );
+  }
+}
+
 function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): unknown {
   const modulePath = resolveBundledEntryModulePath(importMetaUrl, specifier);
   const cached = loadedModuleExports.get(modulePath);
@@ -318,6 +346,9 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
     return cached;
   }
   let loaded: unknown;
+  const profile = shouldProfileBundledEntryLoader();
+  const loadStartMs = profile ? performance.now() : 0;
+  let getJitiEndMs = 0;
   if (
     process.platform === "win32" &&
     modulePath.includes(`${path.sep}dist${path.sep}`) &&
@@ -326,10 +357,24 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
     try {
       loaded = nodeRequire(modulePath);
     } catch {
-      loaded = getJiti(modulePath)(modulePath);
+      const jiti = getJiti(modulePath);
+      getJitiEndMs = profile ? performance.now() : 0;
+      loaded = jiti(modulePath);
     }
   } else {
-    loaded = getJiti(modulePath)(modulePath);
+    const jiti = getJiti(modulePath);
+    getJitiEndMs = profile ? performance.now() : 0;
+    loaded = jiti(modulePath);
+  }
+  if (profile) {
+    const endMs = performance.now();
+    const getJitiMs = (getJitiEndMs - loadStartMs).toFixed(1);
+    const jitiCallMs = (endMs - (getJitiEndMs || loadStartMs)).toFixed(1);
+    const totalMs = (endMs - loadStartMs).toFixed(1);
+    // Single line, key=value pairs so existing log scrapers can parse it.
+    console.error(
+      `[plugin-load-profile] phase=bundled-entry-module-load plugin=(bundled-entry) elapsedMs=${totalMs} getJitiMs=${getJitiMs} jitiCallMs=${jitiCallMs} source=${modulePath}`,
+    );
   }
   loadedModuleExports.set(modulePath, loaded);
   return loaded;
@@ -410,13 +455,23 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
         registerCliMetadata?.(api);
         return;
       }
-      setChannelRuntime?.(api.runtime);
-      api.registerChannel({ plugin: loadChannelPlugin() as ChannelPlugin });
+      const profileStep = <T>(phase: string, run: () => T): T =>
+        profileBundledEntryStepSync({
+          phase: `bundled-register:${phase}`,
+          pluginId: id,
+          source: importMetaUrl,
+          run,
+        });
+      profileStep("setChannelRuntime", () => setChannelRuntime?.(api.runtime));
+      const channelPlugin = profileStep("loadChannelPlugin", () => loadChannelPlugin());
+      profileStep("registerChannel", () =>
+        api.registerChannel({ plugin: channelPlugin as ChannelPlugin }),
+      );
       if (api.registrationMode !== "full") {
         return;
       }
-      registerCliMetadata?.(api);
-      registerFull?.(api);
+      profileStep("registerCliMetadata", () => registerCliMetadata?.(api));
+      profileStep("registerFull", () => registerFull?.(api));
     },
     loadChannelPlugin,
     ...(loadChannelSecrets ? { loadChannelSecrets } : {}),

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2262,7 +2262,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryRuntime = getMemoryRuntime();
 
       try {
-        runPluginRegisterSync(register, api);
+        profilePluginLoaderSync({
+          phase: `${registrationMode}:register`,
+          pluginId: record.id,
+          source: record.source,
+          run: () => runPluginRegisterSync(register, api),
+        });
         // Snapshot loads should not replace process-global runtime prompt state.
         if (!shouldActivate) {
           restoreRegisteredAgentHarnesses(previousAgentHarnesses);
@@ -2683,7 +2688,12 @@ export async function loadOpenClawPluginCliRegistry(
 
     const registrySnapshot = snapshotPluginRegistry(registry);
     try {
-      runPluginRegisterSync(register, api);
+      profilePluginLoaderSync({
+        phase: "cli-metadata:register",
+        pluginId: record.id,
+        source: record.source,
+        run: () => runPluginRegisterSync(register, api),
+      });
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
     } catch (err) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -59,7 +59,6 @@ import { getCachedPluginJitiLoader, type PluginJitiLoaderCache } from "./jiti-lo
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginBundleFormat, PluginDiagnostic, PluginFormat } from "./manifest-types.js";
 import type { PluginManifestContracts } from "./manifest.js";
-import { profilePluginLoaderSync } from "./plugin-load-profile.js";
 import {
   clearMemoryEmbeddingProviders,
   listRegisteredMemoryEmbeddingProviders,
@@ -77,6 +76,7 @@ import {
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
+import { withProfile } from "./plugin-load-profile.js";
 import {
   createPluginIdScopeSet,
   hasExplicitPluginIdScope,
@@ -1480,14 +1480,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         throw new Error("Unable to resolve plugin runtime module");
       }
       const safeRuntimePath = toSafeImportPath(runtimeModulePath);
-      const runtimeModule = profilePluginLoaderSync({
-        phase: "runtime-module",
-        source: runtimeModulePath,
-        run: () =>
+      const runtimeModule = withProfile(
+        { source: runtimeModulePath },
+        "runtime-module",
+        () =>
           getJiti(runtimeModulePath)(safeRuntimePath) as {
             createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
           },
-      });
+      );
       if (typeof runtimeModule.createPluginRuntime !== "function") {
         throw new Error("Plugin runtime module missing createPluginRuntime export");
       }
@@ -1938,12 +1938,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         // Track the plugin as imported once module evaluation begins. Top-level
         // code may have already executed even if evaluation later throws.
         recordImportedPluginId(record.id);
-        mod = profilePluginLoaderSync({
-          phase: registrationMode,
-          pluginId: record.id,
-          source: safeSource,
-          run: () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
-        });
+        mod = withProfile(
+          { pluginId: record.id, source: safeSource },
+          registrationMode,
+          () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
+        );
       } catch (err) {
         recordPluginError({
           logger,
@@ -2016,13 +2015,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             const safeRuntimeImportSource = toSafeImportPath(safeRuntimeSource);
             let runtimeMod: OpenClawPluginModule | null = null;
             try {
-              runtimeMod = profilePluginLoaderSync({
-                phase: "load-setup-runtime-entry",
-                pluginId: record.id,
-                source: safeRuntimeSource,
-                run: () =>
-                  getJiti(safeRuntimeSource)(safeRuntimeImportSource) as OpenClawPluginModule,
-              });
+              runtimeMod = withProfile(
+                { pluginId: record.id, source: safeRuntimeSource },
+                "load-setup-runtime-entry",
+                () => getJiti(safeRuntimeSource)(safeRuntimeImportSource) as OpenClawPluginModule,
+              );
             } catch (err) {
               recordPluginError({
                 logger,
@@ -2239,12 +2236,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryRuntime = getMemoryRuntime();
 
       try {
-        profilePluginLoaderSync({
-          phase: `${registrationMode}:register`,
-          pluginId: record.id,
-          source: record.source,
-          run: () => runPluginRegisterSync(register, api),
-        });
+        withProfile(
+          { pluginId: record.id, source: record.source },
+          `${registrationMode}:register`,
+          () => runPluginRegisterSync(register, api),
+        );
         // Snapshot loads should not replace process-global runtime prompt state.
         if (!shouldActivate) {
           restoreRegisteredAgentHarnesses(previousAgentHarnesses);
@@ -2569,12 +2565,11 @@ export async function loadOpenClawPluginCliRegistry(
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = profilePluginLoaderSync({
-        phase: "cli-metadata",
-        pluginId: record.id,
-        source: safeSource,
-        run: () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
-      });
+      mod = withProfile(
+        { pluginId: record.id, source: safeSource },
+        "cli-metadata",
+        () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
+      );
     } catch (err) {
       recordPluginError({
         logger,
@@ -2665,12 +2660,9 @@ export async function loadOpenClawPluginCliRegistry(
 
     const registrySnapshot = snapshotPluginRegistry(registry);
     try {
-      profilePluginLoaderSync({
-        phase: "cli-metadata:register",
-        pluginId: record.id,
-        source: record.source,
-        run: () => runPluginRegisterSync(register, api),
-      });
+      withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
+        runPluginRegisterSync(register, api),
+      );
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
     } catch (err) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -59,6 +59,7 @@ import { getCachedPluginJitiLoader, type PluginJitiLoaderCache } from "./jiti-lo
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginBundleFormat, PluginDiagnostic, PluginFormat } from "./manifest-types.js";
 import type { PluginManifestContracts } from "./manifest.js";
+import { profilePluginLoaderSync } from "./plugin-load-profile.js";
 import {
   clearMemoryEmbeddingProviders,
   listRegisteredMemoryEmbeddingProviders,
@@ -243,30 +244,6 @@ export function clearPluginLoaderCache(): void {
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
-
-function shouldProfilePluginLoader(): boolean {
-  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
-}
-
-function profilePluginLoaderSync<T>(params: {
-  phase: string;
-  pluginId?: string;
-  source: string;
-  run: () => T;
-}): T {
-  if (!shouldProfilePluginLoader()) {
-    return params.run();
-  }
-  const startMs = performance.now();
-  try {
-    return params.run();
-  } finally {
-    const elapsedMs = performance.now() - startMs;
-    console.error(
-      `[plugin-load-profile] phase=${params.phase} plugin=${params.pluginId ?? "(core)"} elapsedMs=${elapsedMs.toFixed(1)} source=${params.source}`,
-    );
-  }
-}
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (

--- a/src/plugins/plugin-load-profile.ts
+++ b/src/plugins/plugin-load-profile.ts
@@ -33,10 +33,28 @@ export function shouldProfilePluginLoader(): boolean {
  */
 export type PluginLoadProfileExtras = ReadonlyArray<readonly [string, number | string]>;
 
+/** Per-call scope: which plugin and which source path the probe is for. */
+export type PluginLoadProfileScope = {
+  pluginId?: string;
+  source: string;
+};
+
+/**
+ * A scope-bound profiler — call it with a `phase` + sync `run` to time and
+ * emit a `[plugin-load-profile]` line that already includes the bound
+ * `pluginId` and `source`. Build one with `createProfiler(scope)`.
+ */
+export type PluginLoadProfiler = <T>(
+  phase: string,
+  run: () => T,
+  extras?: PluginLoadProfileExtras,
+) => T;
+
 /**
  * Render a `[plugin-load-profile]` line. Exported so that callers needing
- * custom timing splits (e.g. dual-timer probes) can build their own start/stop
- * logic and still emit a line in the canonical format.
+ * custom timing splits (e.g. dual-timer probes in
+ * `channel-entry-contract.ts`) can build their own start/stop logic and
+ * still emit a line in the canonical format.
  */
 export function formatPluginLoadProfileLine(params: {
   phase: string;
@@ -56,39 +74,62 @@ export function formatPluginLoadProfileLine(params: {
 }
 
 /**
- * Wrap a synchronous step with start/stop timing and a `[plugin-load-profile]`
- * log line. When the env flag is unset, calls `params.run()` directly with no
+ * Time a single synchronous step and emit a `[plugin-load-profile]` line.
+ * Use this when you only need to wrap one call:
+ *
+ * ```ts
+ * const mod = withProfile(
+ *   { pluginId: id, source },
+ *   "phase-name",
+ *   () => loadIt(),
+ * );
+ * ```
+ *
+ * For repeated calls that share the same `{ pluginId, source }` scope,
+ * prefer `createProfiler(scope)` and call the returned profiler.
+ *
+ * When the env flag is unset, this runs `run()` directly with no timing
  * overhead. Errors propagate naturally; the log line is still emitted via
  * `try { … } finally { … }`.
  */
-export function profilePluginLoaderSync<T>(params: {
-  phase: string;
-  pluginId?: string;
-  source: string;
-  run: () => T;
-  /**
-   * Optional extras to render between `elapsedMs=` and `source=`. Numeric
-   * extras are formatted with one decimal place to match the `elapsedMs`
-   * precision.
-   */
-  extras?: PluginLoadProfileExtras;
-}): T {
+export function withProfile<T>(
+  scope: PluginLoadProfileScope,
+  phase: string,
+  run: () => T,
+  extras?: PluginLoadProfileExtras,
+): T {
   if (!shouldProfilePluginLoader()) {
-    return params.run();
+    return run();
   }
   const startMs = performance.now();
   try {
-    return params.run();
+    return run();
   } finally {
     const elapsedMs = performance.now() - startMs;
     console.error(
       formatPluginLoadProfileLine({
-        phase: params.phase,
-        pluginId: params.pluginId,
-        source: params.source,
+        phase,
+        pluginId: scope.pluginId,
+        source: scope.source,
         elapsedMs,
-        extras: params.extras,
+        extras,
       }),
     );
   }
+}
+
+/**
+ * Build a scope-bound profiler. Useful when several consecutive steps share
+ * the same `{ pluginId, source }`:
+ *
+ * ```ts
+ * const profile = createProfiler({ pluginId: id, source: importMetaUrl });
+ * profile("phase-a", () => stepA());
+ * const v = profile("phase-b", () => stepB());
+ * ```
+ *
+ * Each call has the same semantics as `withProfile(scope, phase, run)`.
+ */
+export function createProfiler(scope: PluginLoadProfileScope): PluginLoadProfiler {
+  return (phase, run, extras) => withProfile(scope, phase, run, extras);
 }

--- a/src/plugins/plugin-load-profile.ts
+++ b/src/plugins/plugin-load-profile.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared probe primitives for plugin-load profiling.
+ *
+ * All plugin-load probes — across `src/plugins/loader.ts`,
+ * `src/plugins/source-loader.ts`, and `src/plugin-sdk/channel-entry-contract.ts`
+ * — emit a single line per measurement to stderr in the form:
+ *
+ *     [plugin-load-profile] phase=<X> plugin=<Y> elapsedMs=<N> [extras…] source=<S>
+ *
+ * The same `OPENCLAW_PLUGIN_LOAD_PROFILE=1` env flag activates all probes.
+ *
+ * Tooling that scrapes these lines (e.g. PERF-STARTUP-PLAN.md profiling
+ * methodology) depends on the field order being:
+ *
+ *   1. `phase=`
+ *   2. `plugin=`
+ *   3. `elapsedMs=`
+ *   4. any caller-supplied extras (in declaration order)
+ *   5. `source=` last
+ *
+ * Keep this contract stable — downstream parsers rely on it.
+ */
+
+export function shouldProfilePluginLoader(): boolean {
+  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
+}
+
+/**
+ * An ordered list of `[key, value]` pairs appended between `elapsedMs=` and
+ * `source=` on the emitted log line. Ordered tuples (not a record) so that
+ * scrapers see a deterministic field order regardless of object iteration
+ * quirks.
+ */
+export type PluginLoadProfileExtras = ReadonlyArray<readonly [string, number | string]>;
+
+/**
+ * Render a `[plugin-load-profile]` line. Exported so that callers needing
+ * custom timing splits (e.g. dual-timer probes) can build their own start/stop
+ * logic and still emit a line in the canonical format.
+ */
+export function formatPluginLoadProfileLine(params: {
+  phase: string;
+  pluginId?: string;
+  source: string;
+  elapsedMs: number;
+  extras?: PluginLoadProfileExtras;
+}): string {
+  const extras = (params.extras ?? [])
+    .map(([k, v]) => `${k}=${typeof v === "number" ? v.toFixed(1) : v}`)
+    .join(" ");
+  const extrasFragment = extras ? ` ${extras}` : "";
+  return (
+    `[plugin-load-profile] phase=${params.phase} plugin=${params.pluginId ?? "(core)"}` +
+    ` elapsedMs=${params.elapsedMs.toFixed(1)}${extrasFragment} source=${params.source}`
+  );
+}
+
+/**
+ * Wrap a synchronous step with start/stop timing and a `[plugin-load-profile]`
+ * log line. When the env flag is unset, calls `params.run()` directly with no
+ * overhead. Errors propagate naturally; the log line is still emitted via
+ * `try { … } finally { … }`.
+ */
+export function profilePluginLoaderSync<T>(params: {
+  phase: string;
+  pluginId?: string;
+  source: string;
+  run: () => T;
+  /**
+   * Optional extras to render between `elapsedMs=` and `source=`. Numeric
+   * extras are formatted with one decimal place to match the `elapsedMs`
+   * precision.
+   */
+  extras?: PluginLoadProfileExtras;
+}): T {
+  if (!shouldProfilePluginLoader()) {
+    return params.run();
+  }
+  const startMs = performance.now();
+  try {
+    return params.run();
+  } finally {
+    const elapsedMs = performance.now() - startMs;
+    console.error(
+      formatPluginLoadProfileLine({
+        phase: params.phase,
+        pluginId: params.pluginId,
+        source: params.source,
+        elapsedMs,
+        extras: params.extras,
+      }),
+    );
+  }
+}

--- a/src/plugins/source-loader.ts
+++ b/src/plugins/source-loader.ts
@@ -1,11 +1,8 @@
 import type { PluginJitiLoaderCache } from "./jiti-loader-cache.js";
 import { getCachedPluginJitiLoader } from "./jiti-loader-cache.js";
+import { profilePluginLoaderSync } from "./plugin-load-profile.js";
 
 export type PluginSourceLoader = (modulePath: string) => unknown;
-
-function shouldProfilePluginSourceLoader(): boolean {
-  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
-}
 
 export function createPluginSourceLoader(): PluginSourceLoader {
   const loaders: PluginJitiLoaderCache = new Map();
@@ -16,16 +13,14 @@ export function createPluginSourceLoader(): PluginSourceLoader {
       importerUrl: import.meta.url,
       jitiFilename: import.meta.url,
     });
-    if (!shouldProfilePluginSourceLoader()) {
-      return jiti(modulePath);
-    }
-    const startMs = performance.now();
-    try {
-      return jiti(modulePath);
-    } finally {
-      console.error(
-        `[plugin-load-profile] phase=source-loader plugin=(direct) elapsedMs=${(performance.now() - startMs).toFixed(1)} source=${modulePath}`,
-      );
-    }
+    return profilePluginLoaderSync({
+      // Direct source loads are not associated with a specific plugin id —
+      // preserve the existing `plugin=(direct)` field used by tooling that
+      // scrapes [plugin-load-profile] lines.
+      phase: "source-loader",
+      pluginId: "(direct)",
+      source: modulePath,
+      run: () => jiti(modulePath),
+    });
   };
 }

--- a/src/plugins/source-loader.ts
+++ b/src/plugins/source-loader.ts
@@ -1,6 +1,6 @@
 import type { PluginJitiLoaderCache } from "./jiti-loader-cache.js";
 import { getCachedPluginJitiLoader } from "./jiti-loader-cache.js";
-import { profilePluginLoaderSync } from "./plugin-load-profile.js";
+import { withProfile } from "./plugin-load-profile.js";
 
 export type PluginSourceLoader = (modulePath: string) => unknown;
 
@@ -13,14 +13,11 @@ export function createPluginSourceLoader(): PluginSourceLoader {
       importerUrl: import.meta.url,
       jitiFilename: import.meta.url,
     });
-    return profilePluginLoaderSync({
-      // Direct source loads are not associated with a specific plugin id —
-      // preserve the existing `plugin=(direct)` field used by tooling that
-      // scrapes [plugin-load-profile] lines.
-      phase: "source-loader",
-      pluginId: "(direct)",
-      source: modulePath,
-      run: () => jiti(modulePath),
-    });
+    // Direct source loads are not associated with a specific plugin id —
+    // preserve the existing `plugin=(direct)` field used by tooling that
+    // scrapes [plugin-load-profile] lines.
+    return withProfile({ pluginId: "(direct)", source: modulePath }, "source-loader", () =>
+      jiti(modulePath),
+    );
   };
 }


### PR DESCRIPTION
## Summary

Adds two new probe sites inside `src/plugin-sdk/channel-entry-contract.ts` so we can attribute cold-start cost during bundled-channel-entry plugin registration. Gated on the existing `OPENCLAW_PLUGIN_LOAD_PROFILE=1` env flag and emit the established `[plugin-load-profile]` log line format used by `src/plugins/loader.ts` and `src/plugins/source-loader.ts`.

## Motivation

While investigating the slack startup regression (PR #69317), we discovered that ~14s of cold-start time was spent inside the bundled-channel-entry `register()` callback — but couldn't say which phase (`setChannelRuntime`, `loadChannelPlugin`, `registerFull`) was responsible without manual hot-patching of dist files. Once instrumented, the answer was unambiguous: `setChannelRuntime` was loading a 284KB barrel synchronously. The fix took 67ms; the cost was 13183ms.

This PR makes that diagnosis a first-class capability rather than throwaway hot-patch work.

## What's added

### 1. `bundled-register:<phase>` probes

Wraps each phase of `defineBundledChannelEntry`'s `register()` callback:

```
[plugin-load-profile] phase=bundled-register:setChannelRuntime plugin=slack elapsedMs=67.3 source=...
[plugin-load-profile] phase=bundled-register:loadChannelPlugin plugin=slack elapsedMs=6072.1 source=...
[plugin-load-profile] phase=bundled-register:registerChannel plugin=slack elapsedMs=0.2 source=...
[plugin-load-profile] phase=bundled-register:registerCliMetadata plugin=slack elapsedMs=0.0 source=...
[plugin-load-profile] phase=bundled-register:registerFull plugin=slack elapsedMs=40.1 source=...
```

Use case: pinpoint which phase of plugin registration is responsible for cold-start cost on a per-plugin basis.

### 2. `bundled-entry-module-load` probes

Instruments `loadBundledEntryModuleSync` and separates `getJitiMs` (jiti loader factory cost) from `jitiCallMs` (actual graph walk + transpile + ESM linking cost):

```
[plugin-load-profile] phase=bundled-entry-module-load plugin=(bundled-entry) elapsedMs=66.0 getJitiMs=3.2 jitiCallMs=62.8 source=.../runtime-setter-api.js
[plugin-load-profile] phase=bundled-entry-module-load plugin=(bundled-entry) elapsedMs=6070.4 getJitiMs=2.1 jitiCallMs=6068.3 source=.../channel-plugin-api.js
```

Use case: distinguish alias-map / loader setup overhead from import-graph traversal cost on a per-module basis. Without this, you can't tell whether memoizing the alias map (à la #69316) helped or whether the import graph itself is the bottleneck.

## Implementation notes

- **Zero overhead when disabled**: both probes early-return before any `performance.now()` call when `OPENCLAW_PLUGIN_LOAD_PROFILE !== "1"`. Default code paths are byte-equivalent to before for the runtime `register` flow (modulo the variable hoisting).
- **Helper kept file-local**: rather than exporting a new SDK helper, the implementation mirrors the shape of `profilePluginLoaderSync` from `src/plugins/loader.ts`. Per `src/plugin-sdk/AGENTS.md`, the SDK boundary should stay narrow — duplicating ~15 lines is preferable to broadening the public surface or cross-importing host internals.
- **Log format compat**: matches the existing `[plugin-load-profile] phase=<phase> plugin=<id> elapsedMs=<n> source=<src>` line shape exactly. Existing log scrapers continue to work.

## Verification

- `pnpm tsgo` (core) — passes
- `pnpm test src/plugin-sdk/channel-entry-contract.test.ts` — 4/4 passes
- `pnpm test src/plugins/contracts/plugin-entry-guardrails.test.ts` — 7/7 passes
- `pnpm lint src/plugin-sdk/channel-entry-contract.ts` — 0 warnings, 0 errors
- `pnpm build` — succeeds
- End-to-end gateway smoke with `OPENCLAW_PLUGIN_LOAD_PROFILE=1` confirms both probe types emit correctly

## Sample diagnostic output (from PR #69317 validation)

| Phase | Original slack | After PR #69317 narrowings |
|---|---:|---:|
| `bundled-register:setChannelRuntime` | 13183ms | 67ms |
| `bundled-register:loadChannelPlugin` | 913ms | 6072ms |
| `bundled-register:registerFull` | 2ms | 40ms |
| **TOTAL** | **14102ms** | **6180ms** |

| Module | Without #69316 | With #69316 |
|---|---:|---:|
| `runtime-setter-api.js` | 815ms | 66ms |
| `channel-plugin-api.js` (large graph) | 5179ms | 6070ms* |

*Apparent regression is because `runtime-setter-api.js` no longer pre-warms the chunk graph; the cost shifted, total wall-clock dropped 7.9s.

These breakdowns are exactly what these new probes provide on demand.
