### PR TITLE
docs: document PENDING.md pattern for cross-session commitment tracki…

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -3,8 +3,10 @@ summary: "Agent workspace: location, layout, and backup strategy"
 read_when:
   - You need to explain the agent workspace or its file layout
   - You want to back up or migrate an agent workspace
-title: "Agent workspace"
+title: "Agent Workspace"
 ---
+
+# Agent workspace
 
 The workspace is the agent's home. It is the only working directory used for
 file tools and for workspace context. Keep it private and treat it as memory.
@@ -89,8 +91,14 @@ These are the standard files OpenClaw expects inside the workspace:
   - Optional tiny checklist for heartbeat runs.
   - Keep it short to avoid token burn.
 
+- `PENDING.md` (optional)
+  - Cross-session commitment tracking file.
+  - Records user-visible commitments with deadlines.
+  - Useful for multi-day workflows that must survive session reset.
+  - See [PENDING.md Template](/reference/templates/PENDING.md) for details.
+
 - `BOOT.md`
-  - Optional startup checklist run automatically on gateway restart (when [internal hooks](/automation/hooks) are enabled).
+  - Optional startup checklist executed on gateway restart when internal hooks are enabled.
   - Keep it short; use the message tool for outbound sends.
 
 - `BOOTSTRAP.md`

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -391,7 +391,27 @@ Behavior:
 - Task last-run timestamps are stored in session state (`heartbeatTaskState`), so intervals survive normal restarts.
 - Task timestamps are only advanced after a heartbeat run completes its normal reply path. Skipped `empty-heartbeat-file` / `no-tasks-due` runs do not mark tasks as completed.
 
-Task mode is useful when you want one heartbeat file to hold several periodic checks without paying for all of them every tick.
+### Task mode is useful when you want one heartbeat file to hold several periodic checks without paying for all of them every tick
+
+### PENDING.md integration (optional)
+
+A common pattern is to use `HEARTBEAT.md` to check `PENDING.md` for overdue commitments.
+
+`PENDING.md` is an optional workspace file for tracking cross-session commitments with deadlines. See [PENDING.md Template](/reference/templates/PENDING.md) for the full pattern.
+
+Example `HEARTBEAT.md` task for overdue detection:
+
+```md
+tasks:
+
+- name: pending-tasks-check
+  interval: 30m
+  prompt: |
+  Read PENDING.md if it exists.
+  Check each pending item's deadline against the current time.
+  If any item is overdue and not completed, report the overdue items to the user.
+  If all items are on-track, reply HEARTBEAT_OK.
+```
 
 ### Can the agent update HEARTBEAT.md?
 

--- a/docs/reference/templates/PENDING.md
+++ b/docs/reference/templates/PENDING.md
@@ -1,0 +1,208 @@
+---
+title: "PENDING.md Template"
+summary: "Workspace template for PENDING.md — cross-session commitment tracking"
+read_when:
+  - Setting up a workspace for multi-day workflows
+  - Tracking commitments that must survive session reset
+---
+
+# PENDING.md Template
+
+`PENDING.md` is an optional workspace file for tracking cross-session commitments
+that should survive session resets, compaction, or multi-day execution boundaries.
+
+It is especially useful for commitments such as:
+
+- multi-day API-limited batch jobs
+- follow-ups promised to a user
+- manual review tasks with deadlines
+- long-running workflows coordinated across multiple sessions
+
+This file is user-maintained and lives in the workspace, following OpenClaw's
+"workspace as private memory" model.
+
+> **Note:** `PENDING.md` is a community workspace pattern, not a built-in runtime
+> feature. It does not replace Background Tasks, Cron Jobs, Standing Orders, or
+> `HEARTBEAT.md`. Instead, it complements them by recording commitments that need
+> to remain visible across session boundaries.
+
+## When to Use PENDING.md
+
+Use `PENDING.md` when you need to track:
+
+- commitments that must survive session reset or compaction
+- work with a human deadline
+- tasks that span multiple sessions or multiple days
+- reminders that should be checked periodically via `HEARTBEAT.md`
+
+Do not use `PENDING.md` as a replacement for:
+
+- **Background Tasks** — for tracking active/running background work
+- **Cron Jobs** — for scheduling recurring or delayed triggers
+- **Standing Orders** — for persistent authorization/rules
+- **HEARTBEAT.md** — for periodic checks and reporting logic
+
+A common pattern is:
+
+1. Record the commitment in `PENDING.md`
+2. Use `HEARTBEAT.md` to check deadlines periodically
+3. Use Background Tasks or Cron for the actual execution
+4. Mark the item complete in `PENDING.md` when finished
+
+## Recommended Location
+
+Place this file in your workspace:
+
+```text
+~/.openclaw/workspace/PENDING.md
+```
+
+## Recommended Entry Format
+
+Use one section per commitment.
+
+**Core fields (recommended):**
+
+- **Committed** — when the commitment was made
+- **Deadline** — target completion date/time
+- **Description** — what needs to be done
+- **Status** — current state
+- **Notes** — important execution context
+
+**Optional fields:**
+
+- **Owner** — which agent/user made the commitment
+- **Related** — references to sessions, files, jobs, or tickets
+- **Next Checkpoint** — when to check progress (for multi-day work)
+- **Completion Signal** — what counts as done
+
+**Example status values:**
+
+- Not Started
+- In Progress
+- Blocked
+- Completed
+- Cancelled
+
+## Template Example
+
+```md
+# PENDING
+
+## Active
+
+### API Batch Job - Data Export
+
+- **Committed**: 2026-04-17
+- **Deadline**: 2026-04-22
+- **Description**: Export 1000 records via rate-limited API.
+- **Status**: In Progress (800/1000 complete)
+- **Notes**:
+  - API is rate-limited
+  - Cron resumes processing at 02:00 daily
+  - Resume from the last successful checkpoint
+- **Related**:
+  - Job: nightly-export
+  - Workspace file: reports/export-log.md
+
+### Follow Up - Customer Reply
+
+- **Committed**: 2026-04-18
+- **Deadline**: 2026-04-19
+- **Description**: Send a summary and next steps after document review.
+- **Status**: Not Started
+- **Notes**:
+  - Wait for final review notes
+  - Draft should be concise and action-oriented
+
+## Done
+
+### Weekly Review - Inbox Cleanup
+
+- **Committed**: 2026-04-19
+- **Deadline**: 2026-04-20
+- **Description**: Review untriaged items and identify action items.
+- **Status**: Completed
+- **Notes**:
+  - Finished during morning review
+  - No outstanding action items remain
+```
+
+## Minimal Format
+
+If you prefer a lighter format, this also works:
+
+```md
+### API Batch Job
+
+- **Deadline**: 2026-04-22
+- **Status**: In Progress (800/1000 complete)
+- **Notes**: Rate-limited API, resumes nightly via cron
+```
+
+The key requirement is that entries remain easy for both the user and the agent
+to read and update.
+
+## HEARTBEAT.md Integration
+
+A common pattern is to have `HEARTBEAT.md` periodically inspect `PENDING.md` and
+alert the user when an item is overdue.
+
+Example `HEARTBEAT.md` task:
+
+```md
+tasks:
+
+- name: pending-tasks-check
+  interval: 30m
+  prompt: |
+  Read PENDING.md if it exists.
+  Check each pending item's deadline against the current time.
+  If any item is overdue and not completed, report the overdue items.
+  If all items are on-track, reply HEARTBEAT_OK.
+```
+
+See [Heartbeat](/gateway/heartbeat) for full configuration details.
+
+## Suggested Conventions
+
+To keep `PENDING.md` reliable over time:
+
+- keep entries concise and readable
+- use explicit deadlines when possible
+- update status when progress changes
+- mark completed items clearly instead of silently deleting them
+- archive old items periodically if the file grows too large
+- prefer plain text and Markdown over custom syntax
+
+Archive pattern:
+
+- keep active items in `PENDING.md`
+- move completed or cancelled items to `PENDING-ARCHIVE.md`
+
+## Relationship to Native Mechanisms
+
+`PENDING.md` tracks commitments.
+
+Native mechanisms handle other concerns:
+
+| Mechanism        | Answers                                             |
+| ---------------- | --------------------------------------------------- |
+| Cron             | When should something run?                          |
+| Background Tasks | What is this running job doing?                     |
+| Standing Orders  | What is the agent allowed to do persistently?       |
+| HEARTBEAT.md     | What needs periodic attention?                      |
+| PENDING.md       | What commitment must be remembered across sessions? |
+
+This separation avoids overloading any single mechanism.
+
+## Notes
+
+- `PENDING.md` is optional.
+- It is not auto-injected into context.
+- The agent must explicitly read it when needed.
+- The file is intended to remain transparent, editable, and local to the
+  workspace.
+
+This makes it a good fit for OpenClaw's local-first, operator-controlled workflow
+model.


### PR DESCRIPTION
---

## Summary

This PR is documentation-only. It proposes documenting a community workspace pattern, `PENDING.md`, for tracking commitments that should survive session reset, compaction, or context loss.

This is not a new core feature and does not introduce any runtime or code changes. It is a user-maintained workspace file pattern that works alongside existing mechanisms such as Background Tasks, Cron, Standing Orders, and `HEARTBEAT.md`.

## Why this pattern exists

In production use, some commitments span multiple sessions or even multiple days. A common example is a rate-limited batch job that starts today, pauses overnight, resumes later, and still needs a deadline reminder even if the original session context is gone.

OpenClaw already has strong primitives for execution and scheduling:

- Background Tasks track running or completed work
- Cron schedules triggers
- Standing Orders provide persistent authority
- `HEARTBEAT.md` runs periodic checks

What is still easy to lose is the human-level commitment itself: “continue this tomorrow” or “finish this by Friday.” That commitment may outlive the original session, even when the execution context does not.

## Proposed documentation pattern

The pattern is simple:

- Store cross-session commitments in a user-maintained workspace file such as `~/.openclaw/workspace/PENDING.md`
- Use a `HEARTBEAT.md` task to periodically read that file
- Alert the user if an item is overdue or approaching its deadline

Example use case:

- A batch export is partially complete
- The work is paused due to API rate limits
- The deadline still matters tomorrow, even after session reset
- `PENDING.md` preserves that commitment in the workspace, and heartbeat checks keep it visible

## Why this fits OpenClaw

This pattern aligns with OpenClaw’s design principles:

- **Local-first**: all state remains in the user’s workspace
- **Explicit and operator-controlled**: users create and edit the file themselves
- **Workspace as private memory**: long-lived commitments are stored as transparent Markdown, not hidden runtime state

It also keeps a clear boundary with native mechanisms. `PENDING.md` does not replace task execution, scheduling, or authorization. It documents a lightweight way to persist commitments across sessions.

## Scope of this PR

This PR only adds documentation and examples. No TypeScript, Python, dependency, or behavior changes are proposed.

Planned additions:

- a new section in `docs/gateway/heartbeat.md`
- a comparison note in `docs/automation/tasks.md`
- a small entry in `docs/concepts/agent-workspace.md`
- a `docs/templates/PENDING.md.example`
- an optional test/usage report for reference

## Validation

This pattern was validated in a high-volume production environment over roughly 32 hours, including repeated heartbeat checks and real overdue alerts. It has been useful for multi-day, API-limited workflows where commitments must remain visible even when session context does not.

## Feedback requested

I would appreciate maintainer feedback on:

- whether this pattern belongs in the official docs
- whether the proposed doc locations make sense
- whether it should instead live as a community pattern referenced from docs

My goal is to document a practical workspace pattern that complements the current model without expanding core behavior.


This RFC is based on production usage and follow-up discussion in issue #69621 (https://github.com/openclaw/openclaw/issues/69621)
