### PR TITLE
fix(skills): recurse into subdirectories when scanning skill root (#56915)

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -237,8 +237,8 @@ describe("loadWorkspaceSkillEntries", () => {
   it("discovers skills nested under workspace skill subdirectories", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     await writeSkill({
-      dir: path.join(workspaceDir, "skills", "coze", "koze-retrieval"),
-      name: "koze-retrieval",
+      dir: path.join(workspaceDir, "skills", "coze", "coze-retrieval"),
+      name: "coze-retrieval",
       description: "Nested retrieval skill",
     });
     await writeSkill({
@@ -249,9 +249,9 @@ describe("loadWorkspaceSkillEntries", () => {
 
     const entries = loadTestWorkspaceSkillEntries(workspaceDir);
 
-    expect(entries.map((entry) => entry.skill.name).sort()).toEqual([
+    expect(entries.map((entry) => entry.skill.name).toSorted()).toEqual([
+      "coze-retrieval",
       "deeper-skill",
-      "koze-retrieval",
     ]);
   });
 

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -234,6 +234,27 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(hiddenEntry?.exposure?.includeInAvailableSkillsPrompt).toBe(false);
   });
 
+  it("discovers skills nested under workspace skill subdirectories", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "coze", "koze-retrieval"),
+      name: "koze-retrieval",
+      description: "Nested retrieval skill",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "catalog", "coze", "deeper-skill"),
+      name: "deeper-skill",
+      description: "Deeply nested skill",
+    });
+
+    const entries = loadTestWorkspaceSkillEntries(workspaceDir);
+
+    expect(entries.map((entry) => entry.skill.name).sort()).toEqual([
+      "deeper-skill",
+      "koze-retrieval",
+    ]);
+  });
+
   it("applies agent skill filters and replacement semantics", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     await writeWorkspaceSkills(workspaceDir, [

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -154,7 +154,7 @@ function listCandidateSkillDirs(dir: string): string[] {
   };
 
   walk(dir);
-  return skillDirs.sort((left, right) => left.localeCompare(right));
+  return skillDirs.toSorted((left, right) => left.localeCompare(right));
 }
 
 export function loadSkillsFromDirSafe(params: { dir: string; source: string; maxBytes?: number }): {

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -95,6 +95,7 @@ function loadSingleSkillDirectory(params: {
 
 function listCandidateSkillDirs(dir: string): string[] {
   const skillDirs: string[] = [];
+  const visited = new Set<string>();
 
   const walk = (currentDir: string) => {
     let entries: fs.Dirent[];
@@ -121,6 +122,17 @@ function listCandidateSkillDirs(dir: string): string[] {
       if (!isDirectory) {
         continue;
       }
+
+      let realPath: string;
+      try {
+        realPath = fs.realpathSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (visited.has(realPath)) {
+        continue;
+      }
+      visited.add(realPath);
 
       if (fs.existsSync(path.join(fullPath, "SKILL.md"))) {
         skillDirs.push(fullPath);

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -97,6 +97,13 @@ function listCandidateSkillDirs(dir: string): string[] {
   const skillDirs: string[] = [];
   const visited = new Set<string>();
 
+  let rootRealPath: string;
+  try {
+    rootRealPath = fs.realpathSync(dir);
+  } catch {
+    return [];
+  }
+
   const walk = (currentDir: string) => {
     let entries: fs.Dirent[];
     try {
@@ -130,6 +137,9 @@ function listCandidateSkillDirs(dir: string): string[] {
         continue;
       }
       if (visited.has(realPath)) {
+        continue;
+      }
+      if (!realPath.startsWith(rootRealPath + path.sep) && realPath !== rootRealPath) {
         continue;
       }
       visited.add(realPath);

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -94,18 +94,45 @@ function loadSingleSkillDirectory(params: {
 }
 
 function listCandidateSkillDirs(dir: string): string[] {
-  try {
-    return fs
-      .readdirSync(dir, { withFileTypes: true })
-      .filter(
-        (entry) =>
-          entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules",
-      )
-      .map((entry) => path.join(dir, entry.name))
-      .sort((left, right) => left.localeCompare(right));
-  } catch {
-    return [];
-  }
+  const skillDirs: string[] = [];
+
+  const walk = (currentDir: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+
+      const fullPath = path.join(currentDir, entry.name);
+      let isDirectory = entry.isDirectory();
+      if (!isDirectory && entry.isSymbolicLink()) {
+        try {
+          isDirectory = fs.statSync(fullPath).isDirectory();
+        } catch {
+          continue;
+        }
+      }
+      if (!isDirectory) {
+        continue;
+      }
+
+      if (fs.existsSync(path.join(fullPath, "SKILL.md"))) {
+        skillDirs.push(fullPath);
+        continue;
+      }
+
+      walk(fullPath);
+    }
+  };
+
+  walk(dir);
+  return skillDirs.sort((left, right) => left.localeCompare(right));
 }
 
 export function loadSkillsFromDirSafe(params: { dir: string; source: string; maxBytes?: number }): {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -474,31 +474,30 @@ function loadSkillEntries(
         continue;
       }
       const skillMd = path.join(skillDir, "SKILL.md");
-      if (!fs.existsSync(skillMd)) {
-        continue;
-      }
-      const skillMdRealPath = resolveContainedSkillPath({
-        source: params.source,
-        rootDir,
-        rootRealPath: baseDirRealPath,
-        candidatePath: skillMd,
-      });
-      if (!skillMdRealPath) {
-        continue;
-      }
-      try {
-        const size = fs.statSync(skillMdRealPath).size;
-        if (size > limits.maxSkillFileBytes) {
-          skillsLogger.warn("Skipping skill due to oversized SKILL.md.", {
-            skill: name,
-            filePath: skillMd,
-            size,
-            maxSkillFileBytes: limits.maxSkillFileBytes,
-          });
+      if (fs.existsSync(skillMd)) {
+        const skillMdRealPath = resolveContainedSkillPath({
+          source: params.source,
+          rootDir,
+          rootRealPath: baseDirRealPath,
+          candidatePath: skillMd,
+        });
+        if (!skillMdRealPath) {
           continue;
         }
-      } catch {
-        continue;
+        try {
+          const size = fs.statSync(skillMdRealPath).size;
+          if (size > limits.maxSkillFileBytes) {
+            skillsLogger.warn("Skipping skill due to oversized SKILL.md.", {
+              skill: name,
+              filePath: skillMd,
+              size,
+              maxSkillFileBytes: limits.maxSkillFileBytes,
+            });
+            continue;
+          }
+        } catch {
+          continue;
+        }
       }
 
       const loaded = loadSkillsFromDirSafe({


### PR DESCRIPTION
## Summary
- recurse local skill discovery so nested `SKILL.md` files under a configured skills root are found
- allow workspace skill roots to load nested category folders instead of requiring `SKILL.md` at the first child level
- add a regression test covering nested workspace skill directories

## Testing
- `pnpm test src/agents/skills.loadworkspaceskillentries.test.ts`
- `pnpm build` *(fails in this environment during `runtime-postbuild` with `EINVAL: invalid argument, readlink '.../node_modules/acpx/node_modules'` after `pnpm install`)*

Closes #56915