### PR TITLE
Fix skills.update writes from runtime-derived config

### DIFF
--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -13,8 +13,7 @@ import { installSkill } from "../../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../../agents/skills-status.js";
 import { loadWorkspaceSkillEntries, type SkillEntry } from "../../agents/skills.js";
 import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
-import { loadConfig, writeConfigFile } from "../../config/config.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadConfig, mutateConfigFile } from "../../config/config.js";
 import { fetchClawHubSkillDetail } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
@@ -303,44 +302,45 @@ export const skillsHandlers: GatewayRequestHandlers = {
       apiKey?: string;
       env?: Record<string, string>;
     };
-    const cfg = loadConfig();
-    const skills = cfg.skills ? { ...cfg.skills } : {};
-    const entries = skills.entries ? { ...skills.entries } : {};
-    const current = entries[p.skillKey] ? { ...entries[p.skillKey] } : {};
-    if (typeof p.enabled === "boolean") {
-      current.enabled = p.enabled;
-    }
-    if (typeof p.apiKey === "string") {
-      const trimmed = normalizeSecretInput(p.apiKey);
-      if (trimmed) {
-        current.apiKey = trimmed;
-      } else {
-        delete current.apiKey;
-      }
-    }
-    if (p.env && typeof p.env === "object") {
-      const nextEnv = current.env ? { ...current.env } : {};
-      for (const [key, value] of Object.entries(p.env)) {
-        const trimmedKey = key.trim();
-        if (!trimmedKey) {
-          continue;
+    const mutation = await mutateConfigFile({
+      base: "source",
+      mutate: (draft) => {
+        const skills = draft.skills ? { ...draft.skills } : {};
+        const entries = skills.entries ? { ...skills.entries } : {};
+        const current = entries[p.skillKey] ? { ...entries[p.skillKey] } : {};
+        if (typeof p.enabled === "boolean") {
+          current.enabled = p.enabled;
         }
-        const trimmedVal = value.trim();
-        if (!trimmedVal) {
-          delete nextEnv[trimmedKey];
-        } else {
-          nextEnv[trimmedKey] = trimmedVal;
+        if (typeof p.apiKey === "string") {
+          const trimmed = normalizeSecretInput(p.apiKey);
+          if (trimmed) {
+            current.apiKey = trimmed;
+          } else {
+            delete current.apiKey;
+          }
         }
-      }
-      current.env = nextEnv;
-    }
-    entries[p.skillKey] = current;
-    skills.entries = entries;
-    const nextConfig: OpenClawConfig = {
-      ...cfg,
-      skills,
-    };
-    await writeConfigFile(nextConfig);
-    respond(true, { ok: true, skillKey: p.skillKey, config: current }, undefined);
+        if (p.env && typeof p.env === "object") {
+          const nextEnv = current.env ? { ...current.env } : {};
+          for (const [key, value] of Object.entries(p.env)) {
+            const trimmedKey = key.trim();
+            if (!trimmedKey) {
+              continue;
+            }
+            const trimmedVal = value.trim();
+            if (!trimmedVal) {
+              delete nextEnv[trimmedKey];
+            } else {
+              nextEnv[trimmedKey] = trimmedVal;
+            }
+          }
+          current.env = nextEnv;
+        }
+        entries[p.skillKey] = current;
+        skills.entries = entries;
+        draft.skills = skills;
+        return current;
+      },
+    });
+    respond(true, { ok: true, skillKey: p.skillKey, config: mutation.result }, undefined);
   },
 };

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -1,16 +1,46 @@
 import { describe, expect, it, vi } from "vitest";
 
 let writtenConfig: unknown = null;
+let mutateBase: unknown = null;
 
 vi.mock("../../config/config.js", () => {
   return {
     loadConfig: () => ({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            apiKey: "runtime-only-legacy-key",
+          },
+        },
+      },
       skills: {
         entries: {},
       },
     }),
-    writeConfigFile: async (cfg: unknown) => {
-      writtenConfig = cfg;
+    mutateConfigFile: async ({
+      base,
+      mutate,
+    }: {
+      base?: string;
+      mutate: (draft: Record<string, unknown>) => unknown;
+    }) => {
+      mutateBase = base;
+      const draft = {
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+            },
+          },
+        },
+        skills: {
+          entries: {},
+        },
+      };
+      const result = await mutate(draft);
+      writtenConfig = draft;
+      return { result };
     },
   };
 });
@@ -18,8 +48,9 @@ vi.mock("../../config/config.js", () => {
 const { skillsHandlers } = await import("./skills.js");
 
 describe("skills.update", () => {
-  it("strips embedded CR/LF from apiKey", async () => {
+  it("writes skill api keys from the source config snapshot", async () => {
     writtenConfig = null;
+    mutateBase = null;
 
     let ok: boolean | null = null;
     let error: unknown = null;
@@ -40,11 +71,79 @@ describe("skills.update", () => {
 
     expect(ok).toBe(true);
     expect(error).toBeUndefined();
+    expect(mutateBase).toBe("source");
     expect(writtenConfig).toMatchObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+          },
+        },
+      },
       skills: {
         entries: {
           "brave-search": {
             apiKey: "abcdef",
+          },
+        },
+      },
+    });
+    expect(writtenConfig).not.toMatchObject({
+      tools: {
+        web: {
+          search: {
+            apiKey: expect.any(String),
+          },
+        },
+      },
+    });
+  });
+
+  it("disables a skill without persisting runtime-only legacy web search config", async () => {
+    writtenConfig = null;
+    mutateBase = null;
+
+    let ok: boolean | null = null;
+    let error: unknown = null;
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "browserless",
+        enabled: false,
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond: (success, _result, err) => {
+        ok = success;
+        error = err;
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect(mutateBase).toBe("source");
+    expect(writtenConfig).toMatchObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+          },
+        },
+      },
+      skills: {
+        entries: {
+          browserless: {
+            enabled: false,
+          },
+        },
+      },
+    });
+    expect(writtenConfig).not.toMatchObject({
+      tools: {
+        web: {
+          search: {
+            apiKey: expect.any(String),
           },
         },
       },


### PR DESCRIPTION
## Summary
- update `skills.update` to mutate the source config snapshot instead of rewriting the runtime-loaded config
- keep the existing skill field normalization logic while avoiding runtime-only compatibility fields during writes
- add regression coverage for skill API key updates and skill disabling when runtime-only legacy web-search config is present

## Testing
- pnpm vitest --config test/vitest/vitest.gateway-methods.config.ts run src/gateway/server-methods/skills.update.normalizes-api-key.test.ts src/gateway/server-methods/skills.clawhub.test.ts
- pre-commit check:changed (auto-ran during commit, includes gateway test suite)

Closes #69554