### PR TITLE
fix(codex): avoid vision image tool loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Setup/TUI: relaunch the setup hatch TUI in a fresh process while preserving the configured gateway target and auth source, so onboarding recovers terminal state cleanly without exposing gateway secrets on command-line args. (#69524) Thanks @shakkernerd.
+- Codex: avoid re-exposing the image-generation tool on native vision turns with inbound images, and keep bare image-model overrides on the configured image provider. (#65061) Thanks @zhulijin1991.
 - Sessions/reset: clear auto-sourced model, provider, and auth-profile overrides on `/new` and `/reset` while preserving explicit user selections, so channel sessions stop staying pinned to runtime fallback choices. (#69419) Thanks @sk7n4k3d.
 - Sessions/costs: snapshot `estimatedCostUsd` like token counters so repeated persist paths no longer compound the same run cost by up to dozens of times. (#69403) Thanks @MrMiaigi.
 - OpenAI Codex: route ChatGPT/Codex OAuth Responses requests through the `/backend-api/codex` endpoint so `openai-codex/gpt-5.4` no longer hits the removed `/backend-api/responses` alias. (#69336) Thanks @mzogithub.

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -365,10 +365,14 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       input.runAbortController.abort("sessions_yield");
     },
   });
+  const visionFilteredTools = filterToolsForVisionInputs(allTools, {
+    modelHasVision,
+    hasInboundImages: (params.images?.length ?? 0) > 0,
+  });
   const filteredTools =
     params.toolsAllow && params.toolsAllow.length > 0
-      ? allTools.filter((tool) => params.toolsAllow?.includes(tool.name))
-      : allTools;
+      ? visionFilteredTools.filter((tool) => params.toolsAllow?.includes(tool.name))
+      : visionFilteredTools;
   return normalizeProviderToolSchemas({
     tools: filteredTools,
     provider: params.provider,
@@ -379,6 +383,19 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelApi: params.model.api,
     model: params.model,
   });
+}
+
+function filterToolsForVisionInputs<T extends { name?: string }>(
+  tools: T[],
+  params: {
+    modelHasVision: boolean;
+    hasInboundImages: boolean;
+  },
+): T[] {
+  if (!params.modelHasVision || !params.hasInboundImages) {
+    return tools;
+  }
+  return tools.filter((tool) => tool.name !== "image");
 }
 
 async function withCodexStartupTimeout<T>(params: {
@@ -495,6 +512,9 @@ function handleApprovalRequest(params: {
   });
 }
 
-export const __testing = createCodexAppServerClientFactoryTestHooks((factory) => {
-  clientFactory = factory;
-});
+export const __testing = {
+  filterToolsForVisionInputs,
+  ...createCodexAppServerClientFactoryTestHooks((factory) => {
+    clientFactory = factory;
+  }),
+} as const;

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./run-attempt.js";
+
+describe("Codex dynamic tool filtering", () => {
+  it("drops the image tool when the model already has inbound vision input", () => {
+    const toolNames = __testing
+      .filterToolsForVisionInputs(
+        [{ name: "image" }, { name: "read" }, { name: "write" }],
+        {
+          modelHasVision: true,
+          hasInboundImages: true,
+        },
+      )
+      .map((tool) => tool.name);
+
+    expect(toolNames).toContain("read");
+    expect(toolNames).toContain("write");
+    expect(toolNames).not.toContain("image");
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -4,17 +4,31 @@ import { __testing } from "./run-attempt.js";
 describe("Codex dynamic tool filtering", () => {
   it("drops the image tool when the model already has inbound vision input", () => {
     const toolNames = __testing
-      .filterToolsForVisionInputs(
-        [{ name: "image" }, { name: "read" }, { name: "write" }],
-        {
-          modelHasVision: true,
-          hasInboundImages: true,
-        },
-      )
+      .filterToolsForVisionInputs([{ name: "image" }, { name: "read" }, { name: "write" }], {
+        modelHasVision: true,
+        hasInboundImages: true,
+      })
       .map((tool) => tool.name);
 
     expect(toolNames).toContain("read");
     expect(toolNames).toContain("write");
     expect(toolNames).not.toContain("image");
+  });
+
+  it("keeps the image tool unless both model vision and inbound images are present", () => {
+    const tools = [{ name: "image" }, { name: "read" }];
+
+    expect(
+      __testing.filterToolsForVisionInputs(tools, {
+        modelHasVision: false,
+        hasInboundImages: true,
+      }),
+    ).toBe(tools);
+    expect(
+      __testing.filterToolsForVisionInputs(tools, {
+        modelHasVision: true,
+        hasInboundImages: false,
+      }),
+    ).toBe(tools);
   });
 });

--- a/src/agents/model-fallback.image-provider.test.ts
+++ b/src/agents/model-fallback.image-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWithImageModelFallback } from "./model-fallback.js";
+import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+
+describe("runWithImageModelFallback provider resolution", () => {
+  it("inherits the configured image-model provider for bare override ids", async () => {
+    const cfg = makeModelFallbackCfg({
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai-codex/gpt-5.4",
+            fallbacks: ["openai-codex/gpt-5.4-mini"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await runWithImageModelFallback({
+      cfg,
+      modelOverride: "gpt-5.4-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([["openai-codex", "gpt-5.4-mini"]]);
+  });
+});

--- a/src/agents/model-fallback.image-provider.test.ts
+++ b/src/agents/model-fallback.image-provider.test.ts
@@ -25,4 +25,26 @@ describe("runWithImageModelFallback provider resolution", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([["openai-codex", "gpt-5.4-mini"]]);
   });
+
+  it("keeps a fully qualified override provider over the configured default", async () => {
+    const cfg = makeModelFallbackCfg({
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai-codex/gpt-5.4",
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await runWithImageModelFallback({
+      cfg,
+      modelOverride: "google/gemini-3-pro-image",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([["google", "gemini-3-pro-image"]]);
+  });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -375,6 +375,25 @@ function resolveImageFallbackCandidates(params: {
   return candidates;
 }
 
+function resolveImageFallbackDefaultProvider(cfg: OpenClawConfig | undefined): string {
+  const configuredPrimary = resolveAgentModelPrimaryValue(cfg?.agents?.defaults?.imageModel);
+  if (configuredPrimary?.trim()) {
+    const aliasIndex = buildModelAliasIndex({
+      cfg: cfg ?? {},
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    const resolved = resolveModelRefFromString({
+      raw: configuredPrimary,
+      defaultProvider: DEFAULT_PROVIDER,
+      aliasIndex,
+    });
+    if (resolved?.ref.provider) {
+      return resolved.ref.provider;
+    }
+  }
+  return DEFAULT_PROVIDER;
+}
+
 function resolveFallbackCandidates(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -922,7 +941,7 @@ export async function runWithImageModelFallback<T>(params: {
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveImageFallbackCandidates({
     cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
+    defaultProvider: resolveImageFallbackDefaultProvider(params.cfg),
     modelOverride: params.modelOverride,
   });
   if (candidates.length === 0) {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -70,7 +70,7 @@ describe("install-sh smoke runner", () => {
       'HEARTBEAT_INTERVAL="${OPENCLAW_INSTALL_SMOKE_HEARTBEAT_INTERVAL:-60}"',
     );
     expect(script).toContain(
-      'INSTALL_COMMAND_TIMEOUT="${OPENCLAW_INSTALL_SMOKE_COMMAND_TIMEOUT:-300}"',
+      'INSTALL_COMMAND_TIMEOUT="${OPENCLAW_INSTALL_SMOKE_COMMAND_TIMEOUT:-900}"',
     );
     expect(script).toContain("run_with_heartbeat");
     expect(script).toContain("npm_install_global");


### PR DESCRIPTION
Replacement for #65061 because the contributor fork cannot be updated by maintainers and the original branch conflicts with current `main`.

Keeps @zhulijin1991's two fixes, rebased on current `main`, with the run-attempt test hook conflict resolved and extra regression coverage added:
- Codex app-server drops the dynamic `image` tool only when the model already supports vision and the turn has inbound images.
- Image fallback bare override ids inherit the configured image-model provider, while fully-qualified overrides keep their own provider.

Validation run locally:
- `pnpm test extensions/codex/src/app-server/run-attempt.vision-tools.test.ts src/agents/model-fallback.image-provider.test.ts src/agents/model-fallback.test.ts`
- `pnpm check:changed`
- Direct OpenAI live smoke using `.profile` `OPENAI_API_KEY`: `gpt-5.4-nano` Responses API returned `OK`.

Thanks @zhulijin1991 for the original fix in #65061.