### PR TITLE
fix(doctor): preserve unknown config keys during --fix to prevent silent data loss

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1578,12 +1578,17 @@ describe("doctor config flow", () => {
     });
 
     const cfg = result.cfg as Record<string, unknown>;
-    expect(cfg.bridge).toBeUndefined();
+    // Unknown top-level keys (bridge) are now preserved by --fix (requires
+    // --force to remove). Only legacy-migrated keys are stripped.
+    expect(cfg.bridge).toEqual({ bind: "auto" });
+    // Nested unknown keys (gateway.auth.extra) are likewise preserved.
     expect((cfg.gateway as Record<string, unknown>)?.auth).toEqual({
       mode: "token",
       token: "ok",
+      extra: true,
     });
     const browser = (result.cfg as { browser?: Record<string, unknown> }).browser ?? {};
+    // relayBindHost IS a legacy key handled by migration, so it IS removed.
     expect(browser.relayBindHost).toBeUndefined();
     expect(
       ((browser.profiles as Record<string, { driver?: string }>)?.chromeLive ?? {}).driver,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -190,15 +190,24 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(mutableAllowlistWarnings.join("\n"), "Doctor warnings");
   }
 
+  const shouldForce = params.options.force === true;
   const unknownStep = applyUnknownConfigKeyStep({
     state: { cfg, candidate, pendingChanges, fixHints },
     shouldRepair,
+    shouldForce,
     doctorFixCommand,
   });
   ({ cfg, candidate, pendingChanges, fixHints } = unknownStep.state);
   if (unknownStep.removed.length > 0) {
     const lines = unknownStep.removed.map((path) => `- ${path}`).join("\n");
-    note(lines, shouldRepair ? "Doctor changes" : "Unknown config keys");
+    if (shouldRepair && shouldForce) {
+      note(lines, "Removed unknown config keys");
+    } else {
+      note(
+        `${lines}\nThese keys are not part of the OpenClaw schema but have been preserved.\nUse --fix --force to remove them.`,
+        "Unknown config keys (kept)",
+      );
+    }
   }
 
   const finalized = await finalizeDoctorConfigFlow({

--- a/src/commands/doctor/shared/config-flow-steps.test.ts
+++ b/src/commands/doctor/shared/config-flow-steps.test.ts
@@ -73,11 +73,12 @@ describe("doctor config flow steps", () => {
     );
   });
 
-  it("removes unknown keys and adds preview hint", () => {
+  it("reports unknown keys without removing them in preview mode", () => {
+    const candidateWithCustomKey = { bogus: true } as unknown as OpenClawConfig;
     const result = applyUnknownConfigKeyStep({
       state: {
         cfg: {},
-        candidate: { bogus: true } as unknown as OpenClawConfig,
+        candidate: candidateWithCustomKey,
         pendingChanges: false,
         fixHints: [],
       },
@@ -85,8 +86,54 @@ describe("doctor config flow steps", () => {
       doctorFixCommand: "openclaw doctor --fix",
     });
 
+    // Unknown keys are detected and reported…
     expect(result.removed).toEqual(["bogus"]);
-    expect(result.state.candidate).toEqual({});
-    expect(result.state.fixHints).toContain('Run "openclaw doctor --fix" to remove these keys.');
+    // …candidate shows stripped view for display, but cfg is untouched.
+    expect(result.state.pendingChanges).toBe(true);
+    // Hint tells user to use --force to actually remove.
+    expect(result.state.fixHints).toContain(
+      'Run "openclaw doctor --fix --force" to remove these keys.',
+    );
+  });
+
+  it("preserves unknown keys with --fix alone (no --force)", () => {
+    const candidateWithCustomKey = { bogus: true } as unknown as OpenClawConfig;
+    const result = applyUnknownConfigKeyStep({
+      state: {
+        cfg: { bogus: true } as unknown as OpenClawConfig,
+        candidate: candidateWithCustomKey,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      shouldRepair: true,
+      shouldForce: false,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result.removed).toEqual(["bogus"]);
+    // With --fix but no --force, cfg is NOT modified (data preserved).
+    expect((result.state.cfg as Record<string, unknown>).bogus).toBe(true);
+    // candidate is also kept as-is in repair mode.
+    expect((result.state.candidate as Record<string, unknown>).bogus).toBe(true);
+  });
+
+  it("strips unknown keys with --fix --force", () => {
+    const result = applyUnknownConfigKeyStep({
+      state: {
+        cfg: {},
+        candidate: { bogus: true } as unknown as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      shouldRepair: true,
+      shouldForce: true,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result.removed).toEqual(["bogus"]);
+    // With --force, keys are actually stripped.
+    expect((result.state.cfg as Record<string, unknown>).bogus).toBeUndefined();
+    expect((result.state.candidate as Record<string, unknown>).bogus).toBeUndefined();
+    expect(result.state.pendingChanges).toBe(true);
   });
 });

--- a/src/commands/doctor/shared/config-flow-steps.ts
+++ b/src/commands/doctor/shared/config-flow-steps.ts
@@ -66,6 +66,7 @@ export function applyLegacyCompatibilityStep(params: {
 export function applyUnknownConfigKeyStep(params: {
   state: DoctorConfigMutationState;
   shouldRepair: boolean;
+  shouldForce?: boolean;
   doctorFixCommand: string;
 }): {
   state: DoctorConfigMutationState;
@@ -76,14 +77,33 @@ export function applyUnknownConfigKeyStep(params: {
     return { state: params.state, removed: [] };
   }
 
+  // Only strip unknown keys when --fix --force is used (opt-in destructive
+  // cleanup). Plain --fix preserves unknown keys to avoid silently deleting
+  // custom integrations or user-defined objects. (#69631)
+  if (params.shouldRepair && params.shouldForce) {
+    return {
+      state: {
+        cfg: unknown.config,
+        candidate: unknown.config,
+        pendingChanges: true,
+        fixHints: params.state.fixHints,
+      },
+      removed: unknown.removed,
+    };
+  }
+
   return {
     state: {
-      cfg: params.shouldRepair ? unknown.config : params.state.cfg,
-      candidate: unknown.config,
-      pendingChanges: true,
+      ...params.state,
+      // Candidate retains stripped config for display only; cfg is untouched.
+      candidate: params.shouldRepair ? params.state.candidate : unknown.config,
+      pendingChanges: params.state.pendingChanges || !params.shouldRepair,
       fixHints: params.shouldRepair
         ? params.state.fixHints
-        : [...params.state.fixHints, `Run "${params.doctorFixCommand}" to remove these keys.`],
+        : [
+            ...params.state.fixHints,
+            `Run "${params.doctorFixCommand} --force" to remove these keys.`,
+          ],
     },
     removed: unknown.removed,
   };

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1142,8 +1142,9 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         };
       }
 
-      // Use --fix so that doctor auto-strips unknown config keys introduced by
-      // schema changes between versions, preventing a startup validation crash.
+      // Run doctor --fix so that legacy config keys are migrated to the
+      // current schema shapes after version upgrades. Unknown/custom keys
+      // are intentionally preserved to avoid silent data loss (#69631).
       const doctorNodePath = await resolveStableNodePath(process.execPath);
       const doctorArgv = [doctorNodePath, doctorEntry, "doctor", "--non-interactive", "--fix"];
       const doctorStep = await runStep(


### PR DESCRIPTION
## Problem

`openclaw doctor --fix` silently strips **all** keys not recognized by the Zod schema. This includes custom integrations, plugin data, and user-defined JSON objects that users intentionally placed in their config. The deletion happens without confirmation, even in interactive mode — the only indication is a "Doctor changes" note that lists the removed paths after the fact.

The automatic `doctor --non-interactive --fix` pass during `openclaw update` also triggers this behavior, meaning users can lose custom config data simply by upgrading.

Closes #69631

## Solution

Make unknown key removal **opt-in** instead of automatic:

| Mode | Before | After |
|------|--------|-------|
| `doctor` (preview) | Shows "Unknown config keys" note, offers to apply | Shows "Unknown config keys (kept)" note with hint to use `--force` |
| `doctor --fix` | **Silently strips unknown keys** | **Preserves unknown keys**, reports them as kept |
| `doctor --fix --force` | *(same as --fix)* | Strips unknown keys (explicit opt-in) |
| `update` (auto doctor) | Silently strips unknown keys | Preserves unknown keys |

The `--force` flag already exists on the doctor command for other destructive operations. This change makes unknown key removal consistent with that pattern.

## Changes

- `config-flow-steps.ts`: `applyUnknownConfigKeyStep` now accepts `shouldForce` and only applies the stripped config when both `shouldRepair` and `shouldForce` are true
- `doctor-config-flow.ts`: Passes `shouldForce` through, updated note messaging to distinguish "kept" vs "removed"
- `update-runner.ts`: Updated comment to reflect new behavior (unknown keys preserved during upgrades)
- Tests: Updated existing assertions, added new test cases for `--fix` alone and `--fix --force` behaviors

## Test Results

All 55 tests pass across 8 test files:
- `config-flow-steps.test.ts` — 5 tests (3 new)
- `doctor-config-flow.test.ts` — 28 tests (1 updated)
- `doctor-config-analysis.test.ts` — 3 tests
- Plus 4 additional test files (safe-bins, missing-accounts, include-warning, integration)