### PR TITLE
fix(agents): resolve auth profile for imageModel inference calls (#69620)

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -445,4 +445,51 @@ describe("describeImageWithModel", () => {
     );
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
+
+  it("seeds runtime auth before model discovery for SecretRef-backed image auth", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "anthropic",
+        id: "claude-haiku-4-5",
+        input: ["text", "image"],
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "anthropic ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      preferredProfile: "anthropic:default",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "anthropic ok",
+      model: "claude-haiku-4-5",
+    });
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        preferredProfile: "anthropic:default",
+      }),
+    );
+    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("anthropic", "oauth-test");
+    expect(setRuntimeApiKeyMock.mock.invocationCallOrder[0]).toBeLessThan(
+      discoverModelsMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -105,9 +105,18 @@ async function resolveImageRuntime(params: {
 }): Promise<{ apiKey: string; model: Model<Api> }> {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
+  const authStorage = discoverAuthStorage(params.agentDir);
+  const providerAuth = await resolveApiKeyForProvider({
+    provider: resolvedRef.provider,
+    cfg: params.cfg,
+    profileId: params.profile,
+    preferredProfile: params.preferredProfile,
+    store: params.authStore,
+    agentDir: params.agentDir,
+  });
+  authStorage.setRuntimeApiKey(resolvedRef.provider, requireApiKey(providerAuth, resolvedRef.provider));
+  const modelRegistry = discoverModels(authStorage, params.agentDir);
   const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
   if (!model) {
     throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);


### PR DESCRIPTION
## Summary
- seed the image-model runtime auth before media model discovery so SecretRef-backed Anthropic credentials reach the discovered client path
- keep the existing model-specific auth resolution after discovery, and add a regression test that locks the auth-before-discovery ordering

## Root Cause
The image understanding path discovered PI models before seeding runtime auth, so SecretRef-backed credentials were missing when the image-model client was constructed.

## Changes
- `src/media-understanding/image.ts`: resolve provider auth and set the runtime API key before model discovery
- `src/media-understanding/image.test.ts`: add a regression test for SecretRef-backed image auth ordering

## Test
- `pnpm test src/media-understanding/image.test.ts`

Closes #69620