### PR TITLE
Fix scoped plugin CLI loading for memory wiki bridge artifacts

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -260,6 +260,8 @@ not replace `register(...)`, `setupEntry`, or other runtime/plugin entrypoints.
 Current consumers use it as a narrowing hint before broader plugin loading, so
 missing activation metadata usually only costs performance; it should not
 change correctness while legacy manifest ownership fallbacks still exist.
+`requiresSlots` is the exception: omit it only when the plugin can run correctly
+without the selected slot owner being loaded in the same scoped runtime.
 
 ```json
 {
@@ -268,18 +270,20 @@ change correctness while legacy manifest ownership fallbacks still exist.
     "onCommands": ["models"],
     "onChannels": ["web"],
     "onRoutes": ["gateway-webhook"],
-    "onCapabilities": ["provider", "tool"]
+    "onCapabilities": ["provider", "tool"],
+    "requiresSlots": ["memory"]
   }
 }
 ```
 
-| Field            | Required | Type                                                 | What it means                                                     |
-| ---------------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
-| `onProviders`    | No       | `string[]`                                           | Provider ids that should activate this plugin when requested.     |
-| `onCommands`     | No       | `string[]`                                           | Command ids that should activate this plugin.                     |
-| `onChannels`     | No       | `string[]`                                           | Channel ids that should activate this plugin.                     |
-| `onRoutes`       | No       | `string[]`                                           | Route kinds that should activate this plugin.                     |
-| `onCapabilities` | No       | `Array<"provider" \| "channel" \| "tool" \| "hook">` | Broad capability hints used by control-plane activation planning. |
+| Field            | Required | Type                                                 | What it means                                                                                   |
+| ---------------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `onProviders`    | No       | `string[]`                                           | Provider ids that should activate this plugin when requested.                                   |
+| `onCommands`     | No       | `string[]`                                           | Command ids that should activate this plugin.                                                   |
+| `onChannels`     | No       | `string[]`                                           | Channel ids that should activate this plugin.                                                   |
+| `onRoutes`       | No       | `string[]`                                           | Route kinds that should activate this plugin.                                                   |
+| `onCapabilities` | No       | `Array<"provider" \| "channel" \| "tool" \| "hook">` | Broad capability hints used by control-plane activation planning.                               |
+| `requiresSlots`  | No       | `Array<"memory" \| "contextEngine">`                 | Exclusive plugin slots that should load alongside this activation target during scoped startup. |
 
 Current live consumers:
 

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -174,5 +174,8 @@
   "configContracts": {
     "compatibilityMigrationPaths": ["plugins.entries.memory-wiki.config.bridge.readMemoryCore"]
   },
+  "activation": {
+    "requiresSlots": ["memory"]
+  },
   "commandAliases": [{ "name": "wiki" }]
 }

--- a/src/plugins/cli-registry-loader.test.ts
+++ b/src/plugins/cli-registry-loader.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginLogger } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  applyPluginAutoEnable: vi.fn(),
+  loadOpenClawPluginCliRegistry: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
+  loadPluginManifestRegistry: vi.fn(),
+  resolveManifestActivationPluginIds: vi.fn(),
+}));
+
+vi.mock("../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: (...args: unknown[]) => mocks.applyPluginAutoEnable(...args),
+}));
+
+vi.mock("./activation-planner.js", () => ({
+  resolveManifestActivationPluginIds: (...args: unknown[]) =>
+    mocks.resolveManifestActivationPluginIds(...args),
+}));
+
+vi.mock("./loader.js", () => ({
+  loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
+    mocks.loadOpenClawPluginCliRegistry(...args),
+  loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
+}));
+
+vi.mock("./manifest-registry.js", () => ({
+  loadPluginManifestRegistry: (...args: unknown[]) => mocks.loadPluginManifestRegistry(...args),
+}));
+
+let loadPluginCliRegistrationEntries: typeof import("./cli-registry-loader.js").loadPluginCliRegistrationEntries;
+
+const logger: PluginLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function createManifestRegistry(params?: { wikiRequiresSlots?: string[] }) {
+  return {
+    plugins: [
+      {
+        id: "memory-core",
+        kind: "memory",
+        providers: [],
+        channels: [],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        origin: "bundled",
+      },
+      {
+        id: "memory-lancedb",
+        kind: "memory",
+        providers: [],
+        channels: [],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        origin: "bundled",
+      },
+      {
+        id: "memory-wiki",
+        activation:
+          params?.wikiRequiresSlots === undefined
+            ? undefined
+            : { requiresSlots: params.wikiRequiresSlots },
+        providers: [],
+        channels: [],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        origin: "bundled",
+      },
+    ],
+    diagnostics: [],
+  };
+}
+
+describe("plugin CLI registry loader", () => {
+  beforeAll(async () => {
+    ({ loadPluginCliRegistrationEntries } = await import("./cli-registry-loader.js"));
+  });
+
+  beforeEach(() => {
+    mocks.applyPluginAutoEnable.mockReset();
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({
+      config,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.loadOpenClawPluginCliRegistry.mockReset();
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [],
+      diagnostics: [],
+    });
+    mocks.loadOpenClawPlugins.mockReset();
+    mocks.loadOpenClawPlugins.mockReturnValue({
+      cliRegistrars: [],
+      diagnostics: [],
+    });
+    mocks.loadPluginManifestRegistry.mockReset();
+    mocks.loadPluginManifestRegistry.mockReturnValue(createManifestRegistry());
+    mocks.resolveManifestActivationPluginIds.mockReset();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue([]);
+  });
+
+  it("loads required selected slot plugins with a scoped primary plugin command", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-wiki"]);
+    mocks.loadPluginManifestRegistry.mockReturnValue(
+      createManifestRegistry({ wikiRequiresSlots: ["memory"] }),
+    );
+
+    await loadPluginCliRegistrationEntries({
+      cfg: {
+        plugins: {
+          slots: { memory: "memory-lancedb" },
+        },
+      } as OpenClawConfig,
+      logger,
+      primaryCommand: "wiki",
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-lancedb", "memory-wiki"],
+      }),
+    );
+  });
+
+  it("does not load a required slot when the selected slot is none", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-wiki"]);
+    mocks.loadPluginManifestRegistry.mockReturnValue(
+      createManifestRegistry({ wikiRequiresSlots: ["memory"] }),
+    );
+
+    await loadPluginCliRegistrationEntries({
+      cfg: {
+        plugins: {
+          slots: { memory: "none" },
+        },
+      } as OpenClawConfig,
+      logger,
+      primaryCommand: "wiki",
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-wiki"],
+      }),
+    );
+  });
+});

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -1,8 +1,10 @@
 import { collectUniqueCommandDescriptors } from "../cli/program/command-descriptor-utils.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
+import { normalizePluginId, normalizePluginsConfig } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginRegistry } from "./registry.js";
 import {
   buildPluginRuntimeLoadOptions,
@@ -10,6 +12,7 @@ import {
   resolvePluginRuntimeLoadContext,
   type PluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
+import type { PluginSlotKey } from "./slots.js";
 import type {
   OpenClawPluginCliCommandDescriptor,
   OpenClawPluginCliContext,
@@ -67,7 +70,7 @@ function resolvePrimaryCommandPluginIds(
   if (!normalizedPrimary) {
     return [];
   }
-  return resolveManifestActivationPluginIds({
+  const primaryPluginIds = resolveManifestActivationPluginIds({
     trigger: {
       kind: "command",
       command: normalizedPrimary,
@@ -76,6 +79,58 @@ function resolvePrimaryCommandPluginIds(
     workspaceDir: context.workspaceDir,
     env: context.env,
   });
+  if (primaryPluginIds.length === 0) {
+    return [];
+  }
+  return includePrimaryCommandSlotDependencies(context, primaryPluginIds);
+}
+
+function includePrimaryCommandSlotDependencies(
+  context: PluginCliLoadContext,
+  primaryPluginIds: readonly string[],
+): string[] {
+  const requiredSlots = resolvePrimaryCommandRequiredSlots(context, primaryPluginIds);
+  if (requiredSlots.length === 0) {
+    return [...primaryPluginIds];
+  }
+  const slotPluginIds = resolveSelectedSlotPluginIds(context.activationSourceConfig, requiredSlots);
+  return [...new Set([...primaryPluginIds, ...slotPluginIds])].toSorted((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function resolvePrimaryCommandRequiredSlots(
+  context: PluginCliLoadContext,
+  primaryPluginIds: readonly string[],
+): PluginSlotKey[] {
+  const primaryPluginIdSet = new Set(primaryPluginIds);
+  return [
+    ...new Set(
+      loadPluginManifestRegistry({
+        config: context.activationSourceConfig,
+        workspaceDir: context.workspaceDir,
+        env: context.env,
+        cache: true,
+      })
+        .plugins.filter((plugin) => primaryPluginIdSet.has(plugin.id))
+        .flatMap((plugin) => plugin.activation?.requiresSlots ?? []),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+}
+
+function resolveSelectedSlotPluginIds(
+  config: OpenClawConfig | undefined,
+  slotKeys: readonly PluginSlotKey[],
+): string[] {
+  const slots = normalizePluginsConfig(config?.plugins).slots;
+  return [
+    ...new Set(
+      slotKeys
+        .map((slotKey) => slots[slotKey])
+        .filter((pluginId): pluginId is string => Boolean(pluginId))
+        .map((pluginId) => normalizePluginId(pluginId)),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
 }
 
 export function resolvePluginCliLoadContext(params: {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -489,6 +489,7 @@ describe("loadPluginManifestRegistry", () => {
         onChannels: ["web"],
         onRoutes: ["gateway-webhook"],
         onCapabilities: ["provider", "tool"],
+        requiresSlots: ["memory"],
       },
       setup: {
         providers: [
@@ -517,6 +518,7 @@ describe("loadPluginManifestRegistry", () => {
       onChannels: ["web"],
       onRoutes: ["gateway-webhook"],
       onCapabilities: ["provider", "tool"],
+      requiresSlots: ["memory"],
     });
     expect(registry.plugins[0]?.setup).toEqual({
       providers: [

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -111,7 +111,8 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     onCommands: ["models", ""],
     onChannels: ["web", ""],
     onRoutes: ["gateway-webhook", ""],
-    onCapabilities: ["provider", "tool", "wat"]
+    onCapabilities: ["provider", "tool", "wat"],
+    requiresSlots: ["memory", "contextEngine", "wat", ""]
   },
   setup: {
     providers: [
@@ -134,6 +135,7 @@ describe("loadPluginManifest JSON5 tolerance", () => {
         onChannels: ["web"],
         onRoutes: ["gateway-webhook"],
         onCapabilities: ["provider", "tool"],
+        requiresSlots: ["memory", "contextEngine"],
       });
       expect(result.manifest.setup).toEqual({
         providers: [

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -13,6 +13,7 @@ import {
 } from "./manifest-command-aliases.js";
 import type { PluginConfigUiHint } from "./manifest-types.js";
 import type { PluginKind } from "./plugin-kind.types.js";
+import type { PluginSlotKey } from "./slots.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 export const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
@@ -69,6 +70,8 @@ export type PluginManifestActivation = {
   onRoutes?: string[];
   /** Cheap capability hints used by future activation planning. */
   onCapabilities?: PluginManifestActivationCapability[];
+  /** Exclusive plugin slots that must be loaded alongside this plugin's activation target. */
+  requiresSlots?: PluginSlotKey[];
 };
 
 export type PluginManifestSetupProvider = {
@@ -495,6 +498,9 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
       capability === "tool" ||
       capability === "hook",
   );
+  const requiresSlots = normalizeTrimmedStringList(value.requiresSlots).filter(
+    (slot): slot is PluginSlotKey => slot === "memory" || slot === "contextEngine",
+  );
 
   const activation = {
     ...(onProviders.length > 0 ? { onProviders } : {}),
@@ -503,6 +509,7 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
     ...(onChannels.length > 0 ? { onChannels } : {}),
     ...(onRoutes.length > 0 ? { onRoutes } : {}),
     ...(onCapabilities.length > 0 ? { onCapabilities } : {}),
+    ...(requiresSlots.length > 0 ? { requiresSlots } : {}),
   } satisfies PluginManifestActivation;
 
   return Object.keys(activation).length > 0 ? activation : undefined;


### PR DESCRIPTION
## Summary

- Add manifest-declared slot dependencies for plugin activation.
- Include selected slot owners during scoped primary plugin CLI loading.
- Mark memory-wiki as requiring the active memory slot so bridge/status/doctor can see public memory artifacts.

## Motivation

`openclaw wiki status` and `openclaw wiki doctor` scoped CLI loading only activated the `memory-wiki` plugin. In bridge mode, `memory-wiki` reads public artifacts from the active memory plugin, but the active memory slot plugin was not loaded in the same process, so no public artifact provider was registered.

This caused bridge mode to report `0 exported artifacts` even when `memory-core` had memory artifacts available.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Plugins / plugin activation
- [x] CLI
- [x] Memory / wiki
- [x] Docs
- [x] Tests

## Testing

- [x] `pnpm build`
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/cli-registry-loader.test.ts src/plugins/manifest.json5-tolerance.test.ts src/plugins/manifest-registry.test.ts src/plugins/cli.test.ts`
- [x] `node dist/index.js wiki status --json`
- [x] `node dist/index.js wiki doctor --json`

Verified locally:

- `Bridge: enabled (41 exported artifacts)`
- `Pages: 41 sources`
- `Wiki doctor: healthy`

## AI-assisted

Yes. I used an AI coding assistant to investigate and implement the fix. I reviewed the behavior, understand the change, and ran the validation listed above.
