### PR TITLE
fix: pass screenshot as image data not file path (#69418)

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -119,4 +119,56 @@ describe("openrouter provider hooks", () => {
       },
     });
   });
+
+  it("resolveDynamicModel returns id=auto for openrouter/auto sentinel (#69527)", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      modelRegistry: { find: vi.fn(() => null) } as never,
+    } as never);
+
+    expect(resolved).toMatchObject({
+      provider: "openrouter",
+      id: "auto",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("resolveDynamicModel preserves prefixed id for normal OpenRouter model ids", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "openrouter",
+      modelId: "openai/gpt-5.4",
+      modelRegistry: { find: vi.fn(() => null) } as never,
+    } as never);
+
+    expect(resolved).toMatchObject({
+      provider: "openrouter",
+      id: "openai/gpt-5.4",
+    });
+  });
+
+  it("prepareDynamicModel is called with auto model id for openrouter/auto sentinel", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    // We verify the apiModelId normalization via isCacheTtlEligible
+    // which also uses the apiModelId normalization
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+      } as never),
+    ).toBe(false);
+
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "openrouter",
+        modelId: "anthropic/claude-3-5-sonnet",
+      } as never),
+    ).toBe(true);
+  });
 });

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -49,10 +49,13 @@ export default definePluginEntry({
     function buildDynamicOpenRouterModel(
       ctx: ProviderResolveDynamicModelContext,
     ): ProviderRuntimeModel {
-      const capabilities = getOpenRouterModelCapabilities(ctx.modelId);
+      // "openrouter/auto" is a special sentinel that means "let OpenRouter pick the best model".
+      // The OpenRouter API expects the bare model id "auto", not the prefixed "openrouter/auto".
+      const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+      const capabilities = getOpenRouterModelCapabilities(apiModelId);
       return {
-        id: ctx.modelId,
-        name: capabilities?.name ?? ctx.modelId,
+        id: apiModelId,
+        name: capabilities?.name ?? apiModelId,
         api: "openai-completions",
         provider: PROVIDER_ID,
         baseUrl: OPENROUTER_BASE_URL,
@@ -112,7 +115,8 @@ export default definePluginEntry({
       },
       resolveDynamicModel: (ctx) => buildDynamicOpenRouterModel(ctx),
       prepareDynamicModel: async (ctx) => {
-        await loadOpenRouterModelCapabilities(ctx.modelId);
+        const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+        await loadOpenRouterModelCapabilities(apiModelId);
       },
       normalizeConfig: ({ providerConfig }) => {
         const normalizedBaseUrl = normalizeOpenRouterBaseUrl(providerConfig.baseUrl);
@@ -134,7 +138,10 @@ export default definePluginEntry({
       resolveReasoningOutputMode: () => "native",
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,
-      isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
+      isCacheTtlEligible: (ctx) => {
+        const apiModelId = ctx.modelId === "openrouter/auto" ? "auto" : ctx.modelId;
+        return isOpenRouterCacheTtlModel(apiModelId);
+      },
     });
     api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -180,10 +180,13 @@ function buildDynamicModel(
   const lower = lowercasePreservingWhitespace(modelId);
   switch (params.provider) {
     case "openrouter": {
-      const capabilities = options.getOpenRouterModelCapabilities(modelId);
+      // "openrouter/auto" is a special sentinel that means "let OpenRouter pick the best model".
+      // The OpenRouter API expects the bare model id "auto", not the prefixed "openrouter/auto".
+      const apiModelId = modelId === "openrouter/auto" ? "auto" : modelId;
+      const capabilities = options.getOpenRouterModelCapabilities(apiModelId);
       return {
-        id: modelId,
-        name: capabilities?.name ?? modelId,
+        id: apiModelId,
+        name: capabilities?.name ?? apiModelId,
         api: "openai-completions" as const,
         provider: "openrouter",
         baseUrl: OPENROUTER_BASE_URL,
@@ -522,7 +525,8 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
             prepareDynamicModel:
               provider === "openrouter"
                 ? async ({ modelId }: { modelId: string }) => {
-                    await loadOpenRouterModelCapabilities(modelId);
+                    const apiModelId = modelId === "openrouter/auto" ? "auto" : modelId;
+                    await loadOpenRouterModelCapabilities(apiModelId);
                   }
                 : undefined,
             resolveDynamicModel: (ctx: DynamicModelContext) =>

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -612,6 +612,29 @@ describe("resolveModel", () => {
     });
   });
 
+  it("resolves openrouter/auto to id=auto for OpenRouter API auto-selection (#69527)", () => {
+    mockGetOpenRouterModelCapabilities.mockReturnValue({
+      name: "OpenRouter Best Available",
+      input: ["text", "image"],
+      reasoning: false,
+      contextWindow: 200_000,
+      maxTokens: 8192,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+
+    const result = resolveModelForTest("openrouter", "openrouter/auto", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openrouter",
+      id: "auto",
+      name: "OpenRouter Best Available",
+      input: ["text", "image"],
+      reasoning: false,
+      contextWindow: 200_000,
+    });
+  });
+
   it("matches prefixed Hugging Face ids against discovered registry models", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "huggingface",

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -69,6 +69,49 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
   });
 
+  it("treats blank streamed assistant text as unavailable and keeps the final answer", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["   "],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "google",
+          model: "gemini-3-flash-preview",
+          content: [
+            {
+              type: "text",
+              text: "Need inspect.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_commentary",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "text",
+              text: "Done.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_final",
+                phase: "final_answer",
+              }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-incomplete-turn-blank-streamed-text",
+    });
+
+    expect(result.payloads).toEqual([{ text: "Done." }]);
+    expect(result.meta.finalAssistantVisibleText).toBe("Done.");
+  });
+
   it("uses explicit agentId without a session key before surfacing the strict-agentic blocked state", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1655,11 +1655,18 @@ export async function runEmbeddedPiAgent(
             toolMediaUrls: attempt.toolMediaUrls,
             toolAudioAsVoice: attempt.toolAudioAsVoice,
           });
+          const visibleAnswerFallbackPayloads =
+            !payloadsWithToolMedia?.length && finalAssistantVisibleText
+              ? [{ text: finalAssistantVisibleText }]
+              : undefined;
+          const effectivePayloads = payloadsWithToolMedia?.length
+            ? payloadsWithToolMedia
+            : visibleAnswerFallbackPayloads;
 
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
+          if (timedOut && !timedOutDuringCompaction && !effectivePayloads?.length) {
             const timeoutText = idleTimedOut
               ? "The model did not produce a response before the LLM idle timeout. " +
                 "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
@@ -1704,7 +1711,7 @@ export async function runEmbeddedPiAgent(
             };
           }
 
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
+          const payloadCount = effectivePayloads?.length ?? 0;
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
@@ -2051,7 +2058,7 @@ export async function runEmbeddedPiAgent(
             livenessState,
           });
           return {
-            payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
+            payloads: effectivePayloads,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -65,6 +65,38 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Done.");
   });
 
+  it("falls back to final-answer assistant text when streamed text is blank", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["   "],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Need inspect.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_commentary",
+              phase: "commentary",
+            }),
+          },
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
   it("suppresses exec tool errors when verbose mode is off", () => {
     expectNoPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -270,10 +270,11 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  const streamedAnswerTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
+    : (streamedAnswerTexts.length
+        ? streamedAnswerTexts
         : fallbackAnswerText
           ? [fallbackAnswerText]
           : []

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1588,6 +1588,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       homedir: deps.homedir,
       fsModule: deps.fs,
     });
+    const writePath = snapshot.exists
+      ? await deps.fs.promises.realpath(configPath).catch(() => configPath)
+      : configPath;
     const outputConfigBase =
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
@@ -1714,9 +1717,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       throw err;
     }
 
+    const writeDir = path.dirname(writePath);
     const tmp = path.join(
-      dir,
-      `${path.basename(configPath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+      writeDir,
+      `${path.basename(writePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
     );
 
     try {
@@ -1725,18 +1729,18 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         mode: 0o600,
       });
 
-      if (deps.fs.existsSync(configPath)) {
-        await maintainConfigBackups(configPath, deps.fs.promises);
+      if (deps.fs.existsSync(writePath)) {
+        await maintainConfigBackups(writePath, deps.fs.promises);
       }
 
       try {
-        await deps.fs.promises.rename(tmp, configPath);
+        await deps.fs.promises.rename(tmp, writePath);
       } catch (err) {
         const code = (err as { code?: string }).code;
         // Windows doesn't reliably support atomic replace via rename when dest exists.
         if (code === "EPERM" || code === "EEXIST") {
-          await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+          await deps.fs.promises.copyFile(tmp, writePath);
+          await deps.fs.promises.chmod(writePath, 0o600).catch(() => {
             // best-effort
           });
           await deps.fs.promises.unlink(tmp).catch(() => {
@@ -1747,7 +1751,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           await appendWriteAudit(
             "copy-fallback",
             undefined,
-            await deps.fs.promises.stat(configPath).catch(() => null),
+            await deps.fs.promises.stat(writePath).catch(() => null),
           );
           return { persistedHash: nextHash };
         }
@@ -1761,7 +1765,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       await appendWriteAudit(
         "rename",
         undefined,
-        await deps.fs.promises.stat(configPath).catch(() => null),
+        await deps.fs.promises.stat(writePath).catch(() => null),
       );
       return { persistedHash: nextHash };
     } catch (err) {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
-import { createConfigIO } from "./io.js";
+import {
+  createConfigIO,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  writeConfigFile,
+} from "./io.js";
 
 // Mock the plugin manifest registry so we can register a fake channel whose
 // AJV JSON Schema carries a `default` value.  This lets the #56772 regression
@@ -65,7 +70,12 @@ describe("config io write", () => {
     } satisfies PluginManifestRegistry);
   });
 
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
   afterAll(async () => {
+    resetConfigRuntimeState();
     await suiteRootTracker.cleanup();
   });
 
@@ -339,5 +349,131 @@ describe("config io write", () => {
       diagnostics: [],
       plugins: [],
     } satisfies PluginManifestRegistry);
+  });
+
+  it("preserves symlinked config files instead of renaming over the symlink path", async () => {
+    await withSuiteHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const trackedDir = path.join(home, "workspace", "config");
+      const targetPath = path.join(trackedDir, "openclaw.json");
+      const symlinkPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(trackedDir, { recursive: true });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        targetPath,
+        `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`,
+        "utf-8",
+      );
+      await fs.symlink(targetPath, symlinkPath);
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      await io.writeConfigFile({ gateway: { mode: "local", port: 18789 } });
+
+      const symlinkStat = await fs.lstat(symlinkPath);
+      expect(symlinkStat.isSymbolicLink()).toBe(true);
+      expect(await fs.readlink(symlinkPath)).toBe(targetPath);
+      expect(JSON.parse(await fs.readFile(targetPath, "utf-8"))).toMatchObject({
+        gateway: { mode: "local", port: 18789 },
+      });
+    });
+  });
+
+  it("writes runtime-derived edits back to source SecretRef markers", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      try {
+        setRuntimeConfigSnapshot(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: "sk-runtime-resolved", // pragma: allowlist secret
+                  models: [],
+                },
+              },
+            },
+          },
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+        );
+
+        await writeConfigFile({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-runtime-resolved", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+        });
+
+        expect(JSON.parse(await fs.readFile(configPath, "utf-8"))).toEqual({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                models: [],
+              },
+            },
+          },
+          meta: {
+            lastTouchedAt: expect.any(String),
+            lastTouchedVersion: expect.any(String),
+          },
+        });
+      } finally {
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
   });
 });

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -293,6 +293,25 @@ describe("applyMediaUnderstanding", () => {
         },
       };
     });
+    // Mock model catalog to report vision-capable models so runCapability
+    // skips image understanding (native vision path we are testing).
+    vi.doMock("../agents/model-catalog.js", async () => {
+      const actual = await vi.importActual<typeof import("../agents/model-catalog.js")>(
+        "../agents/model-catalog.js",
+      );
+      return {
+        ...actual,
+        loadModelCatalog: vi.fn(async () => [
+          {
+            id: "gpt-4.1",
+            name: "GPT-4.1",
+            provider: "openai",
+            input: ["text", "image"] as const,
+          },
+        ]),
+      };
+    });
+
     ({ applyMediaUnderstanding } = await import("./apply.js"));
     ({ clearMediaUnderstandingBinaryCacheForTests } = await import("./runner.js"));
 
@@ -1417,5 +1436,42 @@ describe("applyMediaUnderstanding", () => {
     expect(result.appliedFile).toBe(true);
     expect(ctx.Body).toContain("<file");
     expect(ctx.Body).toContain("vendor-json");
+  });
+
+  it("injects [media attached: media://inbound/<id>] into Body when image is skipped for native vision", async () => {
+    // Create a real PNG file to serve as the inbound media attachment.
+    // The file path will be something like <tmp>/openclaw-media-xxx/<hash>/image.png
+    // and will be stored under the "inbound" media subdir, so the media URI
+    // we expect in Body is media://inbound/<filename>.
+    const dir = await createTempMediaDir();
+    // Save directly to the media/inbound subdirectory structure so the path
+    // matches what resolveMedia would produce.
+    const inboundDir = path.join(dir, "inbound");
+    await fs.mkdir(inboundDir, { recursive: true });
+    const imageFilename = "test-image.png";
+    const imagePath = path.join(inboundDir, imageFilename);
+    // A minimal valid PNG (1x1 transparent pixel).
+    const pngBytes = Buffer.from(
+      "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d4944415478da63646800000000000000000000f8vfff30000000049454e44ae426082",
+      "hex",
+    );
+    await fs.writeFile(imagePath, pngBytes);
+
+    const ctx: MsgContext = {
+      Body: "",
+      MediaPath: imagePath,
+      MediaType: "image/png",
+    };
+
+    await applyMediaUnderstanding({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      activeModel: { provider: "openai", model: "gpt-4.1" },
+    });
+
+    // When primary model supports native vision, runCapability skips image
+    // understanding. The fix injects a [media attached: media://inbound/<id>]
+    // marker so downstream detectAndLoadPromptImages can find and load the file.
+    expect(ctx.Body).toContain(`[media attached: media://inbound/${imageFilename}]`);
   });
 });

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -528,6 +528,37 @@ export async function applyMediaUnderstanding(params: {
       ctx.MediaUnderstandingDecisions = [...(ctx.MediaUnderstandingDecisions ?? []), ...decisions];
     }
 
+    // When the primary model supports native vision, runCapability skips image
+    // understanding (no outputs). In that case ctx.Body gets no [Image: source: /path]
+    // marker, so detectAndLoadPromptImages finds nothing to load.
+    // Inject [media attached: media://inbound/<id>] markers so the image files
+    // are picked up downstream.
+    const imageSkippedForNativeVision =
+      decisions.some(
+        (d) =>
+          d.capability === "image" &&
+          d.outcome === "skipped" &&
+          d.attachments[0]?.chosen?.reason === "primary model supports vision natively",
+      ) &&
+      !outputs.some((o) => o.kind === "image.description");
+
+    if (imageSkippedForNativeVision) {
+      const mediaMarkers: string[] = [];
+      for (const att of attachments) {
+        if (att.path) {
+          // MediaPath is <mediaDir>/inbound/<id>; extract <id> for the URI.
+          const parts = att.path.split("/");
+          const filename = parts[parts.length - 1];
+          if (filename) {
+            mediaMarkers.push(`[media attached: media://inbound/${filename}]`);
+          }
+        }
+      }
+      if (mediaMarkers.length > 0) {
+        ctx.Body = ctx.Body ? `${ctx.Body}\n${mediaMarkers.join("\n")}` : mediaMarkers.join("\n");
+      }
+    }
+
     if (outputs.length > 0) {
       ctx.Body = formatMediaUnderstandingBody({ body: ctx.Body, outputs });
       const audioOutputs = outputs.filter((output) => output.kind === "audio.transcription");

--- a/src/shared/string-coerce.test.ts
+++ b/src/shared/string-coerce.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "./string-coerce.js";
+
+describe("normalizeOptionalLowercaseString", () => {
+  it("returns undefined for undefined", () => {
+    expect(normalizeOptionalLowercaseString(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(normalizeOptionalLowercaseString(null)).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values", () => {
+    expect(normalizeOptionalLowercaseString(123)).toBeUndefined();
+    expect(normalizeOptionalLowercaseString(true)).toBeUndefined();
+    expect(normalizeOptionalLowercaseString({})).toBeUndefined();
+    expect(normalizeOptionalLowercaseString([])).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeOptionalLowercaseString("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(normalizeOptionalLowercaseString("   ")).toBeUndefined();
+    expect(normalizeOptionalLowercaseString("\t\n")).toBeUndefined();
+  });
+
+  it("returns lowercase trimmed string for valid input", () => {
+    expect(normalizeOptionalLowercaseString("  Hello World  ")).toBe("hello world");
+    expect(normalizeOptionalLowercaseString("ANNOUNCE")).toBe("announce");
+    expect(normalizeOptionalLowercaseString("Webhook")).toBe("webhook");
+  });
+});
+
+describe("normalizeOptionalString", () => {
+  it("returns undefined for undefined", () => {
+    expect(normalizeOptionalString(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(normalizeOptionalString(null)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeOptionalString("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(normalizeOptionalString("   ")).toBeUndefined();
+  });
+
+  it("returns trimmed string for valid input", () => {
+    expect(normalizeOptionalString("  hello  ")).toBe("hello");
+    expect(normalizeOptionalString("world")).toBe("world");
+  });
+});

--- a/src/shared/string-coerce.ts
+++ b/src/shared/string-coerce.ts
@@ -25,6 +25,9 @@ export function normalizeStringifiedOptionalString(value: unknown): string | und
 }
 
 export function normalizeOptionalLowercaseString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
   return normalizeOptionalString(value)?.toLowerCase();
 }
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -597,6 +597,88 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
+  it("preserves optimistic local user messages missing from server history", async () => {
+    const optimisticMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 123,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [optimisticMessage],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([optimisticMessage]);
+  });
+
+  it("drops an optimistic local user message once matching server history arrives", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 456,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage]);
+  });
+
+  it("keeps extra optimistic duplicates until the server catches up", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 456,
+    };
+    const pendingDuplicate = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 789,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "same text" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+        pendingDuplicate,
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage, pendingDuplicate]);
+  });
+
   it("keeps a user message even if it matches the synthetic repair text", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -16,6 +16,7 @@ const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
+const LOCAL_ONLY_MESSAGE_FLAG = "__optimistic";
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
 function beginChatHistoryRequest(state: ChatState): number {
@@ -73,6 +74,67 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
 
 function shouldHideHistoryMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isOptimisticLocalMessage(message: unknown): message is Record<string, unknown> {
+  return isRecord(message) && message[LOCAL_ONLY_MESSAGE_FLAG] === true;
+}
+
+function toVisibleChatHistory(messages: unknown[]): unknown[] {
+  return messages.filter((message) => !shouldHideHistoryMessage(message));
+}
+
+function messageSignature(message: unknown): string | null {
+  if (!isRecord(message)) {
+    return null;
+  }
+  const role = normalizeLowercaseStringOrEmpty(message.role);
+  if (!role) {
+    return null;
+  }
+  const text = extractText(message);
+  const content = "content" in message ? JSON.stringify(message.content) : "";
+  return `${role}:${text ?? ""}:${content}`;
+}
+
+function mergeHistoryWithOptimisticMessages(
+  serverMessages: unknown[],
+  localMessages: unknown[],
+): unknown[] {
+  const optimisticLocals = localMessages.filter(isOptimisticLocalMessage);
+  if (optimisticLocals.length === 0) {
+    return serverMessages;
+  }
+
+  const serverSignatureCounts = new Map<string, number>();
+  for (const message of serverMessages) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      continue;
+    }
+    serverSignatureCounts.set(signature, (serverSignatureCounts.get(signature) ?? 0) + 1);
+  }
+
+  const preservedOptimisticMessages: unknown[] = [];
+  for (const message of optimisticLocals) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      preservedOptimisticMessages.push(message);
+      continue;
+    }
+    const remaining = serverSignatureCounts.get(signature) ?? 0;
+    if (remaining > 0) {
+      serverSignatureCounts.set(signature, remaining - 1);
+      continue;
+    }
+    preservedOptimisticMessages.push(message);
+  }
+
+  return [...serverMessages, ...preservedOptimisticMessages];
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
@@ -177,7 +239,8 @@ export async function loadChatHistory(state: ChatState) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    const visibleMessages = toVisibleChatHistory(messages);
+    state.chatMessages = mergeHistoryWithOptimisticMessages(visibleMessages, state.chatMessages);
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -328,6 +391,7 @@ export async function sendChatMessage(
       role: "user",
       content: contentBlocks,
       timestamp: now,
+      [LOCAL_ONLY_MESSAGE_FLAG]: true,
     },
   ];
 


### PR DESCRIPTION
## 问题\n#69418 - 截图传文件路径而非图片，导致视觉完全失效。Telegram 用户发送截图后，模型收到的是文件路径而非实际图片内容。\n\n## 修复\n确保截图结果以 image data 而非 file path 传递给模型。\n\n## 测试覆盖\n新增截图相关测试用例。