### PR TITLE
fix(memory): recognize github-copilot as valid memory embedding provider (#69180)

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -36,6 +36,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["directory"], policy: { loadPlugins: "always" } },
   { commandPath: ["agents"], policy: { loadPlugins: "always" } },
   { commandPath: ["configure"], policy: { loadPlugins: "always" } },
+  { commandPath: ["memory"], policy: { loadPlugins: "always" } },
   {
     commandPath: ["status"],
     policy: {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -29,6 +29,16 @@ describe("command-path-policy", () => {
     });
   });
 
+  it("always preloads plugins for memory commands", () => {
+    expect(resolveCliCommandPathPolicy(["memory", "status"])).toEqual({
+      bypassConfigGuard: false,
+      routeConfigGuard: "never",
+      loadPlugins: "always",
+      hideBanner: false,
+      ensureCliPath: true,
+    });
+  });
+
   it("resolves mixed startup-only rules", () => {
     expect(resolveCliCommandPathPolicy(["config", "validate"])).toEqual({
       bypassConfigGuard: true,

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -62,6 +62,12 @@ describe("command-startup-policy", () => {
         jsonOutputMode: false,
       }),
     ).toBe(true);
+    expect(
+      shouldLoadPluginsForCommandPath({
+        commandPath: ["memory", "status"],
+        jsonOutputMode: true,
+      }),
+    ).toBe(true);
   });
 
   it("matches banner suppression policy", () => {


### PR DESCRIPTION
## Summary
- load bundled plugins for `openclaw memory` commands so plugin-provided embedding adapters are registered before memory manager startup
- keep GitHub Copilot memory embeddings available for `memory status` and `memory index` when `agents.defaults.memorySearch.provider` is set to `github-copilot`

## Root Cause
`openclaw memory` inherited the default CLI startup policy, which skipped plugin loading before the memory manager resolved embedding providers. That left the `github-copilot` memory embedding adapter unregistered, so memory commands failed with `Unknown memory embedding provider: github-copilot`.

## Changes
- `src/cli/command-catalog.ts`: always preload plugins for `memory` commands
- `src/cli/command-path-policy.test.ts`: cover the `memory` command path policy
- `src/cli/command-startup-policy.test.ts`: cover startup plugin loading for `memory status`

## Test
- `pnpm test src/cli/command-path-policy.test.ts src/cli/command-startup-policy.test.ts`
- build steps passed via the repo build sequence, using direct `tsdown` invocation because `pnpm exec tsdown` was unavailable in this local shell

Closes #69180