### PR TITLE
Fix exec approvals snapshot transport redaction

### DIFF
--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -3,6 +3,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  redactExecApprovalsForTransport,
   saveExecApprovals,
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
@@ -69,20 +70,12 @@ function requireApprovalsBaseHash(
   return true;
 }
 
-function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
-  const socketPath = file.socket?.path?.trim();
-  return {
-    ...file,
-    socket: socketPath ? { path: socketPath } : undefined,
-  };
-}
-
 function toExecApprovalsPayload(snapshot: ExecApprovalsSnapshot) {
   return {
     path: snapshot.path,
     exists: snapshot.exists,
     hash: snapshot.hash,
-    file: redactExecApprovals(snapshot.file),
+    file: redactExecApprovalsForTransport(snapshot.file),
   };
 }
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -279,7 +279,7 @@ describe("exec approvals store helpers", () => {
     ).not.toHaveProperty("commandText");
   });
 
-  it("redacts internal allowlist metadata from transport payloads", () => {
+  it("preserves durable allowlist metadata while redacting socket tokens", () => {
     const redacted = redactExecApprovalsForTransport({
       version: 1,
       socket: { path: " ~/.openclaw/exec-approvals.sock ", token: "secret-token" },
@@ -310,6 +310,7 @@ describe("exec approvals store helpers", () => {
               id: "entry-1",
               pattern: "/usr/bin/python3",
               argPattern: "^script\\.py\\x00$",
+              source: "allow-always",
               lastUsedAt: 321_000,
               lastUsedCommand: "python3 script.py",
               lastResolvedPath: "/opt/homebrew/bin/python3",

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -20,6 +20,7 @@ let mergeExecApprovalsSocketDefaults: ExecApprovalsModule["mergeExecApprovalsSoc
 let normalizeExecApprovals: ExecApprovalsModule["normalizeExecApprovals"];
 let persistAllowAlwaysPatterns: ExecApprovalsModule["persistAllowAlwaysPatterns"];
 let readExecApprovalsSnapshot: ExecApprovalsModule["readExecApprovalsSnapshot"];
+let redactExecApprovalsForTransport: ExecApprovalsModule["redactExecApprovalsForTransport"];
 let recordAllowlistMatchesUse: ExecApprovalsModule["recordAllowlistMatchesUse"];
 let recordAllowlistUse: ExecApprovalsModule["recordAllowlistUse"];
 let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSocket"];
@@ -39,6 +40,7 @@ beforeAll(async () => {
     normalizeExecApprovals,
     persistAllowAlwaysPatterns,
     readExecApprovalsSnapshot,
+    redactExecApprovalsForTransport,
     recordAllowlistMatchesUse,
     recordAllowlistUse,
     requestExecApprovalViaSocket,
@@ -275,6 +277,47 @@ describe("exec approvals store helpers", () => {
         },
       }).agents?.main?.allowlist?.[0],
     ).not.toHaveProperty("commandText");
+  });
+
+  it("redacts internal allowlist metadata from transport payloads", () => {
+    const redacted = redactExecApprovalsForTransport({
+      version: 1,
+      socket: { path: " ~/.openclaw/exec-approvals.sock ", token: "secret-token" },
+      agents: {
+        main: {
+          allowlist: [
+            {
+              id: "entry-1",
+              pattern: "/usr/bin/python3",
+              argPattern: "^script\\.py\\x00$",
+              source: "allow-always",
+              lastUsedAt: 321_000,
+              lastUsedCommand: "python3 script.py",
+              lastResolvedPath: "/opt/homebrew/bin/python3",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(redacted).toEqual({
+      version: 1,
+      socket: { path: "~/.openclaw/exec-approvals.sock" },
+      agents: {
+        main: {
+          allowlist: [
+            {
+              id: "entry-1",
+              pattern: "/usr/bin/python3",
+              argPattern: "^script\\.py\\x00$",
+              lastUsedAt: 321_000,
+              lastUsedCommand: "python3 script.py",
+              lastResolvedPath: "/opt/homebrew/bin/python3",
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("preserves source and argPattern metadata for allow-always entries", () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -433,7 +433,7 @@ export function redactExecApprovalsForTransport(file: ExecApprovalsFile): ExecAp
           agentId,
           {
             ...agent,
-            allowlist: agent.allowlist?.map(({ source: _source, ...entry }) => entry),
+            allowlist: agent.allowlist?.map((entry) => ({ ...entry })),
           },
         ]),
       )

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -425,6 +425,26 @@ export function mergeExecApprovalsSocketDefaults(params: {
   };
 }
 
+export function redactExecApprovalsForTransport(file: ExecApprovalsFile): ExecApprovalsFile {
+  const socketPath = file.socket?.path?.trim();
+  const agents = file.agents
+    ? Object.fromEntries(
+        Object.entries(file.agents).map(([agentId, agent]) => [
+          agentId,
+          {
+            ...agent,
+            allowlist: agent.allowlist?.map(({ source: _source, ...entry }) => entry),
+          },
+        ]),
+      )
+    : undefined;
+  return {
+    ...file,
+    socket: socketPath ? { path: socketPath } : undefined,
+    agents,
+  };
+}
+
 function generateToken(): string {
   return crypto.randomBytes(24).toString("base64url");
 }

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -7,6 +7,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  redactExecApprovalsForTransport,
   saveExecApprovals,
   type ExecAsk,
   type ExecApprovalsFile,
@@ -162,14 +163,6 @@ export function decodeCapturedOutputBuffer(params: {
   } catch {
     return utf8;
   }
-}
-
-function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
-  const socketPath = file.socket?.path?.trim();
-  return {
-    ...file,
-    socket: socketPath ? { path: socketPath } : undefined,
-  };
 }
 
 function requireExecApprovalsBaseHash(
@@ -430,7 +423,7 @@ export async function handleInvoke(
         path: snapshot.path,
         exists: snapshot.exists,
         hash: snapshot.hash,
-        file: redactExecApprovals(snapshot.file),
+        file: redactExecApprovalsForTransport(snapshot.file),
       };
       await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {
@@ -460,7 +453,7 @@ export async function handleInvoke(
         path: nextSnapshot.path,
         exists: nextSnapshot.exists,
         hash: nextSnapshot.hash,
-        file: redactExecApprovals(nextSnapshot.file),
+        file: redactExecApprovalsForTransport(nextSnapshot.file),
       };
       await sendJsonPayloadResult(client, frame, payload);
     } catch (err) {


### PR DESCRIPTION
## Summary
- redact internal exec approval allowlist metadata from transport payloads
- reuse the same transport redaction for both gateway and node-host approval snapshots
- add coverage for redacting `source` while preserving user-visible allowlist fields

## Testing
- node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/exec-approvals-store.test.ts
- pnpm tsgo:core
- pre-commit `check:changed` hooks

Closes #69698
