### PR TITLE
fix(slack): preserve thread-specific routing

### DIFF
--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -101,6 +101,29 @@ describe("slackOutbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-final" });
   });
 
+  it("prefers threadId over replyToId for threaded sends", async () => {
+    sendMessageSlackMock.mockResolvedValue({ messageId: "m-thread-root" });
+
+    await slackOutbound.sendText!({
+      cfg,
+      to: "C123",
+      text: "reply",
+      accountId: "default",
+      replyToId: "1712000000.000099",
+      threadId: "1712000000.000001",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "reply",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+        threadTs: "1712000000.000001",
+      }),
+    );
+  });
+
   it("cancels sendMedia when message_sending hooks block it", async () => {
     hasHooksMock.mockReturnValue(true);
     runMessageSendingMock.mockResolvedValue({ cancel: true });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -115,7 +115,7 @@ async function sendSlackOutboundMessage(params: {
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
     (await loadSlackSendRuntime()).sendMessageSlack;
   const threadTs =
-    params.replyToId ?? (params.threadId != null ? String(params.threadId) : undefined);
+    params.threadId != null ? String(params.threadId) : (params.replyToId ?? undefined);
   const hookResult = await applySlackMessageSendingHooks({
     cfg: params.cfg,
     to: params.to,

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -799,6 +799,49 @@ describe("gateway send mirroring", () => {
     });
   });
 
+  it("preserves derived thread-specific routing when a broader sessionKey is provided", async () => {
+    mockDeliverySuccess("m-thread-route");
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
+      sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:c1",
+      peer: { kind: "channel", id: "c1" },
+      chatType: "channel",
+      from: "slack:channel:c1",
+      to: "channel:c1",
+      threadId: "1710000000.9999",
+    });
+
+    await runSend({
+      to: "channel:C1",
+      message: "hi",
+      channel: "slack",
+      sessionKey: "agent:main:slack:channel:c1",
+      threadId: "1710000000.9999",
+      idempotencyKey: "idem-thread-route",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining({
+          sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
+          baseSessionKey: "agent:main:slack:channel:c1",
+          threadId: "1710000000.9999",
+        }),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1710000000.9999",
+        session: expect.objectContaining({
+          key: "agent:main:slack:channel:c1:thread:1710000000.9999",
+        }),
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
+        }),
+      }),
+    );
+  });
+
   it("forwards threadId to outbound delivery when provided", async () => {
     mockDeliverySuccess("m-thread");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -4,6 +4,7 @@ import { dispatchChannelMessageAction } from "../../channels/plugins/message-act
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
+import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
@@ -446,8 +447,14 @@ export const sendHandlers: GatewayRequestHandlers = {
           resolvedTarget: idLikeTarget,
           threadId,
         });
+        const providedSessionThread = parseSessionThreadInfo(providedSessionKey);
+        const shouldPreserveDerivedThreadRoute =
+          Boolean(providedSessionKey) &&
+          !providedSessionThread.threadId &&
+          Boolean(derivedRoute?.threadId) &&
+          providedSessionThread.baseSessionKey === derivedRoute?.baseSessionKey;
         const outboundRoute = derivedRoute
-          ? providedSessionKey
+          ? providedSessionKey && !shouldPreserveDerivedThreadRoute
             ? {
                 ...derivedRoute,
                 sessionKey: providedSessionKey,


### PR DESCRIPTION
## Summary
- prefer `threadId` over `replyToId` when Slack outbound delivery sends threaded replies
- preserve derived thread-scoped session routing when a broader session key is provided
- add regression coverage for outbound adapter precedence and gateway routing

## Testing
- corepack pnpm vitest run extensions/slack/src/outbound-adapter.test.ts src/gateway/server-methods/send.test.ts

Fixes #69741