### PR TITLE
fix(cli): clarify mcp list registry scope

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1162,7 +1162,8 @@ Options:
 
 #### `mcp list`
 
-List saved MCP server definitions.
+List saved OpenClaw-managed MCP server definitions from `mcp.servers`. This does
+not include mcporter servers from `config/mcporter.json`.
 
 Options:
 

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -364,6 +364,8 @@ MCP server lists.
 Important behavior:
 
 - these commands only read or write OpenClaw config
+- they do not read mcporter servers from `config/mcporter.json`; use
+  `mcporter list --output json` for that registry
 - they do not connect to the target MCP server
 - they do not validate whether the command, URL, or remote transport is
   reachable right now

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -79,6 +79,12 @@ describe("mcp cli", () => {
       mockLog.mockClear();
       await runMcpCommand(["mcp", "show", "context7", "--json"]);
       expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"command": "uvx"'));
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "context7"]);
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining('OpenClaw-managed MCP server "context7"'),
+      );
     });
   });
 
@@ -94,6 +100,22 @@ describe("mcp cli", () => {
 
       expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("OpenClaw-managed MCP servers"));
       expect(mockLog).toHaveBeenCalledWith("- context7");
+      expect(mockLog).toHaveBeenCalledWith(
+        "Note: this command does not include mcporter servers from config/mcporter.json.",
+      );
+    });
+  });
+
+  it("clarifies the OpenClaw-managed scope when mcp list is empty", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand(["mcp", "list"]);
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("No OpenClaw-managed MCP servers configured"),
+      );
       expect(mockLog).toHaveBeenCalledWith(
         "Note: this command does not include mcporter servers from config/mcporter.json.",
       );

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -82,6 +82,24 @@ describe("mcp cli", () => {
     });
   });
 
+  it("clarifies that mcp list shows only OpenClaw-managed servers", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand(["mcp", "set", "context7", '{"command":"uvx","args":["context7-mcp"]}']);
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "list"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("OpenClaw-managed MCP servers"));
+      expect(mockLog).toHaveBeenCalledWith("- context7");
+      expect(mockLog).toHaveBeenCalledWith(
+        "Note: this command does not include mcporter servers from config/mcporter.json.",
+      );
+    });
+  });
+
   it("fails when removing an unknown MCP server", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -23,6 +23,9 @@ function printJson(value: unknown): void {
   defaultRuntime.writeJson(value);
 }
 
+const MCP_REGISTRY_SCOPE_NOTE =
+  "Note: this command does not include mcporter servers from config/mcporter.json.";
+
 export function registerMcpCli(program: Command) {
   const mcp = program.command("mcp").description("Manage OpenClaw MCP config and channel bridge");
 
@@ -68,7 +71,7 @@ export function registerMcpCli(program: Command) {
 
   mcp
     .command("list")
-    .description("List configured MCP servers")
+    .description("List OpenClaw-managed MCP servers from mcp.servers")
     .option("--json", "Print JSON")
     .action(async (opts: { json?: boolean }) => {
       const loaded = await listConfiguredMcpServers();
@@ -81,18 +84,20 @@ export function registerMcpCli(program: Command) {
       }
       const names = Object.keys(loaded.mcpServers).toSorted();
       if (names.length === 0) {
-        defaultRuntime.log(`No MCP servers configured in ${loaded.path}.`);
+        defaultRuntime.log(`No OpenClaw-managed MCP servers configured in ${loaded.path}.`);
+        defaultRuntime.log(MCP_REGISTRY_SCOPE_NOTE);
         return;
       }
-      defaultRuntime.log(`MCP servers (${loaded.path}):`);
+      defaultRuntime.log(`OpenClaw-managed MCP servers (${loaded.path}):`);
       for (const name of names) {
         defaultRuntime.log(`- ${name}`);
       }
+      defaultRuntime.log(MCP_REGISTRY_SCOPE_NOTE);
     });
 
   mcp
     .command("show")
-    .description("Show one configured MCP server or the full MCP config")
+    .description("Show one OpenClaw-managed MCP server or the full MCP config")
     .argument("[name]", "MCP server name")
     .option("--json", "Print JSON")
     .action(async (name: string | undefined, opts: { json?: boolean }) => {
@@ -118,7 +123,7 @@ export function registerMcpCli(program: Command) {
 
   mcp
     .command("set")
-    .description("Set one configured MCP server from a JSON object")
+    .description("Set one OpenClaw-managed MCP server from a JSON object")
     .argument("<name>", "MCP server name")
     .argument("<value>", 'JSON object, for example {"command":"uvx","args":["context7-mcp"]}')
     .action(async (name: string, rawValue: string) => {
@@ -135,7 +140,7 @@ export function registerMcpCli(program: Command) {
 
   mcp
     .command("unset")
-    .description("Remove one configured MCP server")
+    .description("Remove one OpenClaw-managed MCP server")
     .argument("<name>", "MCP server name")
     .action(async (name: string) => {
       const result = await unsetConfiguredMcpServer({ name });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -114,9 +114,9 @@ export function registerMcpCli(program: Command) {
         return;
       }
       if (name) {
-        defaultRuntime.log(`MCP server "${name}" (${loaded.path}):`);
+        defaultRuntime.log(`OpenClaw-managed MCP server "${name}" (${loaded.path}):`);
       } else {
-        defaultRuntime.log(`MCP servers (${loaded.path}):`);
+        defaultRuntime.log(`OpenClaw-managed MCP servers (${loaded.path}):`);
       }
       printJson(value ?? {});
     });


### PR DESCRIPTION
## Summary

- Problem: `openclaw mcp list` looked like it listed all MCP servers OpenClaw users might know about, but it only reads OpenClaw config under `mcp.servers`.
- Why it matters: users with mcporter servers in `config/mcporter.json` can mistake the current output for missing servers.
- What changed: relabeled `mcp list` output as OpenClaw-managed, added a mcporter scope note, tightened CLI help descriptions, documented the distinction, and added a CLI test.
- What did NOT change (scope boundary): no mcporter discovery, merge behavior, config schema, or `--json` output shape changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65209
- Related #34097
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: CLI wording used generic “MCP servers” labels for an OpenClaw-owned registry command.
- Missing detection / guardrail: no CLI test asserted the user-facing `mcp list` scope label.
- Contributing context (if known): docs already explained the registry split in more detail, but the command output and short CLI reference were easy to misread.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/mcp-cli.test.ts`
- Scenario the test should lock in: `openclaw mcp list` labels results as OpenClaw-managed and prints the mcporter exclusion note.
- Why this is the smallest reliable guardrail: the bug is command wording, so the CLI command unit test is enough.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw mcp list` now prints `OpenClaw-managed MCP servers (...)` and a note that mcporter servers from `config/mcporter.json` are not included. The command still reads the same OpenClaw config and `--json` output remains machine-readable without the note.

## Diagram (if applicable)

```text
Before:
openclaw mcp list -> "MCP servers" -> users may expect mcporter entries too

After:
openclaw mcp list -> "OpenClaw-managed MCP servers" -> note points mcporter users to mcporter list
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): CLI
- Relevant config (redacted): temporary test home with one `mcp.servers.context7` entry

### Steps

1. Configure an OpenClaw MCP server.
2. Run `openclaw mcp list`.
3. Read the CLI output and `docs/cli/mcp.md`.

### Expected

- CLI output makes clear that the list is OpenClaw-managed.
- Docs explain that mcporter servers live in a separate registry.

### Actual

- CLI output and docs now make that distinction explicit.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

```bash
pnpm exec oxfmt --check src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts docs/cli/index.md docs/cli/mcp.md
pnpm dlx markdownlint-cli2 docs/cli/index.md docs/cli/mcp.md
node scripts/test-projects.mjs src/cli/mcp-cli.test.ts
```

Pre-commit `check:changed` also passed, including core typecheck, core test typecheck, lint:core, import-cycle checks, and the CLI test group: 101 files / 955 tests passed.

## Human Verification (required)

- Verified scenarios: reviewed the CLI output diff, help descriptions, docs text, and the new test assertion.
- Edge cases checked: kept `--json` output unchanged so scripts do not receive human-readable notes.
- What you did **not** verify: a live mcporter installation, because this PR only clarifies OpenClaw CLI registry scope.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the extra note adds one more human-readable line to non-JSON `mcp list` output.
  - Mitigation: `--json` output is unchanged for automation.
