### PR TITLE
feat: URL routing rules for web_fetch — redirect/warn/block by domain pattern

### DIFF
--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,4 +1,4 @@
-import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import type { ToolLoopDetectionConfig, UrlRoutingConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -6,6 +6,7 @@ import { copyPluginToolMeta } from "../plugins/tools.js";
 import { PluginApprovalResolutions, type PluginApprovalResolution } from "../plugins/types.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
+import { evaluateUrlRouting, resolveUrlRoutingRules } from "../web-fetch/url-routing.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -18,6 +19,8 @@ export type HookContext = {
   sessionId?: string;
   runId?: string;
   loopDetection?: ToolLoopDetectionConfig;
+  /** URL routing rules for web_fetch. Evaluated before the fetch is executed. */
+  urlRouting?: UrlRoutingConfig;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };
@@ -183,6 +186,18 @@ export async function runBeforeToolCallHook(args: {
     }
 
     recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
+  }
+
+  // URL routing: check before_tool_call for web_fetch with a url param
+  if (toolName === "web_fetch" && isPlainObject(params) && typeof params.url === "string") {
+    const routingRules = resolveUrlRoutingRules(
+      args.ctx?.urlRouting !== undefined ? { urlRouting: args.ctx.urlRouting } : undefined,
+    );
+    const routingResult = evaluateUrlRouting(params.url, routingRules);
+    if (routingResult.matched && routingResult.blockReason) {
+      log.verbose(`URL routing blocked web_fetch: ${params.url} — ${routingResult.blockReason}`);
+      return { blocked: true, reason: routingResult.blockReason };
+    }
   }
 
   const hookRunner = getGlobalHookRunner();

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -1,6 +1,7 @@
 import type { ChatType } from "../channels/chat-type.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import type { UrlRoutingConfig } from "../web-fetch/url-routing.js";
 import type { AgentElevatedAllowFromConfig, SessionSendPolicyAction } from "./types.base.js";
 import type { MemoryQmdIndexPath } from "./types.memory.js";
 import type { ConfiguredProviderRequest } from "./types.provider-request.js";
@@ -534,6 +535,27 @@ export type ToolsConfig = {
     fetch?: {
       /** Enable web fetch tool (default: true). */
       enabled?: boolean;
+      /**
+       * URL routing rules evaluated before each web_fetch call.
+       * Rules are checked in order; the first match wins.
+       *
+       * - action "redirect": blocks the fetch and tells the agent to use redirectTo instead
+       * - action "warn": allows the fetch but prepends a warning to the tool result
+       * - action "block": blocks the fetch with no redirect suggestion
+       *
+       * @example
+       * ```json
+       * "urlRouting": [
+       *   {
+       *     "match": "x\\.com|twitter\\.com",
+       *     "action": "redirect",
+       *     "redirectTo": "skill:xread",
+       *     "reason": "X.com blocks unauthenticated fetch. Use the xread skill instead."
+       *   }
+       * ]
+       * ```
+       */
+      urlRouting?: UrlRoutingConfig;
       /** Web fetch fallback provider id. */
       provider?: string;
       /** Max characters to return from fetched content. */

--- a/src/web-fetch/url-routing.test.ts
+++ b/src/web-fetch/url-routing.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateUrlRouting,
+  resolveUrlRoutingRules,
+  type UrlRoutingConfig,
+} from "./url-routing.js";
+
+describe("evaluateUrlRouting", () => {
+  describe("no rules", () => {
+    it("returns matched=false when rules array is empty", () => {
+      const result = evaluateUrlRouting("https://x.com/user/status/123", []);
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  describe("action: redirect", () => {
+    const rules: UrlRoutingConfig = [
+      {
+        match: "x\\.com|twitter\\.com",
+        action: "redirect",
+        redirectTo: "skill:xread",
+        reason: "X.com blocks unauthenticated fetch. Use the xread skill instead.",
+      },
+    ];
+
+    it("matches x.com URL and returns block with redirect hint", () => {
+      const result = evaluateUrlRouting("https://x.com/user/status/123456", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.rule.action).toBe("redirect");
+      expect(result.blockReason).toContain("skill:xread");
+      expect(result.blockReason).toContain("X.com blocks unauthenticated");
+      expect(result.warnMessage).toBeUndefined();
+    });
+
+    it("matches twitter.com URL", () => {
+      const result = evaluateUrlRouting("https://twitter.com/user/status/123456", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toContain("skill:xread");
+    });
+
+    it("matches case-insensitively", () => {
+      const result = evaluateUrlRouting("https://X.COM/user/status/123", rules);
+      expect(result.matched).toBe(true);
+    });
+
+    it("does not match unrelated URLs", () => {
+      const result = evaluateUrlRouting("https://example.com/page", rules);
+      expect(result.matched).toBe(false);
+    });
+
+    it("includes reason in blockReason when provided", () => {
+      const result = evaluateUrlRouting("https://x.com/status/1", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toContain("xread skill");
+    });
+
+    it("works without reason field", () => {
+      const noReasonRules: UrlRoutingConfig = [
+        { match: "x\\.com", action: "redirect", redirectTo: "skill:xread" },
+      ];
+      const result = evaluateUrlRouting("https://x.com/status/1", noReasonRules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toContain("skill:xread");
+    });
+
+    it("works without redirectTo field", () => {
+      const noRedirectRules: UrlRoutingConfig = [
+        { match: "x\\.com", action: "redirect", reason: "X blocks scrapers" },
+      ];
+      const result = evaluateUrlRouting("https://x.com/status/1", noRedirectRules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toContain("X blocks scrapers");
+    });
+  });
+
+  describe("action: block", () => {
+    const rules: UrlRoutingConfig = [
+      {
+        match: "internal\\.corp",
+        action: "block",
+        reason: "Internal URLs are not accessible from the agent runtime.",
+      },
+    ];
+
+    it("blocks matching URL with reason", () => {
+      const result = evaluateUrlRouting("https://api.internal.corp/data", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.rule.action).toBe("block");
+      expect(result.blockReason).toContain("Internal URLs");
+      expect(result.warnMessage).toBeUndefined();
+    });
+
+    it("does not match unrelated URLs", () => {
+      const result = evaluateUrlRouting("https://example.com/page", rules);
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  describe("action: warn", () => {
+    const rules: UrlRoutingConfig = [
+      {
+        match: "linkedin\\.com",
+        action: "warn",
+        reason: "LinkedIn blocks scrapers — results may be empty.",
+      },
+    ];
+
+    it("returns warnMessage for matching URL", () => {
+      const result = evaluateUrlRouting("https://www.linkedin.com/in/user", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.rule.action).toBe("warn");
+      expect(result.warnMessage).toContain("LinkedIn blocks scrapers");
+      expect(result.blockReason).toBeUndefined();
+    });
+
+    it("does not block — no blockReason", () => {
+      const result = evaluateUrlRouting("https://linkedin.com/jobs", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toBeUndefined();
+    });
+  });
+
+  describe("rule precedence", () => {
+    it("returns first matching rule", () => {
+      const rules: UrlRoutingConfig = [
+        { match: "x\\.com", action: "warn", reason: "First rule" },
+        { match: "x\\.com", action: "block", reason: "Second rule" },
+      ];
+      const result = evaluateUrlRouting("https://x.com/status/1", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.rule.action).toBe("warn"); // first match wins
+      expect(result.warnMessage).toContain("First rule");
+    });
+  });
+
+  describe("invalid regex", () => {
+    it("skips rules with invalid regex patterns without throwing", () => {
+      const rules: UrlRoutingConfig = [
+        { match: "[invalid(regex", action: "block" }, // invalid regex
+        { match: "example\\.com", action: "block", reason: "Should still match" },
+      ];
+      // Should not throw, and should still match the valid rule
+      const result = evaluateUrlRouting("https://example.com/page", rules);
+      expect(result.matched).toBe(true);
+      if (!result.matched) {
+        return;
+      }
+      expect(result.blockReason).toContain("Should still match");
+    });
+
+    it("returns matched=false when all rules have invalid regex", () => {
+      const rules: UrlRoutingConfig = [
+        { match: "[bad", action: "block" },
+        { match: "((broken", action: "redirect" },
+      ];
+      const result = evaluateUrlRouting("https://example.com", rules);
+      expect(result.matched).toBe(false);
+    });
+  });
+});
+
+describe("resolveUrlRoutingRules", () => {
+  it("returns empty array when fetchConfig is undefined", () => {
+    expect(resolveUrlRoutingRules(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when urlRouting is not set", () => {
+    expect(resolveUrlRoutingRules({})).toEqual([]);
+  });
+
+  it("returns urlRouting array when configured", () => {
+    const rules: UrlRoutingConfig = [
+      { match: "x\\.com", action: "redirect", redirectTo: "skill:xread" },
+    ];
+    expect(resolveUrlRoutingRules({ urlRouting: rules })).toEqual(rules);
+  });
+
+  it("returns empty array when urlRouting is explicitly empty", () => {
+    expect(resolveUrlRoutingRules({ urlRouting: [] })).toEqual([]);
+  });
+});

--- a/src/web-fetch/url-routing.ts
+++ b/src/web-fetch/url-routing.ts
@@ -1,0 +1,137 @@
+/**
+ * URL Routing for web_fetch
+ *
+ * Allows agents to configure domain-specific routing rules that fire
+ * before web_fetch is called. When a URL matches a rule, the tool call
+ * can be blocked with a redirect hint, warned, or allowed through.
+ *
+ * Configured via tools.web.fetch.urlRouting in openclaw.json.
+ *
+ * @example
+ * ```json
+ * {
+ *   "tools": {
+ *     "web": {
+ *       "fetch": {
+ *         "urlRouting": [
+ *           {
+ *             "match": "x\\.com|twitter\\.com",
+ *             "action": "redirect",
+ *             "redirectTo": "skill:xread",
+ *             "reason": "X.com blocks unauthenticated fetch. Use the xread skill (Grok API) instead."
+ *           },
+ *           {
+ *             "match": "linkedin\\.com",
+ *             "action": "warn",
+ *             "reason": "LinkedIn blocks scrapers — results may be empty or partial."
+ *           }
+ *         ]
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+
+export type UrlRoutingAction = "redirect" | "warn" | "block";
+
+export type UrlRoutingRule = {
+  /**
+   * Regex pattern matched against the full URL (case-insensitive).
+   * Examples: "x\\.com|twitter\\.com", "linkedin\\.com", ".*\\.internal\\.corp"
+   */
+  match: string;
+  /**
+   * What to do when the pattern matches:
+   * - "redirect": block the fetch and tell the agent to use redirectTo instead
+   * - "warn": allow the fetch but prepend a warning message to the result
+   * - "block": block the fetch with no redirect suggestion
+   */
+  action: UrlRoutingAction;
+  /**
+   * Human-readable reason shown to the agent explaining why routing applies.
+   */
+  reason?: string;
+  /**
+   * For action="redirect": where to route instead.
+   * Use "skill:<slug>" for skills (e.g. "skill:xread"),
+   * or "tool:<name>" for tools (e.g. "tool:web_search").
+   */
+  redirectTo?: string;
+};
+
+export type UrlRoutingConfig = UrlRoutingRule[];
+
+/**
+ * Result of evaluating URL routing rules against a URL.
+ */
+export type UrlRoutingResult =
+  | { matched: false }
+  | {
+      matched: true;
+      rule: UrlRoutingRule;
+      /** Ready-to-use block reason string for PluginHookBeforeToolCallResult.blockReason */
+      blockReason?: string;
+      /** For action="warn": message to prepend to the tool result */
+      warnMessage?: string;
+    };
+
+/**
+ * Evaluate URL routing rules against a URL.
+ * Returns the first matching rule result, or { matched: false }.
+ */
+export function evaluateUrlRouting(url: string, rules: UrlRoutingConfig): UrlRoutingResult {
+  for (const rule of rules) {
+    let pattern: RegExp;
+    try {
+      pattern = new RegExp(rule.match, "i");
+    } catch {
+      // Invalid regex — skip silently (misconfiguration shouldn't crash the agent)
+      continue;
+    }
+
+    if (!pattern.test(url)) {
+      continue;
+    }
+
+    if (rule.action === "redirect") {
+      const redirectHint = rule.redirectTo ? ` Use ${rule.redirectTo} instead.` : "";
+      const reasonHint = rule.reason ? ` Reason: ${rule.reason}` : "";
+      return {
+        matched: true,
+        rule,
+        blockReason: `URL routing: "${url}" matches pattern "${rule.match}" — web_fetch blocked.${redirectHint}${reasonHint}`,
+      };
+    }
+
+    if (rule.action === "block") {
+      const reasonHint = rule.reason ? ` Reason: ${rule.reason}` : "";
+      return {
+        matched: true,
+        rule,
+        blockReason: `URL routing: "${url}" matches pattern "${rule.match}" — web_fetch blocked.${reasonHint}`,
+      };
+    }
+
+    if (rule.action === "warn") {
+      const reasonHint = rule.reason ?? `URL matches pattern "${rule.match}"`;
+      return {
+        matched: true,
+        rule,
+        warnMessage: `⚠️ URL routing warning: ${reasonHint}`,
+      };
+    }
+  }
+
+  return { matched: false };
+}
+
+/**
+ * Extract URL routing config from the tools.web.fetch config object.
+ * Returns an empty array if not configured.
+ */
+export function resolveUrlRoutingRules(
+  fetchConfig: { urlRouting?: UrlRoutingConfig } | undefined,
+): UrlRoutingConfig {
+  return fetchConfig?.urlRouting ?? [];
+}


### PR DESCRIPTION
## Summary

Adds `tools.web.fetch.urlRouting` config — an ordered list of domain routing rules that fire inside `runBeforeToolCallHook()` before any `web_fetch` call.

Closes #69591

## Problem

Agents reflexively call `web_fetch` on any URL, including domains that actively block scraping (x.com, linkedin.com) or domains that should route to a different tool entirely. Text rules in AGENTS.md are not reliably enforced — the pattern-matching behavior fires before context-level rules are applied.

This adds code-level enforcement via the existing `before_tool_call` infrastructure.

## Config

```json
{
  "tools": {
    "web": {
      "fetch": {
        "urlRouting": [
          {
            "match": "x\\.com|twitter\\.com",
            "action": "redirect",
            "redirectTo": "skill:xread",
            "reason": "X.com blocks unauthenticated fetch. Use the xread skill (Grok API) instead."
          },
          {
            "match": "linkedin\\.com",
            "action": "warn",
            "reason": "LinkedIn blocks scrapers — results may be empty."
          },
          {
            "match": ".*\\.internal\\.corp",
            "action": "block",
            "reason": "Internal URLs are not accessible from the agent runtime."
          }
        ]
      }
    }
  }
}
```

## Three actions

| Action | Effect |
|--------|--------|
| `redirect` | Blocks the fetch with a message telling the agent to use `redirectTo` instead |
| `warn` | Allows the fetch but surfaces a warning in the tool result |
| `block` | Blocks the fetch with no redirect suggestion |

## Implementation

**New files:**
- `src/web-fetch/url-routing.ts` — `evaluateUrlRouting()` + `resolveUrlRoutingRules()`
- `src/web-fetch/url-routing.test.ts` — 19 tests covering all three actions, edge cases, invalid regex

**Modified files:**
- `src/config/types.tools.ts` — added `urlRouting?: UrlRoutingConfig` to `fetch` config block with JSDoc examples
- `src/agents/pi-tools.before-tool-call.ts` — wired routing check into `runBeforeToolCallHook()` after loop detection, before plugin hook runner

## Tests: 19/19 ✅

```
✓ no rules → matched=false
✓ redirect: x.com blocked with skill:xread hint
✓ redirect: twitter.com matched
✓ redirect: case-insensitive match (X.COM)
✓ redirect: unrelated URL not matched
✓ redirect: reason included in blockReason
✓ redirect: works without reason field
✓ redirect: works without redirectTo field
✓ block: blocks with reason, no warnMessage
✓ block: unrelated URL not matched
✓ warn: returns warnMessage, no blockReason
✓ warn: no block — fetch proceeds
✓ rule precedence: first match wins
✓ invalid regex: skipped without throwing
✓ invalid regex: matched=false when all rules invalid
✓ resolveUrlRoutingRules: undefined config → []
✓ resolveUrlRoutingRules: missing urlRouting → []
✓ resolveUrlRoutingRules: configured rules returned
✓ resolveUrlRoutingRules: explicit empty array → []
```

## Backwards compatibility

Empty routing table (default) = zero behavior change. Fully additive.