### PR TITLE
fix(mcp): block dangerous stdio env overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Lobster/TaskFlow: allow managed approval resumes to use `approvalId` without a resume token, and persist that id in approval wait state. (#69559) Thanks @kirkluokun.
 - Plugins/startup: install bundled runtime dependencies into each plugin's own runtime directory, reuse source-checkout repair caches after rebuilds, and log only packages that were actually installed so repeated Gateway starts stay quiet once deps are present.
 - Plugins/startup: ignore pnpm's `npm_execpath` when repairing bundled plugin runtime dependencies and skip workspace-only package specs so npm-only install flags or local workspace links do not break packaged plugin startup.
+- MCP: block interpreter-startup env keys such as `NODE_OPTIONS` for stdio servers while preserving ordinary credential and proxy env vars. (#69540) Thanks @drobison00.
 - Setup/TUI: relaunch the setup hatch TUI in a fresh process while preserving the configured gateway target and auth source, so onboarding recovers terminal state cleanly without exposing gateway secrets on command-line args. (#69524) Thanks @shakkernerd.
 - Codex: avoid re-exposing the image-generation tool on native vision turns with inbound images, and keep bare image-model overrides on the configured image provider. (#65061) Thanks @zhulijin1991.
 - Sessions/reset: clear auto-sourced model, provider, and auth-profile overrides on `/new` and `/reset` while preserving explicit user selections, so channel sessions stop staying pinned to runtime fallback choices. (#69419) Thanks @sk7n4k3d.

--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -1,16 +1,28 @@
+import {
+  isDangerousHostEnvOverrideVarName,
+  isDangerousHostEnvVarName,
+} from "../infra/host-env-security.js";
+
 export function isMcpConfigRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export function toMcpStringRecord(
+function toMcpFilteredStringRecord(
   value: unknown,
-  options?: { onDroppedEntry?: (key: string, value: unknown) => void },
+  options?: {
+    onDroppedEntry?: (key: string, value: unknown) => void;
+    shouldDropKey?: (key: string) => boolean;
+  },
 ): Record<string, string> | undefined {
   if (!isMcpConfigRecord(value)) {
     return undefined;
   }
   const entries = Object.entries(value)
     .map(([key, entry]) => {
+      if (options?.shouldDropKey?.(key)) {
+        options?.onDroppedEntry?.(key, entry);
+        return null;
+      }
       if (typeof entry === "string") {
         return [key, entry] as const;
       }
@@ -22,6 +34,24 @@ export function toMcpStringRecord(
     })
     .filter((entry): entry is readonly [string, string] => entry !== null);
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+export function toMcpStringRecord(
+  value: unknown,
+  options?: { onDroppedEntry?: (key: string, value: unknown) => void },
+): Record<string, string> | undefined {
+  return toMcpFilteredStringRecord(value, options);
+}
+
+export function toMcpEnvRecord(
+  value: unknown,
+  options?: { onDroppedEntry?: (key: string, value: unknown) => void },
+): Record<string, string> | undefined {
+  return toMcpFilteredStringRecord(value, {
+    ...options,
+    shouldDropKey: (key) =>
+      isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key),
+  });
 }
 
 export function toMcpStringArray(value: unknown): string[] | undefined {

--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -1,7 +1,4 @@
-import {
-  isDangerousHostEnvOverrideVarName,
-  isDangerousHostEnvVarName,
-} from "../infra/host-env-security.js";
+import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 
 export function isMcpConfigRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -11,15 +8,18 @@ function toMcpFilteredStringRecord(
   value: unknown,
   options?: {
     onDroppedEntry?: (key: string, value: unknown) => void;
+    preserveEmptyWhenKeysDropped?: boolean;
     shouldDropKey?: (key: string) => boolean;
   },
 ): Record<string, string> | undefined {
   if (!isMcpConfigRecord(value)) {
     return undefined;
   }
+  let droppedByKey = false;
   const entries = Object.entries(value)
     .map(([key, entry]) => {
       if (options?.shouldDropKey?.(key)) {
+        droppedByKey = true;
         options?.onDroppedEntry?.(key, entry);
         return null;
       }
@@ -33,6 +33,9 @@ function toMcpFilteredStringRecord(
       return null;
     })
     .filter((entry): entry is readonly [string, string] => entry !== null);
+  if (entries.length === 0 && droppedByKey && options?.preserveEmptyWhenKeysDropped) {
+    return {};
+  }
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
@@ -49,8 +52,8 @@ export function toMcpEnvRecord(
 ): Record<string, string> | undefined {
   return toMcpFilteredStringRecord(value, {
     ...options,
-    shouldDropKey: (key) =>
-      isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key),
+    preserveEmptyWhenKeysDropped: true,
+    shouldDropKey: (key) => isDangerousHostEnvVarName(key),
   });
 }
 

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -1,4 +1,4 @@
-import { isMcpConfigRecord, toMcpStringArray, toMcpStringRecord } from "./mcp-config-shared.js";
+import { isMcpConfigRecord, toMcpEnvRecord, toMcpStringArray } from "./mcp-config-shared.js";
 
 type StdioMcpServerLaunchConfig = {
   command: string;
@@ -35,7 +35,7 @@ export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerL
     config: {
       command: raw.command,
       args: toMcpStringArray(raw.args),
-      env: toMcpStringRecord(raw.env),
+      env: toMcpEnvRecord(raw.env),
       cwd,
     },
   };

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -11,7 +11,10 @@ type StdioMcpServerLaunchResult =
   | { ok: true; config: StdioMcpServerLaunchConfig }
   | { ok: false; reason: string };
 
-export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerLaunchResult {
+export function resolveStdioMcpServerLaunchConfig(
+  raw: unknown,
+  options?: { onDroppedEnv?: (key: string, value: unknown) => void },
+): StdioMcpServerLaunchResult {
   if (!isMcpConfigRecord(raw)) {
     return { ok: false, reason: "server config must be an object" };
   }
@@ -35,7 +38,7 @@ export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerL
     config: {
       command: raw.command,
       args: toMcpStringArray(raw.args),
-      env: toMcpEnvRecord(raw.env),
+      env: toMcpEnvRecord(raw.env, { onDroppedEntry: options?.onDroppedEnv }),
       cwd,
     },
   };

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logWarn } from "../logger.js";
 import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
 
+vi.mock("../logger.js", () => ({ logWarn: vi.fn() }));
+
 describe("resolveMcpTransportConfig", () => {
+  beforeEach(() => {
+    vi.mocked(logWarn).mockClear();
+  });
+
   it("resolves stdio config with connection timeout", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
@@ -25,6 +32,8 @@ describe("resolveMcpTransportConfig", () => {
         SAFE_VALUE: "ok",
         PORT: 3000,
         ENABLED: true,
+        GITHUB_TOKEN: "token",
+        HTTP_PROXY: "http://proxy.example",
         NODE_OPTIONS: "--require=./evil.js",
         LD_PRELOAD: "/tmp/pwn.so",
         BASH_ENV: "/tmp/pwn.sh",
@@ -40,10 +49,37 @@ describe("resolveMcpTransportConfig", () => {
         SAFE_VALUE: "ok",
         PORT: "3000",
         ENABLED: "true",
+        GITHUB_TOKEN: "token",
+        HTTP_PROXY: "http://proxy.example",
       },
       cwd: undefined,
       description: "node",
       connectionTimeoutMs: 30_000,
+    });
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "LD_PRELOAD" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "BASH_ENV" is blocked for stdio startup safety and was ignored.',
+    );
+  });
+
+  it("uses an explicit empty stdio env when all configured env keys are blocked", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+      env: {
+        NODE_OPTIONS: "--require=./evil.js",
+        BASH_ENV: "/tmp/pwn.sh",
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      kind: "stdio",
+      command: "node",
+      env: {},
     });
   });
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -18,6 +18,35 @@ describe("resolveMcpTransportConfig", () => {
     });
   });
 
+  it("drops dangerous env overrides from stdio config", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+      env: {
+        SAFE_VALUE: "ok",
+        PORT: 3000,
+        ENABLED: true,
+        NODE_OPTIONS: "--require=./evil.js",
+        LD_PRELOAD: "/tmp/pwn.so",
+        BASH_ENV: "/tmp/pwn.sh",
+      },
+    });
+
+    expect(resolved).toEqual({
+      kind: "stdio",
+      transportType: "stdio",
+      command: "node",
+      args: undefined,
+      env: {
+        SAFE_VALUE: "ok",
+        PORT: "3000",
+        ENABLED: "true",
+      },
+      cwd: undefined,
+      description: "node",
+      connectionTimeoutMs: 30_000,
+    });
+  });
+
   it("resolves SSE config by default", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       url: "https://mcp.example.com/sse",
@@ -34,6 +63,26 @@ describe("resolveMcpTransportConfig", () => {
       headers: {
         Authorization: "Bearer token",
         "X-Count": "42",
+      },
+      description: "https://mcp.example.com/sse",
+      connectionTimeoutMs: 30_000,
+    });
+  });
+
+  it("keeps HTTP header parsing unchanged for env-like names", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      url: "https://mcp.example.com/sse",
+      headers: {
+        NODE_OPTIONS: "allowed-header",
+      },
+    });
+
+    expect(resolved).toEqual({
+      kind: "http",
+      transportType: "sse",
+      url: "https://mcp.example.com/sse",
+      headers: {
+        NODE_OPTIONS: "allowed-header",
       },
       description: "https://mcp.example.com/sse",
       connectionTimeoutMs: 30_000,

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -96,7 +96,13 @@ export function resolveMcpTransportConfig(
   rawServer: unknown,
 ): ResolvedMcpTransportConfig | null {
   const requestedTransport = getRequestedTransport(rawServer);
-  const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer);
+  const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer, {
+    onDroppedEnv: (key) => {
+      logWarn(
+        `bundle-mcp: server "${serverName}": env "${key}" is blocked for stdio startup safety and was ignored.`,
+      );
+    },
+  });
   if (stdioLaunch.ok) {
     return {
       kind: "stdio",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: MCP stdio server configs accepted dangerous startup environment keys from config and passed them through to spawned subprocesses.
- Why it matters: interpreter-startup keys such as `NODE_OPTIONS`, `LD_PRELOAD`, and `BASH_ENV` can execute code before the intended MCP server logic starts.
- What changed: stdio env parsing now uses an env-specific filter backed by the existing host-env dangerous-key denylist, and targeted tests cover blocked env keys plus unchanged HTTP header parsing.
- What did NOT change (scope boundary): HTTP header parsing, non-stdio transport behavior, and broader MCP config policy were left unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the stdio launch path reused a generic MCP string-record helper that coerced env entries to strings but never applied the existing dangerous host-env denylist.
- Missing detection / guardrail: there was no env-specific helper or focused regression test asserting that dangerous startup env keys are stripped before subprocess launch.
- Contributing context (if known): the shared helper is also used for HTTP headers, so the missing stdio-only policy stayed hidden behind a more permissive utility.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/mcp-transport-config.test.ts`
- Scenario the test should lock in: dangerous stdio env keys are dropped, safe values are still stringified, and env-like HTTP header names remain unchanged.
- Why this is the smallest reliable guardrail: the bug is introduced during transport-config normalization before any subprocess is spawned, so a focused unit test catches the exact decision point.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- MCP stdio server configs now ignore dangerous startup env keys such as `NODE_OPTIONS`, `LD_PRELOAD`, and `BASH_ENV`.

## Diagram (if applicable)

```text
Before:
[stdio MCP config env] -> [generic string coercion] -> [spawned subprocess gets dangerous startup env]

After:
[stdio MCP config env] -> [env-specific denylist filter] -> [safe env only] -> [spawned subprocess]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: MCP subprocess launches no longer honor dangerous interpreter-startup env keys from config. The change narrows subprocess startup behavior by reusing the existing host-env denylist while preserving safe env entries and leaving HTTP header parsing unchanged.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Codex task workspace
- Model/provider: <operator to fill>
- Integration/channel (if any): MCP stdio
- Relevant config (redacted): stdio MCP config with safe env entries plus dangerous startup env keys

### Steps

1. Construct an MCP stdio transport config with safe env values and dangerous startup keys such as `NODE_OPTIONS`, `LD_PRELOAD`, and `BASH_ENV`.
2. Resolve the transport config through `resolveMcpTransportConfig()`.
3. Verify the resolved stdio env omits the dangerous keys while a separate HTTP transport config still preserves an env-like header name.

### Expected

- Dangerous startup env keys are omitted from stdio launch config, safe env values remain, and HTTP header parsing is unchanged.

### Actual

- Targeted unit tests pass with dangerous stdio env keys removed, safe env values preserved, and HTTP header parsing unchanged.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/mcp-transport-config.test.ts` (pass)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the final diff and ran the targeted MCP transport unit test covering blocked dangerous stdio env keys, safe env stringification, and unchanged HTTP header parsing.
- Edge cases checked: numeric and boolean safe env values still stringify correctly, and header keys that resemble env names still pass through the HTTP path.
- What you did **not** verify: end-to-end subprocess spawn behavior with a live MCP server process or workspace-local config loading.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Yes
- If yes, exact upgrade steps: remove dangerous interpreter-startup env overrides from MCP stdio configs and replace them with safe env values or server-side configuration.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: existing MCP stdio configs that relied on blocked startup env keys will stop receiving those overrides.
  - Mitigation: the denylist reuses the existing host-env policy, the change is limited to stdio env parsing, and the regression test locks safe env plus HTTP header behavior in place.