### PR TITLE
fix(minimax): recognize MiniMax-M2.7 as VLM-capable model

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -83,10 +83,13 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
 });
 
 describe("isMinimaxVlmModel", () => {
-  it("only matches the canonical MiniMax VLM model id", async () => {
+  it("matches known MiniMax VLM model ids", async () => {
     expect(isMinimaxVlmModel("minimax", "MiniMax-VL-01")).toBe(true);
     expect(isMinimaxVlmModel("minimax-portal", "MiniMax-VL-01")).toBe(true);
+    expect(isMinimaxVlmModel("minimax", "MiniMax-M2.7")).toBe(true);
+    expect(isMinimaxVlmModel("minimax-portal", "MiniMax-M2.7")).toBe(true);
     expect(isMinimaxVlmModel("minimax-portal", "custom-vision")).toBe(false);
     expect(isMinimaxVlmModel("openai", "MiniMax-VL-01")).toBe(false);
+    expect(isMinimaxVlmModel("openai", "MiniMax-M2.7")).toBe(false);
   });
 });

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -11,8 +11,13 @@ export function isMinimaxVlmProvider(provider: string): boolean {
   return provider === "minimax" || provider === "minimax-portal";
 }
 
+const MINIMAX_VLM_MODELS = new Set([
+  "MiniMax-VL-01",
+  "MiniMax-M2.7",
+]);
+
 export function isMinimaxVlmModel(provider: string, modelId: string): boolean {
-  return isMinimaxVlmProvider(provider) && modelId.trim() === "MiniMax-VL-01";
+  return isMinimaxVlmProvider(provider) && MINIMAX_VLM_MODELS.has(modelId.trim());
 }
 
 function coerceApiHost(params: {


### PR DESCRIPTION
Fixes #69648

MiniMax-M2.7 supports image understanding via the `/v1/coding_plan/vlm` endpoint, but `isMinimaxVlmModel()` only recognized `MiniMax-VL-01`. This caused M2.7 to be incorrectly routed to the generic `anthropic-messages` API path, producing:

```
Image model failed (minimax/MiniMax-M2.7): 400 {"type":"error","error":{"type":"invalid_request_error","message":"invalid params, chat content is empty (2013)"}}
```

**Fix:** Replace the hard-coded single-model check with a `Set` lookup that includes both `MiniMax-VL-01` and `MiniMax-M2.7`.

**Test coverage:** Updated existing `isMinimaxVlmModel` test to assert both models are recognized and non-MiniMax providers are still rejected.
