### PR TITLE
fix(agents): build local system.run plan when node omits system.run.prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,6 +734,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec host=node/macOS: when the paired node advertises `system.run` without `system.run.prepare` (for example the macOS companion app predating the prepare handshake), synthesize the canonical approval plan on the agent side instead of failing the preflight, so `exec host=node` against macOS nodes no longer errors with `node command not allowed: the node ... does not support "system.run.prepare"`. Fixes #66839.
 - Exec/YOLO: stop rejecting gateway-host exec in `security=full` plus `ask=off` mode via the Python/Node script preflight hardening path, so promptless YOLO exec once again runs direct interpreter stdin and heredoc forms such as `node <<'NODE' ... NODE`. Thanks @steipete.
 - OpenAI Codex: normalize legacy `openai-completions` transport overrides on default OpenAI/Codex and GitHub Copilot-compatible hosts back to the native Codex Responses transport while leaving custom proxies untouched. (#45304, #42194) Thanks @dyss1992 and @DeadlySilent.
 - Anthropic/plugins: scope Anthropic `api: "anthropic-messages"` defaulting to Anthropic-owned providers, so `openai-codex` and other providers without an explicit `api` no longer get rewritten to the wrong transport. Fixes #64534. Thanks @steipete.

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -182,7 +182,11 @@ describe("executeNodeHostCommand", () => {
     );
     listNodesMock.mockReset();
     listNodesMock.mockResolvedValue([
-      { nodeId: "node-1", commands: ["system.run"], platform: process.platform },
+      {
+        nodeId: "node-1",
+        commands: ["system.run", "system.run.prepare"],
+        platform: process.platform,
+      },
     ]);
     parsePreparedSystemRunPayloadMock.mockReset();
     parsePreparedSystemRunPayloadMock.mockReturnValue({ plan: preparedPlan });
@@ -348,5 +352,54 @@ describe("executeNodeHostCommand", () => {
       );
     });
     expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips system.run.prepare and builds a local plan when the node does not advertise it", async () => {
+    // Repro of #66839: macOS app nodes advertise system.run + system.which but
+    // omit system.run.prepare. Gateway declaration check rejects the prepare
+    // RPC before it reaches the node, breaking exec host=node.
+    listNodesMock.mockResolvedValueOnce([
+      {
+        nodeId: "node-1",
+        commands: ["system.run", "system.which", "system.notify"],
+        platform: "macos",
+      },
+    ]);
+    requiresExecApprovalMock.mockReturnValueOnce(false);
+
+    const result = await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    expect(result.details?.status).toBe("completed");
+    expect(parsePreparedSystemRunPayloadMock).not.toHaveBeenCalled();
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayToolMock).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({
+        command: "system.run",
+        params: expect.objectContaining({
+          command: ["bash", "-lc", "bun ./script.ts"],
+          systemRunPlan: {
+            argv: ["bash", "-lc", "bun ./script.ts"],
+            cwd: "/tmp/work",
+            commandText: 'bash -lc "bun ./script.ts"',
+            commandPreview: null,
+            agentId: "requested-agent",
+            sessionKey: "requested-session",
+          },
+        }),
+      }),
+    );
   });
 });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -4,6 +4,7 @@ import {
   type ExecApprovalsFile,
   type ExecAsk,
   type ExecSecurity,
+  type SystemRunApprovalPlan,
   evaluateShellAllowlist,
   hasDurableExecApproval,
   requiresExecApproval,
@@ -16,6 +17,8 @@ import {
 } from "../infra/exec-inline-eval.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import { parsePreparedSystemRunPayload } from "../infra/system-run-approval-context.js";
+import { formatExecCommand } from "../infra/system-run-command.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -57,6 +60,60 @@ export type ExecuteNodeHostCommandParams = {
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
 
+async function requestRemoteSystemRunPlan(params: {
+  nodeId: string;
+  argv: string[];
+  rawCommand: string;
+  workdir: string | undefined;
+  agentId: string | undefined;
+  sessionKey: string | undefined;
+}): Promise<{ plan: SystemRunApprovalPlan }> {
+  const prepareRaw = await callGatewayTool(
+    "node.invoke",
+    { timeoutMs: 15_000 },
+    {
+      nodeId: params.nodeId,
+      command: "system.run.prepare",
+      params: {
+        command: params.argv,
+        rawCommand: params.rawCommand,
+        ...(params.workdir != null ? { cwd: params.workdir } : {}),
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      },
+      idempotencyKey: crypto.randomUUID(),
+    },
+  );
+  const prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
+  if (!prepared) {
+    throw new Error("invalid system.run.prepare response");
+  }
+  return prepared;
+}
+
+// Legacy nodes advertise `system.run` without `system.run.prepare`. Build the
+// canonical approval plan on the agent side so the exec flow can still bind
+// approvals to a stable argv/cwd without a round-trip to the node. Plan
+// hardening that depends on the node's filesystem is skipped; these nodes
+// already ignore `systemRunPlan` when executing.
+function buildLocalSystemRunPlan(params: {
+  argv: string[];
+  workdir: string | undefined;
+  agentId: string | undefined;
+  sessionKey: string | undefined;
+}): { plan: SystemRunApprovalPlan } {
+  return {
+    plan: {
+      argv: [...params.argv],
+      cwd: normalizeOptionalString(params.workdir) ?? null,
+      commandText: formatExecCommand(params.argv),
+      commandPreview: null,
+      agentId: normalizeOptionalString(params.agentId) ?? null,
+      sessionKey: normalizeOptionalString(params.sessionKey) ?? null,
+    },
+  };
+}
+
 export async function executeNodeHostCommand(
   params: ExecuteNodeHostCommandParams,
 ): Promise<AgentToolResult<ExecToolDetails>> {
@@ -89,35 +146,30 @@ export async function executeNodeHostCommand(
     throw err;
   }
   const nodeInfo = nodes.find((entry) => entry.nodeId === nodeId);
-  const supportsSystemRun = Array.isArray(nodeInfo?.commands)
-    ? nodeInfo?.commands?.includes("system.run")
-    : false;
+  const declaredCommands = Array.isArray(nodeInfo?.commands) ? nodeInfo.commands : [];
+  const supportsSystemRun = declaredCommands.includes("system.run");
   if (!supportsSystemRun) {
     throw new Error(
       "exec host=node requires a node that supports system.run (companion app or node host).",
     );
   }
+  const supportsSystemRunPrepare = declaredCommands.includes("system.run.prepare");
   const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
-  const prepareRaw = await callGatewayTool(
-    "node.invoke",
-    { timeoutMs: 15_000 },
-    {
-      nodeId,
-      command: "system.run.prepare",
-      params: {
-        command: argv,
+  const prepared = supportsSystemRunPrepare
+    ? await requestRemoteSystemRunPlan({
+        nodeId,
+        argv,
         rawCommand: params.command,
-        ...(params.workdir != null ? { cwd: params.workdir } : {}),
+        workdir: params.workdir,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
-      },
-      idempotencyKey: crypto.randomUUID(),
-    },
-  );
-  const prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
-  if (!prepared) {
-    throw new Error("invalid system.run.prepare response");
-  }
+      })
+    : buildLocalSystemRunPlan({
+        argv,
+        workdir: params.workdir,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      });
   const runArgv = prepared.plan.argv;
   const runRawCommand = prepared.plan.commandText;
   const runCwd = prepared.plan.cwd ?? params.workdir;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -15,7 +15,11 @@ vi.mock("./tools/gateway.js", () => ({
 
 vi.mock("./tools/nodes-utils.js", () => ({
   listNodes: vi.fn(async () => [
-    { nodeId: "node-1", commands: ["system.run"], platform: "darwin" },
+    {
+      nodeId: "node-1",
+      commands: ["system.run", "system.run.prepare"],
+      platform: "darwin",
+    },
   ]),
   resolveNodeIdFromList: vi.fn((nodes: Array<{ nodeId: string }>) => nodes[0]?.nodeId),
 }));


### PR DESCRIPTION
## Summary

Fixes #66839. `exec host=node` against the macOS companion app currently fails preflight with:

```
node command not allowed: the node (platform: macOS 15.7.5) does not support "system.run.prepare"
```

Root cause: `executeNodeHostCommand` unconditionally issues a `system.run.prepare` RPC, but the macOS companion Swift node (`apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift`, `apps/macos/.../MacNodeModeCoordinator.swift`) only advertises `system.run` / `system.which` / `system.notify`. The gateway node-command-policy rejects the undeclared command before it ever reaches the node, so any agent trying to `exec host=node` on a macOS pair errors out on the preflight.

## Fix

Route on the node's declared commands:

- If the node advertises `system.run.prepare`, keep the existing remote round-trip that returns a canonical `SystemRunApprovalPlan`.
- If it only advertises `system.run`, synthesize the approval plan locally so exec can still bind approvals to a stable argv/cwd and proceed to `system.run`.

Filesystem hardening is intentionally skipped on the local path — legacy Swift nodes already ignore `systemRunPlan` on the execution side (`MacNodeRuntime.handleSystemRun` uses the raw argv), and cross-machine path resolution is meaningless from the agent side. Behavior for nodes that *do* implement prepare is unchanged.

## Test plan

- [x] Added `bash-tools.exec-host-node.test.ts` case: macOS node with `commands: ["system.run","system.which","system.notify"]` no longer calls the prepare parser and emits a locally-built `systemRunPlan` on `system.run`.
- [x] Updated existing default `listNodes` mocks to include `system.run.prepare` so the 26+ approval-id / happy-path tests keep exercising the RPC path.
- [x] `pnpm check:changed --staged` green (typecheck core + core tests, lint, import cycles, webhook/pairing guards).
- [x] `pnpm test` agents suite: 3964 passed / 4 skipped.

### Build note

`pnpm build` fails on `main` at `scripts/stage-bundled-plugin-runtime-deps.mjs` for the Discord plugin (`discord-api-types must resolve to an exact installed version, got: ^0.38.47`). This is pre-existing and unrelated — this change is a pure agent-side TS edit and does not touch build output, packaging, lazy/module boundaries, or published surfaces.