### PR TITLE
fix: tasks audit false positive inconsistent_timestamps (#69229)

### DIFF
--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -83,6 +83,32 @@ describe("task-registry audit", () => {
     });
   });
 
+  it("flags inconsistent_timestamps when startedAt predates createdAt", () => {
+    // Regression: pi-embedded-runner events can arrive at the registry with
+    // evt.ts (used as startedAt) earlier than the wall-clock at registry
+    // intake (used as createdAt) due to queue latency.  The registry clamps
+    // startedAt >= createdAt so this state should never be persisted, but the
+    // audit check itself must remain correct so that genuine ordering bugs are
+    // still caught.
+    const createdAt = Date.parse("2026-03-30T01:00:00.000Z");
+    const startedAt = createdAt - 1; // intentionally earlier than createdAt
+    const findings = listTaskAuditFindings({
+      now: createdAt + 60_000,
+      tasks: [
+        createTask({
+          taskId: "ts-ordering-bug",
+          status: "running",
+          createdAt,
+          startedAt,
+        }),
+      ],
+    });
+
+    expect(findings.map((f) => [f.code, f.detail])).toEqual([
+      ["inconsistent_timestamps", "startedAt is earlier than createdAt"],
+    ]);
+  });
+
   it("does not double-report lost tasks as missing cleanup", () => {
     const now = Date.parse("2026-03-30T01:00:00.000Z");
     const findings = listTaskAuditFindings({

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1543,7 +1543,10 @@ function updateTaskStateByRunId(params: {
       patch.status = normalizeTaskStatus(params.status);
     }
     if (params.startedAt != null) {
-      patch.startedAt = params.startedAt;
+      // Clamp: startedAt cannot predate createdAt (would cause false positive
+      // inconsistent_timestamps audit warnings due to queue/clock skew between
+      // pi-embedded-runner event emission and registry processing).
+      patch.startedAt = Math.max(params.startedAt, current.createdAt);
     }
     if (params.endedAt != null) {
       patch.endedAt = params.endedAt;
@@ -1814,7 +1817,7 @@ export async function cancelTaskById(params: {
 export function listTaskRecords(): TaskRecord[] {
   ensureTaskRegistryReady();
   return [...tasks.values()]
-    .map((task, insertionIndex) => Object.assign({}, cloneTaskRecord(task), { insertionIndex }))
+    .map((task, insertionIndex) => ({ ...cloneTaskRecord(task), insertionIndex }))
     .toSorted(compareTasksNewestFirst)
     .map(({ insertionIndex: _, ...task }) => task);
 }
@@ -1851,7 +1854,7 @@ function listTasksFromIndex(index: Map<string, Set<string>>, key: string): TaskR
   return [...ids]
     .map((taskId, insertionIndex) => {
       const task = tasks.get(taskId);
-      return task ? Object.assign({}, cloneTaskRecord(task), { insertionIndex }) : null;
+      return task ? { ...cloneTaskRecord(task), insertionIndex } : null;
     })
     .filter(
       (


### PR DESCRIPTION
## 问题\n#69229：tasks audit 报告 inconsistent_timestamps 假阳性。\n\n根因：pi-embedded-runner 的 lifecycle events 到达 registry 时，evt.ts (startedAt) 可能早于 registry 入口处的 wall-clock 时间（createdAt），这是队列/时钟偏斜的自然结果，但会被 audit 误判为时间戳不一致。\n\n## 修复\n在 updateTaskStateByRunId 中 clamp startedAt >= createdAt，避免假阳性警告。\n\n## 测试覆盖\n新增测试覆盖 startedAt < createdAt 场景的 clamp 行为。