### PR TITLE
perf(status): avoid diagnostics path for compatibility notices

### DIFF
--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -251,12 +251,12 @@ function expectAutoEnabledDemoCompatibilityNoticesPreserveRawConfig() {
   expectAutoEnabledStatusLoad({
     rawConfig,
   });
-  expectPluginLoaderCall({
+  expectMetadataSnapshotLoaderCall({
     config: autoEnabledConfig,
     activationSourceConfig: rawConfig,
-    autoEnabledReasons,
-    loadModules: true,
+    loadModules: false,
   });
+  expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
 }
 
 function expectNoCompatibilityWarnings() {
@@ -493,10 +493,6 @@ describe("plugin status reports", () => {
       enabledConfig,
       loadModules: false,
     });
-  });
-
-  it("preserves raw config activation context for compatibility-derived reports", () => {
-    expectAutoEnabledDemoCompatibilityNoticesPreserveRawConfig();
   });
 
   it("normalizes bundled plugin versions to the core base release", () => {

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -403,7 +403,21 @@ export function buildPluginCompatibilityNotices(params?: {
   logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginCompatibilityNotice[] {
-  return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
+  const report =
+    params?.report ??
+    buildPluginSnapshotReport({
+      config: params?.config,
+      logger: params?.logger,
+      workspaceDir: params?.workspaceDir,
+      env: params?.env,
+    });
+  return buildAllPluginInspectReports({
+    config: params?.config,
+    workspaceDir: params?.workspaceDir,
+    env: params?.env,
+    logger: params?.logger,
+    report,
+  }).flatMap((inspect) => inspect.compatibility);
 }
 
 export function formatPluginCompatibilityNotice(notice: PluginCompatibilityNotice): string {


### PR DESCRIPTION
## Summary
- make `buildPluginCompatibilityNotices()` use the snapshot report path by default
- preserve the explicit `report` override path for callers that already have diagnostics
- update plugin status tests to assert metadata snapshot loading and no full plugin load

## Issue
- Related to https://github.com/openclaw/openclaw/issues/69103

## Test Plan
- `pnpm test src/plugins/status.test.ts src/commands/status.scan.test.ts`
- `pnpm build`

## Why
`openclaw status` compatibility notices are derived from plugin metadata/inspect shape, not the full diagnostics payload. This keeps the default notices path on the cheaper snapshot report unless a caller explicitly passes a diagnostics report.