### PR TITLE
Fix Telegram media file delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
+- Telegram/media: parse lowercase media directives in block replies and preserve outbound attachment filenames, so generated files send once with their original names. (#69641) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -125,6 +125,20 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("parses lowercase media directives in block replies before path normalization", () => {
+    const normalized = normalizeReplyPayloadDirectives({
+      payload: { text: "media: ./report.pdf" },
+      trimLeadingWhitespace: true,
+      parseMode: "auto",
+    });
+
+    expect(normalized.payload).toMatchObject({
+      text: undefined,
+      mediaUrl: "./report.pdf",
+      mediaUrls: ["./report.pdf"],
+    });
+  });
+
   it("passes normalized media block replies through media path normalization", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -26,7 +26,7 @@ export function normalizeReplyPayloadDirectives(params: {
     parseMode === "always" ||
     (parseMode === "auto" &&
       (sourceText.includes("[[") ||
-        sourceText.includes("MEDIA:") ||
+        /media:/i.test(sourceText) ||
         sourceText.includes(silentToken)));
 
   const parsed = shouldParse

--- a/src/media/outbound-attachment.test.ts
+++ b/src/media/outbound-attachment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+const loadWebMedia = vi.hoisted(() => vi.fn());
+const saveMediaBuffer = vi.hoisted(() => vi.fn());
+
+vi.mock("./web-media.js", () => ({
+  loadWebMedia,
+}));
+
+vi.mock("./store.js", () => ({
+  saveMediaBuffer,
+}));
+
+const { resolveOutboundAttachmentFromUrl } = await import("./outbound-attachment.js");
+
+describe("resolveOutboundAttachmentFromUrl", () => {
+  it("preserves the loaded file name when staging outbound media", async () => {
+    const buffer = Buffer.from("pdf");
+    loadWebMedia.mockResolvedValueOnce({
+      buffer,
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/media/outbound/report---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    await resolveOutboundAttachmentFromUrl("./report.pdf", 1024);
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      buffer,
+      "application/pdf",
+      "outbound",
+      1024,
+      "report.pdf",
+    );
+  });
+});

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -25,6 +25,7 @@ export async function resolveOutboundAttachmentFromUrl(
     media.contentType ?? undefined,
     "outbound",
     maxBytes,
+    media.fileName,
   );
   return { path: saved.path, contentType: saved.contentType };
 }

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -184,7 +184,7 @@ export function splitMediaFromOutput(raw: string): {
     }
 
     const trimmedStart = line.trimStart();
-    if (!trimmedStart.startsWith("MEDIA:")) {
+    if (!trimmedStart.toUpperCase().startsWith("MEDIA:")) {
       keptLines.push(line);
       pushTextSegment(line);
       lineOffset += line.length + 1; // +1 for newline


### PR DESCRIPTION
Fixes Telegram outbound file delivery in two spots:

- parse lowercase `media:` directives during block reply handling so media is sent once
- preserve the original filename when staging outbound attachments so Telegram does not show the UUID

Tests:
- `pnpm check:changed`
