### PR TITLE
docs: document avatar image size limit

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -159,6 +159,8 @@ Each agent workspace can include an `IDENTITY.md` at the workspace root:
 - `set-identity --from-identity` reads from the workspace root (or an explicit `--identity-file`)
 
 Avatar paths resolve relative to the workspace root.
+Local avatar image files must be 2 MB or smaller; larger files are not served as
+agent avatars.
 
 ## Set identity
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1797,6 +1797,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `embeddedHarness`: optional per-agent low-level harness policy override. Use `{ runtime: "codex", fallback: "none" }` to make one agent Codex-only while other agents keep the default PI fallback.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+  Local workspace avatar image files must be 2 MB or smaller.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.


### PR DESCRIPTION
## Summary

- Problem: Agent avatar docs did not mention the local avatar file size limit.
- Why it matters: Users can spend time debugging valid-looking avatar paths when the file size is the reason the avatar is not served.
- What changed: Added the 2 MB local avatar image limit to the CLI agent identity docs and gateway configuration reference.
- What did NOT change (scope boundary): No runtime behavior, config schema, avatar resolution, or serving logic changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65312
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): Existing code enforces `AVATAR_MAX_BYTES = 2 * 1024 * 1024`, but the docs did not state the limit.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): `src/agents/identity-avatar.test.ts` already covers oversized local avatars.
- If no new test is added, why not: Docs-only change documenting existing behavior.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v24.15.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Confirmed the current local avatar limit in `src/shared/avatar-policy.ts` and oversized-avatar behavior in `src/agents/identity-avatar.ts`.
2. Updated `docs/cli/agents.md` and `docs/gateway/configuration-reference.md` to document the 2 MB local avatar image limit.
3. Ran targeted docs formatting and lint checks.
4. Ran local Codex review against `upstream/main`.

### Expected

- Docs mention the local avatar image size limit where users configure agent identity/avatar values.

### Actual

- Docs now mention that local avatar image files must be 2 MB or smaller.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands:

```text
pnpm exec oxfmt --check docs/cli/agents.md docs/gateway/configuration-reference.md
# All matched files use the correct format.

pnpm dlx markdownlint-cli2 docs/cli/agents.md docs/gateway/configuration-reference.md
# Summary: 0 error(s)

codex review --base upstream/main --title "docs: document avatar image size limit"
# No actionable correctness issues identified.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the documented 2 MB value matches `AVATAR_MAX_BYTES`; checked both changed docs render as plain Markdown; ran targeted format/lint checks.
- Edge cases checked: Confirmed the change is limited to local workspace avatar files and does not claim the limit applies to remote URLs or data URIs.
- What you did **not** verify: Full `pnpm build && pnpm check && pnpm test`; runtime avatar serving behavior, because this is a docs-only change for existing behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.

## AI Assistance

- [x] AI-assisted: prepared with Codex.
- Testing degree: Lightly tested with targeted docs format/lint checks and local Codex review.
- Prompts or session logs: Not attached beyond this PR description.
- [x] I understand this docs-only change and the existing code behavior it documents.
