### PR TITLE
exec tool: strip model-visible `security` / `ask` params

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { analyzeShellCommand } from "../infra/exec-approvals-analysis.js";
-import { type ExecHost, loadExecApprovals, maxAsk, minSecurity } from "../infra/exec-approvals.js";
+import { type ExecHost, loadExecApprovals } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
 import {
@@ -28,8 +28,6 @@ import {
   type ExecProcessOutcome,
   applyPathPrepend,
   applyShellPath,
-  normalizeExecAsk,
-  normalizeExecSecurity,
   normalizeExecTarget,
   normalizePathPrepend,
   resolveExecTarget,
@@ -1465,15 +1463,20 @@ export function createExecTool(
       const approvalDefaults = loadExecApprovals().defaults;
       const configuredSecurity =
         defaults?.security ?? approvalDefaults?.security ?? (host === "sandbox" ? "deny" : "full");
-      const requestedSecurity = normalizeExecSecurity(params.security);
-      let security = minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity);
+      // Trust-boundary note: `security` is config-derived only. We intentionally do NOT
+      // read `params.security` — the exec tool schema no longer exposes it to the model.
+      // Prior behavior (`minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity)`)
+      // treated the configured tier as an upper bound and let the model downgrade
+      // per call, which silently broke cron agents whose training priors defaulted to
+      // `security="allowlist"` against `configured="full"`.
+      let security = configuredSecurity;
       if (elevatedRequested && elevatedMode === "full") {
         security = "full";
       }
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
       const configuredAsk = defaults?.ask ?? approvalDefaults?.ask ?? "off";
-      const requestedAsk = normalizeExecAsk(params.ask);
-      let ask = maxAsk(configuredAsk, requestedAsk ?? configuredAsk);
+      // Same rationale as `security` above: `ask` is config-derived only.
+      let ask = configuredAsk;
       const bypassApprovals = elevatedRequested && elevatedMode === "full";
       if (bypassApprovals) {
         ask = "off";

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -31,16 +31,14 @@ export const execSchema = Type.Object({
       description: "Exec host/target (auto|sandbox|gateway|node).",
     }),
   ),
-  security: Type.Optional(
-    Type.String({
-      description: "Exec security mode (deny|allowlist|full).",
-    }),
-  ),
-  ask: Type.Optional(
-    Type.String({
-      description: "Exec ask mode (off|on-miss|always).",
-    }),
-  ),
+  // NOTE: `security` and `ask` are intentionally NOT model-visible.
+  // Exec security tier and ask-mode are trust-boundary decisions that must be
+  // resolved from agent config only (agents[].tools.exec.security /
+  // top-level tools.exec.security / security-v2.defaultSecurity). Allowing the
+  // model to pick a per-call `security`/`ask` value let models with a strong
+  // "allowlist"-prior silently downgrade `configured="full"` to
+  // `effective="allowlist"` and trigger `exec denied: allowlist miss` on
+  // legitimate commands. See GH issue / linked PR for the smoking-gun case.
   node: Type.Optional(
     Type.String({
       description: "Node id/name for host=node.",


### PR DESCRIPTION
# Upstream OpenClaw PR Proposal: Remove Model-Visible `security` / `ask` Params from `exec` Tool Schema

**Target repo:** `openclaw/openclaw`
**Target branch:** `main`
**Status:** Draft — ready to file after operator review.
**Tracking audit item:** `8.5` in `docs/plans/Audit-2026-04-19/PROGRESS.md`.
**Session provenance:** Session 112 operator direction `upstream-first`.

## Problem Statement

The `exec` tool in OpenClaw exposes `security` and `ask` as model-controllable parameters on its tool-call schema. The resolver at `/app/dist/bash-tools-4xP7Pdtq.js` (compiled output of the upstream `bash-tools.ts`) computes:

```js
security = minSecurity(configured, params.security ?? configured)
```

This treats the configured value as an **upper bound** that the model can **downgrade per call**. Paired with the schema at `/app/dist/bash-tools.schemas-Hw2HS_ba.js`:

```js
security: Type.Optional(Type.String({ description: "deny | allowlist | full" }))
ask: Type.Optional(Type.String({ description: "never | on-miss | always" }))
```

— the description string literally teaches models that `allowlist` is a valid option even when the surrounding agent config sets `tools.exec.security="full"`.

## Smoking Gun (Production Evidence)

`gpt-5.4` in isolated cron sessions defaults `security:"allowlist"` when issuing shell-looking commands. Observed on Sharkey's production instance (`docs/plans/Audit-2026-04-19/findings-84-85-control-plane-truth-20260420.md`):

```
Session /home/mikesharkey/.openclaw/agents/cron/sessions/4c38735e-...jsonl:
  [assistant toolCall 2026-04-20T06:18:48Z]:
    exec args={ command: ".../cron_safe_exec.sh polymarket-position-monitor",
                host: "auto", security: "allowlist", ask: "off" }
  [toolResult 2026-04-20T06:18:48.157Z]:
    { "status": "error", "tool": "exec", "error": "exec denied: allowlist miss" }
```

The agent's `openclaw.json` sets `tools.exec.security="full"` at every scope. No allowlist entries for `cron_safe_exec.sh <mode>` existed pre-fix. The model unilaterally downgraded the exec security tier via a per-call parameter, and the resolver honored the downgrade.

Scale at time of discovery: ~60-80 `tasks list --status succeeded` entries across recent days carried the canned blocker reply:

```
Blocked: cron shell unavailable.
```

(from the cron prompt literal `Only reply 'Blocked: cron shell unavailable.' if the exec tool itself fails before the wrapper starts.`)

The task looked `succeeded` because the LLM replied. The wrapper never ran. Silent failure of 15-minute `polymarket-position-monitor` and 30-minute `polymarket-position-sync` was the largest observable impact.

## Why This Is a Trust-Boundary Bug

`security` is a trust-boundary decision. Whether a tool call is `"full"` vs `"allowlist"` vs `"deny"` is policy, not content. Policy belongs to the operator / agent config, not to the LLM.

Making it a per-call model argument invites three failure modes:

1. **Training-prior downgrade (observed).** Any model with a strong prior for "allowlist when touching shell" will silently fail legitimate commands.
2. **Adversarial model downgrade.** A compromised or jailbroken model can pick `security="deny"` to deny service, or — if the resolver ever used `params.security` as an upper bound or conditional instead of a downgrade — could escalate.
3. **Prompt-injection via tool descriptions.** Tool descriptions are visible to models. A description that enumerates valid security tiers is itself a priming vector.

## Proposed Fix

**Strip `security` and `ask` from the model-visible exec tool schema. Enforce both entirely from agent config, gateway-side.**

### Concrete changes

1. `bash-tools.ts` (or wherever the TypeBox schema for `exec` lives in upstream):
   - Remove `security: Type.Optional(...)` and `ask: Type.Optional(...)` from the Type literal.
   - Remove any references to `params.security` / `params.ask` in the resolver.
   - Resolver computes `security` and `ask` from agent config only.

2. `OpenClawTools.md` / docs pages describing the `exec` tool:
   - Drop the per-call `security` / `ask` parameter documentation.
   - Clarify that security tier is a per-agent config decision (`agents[].tools.exec.security` / top-level `tools.exec.security` / `security-v2.defaultSecurity`).

3. Migration note in `CHANGELOG.md` / release notes:
   - Document that any agent/session relying on model-side `security` override will now use config as the single source of truth.
   - Point to the `approvals` CLI and `tools.exec.security` as the canonical config surfaces.

### Backwards compatibility

Based on a grep through Sharkey's production openclaw.json (v2026.4.15), nothing in the visible config relies on model-side `security` override. All agents use the default resolver path with `tools.exec.security="full"` at the top level and implicit per-agent configuration. Removing the model-visible field is a pure tightening — no existing config would break.

If upstream discovers consumers that rely on model-side override (unlikely), the migration can be staged:

- Phase 1: emit a deprecation warning when `params.security` or `params.ask` is present in an exec tool call, but continue honoring it. One release cycle.
- Phase 2: remove the fields. Observability from Phase 1 tells you who (if anyone) was affected.

A faster alternative (preferred) is to ship the removal in a single release with a clear changelog entry. Consumers that actually want per-call security control can re-introduce it via their own plugin — keeping the core schema minimal.

### Interim stopgap already in place on Sharkey's fleet

Until this upstream change lands and is deployed, Sharkey runs a local allowlist entry in `~/.openclaw/exec-approvals.json`:

```jsonc
{
  "agents": {
    "cron": {
      "allowlist": [
        {
          "pattern": "/home/node/.openclaw/workspace/trading-env/cron_safe_exec.sh",
          "... provenance fields ..."
        }
      ]
    }
  }
}
```

This allowlist is satisfied on every wrapper invocation even when the model still sends `security:"allowlist"`, because the gateway's `loadExecApprovals()` resolves against the command's resolved path and the pattern matches. That's a **functional INTERIM** but keeps the root-cause trust-boundary bug live. It also requires manual edits for every new wrapper command — expensive at scale.

## Test Plan (upstream)

1. **Unit:** exec resolver no longer reads `params.security` or `params.ask`. Repeated calls with bogus `security` values in `params` are silently ignored.
2. **Integration:** with `tools.exec.security="full"` in config, the old production evidence (`security:"allowlist"` in params) now resolves `security="full"` (from config) and the exec succeeds.
3. **Schema:** Ajv / TypeBox introspection of the exec tool schema no longer enumerates `security` or `ask` as accepted params. Agent system prompts that currently describe those params are updated so the model stops sending them.
4. **Docs:** `OpenClawTools.md` no longer documents per-call `security`/`ask`.

## Rollout Checklist (Sharkey's fleet)

After upstream lands and is published:

1. `ssh openclaw "docker exec openclaw-openclaw-gateway-1 node dist/index.js --version"` — confirm new release deployed.
2. Tail `cron/sessions/*.jsonl` for new cron runs — confirm the `security:"allowlist"` pattern no longer appears in model tool calls (schema no longer exposes the field).
3. Remove the INTERIM allowlist entry from `~/.openclaw/exec-approvals.json` — pre-edit backup already at `~/.openclaw/backups/cron-jobs/jobs.json.pre-enable-55.20260421T010900Z` (unrelated, but the pattern is the same).
4. Observe the next three 15-minute `polymarket-position-monitor` cron cycles. They should run cleanly with `tools.exec.security="full"` from config and no allowlist dependency.
5. Flip audit item `8.5` from INTERIM → CLOSED in `docs/plans/Audit-2026-04-19/PROGRESS.md`.

## Attribution

Evidence-of-bug discovery: Session 107 (Codex + Claude Opus 4.7, MBP, 2026-04-20).
Root-cause lens + upstream-first direction: Session 109 handoff prompt + Session 111 operator decision (Sharkey, 2026-04-20).
Upstream PR draft: Session 112 (Claude Opus 4.7, MBP, 2026-04-20 → 2026-04-21).

## What This Proposal Does NOT Do

- Does not introduce a new tool, config key, or plugin surface.
- Does not change OpenClaw's default security tier or deny semantics.
- Does not touch the `approvals` CLI or allowlist mechanism — those remain available for operators who want selective command control, as they already are.
- Does not address the orthogonal gpt-5.4 training prior. Once the model-visible field is gone, the model can no longer express the unsafe preference regardless of its prior.
