### PR TITLE
fix(approvals): add missing source field to allowlist entry schema

### DIFF
--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -5,6 +5,7 @@ export const ExecApprovalsAllowlistEntrySchema = Type.Object(
   {
     id: Type.Optional(NonEmptyString),
     pattern: Type.String(),
+    source: Type.Optional(Type.Literal("allow-always")),
     argPattern: Type.Optional(Type.String()),
     lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
     lastUsedCommand: Type.Optional(Type.String()),


### PR DESCRIPTION
Fixes #69482

The Telegram "Allow always" approval handler writes allowlist entries with a `source: "allow-always"` field, but the gateway schema (ExecApprovalsAllowlistEntrySchema) did not include this field.

This caused `openclaw approvals set --gateway --file` to reject every entry containing `source` with:

```
invalid exec.approvals.set params: unexpected property 'source'
```

**Fix:** Add `source: Type.Optional(Type.Literal("allow-always"))` to the allowlist entry schema so the CLI write path and gateway validation path agree on the schema.

The `ExecAllowlistEntry` type in `src/infra/exec-approvals.types.ts` already declared `source?: "allow-always"`, so this change only aligns the runtime validation schema with the existing type definition.
