### PR TITLE
test(brave): add regression tests for X-Subscription-Token header auth (#69673)

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -189,4 +189,78 @@ describe("brave web search provider", () => {
     const requestUrl = new URL(String(mockFetch.mock.calls[0]?.[0]));
     expect(requestUrl.searchParams.get("country")).toBe("ALL");
   });
+
+  it("sends API key as X-Subscription-Token header, not as a URL query param (web mode)", async () => {
+    const apiKey = "BSA-test-key-abc123";
+    vi.stubEnv("BRAVE_API_KEY", "");
+    const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {
+      return {
+        ok: true,
+        json: async () => ({ web: { results: [] } }),
+      } as Response;
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+
+    const provider = createBraveWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        apiKey,
+        brave: { apiKey },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ query: "brave auth regression" });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [callUrl, callInit] = mockFetch.mock.calls[0] as [unknown, RequestInit | undefined];
+    const requestUrl = new URL(String(callUrl));
+    const headers = callInit?.headers as Record<string, string> | undefined;
+
+    // API key must be sent as a request header
+    expect(headers?.["X-Subscription-Token"]).toBe(apiKey);
+    // API key must NOT appear as a URL query parameter
+    expect(requestUrl.searchParams.has("apikey")).toBe(false);
+    expect(requestUrl.searchParams.has("key")).toBe(false);
+  });
+
+  it("sends API key as X-Subscription-Token header, not as a URL query param (llm-context mode)", async () => {
+    const apiKey = "BSA-test-key-xyz456";
+    vi.stubEnv("BRAVE_API_KEY", "");
+    const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {
+      return {
+        ok: true,
+        json: async () => ({ grounding: { generic: [] } }),
+      } as Response;
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+
+    const provider = createBraveWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        apiKey,
+        brave: { apiKey, mode: "llm-context" },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ query: "brave auth regression llm-context" });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [callUrl, callInit] = mockFetch.mock.calls[0] as [unknown, RequestInit | undefined];
+    const requestUrl = new URL(String(callUrl));
+    const headers = callInit?.headers as Record<string, string> | undefined;
+
+    // API key must be sent as a request header
+    expect(headers?.["X-Subscription-Token"]).toBe(apiKey);
+    // API key must NOT appear as a URL query parameter
+    expect(requestUrl.searchParams.has("apikey")).toBe(false);
+    expect(requestUrl.searchParams.has("key")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #69673 — Brave Search API authentication broken.

The Brave Search API requires the API key to be sent via the `X-Subscription-Token` request header (not as a URL query parameter). The runtime implementation already sends the header correctly, but there were no tests verifying this behavior, leaving the door open for regressions.

## Changes

Added two regression tests in `extensions/brave/src/brave-web-search-provider.test.ts`:

| Test | What it verifies |
|------|-----------------|
| web mode auth header | `X-Subscription-Token` header is sent with the correct API key |
| llm-context mode auth header | Same verification for the LLM Context endpoint |

Both tests also assert that the API key does **not** appear as a URL query parameter (`apikey` or `key`), which is the exact failure mode reported in #69673.

## Why this matters

Without these tests, a refactor could silently regress to sending `apikey` as a query param and break every Brave Search user — exactly what the issue reports happened. This locks in the correct auth behavior for both API modes.

## Testing

```
✓ extensions/brave/src/brave-web-search-provider.test.ts (11 tests) 300ms
```

All 11 tests pass, including the 2 new regression tests.