### PR TITLE
fix: suppress repeated bundled runtime deps gateway logs

### DIFF
--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -40,6 +40,7 @@ describe("ensureRuntimePluginsLoaded", () => {
     expect(hoisted.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
       config: {} as never,
       workspaceDir: "/tmp/workspace",
+      suppressLoaderInfoLogs: true,
       runtimeOptions: {
         allowGatewaySubagentBinding: true,
       },

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -14,6 +14,9 @@ export function ensureRuntimePluginsLoaded(params: {
   const loadOptions = {
     config: params.config,
     workspaceDir,
+    // Embedded runs can warm a scoped registry on demand; suppress info-level plugin
+    // loader chatter so per-turn gateway logs only show warnings and errors.
+    suppressLoaderInfoLogs: true,
     runtimeOptions: params.allowGatewaySubagentBinding
       ? {
           allowGatewaySubagentBinding: true,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1115,6 +1115,81 @@ module.exports = {
     ]);
   });
 
+  it("can suppress loader-owned runtime-deps info logs without muting plugin info logs", () => {
+    const bundledDir = makeTempDir();
+    const plugin = writePlugin({
+      id: "openai",
+      dir: path.join(bundledDir, "openai"),
+      filename: "index.cjs",
+      body: `module.exports = {
+        id: "openai",
+        register(api) {
+          api.logger.info("plugin registered");
+        },
+      };`,
+    });
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+    fs.writeFileSync(
+      path.join(plugin.dir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/openai",
+          version: "1.0.0",
+          dependencies: {
+            "openai-runtime": "1.0.0",
+          },
+          openclaw: { extensions: ["./index.cjs"] },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "openai",
+          enabledByDefault: true,
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    const infoMessages: string[] = [];
+
+    loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+      logger: {
+        info: (message) => infoMessages.push(message),
+        warn: () => undefined,
+        error: () => undefined,
+        debug: () => undefined,
+      },
+      suppressLoaderInfoLogs: true,
+      bundledRuntimeDepsInstaller: ({ installRoot, installSpecs, missingSpecs }) => {
+        for (const spec of installSpecs ?? missingSpecs) {
+          const name = spec.split("@")[0] || spec;
+          fs.mkdirSync(path.join(installRoot, "node_modules", name), { recursive: true });
+          fs.writeFileSync(
+            path.join(installRoot, "node_modules", name, "package.json"),
+            JSON.stringify({ name, version: "1.0.0" }),
+            "utf-8",
+          );
+        }
+      },
+    });
+
+    expect(infoMessages).toEqual(["plugin registered"]);
+  });
+
   it("registers standalone text transforms", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -133,6 +133,8 @@ export type PluginLoadOptions = {
   mode?: "full" | "validate";
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
+  /** Suppress loader-owned info chatter while preserving plugin/runtime logger behavior. */
+  suppressLoaderInfoLogs?: boolean;
   /**
    * Prefer `setupEntry` for configured channel plugins that explicitly opt in
    * via package metadata because their setup entry covers the pre-listen startup surface.
@@ -1753,9 +1755,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 (left, right) => left.localeCompare(right),
               ),
             );
-            logger.info(
-              `[plugins] ${record.id} installed bundled runtime deps: ${depsInstallResult.installedSpecs.join(", ")}`,
-            );
+            if (options.suppressLoaderInfoLogs !== true) {
+              logger.info(
+                `[plugins] ${record.id} installed bundled runtime deps: ${depsInstallResult.installedSpecs.join(", ")}`,
+              );
+            }
           }
         } catch (error) {
           pushPluginLoadError(`failed to install bundled runtime deps: ${String(error)}`);


### PR DESCRIPTION
## Summary

- Problem: gateway logs repeatedly print `[plugins] ... installed bundled runtime deps ...` during embedded runtime plugin warmups, so normal Telegram or subagent traffic can flood `gateway:watch` with install-style noise.
- Why it matters: the log line implies fresh installs even when the runtime is just reloading a scoped plugin registry, which makes real plugin warnings and channel events harder to spot.
- What changed: added a loader-only `suppressLoaderInfoLogs` option, enabled it for embedded runtime plugin warmups, and added coverage that proves plugin-owned `api.logger.info(...)` messages still flow while the bundled-runtime-deps line stays suppressed.
- What did NOT change (scope boundary): this does not change bundled runtime dependency installation behavior, startup-time gateway plugin logging, or plugin-owned runtime logging.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: embedded runs call `ensureRuntimePluginsLoaded(...)`, which resolves a scoped runtime plugin registry through the shared loader. The loader always logged bundled runtime dependency installs at info level, so those hot-path runtime loads replayed startup-style install logs in normal gateway traffic.
- Missing detection / guardrail: there was no way to suppress loader-owned info chatter without also muting plugin-owned `api.logger` output.
- Contributing context (if known): gateway startup already had a coarse logger-muting path, but embedded runtime warmups did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`, `src/agents/runtime-plugins.test.ts`
- Scenario the test should lock in: embedded runtime plugin warmups can suppress the loader-owned bundled-runtime-deps info line without suppressing plugin-owned info logs.
- Why this is the smallest reliable guardrail: the bug lives at the boundary between `ensureRuntimePluginsLoaded(...)` and the shared plugin loader, so one loader-focused test plus one helper callsite test covers the regression without needing a full gateway/channel repro.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Normal gateway traffic should stop replaying long `[plugins] ... installed bundled runtime deps ...` lines during embedded runtime plugin warmups.
- Startup-time plugin dependency logs still appear when the gateway actually performs its main plugin load.

## Diagram (if applicable)

```text
Before:
[embedded runtime warmup] -> loadOpenClawPlugins() -> loader emits bundled-runtime-deps info logs -> gateway:watch noise

After:
[embedded runtime warmup] -> loadOpenClawPlugins(suppressLoaderInfoLogs=true) -> loader skips its own info line -> gateway:watch stays focused on warnings/errors
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway via `pnpm gateway:watch`
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Telegram embedded runs
- Relevant config (redacted): standard local workspace with bundled plugins enabled

### Steps

1. Start the gateway under `pnpm gateway:watch`.
2. Trigger embedded runtime activity, for example by sending a Telegram message that warms the runtime plugin registry.
3. Observe the gateway log stream.

### Expected

- Embedded runtime warmups do not spam repeated `[plugins] ... installed bundled runtime deps ...` lines.

### Actual

- The gateway repeatedly logged install-style bundled-runtime-deps lines on normal runtime warmups.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed gateway noise before this fix included repeated lines like:

```text
[plugins] anthropic installed bundled runtime deps: ...
[plugins] github-copilot installed bundled runtime deps: ...
```

## Human Verification (required)

- Verified scenarios: targeted runtime-plugin loader tests, full `pnpm check`, full `pnpm build`, and `codex review --base origin/main` on the final tree.
- Edge cases checked: plugin-owned `api.logger.info(...)` messages remain visible when loader-owned bundled-runtime-deps logs are suppressed.
- What you did **not** verify: a fresh end-to-end gateway watch capture after the code change in this exact shell.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a caller could use `suppressLoaderInfoLogs` when they actually wanted startup-time loader info.
  - Mitigation: only embedded runtime warmups opt in; the main gateway plugin load path is unchanged.