### PR TITLE
fix(agents): strip final tags from persisted assistant message

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -35,7 +35,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
-  stripFinalTagsFromMessage,
+  stripReasoningTagsFromMessage,
 } from "./pi-embedded-utils.js";
 
 function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
@@ -626,7 +626,7 @@ export function handleMessageEnd(
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);
-  stripFinalTagsFromMessage(assistantMessage);
+  stripReasoningTagsFromMessage(assistantMessage);
 
   const rawText = coerceChatContentText(extractAssistantText(assistantMessage));
   const rawVisibleText = coerceChatContentText(extractAssistantVisibleText(assistantMessage));

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -35,6 +35,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripFinalTagsFromMessage,
 } from "./pi-embedded-utils.js";
 
 function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
@@ -625,6 +626,7 @@ export function handleMessageEnd(
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);
+  stripFinalTagsFromMessage(assistantMessage);
 
   const rawText = coerceChatContentText(extractAssistantText(assistantMessage));
   const rawVisibleText = coerceChatContentText(extractAssistantVisibleText(assistantMessage));

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -7,7 +7,7 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
-  stripFinalTagsFromMessage,
+  stripReasoningTagsFromMessage,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -827,14 +827,14 @@ describe("promoteThinkingTagsToBlocks", () => {
   });
 });
 
-describe("stripFinalTagsFromMessage", () => {
+describe("stripReasoningTagsFromMessage", () => {
   it("strips <final> and </final> tags from text blocks", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
       content: [{ type: "text", text: "<final>Hello world!</final>" }],
       timestamp: Date.now(),
     });
-    stripFinalTagsFromMessage(msg);
+    stripReasoningTagsFromMessage(msg);
     expect(msg.content).toEqual([{ type: "text", text: "Hello world!" }]);
   });
 
@@ -844,7 +844,7 @@ describe("stripFinalTagsFromMessage", () => {
       content: [{ type: "text", text: "Hello<final/>" }],
       timestamp: Date.now(),
     });
-    stripFinalTagsFromMessage(msg);
+    stripReasoningTagsFromMessage(msg);
     expect(msg.content).toEqual([{ type: "text", text: "Hello" }]);
   });
 
@@ -857,7 +857,7 @@ describe("stripFinalTagsFromMessage", () => {
       ],
       timestamp: Date.now(),
     });
-    stripFinalTagsFromMessage(msg);
+    stripReasoningTagsFromMessage(msg);
     expect(msg.content).toEqual([
       { type: "thinking", thinking: "internal reasoning" },
       { type: "text", text: "visible" },
@@ -874,18 +874,86 @@ describe("stripFinalTagsFromMessage", () => {
       ],
       timestamp: Date.now(),
     });
-    stripFinalTagsFromMessage(msg);
+    stripReasoningTagsFromMessage(msg);
     expect(msg.content).toEqual([{ type: "text", text: "Hello" }]);
   });
 
-  it("does not mutate message without final tags", () => {
+  it("does not mutate message without reasoning tags", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
       content: [{ type: "text", text: "no tags here" }],
       timestamp: Date.now(),
     });
-    stripFinalTagsFromMessage(msg);
+    stripReasoningTagsFromMessage(msg);
     expect(msg.content).toEqual([{ type: "text", text: "no tags here" }]);
+  });
+
+  it("strips inline <think> left in text when a native thinking block is present", () => {
+    // gemma/gemini sometimes emit native reasoning AND inline <think> tags in
+    // the same turn. promoteThinkingTagsToBlocks early-returns on the pre-
+    // existing thinking block, so this safety net must still clean the text.
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "native" },
+        { type: "text", text: "<think>inline reasoning</think> <final>answer</final>" },
+      ],
+      timestamp: Date.now(),
+    });
+    stripReasoningTagsFromMessage(msg);
+    expect(msg.content).toEqual([
+      { type: "thinking", thinking: "native" },
+      { type: "text", text: " answer" },
+    ]);
+  });
+
+  it("strips <think> content when preamble text blocks promoteThinkingTagsToBlocks", () => {
+    // Any text before the opening <think> makes splitThinkingTaggedText bail,
+    // so the inline think block gets persisted raw unless this sanitizer
+    // catches it.
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "preface <think>reasoning</think> <final>answer</final>",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    stripReasoningTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "preface  answer" }]);
+  });
+
+  it("drops unclosed <think> content (strict mode)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "<think>truncated reasoning never closed" }],
+      timestamp: Date.now(),
+    });
+    stripReasoningTagsFromMessage(msg);
+    expect(msg.content).toEqual([]);
+  });
+
+  it("preserves <final> tags inside code fences (matches streaming behavior)", () => {
+    const text = "Here's an example:\n```html\n<final>wrapper</final>\n```";
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    });
+    stripReasoningTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text }]);
+  });
+
+  it("does not throw on non-string block.text (malformed content guard)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: 42 as unknown as string }],
+      timestamp: Date.now(),
+    });
+    expect(() => stripReasoningTagsFromMessage(msg)).not.toThrow();
+    expect(msg.content).toEqual([{ type: "text", text: 42 as unknown as string }]);
   });
 });
 

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
+  stripFinalTagsFromMessage,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -823,6 +824,68 @@ describe("promoteThinkingTagsToBlocks", () => {
     });
     promoteThinkingTagsToBlocks(msg);
     expect(msg.content).toEqual([{ type: "text", text: "hello world" }]);
+  });
+});
+
+describe("stripFinalTagsFromMessage", () => {
+  it("strips <final> and </final> tags from text blocks", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "<final>Hello world!</final>" }],
+      timestamp: Date.now(),
+    });
+    stripFinalTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "Hello world!" }]);
+  });
+
+  it("strips self-closing <final/> variant", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello<final/>" }],
+      timestamp: Date.now(),
+    });
+    stripFinalTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("preserves non-text blocks", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "internal reasoning" },
+        { type: "text", text: "<final>visible</final>" },
+      ],
+      timestamp: Date.now(),
+    });
+    stripFinalTagsFromMessage(msg);
+    expect(msg.content).toEqual([
+      { type: "thinking", thinking: "internal reasoning" },
+      { type: "text", text: "visible" },
+    ]);
+  });
+
+  it("removes empty text blocks after stripping", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "<final>" },
+        { type: "text", text: "Hello" },
+        { type: "text", text: "</final>" },
+      ],
+      timestamp: Date.now(),
+    });
+    stripFinalTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("does not mutate message without final tags", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "no tags here" }],
+      timestamp: Date.now(),
+    });
+    stripFinalTagsFromMessage(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "no tags here" }]);
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -295,16 +295,18 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   message.content = next;
 }
 
-const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/gi;
-
 /**
- * Strip `<final>` / `</final>` wrapper tags from text content blocks in an
+ * Strip `<think>` / `<final>` wrapper tags from text content blocks in an
  * assistant message so they do not leak into the persisted session transcript.
- * The streaming path already strips these via `stripBlockTags`, but the stored
- * message retains the raw LLM output. Mutates in place (same pattern as
- * `promoteThinkingTagsToBlocks`).
+ * The streaming path strips these live via `stripBlockTags`, but the stored
+ * message retains the raw LLM output; when the UI rehydrates from storage the
+ * tags reappear. Reuses the canonical `stripReasoningTagsFromText` helper so
+ * the persistence side matches streaming behavior, including code-span
+ * preservation. Runs after `promoteThinkingTagsToBlocks` as a safety net for
+ * the cases where that helper bails (preamble text, unbalanced tags, or a
+ * pre-existing native thinking block). Mutates in place.
  */
-export function stripFinalTagsFromMessage(message: AssistantMessage): void {
+export function stripReasoningTagsFromMessage(message: AssistantMessage): void {
   if (!Array.isArray(message.content)) {
     return;
   }
@@ -313,7 +315,10 @@ export function stripFinalTagsFromMessage(message: AssistantMessage): void {
     if (!block || typeof block !== "object" || block.type !== "text") {
       continue;
     }
-    const stripped = block.text.replace(FINAL_TAG_RE, "");
+    if (typeof block.text !== "string") {
+      continue;
+    }
+    const stripped = stripReasoningTagsFromText(block.text, { mode: "strict", trim: "none" });
     if (stripped !== block.text) {
       block.text = stripped;
       changed = true;
@@ -322,7 +327,13 @@ export function stripFinalTagsFromMessage(message: AssistantMessage): void {
   if (changed) {
     message.content = message.content.filter(
       (block) =>
-        !(block && typeof block === "object" && block.type === "text" && !block.text.trim()),
+        !(
+          block &&
+          typeof block === "object" &&
+          block.type === "text" &&
+          typeof block.text === "string" &&
+          !block.text.trim()
+        ),
     );
   }
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -295,6 +295,38 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   message.content = next;
 }
 
+const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/gi;
+
+/**
+ * Strip `<final>` / `</final>` wrapper tags from text content blocks in an
+ * assistant message so they do not leak into the persisted session transcript.
+ * The streaming path already strips these via `stripBlockTags`, but the stored
+ * message retains the raw LLM output. Mutates in place (same pattern as
+ * `promoteThinkingTagsToBlocks`).
+ */
+export function stripFinalTagsFromMessage(message: AssistantMessage): void {
+  if (!Array.isArray(message.content)) {
+    return;
+  }
+  let changed = false;
+  for (const block of message.content) {
+    if (!block || typeof block !== "object" || block.type !== "text") {
+      continue;
+    }
+    const stripped = block.text.replace(FINAL_TAG_RE, "");
+    if (stripped !== block.text) {
+      block.text = stripped;
+      changed = true;
+    }
+  }
+  if (changed) {
+    message.content = message.content.filter(
+      (block) =>
+        !(block && typeof block === "object" && block.type === "text" && !block.text.trim()),
+    );
+  }
+}
+
 export function extractThinkingFromTaggedText(text: string): string {
   if (!text) {
     return "";


### PR DESCRIPTION
## Summary

- Strips `<final>` / `</final>` / `<final/>` wrapper tags from assistant message text blocks before the message is persisted to the session transcript
- Fixes the Control UI showing raw `<final>` tags after streaming ends, even though they are correctly stripped during streaming

## Root Cause

`stripBlockTags` in `pi-embedded-subscribe.ts` strips `<final>` tags from streaming chunks before they reach the UI. But the raw `AssistantMessage` object stored in the session transcript retains the original tags. When the Control UI re-renders after streaming (loading from the persisted message), the unstripped tags reappear.

`promoteThinkingTagsToBlocks` already handles `<think>` tags by converting them to proper thinking blocks on the persisted message. But no equivalent stripping existed for `<final>` tags.

## Fix

Added `stripFinalTagsFromMessage` in `pi-embedded-utils.ts` that:
1. Strips `<final>`, `</final>`, and `<final/>` tags from text content blocks
2. Removes any text blocks left empty after stripping
3. Mutates in place (same pattern as `promoteThinkingTagsToBlocks`)

Called right after `promoteThinkingTagsToBlocks` in `handleMessageEnd` so the persisted message matches what the streaming path already delivers.

## Companion to #66225

PR #66225 fixes the streaming regex to handle `<final/>` self-closing variants. This PR closes the second leak path: the persistence/replay side.

Closes #65867

## Test plan

- 5 regression tests covering: normal tags, self-closing `<final/>`, non-text block preservation, empty block cleanup, and no-op passthrough
- All 39 tests in `pi-embedded-utils.test.ts` pass