### PR TITLE
Hide subagent sessions from chat session picker

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -392,62 +392,28 @@ describe("isCronSessionKey", () => {
 });
 
 describe("resolveSessionOptionGroups", () => {
-  it("prefers grouped session labels over display names", () => {
-    const sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
+  it("hides subagent sessions from the chat session picker", () => {
+    const sessionKey = "agent:alpha:main";
     const labels = labelsForSessionOptions({
       sessionKey,
       sessions: [
+        row({ key: sessionKey, label: "alpha / webchat" }),
         row({
-          key: sessionKey,
+          key: "agent:alpha:subagent:4f2146de-887b-4176-9abe-91140082959b",
           label: "cron-config-check",
-          displayName: "webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
+          displayName: "Subagent: cron-config-check",
+        }),
+        row({
+          key: "agent:alpha:subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
+          label: "other-subagent",
         }),
       ],
     });
 
-    expect(labels).toContain("Subagent: cron-config-check");
-    expect(labels).not.toContain(sessionKey);
-    expect(labels).not.toContain(
-      "subagent:4f2146de-887b-4176-9abe-91140082959b · webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
-    );
-  });
-
-  it("keeps scoped fallbacks for active grouped sessions without useful row metadata", () => {
-    const sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
-
-    expect(labelsForSessionOptions({ sessionKey })).toContain(
-      "subagent:4f2146de-887b-4176-9abe-91140082959b",
-    );
-    expect(
-      labelsForSessionOptions({
-        sessionKey,
-        sessions: [row({ key: sessionKey })],
-      }),
-    ).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
-  });
-
-  it("disambiguates duplicate grouped labels with scoped suffixes", () => {
-    const labels = labelsForSessionOptions({
-      sessionKey: "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
-      sessions: [
-        row({
-          key: "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
-          label: "cron-config-check",
-        }),
-        row({
-          key: "agent:main:subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
-          label: "cron-config-check",
-        }),
-      ],
-    });
-
-    expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
-    );
-    expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
-    );
+    expect(labels).toContain("alpha / webchat");
     expect(labels).not.toContain("Subagent: cron-config-check");
+    expect(labels).not.toContain("other-subagent");
+    expect(labels.every((label) => !label.includes("Subagent:"))).toBe(true);
   });
 
   it("uses agent group labels to keep duplicate main sessions unique", () => {

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -470,7 +470,7 @@ export function resolveSessionOptionGroups(
   };
 
   const addOption = (key: string) => {
-    if (!key || seenKeys.has(key)) {
+    if (!key || seenKeys.has(key) || key.includes(":subagent:")) {
       return;
     }
     seenKeys.add(key);


### PR DESCRIPTION
## Summary
- hide subagent sessions from the human-facing chat session picker
- keep subagent session records intact for internal/runtime use
- update the UI test to assert subagent sessions are excluded from picker options

## Why
Subagent sessions are standard runtime artifacts, but showing them in the normal chat session picker pollutes the menu and leaks internal execution details into the user-facing UI. The picker already recognizes subagent keys for labeling, so the smallest safe fix is to filter them from the picker list while keeping underlying session data untouched.

## Testing
- pnpm test ui/src/ui/app-render.helpers.node.test.ts
- pre-commit changed-file checks and related UI test suite passed during commit