### PR TITLE
fix(browser): reset Chrome MCP session after navigate_page timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser/Chrome MCP: reset cached existing-session control sessions when a `navigate_page` call times out, so one stuck navigation no longer poisons the browser profile until a gateway restart. (#69733) Thanks @ayeshakhalid192007-dev.
 - Channels/preview streaming: centralize draft-preview finalization so Slack, Discord, Mattermost, and Matrix no longer flush temporary preview messages for media/error finals, and preserve first-reply threading for normal fallback delivery.
 - Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel. (#69869) thanks @gumadeiras.
 - Plugins/discovery: reject package plugin source entries that escape the package directory before explicit runtime entries or inferred built JavaScript peers can be used. (#69868) thanks @gumadeiras.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildChromeMcpArgs,
   evaluateChromeMcpScript,
   listChromeMcpTabs,
+  navigateChromeMcpPage,
   openChromeMcpTab,
   resetChromeMcpSessionsForTest,
   setChromeMcpSessionFactoryForTest,
@@ -95,6 +96,10 @@ function createFakeSession(): ChromeMcpSession {
 describe("chrome MCP page parsing", () => {
   beforeEach(async () => {
     await resetChromeMcpSessionsForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("parses list_pages text responses when structuredContent is missing", async () => {
@@ -340,6 +345,66 @@ describe("chrome MCP page parsing", () => {
 
     await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(/attach failed/);
 
+    const tabs = await listChromeMcpTabs("chrome-live");
+    expect(factoryCalls).toBe(2);
+    expect(tabs).toHaveLength(2);
+  });
+
+  it("always passes a default timeout to navigate_page when none is specified", async () => {
+    const session = createFakeSession();
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    await navigateChromeMcpPage({
+      profileName: "chrome-live",
+      targetId: "1",
+      url: "https://example.com",
+      // intentionally no timeoutMs
+    });
+
+    expect(session.client.callTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "navigate_page",
+        arguments: expect.objectContaining({ timeout: 20_000 }),
+      }),
+    );
+  });
+
+  it("resets the Chrome MCP session when a navigate_page call hangs past the safety-net timeout", async () => {
+    vi.useFakeTimers();
+    let factoryCalls = 0;
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      if (factoryCalls === 1) {
+        // First session: all tool calls hang — simulates a Chrome MCP subprocess that is
+        // completely blocked (e.g., stuck waiting for a slow navigation to complete).
+        session.client.callTool = vi.fn(
+          async () => new Promise<never>(() => {}),
+        ) as typeof session.client.callTool;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    // Start navigation — will hang.
+    const navPromise = navigateChromeMcpPage({
+      profileName: "chrome-live",
+      targetId: "1",
+      url: "https://slow-site.example",
+    });
+    // Suppress unhandled-rejection detection: navPromise rejects during timer
+    // advancement, before the expect below attaches its handler.
+    void navPromise.catch(() => {});
+
+    // Advance past the 25 s safety-net (CHROME_MCP_NAVIGATE_TIMEOUT_MS 20 s + 5 s buffer).
+    await vi.advanceTimersByTimeAsync(25_001);
+
+    await expect(navPromise).rejects.toThrow(/Chrome MCP "navigate_page".*timed out/);
+
+    // Switch back to real timers before testing reconnect behaviour.
+    vi.useRealTimers();
+
+    // Next call must use a fresh session — factory is called a second time.
     const tabs = await listChromeMcpTabs("chrome-live");
     expect(factoryCalls).toBe(2);
     expect(tabs).toHaveLength(2);

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -44,7 +44,6 @@ const DEFAULT_CHROME_MCP_ARGS = [
 ];
 const CHROME_MCP_NEW_PAGE_TIMEOUT_MS = 5_000;
 const CHROME_MCP_NAVIGATE_TIMEOUT_MS = 20_000;
-const CHROME_MCP_NAVIGATE_CALL_SAFETY_TIMEOUT_MS = 25_000;
 
 const sessions = new Map<string, ChromeMcpSession>();
 const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
@@ -350,11 +349,12 @@ async function callTool(
   } catch (err) {
     // Transport/connection error or safety-net timeout — tear down session so it reconnects.
     // Transport-identity check prevents clobbering a replacement session created concurrently.
+    // Only close the client here if the timeout callback hasn't already done so.
     const cur = sessions.get(cacheKey);
     if (cur?.transport === session.transport) {
       sessions.delete(cacheKey);
+      await session.client.close().catch(() => {});
     }
-    await session.client.close().catch(() => {});
     throw err;
   } finally {
     if (timeoutHandle !== undefined) {
@@ -507,7 +507,7 @@ export async function navigateChromeMcpPage(params: {
       url: params.url,
       timeout: resolvedTimeoutMs,
     },
-    CHROME_MCP_NAVIGATE_CALL_SAFETY_TIMEOUT_MS,
+    resolvedTimeoutMs + 5_000,
   );
   const page = await findPageById(
     params.profileName,

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -44,6 +44,7 @@ const DEFAULT_CHROME_MCP_ARGS = [
 ];
 const CHROME_MCP_NEW_PAGE_TIMEOUT_MS = 5_000;
 const CHROME_MCP_NAVIGATE_TIMEOUT_MS = 20_000;
+const CHROME_MCP_NAVIGATE_CALL_SAFETY_TIMEOUT_MS = 25_000;
 
 const sessions = new Map<string, ChromeMcpSession>();
 const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
@@ -310,20 +311,55 @@ async function callTool(
   userDataDir: string | undefined,
   name: string,
   args: Record<string, unknown> = {},
+  timeoutMs?: number,
 ): Promise<ChromeMcpToolResult> {
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
   const session = await getSession(profileName, userDataDir);
+
+  const rawCall = session.client.callTool({
+    name,
+    arguments: args,
+  }) as Promise<ChromeMcpToolResult>;
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const callPromise: Promise<ChromeMcpToolResult> =
+    timeoutMs !== undefined && timeoutMs > 0
+      ? Promise.race([
+          rawCall,
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(() => {
+              // Use transport-identity check so we never delete a freshly-created replacement session.
+              const cur = sessions.get(cacheKey);
+              if (cur?.transport === session.transport) {
+                sessions.delete(cacheKey);
+              }
+              void session.client.close().catch(() => {});
+              reject(
+                new Error(
+                  `Chrome MCP "${name}" timed out after ${timeoutMs}ms. Session reset for reconnect.`,
+                ),
+              );
+            }, timeoutMs);
+          }),
+        ])
+      : rawCall;
+
   let result: ChromeMcpToolResult;
   try {
-    result = (await session.client.callTool({
-      name,
-      arguments: args,
-    })) as ChromeMcpToolResult;
+    result = await callPromise;
   } catch (err) {
-    // Transport/connection error — tear down session so it reconnects on next call
-    sessions.delete(cacheKey);
+    // Transport/connection error or safety-net timeout — tear down session so it reconnects.
+    // Transport-identity check prevents clobbering a replacement session created concurrently.
+    const cur = sessions.get(cacheKey);
+    if (cur?.transport === session.transport) {
+      sessions.delete(cacheKey);
+    }
     await session.client.close().catch(() => {});
     throw err;
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
   }
   // Tool-level errors (element not found, script error, etc.) don't indicate a
   // broken connection — don't tear down the session for these.
@@ -460,12 +496,19 @@ export async function navigateChromeMcpPage(params: {
   url: string;
   timeoutMs?: number;
 }): Promise<{ url: string }> {
-  await callTool(params.profileName, params.userDataDir, "navigate_page", {
-    pageId: parsePageId(params.targetId),
-    type: "url",
-    url: params.url,
-    ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
-  });
+  const resolvedTimeoutMs = params.timeoutMs ?? CHROME_MCP_NAVIGATE_TIMEOUT_MS;
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "navigate_page",
+    {
+      pageId: parsePageId(params.targetId),
+      type: "url",
+      url: params.url,
+      timeout: resolvedTimeoutMs,
+    },
+    CHROME_MCP_NAVIGATE_CALL_SAFETY_TIMEOUT_MS,
+  );
   const page = await findPageById(
     params.profileName,
     parsePageId(params.targetId),

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -232,7 +232,11 @@ describe("chrome.ts internal", () => {
           }
           return true;
         }
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         return false;
@@ -321,7 +325,11 @@ describe("chrome.ts internal", () => {
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
         // Pretend the mac Chrome binary exists and the preference files exist.
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -693,7 +701,11 @@ describe("chrome.ts internal", () => {
         );
         vi.spyOn(fs, "existsSync").mockImplementation((p) => {
           const s = String(p);
-          if (s.includes("Google Chrome")) {
+          if (
+            s.includes("Google Chrome") ||
+            s.includes("google-chrome") ||
+            s.includes("/usr/bin/chromium")
+          ) {
             return true;
           }
           // Fall through to real fs for the user-data-dir files.
@@ -731,7 +743,11 @@ describe("chrome.ts internal", () => {
       // Covers the `profile.color ?? DEFAULT_OPENCLAW_BROWSER_COLOR` coalescing.
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -767,7 +783,11 @@ describe("chrome.ts internal", () => {
       // stderrHint truthy branch on failure.
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -804,7 +824,11 @@ describe("chrome.ts internal", () => {
       try {
         vi.spyOn(fs, "existsSync").mockImplementation((p) => {
           const s = String(p);
-          if (s.includes("Google Chrome")) {
+          if (
+            s.includes("Google Chrome") ||
+            s.includes("google-chrome") ||
+            s.includes("/usr/bin/chromium")
+          ) {
             return true;
           }
           if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -850,7 +874,11 @@ describe("chrome.ts internal", () => {
       }, 50);
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -892,7 +920,11 @@ describe("chrome.ts internal", () => {
       let prefsProbeCount = 0;
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -942,7 +974,11 @@ describe("chrome.ts internal", () => {
       const { decorateOpenClawProfile } = await import("./chrome.profile-decoration.js");
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -992,7 +1028,11 @@ describe("chrome.ts internal", () => {
       // Covers the `proc.pid ?? -1` falsy side.
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (s.includes("Google Chrome")) {
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {


### PR DESCRIPTION
## Summary

Fixes #69624 — browser profile `existing-session` gets permanently stuck after the first navigation timeout, requiring a gateway restart.

## Root Cause

`navigateChromeMcpPage()` only forwarded a timeout to the Chrome MCP `navigate_page` tool when the caller explicitly provided `timeoutMs`. The route in `agent.snapshot.ts` never provides one, so Chrome MCP's subprocess could block indefinitely on a slow navigation. Because the stuck session was cached and returned to all subsequent callers, the entire profile became unresponsive until the gateway restarted.

`callTool()` also lacked a safety-net: even if Chrome MCP honoured its own timeout internally, there was no outer guard to tear down and evict the session. The existing `catch` block also had a pre-existing race where it deleted the session cache entry without a transport-identity check, so a concurrently-created replacement session could be clobbered.

## Changes

**`extensions/browser/src/browser/chrome-mcp.ts`**
- `callTool()` gains an optional `timeoutMs` parameter. When set, `Promise.race` competes the raw MCP call against a `setTimeout`-based rejection; on timeout the session is torn down (transport-identity-checked) and the error surfaces to the caller so the next request reconnects with a fresh subprocess.
- `navigateChromeMcpPage()` now defaults `timeoutMs` to `CHROME_MCP_NAVIGATE_TIMEOUT_MS` (20 s) and always forwards it to Chrome MCP, plus passes `CHROME_MCP_NAVIGATE_CALL_SAFETY_TIMEOUT_MS` (25 s) as the outer safety-net to `callTool()`.
- The `catch` block in `callTool()` gains the same transport-identity guard used elsewhere in the file, fixing the pre-existing replacement-session race.

**`extensions/browser/src/browser/chrome-mcp.test.ts`**
- Two new tests: one asserting the default timeout is always forwarded; one using `vi.useFakeTimers()` to advance past the 25 s safety-net and confirm the session is reset and the next call reconnects.

**`extensions/browser/src/browser/chrome.internal.test.ts`**
- Pre-existing test failures on Linux: `existsSync` mocks matched only the macOS Chrome app path (`"Google Chrome"`). Extended all affected mocks to also match Linux paths (`google-chrome`, `/usr/bin/chromium`). No logic changes to the tests themselves.

## Why This Is Safe

- No change to any public export signatures — `timeoutMs` was already an optional parameter on `navigateChromeMcpPage()`.
- The 25 s safety-net gives Chrome MCP the full 20 s to honour its own timeout plus a 5 s buffer; the two timeouts do not conflict.
- `openChromeMcpTab()` already passed an explicit `timeoutMs` — its behaviour is unchanged.
- `agent.snapshot.ts` passes no `timeoutMs`; the new default covers it with no edit to that file.

## Testing

All 94 browser extension test files pass (809 tests), including two new cases:
- **"always passes a default timeout to navigate_page when none is specified"**
- **"resets the Chrome MCP session when a navigate_page call hangs past the safety-net timeout"**

Fixes #69624