### PR TITLE
feat: harden embedded runner lifecycle seam

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -50,7 +50,7 @@ const ZAI_AUTH_ERROR_PATTERNS = [
 
 const ERROR_PATTERNS = {
   rateLimit: [
-    /rate[_ ]limit|too many requests|429/,
+    /rate(?:[_ ]limit(?:ed)?| limited)|too many requests|429/,
     /too many (?:concurrent )?requests/i,
     /throttling(?:exception)?/i,
     "model_cooldown",

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -9,7 +9,10 @@ import {
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
 } from "./pi-embedded-runner/run.overflow-compaction.harness.js";
-import { buildEmbeddedRunLifecycleReceipt } from "./pi-embedded-runner/run/lifecycle-seam.js";
+import {
+  buildEmbeddedRunLifecycleReceipt,
+  createExecutionProfileLifecycleSeam,
+} from "./pi-embedded-runner/run/lifecycle-seam.js";
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
 
@@ -79,41 +82,30 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
       ...baseline.meta,
       durationMs: withSeam.meta.durationMs,
     });
-    expect(receipts).toEqual([
-      {
-        runtimeSurface: "m13_lifecycle_seam_v1",
-        lifecycleSeamVersion: 1,
-        event: "pass_start",
-        passIndex: 1,
-        passKind: "model_call",
-        correlationId: receipts[0]?.correlationId,
-        envelopeOnly: true,
-        decisionEffective: false,
-        outcome: "observed",
-      },
-      {
-        runtimeSurface: "m13_lifecycle_seam_v1",
-        lifecycleSeamVersion: 1,
-        event: "pass_end",
-        passIndex: 1,
-        passKind: "model_call",
-        correlationId: receipts[0]?.correlationId,
-        envelopeOnly: true,
-        decisionEffective: false,
-        outcome: "observed",
-      },
-      {
-        runtimeSurface: "m13_lifecycle_seam_v1",
-        lifecycleSeamVersion: 1,
-        event: "pass_transition_decision",
-        passIndex: 1,
-        passKind: "model_call",
-        correlationId: receipts[0]?.correlationId,
-        envelopeOnly: true,
-        decisionEffective: false,
-        outcome: "noop",
-      },
-    ]);
+    expect(receipts[0]).toMatchObject({
+      runtimeSurface: "m13_lifecycle_seam_v1",
+      lifecycleSeamVersion: 1,
+      event: "pass_start",
+      passIndex: 1,
+      passKind: "model_call",
+      envelopeOnly: true,
+      decisionEffective: false,
+      outcome: "observed",
+    });
+    expect(receipts[1]).toMatchObject({
+      runtimeSurface: "m13_lifecycle_seam_v1",
+      lifecycleSeamVersion: 1,
+      event: "pass_end",
+      passIndex: 1,
+      passKind: "model_call",
+      correlationId: receipts[0]?.correlationId,
+      envelopeOnly: true,
+      decisionEffective: false,
+      outcome: "observed",
+    });
+    const transitionReceipts = receipts.filter((receipt) => receipt.event === "pass_transition_decision");
+    expect(transitionReceipts.length).toBeGreaterThanOrEqual(1);
+    expect(transitionReceipts.every((receipt) => receipt.outcome === "noop")).toBe(true);
   });
 
   it("threads the observe_only decision mode through the runner without changing behavior", async () => {
@@ -132,7 +124,9 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
     });
 
     expect(result.meta.error).toBeUndefined();
-    expect(decisions).toEqual([{ event: "pass_transition_decision", next: "noop" }]);
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    expect(decisions.every((decision) => decision.event === "pass_transition_decision")).toBe(true);
+    expect(decisions.every((decision) => decision.next === "noop")).toBe(true);
   });
 
   it("emits assistant_retry when the assistant ends the pass with an error", async () => {
@@ -216,7 +210,9 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
       ...overflowBaseRunParams,
       lifecycleDecisionMode: "decide",
       lifecycleSeam: {
-        onPassTransitionDecision: vi.fn(async () => ({ next: "continue" as const })),
+        onPassTransitionDecision: vi.fn(async (event) =>
+          event.source === "prompt" ? { next: "continue" as const } : { next: "noop" as const },
+        ),
       },
     });
 
@@ -254,5 +250,92 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
 
     expect(result.meta.error).toBeUndefined();
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("supports successful pass dispatch continuation in decide mode", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const sources: string[] = [];
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: {
+        onPassTransitionDecision: vi.fn(async (event) => {
+          sources.push(`${event.source}:${event.passIndex}`);
+          if (event.source === "pass_dispatch" && event.passIndex === 1) {
+            return { next: "continue" as const, reason: "execution_profile:double-pass" };
+          }
+          return { next: "noop" as const };
+        }),
+      },
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(sources).toContain("pass_dispatch:1");
+    expect(sources).toContain("pass_dispatch:2");
+  });
+
+  it("policy-bound execution-profile seam continues until the planned max pass count", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: createExecutionProfileLifecycleSeam({
+        requestedProfile: "double-pass",
+        plannedMaxPasses: 2,
+        controllerLabel: "test_policy_bridge",
+      }),
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not continue pass_dispatch when the pass ended with pending tool calls", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        clientToolCall: {
+          name: "demo_tool",
+          params: { value: 1 },
+        } as never,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: createExecutionProfileLifecycleSeam({
+        requestedProfile: "double-pass",
+        plannedMaxPasses: 2,
+        controllerLabel: "test_policy_bridge",
+      }),
+    });
+
+    expect(result.meta.pendingToolCalls).toBeTruthy();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes malformed plannedMaxPasses to a single bounded pass", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: createExecutionProfileLifecycleSeam({
+        requestedProfile: "double-pass",
+        plannedMaxPasses: Number.POSITIVE_INFINITY,
+        controllerLabel: "test_policy_bridge",
+      }),
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -132,6 +132,30 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
     expect(decisions).toEqual([{ event: "pass_transition_decision", next: "noop" }]);
   });
 
+  it("emits assistant_retry when the assistant ends the pass with an error", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        lastAssistant: {
+          stopReason: "error",
+          errorMessage: "rate limited",
+        } as never,
+      }),
+    );
+    const events: string[] = [];
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleSeam: {
+        onPassEnd: async (event) => {
+          events.push(`${event.event}:${event.passIndex}:${event.outcome}`);
+        },
+      },
+    });
+
+    expect(result.meta.livenessState).toBe("abandoned");
+    expect(events).toEqual(["pass_end:1:assistant_retry"]);
+  });
+
   it("fails closed on decision events when a seam returns non-noop control", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -147,5 +171,23 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
         },
       }),
     ).rejects.toThrow(/decision mode is observe_only/i);
+  });
+
+  it("fails closed in decide mode until transition execution is explicitly wired", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new Error("plain prompt failure"),
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        lifecycleDecisionMode: "decide",
+        lifecycleSeam: {
+          onPassTransitionDecision: vi.fn(async () => ({ next: "halt" as const })),
+        },
+      }),
+    ).rejects.toThrow(/before transition execution is wired/i);
   });
 });

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -173,7 +173,7 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
     ).rejects.toThrow(/decision mode is observe_only/i);
   });
 
-  it("fails closed in decide mode until transition execution is explicitly wired", async () => {
+  it("halts prompt transitions in decide mode when the seam returns halt", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         promptError: new Error("plain prompt failure"),
@@ -188,6 +188,24 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
           onPassTransitionDecision: vi.fn(async () => ({ next: "halt" as const })),
         },
       }),
-    ).rejects.toThrow(/before transition execution is wired/i);
+    ).rejects.toThrow(/halted prompt transition/i);
+  });
+
+  it("keeps continue decisions fail-closed in decide mode until live continue wiring exists", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new Error("plain prompt failure"),
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        lifecycleDecisionMode: "decide",
+        lifecycleSeam: {
+          onPassTransitionDecision: vi.fn(async () => ({ next: "continue" as const })),
+        },
+      }),
+    ).rejects.toThrow(/continue transition execution is wired/i);
   });
 });

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -200,21 +200,52 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
     );
   });
 
-  it("continues prompt transitions in decide mode when the seam returns continue", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        promptError: new Error("plain prompt failure"),
-      }),
-    );
+  it("continues prompt transitions in decide mode by retrying the run", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("plain prompt failure"),
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
-    await expect(
-      runEmbeddedPiAgent({
-        ...overflowBaseRunParams,
-        lifecycleDecisionMode: "decide",
-        lifecycleSeam: {
-          onPassTransitionDecision: vi.fn(async () => ({ next: "continue" as const })),
-        },
-      }),
-    ).rejects.toThrow(/plain prompt failure/i);
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: {
+        onPassTransitionDecision: vi.fn(async () => ({ next: "continue" as const })),
+      },
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues assistant halt transitions in decide mode by retrying the run", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          lastAssistant: {
+            stopReason: "error",
+            errorMessage: "rate limited",
+            provider: "openai",
+            model: "gpt-5.4",
+          } as never,
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "decide",
+      lifecycleSeam: {
+        onPassTransitionDecision: vi.fn(async (event) =>
+          event.source === "assistant" ? { next: "continue" as const } : { next: "noop" as const },
+        ),
+      },
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -185,10 +185,13 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
         ...overflowBaseRunParams,
         lifecycleDecisionMode: "decide",
         lifecycleSeam: {
-          onPassTransitionDecision: vi.fn(async () => ({ next: "halt" as const })),
+          onPassTransitionDecision: vi.fn(async () => ({
+            next: "halt" as const,
+            reason: "operator_requested",
+          })),
         },
       }),
-    ).rejects.toThrow(/halted prompt transition/i);
+    ).rejects.toThrow(/halted prompt transition before surface_error\. \(reason: operator_requested\)/i);
   });
 
   it("continues prompt transitions in decide mode when the seam returns continue", async () => {

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -1,0 +1,151 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeAttemptResult } from "./pi-embedded-runner/run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./pi-embedded-runner/run.overflow-compaction.harness.js";
+import { buildEmbeddedRunLifecycleReceipt } from "./pi-embedded-runner/run/lifecycle-seam.js";
+
+let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
+
+describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+  });
+
+  it("emits pass_start and pass_end without changing successful run behavior", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    const events: string[] = [];
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleSeam: {
+        onPassStart: async (event) => {
+          events.push(`${event.event}:${event.passIndex}:${event.passKind}`);
+        },
+        onPassEnd: async (event) => {
+          events.push(`${event.event}:${event.passIndex}:${event.outcome}`);
+        },
+      },
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(events).toEqual(["pass_start:1:model_call", "pass_end:1:success"]);
+  });
+
+  it("preserves the golden path when a noop seam is installed", async () => {
+    const baselineAttempt = makeAttemptResult({ promptError: null });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(baselineAttempt);
+    const baseline = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+    });
+
+    resetRunOverflowCompactionHarnessMocks();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    const receipts: ReturnType<typeof buildEmbeddedRunLifecycleReceipt>[] = [];
+    const withSeam = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleSeam: {
+        onPassStart: async (event) => {
+          receipts.push(buildEmbeddedRunLifecycleReceipt({ event, outcome: "observed" }));
+        },
+        onPassEnd: async (event) => {
+          receipts.push(buildEmbeddedRunLifecycleReceipt({ event, outcome: "observed" }));
+        },
+        onPassTransitionDecision: async (event) => {
+          receipts.push(
+            buildEmbeddedRunLifecycleReceipt({
+              event,
+              outcome: "noop",
+              reason: event.proposedReason ?? undefined,
+            }),
+          );
+          return { next: "noop" as const };
+        },
+      },
+    });
+
+    expect(withSeam.payloads).toEqual(baseline.payloads);
+    expect(withSeam.meta).toMatchObject({
+      ...baseline.meta,
+      durationMs: withSeam.meta.durationMs,
+    });
+    expect(receipts).toEqual([
+      {
+        runtimeSurface: "m13_lifecycle_seam_v1",
+        lifecycleSeamVersion: 1,
+        event: "pass_start",
+        passIndex: 1,
+        passKind: "model_call",
+        correlationId: receipts[0]?.correlationId,
+        envelopeOnly: true,
+        decisionEffective: false,
+        outcome: "observed",
+      },
+      {
+        runtimeSurface: "m13_lifecycle_seam_v1",
+        lifecycleSeamVersion: 1,
+        event: "pass_end",
+        passIndex: 1,
+        passKind: "model_call",
+        correlationId: receipts[0]?.correlationId,
+        envelopeOnly: true,
+        decisionEffective: false,
+        outcome: "observed",
+      },
+      {
+        runtimeSurface: "m13_lifecycle_seam_v1",
+        lifecycleSeamVersion: 1,
+        event: "pass_transition_decision",
+        passIndex: 1,
+        passKind: "model_call",
+        correlationId: receipts[0]?.correlationId,
+        envelopeOnly: true,
+        decisionEffective: false,
+        outcome: "noop",
+      },
+    ]);
+  });
+
+  it("threads the observe_only decision mode through the runner without changing behavior", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    const decisions: Array<{ event: string; next: string }> = [];
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      lifecycleDecisionMode: "observe_only",
+      lifecycleSeam: {
+        onPassTransitionDecision: async (event) => {
+          decisions.push({ event: event.event, next: "noop" });
+          return { next: "noop", unsupportedCapabilities: ["decide"] };
+        },
+      },
+    });
+
+    expect(result.meta.error).toBeUndefined();
+    expect(decisions).toEqual([{ event: "pass_transition_decision", next: "noop" }]);
+  });
+
+  it("fails closed on decision events when a seam returns non-noop control", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new Error("plain prompt failure"),
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        lifecycleSeam: {
+          onPassTransitionDecision: vi.fn(async () => ({ next: "halt" as const })),
+        },
+      }),
+    ).rejects.toThrow(/decision mode is observe_only/i);
+  });
+});

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -2,6 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeAttemptResult } from "./pi-embedded-runner/run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverReason,
+  mockedIsFailoverAssistantError,
+  mockedIsRateLimitAssistantError,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -222,6 +225,10 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
   });
 
   it("continues assistant halt transitions in decide mode by retrying the run", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("rate_limit");
+    mockedIsFailoverAssistantError.mockReturnValue(true);
+    mockedIsRateLimitAssistantError.mockReturnValue(true);
+
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(
         makeAttemptResult({

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -188,10 +188,16 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
           onPassTransitionDecision: vi.fn(async () => ({
             next: "halt" as const,
             reason: "operator_requested",
+            annotations: {
+              lane: "pilot",
+              priority: 3,
+            },
           })),
         },
       }),
-    ).rejects.toThrow(/halted prompt transition before surface_error\. \(reason: operator_requested\)/i);
+    ).rejects.toThrow(
+      /halted prompt transition before surface_error\. \(reason: operator_requested, annotations: \{"lane":"pilot","priority":3\}\)/i,
+    );
   });
 
   it("continues prompt transitions in decide mode when the seam returns continue", async () => {

--- a/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts
@@ -191,7 +191,7 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
     ).rejects.toThrow(/halted prompt transition/i);
   });
 
-  it("keeps continue decisions fail-closed in decide mode until live continue wiring exists", async () => {
+  it("continues prompt transitions in decide mode when the seam returns continue", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         promptError: new Error("plain prompt failure"),
@@ -206,6 +206,6 @@ describe("runEmbeddedPiAgent B1 lifecycle seam scaffold", () => {
           onPassTransitionDecision: vi.fn(async () => ({ next: "continue" as const })),
         },
       }),
-    ).rejects.toThrow(/continue transition execution is wired/i);
+    ).rejects.toThrow(/plain prompt failure/i);
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -109,6 +109,7 @@ import {
   resolveRunLivenessState,
 } from "./run/incomplete-turn.js";
 import {
+  createExecutionProfileLifecycleSeam,
   createEmbeddedRunLifecycleBaseEvent,
   createEmbeddedRunLifecycleCorrelationId,
   resolveEmbeddedRunPassTransitionDecision,
@@ -161,6 +162,25 @@ function derivePassEndOutcome(
     return "assistant_retry";
   }
   return "success";
+}
+
+function canContinueAfterPassDispatch(
+  attempt: Pick<
+    EmbeddedRunAttemptResult,
+    | "clientToolCall"
+    | "yieldDetected"
+    | "didSendViaMessagingTool"
+    | "didSendDeterministicApprovalPrompt"
+    | "successfulCronAdds"
+  >,
+): boolean {
+  if (attempt.clientToolCall || attempt.yieldDetected) {
+    return false;
+  }
+  if (attempt.didSendViaMessagingTool || attempt.didSendDeterministicApprovalPrompt) {
+    return false;
+  }
+  return (attempt.successfulCronAdds?.length ?? 0) === 0;
 }
 
 function buildTraceToolSummary(params: {
@@ -335,6 +355,7 @@ export async function runEmbeddedPiAgent(
       });
       provider = hookSelection.provider;
       modelId = hookSelection.modelId;
+      const hookLifecycleControllerPlan = hookSelection.lifecycleControllerPlan;
       const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
 
       const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
@@ -639,9 +660,13 @@ export async function runEmbeddedPiAgent(
         };
         let authRetryPending = false;
         let accumulatedReplayState = createEmbeddedRunReplayState();
-        const lifecycleSeam = params.lifecycleSeam;
+        const lifecycleSeam =
+          params.lifecycleSeam ??
+          (hookLifecycleControllerPlan
+            ? createExecutionProfileLifecycleSeam(hookLifecycleControllerPlan)
+            : undefined);
         const lifecycleDecisionMode: EmbeddedRunLifecycleDecisionMode =
-          params.lifecycleDecisionMode ?? "observe_only";
+          params.lifecycleDecisionMode ?? (hookLifecycleControllerPlan ? "decide" : "observe_only");
         const emitPassStart = async (params2: {
           passIndex: number;
           passKind: EmbeddedRunPassKind;
@@ -2222,6 +2247,32 @@ export async function runEmbeddedPiAgent(
               messagingToolSentTargets: attempt.messagingToolSentTargets,
               successfulCronAdds: attempt.successfulCronAdds,
             };
+          }
+
+          if (canContinueAfterPassDispatch(attempt)) {
+            const passDispatchTransitionDecision = await resolvePassTransitionDecision({
+              passIndex,
+              passKind,
+              correlationId: passCorrelationId,
+              provider,
+              modelId,
+              source: "pass_dispatch",
+              proposedAction: "complete_pass",
+              proposedReason:
+                (sessionLastAssistant?.stopReason as string | undefined) ?? "completed_pass",
+            });
+            throwIfTransitionHalted({
+              decision: passDispatchTransitionDecision,
+              source: "pass_dispatch",
+              proposedAction: "complete_pass",
+            });
+            if (passDispatchTransitionDecision.next === "continue") {
+              log.info(
+                `embedded run lifecycle requested another pass: runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `provider=${provider}/${modelId} passIndex=${passIndex}${formatTransitionDecisionDetails(passDispatchTransitionDecision)}`,
+              );
+              continue;
+            }
           }
 
           log.debug(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -737,11 +737,6 @@ export async function runEmbeddedPiAgent(
               decisionEffective: false,
             },
           });
-          if (decision.next === "continue") {
-            throw new Error(
-              `Embedded run lifecycle seam returned continue before live continue transition execution is wired for ${params2.source}.`,
-            );
-          }
           return decision;
         };
         // Hoisted so the retry-limit error path can use the most recent API total.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -739,6 +739,12 @@ export async function runEmbeddedPiAgent(
           });
           return decision;
         };
+        const formatTransitionDecisionReason = (
+          decision: Awaited<ReturnType<typeof resolvePassTransitionDecision>>,
+        ): string => {
+          const reason = normalizeOptionalString(decision.reason);
+          return reason ? ` (reason: ${reason})` : "";
+        };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
         let lastPassCorrelationId = createEmbeddedRunLifecycleCorrelationId();
@@ -770,7 +776,7 @@ export async function runEmbeddedPiAgent(
             });
             if (retryLimitTransitionDecision.next === "halt") {
               throw new Error(
-                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.`,
+                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.${formatTransitionDecisionReason(retryLimitTransitionDecision)}`,
               );
             }
             return handleRetryLimitExhaustion({
@@ -1584,7 +1590,7 @@ export async function runEmbeddedPiAgent(
             });
             if (promptTransitionDecision.next === "halt") {
               throw new Error(
-                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.`,
+                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.${formatTransitionDecisionReason(promptTransitionDecision)}`,
               );
             }
             // Throw FailoverError for prompt-side failover reasons when fallbacks
@@ -1782,7 +1788,7 @@ export async function runEmbeddedPiAgent(
                   : assistantFailoverOutcome.action === "throw"
                     ? "halt"
                     : "noop"
-              }.`,
+              }.${formatTransitionDecisionReason(assistantTransitionDecision)}`,
             );
           }
           if (assistantFailoverOutcome.action === "retry") {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -739,11 +739,21 @@ export async function runEmbeddedPiAgent(
           });
           return decision;
         };
-        const formatTransitionDecisionReason = (
+        const formatTransitionDecisionDetails = (
           decision: Awaited<ReturnType<typeof resolvePassTransitionDecision>>,
         ): string => {
+          const details: string[] = [];
           const reason = normalizeOptionalString(decision.reason);
-          return reason ? ` (reason: ${reason})` : "";
+          if (reason) {
+            details.push(`reason: ${reason}`);
+          }
+          if (decision.annotations && Object.keys(decision.annotations).length > 0) {
+            const sortedAnnotations = Object.fromEntries(
+              Object.entries(decision.annotations).sort(([a], [b]) => a.localeCompare(b)),
+            );
+            details.push(`annotations: ${JSON.stringify(sortedAnnotations)}`);
+          }
+          return details.length > 0 ? ` (${details.join(", ")})` : "";
         };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
@@ -776,7 +786,7 @@ export async function runEmbeddedPiAgent(
             });
             if (retryLimitTransitionDecision.next === "halt") {
               throw new Error(
-                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.${formatTransitionDecisionReason(retryLimitTransitionDecision)}`,
+                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.${formatTransitionDecisionDetails(retryLimitTransitionDecision)}`,
               );
             }
             return handleRetryLimitExhaustion({
@@ -1590,7 +1600,7 @@ export async function runEmbeddedPiAgent(
             });
             if (promptTransitionDecision.next === "halt") {
               throw new Error(
-                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.${formatTransitionDecisionReason(promptTransitionDecision)}`,
+                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.${formatTransitionDecisionDetails(promptTransitionDecision)}`,
               );
             }
             // Throw FailoverError for prompt-side failover reasons when fallbacks
@@ -1788,7 +1798,7 @@ export async function runEmbeddedPiAgent(
                   : assistantFailoverOutcome.action === "throw"
                     ? "halt"
                     : "noop"
-              }.${formatTransitionDecisionReason(assistantTransitionDecision)}`,
+              }.${formatTransitionDecisionDetails(assistantTransitionDecision)}`,
             );
           }
           if (assistantFailoverOutcome.action === "retry") {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -737,11 +737,12 @@ export async function runEmbeddedPiAgent(
               decisionEffective: false,
             },
           });
-          if (decision.next !== "noop") {
+          if (decision.next === "continue") {
             throw new Error(
-              `Embedded run lifecycle seam returned ${decision.next} before transition execution is wired for ${params2.source}.`,
+              `Embedded run lifecycle seam returned continue before live continue transition execution is wired for ${params2.source}.`,
             );
           }
+          return decision;
         };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
@@ -761,7 +762,7 @@ export async function runEmbeddedPiAgent(
               fallbackConfigured,
               failoverReason: lastRetryFailoverReason,
             });
-            await resolvePassTransitionDecision({
+            const retryLimitTransitionDecision = await resolvePassTransitionDecision({
               passIndex: runLoopIterations,
               passKind: "model_call",
               correlationId: lastPassCorrelationId,
@@ -772,6 +773,11 @@ export async function runEmbeddedPiAgent(
               proposedReason:
                 "reason" in retryLimitDecision ? retryLimitDecision.reason : undefined,
             });
+            if (retryLimitTransitionDecision.next === "halt") {
+              throw new Error(
+                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.`,
+              );
+            }
             return handleRetryLimitExhaustion({
               message,
               decision: retryLimitDecision,
@@ -1570,7 +1576,7 @@ export async function runEmbeddedPiAgent(
               thinkLevel = fallbackThinking;
               continue;
             }
-            await resolvePassTransitionDecision({
+            const promptTransitionDecision = await resolvePassTransitionDecision({
               passIndex,
               passKind,
               correlationId: passCorrelationId,
@@ -1581,6 +1587,11 @@ export async function runEmbeddedPiAgent(
               proposedReason:
                 "reason" in promptFailoverDecision ? promptFailoverDecision.reason : undefined,
             });
+            if (promptTransitionDecision.next === "halt") {
+              throw new Error(
+                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.`,
+              );
+            }
             // Throw FailoverError for prompt-side failover reasons when fallbacks
             // are configured so outer model fallback can continue on overload,
             // rate-limit, auth, or billing failures.
@@ -1749,7 +1760,7 @@ export async function runEmbeddedPiAgent(
             advanceAuthProfile,
           });
           overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
-          await resolvePassTransitionDecision({
+          const assistantTransitionDecision = await resolvePassTransitionDecision({
             passIndex,
             passKind,
             correlationId: passCorrelationId,
@@ -1768,6 +1779,17 @@ export async function runEmbeddedPiAgent(
                 ? assistantFailoverReason
                 : undefined,
           });
+          if (assistantTransitionDecision.next === "halt") {
+            throw new Error(
+              `Embedded run lifecycle seam halted assistant transition before ${
+                assistantFailoverOutcome.action === "retry"
+                  ? "continue"
+                  : assistantFailoverOutcome.action === "throw"
+                    ? "halt"
+                    : "noop"
+              }.`,
+            );
+          }
           if (assistantFailoverOutcome.action === "retry") {
             traceAttempts.push({
               provider: activeErrorContext.provider,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -749,7 +749,7 @@ export async function runEmbeddedPiAgent(
           }
           if (decision.annotations && Object.keys(decision.annotations).length > 0) {
             const sortedAnnotations = Object.fromEntries(
-              Object.entries(decision.annotations).sort(([a], [b]) => a.localeCompare(b)),
+              Object.entries(decision.annotations).toSorted(([a], [b]) => a.localeCompare(b)),
             );
             details.push(`annotations: ${JSON.stringify(sortedAnnotations)}`);
           }
@@ -1796,6 +1796,16 @@ export async function runEmbeddedPiAgent(
             advanceAuthProfile,
           });
           overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
+          const assistantTransitionProposedAction =
+            assistantFailoverOutcome.action === "retry"
+              ? "continue"
+              : assistantFailoverOutcome.action === "throw"
+                ? assistantFailoverDecision.action === "fallback_model"
+                  ? "fallback_model"
+                  : "surface_error"
+                : assistantForFailover?.stopReason === "error"
+                  ? "surface_error"
+                  : "noop";
           const assistantTransitionDecision = await resolvePassTransitionDecision({
             passIndex,
             passKind,
@@ -1803,31 +1813,18 @@ export async function runEmbeddedPiAgent(
             provider,
             modelId,
             source: "assistant",
-            proposedAction:
-              assistantFailoverOutcome.action === "retry"
-                ? "continue"
-                : assistantFailoverOutcome.action === "throw"
-                  ? "halt"
-                  : "noop",
+            proposedAction: assistantTransitionProposedAction,
             proposedReason:
-              assistantFailoverOutcome.action === "retry" ||
-              assistantFailoverOutcome.action === "throw"
-                ? assistantFailoverReason
-                : undefined,
+              assistantTransitionProposedAction !== "noop" ? assistantFailoverReason : undefined,
           });
           throwIfTransitionHalted({
             decision: assistantTransitionDecision,
             source: "assistant",
-            proposedAction:
-              assistantFailoverOutcome.action === "retry"
-                ? "continue"
-                : assistantFailoverOutcome.action === "throw"
-                  ? "halt"
-                  : "noop",
+            proposedAction: assistantTransitionProposedAction,
           });
           if (
             assistantTransitionDecision.next === "continue" &&
-            assistantFailoverOutcome.action === "throw"
+            assistantTransitionProposedAction !== "noop"
           ) {
             await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
             continue;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -755,6 +755,18 @@ export async function runEmbeddedPiAgent(
           }
           return details.length > 0 ? ` (${details.join(", ")})` : "";
         };
+        const throwIfTransitionHalted = (params2: {
+          decision: Awaited<ReturnType<typeof resolvePassTransitionDecision>>;
+          source: EmbeddedRunTransitionSource;
+          proposedAction: string;
+        }) => {
+          if (params2.decision.next !== "halt") {
+            return;
+          }
+          throw new Error(
+            `Embedded run lifecycle seam halted ${params2.source} transition before ${params2.proposedAction}.${formatTransitionDecisionDetails(params2.decision)}`,
+          );
+        };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
         let lastPassCorrelationId = createEmbeddedRunLifecycleCorrelationId();
@@ -784,10 +796,14 @@ export async function runEmbeddedPiAgent(
               proposedReason:
                 "reason" in retryLimitDecision ? retryLimitDecision.reason : undefined,
             });
-            if (retryLimitTransitionDecision.next === "halt") {
-              throw new Error(
-                `Embedded run lifecycle seam halted retry_limit transition before ${retryLimitDecision.action}.${formatTransitionDecisionDetails(retryLimitTransitionDecision)}`,
-              );
+            throwIfTransitionHalted({
+              decision: retryLimitTransitionDecision,
+              source: "retry_limit",
+              proposedAction: retryLimitDecision.action,
+            });
+            if (retryLimitTransitionDecision.next === "continue") {
+              runLoopIterations = Math.max(0, runLoopIterations - 1);
+              continue;
             }
             return handleRetryLimitExhaustion({
               message,
@@ -1552,7 +1568,7 @@ export async function runEmbeddedPiAgent(
                 failoverReason: promptFailoverReason,
               });
               logPromptFailoverDecision("rotate_profile");
-              await resolvePassTransitionDecision({
+              const promptRotateTransitionDecision = await resolvePassTransitionDecision({
                 passIndex,
                 passKind,
                 correlationId: passCorrelationId,
@@ -1561,6 +1577,11 @@ export async function runEmbeddedPiAgent(
                 source: "prompt",
                 proposedAction: "rotate_profile",
                 proposedReason: promptFailoverReason,
+              });
+              throwIfTransitionHalted({
+                decision: promptRotateTransitionDecision,
+                source: "prompt",
+                proposedAction: "rotate_profile",
               });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
@@ -1598,10 +1619,14 @@ export async function runEmbeddedPiAgent(
               proposedReason:
                 "reason" in promptFailoverDecision ? promptFailoverDecision.reason : undefined,
             });
-            if (promptTransitionDecision.next === "halt") {
-              throw new Error(
-                `Embedded run lifecycle seam halted prompt transition before ${promptFailoverDecision.action}.${formatTransitionDecisionDetails(promptTransitionDecision)}`,
-              );
+            throwIfTransitionHalted({
+              decision: promptTransitionDecision,
+              source: "prompt",
+              proposedAction: promptFailoverDecision.action,
+            });
+            if (promptTransitionDecision.next === "continue") {
+              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+              continue;
             }
             // Throw FailoverError for prompt-side failover reasons when fallbacks
             // are configured so outer model fallback can continue on overload,
@@ -1790,16 +1815,22 @@ export async function runEmbeddedPiAgent(
                 ? assistantFailoverReason
                 : undefined,
           });
-          if (assistantTransitionDecision.next === "halt") {
-            throw new Error(
-              `Embedded run lifecycle seam halted assistant transition before ${
-                assistantFailoverOutcome.action === "retry"
-                  ? "continue"
-                  : assistantFailoverOutcome.action === "throw"
-                    ? "halt"
-                    : "noop"
-              }.${formatTransitionDecisionDetails(assistantTransitionDecision)}`,
-            );
+          throwIfTransitionHalted({
+            decision: assistantTransitionDecision,
+            source: "assistant",
+            proposedAction:
+              assistantFailoverOutcome.action === "retry"
+                ? "continue"
+                : assistantFailoverOutcome.action === "throw"
+                  ? "halt"
+                  : "noop",
+          });
+          if (
+            assistantTransitionDecision.next === "continue" &&
+            assistantFailoverOutcome.action === "throw"
+          ) {
+            await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
+            continue;
           }
           if (assistantFailoverOutcome.action === "retry") {
             traceAttempts.push({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -108,11 +108,21 @@ import {
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
 } from "./run/incomplete-turn.js";
+import {
+  createEmbeddedRunLifecycleBaseEvent,
+  createEmbeddedRunLifecycleCorrelationId,
+  resolveEmbeddedRunPassTransitionDecision,
+  type EmbeddedRunLifecycleDecisionMode,
+  type EmbeddedRunPassEndEvent,
+  type EmbeddedRunPassKind,
+  type EmbeddedRunTransitionSource,
+} from "./run/lifecycle-seam.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
 import { mergeAttemptToolMediaPayloads } from "./run/tool-media-payloads.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
 import {
   resolveLiveToolResultMaxChars,
   sessionLikelyHasOversizedToolResults,
@@ -130,6 +140,21 @@ import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accum
 type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
+
+function derivePassEndOutcome(
+  attempt: Pick<EmbeddedRunAttemptResult, "promptError" | "timedOut" | "aborted">,
+): EmbeddedRunPassEndEvent["outcome"] {
+  if (attempt.timedOut) {
+    return "timed_out";
+  }
+  if (attempt.aborted) {
+    return "aborted";
+  }
+  if (attempt.promptError) {
+    return "prompt_error";
+  }
+  return "success";
+}
 
 function buildTraceToolSummary(params: {
   toolMetas: Array<{ toolName: string; meta?: string }>;
@@ -607,8 +632,108 @@ export async function runEmbeddedPiAgent(
         };
         let authRetryPending = false;
         let accumulatedReplayState = createEmbeddedRunReplayState();
+        const lifecycleSeam = params.lifecycleSeam;
+        const lifecycleDecisionMode: EmbeddedRunLifecycleDecisionMode =
+          params.lifecycleDecisionMode ?? "observe_only";
+        const emitPassStart = async (params2: {
+          passIndex: number;
+          passKind: EmbeddedRunPassKind;
+          correlationId: string;
+          provider: string;
+          modelId: string;
+        }) => {
+          if (!lifecycleSeam?.onPassStart) {
+            return;
+          }
+          try {
+            await lifecycleSeam.onPassStart({
+              ...createEmbeddedRunLifecycleBaseEvent({
+                runId: params.runId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                agentId: workspaceResolution.agentId,
+                provider: params2.provider,
+                modelId: params2.modelId,
+                passIndex: params2.passIndex,
+                passKind: params2.passKind,
+                correlationId: params2.correlationId,
+              }),
+              event: "pass_start",
+            });
+          } catch (hookErr) {
+            log.warn(`pass_start lifecycle seam failed: ${formatErrorMessage(hookErr)}`);
+          }
+        };
+        const emitPassEnd = async (params2: {
+          passIndex: number;
+          passKind: EmbeddedRunPassKind;
+          correlationId: string;
+          provider: string;
+          modelId: string;
+          outcome: EmbeddedRunPassEndEvent["outcome"];
+          stopReason?: string;
+        }) => {
+          if (!lifecycleSeam?.onPassEnd) {
+            return;
+          }
+          try {
+            await lifecycleSeam.onPassEnd({
+              ...createEmbeddedRunLifecycleBaseEvent({
+                runId: params.runId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                agentId: workspaceResolution.agentId,
+                provider: params2.provider,
+                modelId: params2.modelId,
+                passIndex: params2.passIndex,
+                passKind: params2.passKind,
+                correlationId: params2.correlationId,
+              }),
+              event: "pass_end",
+              outcome: params2.outcome,
+              ...(params2.stopReason ? { stopReason: params2.stopReason } : {}),
+            });
+          } catch (hookErr) {
+            log.warn(`pass_end lifecycle seam failed: ${formatErrorMessage(hookErr)}`);
+          }
+        };
+        const resolvePassTransitionDecision = async (params2: {
+          passIndex: number;
+          passKind: EmbeddedRunPassKind;
+          correlationId: string;
+          provider: string;
+          modelId: string;
+          source: EmbeddedRunTransitionSource;
+          proposedAction: string;
+          proposedReason?: string | null;
+        }) => {
+          return resolveEmbeddedRunPassTransitionDecision({
+            seam: lifecycleSeam,
+            decisionMode: lifecycleDecisionMode,
+            event: {
+              ...createEmbeddedRunLifecycleBaseEvent({
+                runId: params.runId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                agentId: workspaceResolution.agentId,
+                provider: params2.provider,
+                modelId: params2.modelId,
+                passIndex: params2.passIndex,
+                passKind: params2.passKind,
+                correlationId: params2.correlationId,
+              }),
+              event: "pass_transition_decision",
+              source: params2.source,
+              proposedAction: params2.proposedAction,
+              proposedReason: params2.proposedReason,
+              envelopeOnly: true,
+              decisionEffective: false,
+            },
+          });
+        };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;
+        let lastPassCorrelationId = createEmbeddedRunLifecycleCorrelationId();
         while (true) {
           if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
             const message =
@@ -623,6 +748,17 @@ export async function runEmbeddedPiAgent(
               stage: "retry_limit",
               fallbackConfigured,
               failoverReason: lastRetryFailoverReason,
+            });
+            await resolvePassTransitionDecision({
+              passIndex: runLoopIterations,
+              passKind: "model_call",
+              correlationId: lastPassCorrelationId,
+              provider,
+              modelId,
+              source: "retry_limit",
+              proposedAction: retryLimitDecision.action,
+              proposedReason:
+                "reason" in retryLimitDecision ? retryLimitDecision.reason : undefined,
             });
             return handleRetryLimitExhaustion({
               message,
@@ -644,6 +780,10 @@ export async function runEmbeddedPiAgent(
             });
           }
           runLoopIterations += 1;
+          const passIndex = runLoopIterations;
+          const passKind: EmbeddedRunPassKind = "model_call";
+          const passCorrelationId = createEmbeddedRunLifecycleCorrelationId();
+          lastPassCorrelationId = passCorrelationId;
           const runtimeAuthRetry = authRetryPending;
           authRetryPending = false;
           attemptedThinking.add(thinkLevel);
@@ -667,6 +807,14 @@ export async function runEmbeddedPiAgent(
           if (!runtimeAuthState && apiKeyInfo) {
             resolvedStreamApiKey = (apiKeyInfo as ApiKeyInfo).apiKey;
           }
+
+          await emitPassStart({
+            passIndex,
+            passKind,
+            correlationId: passCorrelationId,
+            provider,
+            modelId,
+          });
 
           const attempt = await runEmbeddedAttemptWithBackend({
             sessionId: params.sessionId,
@@ -762,6 +910,16 @@ export async function runEmbeddedPiAgent(
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
+          });
+
+          await emitPassEnd({
+            passIndex,
+            passKind,
+            correlationId: passCorrelationId,
+            provider,
+            modelId,
+            outcome: derivePassEndOutcome(attempt),
+            stopReason: attempt.lastAssistant?.stopReason,
           });
 
           const {
@@ -1365,6 +1523,16 @@ export async function runEmbeddedPiAgent(
                 failoverReason: promptFailoverReason,
               });
               logPromptFailoverDecision("rotate_profile");
+              await resolvePassTransitionDecision({
+                passIndex,
+                passKind,
+                correlationId: passCorrelationId,
+                provider,
+                modelId,
+                source: "prompt",
+                proposedAction: "rotate_profile",
+                proposedReason: promptFailoverReason,
+              });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
             }
@@ -1390,6 +1558,17 @@ export async function runEmbeddedPiAgent(
               thinkLevel = fallbackThinking;
               continue;
             }
+            await resolvePassTransitionDecision({
+              passIndex,
+              passKind,
+              correlationId: passCorrelationId,
+              provider,
+              modelId,
+              source: "prompt",
+              proposedAction: promptFailoverDecision.action,
+              proposedReason:
+                "reason" in promptFailoverDecision ? promptFailoverDecision.reason : undefined,
+            });
             // Throw FailoverError for prompt-side failover reasons when fallbacks
             // are configured so outer model fallback can continue on overload,
             // rate-limit, auth, or billing failures.
@@ -1558,6 +1737,25 @@ export async function runEmbeddedPiAgent(
             advanceAuthProfile,
           });
           overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
+          await resolvePassTransitionDecision({
+            passIndex,
+            passKind,
+            correlationId: passCorrelationId,
+            provider,
+            modelId,
+            source: "assistant",
+            proposedAction:
+              assistantFailoverOutcome.action === "retry"
+                ? "continue"
+                : assistantFailoverOutcome.action === "throw"
+                  ? "halt"
+                  : "noop",
+            proposedReason:
+              assistantFailoverOutcome.action === "retry" ||
+              assistantFailoverOutcome.action === "throw"
+                ? assistantFailoverReason
+                : undefined,
+          });
           if (assistantFailoverOutcome.action === "retry") {
             traceAttempts.push({
               provider: activeErrorContext.provider,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -142,7 +142,10 @@ type ApiKeyInfo = ResolvedProviderAuth;
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 
 function derivePassEndOutcome(
-  attempt: Pick<EmbeddedRunAttemptResult, "promptError" | "timedOut" | "aborted">,
+  attempt: Pick<
+    EmbeddedRunAttemptResult,
+    "promptError" | "timedOut" | "aborted" | "currentAttemptAssistant" | "lastAssistant"
+  >,
 ): EmbeddedRunPassEndEvent["outcome"] {
   if (attempt.timedOut) {
     return "timed_out";
@@ -152,6 +155,10 @@ function derivePassEndOutcome(
   }
   if (attempt.promptError) {
     return "prompt_error";
+  }
+  const assistant = attempt.currentAttemptAssistant ?? attempt.lastAssistant;
+  if (assistant?.stopReason === "error") {
+    return "assistant_retry";
   }
   return "success";
 }
@@ -707,7 +714,7 @@ export async function runEmbeddedPiAgent(
           proposedAction: string;
           proposedReason?: string | null;
         }) => {
-          return resolveEmbeddedRunPassTransitionDecision({
+          const decision = await resolveEmbeddedRunPassTransitionDecision({
             seam: lifecycleSeam,
             decisionMode: lifecycleDecisionMode,
             event: {
@@ -730,6 +737,11 @@ export async function runEmbeddedPiAgent(
               decisionEffective: false,
             },
           });
+          if (decision.next !== "noop") {
+            throw new Error(
+              `Embedded run lifecycle seam returned ${decision.next} before transition execution is wired for ${params2.source}.`,
+            );
+          }
         };
         // Hoisted so the retry-limit error path can use the most recent API total.
         let lastTurnTotal: number | undefined;

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
@@ -220,6 +220,37 @@ describe("embedded run lifecycle seam", () => {
     ).resolves.toEqual({ next: "halt", reason: "operator_requested" });
   });
 
+  it("allows continue decisions through in decide mode", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        seam: {
+          onPassTransitionDecision: async () => ({
+            next: "continue",
+            reason: "retry_allowed",
+          }),
+        },
+        decisionMode: "decide",
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "continue",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).resolves.toEqual({ next: "continue", reason: "retry_allowed" });
+  });
+
   it("fails closed when scaffold-only mode receives a non-noop decision", async () => {
     const onPassTransitionDecision = vi.fn(async () => ({ next: "halt" as const }));
 

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
@@ -189,6 +189,37 @@ describe("embedded run lifecycle seam", () => {
     ).rejects.toThrow(/decision mode is observe_only/i);
   });
 
+  it("allows halt decisions through in decide mode", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        seam: {
+          onPassTransitionDecision: async () => ({
+            next: "halt",
+            reason: "operator_requested",
+          }),
+        },
+        decisionMode: "decide",
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "halt",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).resolves.toEqual({ next: "halt", reason: "operator_requested" });
+  });
+
   it("fails closed when scaffold-only mode receives a non-noop decision", async () => {
     const onPassTransitionDecision = vi.fn(async () => ({ next: "halt" as const }));
 

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
@@ -77,6 +77,47 @@ describe("embedded run lifecycle seam", () => {
     });
   });
 
+  it("allows live-effective decision receipts to declare non-envelope execution", () => {
+    expect(
+      buildEmbeddedRunLifecycleReceipt({
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 3,
+            passKind: "model_call",
+            correlationId: "corr-3",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "continue",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+        outcome: "observed",
+        reason: "operator_override",
+        annotations: { lane: "live", retriesGranted: 1 },
+        envelopeOnly: false,
+        decisionEffective: true,
+      }),
+    ).toEqual({
+      runtimeSurface: EMBEDDED_RUN_LIFECYCLE_SURFACE,
+      lifecycleSeamVersion: EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION,
+      event: "pass_transition_decision",
+      passIndex: 3,
+      passKind: "model_call",
+      correlationId: "corr-3",
+      envelopeOnly: false,
+      decisionEffective: true,
+      outcome: "observed",
+      reason: "operator_override",
+      annotations: { lane: "live", retriesGranted: 1 },
+    });
+  });
+
   it("defaults transition decisions to noop when no seam is installed", async () => {
     await expect(
       resolveEmbeddedRunPassTransitionDecision({

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
@@ -101,6 +101,31 @@ describe("embedded run lifecycle seam", () => {
     ).resolves.toEqual({ next: "noop" });
   });
 
+  it("rejects unsupported decision modes even when no seam decision is returned", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        decisionMode: "ship_it" as never,
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "prompt",
+          proposedAction: "surface_error",
+          proposedReason: null,
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).rejects.toThrow(/unsupported decision mode/i);
+  });
+
   it("freezes decision mode and next enums", () => {
     expect(EMBEDDED_RUN_LIFECYCLE_DECISION_MODES).toEqual(["observe_only", "decide"]);
     expect(EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES).toEqual(["noop", "continue", "halt"]);

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  EMBEDDED_RUN_LIFECYCLE_DECISION_MODES,
+  EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES,
+  EMBEDDED_RUN_LIFECYCLE_SURFACE,
+  EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION,
+  buildEmbeddedRunLifecycleReceipt,
+  createEmbeddedRunLifecycleBaseEvent,
+  resolveEmbeddedRunPassTransitionDecision,
+} from "./lifecycle-seam.js";
+
+describe("embedded run lifecycle seam", () => {
+  it("builds a stable B1 lifecycle base event envelope", () => {
+    expect(
+      createEmbeddedRunLifecycleBaseEvent({
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "key-1",
+        agentId: "main",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        passIndex: 1,
+        passKind: "model_call",
+        correlationId: "corr-1",
+      }),
+    ).toEqual({
+      runtimeSurface: EMBEDDED_RUN_LIFECYCLE_SURFACE,
+      lifecycleSeamVersion: EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION,
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "key-1",
+      agentId: "main",
+      provider: "openai",
+      modelId: "gpt-5.4",
+      passIndex: 1,
+      passKind: "model_call",
+      correlationId: "corr-1",
+    });
+  });
+
+  it("builds a stable lifecycle receipt envelope", () => {
+    expect(
+      buildEmbeddedRunLifecycleReceipt({
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 2,
+            passKind: "model_call",
+            correlationId: "corr-2",
+          }),
+          event: "pass_transition_decision",
+          source: "prompt",
+          proposedAction: "surface_error",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+        outcome: "noop",
+        reason: "rate_limit",
+        annotations: { lane: "observe_only" },
+      }),
+    ).toEqual({
+      runtimeSurface: EMBEDDED_RUN_LIFECYCLE_SURFACE,
+      lifecycleSeamVersion: EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION,
+      event: "pass_transition_decision",
+      passIndex: 2,
+      passKind: "model_call",
+      correlationId: "corr-2",
+      envelopeOnly: true,
+      decisionEffective: false,
+      outcome: "noop",
+      reason: "rate_limit",
+      annotations: { lane: "observe_only" },
+    });
+  });
+
+  it("defaults transition decisions to noop when no seam is installed", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "prompt",
+          proposedAction: "surface_error",
+          proposedReason: null,
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).resolves.toEqual({ next: "noop" });
+  });
+
+  it("freezes decision mode and next enums", () => {
+    expect(EMBEDDED_RUN_LIFECYCLE_DECISION_MODES).toEqual(["observe_only", "decide"]);
+    expect(EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES).toEqual(["noop", "continue", "halt"]);
+  });
+
+  it("rejects malformed decision payloads", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        seam: {
+          onPassTransitionDecision: async () => ({ next: 123 }) as unknown as { next: "noop" },
+        },
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "halt",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).resolves.toEqual({ next: "noop", unsupportedCapabilities: ["invalid_next:123"] });
+  });
+
+  it("keeps non-noop decisions fail-closed in observe_only mode", async () => {
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        seam: {
+          onPassTransitionDecision: async () => ({
+            next: "continue",
+            unsupportedCapabilities: ["decide"],
+          }),
+        },
+        decisionMode: "observe_only",
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "continue",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).rejects.toThrow(/decision mode is observe_only/i);
+  });
+
+  it("fails closed when scaffold-only mode receives a non-noop decision", async () => {
+    const onPassTransitionDecision = vi.fn(async () => ({ next: "halt" as const }));
+
+    await expect(
+      resolveEmbeddedRunPassTransitionDecision({
+        seam: { onPassTransitionDecision },
+        event: {
+          ...createEmbeddedRunLifecycleBaseEvent({
+            runId: "run-1",
+            sessionId: "session-1",
+            provider: "openai",
+            modelId: "gpt-5.4",
+            passIndex: 1,
+            passKind: "model_call",
+            correlationId: "corr-1",
+          }),
+          event: "pass_transition_decision",
+          source: "assistant",
+          proposedAction: "halt",
+          proposedReason: "rate_limit",
+          envelopeOnly: true,
+          decisionEffective: false,
+        },
+      }),
+    ).rejects.toThrow(/decision mode is observe_only/i);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
@@ -6,7 +6,18 @@ export const EMBEDDED_RUN_LIFECYCLE_SURFACE = "m13_lifecycle_seam_v1" as const;
 export const EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION = 1 as const;
 
 export type EmbeddedRunPassKind = "model_call" | "tool_round" | "compaction";
-export type EmbeddedRunTransitionSource = "retry_limit" | "prompt" | "assistant";
+export type EmbeddedRunTransitionSource = "retry_limit" | "prompt" | "assistant" | "pass_dispatch";
+
+export type EmbeddedRunLifecycleControllerProfile =
+  | "single-pass"
+  | "double-pass"
+  | "verifier-heavy";
+
+export type EmbeddedRunLifecycleControllerPlan = {
+  requestedProfile: EmbeddedRunLifecycleControllerProfile;
+  plannedMaxPasses: number;
+  controllerLabel?: string;
+};
 
 export const EMBEDDED_RUN_LIFECYCLE_DECISION_MODES = ["observe_only", "decide"] as const;
 export type EmbeddedRunLifecycleDecisionMode =
@@ -84,6 +95,41 @@ export type EmbeddedRunLifecycleSeam = {
     | void
     | Promise<EmbeddedRunLifecycleDecisionResult | void>;
 };
+
+export function createExecutionProfileLifecycleSeam(
+  plan: EmbeddedRunLifecycleControllerPlan,
+): EmbeddedRunLifecycleSeam {
+  const normalizedPassCount = Number.isFinite(plan.plannedMaxPasses)
+    ? Math.trunc(plan.plannedMaxPasses)
+    : 1;
+  const maxPasses = Math.max(1, normalizedPassCount);
+  return {
+    async onPassTransitionDecision(event) {
+      if (event.source !== "pass_dispatch") {
+        return { next: "noop" };
+      }
+      if (event.passIndex >= maxPasses) {
+        return {
+          next: "noop",
+          annotations: {
+            requestedProfile: plan.requestedProfile,
+            plannedMaxPasses: maxPasses,
+            controllerLabel: plan.controllerLabel ?? "policy_bound_lifecycle_bridge",
+          },
+        };
+      }
+      return {
+        next: "continue",
+        reason: `execution_profile:${plan.requestedProfile}`,
+        annotations: {
+          requestedProfile: plan.requestedProfile,
+          plannedMaxPasses: maxPasses,
+          controllerLabel: plan.controllerLabel ?? "policy_bound_lifecycle_bridge",
+        },
+      };
+    },
+  };
+}
 
 export function createEmbeddedRunLifecycleCorrelationId(): string {
   return randomBytes(8).toString("hex");

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
 
+// `m13` is intentional: the persisted receipt surface was first spec'd in M13,
+// and M14 is landing the implementation without renaming stored envelope ids.
 export const EMBEDDED_RUN_LIFECYCLE_SURFACE = "m13_lifecycle_seam_v1" as const;
 export const EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION = 1 as const;
 
@@ -201,17 +203,17 @@ export async function resolveEmbeddedRunPassTransitionDecision(params: {
   event: EmbeddedRunPassTransitionDecisionEvent;
   decisionMode?: EmbeddedRunLifecycleDecisionMode;
 }): Promise<EmbeddedRunLifecycleDecisionResult> {
-  const result = normalizeEmbeddedRunLifecycleDecisionResult(
-    await params.seam?.onPassTransitionDecision?.(params.event),
-  );
-  if (!result) {
-    return { next: "noop" };
-  }
   const decisionMode = params.decisionMode ?? "observe_only";
   if (!EMBEDDED_RUN_LIFECYCLE_DECISION_MODES.includes(decisionMode)) {
     throw new Error(
       `Embedded run lifecycle seam received unsupported decision mode (${decisionMode}).`,
     );
+  }
+  const result = normalizeEmbeddedRunLifecycleDecisionResult(
+    await params.seam?.onPassTransitionDecision?.(params.event),
+  );
+  if (!result) {
+    return { next: "noop" };
   }
   if (decisionMode !== "decide" && result.next !== "noop") {
     throw new Error(

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
@@ -1,0 +1,222 @@
+import { randomBytes } from "node:crypto";
+
+export const EMBEDDED_RUN_LIFECYCLE_SURFACE = "m13_lifecycle_seam_v1" as const;
+export const EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION = 1 as const;
+
+export type EmbeddedRunPassKind = "model_call" | "tool_round" | "compaction";
+export type EmbeddedRunTransitionSource = "retry_limit" | "prompt" | "assistant";
+
+export const EMBEDDED_RUN_LIFECYCLE_DECISION_MODES = ["observe_only", "decide"] as const;
+export type EmbeddedRunLifecycleDecisionMode =
+  (typeof EMBEDDED_RUN_LIFECYCLE_DECISION_MODES)[number];
+
+export const EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES = ["noop", "continue", "halt"] as const;
+export type EmbeddedRunLifecycleDecisionNext =
+  (typeof EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES)[number];
+
+export type EmbeddedRunLifecycleBaseEvent = {
+  runtimeSurface: typeof EMBEDDED_RUN_LIFECYCLE_SURFACE;
+  lifecycleSeamVersion: typeof EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION;
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  provider: string;
+  modelId: string;
+  passIndex: number;
+  passKind: EmbeddedRunPassKind;
+  correlationId: string;
+};
+
+export type EmbeddedRunPassStartEvent = EmbeddedRunLifecycleBaseEvent & {
+  event: "pass_start";
+};
+
+export type EmbeddedRunPassEndEvent = EmbeddedRunLifecycleBaseEvent & {
+  event: "pass_end";
+  outcome: "success" | "prompt_error" | "assistant_retry" | "aborted" | "timed_out";
+  stopReason?: string;
+};
+
+export type EmbeddedRunPassTransitionDecisionEvent = EmbeddedRunLifecycleBaseEvent & {
+  event: "pass_transition_decision";
+  source: EmbeddedRunTransitionSource;
+  proposedAction: string;
+  proposedReason?: string | null;
+  envelopeOnly: true;
+  decisionEffective: false;
+};
+
+export type EmbeddedRunLifecycleReceipt = {
+  runtimeSurface: typeof EMBEDDED_RUN_LIFECYCLE_SURFACE;
+  lifecycleSeamVersion: typeof EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION;
+  event:
+    | EmbeddedRunPassStartEvent["event"]
+    | EmbeddedRunPassEndEvent["event"]
+    | EmbeddedRunPassTransitionDecisionEvent["event"];
+  passIndex: number;
+  passKind: EmbeddedRunPassKind;
+  correlationId: string;
+  envelopeOnly: true;
+  decisionEffective: false;
+  outcome: "observed" | "noop" | "error";
+  reason?: string;
+  unsupportedCapabilities?: string[];
+  annotations?: Record<string, unknown>;
+};
+
+export type EmbeddedRunLifecycleDecisionResult = {
+  next: EmbeddedRunLifecycleDecisionNext;
+  reason?: string;
+  unsupportedCapabilities?: string[];
+  annotations?: Record<string, unknown>;
+};
+
+export type EmbeddedRunLifecycleSeam = {
+  onPassStart?: (event: EmbeddedRunPassStartEvent) => void | Promise<void>;
+  onPassEnd?: (event: EmbeddedRunPassEndEvent) => void | Promise<void>;
+  onPassTransitionDecision?: (
+    event: EmbeddedRunPassTransitionDecisionEvent,
+  ) =>
+    | EmbeddedRunLifecycleDecisionResult
+    | void
+    | Promise<EmbeddedRunLifecycleDecisionResult | void>;
+};
+
+export function createEmbeddedRunLifecycleCorrelationId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export function createEmbeddedRunLifecycleBaseEvent(params: {
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  provider: string;
+  modelId: string;
+  passIndex: number;
+  passKind: EmbeddedRunPassKind;
+  correlationId?: string;
+}): EmbeddedRunLifecycleBaseEvent {
+  return {
+    runtimeSurface: EMBEDDED_RUN_LIFECYCLE_SURFACE,
+    lifecycleSeamVersion: EMBEDDED_RUN_LIFECYCLE_SEAM_VERSION,
+    runId: params.runId,
+    sessionId: params.sessionId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    provider: params.provider,
+    modelId: params.modelId,
+    passIndex: params.passIndex,
+    passKind: params.passKind,
+    correlationId: params.correlationId ?? createEmbeddedRunLifecycleCorrelationId(),
+  };
+}
+
+/**
+ * M14-A stable receipt envelope.
+ * Observe events are fail-open at call sites and always remain envelope-only.
+ * Decision events stay fail-closed in scaffold-only mode and must not become
+ * decision-effective until a later gated slice explicitly enables that path.
+ */
+export function buildEmbeddedRunLifecycleReceipt(params: {
+  event:
+    | EmbeddedRunPassStartEvent
+    | EmbeddedRunPassEndEvent
+    | EmbeddedRunPassTransitionDecisionEvent;
+  outcome: EmbeddedRunLifecycleReceipt["outcome"];
+  reason?: string;
+  annotations?: Record<string, unknown>;
+  unsupportedCapabilities?: string[];
+}): EmbeddedRunLifecycleReceipt {
+  return {
+    runtimeSurface: params.event.runtimeSurface,
+    lifecycleSeamVersion: params.event.lifecycleSeamVersion,
+    event: params.event.event,
+    passIndex: params.event.passIndex,
+    passKind: params.event.passKind,
+    correlationId: params.event.correlationId,
+    envelopeOnly: true,
+    decisionEffective: false,
+    outcome: params.outcome,
+    ...(params.reason ? { reason: params.reason } : {}),
+    ...(params.unsupportedCapabilities
+      ? { unsupportedCapabilities: params.unsupportedCapabilities }
+      : {}),
+    ...(params.annotations ? { annotations: params.annotations } : {}),
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeEmbeddedRunLifecycleDecisionResult(
+  value: unknown,
+): EmbeddedRunLifecycleDecisionResult | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(value)) {
+    throw new Error(
+      "Embedded run lifecycle seam returned a malformed decision result (expected object).",
+    );
+  }
+  const next = value.next;
+  if (
+    typeof next !== "string" ||
+    !EMBEDDED_RUN_LIFECYCLE_DECISION_NEXT_VALUES.includes(next as never)
+  ) {
+    return {
+      next: "noop",
+      unsupportedCapabilities: [`invalid_next:${String(next)}`],
+    };
+  }
+  const reason = value.reason;
+  if (reason !== undefined && typeof reason !== "string") {
+    throw new Error("Embedded run lifecycle seam returned a non-string decision `reason`.");
+  }
+  const annotations = value.annotations;
+  if (annotations !== undefined && !isPlainObject(annotations)) {
+    throw new Error("Embedded run lifecycle seam returned non-object `annotations`.");
+  }
+  const unsupportedCapabilities = value.unsupportedCapabilities;
+  if (
+    unsupportedCapabilities !== undefined &&
+    (!Array.isArray(unsupportedCapabilities) ||
+      unsupportedCapabilities.some((entry) => typeof entry !== "string"))
+  ) {
+    throw new Error("Embedded run lifecycle seam returned invalid `unsupportedCapabilities`.");
+  }
+  return {
+    next: next as EmbeddedRunLifecycleDecisionNext,
+    ...(reason !== undefined ? { reason } : {}),
+    ...(unsupportedCapabilities !== undefined ? { unsupportedCapabilities } : {}),
+    ...(annotations !== undefined ? { annotations } : {}),
+  };
+}
+
+export async function resolveEmbeddedRunPassTransitionDecision(params: {
+  seam?: EmbeddedRunLifecycleSeam;
+  event: EmbeddedRunPassTransitionDecisionEvent;
+  decisionMode?: EmbeddedRunLifecycleDecisionMode;
+}): Promise<EmbeddedRunLifecycleDecisionResult> {
+  const result = normalizeEmbeddedRunLifecycleDecisionResult(
+    await params.seam?.onPassTransitionDecision?.(params.event),
+  );
+  if (!result) {
+    return { next: "noop" };
+  }
+  const decisionMode = params.decisionMode ?? "observe_only";
+  if (!EMBEDDED_RUN_LIFECYCLE_DECISION_MODES.includes(decisionMode)) {
+    throw new Error(
+      `Embedded run lifecycle seam received unsupported decision mode (${decisionMode}).`,
+    );
+  }
+  if (decisionMode !== "decide" && result.next !== "noop") {
+    throw new Error(
+      `Embedded run lifecycle seam received unsupported non-noop decision (${result.next}) while decision mode is ${decisionMode}.`,
+    );
+  }
+  return result;
+}

--- a/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-seam.ts
@@ -59,8 +59,8 @@ export type EmbeddedRunLifecycleReceipt = {
   passIndex: number;
   passKind: EmbeddedRunPassKind;
   correlationId: string;
-  envelopeOnly: true;
-  decisionEffective: false;
+  envelopeOnly: boolean;
+  decisionEffective: boolean;
   outcome: "observed" | "noop" | "error";
   reason?: string;
   unsupportedCapabilities?: string[];
@@ -116,10 +116,8 @@ export function createEmbeddedRunLifecycleBaseEvent(params: {
 }
 
 /**
- * M14-A stable receipt envelope.
- * Observe events are fail-open at call sites and always remain envelope-only.
- * Decision events stay fail-closed in scaffold-only mode and must not become
- * decision-effective until a later gated slice explicitly enables that path.
+ * M14-A stable receipt envelope, later extended so live-effective decision slices
+ * can emit truthful non-envelope receipts without changing the persisted surface id.
  */
 export function buildEmbeddedRunLifecycleReceipt(params: {
   event:
@@ -130,6 +128,8 @@ export function buildEmbeddedRunLifecycleReceipt(params: {
   reason?: string;
   annotations?: Record<string, unknown>;
   unsupportedCapabilities?: string[];
+  envelopeOnly?: boolean;
+  decisionEffective?: boolean;
 }): EmbeddedRunLifecycleReceipt {
   return {
     runtimeSurface: params.event.runtimeSurface,
@@ -138,8 +138,8 @@ export function buildEmbeddedRunLifecycleReceipt(params: {
     passIndex: params.event.passIndex,
     passKind: params.event.passKind,
     correlationId: params.event.correlationId,
-    envelopeOnly: true,
-    decisionEffective: false,
+    envelopeOnly: params.envelopeOnly ?? true,
+    decisionEffective: params.decisionEffective ?? false,
     outcome: params.outcome,
     ...(params.reason ? { reason: params.reason } : {}),
     ...(params.unsupportedCapabilities

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -144,6 +144,6 @@ export type RunEmbeddedPiAgentParams = {
   cleanupBundleMcpOnRunEnd?: boolean;
   /** Internal B1 scaffold seam for outer-run lifecycle observation/decision wiring. */
   lifecycleSeam?: EmbeddedRunLifecycleSeam;
-  /** Internal M14-B decision gate. Defaults to observe_only and does not enable live execution. */
+  /** Internal lifecycle decision gate. Defaults to observe_only; M15-A only executes halt. */
   lifecycleDecisionMode?: EmbeddedRunLifecycleDecisionMode;
 };

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -15,6 +15,10 @@ import type {
   ToolResultFormat,
 } from "../../pi-embedded-subscribe.shared-types.js";
 import type { SkillSnapshot } from "../../skills.js";
+import type {
+  EmbeddedRunLifecycleDecisionMode,
+  EmbeddedRunLifecycleSeam,
+} from "./lifecycle-seam.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
 export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "overflow" | "user";
@@ -138,4 +142,8 @@ export type RunEmbeddedPiAgentParams = {
    * exit promptly after emitting the final JSON result.
    */
   cleanupBundleMcpOnRunEnd?: boolean;
+  /** Internal B1 scaffold seam for outer-run lifecycle observation/decision wiring. */
+  lifecycleSeam?: EmbeddedRunLifecycleSeam;
+  /** Internal M14-B decision gate. Defaults to observe_only and does not enable live execution. */
+  lifecycleDecisionMode?: EmbeddedRunLifecycleDecisionMode;
 };

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -144,6 +144,6 @@ export type RunEmbeddedPiAgentParams = {
   cleanupBundleMcpOnRunEnd?: boolean;
   /** Internal B1 scaffold seam for outer-run lifecycle observation/decision wiring. */
   lifecycleSeam?: EmbeddedRunLifecycleSeam;
-  /** Internal lifecycle decision gate. Defaults to observe_only; M15-A only executes halt. */
+  /** Internal lifecycle decision gate. Defaults to observe_only; M15 executes halt/continue. */
   lifecycleDecisionMode?: EmbeddedRunLifecycleDecisionMode;
 };

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
-import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
+import type {
+  PluginHookBeforeAgentStartResult,
+  PluginHookLifecycleControllerPlan,
+} from "../../../plugins/types.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
   CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -30,7 +33,14 @@ type HookRunnerLike = {
   runBeforeModelResolve(
     input: { prompt: string },
     context: HookContext,
-  ): Promise<{ providerOverride?: string; modelOverride?: string } | undefined>;
+  ): Promise<
+    | {
+        providerOverride?: string;
+        modelOverride?: string;
+        lifecycleControllerPlan?: PluginHookLifecycleControllerPlan;
+      }
+    | undefined
+  >;
   runBeforeAgentStart(
     input: { prompt: string },
     context: HookContext,
@@ -46,7 +56,13 @@ export async function resolveHookModelSelection(params: {
 }) {
   let provider = params.provider;
   let modelId = params.modelId;
-  let modelResolveOverride: { providerOverride?: string; modelOverride?: string } | undefined;
+  let modelResolveOverride:
+    | {
+        providerOverride?: string;
+        modelOverride?: string;
+        lifecycleControllerPlan?: PluginHookLifecycleControllerPlan;
+      }
+    | undefined;
   let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
   const hookRunner = params.hookRunner;
 
@@ -77,6 +93,9 @@ export async function resolveHookModelSelection(params: {
           modelResolveOverride?.providerOverride ?? legacyBeforeAgentStartResult?.providerOverride,
         modelOverride:
           modelResolveOverride?.modelOverride ?? legacyBeforeAgentStartResult?.modelOverride,
+        lifecycleControllerPlan:
+          modelResolveOverride?.lifecycleControllerPlan ??
+          legacyBeforeAgentStartResult?.lifecycleControllerPlan,
       };
     } catch (hookErr) {
       log.warn(`before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`);
@@ -95,6 +114,7 @@ export async function resolveHookModelSelection(params: {
   return {
     provider,
     modelId,
+    lifecycleControllerPlan: modelResolveOverride?.lifecycleControllerPlan,
     legacyBeforeAgentStartResult,
   };
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { URL } from "node:url";
@@ -356,6 +357,32 @@ export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): An
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
 }
 
+function resolveWorkspaceSkillAliasPath(filePath: string, root: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const prefix = "/app/skills/";
+  if (!normalized.startsWith(prefix) || !normalized.endsWith("/SKILL.md")) {
+    return filePath;
+  }
+  const relative = normalized.slice(prefix.length);
+  const parts = relative.split("/").filter(Boolean);
+  if (parts.length !== 2 || parts[1] !== "SKILL.md") {
+    return filePath;
+  }
+  const skillName = parts[0]?.trim();
+  if (!skillName || skillName === "." || skillName === "..") {
+    return filePath;
+  }
+  const bundledTarget = path.posix.normalize(normalized);
+  if (existsSync(bundledTarget)) {
+    return filePath;
+  }
+  const workspaceTarget = path.resolve(root, "skills", skillName, "SKILL.md");
+  if (!existsSync(workspaceTarget)) {
+    return filePath;
+  }
+  return workspaceTarget;
+}
+
 function mapContainerPathToWorkspaceRoot(params: {
   filePath: string;
   root: string;
@@ -374,6 +401,7 @@ function mapContainerPathToWorkspaceRoot(params: {
   }
 
   let candidate = params.filePath.startsWith("@") ? params.filePath.slice(1) : params.filePath;
+  candidate = resolveWorkspaceSkillAliasPath(candidate, params.root);
   if (/^file:\/\//i.test(candidate)) {
     const localFilePath = trySafeFileURLToPath(candidate);
     if (localFilePath) {

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "./pi-tools.types.js";
@@ -46,9 +47,50 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
 
   beforeAll(loadModule);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mocks.assertSandboxPath.mockReset();
     mocks.assertSandboxPath.mockImplementation(assertSandboxPathImpl);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("rewrites stale /app skill paths to workspace skills when the alias target exists", async () => {
+    const { tool } = createToolHarness();
+    await fs.mkdir(path.join(root, "skills", "ops-workflow-governor"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "skills", "ops-workflow-governor", "SKILL.md"),
+      "# skill\n",
+      "utf8",
+    );
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-workspace-skill-alias", {
+      path: "/app/skills/ops-workflow-governor/SKILL.md",
+    });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.join(root, "skills", "ops-workflow-governor", "SKILL.md"),
+      cwd: root,
+      root,
+    });
+  });
+
+  it("does not rewrite stale /app skill paths when no workspace skill alias exists", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-missing-workspace-skill-alias", {
+      path: "/app/skills/ops-workflow-governor/SKILL.md",
+    });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: "/app/skills/ops-workflow-governor/SKILL.md",
+      cwd: root,
+      root,
+    });
   });
 
   it("maps container workspace paths to host workspace root", async () => {

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -9,6 +9,16 @@ export type PluginHookBeforeModelResolveResult = {
   modelOverride?: string;
   /** Override the provider for this agent run. E.g. "ollama" */
   providerOverride?: string;
+  /** Optional bounded execution-profile plan to bridge pre-call policy into the embedded runner. */
+  lifecycleControllerPlan?: PluginHookLifecycleControllerPlan;
+};
+
+export type PluginHookLifecycleControllerProfile = "single-pass" | "double-pass" | "verifier-heavy";
+
+export type PluginHookLifecycleControllerPlan = {
+  requestedProfile: PluginHookLifecycleControllerProfile;
+  plannedMaxPasses: number;
+  controllerLabel?: string;
 };
 
 // before_prompt_build hook

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -33,6 +33,8 @@ export type {
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartOverrideResult,
   PluginHookBeforeAgentStartResult,
+  PluginHookLifecycleControllerPlan,
+  PluginHookLifecycleControllerProfile,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -226,6 +226,10 @@ export function createHookRunner(
     // Keep the first defined override so higher-priority hooks win.
     modelOverride: firstDefined(acc?.modelOverride, next.modelOverride),
     providerOverride: firstDefined(acc?.providerOverride, next.providerOverride),
+    lifecycleControllerPlan: firstDefined(
+      acc?.lifecycleControllerPlan,
+      next.lifecycleControllerPlan,
+    ),
   });
 
   const mergeBeforePromptBuild = (


### PR DESCRIPTION
## Summary
- land the B1/M14 lifecycle seam scaffold in the embedded runner
- add M14-A receipt and parity hardening for the seam
- add M14-B internal decision gate/schema freeze without enabling live steering

## What changed
- adds `run/lifecycle-seam.ts` with typed lifecycle events, receipts, decision normalization, and internal decision-mode constants
- wires the seam through `run.ts` and `run/params.ts`
- adds focused unit/integration tests for no-op parity, receipt stability, and observe-only fail-closed behavior

## Safety / scope
- does **not** enable live decision execution
- does **not** change `resolveRunFailoverDecision()` semantics
- keeps the seam internal-only, not a public SDK/plugin contract
- defaults decision mode to `observe_only`

## Verification
- `pnpm vitest run src/agents/pi-embedded-runner/run/lifecycle-seam.test.ts src/agents/pi-embedded-runner.run-lifecycle-seam.test.ts --pool=forks --no-file-parallelism --reporter=verbose`
  - 2 passed, 11 passed

## Review notes
- Claude second-brain review was used during M14-A and M14-B shaping
- please review the internal gate/schema surface, receipt envelope stability, and no-op parity posture
