### PR TITLE
docs: warn about node Accessibility grants

### DIFF
--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -47,6 +47,10 @@ export PEEKABOO_BRIDGE_SOCKET=/path/to/bridge.sock
 
 - The bridge validates **caller code signatures**; an allowlist of TeamIDs is
   enforced (Peekaboo host TeamID + OpenClaw app TeamID).
+- Prefer the signed bridge/app identity over a generic `node` runtime for
+  Accessibility. Granting Accessibility to `node` lets any package launched by
+  that Node executable inherit GUI automation access; see
+  [macOS permissions](/platforms/mac/permissions#accessibility-grants-for-node-and-cli-runtimes).
 - Requests time out after ~10 seconds.
 - If required permissions are missing, the bridge returns a clear error message
   rather than launching System Settings.

--- a/docs/platforms/mac/permissions.md
+++ b/docs/platforms/mac/permissions.md
@@ -2,6 +2,7 @@
 summary: "macOS permission persistence (TCC) and signing requirements"
 read_when:
   - Debugging missing or stuck macOS permission prompts
+  - Deciding whether to grant Accessibility to node or a CLI runtime
   - Packaging or signing the macOS app
   - Changing bundle IDs or app install paths
 title: "macOS Permissions"
@@ -23,6 +24,25 @@ macOS treats the app as new and may drop or hide prompts.
 
 Ad-hoc signatures generate a new identity every build. macOS will forget previous
 grants, and prompts can disappear entirely until the stale entries are cleared.
+
+## Accessibility grants for Node and CLI runtimes
+
+Prefer granting Accessibility to OpenClaw.app, Peekaboo.app, or another signed
+helper with its own bundle identifier instead of a generic `node` binary.
+
+macOS TCC grants Accessibility to the code identity of the process it sees. If a
+Homebrew, nvm, pnpm, or npm workflow causes a shared `node` executable to
+receive Accessibility, any JavaScript package launched through that same
+executable may inherit GUI automation privileges.
+
+Treat a `node` entry in System Settings as broad permission for that Node
+runtime, not as permission for one npm package. Avoid granting Accessibility to
+`node` unless you trust every script and package launched through that exact
+Node install.
+
+If you accidentally granted Accessibility to `node`, remove that entry from
+System Settings -> Privacy & Security -> Accessibility. Then grant the signed
+app or helper that should own UI automation.
 
 ## Recovery checklist when prompts disappear
 


### PR DESCRIPTION
## Summary

- Problem: macOS Accessibility docs did not clearly warn about granting permissions to a shared `node` runtime.
- Why it matters: TCC grants Accessibility to the process identity macOS sees, so a `node` grant can apply to any npm package launched through that same binary.
- What changed: Added a prominent Node/CLI runtime warning to the macOS permissions docs and linked to it from the Peekaboo Bridge security notes.
- What did NOT change (scope boundary): No runtime behavior, permission prompts, signing logic, or bridge authorization behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69561
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `pnpm check:docs`
- Scenario the test should lock in: Documentation formatting, linting, glossary, and internal links remain valid.
- Why this is the smallest reliable guardrail: The change is docs-only.
- Existing test that already covers this (if any): `pnpm check:docs`
- If no new test is added, why not: Docs-only change.

## User-visible / Behavior Changes

Users reading macOS permission docs now see a warning that granting Accessibility to `node` is broader than granting it to a signed app/helper.

## Diagram (if applicable)

N/A

```text
Before:
[user reads macOS permission docs] -> [no explicit node Accessibility warning]

After:
[user reads macOS permission docs] -> [sees node runtime warning] -> [can choose signed app/helper instead]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repository checkout
- Model/provider: N/A
- Integration/channel (if any): docs
- Relevant config (redacted): N/A

### Steps

1. Read `docs/platforms/mac/permissions.md`.
2. Read `docs/platforms/mac/peekaboo.md`.
3. Run `pnpm check:docs`.

### Expected

- Docs warn that granting Accessibility to `node` grants broad GUI automation access to packages run by that Node binary.
- Docs checks pass.

### Actual

- Docs warning added.
- `pnpm check:docs` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm check:docs` passed locally:

- `markdownlint`: 0 errors
- `docs-link-audit`: `broken_links=0`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the updated docs and ran `pnpm check:docs`.
- Edge cases checked: Internal link from Peekaboo docs to the new permissions section resolves in the docs link audit.
- What you did **not** verify: Rendered docs site in a browser.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The warning could be interpreted as a runtime change.
  - Mitigation: The summary and security impact sections explicitly state this is docs-only.