### PR TITLE
fix(ui): reserve bubble space for code block copy (#69605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: reserve right padding (`has-copy`) when assistant bubbles show Copy-as-markdown / expand controls so floating actions no longer overlap fenced code-block copy buttons (mis-clicks pasted the whole message). Fixes #69605.
 - fix(qqbot): add SSRF guard to direct-upload URL paths in uploadC2CMedia and uploadGroupMedia [AI-assisted]. (#69595) Thanks @pgondhi987.
 - fix(gateway): enforce allowRequestSessionKey gate on template-rendered mapping sessionKeys. (#69381) Thanks @pgondhi987.
 - Webchat/images: treat inline image attachments as media for empty-turn gating while still ignoring metadata-only blank turns. (#69474) Thanks @Jaswir.

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -506,6 +506,38 @@ describe("grouped chat rendering", () => {
     expect(container.textContent).toContain("Tic-Tac-Toe");
   });
 
+  it("adds has-copy class when assistant copy/expand actions reserve top-right bubble space (#69605)", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-has-copy-actions",
+        role: "assistant",
+        content: [{ type: "text", text: "Intro\n\n```ts\nconst x = 1;\n```" }],
+        timestamp: Date.now(),
+      },
+    );
+
+    const bubble = container.querySelector(".chat-group.assistant .chat-bubble");
+    expect(bubble?.classList.contains("has-copy")).toBe(true);
+  });
+
+  it("does not add has-copy for user bubbles (#69605)", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-no-has-copy",
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: Date.now(),
+      },
+      "user",
+    );
+    const bubble = container.querySelector(".chat-group .chat-bubble");
+    expect(bubble?.classList.contains("has-copy")).toBe(false);
+  });
+
   it("opens only safe assistant image URLs in a hardened new tab", () => {
     const container = document.createElement("div");
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1207,11 +1207,17 @@ function renderGroupedMessage(
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const hasActions = canCopyMarkdown || canExpand;
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
-  const bubbleClasses = ["chat-bubble", opts.isStreaming ? "streaming" : "", "fade-in"]
+  const bubbleClasses = [
+    "chat-bubble",
+    opts.isStreaming ? "streaming" : "",
+    hasActions ? "has-copy" : "",
+    "fade-in",
+  ]
     .filter(Boolean)
     .join(" ");
 
@@ -1245,8 +1251,6 @@ function renderGroupedMessage(
         ? "Tool output"
         : "Tool call"
       : "Tool output";
-
-  const hasActions = canCopyMarkdown || canExpand;
 
   return html`
     <div class="${bubbleClasses}">


### PR DESCRIPTION
## Summary

- **Problem:** In Control UI webchat, clicking Copy on a fenced code block pasted the entire assistant Markdown instead of only the snippet (#69605).
- **Why it matters:** Floating “Copy as markdown” / expand controls overlap the code-block header when both appear; mis-clicks trigger the bubble-level copy handler.
- **What changed:** Apply the existing `.chat-bubble.has-copy` class when assistant bubbles show copy/expand actions (`ui/src/ui/chat/grouped-render.ts`), reserving right padding per `ui/src/styles/chat/grouped.css`.
- **What did NOT change:** Markdown rendering, `handleCodeBlockCopy`, or clipboard APIs.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69605
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `has-copy` CSS existed for bubble actions but was never applied in `renderAssistantBubble`, so `.chat-bubble-actions` could overlap fenced code-block Copy controls; users hit “Copy as markdown” instead.
- **Missing detection / guardrail:** No structural spacing when actions render.
- **Contributing context:** Hover/coarse-pointer (`hover: none`) keeps actions always interactive on some setups, increasing overlap risk.

## Regression Test Plan

- **Coverage:** Unit test
- **Target:** `ui/src/ui/chat/grouped-render.test.ts`
- **Scenario:** Assistant bubble with markdown actions gets `has-copy`; user bubbles do not.
- **Guardrail:** Locks the layout contract between bubble actions and markdown chrome.

## User-visible / Behavior Changes

- Assistant messages with copy/expand actions gain right padding so code-block Copy no longer sits under floating buttons.

## Diagram

```text
Before:
[hover bubble] -> [actions + code header overlap] -> mis-click -> full Markdown copied

After:
[hover bubble] -> [has-copy padding shifts content] -> code Copy hit target -> snippet copied
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Windows / Linux (issue reported on Ubuntu)
- Control UI webchat with assistant reply containing fenced code at top of bubble

### Steps

1. Open Control UI chat; get an assistant reply with a fenced code block near the top.
2. Hover the bubble so “Copy as markdown” appears.
3. Click the code-block **Copy** control.

### Expected

- Clipboard contains only the code inside the fence.

### Actual (before fix)

- Clipboard often contained the full assistant message (Markdown).

## Evidence

- [x] `pnpm test ui/src/ui/chat/grouped-render.test.ts` — pass
- [x] `pnpm check:changed` — pass

## Human Verification

- Verified scenarios: unit tests + layout contract (`has-copy` when actions present).
- Edge cases: user bubble without actions (no `has-copy`).
- Not verified: manual browser click on physical device (CI/agent only).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Slightly narrower assistant bubble text when actions show.
  - **Mitigation:** Matches existing CSS intent; padding only when actions exist.
