### PR TITLE
test(ollama): cover native model id normalization

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -56,6 +56,22 @@ describe("buildOllamaChatRequest", () => {
       model: "qwen3:14b-q8_0",
     });
   });
+
+  it("leaves bare Ollama model IDs unchanged", () => {
+    const request = buildOllamaChatRequest({
+      modelId: "llama3.1:8b",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(request.model).toBe("llama3.1:8b");
+  });
+
+  it("does not strip non-ollama provider prefixes", () => {
+    const request = buildOllamaChatRequest({
+      modelId: "some_org/custom-model:latest",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(request.model).toBe("some_org/custom-model:latest");
+  });
 });
 
 describe("createConfiguredOllamaCompatStreamWrapper", () => {


### PR DESCRIPTION
## Summary
- Problem: OpenClaw's native Ollama request path must normalize internal `ollama/<model>` ids before sending requests to Ollama, while still preserving valid bare model ids.
- Why it matters: Without explicit regression coverage, future changes could accidentally send provider-prefixed ids such as `ollama/llama3.1:8b` to the local Ollama API or over-normalize namespaced bare ids.
- What changed: This PR adds focused `buildOllamaChatRequest` regression coverage for bare Ollama ids and non-`ollama/` namespaced ids.
- What did NOT change (scope boundary): The implementation behavior is unchanged by this branch after rebasing; latest `main` already contains the native Ollama prefix-stripping implementation.

## Change Type 

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The original issue was that the native Ollama request builder could use OpenClaw's provider-prefixed model id directly as the Ollama API payload `model`.
- Missing detection / guardrail: Existing request-builder coverage only checked basic payload shape and did not lock in the boundary between OpenClaw provider ids and Ollama wire ids.
- Contributing context (if known): Latest `main` now includes `normalizeOllamaWireModelId`; this PR keeps extra edge-case coverage on top of that implementation.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/ollama/src/stream-runtime.test.ts`
- Scenario the test should lock in: `buildOllamaChatRequest` leaves `llama3.1:8b` unchanged and preserves namespaced bare ids such as `some_org/custom-model:latest`.
- Why this is the smallest reliable guardrail: The behavior is isolated to pure request payload construction, so a focused unit test verifies the exact model id before any network call.
- Existing test that already covers this (if any): Latest `main` already covers stripping `ollama/qwen3:14b-q8_0` to `qwen3:14b-q8_0`; this PR adds the complementary non-stripping cases.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None. This branch adds regression coverage only after rebasing onto latest `main`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[future edit changes model normalization]
  -> [tests only cover prefix stripping]
  -> [over-normalization of bare ids could slip through]

After:
[future edit changes model normalization]
  -> [tests cover prefix stripping plus non-stripping cases]
  -> [bare and namespaced model ids stay protected]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node via repo pnpm test wrapper
- Model/provider: Ollama native provider request builder
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Rebase the branch onto latest `upstream/main`.
2. Resolve the Ollama stream test conflict by keeping upstream's implementation coverage and adding the two complementary model-id tests.
3. Run the focused Ollama request-builder test.

### Expected

- `buildOllamaChatRequest` strips `ollama/` provider prefixes.
- `buildOllamaChatRequest` leaves bare model ids unchanged.
- `buildOllamaChatRequest` does not strip non-`ollama/` namespaced ids.

### Actual

- Focused Ollama request-builder coverage passes with 4 matching tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Checks after rebasing onto latest `upstream/main`:

```text
git diff --check upstream/main...HEAD
pnpm exec oxfmt --check extensions/ollama/src/stream-runtime.test.ts
pnpm test -- extensions/ollama/src/stream-runtime.test.ts -t buildOllamaChatRequest
```

Result:

```text
Test Files  1 passed (1)
Tests       4 passed | 43 skipped (47)
```

Earlier manual smoke before the rebase also confirmed the behavior end to end:

```text
Direct Ollama /api/chat returned: OLLAMA_DIRECT_OK
OpenClaw local agent with ollama/llama3.1:8b returned: OPENCLAW_OLLAMA_OK
Dashboard served OpenClaw Control HTML from the local source gateway.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Rebase conflict resolution against latest `upstream/main`.
  - Request-builder coverage for the Ollama model-id normalization boundary.
  - Focused formatting and whitespace checks on the final diff.
- Edge cases checked:
  - `ollama/qwen3:14b-q8_0` becomes `qwen3:14b-q8_0` through existing upstream coverage.
  - `llama3.1:8b` stays unchanged through this PR's added coverage.
  - `some_org/custom-model:latest` stays unchanged through this PR's added coverage.
- What you did **not** verify:
  - Remote Ollama hosts.
  - Ollama cloud models.
  - Full repo test suite after the rebase.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: This PR is now test-only because latest `main` already contains the implementation fix.
  - Mitigation: The added tests still strengthen the exact edge cases reviewers care about: preserving bare ids and non-`ollama/` namespaced ids.
