### PR TITLE
docs: document Zalo profile env vars

### DIFF
--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -163,6 +163,23 @@ Accounts map to `zalouser` profiles in OpenClaw state. Example:
 }
 ```
 
+## Environment variables
+
+The Zalo Personal plugin can also read profile selection from environment variables:
+
+- `ZALOUSER_PROFILE`: profile name to use when no `profile` is set in channel or account config.
+- `ZCA_PROFILE`: legacy fallback profile name, used only when `ZALOUSER_PROFILE` is not set.
+
+Profile names select the saved Zalo login credentials in OpenClaw state. Resolution order is:
+
+1. Explicit `profile` in config.
+2. `ZALOUSER_PROFILE`.
+3. `ZCA_PROFILE`.
+4. The account id for non-default accounts, or `default` for the default account.
+
+For multi-account setups, prefer setting `profile` on each account in config so one
+environment variable does not make multiple accounts share the same login session.
+
 ## Typing, reactions, and delivery acknowledgements
 
 - OpenClaw sends a typing event before dispatching a reply (best-effort).


### PR DESCRIPTION
## Summary

- Problem: Zalo Personal docs did not mention the profile environment variables declared and read by the bundled plugin.
- Why it matters: users had to inspect source code to discover how to select saved Zalo login profiles.
- What changed: added an Environment variables section for `ZALOUSER_PROFILE` and `ZCA_PROFILE`, including profile resolution order and a multi-account caveat.
- What did NOT change (scope boundary): no runtime behavior, schema, or credential storage changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65864
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A; documentation gap only.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): env vars were already declared in the plugin manifest and used by the Zalo Personal account resolution code.

## Regression Test Plan (if applicable)

N/A; documentation-only change.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: docs-only change; no runtime behavior changed.

## User-visible / Behavior Changes

Zalo Personal users can now find the profile environment variables and resolution order in the channel docs.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Zalo Personal (`zalouser`)
- Relevant config (redacted): N/A

### Steps

1. Verified the env vars in `extensions/zalouser/openclaw.plugin.json` and account/profile resolution code.
2. Added the docs section to `docs/channels/zalouser.md`.
3. Ran `pnpm check:docs`.

### Expected

- Zalo Personal docs mention `ZALOUSER_PROFILE` and `ZCA_PROFILE`.
- Docs checks pass.

### Actual

- Zalo Personal docs now document both env vars and profile resolution order.
- `pnpm check:docs` passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm check:docs` completed with `broken_links=0` and markdownlint reported `0 error(s)`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: compared the new docs against `resolveProfile` in `extensions/zalouser/src/accounts.ts`, `resolveZalouserQrProfile` in `extensions/zalouser/src/channel.adapters.ts`, and `channelEnvVars` in `extensions/zalouser/openclaw.plugin.json`.
- Edge cases checked: `ZALOUSER_PROFILE` precedence over `ZCA_PROFILE`; config `profile` precedence over env fallback; default/non-default account fallback behavior.
- What you did **not** verify: actual Zalo QR login or credential reuse at runtime.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No runtime changes; docs only
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.