### PR TITLE
fix: skip update when already on target version

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -773,7 +773,13 @@ describe("update-cli", () => {
     readPackageName.mockResolvedValue("openclaw");
     readPackageVersion.mockResolvedValue("2026.4.15");
     resolveGlobalManager.mockResolvedValue("npm");
+    // Mock both resolution paths so versions genuinely match — proving
+    // that !explicitTag is the guard that bypasses the early exit.
     vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.15",
+    });
+    vi.mocked(fetchNpmTagVersion).mockResolvedValue({
       tag: "latest",
       version: "2026.4.15",
     });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -744,6 +744,46 @@ describe("update-cli", () => {
     );
   });
 
+  it("skips the package install when already on the target version (#69412)", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    mockPackageInstallStatus(tempDir);
+    readPackageName.mockResolvedValue("openclaw");
+    readPackageVersion.mockResolvedValue("2026.4.15");
+    resolveGlobalManager.mockResolvedValue("npm");
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.15",
+    });
+
+    await updateCommand({});
+
+    // Should NOT invoke npm install or doctor checks.
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+    // Should exit cleanly.
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    // Should print the "already on" message.
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Already on 2026.4.15");
+  });
+
+  it("does NOT skip the install when --tag is explicitly provided even if version matches", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    mockPackageInstallStatus(tempDir);
+    readPackageName.mockResolvedValue("openclaw");
+    readPackageVersion.mockResolvedValue("2026.4.15");
+    resolveGlobalManager.mockResolvedValue("npm");
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.15",
+    });
+
+    await updateCommand({ tag: "latest" });
+
+    // With --tag, the install should proceed even when versions match.
+    expect(runCommandWithTimeout).toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "explicit dist-tag",

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -929,6 +929,39 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     });
   }
 
+  // ── Early-exit: already on the target version ─────────────────────────
+  // Skip the full update when the installed version matches the registry
+  // target.  This avoids 2-3+ minutes of npm install, native-module
+  // recompilation, and doctor checks on a no-op — and prevents OOM
+  // conditions on resource-constrained systems (see #69412).
+  const alreadyUpToDate =
+    updateInstallKind !== "git" &&
+    !switchToGit &&
+    !switchToPackage &&
+    !explicitTag &&
+    currentVersion != null &&
+    targetVersion != null &&
+    compareSemverStrings(currentVersion, targetVersion) === 0 &&
+    // A channel switch still needs a config write even when versions match.
+    (!requestedChannel || requestedChannel === storedChannel);
+
+  if (alreadyUpToDate && !opts.dryRun) {
+    if (opts.json) {
+      defaultRuntime.writeJson({
+        status: "up-to-date",
+        version: currentVersion,
+        channel,
+        root,
+      });
+    } else {
+      defaultRuntime.log(
+        theme.success(`Already on ${currentVersion} (${channel}). Nothing to update.`),
+      );
+    }
+    defaultRuntime.exit(0);
+    return;
+  }
+
   if (opts.dryRun) {
     let mode: UpdateRunResult["mode"] = "unknown";
     if (updateInstallKind === "git") {
@@ -963,6 +996,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     );
 
     const notes: string[] = [];
+    if (alreadyUpToDate) {
+      notes.push(
+        `Already on ${currentVersion} (${channel}). A real run would exit early with no install.`,
+      );
+    }
     if (opts.tag && updateInstallKind === "git") {
       notes.push("--tag applies to npm installs only; git updates ignore it.");
     }


### PR DESCRIPTION
## Summary

`openclaw update` currently runs a full package-manager install, native-module recompilation, and doctor checks even when the installed version already matches the registry target. On resource-constrained systems (e.g., 4 GB RAM VPS without swap), this unnecessary work can trigger OOM conditions and require a hard reboot.

This PR adds an early-exit check that compares `currentVersion` against `targetVersion` using the existing `compareSemverStrings` utility. When versions match, the command prints `Already on <version> (<channel>). Nothing to update.` and exits cleanly.

**Changes:**
- **`src/cli/update-cli/update-command.ts`** — added `alreadyUpToDate` guard clause after version resolution (line ~932). Supports both human-readable and `--json` output. Also surfaces the up-to-date state in `--dry-run` notes.
- **`src/cli/update-cli.test.ts`** — two new test cases: (1) verifies the early exit when versions match, (2) verifies `--tag` bypasses the check even when versions match.

**The early-exit is bypassed when:**
- `--tag` is explicitly provided (user wants a forced reinstall)
- `--channel` changes the update channel (config persistence still needed)
- The install kind is switching between git and package

## Test plan

- [ ] `openclaw update` when already on latest → prints "Already on X" and exits in <1s
- [ ] `openclaw update --tag latest` when already on latest → runs the full install (bypass)
- [ ] `openclaw update --channel beta` (switching from stable) → runs even if version matches
- [ ] `openclaw update --json` when already on latest → outputs `{"status":"up-to-date",...}`
- [ ] `openclaw update --dry-run` when already on latest → includes "Already on" note
- [ ] CI passes (unit tests in `src/cli/update-cli.test.ts`)

Closes #69412

🤖 Generated with [Claude Code](https://claude.ai/claude-code)