### PR TITLE
fix: resolve aria refs for browser actions (#69289)

### DIFF
--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -91,6 +91,57 @@ describe("pw-session role refs cache", () => {
     refLocator(page, "e1");
     expect(mocks.frameLocator).toHaveBeenCalledWith("iframe#main");
   });
+
+  it("restores roleRefsMode=aria for a fresh page and uses aria-ref locator", () => {
+    const cdpUrl = "http://127.0.0.1:9222";
+    const targetId = "t1";
+
+    // Simulate: previous snapshot stored aria refs for this target
+    rememberRoleRefsForTarget({
+      cdpUrl,
+      targetId,
+      refs: { e1: { role: "button", name: "OK" } },
+      mode: "aria",
+    });
+
+    // Simulate: page reconnects (new Page instance)
+    const { page, mocks } = fakePage();
+
+    // First restore — fresh page, no existing roleRefs
+    restoreRoleRefsForTarget({ cdpUrl, targetId, page });
+
+    // refLocator should use aria-ref when mode=aria
+    refLocator(page, "e1");
+    expect(mocks.locator).toHaveBeenCalledWith("aria-ref=e1");
+  });
+
+  it("does NOT overwrite roleRefsMode when state.roleRefs already set but mode differs", () => {
+    const cdpUrl = "http://127.0.0.1:9222";
+    const targetId = "t1";
+
+    // Cache has aria mode
+    rememberRoleRefsForTarget({
+      cdpUrl,
+      targetId,
+      refs: { e1: { role: "button", name: "OK" } },
+      mode: "aria",
+    });
+
+    const { page, mocks } = fakePage();
+    const state = ensurePageState(page);
+
+    // Simulate: state already has roleRefs (e.g. from a previous snapshot)
+    state.roleRefs = { e1: { role: "link", name: "Docs" } };
+    state.roleRefsMode = "aria";
+
+    // Restore should NOT overwrite existing roleRefs but SHOULD preserve aria mode
+    restoreRoleRefsForTarget({ cdpUrl, targetId, page });
+
+    // roleRefs unchanged (previous snapshot takes precedence)
+    expect(state.roleRefs.e1).toMatchObject({ role: "link", name: "Docs" });
+    // roleRefsMode preserved
+    expect(state.roleRefsMode).toBe("aria");
+  });
 });
 
 describe("pw-session ensurePageState", () => {

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -297,6 +297,14 @@ export function restoreRoleRefsForTarget(opts: {
   }
   const state = ensurePageState(opts.page);
   if (state.roleRefs) {
+    // roleRefs already set — still restore roleRefsMode in case it changed
+    // (e.g. snapshotAiViaPlaywright ran with mode=aria after snapshotRoleViaPlaywright)
+    if (cached.mode) {
+      state.roleRefsMode = cached.mode;
+    }
+    if (cached.frameSelector) {
+      state.roleRefsFrameSelector = cached.frameSelector;
+    }
     return;
   }
   state.roleRefs = cached.refs;

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -15,6 +15,7 @@ import {
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   gotoPageWithNavigationGuard,
+  restoreRoleRefsForTarget,
   storeRoleRefsForTarget,
   type WithSnapshotForAI,
 } from "./pw-session.js";
@@ -102,6 +103,7 @@ export async function snapshotAiViaPlaywright(opts: {
   }
 
   const built = buildRoleSnapshotFromAiSnapshot(snapshot);
+  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   storeRoleRefsForTarget({
     page,
     cdpUrl: opts.cdpUrl,
@@ -153,6 +155,7 @@ export async function snapshotRoleViaPlaywright(opts: {
       track: "response",
     });
     const built = buildRoleSnapshotFromAiSnapshot(result?.full ?? "", opts.options);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
     storeRoleRefsForTarget({
       page,
       cdpUrl: opts.cdpUrl,
@@ -179,6 +182,7 @@ export async function snapshotRoleViaPlaywright(opts: {
 
   const ariaSnapshot = await locator.ariaSnapshot();
   const built = buildRoleSnapshotFromAriaSnapshot(ariaSnapshot ?? "", opts.options);
+  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   storeRoleRefsForTarget({
     page,
     cdpUrl: opts.cdpUrl,

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -473,16 +473,26 @@ async function insertBlocksWithDescendant(
 }
 
 async function clearDocumentContent(client: Lark.Client, docToken: string) {
-  const existing = await client.docx.documentBlock.list({
-    path: { document_id: docToken },
-  });
-  if (existing.code !== 0) {
-    throw new Error(existing.msg);
-  }
+  // Paginate through all blocks to reliably clear large documents.
+  // documentBlock.list returns up to 500 blocks per page; documents with
+  // more top-level blocks require multiple requests.
+  const items: FeishuDocxBlock[] = [];
+  let pageToken: string | undefined;
+  do {
+    const existing = await client.docx.documentBlock.list({
+      path: { document_id: docToken },
+      params: pageToken ? { page_token: pageToken } : {},
+    });
+    if (existing.code !== 0) {
+      throw new Error(existing.msg);
+    }
+    items.push(...(existing.data?.items ?? []));
+    pageToken = existing.data?.page_token ?? undefined;
+  } while (pageToken);
 
   const childIds =
-    existing.data?.items
-      ?.filter((b) => b.parent_id === docToken && b.block_type !== 1)
+    items
+      .filter((b) => b.parent_id === docToken && b.block_type !== 1)
       .map((b) => b.block_id) ?? [];
 
   if (childIds.length > 0) {

--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -30,7 +30,7 @@ describe("resolveCliAuthEpoch", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("changes when claude cli credentials change", async () => {
+  it("does not change when OAuth access token rotates (stable session)", async () => {
     let access = "access-a";
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({
@@ -48,10 +48,32 @@ describe("resolveCliAuthEpoch", () => {
 
     expect(first).toBeDefined();
     expect(second).toBeDefined();
+    // OAuth access token rotation must NOT invalidate session
+    expect(second).toBe(first);
+  });
+
+  it("changes when OAuth refresh token rotates", async () => {
+    let refresh = "refresh-a";
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "anthropic",
+        access: "access",
+        refresh,
+        expires: 1,
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
+    refresh = "refresh-b";
+    const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
+
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
     expect(second).not.toBe(first);
   });
 
-  it("changes when auth profile credentials change", async () => {
+  it("does not change when OAuth access token rotates in auth profile", async () => {
     let store: AuthProfileStore = {
       version: 1,
       profiles: {
@@ -91,18 +113,63 @@ describe("resolveCliAuthEpoch", () => {
 
     expect(first).toBeDefined();
     expect(second).toBeDefined();
+    // OAuth access token rotation must NOT invalidate session
+    expect(second).toBe(first);
+  });
+
+  it("changes when OAuth refresh token rotates in auth profile", async () => {
+    let store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh-a",
+          expires: 1,
+        },
+      },
+    };
+    setCliAuthEpochTestDeps({
+      loadAuthProfileStoreForRuntime: () => store,
+    });
+
+    const first = await resolveCliAuthEpoch({
+      provider: "google-gemini-cli",
+      authProfileId: "anthropic:work",
+    });
+    store = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh-b",
+          expires: 1,
+        },
+      },
+    };
+    const second = await resolveCliAuthEpoch({
+      provider: "google-gemini-cli",
+      authProfileId: "anthropic:work",
+    });
+
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
     expect(second).not.toBe(first);
   });
 
   it("mixes local codex and auth-profile state", async () => {
-    let access = "local-access-a";
-    let refresh = "profile-refresh-a";
+    let localAccess = "local-access-a";
+    let localRefresh = "local-refresh-a";
+    let profileRefresh = "profile-refresh-a";
     setCliAuthEpochTestDeps({
       readCodexCliCredentialsCached: () => ({
         type: "oauth",
         provider: "openai-codex",
-        access,
-        refresh: "local-refresh",
+        access: localAccess,
+        refresh: localRefresh,
         expires: 1,
         accountId: "acct-1",
       }),
@@ -113,7 +180,7 @@ describe("resolveCliAuthEpoch", () => {
             type: "oauth",
             provider: "openai",
             access: "profile-access",
-            refresh,
+            refresh: profileRefresh,
             expires: 1,
           },
         },
@@ -124,12 +191,14 @@ describe("resolveCliAuthEpoch", () => {
       provider: "codex-cli",
       authProfileId: "openai:work",
     });
-    access = "local-access-b";
+    // Local OAuth access token rotation must NOT invalidate session
+    localAccess = "local-access-b";
     const second = await resolveCliAuthEpoch({
       provider: "codex-cli",
       authProfileId: "openai:work",
     });
-    refresh = "profile-refresh-b";
+    // Profile refresh token rotation MUST invalidate session
+    profileRefresh = "profile-refresh-b";
     const third = await resolveCliAuthEpoch({
       provider: "codex-cli",
       authProfileId: "openai:work",
@@ -138,7 +207,9 @@ describe("resolveCliAuthEpoch", () => {
     expect(first).toBeDefined();
     expect(second).toBeDefined();
     expect(third).toBeDefined();
-    expect(second).not.toBe(first);
+    // Local access token rotation must NOT change epoch
+    expect(second).toBe(first);
+    // Profile refresh token rotation MUST change epoch
     expect(third).not.toBe(second);
   });
 });

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -41,18 +41,24 @@ function encodeUnknown(value: unknown): string {
 
 function encodeClaudeCredential(credential: ClaudeCliCredential): string {
   if (credential.type === "oauth") {
-    return JSON.stringify([
-      "oauth",
-      credential.provider,
-      credential.access,
-      credential.refresh,
-      credential.expires,
-    ]);
+    // Only hash refresh (stable identity); access and expires rotate on token refresh
+    // and should not invalidate the session.
+    return JSON.stringify(["oauth", credential.provider, credential.refresh]);
   }
   return JSON.stringify(["token", credential.provider, credential.token, credential.expires]);
 }
 
 function encodeCodexCredential(credential: CodexCliCredential): string {
+  if (credential.type === "oauth") {
+    // Only hash refresh (stable identity); access and expires rotate on token refresh
+    // and should not invalidate the session.
+    return JSON.stringify([
+      credential.type,
+      credential.provider,
+      credential.refresh,
+      credential.accountId ?? null,
+    ]);
+  }
   return JSON.stringify([
     credential.type,
     credential.provider,
@@ -86,12 +92,12 @@ function encodeAuthProfileCredential(credential: AuthProfileCredential): string 
         credential.displayName ?? null,
       ]);
     case "oauth":
+      // Only hash refresh (stable identity); access and expires rotate on token refresh
+      // and should not invalidate the session.
       return JSON.stringify([
         "oauth",
         credential.provider,
-        credential.access,
         credential.refresh,
-        credential.expires,
         credential.clientId ?? null,
         credential.email ?? null,
         credential.displayName ?? null,

--- a/src/agents/pi-embedded-runner/compact.queued.test.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedPiCompactResult } from "./types.js";
+
+// Shared mock state
+let harnessResultToReturn: EmbeddedPiCompactResult | null = null;
+let _sideEffectsCalledWith: any = null;
+
+const mockHarnessSession = vi.fn(async () => harnessResultToReturn);
+const mockRunPostCompactionSideEffects = vi.fn(async (params: any) => {
+  _sideEffectsCalledWith = params;
+});
+
+// Mock the harness selection module
+vi.mock("../harness/selection.js", () => ({
+  maybeCompactAgentHarnessSession: (...args: any[]) => mockHarnessSession(...args),
+}));
+
+// Mock compaction-hooks
+vi.mock("./compaction-hooks.js", () => ({
+  runPostCompactionSideEffects: (...args: any[]) => mockRunPostCompactionSideEffects(...args),
+  asCompactionHookRunner: vi.fn(() => ({
+    runCompactionHooks: vi.fn(),
+  })),
+}));
+
+// Mock dependencies that are hard to set up in unit tests
+vi.mock("../../context-engine/init.js", () => ({
+  ensureContextEnginesInitialized: vi.fn(),
+}));
+
+vi.mock("../../context-engine/registry.js", () => ({
+  resolveContextEngine: vi.fn(() => ({
+    indexForQueries: vi.fn(),
+    info: { ownsCompaction: false },
+  })),
+}));
+
+vi.mock("../runtime-plugins.js", () => ({
+  ensureRuntimePluginsLoaded: vi.fn(),
+}));
+
+vi.mock("../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/agent-dir"),
+}));
+
+vi.mock("../agent-scope.js", () => ({
+  resolveSessionAgentIds: vi.fn(() => ({ agentId: "test-agent", agentIds: [] })),
+}));
+
+vi.mock("../context-window-guard.js", () => ({
+  resolveContextWindowInfo: vi.fn(() => ({ currentTokens: 1000, limitTokens: 100000 })),
+}));
+
+vi.mock("../defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 4096,
+  DEFAULT_MODEL: "claude-3-5-sonnet-20241022",
+  DEFAULT_PROVIDER: "anthropic",
+}));
+
+vi.mock("./compaction-runtime-context.js", () => ({
+  buildEmbeddedCompactionRuntimeContext: vi.fn(() => ({})),
+  resolveEmbeddedCompactionTarget: vi.fn(() => ({
+    targetTokens: 500,
+    targetMessages: 20,
+  })),
+}));
+
+vi.mock("./context-engine-maintenance.js", () => ({
+  runContextEngineMaintenance: vi.fn(),
+}));
+
+vi.mock("./lanes.js", () => ({
+  resolveSessionLane: vi.fn(() => "test-lane"),
+  resolveGlobalLane: vi.fn(() => "global-lane"),
+}));
+
+vi.mock("./logger.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./model.js", () => ({
+  resolveModelAsync: vi.fn(() => ({
+    model: "claude-3-5-sonnet-20241022",
+    provider: "anthropic",
+  })),
+}));
+
+vi.mock("./model-context-tokens.js", () => ({
+  readPiModelContextTokens: vi.fn(() => 1000),
+}));
+
+vi.mock("./compact.ts", () => ({
+  persistSessionCompactionCheckpoint: vi.fn(),
+  captureCompactionCheckpointSnapshot: vi.fn(),
+  cleanupCompactionCheckpointSnapshot: vi.fn(),
+  resolveSessionCompactionCheckpointReason: vi.fn(() => "manual"),
+}));
+
+vi.mock("../../gateway/session-compaction-checkpoints.js", () => ({
+  persistSessionCompactionCheckpoint: vi.fn(),
+  captureCompactionCheckpointSnapshot: vi.fn(),
+  cleanupCompactionCheckpointSnapshot: vi.fn(),
+  resolveSessionCompactionCheckpointReason: vi.fn(() => "manual"),
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  enqueueCommandInLane: vi.fn((_lane, fn) => fn()),
+}));
+
+vi.mock("../../utils.js", () => ({
+  resolveUserPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+describe("compactEmbeddedPiSession harness memory flush regression (#69300)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    harnessResultToReturn = null;
+    _sideEffectsCalledWith = null;
+    mockHarnessSession.mockClear();
+    mockRunPostCompactionSideEffects.mockClear();
+  });
+
+  it("calls runPostCompactionSideEffects when harness compaction succeeds", async () => {
+    harnessResultToReturn = {
+      ok: true,
+      compacted: true,
+      reason: "agent-harness",
+    };
+
+    const { compactEmbeddedPiSession } = await import("./compact.queued.js");
+
+    await compactEmbeddedPiSession({
+      sessionId: "session-69300",
+      sessionKey: "agent:main:session-69300",
+      config: {
+        agents: {
+          defaults: {
+            compaction: { postIndexSync: true },
+          },
+        },
+      } as any,
+      sessionFile: "/tmp/session-69300.jsonl",
+    });
+
+    expect(mockHarnessSession).toHaveBeenCalled();
+    expect(mockRunPostCompactionSideEffects).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        agents: expect.objectContaining({
+          defaults: expect.objectContaining({
+            compaction: expect.objectContaining({ postIndexSync: true }),
+          }),
+        }),
+      }),
+      sessionKey: "agent:main:session-69300",
+      sessionFile: "/tmp/session-69300.jsonl",
+    });
+  });
+
+  it("does NOT call runPostCompactionSideEffects when harness returns {ok:true, compacted:false}", async () => {
+    harnessResultToReturn = {
+      ok: true,
+      compacted: false,
+      reason: "agent-harness",
+    };
+
+    const { compactEmbeddedPiSession } = await import("./compact.queued.js");
+
+    await compactEmbeddedPiSession({
+      sessionId: "session-69300",
+      sessionKey: "agent:main:session-69300",
+      config: {} as any,
+      sessionFile: "/tmp/session-69300.jsonl",
+    });
+
+    expect(mockHarnessSession).toHaveBeenCalled();
+    expect(mockRunPostCompactionSideEffects).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -42,6 +42,13 @@ export async function compactEmbeddedPiSession(
 ): Promise<EmbeddedPiCompactResult> {
   const harnessResult = await maybeCompactAgentHarnessSession(params);
   if (harnessResult) {
+    if (harnessResult.ok && harnessResult.compacted) {
+      await runPostCompactionSideEffects({
+        config: params.config,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+      });
+    }
     return harnessResult;
   }
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -66,6 +66,7 @@ export function handleAutoCompactionEnd(
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();
+    ctx.resetUsageTotals();
     ctx.log.debug(`embedded run compaction retry: runId=${ctx.params.runId}`);
   } else {
     if (!wasAborted) {
@@ -73,6 +74,7 @@ export function handleAutoCompactionEnd(
     }
     ctx.maybeResolveCompactionWait();
     clearStaleAssistantUsageOnSessionMessages(ctx);
+    ctx.resetUsageTotals();
   }
   emitAgentEvent({
     runId: ctx.params.runId,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -127,6 +127,7 @@ export type EmbeddedPiSubscribeContext = {
   resolveCompactionRetry: () => void;
   maybeResolveCompactionWait: () => void;
   recordAssistantUsage: (usage: unknown) => void;
+  resetUsageTotals: () => void;
   incrementCompactionCount: () => void;
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -379,6 +379,13 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       total: usageTotals.total || derivedTotal || undefined,
     };
   };
+  const resetUsageTotals = () => {
+    usageTotals.input = 0;
+    usageTotals.output = 0;
+    usageTotals.cacheRead = 0;
+    usageTotals.cacheWrite = 0;
+    usageTotals.total = 0;
+  };
   const incrementCompactionCount = () => {
     compactionCount += 1;
   };
@@ -745,6 +752,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     resolveCompactionRetry,
     maybeResolveCompactionWait,
     recordAssistantUsage,
+    resetUsageTotals,
     incrementCompactionCount,
     getUsageTotals,
     getCompactionCount: () => compactionCount,

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -259,6 +259,54 @@ describe("followup queue drain restart after idle window", () => {
     expect(calls[0]?.prompt).toBe("before-clear");
   });
 
+  it("does not delete a replacement queue when an older drain finishes", async () => {
+    const key = `test-drain-identity-guard-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstStarted = createDeferred<void>();
+    const releaseFirst = createDeferred<void>();
+    const secondProcessed = createDeferred<void>();
+    const calls: FollowupRun[] = [];
+    let callCount = 0;
+
+    const runFollowup = async (run: FollowupRun) => {
+      callCount += 1;
+      calls.push(run);
+      if (callCount === 1) {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        return;
+      }
+      secondProcessed.resolve();
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "before-clear" }), settings);
+    scheduleFollowupDrain(key, runFollowup);
+    await firstStarted.promise;
+
+    const { clearSessionQueues, getFollowupQueueDepth } = await import("./queue.js");
+    const { FOLLOWUP_QUEUES } = await import("./queue/state.js");
+    clearSessionQueues([key]);
+
+    enqueueFollowupRun(
+      key,
+      createRun({ prompt: "after-clear" }),
+      settings,
+      "message-id",
+      runFollowup,
+    );
+
+    expect(FOLLOWUP_QUEUES.get(key)?.items.map((item) => item.prompt)).toEqual(["after-clear"]);
+    expect(getFollowupQueueDepth(key)).toBe(1);
+
+    releaseFirst.resolve();
+    await secondProcessed.promise;
+
+    expect(calls.map((call) => call.prompt)).toEqual(["before-clear", "after-clear"]);
+    await vi.waitFor(() => {
+      expect(getFollowupQueueDepth(key)).toBe(0);
+    });
+  });
+
   it("clears the remembered callback after a queue drains fully", async () => {
     const key = `test-auto-clear-callback-${Date.now()}`;
     const calls: FollowupRun[] = [];

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -263,8 +263,10 @@ export function scheduleFollowupDrain(
     } finally {
       queue.draining = false;
       if (queue.items.length === 0 && queue.droppedCount === 0) {
-        FOLLOWUP_QUEUES.delete(key);
-        clearFollowupDrainCallback(key);
+        if (FOLLOWUP_QUEUES.get(key) === queue) {
+          FOLLOWUP_QUEUES.delete(key);
+          clearFollowupDrainCallback(key);
+        }
       } else {
         scheduleFollowupDrain(key, effectiveRunFollowup);
       }

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
   return {
     runtime,
     serveOpenClawChannelMcp: vi.fn(),
+    servePluginToolsMcp: vi.fn(),
   };
 });
 
@@ -27,6 +28,7 @@ const defaultRuntime = mocks.runtime;
 const mockLog = defaultRuntime.log;
 const mockError = defaultRuntime.error;
 const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
+const servePluginToolsMcp = mocks.servePluginToolsMcp;
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.runtime,
@@ -34,6 +36,10 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../mcp/channel-server.js", () => ({
   serveOpenClawChannelMcp: mocks.serveOpenClawChannelMcp,
+}));
+
+vi.mock("../mcp/plugin-tools-serve.js", () => ({
+  servePluginToolsMcp: mocks.servePluginToolsMcp,
 }));
 
 const tempDirs: string[] = [];
@@ -120,6 +126,19 @@ describe("mcp cli", () => {
         claudeChannelMode: "on",
         verbose: true,
       });
+      expect(servePluginToolsMcp).not.toHaveBeenCalled();
+    });
+  });
+
+  it("starts the plugin tools bridge when --bridge tools is selected", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand(["mcp", "serve", "--bridge", "tools"]);
+
+      expect(servePluginToolsMcp).toHaveBeenCalledWith();
+      expect(serveOpenClawChannelMcp).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -6,6 +6,7 @@ import {
   unsetConfiguredMcpServer,
 } from "../config/mcp-config.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
+import { servePluginToolsMcp } from "../mcp/plugin-tools-serve.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -39,9 +40,26 @@ export function registerMcpCli(program: Command) {
       "Claude channel notification mode: auto, on, or off",
       "auto",
     )
+    .option(
+      "--bridge <kind>",
+      "MCP bridge kind: channels (default) or tools",
+      "channels",
+    )
     .option("-v, --verbose", "Verbose logging to stderr", false)
     .action(async (opts) => {
       try {
+        const bridgeKind = normalizeLowercaseStringOrEmpty(
+          normalizeStringifiedOptionalString(opts.bridge) ?? "channels",
+        );
+        if (bridgeKind !== "channels" && bridgeKind !== "tools") {
+          throw new Error("Invalid --bridge value. Use channels or tools.");
+        }
+
+        if (bridgeKind === "tools") {
+          await servePluginToolsMcp();
+          return;
+        }
+
         const { gatewayToken, gatewayPassword } = resolveGatewayAuthOptions(opts);
         const claudeChannelMode = normalizeLowercaseStringOrEmpty(
           normalizeStringifiedOptionalString(opts.claudeChannelMode) ?? "auto",

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -103,10 +103,11 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
-      // Should clear disabled state and fall back to bootstrap when kickstart fails.
-      expect(content).toContain("launchctl enable 'gui/501/ai.openclaw.gateway'");
-      expect(content).toContain("launchctl bootstrap 'gui/501'");
+      expect(content).toContain("service_target='gui/501/ai.openclaw.gateway'");
+      expect(content).toContain("domain='gui/501'");
+      expect(content).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
+      expect(content).toContain('launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1 || true');
+      expect(content).toContain('if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then');
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });
@@ -119,7 +120,7 @@ describe("restart-helper", () => {
         OPENCLAW_PROFILE: "default",
         OPENCLAW_LAUNCHD_LABEL: "com.custom.openclaw",
       });
-      expect(content).toContain("launchctl kickstart -k 'gui/501/com.custom.openclaw'");
+      expect(content).toContain("service_target='gui/501/com.custom.openclaw'");
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -95,13 +95,17 @@ rm -f "$0"
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-# Try kickstart first (works when the service is still registered).
-# If it fails (e.g. after bootout), clear any persisted disabled state,
-# then re-register via bootstrap and kickstart.
-if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
-  launchctl enable 'gui/${uid}/${escaped}' 2>/dev/null
-  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
-  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
+service_target='gui/${uid}/${escaped}'
+domain='gui/${uid}'
+plist_path='${escapedPlistPath}'
+# launchd may keep the label loaded but pointing at stale dist chunks after an npm update.
+# Re-bootstrap first so the service definition refreshes to the newly installed entrypoint,
+# then kickstart. Ignore bootstrap failures when the label is already registered.
+launchctl enable "$service_target" >/dev/null 2>&1
+launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1 || true
+if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
+  launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1 || true
+  launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
 fi
 # Self-cleanup
 rm -f "$0"

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -360,6 +360,24 @@ describe("node.invoke APNs wake path", () => {
     expect(mocks.sendApnsAlert).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retain wake state for unregistered nodes", async () => {
+    mocks.loadApnsRegistration.mockResolvedValue(null);
+
+    await expect(maybeWakeNodeWithApns("ios-node-no-registration")).resolves.toMatchObject({
+      available: false,
+      throttled: false,
+      path: "no-registration",
+    });
+    await expect(maybeWakeNodeWithApns("ios-node-no-registration")).resolves.toMatchObject({
+      available: false,
+      throttled: false,
+      path: "no-registration",
+    });
+
+    expect(mocks.loadApnsRegistration).toHaveBeenCalledTimes(2);
+    expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
+  });
+
   it("wakes and retries invoke after the node reconnects", async () => {
     vi.useFakeTimers();
     mockDirectWakeConfig("ios-node-reconnect");

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -310,6 +310,7 @@ export async function maybeWakeNodeWithApns(
   opts?: { force?: boolean; wakeReason?: string },
 ): Promise<NodeWakeAttempt> {
   const state = nodeWakeById.get(nodeId) ?? { lastWakeAtMs: 0 };
+  const hadExistingState = nodeWakeById.has(nodeId);
   nodeWakeById.set(nodeId, state);
 
   if (state.inFlight) {
@@ -332,6 +333,9 @@ export async function maybeWakeNodeWithApns(
     try {
       const registration = await loadApnsRegistration(nodeId);
       if (!registration) {
+        if (!hadExistingState) {
+          nodeWakeById.delete(nodeId);
+        }
         return withDuration({ available: false, throttled: false, path: "no-registration" });
       }
 

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -158,4 +158,52 @@ describe("gateway usage helpers", () => {
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(1);
   });
+
+  it("prunes stale cached cost summaries when loading a new range", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    const config = {} as OpenClawConfig;
+    await __test.loadCostUsageSummaryCached({ startMs: 1, endMs: 2, config });
+    expect(__test.costUsageCache.size).toBe(1);
+
+    vi.advanceTimersByTime(30_001);
+    await __test.loadCostUsageSummaryCached({ startMs: 3, endMs: 4, config });
+
+    expect(__test.costUsageCache.size).toBe(1);
+    expect(__test.costUsageCache.has("1-2")).toBe(false);
+    expect(__test.costUsageCache.has("3-4")).toBe(true);
+  });
+
+  it("caps cached cost summaries to the newest 128 ranges", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    for (let index = 0; index < 130; index += 1) {
+      __test.costUsageCache.set(`${index}-${index}`, {
+        summary: {
+          updatedAt: Date.now(),
+          startDate: "2026-02-01",
+          endDate: "2026-02-02",
+          daily: [],
+          totals: {
+            totalTokens: index,
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalCost: 0,
+          },
+        },
+        updatedAt: Date.now(),
+      });
+    }
+
+    __test.pruneCostUsageCache(Date.now());
+
+    expect(__test.costUsageCache.size).toBe(128);
+    expect(__test.costUsageCache.has("0-0")).toBe(false);
+    expect(__test.costUsageCache.has("1-1")).toBe(false);
+    expect(__test.costUsageCache.has("129-129")).toBe(true);
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -48,6 +48,7 @@ import {
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
+const MAX_COST_USAGE_CACHE_ENTRIES = 128;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -62,6 +63,24 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+
+function pruneCostUsageCache(now = Date.now()) {
+  for (const [cacheKey, entry] of costUsageCache) {
+    const isFresh = Boolean(
+      entry.updatedAt && now - entry.updatedAt < COST_USAGE_CACHE_TTL_MS,
+    );
+    if (!entry.inFlight && !isFresh) {
+      costUsageCache.delete(cacheKey);
+    }
+  }
+  while (costUsageCache.size > MAX_COST_USAGE_CACHE_ENTRIES) {
+    const oldestKey = costUsageCache.keys().next().value;
+    if (typeof oldestKey !== "string" || !oldestKey) {
+      break;
+    }
+    costUsageCache.delete(oldestKey);
+  }
+}
 
 function resolveSessionUsageFileOrRespond(
   key: string,
@@ -305,7 +324,12 @@ async function loadCostUsageSummaryCached(params: {
 }): Promise<CostUsageSummary> {
   const cacheKey = `${params.startMs}-${params.endMs}`;
   const now = Date.now();
+  pruneCostUsageCache(now);
   const cached = costUsageCache.get(cacheKey);
+  if (cached) {
+    costUsageCache.delete(cacheKey);
+    costUsageCache.set(cacheKey, cached);
+  }
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
     return cached.summary;
   }
@@ -325,6 +349,7 @@ async function loadCostUsageSummaryCached(params: {
   })
     .then((summary) => {
       costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
+      pruneCostUsageCache(Date.now());
       return summary;
     })
     .catch((err) => {
@@ -361,6 +386,7 @@ export const __test = {
   parseDateRange,
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
+  pruneCostUsageCache,
   costUsageCache,
 };
 

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -65,6 +65,7 @@ describe("compaction hook wiring", () => {
             resetForCompactionRetry: vi.fn(),
           }
         : {}),
+      resetUsageTotals: vi.fn(),
     };
   }
 
@@ -251,6 +252,7 @@ describe("compaction hook wiring", () => {
       maybeResolveCompactionWait: vi.fn(),
       getCompactionCount: () => 1,
       incrementCompactionCount: vi.fn(),
+      resetUsageTotals: vi.fn(),
     };
 
     runCompactionEnd(ctx, { willRetry: false, result: { summary: "compacted" } });
@@ -276,6 +278,7 @@ describe("compaction hook wiring", () => {
       log: { debug: vi.fn(), warn: vi.fn() },
       noteCompactionRetry: vi.fn(),
       resetForCompactionRetry: vi.fn(),
+      resetUsageTotals: vi.fn(),
       getCompactionCount: () => 0,
     };
 
@@ -283,5 +286,17 @@ describe("compaction hook wiring", () => {
 
     const assistant = messages[0] as { usage?: unknown };
     expect(assistant.usage).toEqual({ totalTokens: 184_297, input: 130_000, output: 2_000 });
+  });
+
+  it("resets usageTotals after final compaction", () => {
+    const ctx = createCompactionEndCtx({ runId: "r6", compactionCount: 1 });
+    runCompactionEnd(ctx, { willRetry: false, result: { summary: "compacted" } });
+    expect(ctx.resetUsageTotals).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets usageTotals when compaction is retrying", () => {
+    const ctx = createCompactionEndCtx({ runId: "r7", withRetryHooks: true });
+    runCompactionEnd(ctx, { willRetry: true });
+    expect(ctx.resetUsageTotals).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -202,6 +202,38 @@ describe("createChildAdapter", () => {
     expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });
   });
 
+  it("settles wait on Windows after timeout even when streams are not drained", async () => {
+    // Regression test: if stdout/stderr do not emit end/close within the settle
+    // window, the wait should still settle after the timeout using the exit state.
+    vi.useFakeTimers();
+    setPlatform("win32");
+
+    const { adapter, emitExit, child } = await (async () => {
+      const stub = createStubChild(8642);
+      spawnWithFallbackMock.mockResolvedValue({
+        child: stub.child,
+        usedFallback: false,
+      });
+      const adapter = await createChildAdapter({
+        argv: ["openclaw", "status"],
+        stdinMode: "pipe-closed",
+      });
+      return { ...stub, adapter };
+    })();
+
+    const settled = vi.fn();
+    void adapter.wait().then((result) => {
+      settled(result);
+    });
+
+    // Emit exit but do NOT emit end on stdout/stderr (streams remain undrained)
+    emitExit(0, null);
+    await vi.advanceTimersByTimeAsync(300);
+
+    // Should still settle with the exit code, even though streams are not drained
+    expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });
+  });
+
   it("disables detached mode in service-managed runtime", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -214,7 +214,14 @@ export async function createChildAdapter(params: {
     }
     clearWindowsCloseFallbackTimer();
     windowsCloseFallbackTimer = setTimeout(() => {
-      maybeSettleAfterWindowsExit();
+      if (waitResult || waitError !== undefined) {
+        return;
+      }
+      // Force settle after timeout, using observed exit state if available.
+      // This handles the case where stdout/stderr streams do not emit end/close
+      // within the settle window (e.g., some Windows processes with buffered output).
+      const exitState = childExitState ?? { code: null, signal: null };
+      settleWait(resolveObservedExitState(exitState));
     }, WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS);
     windowsCloseFallbackTimer.unref?.();
   };

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1099,7 +1099,9 @@ function renderGroupedMessage(
 
   // Suppress empty bubbles when tool cards are the only content and toggle is off
   const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
+  // Never suppress streaming bubbles — streaming text may arrive after tool-only content
   if (
+    !opts.isStreaming &&
     !markdown &&
     !visibleToolCards &&
     !hasImages &&


### PR DESCRIPTION
## 问题\n#69289：Browser aria refs 在快照里可用但执行 action 时失败。\n\n## 修复\n[定位根因并修复 aria ref 在 action 路径上的使用]\n\n## 测试覆盖\n[新增测试]