### PR TITLE
fix: respect openrouter/auto model selection (#69527)

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -119,4 +119,56 @@ describe("openrouter provider hooks", () => {
       },
     });
   });
+
+  it("resolveDynamicModel returns id=auto for openrouter/auto sentinel (#69527)", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      modelRegistry: { find: vi.fn(() => null) } as never,
+    } as never);
+
+    expect(resolved).toMatchObject({
+      provider: "openrouter",
+      id: "auto",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("resolveDynamicModel preserves prefixed id for normal OpenRouter model ids", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "openrouter",
+      modelId: "openai/gpt-5.4",
+      modelRegistry: { find: vi.fn(() => null) } as never,
+    } as never);
+
+    expect(resolved).toMatchObject({
+      provider: "openrouter",
+      id: "openai/gpt-5.4",
+    });
+  });
+
+  it("prepareDynamicModel is called with auto model id for openrouter/auto sentinel", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    // We verify the apiModelId normalization via isCacheTtlEligible
+    // which also uses the apiModelId normalization
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+      } as never),
+    ).toBe(false);
+
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "openrouter",
+        modelId: "anthropic/claude-3-5-sonnet",
+      } as never),
+    ).toBe(true);
+  });
 });

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -49,10 +49,13 @@ export default definePluginEntry({
     function buildDynamicOpenRouterModel(
       ctx: ProviderResolveDynamicModelContext,
     ): ProviderRuntimeModel {
-      const capabilities = getOpenRouterModelCapabilities(ctx.modelId);
+      // "openrouter/auto" is a special sentinel that means "let OpenRouter pick the best model".
+      // The OpenRouter API expects the bare model id "auto", not the prefixed "openrouter/auto".
+      const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+      const capabilities = getOpenRouterModelCapabilities(apiModelId);
       return {
-        id: ctx.modelId,
-        name: capabilities?.name ?? ctx.modelId,
+        id: apiModelId,
+        name: capabilities?.name ?? apiModelId,
         api: "openai-completions",
         provider: PROVIDER_ID,
         baseUrl: OPENROUTER_BASE_URL,
@@ -112,7 +115,8 @@ export default definePluginEntry({
       },
       resolveDynamicModel: (ctx) => buildDynamicOpenRouterModel(ctx),
       prepareDynamicModel: async (ctx) => {
-        await loadOpenRouterModelCapabilities(ctx.modelId);
+        const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+        await loadOpenRouterModelCapabilities(apiModelId);
       },
       normalizeConfig: ({ providerConfig }) => {
         const normalizedBaseUrl = normalizeOpenRouterBaseUrl(providerConfig.baseUrl);
@@ -134,7 +138,10 @@ export default definePluginEntry({
       resolveReasoningOutputMode: () => "native",
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,
-      isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
+      isCacheTtlEligible: (ctx) => {
+        const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+        return isOpenRouterCacheTtlModel(apiModelId);
+      },
     });
     api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -180,10 +180,13 @@ function buildDynamicModel(
   const lower = lowercasePreservingWhitespace(modelId);
   switch (params.provider) {
     case "openrouter": {
-      const capabilities = options.getOpenRouterModelCapabilities(modelId);
+      // "openrouter/auto" is a special sentinel that means "let OpenRouter pick the best model".
+      // The OpenRouter API expects the bare model id "auto", not the prefixed "openrouter/auto".
+      const apiModelId = modelId === "openrouter/auto" ? "auto" : modelId;
+      const capabilities = options.getOpenRouterModelCapabilities(apiModelId);
       return {
-        id: modelId,
-        name: capabilities?.name ?? modelId,
+        id: apiModelId,
+        name: capabilities?.name ?? apiModelId,
         api: "openai-completions" as const,
         provider: "openrouter",
         baseUrl: OPENROUTER_BASE_URL,
@@ -522,7 +525,8 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
             prepareDynamicModel:
               provider === "openrouter"
                 ? async ({ modelId }: { modelId: string }) => {
-                    await loadOpenRouterModelCapabilities(modelId);
+                    const apiModelId = modelId === "openrouter/auto" ? "auto" : modelId;
+                    await loadOpenRouterModelCapabilities(apiModelId);
                   }
                 : undefined,
             resolveDynamicModel: (ctx: DynamicModelContext) =>

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -612,6 +612,29 @@ describe("resolveModel", () => {
     });
   });
 
+  it("resolves openrouter/auto to id=auto for OpenRouter API auto-selection (#69527)", () => {
+    mockGetOpenRouterModelCapabilities.mockReturnValue({
+      name: "OpenRouter Best Available",
+      input: ["text", "image"],
+      reasoning: false,
+      contextWindow: 200_000,
+      maxTokens: 8192,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+
+    const result = resolveModelForTest("openrouter", "openrouter/auto", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openrouter",
+      id: "auto",
+      name: "OpenRouter Best Available",
+      input: ["text", "image"],
+      reasoning: false,
+      contextWindow: 200_000,
+    });
+  });
+
   it("matches prefixed Hugging Face ids against discovered registry models", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "huggingface",


### PR DESCRIPTION
## 问题\nopenrouter/auto 模型被忽略，强制降级到 gpt-4.1-mini。\n\n## 修复\n确保 openrouter/auto 模型选择被正确传递到 provider wrapper，不被覆盖。\n\n## 测试覆盖\n新增相关测试用例。