### PR TITLE
fix(slack): ignore edit/delete system events for AI re-trigger

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -140,9 +140,9 @@ async function runMessageCase(input: MessageCase = {}): Promise<void> {
 describe("registerSlackMessageEvents", () => {
   const cases: Array<{ name: string; input: MessageCase; calls: number }> = [
     {
-      name: "enqueues message_changed system events when dmPolicy is open",
+      name: "ignores message_changed system events when dmPolicy is open",
       input: { overrides: { dmPolicy: "open" }, event: makeChangedEvent() },
-      calls: 1,
+      calls: 0,
     },
     {
       name: "blocks message_changed system events when dmPolicy is disabled",
@@ -236,7 +236,7 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("applies subtype system-event handling for channel messages", async () => {
+  it("ignores message_changed subtype events for channel messages", async () => {
     // message_changed events from channels arrive via the generic "message"
     // handler with channel_type:"channel" — not a separate event type.
     const { handleSlackMessage } = await invokeRegisteredHandler({
@@ -252,7 +252,7 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).not.toHaveBeenCalled();
-    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
   it("skips app_mention events for DM channel ids even with contradictory channel_type", async () => {

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -145,12 +145,12 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "blocks message_changed system events when dmPolicy is disabled",
+      name: "ignores message_changed system events regardless of dmPolicy (disabled)",
       input: { overrides: { dmPolicy: "disabled" }, event: makeChangedEvent() },
       calls: 0,
     },
     {
-      name: "blocks message_changed system events for unauthorized senders in allowlist mode",
+      name: "ignores message_changed system events regardless of dmPolicy (allowlist)",
       input: {
         overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
         event: makeChangedEvent({ user: "U1" }),
@@ -158,12 +158,11 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "ignores message_deleted system events",
+      name: "ignores message_deleted system events regardless of channel auth config",
       input: {
         overrides: {
           dmPolicy: "open",
           channelType: "channel",
-          channelUsers: ["U_OWNER"],
         },
         event: makeDeletedEvent({ channel: "C1", user: "U_ATTACKER" }),
       },

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -158,7 +158,7 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "blocks message_deleted system events for users outside channel users allowlist",
+      name: "ignores message_deleted system events",
       input: {
         overrides: {
           dmPolicy: "open",

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -23,7 +23,10 @@ export function registerSlackMessageEvents(params: {
       const message = event as SlackMessageEvent;
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
       if (subtypeHandler) {
-        if (subtypeHandler.eventKind === "message_changed") {
+        if (
+          subtypeHandler.eventKind === "message_changed" ||
+          subtypeHandler.eventKind === "message_deleted"
+        ) {
           return;
         }
         const channelId = subtypeHandler.resolveChannelId(message);

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -23,6 +23,9 @@ export function registerSlackMessageEvents(params: {
       const message = event as SlackMessageEvent;
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
       if (subtypeHandler) {
+        if (subtypeHandler.eventKind === "message_changed") {
+          return;
+        }
         const channelId = subtypeHandler.resolveChannelId(message);
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,


### PR DESCRIPTION
## Summary
- ignore `message_changed` and `message_deleted` subtype events in the Slack message monitor
- keep those system events from re-enqueueing AI handling for prior messages
- update targeted Slack monitor tests to assert the events are ignored

## Test Plan
- `pnpm exec vitest run extensions/slack/src/monitor/events/messages.test.ts`