### PR TITLE
feat(provider): add agnes-ai bundled provider

### DIFF
--- a/docs/providers/agnes-ai.md
+++ b/docs/providers/agnes-ai.md
@@ -1,4 +1,17 @@
-# Agnes AI Provider
+# Agnes AI
 
-- Default model: agnes-ai/agnes-1.5-pro
-- Auth: API key
+Agnes AI provider for OpenClaw.
+
+## Models
+
+- agnes-ai/agnes-1.5-pro
+
+## Authentication
+
+Requires API key.
+
+## Usage
+
+Select:
+
+agnes-ai/agnes-1.5-pro

--- a/docs/providers/agnes-ai.md
+++ b/docs/providers/agnes-ai.md
@@ -1,0 +1,4 @@
+# Agnes AI Provider
+
+- Default model: agnes-ai/agnes-1.5-pro
+- Auth: API key

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -23,7 +23,14 @@ export default definePluginEntry({
           flagName: "--agnes-ai-api-key",
           envVar: "AGNES_API_KEY",
           promptMessage: "Enter your Agnes AI API key",
-          defaultModel: "agnes-ai/agnes-1.5-pro"
+          defaultModel: "agnes-ai/agnes-1.5-pro",
+          wizard: {
+            setup: {
+              title: "Agnes AI",
+              description: "Use Agnes AI models via API key",
+              envVars: ["AGNES_API_KEY"]
+            }
+          }
         })
       ]
     });

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -25,11 +25,9 @@ export default definePluginEntry({
           promptMessage: "Enter your Agnes AI API key",
           defaultModel: "agnes-ai/agnes-1.5-pro",
           wizard: {
-            setup: {
-              title: "Agnes AI",
-              description: "Use Agnes AI models via API key",
-              envVars: ["AGNES_API_KEY"]
-            }
+            choiceId: "agnes-ai",
+            choiceLabel: "Agnes AI",
+            choiceHint: "Use Agnes AI models via API key"
           }
         })
       ]

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -1,13 +1,23 @@
-export default function register({ registerProvider }: any) {
-  registerProvider({
-    id: "agnes-ai",
-    name: "Agnes AI",
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+
+export default defineSingleProviderPluginEntry({
+  providerId: "agnes-ai",
+
+  catalog: {
     models: [
       {
-        id: "agnes-ai/agnes-1.5-pro",
+        id: "agnes-1.5-pro",
         name: "Agnes 1.5 Pro",
         type: "text"
       }
     ]
-  });
-}
+  },
+
+  auth: [
+    {
+      id: "apiKey",
+      label: "API Key",
+      envVars: ["AGNES_API_KEY"]
+    }
+  ]
+});

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -18,20 +18,14 @@ export default definePluginEntry({
           providerId: "agnes-ai",
           methodId: "api-key",
           label: "Agnes AI API key",
+          hint: "API key from Agnes AI dashboard",
+          optionKey: "agnesAiApiKey",
+          flagName: "--agnes-ai-api-key",
           envVar: "AGNES_API_KEY",
+          promptMessage: "Enter your Agnes AI API key",
           defaultModel: "agnes-ai/agnes-1.5-pro"
         })
-      ],
-
-      catalog: {
-        models: [
-          {
-            id: "agnes-ai/agnes-1.5-pro",
-            name: "Agnes 1.5 Pro",
-            type: "text"
-          }
-        ]
-      }
+      ]
     });
   }
 });

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -1,3 +1,13 @@
-export default function register() {
-  // TODO
+export default function register({ registerProvider }: any) {
+  registerProvider({
+    id: "agnes-ai",
+    name: "Agnes AI",
+    models: [
+      {
+        id: "agnes-ai/agnes-1.5-pro",
+        name: "Agnes 1.5 Pro",
+        type: "text"
+      }
+    ]
+  });
 }

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -1,23 +1,37 @@
-import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
 
-export default defineSingleProviderPluginEntry({
-  providerId: "agnes-ai",
+export default definePluginEntry({
+  id: "agnes-ai",
+  name: "Agnes AI",
+  description: "Agnes AI model provider",
 
-  catalog: {
-    models: [
-      {
-        id: "agnes-1.5-pro",
-        name: "Agnes 1.5 Pro",
-        type: "text"
+  register(api) {
+    api.registerProvider({
+      id: "agnes-ai",
+      label: "Agnes AI",
+      docsPath: "/providers/agnes-ai",
+      envVars: ["AGNES_API_KEY"],
+
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: "agnes-ai",
+          methodId: "api-key",
+          label: "Agnes AI API key",
+          envVar: "AGNES_API_KEY",
+          defaultModel: "agnes-ai/agnes-1.5-pro"
+        })
+      ],
+
+      catalog: {
+        models: [
+          {
+            id: "agnes-ai/agnes-1.5-pro",
+            name: "Agnes 1.5 Pro",
+            type: "text"
+          }
+        ]
       }
-    ]
-  },
-
-  auth: [
-    {
-      id: "apiKey",
-      label: "API Key",
-      envVars: ["AGNES_API_KEY"]
-    }
-  ]
+    });
+  }
 });

--- a/extensions/agnes-ai/index.ts
+++ b/extensions/agnes-ai/index.ts
@@ -1,0 +1,3 @@
+export default function register() {
+  // TODO
+}

--- a/extensions/agnes-ai/openclaw.plugin.json
+++ b/extensions/agnes-ai/openclaw.plugin.json
@@ -1,0 +1,5 @@
+{
+  "id": "agnes-ai",
+  "name": "Agnes AI",
+  "type": "provider"
+}

--- a/extensions/agnes-ai/openclaw.plugin.json
+++ b/extensions/agnes-ai/openclaw.plugin.json
@@ -1,5 +1,12 @@
 {
   "id": "agnes-ai",
   "name": "Agnes AI",
-  "type": "provider"
+  "enabledByDefault": false,
+  "providers": ["agnes-ai"],
+  "providerAuthEnvVars": ["AGNES_API_KEY"],
+  "providerAuthChoices": ["apiKey"],
+  "configSchema": {
+    "type": "object",
+    "properties": {}
+  }
 }

--- a/extensions/agnes-ai/package.json
+++ b/extensions/agnes-ai/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@openclaw/agnes-ai",
   "version": "0.0.1",
-  "private": true
+  "private": true,
+  "type": "module",
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
 }

--- a/extensions/agnes-ai/package.json
+++ b/extensions/agnes-ai/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@openclaw/agnes-ai",
+  "version": "0.0.1",
+  "private": true
+}


### PR DESCRIPTION
## Summary

We'd like to contribute a bundled model provider plugin for Agnes AI to OpenClaw.

The proposed provider would:

- register a new bundled provider id: `agnes-ai`
- expose Agnes AI models through the standard OpenClaw model/provider flow
- use `agnes-ai/agnes-1.5-pro` as the initial default model
- keep provider-specific auth, onboarding, catalog, and transport behavior inside a standard bundled provider plugin under `extensions/agnes-ai`

This is intended as a standard bundled provider plugin contribution, not a core architecture change.

## Naming

To keep the integration consistent for users:

- Company: `Sapiens AI`
- Provider label: `Agnes AI`
- Provider id: `agnes-ai`
- Model family: `agnes-*`
- Initial default model: `agnes-ai/agnes-1.5-pro`

## Proposed implementation shape

We plan to follow the existing bundled provider structure used by providers like `together`, `deepseek`, and `vllm`, with files along these lines:

- `extensions/agnes-ai/package.json`
- `extensions/agnes-ai/openclaw.plugin.json`
- `extensions/agnes-ai/index.ts`
- `extensions/agnes-ai/provider-catalog.ts`
- `extensions/agnes-ai/onboard.ts`
- `docs/providers/agnes-ai.md`

The goal is to keep vendor-specific behavior inside the provider plugin and avoid adding special-case logic to core.

## Initial scope

To keep the first PR focused and easy to review, we plan to keep the initial contribution narrow:

- API key auth
- bundled model catalog
- onboarding support
- text model support first
- standard `provider/model` selection flow
- docs and targeted tests

We can expand to additional model capabilities later if maintainers prefer the first PR to stay narrowly scoped.

## Additional context

Agnes AI is also actively building and showcasing `AgnesClaw`, an agent experience built around Agnes models and the OpenClaw ecosystem. We mention this only as evidence of ongoing investment and real-world usage around OpenClaw, not as the provider name. The bundled provider proposed here would remain `agnes-ai`.

## Questions for maintainers

Before preparing the PR, we wanted to confirm:

1. Would you accept a bundled provider plugin for `agnes-ai` in principle?
2. Do you prefer the first PR to stay text-only?
3. Are there any maintainer preferences for provider naming, manifest metadata, docs, or test coverage beyond the current bundled provider pattern?

## Maintenance

We understand bundled providers imply ongoing maintenance responsibility, and we are prepared to maintain this integration.