### PR TITLE
fix(failover): classify MiniMax 529 high-traffic as overloaded

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -78,6 +78,10 @@ const ERROR_PATTERNS = {
     // provider-overload (#32828).
     /service[_ ]unavailable.*(?:overload|capacity|high[_ ]demand)|(?:overload|capacity|high[_ ]demand).*service[_ ]unavailable/i,
     "high demand",
+    // MiniMax returns 529 with "High traffic detected. For a more stable
+    // experience, upgrade to our Plus plan" — treat as overloaded so failover
+    // works correctly (#69642).
+    /high traffic detected.*upgrade to our plus plan/i,
   ],
   serverError: [
     "an error occurred while processing",


### PR DESCRIPTION
Fixes #69642

MiniMax returns HTTP 529 with the message "High traffic detected. For a more stable experience, upgrade to our Plus plan". The existing failover logic already maps status 529 to `reason=overloaded` in `classifyFailoverReasonFromStatus()`, but the text-based classifier `isOverloadedErrorMessage()` did not match this wording, so some code paths failed to trigger failover.

**Fix:** Add `/high traffic detected.*upgrade to our plus plan/i` to `ERROR_PATTERNS.overloaded` so that text-based classification also treats this as an overloaded signal.

This ensures that when MiniMax returns a 529 error, OpenClaw correctly classifies it as `overloaded` and triggers the configured fallback providers instead of surfacing the error directly to the user.
