### PR TITLE
[codex] Route message_sending hooks through generic reply delivery

### DIFF
--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./plugin-runtime.js", () => ({
+vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: getGlobalHookRunnerMock,
 }));
 import {

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./plugin-runtime.js", () => ({
+  getGlobalHookRunner: getGlobalHookRunnerMock,
+}));
 import {
   countOutboundMedia,
   createNormalizedOutboundDeliverer,
@@ -16,6 +21,11 @@ import {
   sendMediaWithLeadingCaption,
   sendPayloadWithChunkedTextAndMedia,
 } from "./reply-payload.js";
+
+beforeEach(() => {
+  getGlobalHookRunnerMock.mockReset();
+  getGlobalHookRunnerMock.mockReturnValue(null);
+});
 
 describe("isReasoningReplyPayload", () => {
   it.each([
@@ -399,6 +409,126 @@ describe("deliverTextOrMediaReply", () => {
       mediaUrl: "https://a",
       caption: "hello",
     });
+  });
+
+  it("applies message_sending mutations to generic text replies", async () => {
+    const sendMedia = vi.fn(async () => undefined);
+    const sendText = vi.fn(async () => undefined);
+    const runMessageSending = vi.fn(async () => ({ content: "rewritten" }));
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending,
+    });
+
+    await expect(
+      deliverTextOrMediaReply({
+        payload: { text: "hello" },
+        text: "hello",
+        sendText,
+        sendMedia,
+        messageSending: {
+          to: "chat-1",
+          channel: "signal",
+          accountId: "acct-1",
+          conversationId: "chat-1",
+          metadata: {
+            threadId: "t-1",
+          },
+        },
+      }),
+    ).resolves.toBe("text");
+
+    expect(runMessageSending).toHaveBeenCalledWith(
+      {
+        to: "chat-1",
+        content: "hello",
+        metadata: {
+          threadId: "t-1",
+          channel: "signal",
+          accountId: "acct-1",
+          mediaUrls: [],
+        },
+      },
+      {
+        channelId: "signal",
+        accountId: "acct-1",
+        conversationId: "chat-1",
+      },
+    );
+    expect(sendText).toHaveBeenCalledWith("rewritten");
+    expect(sendMedia).not.toHaveBeenCalled();
+  });
+
+  it("applies message_sending mutations to generic media replies", async () => {
+    const sendMedia = vi.fn(async () => undefined);
+    const sendText = vi.fn(async () => undefined);
+    const runMessageSending = vi.fn(async () => ({ content: "rewritten" }));
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending,
+    });
+
+    await expect(
+      deliverTextOrMediaReply({
+        payload: { text: "hello", mediaUrls: ["https://a", "https://b"] },
+        text: "hello",
+        sendText,
+        sendMedia,
+        messageSending: {
+          to: "chat-1",
+          channel: "signal",
+        },
+      }),
+    ).resolves.toBe("media");
+
+    expect(runMessageSending).toHaveBeenCalledWith(
+      {
+        to: "chat-1",
+        content: "hello",
+        metadata: {
+          channel: "signal",
+          mediaUrls: ["https://a", "https://b"],
+        },
+      },
+      {
+        channelId: "signal",
+      },
+    );
+    expect(sendMedia).toHaveBeenNthCalledWith(1, {
+      mediaUrl: "https://a",
+      caption: "rewritten",
+    });
+    expect(sendMedia).toHaveBeenNthCalledWith(2, {
+      mediaUrl: "https://b",
+      caption: undefined,
+    });
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("cancels generic reply delivery when message_sending blocks it", async () => {
+    const sendMedia = vi.fn(async () => undefined);
+    const sendText = vi.fn(async () => undefined);
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending,
+    });
+
+    await expect(
+      deliverTextOrMediaReply({
+        payload: { text: "hello", mediaUrls: ["https://a"] },
+        text: "hello",
+        sendText,
+        sendMedia,
+        messageSending: {
+          to: "chat-1",
+          channel: "signal",
+        },
+      }),
+    ).resolves.toBe("empty");
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(sendMedia).not.toHaveBeenCalled();
   });
 });
 

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -1,7 +1,7 @@
 import type { ReplyPayload as InternalReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeLowercaseStringOrEmpty, readStringValue } from "../shared/string-coerce.js";
-import { getGlobalHookRunner } from "./plugin-runtime.js";
 
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -1,6 +1,7 @@
 import type { ReplyPayload as InternalReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
 import { normalizeLowercaseStringOrEmpty, readStringValue } from "../shared/string-coerce.js";
+import { getGlobalHookRunner } from "./plugin-runtime.js";
 
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
@@ -27,6 +28,14 @@ export type SendableOutboundReplyParts = {
   hasText: boolean;
   hasMedia: boolean;
   hasContent: boolean;
+};
+
+export type ReplyMessageSendingContext = {
+  to: string;
+  channel: string;
+  accountId?: string;
+  conversationId?: string;
+  metadata?: Record<string, unknown>;
 };
 
 type SendPayloadContext = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0];
@@ -386,6 +395,7 @@ export async function deliverTextOrMediaReply(params: {
   chunkText?: (text: string) => readonly string[];
   sendText: (text: string) => Promise<void>;
   sendMedia: (payload: { mediaUrl: string; caption?: string }) => Promise<void>;
+  messageSending?: ReplyMessageSendingContext;
   onMediaError?: (params: {
     error: unknown;
     mediaUrl: string;
@@ -397,19 +407,28 @@ export async function deliverTextOrMediaReply(params: {
   const { mediaUrls } = resolveSendableOutboundReplyParts(params.payload, {
     text: params.text,
   });
+  const hookResult = await applyReplyMessageSendingHook({
+    text: params.text,
+    mediaUrls,
+    context: params.messageSending,
+  });
+  if (hookResult.cancelled) {
+    return "empty";
+  }
+  const effectiveText = hookResult.text;
   const sentMedia = await sendMediaWithLeadingCaption({
     mediaUrls,
-    caption: params.text,
+    caption: effectiveText,
     send: params.sendMedia,
     onError: params.onMediaError,
   });
   if (sentMedia) {
     return "media";
   }
-  if (!params.text) {
+  if (!effectiveText) {
     return "empty";
   }
-  const chunks = params.chunkText ? params.chunkText(params.text) : [params.text];
+  const chunks = params.chunkText ? params.chunkText(effectiveText) : [effectiveText];
   let sentText = false;
   for (const chunk of chunks) {
     if (!chunk) {
@@ -419,6 +438,52 @@ export async function deliverTextOrMediaReply(params: {
     sentText = true;
   }
   return sentText ? "text" : "empty";
+}
+
+async function applyReplyMessageSendingHook(params: {
+  text: string;
+  mediaUrls: readonly string[];
+  context?: ReplyMessageSendingContext;
+}): Promise<{ cancelled: boolean; text: string }> {
+  if (!params.context) {
+    return { cancelled: false, text: params.text };
+  }
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("message_sending")) {
+    return { cancelled: false, text: params.text };
+  }
+  try {
+    const metadata = {
+      ...params.context.metadata,
+      channel: params.context.channel,
+      ...(params.context.accountId === undefined ? {} : { accountId: params.context.accountId }),
+      mediaUrls: [...params.mediaUrls],
+    };
+    const hookContext = {
+      channelId: params.context.channel,
+      ...(params.context.accountId === undefined ? {} : { accountId: params.context.accountId }),
+      ...(params.context.conversationId === undefined
+        ? {}
+        : { conversationId: params.context.conversationId }),
+    };
+    const result = await hookRunner.runMessageSending(
+      {
+        to: params.context.to,
+        content: params.text,
+        metadata,
+      },
+      hookContext,
+    );
+    if (result?.cancel) {
+      return { cancelled: true, text: params.text };
+    }
+    if (typeof result?.content === "string") {
+      return { cancelled: false, text: result.content };
+    }
+  } catch {
+    // Hook failures should not block reply delivery.
+  }
+  return { cancelled: false, text: params.text };
 }
 
 export async function deliverFormattedTextWithAttachments(params: {


### PR DESCRIPTION
## Summary
- route `message_sending` hooks through the shared `deliverTextOrMediaReply` helper
- thread message-sending context through the generic reply-based channel adapters
- add regression tests for mutation and cancel behavior in the generic reply path

## Why
`message_sending` already governs proactive outbound sends, but generic reply delivery still bypassed that hook. That left plugins unable to mutate or cancel agent replies on channels that rely on `deliverTextOrMediaReply`.

## Validation
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test src/plugin-sdk/reply-payload.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm build`
