### PR TITLE
fix(skills): refresh stale session skill snapshots after restart

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -85,4 +85,12 @@ describe("ensureSkillsWatcher", () => {
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
   });
+
+  it("seeds a non-zero version when attaching the first watcher", async () => {
+    expect(refreshModule.getSkillsSnapshotVersion("/tmp/workspace")).toBe(0);
+
+    refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
+
+    expect(refreshModule.getSkillsSnapshotVersion("/tmp/workspace")).toBeGreaterThan(0);
+  });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -167,6 +167,15 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   });
 
   watchers.set(workspaceDir, state);
+
+  // Seed a non-zero workspace version the first time this process attaches a
+  // watcher. Persisted session snapshots can carry version 0 across restarts;
+  // without an initial bump, those stale snapshots compare equal to the fresh
+  // process state and never rebuild, even if skills changed while the gateway
+  // was down.
+  if (getSkillsSnapshotVersion(workspaceDir) === 0) {
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "manual" });
+  }
 }
 
 export async function resetSkillsRefreshForTest(): Promise<void> {

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -105,4 +105,28 @@ describe("ensureSkillSnapshot", () => {
     );
     expect(resolveAgentIdFromSessionKeyMock).not.toHaveBeenCalled();
   });
+
+  it("reads the snapshot version after ensuring the watcher", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    ensureSkillsWatcherMock.mockImplementation(() => {
+      getSkillsSnapshotVersionMock.mockReturnValue(123);
+    });
+
+    await ensureSkillSnapshot({
+      sessionStore: {},
+      sessionKey: "main",
+      isFirstTurnInSession: true,
+      workspaceDir: "/tmp/workspace",
+      cfg: {},
+    });
+
+    expect(ensureSkillsWatcherMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+    });
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledWith(
+      "/tmp/workspace",
+      expect.objectContaining({ snapshotVersion: 123 }),
+    );
+  });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -142,9 +142,9 @@ export async function ensureSkillSnapshot(params: {
       agentId: sessionAgentId,
     }),
   });
-  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const existingSnapshot = nextEntry?.skillsSnapshot;
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const shouldRefreshSnapshot =
     shouldRefreshSnapshotForVersion(existingSnapshot?.version, snapshotVersion) ||
     !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter);


### PR DESCRIPTION
## Summary
Fixes a stale-session edge case where newly added skills can stay invisible after a gateway restart.

Fixes #69715.

## What Changed
- seed a non-zero skills snapshot version when the first workspace watcher is attached
- read `snapshotVersion` after `ensureSkillsWatcher()` in `ensureSkillSnapshot()`
- add regression coverage for both behaviors

## Why
A persisted session snapshot with `version = 0` could compare equal to the fresh process state after restart, so the next turn would skip rebuilding the snapshot. In practice that let existing sessions miss newly added workspace skills until the session was reset or otherwise refreshed.

## Testing
- `git diff --check`
- Added focused unit tests in:
  - `src/agents/skills/refresh.test.ts`
  - `src/auto-reply/reply/session-updates.test.ts`
- Not run locally: this checkout does not have `node_modules`, `vitest`, or `pnpm` installed, so `node scripts/run-vitest.mjs ...` fails with `Cannot find module 'vitest/package.json'`.
