### PR TITLE
Fix Telegram reply mode by chat type

### DIFF
--- a/extensions/telegram/config-api.ts
+++ b/extensions/telegram/config-api.ts
@@ -1,7 +1,7 @@
 export {
   buildChannelConfigSchema,
   TelegramConfigSchema,
-} from "openclaw/plugin-sdk/channel-config-schema";
+} from "../../src/plugin-sdk/channel-config-schema.js";
 export {
   normalizeTelegramCommandDescription,
   normalizeTelegramCommandName,

--- a/extensions/telegram/openclaw.plugin.json
+++ b/extensions/telegram/openclaw.plugin.json
@@ -8,5 +8,2199 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "channelConfigs": {
+    "telegram": {
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "capabilities": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "inlineButtons": {
+                    "type": "string",
+                    "enum": ["off", "dm", "group", "all", "allowlist"]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "execApprovals": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "approvers": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              },
+              "agentFilter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sessionFilter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "target": {
+                "type": "string",
+                "enum": ["dm", "channel", "both"]
+              }
+            },
+            "additionalProperties": false
+          },
+          "markdown": {
+            "type": "object",
+            "properties": {
+              "tables": {
+                "type": "string",
+                "enum": ["off", "bullets", "code", "block"]
+              }
+            },
+            "additionalProperties": false
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "commands": {
+            "type": "object",
+            "properties": {
+              "native": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "string",
+                    "const": "auto"
+                  }
+                ]
+              },
+              "nativeSkills": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "string",
+                    "const": "auto"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "customCommands": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": ["command", "description"],
+              "additionalProperties": false
+            }
+          },
+          "configWrites": {
+            "type": "boolean"
+          },
+          "dmPolicy": {
+            "default": "pairing",
+            "type": "string",
+            "enum": ["pairing", "allowlist", "open", "disabled"]
+          },
+          "botToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "env"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "file"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "exec"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            ]
+          },
+          "tokenFile": {
+            "type": "string"
+          },
+          "replyToModeByChatType": {
+            "type": "object",
+            "properties": {
+              "direct": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              },
+              "channel": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "replyToMode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "off"
+              },
+              {
+                "type": "string",
+                "const": "first"
+              },
+              {
+                "type": "string",
+                "const": "all"
+              },
+              {
+                "type": "string",
+                "const": "batched"
+              }
+            ]
+          },
+          "groups": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "requireMention": {
+                  "type": "boolean"
+                },
+                "ingest": {
+                  "type": "boolean"
+                },
+                "disableAudioPreflight": {
+                  "type": "boolean"
+                },
+                "groupPolicy": {
+                  "type": "string",
+                  "enum": ["open", "disabled", "allowlist"]
+                },
+                "tools": {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alsoAllow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolsBySender": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "allow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "alsoAllow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deny": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "skills": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "topics": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "agentId": {
+                        "type": "string"
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "defaultTo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "groupAllowFrom": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "groupPolicy": {
+            "default": "allowlist",
+            "type": "string",
+            "enum": ["open", "disabled", "allowlist"]
+          },
+          "contextVisibility": {
+            "type": "string",
+            "enum": ["all", "allowlist", "allowlist_quote"]
+          },
+          "historyLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "dmHistoryLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "dms": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "historyLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "direct": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "dmPolicy": {
+                  "type": "string",
+                  "enum": ["pairing", "allowlist", "open", "disabled"]
+                },
+                "tools": {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alsoAllow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolsBySender": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "allow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "alsoAllow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deny": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "skills": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "topics": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "agentId": {
+                        "type": "string"
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "requireTopic": {
+                  "type": "boolean"
+                },
+                "autoTopicLabel": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "prompt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "streaming": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["off", "partial", "block", "progress"]
+              },
+              "chunkMode": {
+                "type": "string",
+                "enum": ["length", "newline"]
+              },
+              "preview": {
+                "type": "object",
+                "properties": {
+                  "chunk": {
+                    "type": "object",
+                    "properties": {
+                      "minChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "maxChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "breakPreference": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "const": "paragraph"
+                          },
+                          {
+                            "type": "string",
+                            "const": "newline"
+                          },
+                          {
+                            "type": "string",
+                            "const": "sentence"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "block": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "coalesce": {
+                    "type": "object",
+                    "properties": {
+                      "minChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "maxChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "idleMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "mediaMaxMb": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "timeoutSeconds": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "retry": {
+            "type": "object",
+            "properties": {
+              "attempts": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 9007199254740991
+              },
+              "minDelayMs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "maxDelayMs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "jitter": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "network": {
+            "type": "object",
+            "properties": {
+              "autoSelectFamily": {
+                "type": "boolean"
+              },
+              "dnsResultOrder": {
+                "type": "string",
+                "enum": ["ipv4first", "verbatim"]
+              },
+              "dangerouslyAllowPrivateNetwork": {
+                "description": "Dangerous opt-in for trusted Telegram fake-IP or transparent-proxy environments where api.telegram.org resolves to private/internal/special-use addresses during media downloads.",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "proxy": {
+            "type": "string"
+          },
+          "webhookUrl": {
+            "description": "Public HTTPS webhook URL registered with Telegram for inbound updates. This must be internet-reachable and requires channels.telegram.webhookSecret.",
+            "type": "string"
+          },
+          "webhookSecret": {
+            "description": "Secret token sent to Telegram during webhook registration and verified on inbound webhook requests. Telegram returns this value for verification; this is not the gateway auth token and not the bot token.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "env"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "file"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "exec"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            ]
+          },
+          "webhookPath": {
+            "description": "Local webhook route path served by the gateway listener. Defaults to /telegram-webhook.",
+            "type": "string"
+          },
+          "webhookHost": {
+            "description": "Local bind host for the webhook listener. Defaults to 127.0.0.1; keep loopback unless you intentionally expose direct ingress.",
+            "type": "string"
+          },
+          "webhookPort": {
+            "description": "Local bind port for the webhook listener. Defaults to 8787; set to 0 to let the OS assign an ephemeral port.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "webhookCertPath": {
+            "description": "Path to the self-signed certificate (PEM) to upload to Telegram during webhook registration. Required for self-signed certs (direct IP or no domain).",
+            "type": "string"
+          },
+          "actions": {
+            "type": "object",
+            "properties": {
+              "reactions": {
+                "type": "boolean"
+              },
+              "sendMessage": {
+                "type": "boolean"
+              },
+              "poll": {
+                "type": "boolean"
+              },
+              "deleteMessage": {
+                "type": "boolean"
+              },
+              "editMessage": {
+                "type": "boolean"
+              },
+              "sticker": {
+                "type": "boolean"
+              },
+              "createForumTopic": {
+                "type": "boolean"
+              },
+              "editForumTopic": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "threadBindings": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "idleHours": {
+                "type": "number",
+                "minimum": 0
+              },
+              "maxAgeHours": {
+                "type": "number",
+                "minimum": 0
+              },
+              "spawnSubagentSessions": {
+                "type": "boolean"
+              },
+              "spawnAcpSessions": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "reactionNotifications": {
+            "type": "string",
+            "enum": ["off", "own", "all"]
+          },
+          "reactionLevel": {
+            "type": "string",
+            "enum": ["off", "ack", "minimal", "extensive"]
+          },
+          "heartbeat": {
+            "type": "object",
+            "properties": {
+              "showOk": {
+                "type": "boolean"
+              },
+              "showAlerts": {
+                "type": "boolean"
+              },
+              "useIndicator": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "healthMonitor": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "linkPreview": {
+            "type": "boolean"
+          },
+          "silentErrorReplies": {
+            "type": "boolean"
+          },
+          "responsePrefix": {
+            "type": "string"
+          },
+          "ackReaction": {
+            "type": "string"
+          },
+          "errorPolicy": {
+            "type": "string",
+            "enum": ["always", "once", "silent"]
+          },
+          "errorCooldownMs": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "apiRoot": {
+            "type": "string",
+            "format": "uri"
+          },
+          "trustedLocalFileRoots": {
+            "description": "Trusted local filesystem roots for self-hosted Telegram Bot API absolute file_path values. Only absolute paths under these roots are read directly; all other absolute paths are rejected.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "autoTopicLabel": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "accounts": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "capabilities": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "inlineButtons": {
+                          "type": "string",
+                          "enum": ["off", "dm", "group", "all", "allowlist"]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "execApprovals": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "approvers": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      }
+                    },
+                    "agentFilter": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "sessionFilter": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "target": {
+                      "type": "string",
+                      "enum": ["dm", "channel", "both"]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "markdown": {
+                  "type": "object",
+                  "properties": {
+                    "tables": {
+                      "type": "string",
+                      "enum": ["off", "bullets", "code", "block"]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "commands": {
+                  "type": "object",
+                  "properties": {
+                    "native": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "auto"
+                        }
+                      ]
+                    },
+                    "nativeSkills": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "auto"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "customCommands": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["command", "description"],
+                    "additionalProperties": false
+                  }
+                },
+                "configWrites": {
+                  "type": "boolean"
+                },
+                "dmPolicy": {
+                  "default": "pairing",
+                  "type": "string",
+                  "enum": ["pairing", "allowlist", "open", "disabled"]
+                },
+                "botToken": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "env"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "file"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "exec"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "tokenFile": {
+                  "type": "string"
+                },
+                "replyToModeByChatType": {
+                  "type": "object",
+                  "properties": {
+                    "direct": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "replyToMode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "off"
+                    },
+                    {
+                      "type": "string",
+                      "const": "first"
+                    },
+                    {
+                      "type": "string",
+                      "const": "all"
+                    },
+                    {
+                      "type": "string",
+                      "const": "batched"
+                    }
+                  ]
+                },
+                "groups": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "tools": {
+                        "type": "object",
+                        "properties": {
+                          "allow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "alsoAllow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "deny": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "toolsBySender": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "allow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "alsoAllow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deny": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "topics": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "requireMention": {
+                              "type": "boolean"
+                            },
+                            "ingest": {
+                              "type": "boolean"
+                            },
+                            "disableAudioPreflight": {
+                              "type": "boolean"
+                            },
+                            "groupPolicy": {
+                              "type": "string",
+                              "enum": ["open", "disabled", "allowlist"]
+                            },
+                            "skills": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "allowFrom": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              }
+                            },
+                            "systemPrompt": {
+                              "type": "string"
+                            },
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "errorPolicy": {
+                              "type": "string",
+                              "enum": ["always", "once", "silent"]
+                            },
+                            "errorCooldownMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "defaultTo": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "groupAllowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "groupPolicy": {
+                  "default": "allowlist",
+                  "type": "string",
+                  "enum": ["open", "disabled", "allowlist"]
+                },
+                "contextVisibility": {
+                  "type": "string",
+                  "enum": ["all", "allowlist", "allowlist_quote"]
+                },
+                "historyLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "dmHistoryLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "dms": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "historyLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "direct": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "dmPolicy": {
+                        "type": "string",
+                        "enum": ["pairing", "allowlist", "open", "disabled"]
+                      },
+                      "tools": {
+                        "type": "object",
+                        "properties": {
+                          "allow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "alsoAllow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "deny": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "toolsBySender": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "allow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "alsoAllow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deny": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "topics": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "requireMention": {
+                              "type": "boolean"
+                            },
+                            "ingest": {
+                              "type": "boolean"
+                            },
+                            "disableAudioPreflight": {
+                              "type": "boolean"
+                            },
+                            "groupPolicy": {
+                              "type": "string",
+                              "enum": ["open", "disabled", "allowlist"]
+                            },
+                            "skills": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "allowFrom": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              }
+                            },
+                            "systemPrompt": {
+                              "type": "string"
+                            },
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "errorPolicy": {
+                              "type": "string",
+                              "enum": ["always", "once", "silent"]
+                            },
+                            "errorCooldownMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "requireTopic": {
+                        "type": "boolean"
+                      },
+                      "autoTopicLabel": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "prompt": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "textChunkLimit": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "streaming": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": ["off", "partial", "block", "progress"]
+                    },
+                    "chunkMode": {
+                      "type": "string",
+                      "enum": ["length", "newline"]
+                    },
+                    "preview": {
+                      "type": "object",
+                      "properties": {
+                        "chunk": {
+                          "type": "object",
+                          "properties": {
+                            "minChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "maxChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "breakPreference": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "paragraph"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "newline"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "sentence"
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "block": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "coalesce": {
+                          "type": "object",
+                          "properties": {
+                            "minChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "maxChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "idleMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "mediaMaxMb": {
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                },
+                "timeoutSeconds": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "retry": {
+                  "type": "object",
+                  "properties": {
+                    "attempts": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
+                    },
+                    "minDelayMs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "maxDelayMs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "jitter": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "network": {
+                  "type": "object",
+                  "properties": {
+                    "autoSelectFamily": {
+                      "type": "boolean"
+                    },
+                    "dnsResultOrder": {
+                      "type": "string",
+                      "enum": ["ipv4first", "verbatim"]
+                    },
+                    "dangerouslyAllowPrivateNetwork": {
+                      "description": "Dangerous opt-in for trusted Telegram fake-IP or transparent-proxy environments where api.telegram.org resolves to private/internal/special-use addresses during media downloads.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "proxy": {
+                  "type": "string"
+                },
+                "webhookUrl": {
+                  "description": "Public HTTPS webhook URL registered with Telegram for inbound updates. This must be internet-reachable and requires channels.telegram.webhookSecret.",
+                  "type": "string"
+                },
+                "webhookSecret": {
+                  "description": "Secret token sent to Telegram during webhook registration and verified on inbound webhook requests. Telegram returns this value for verification; this is not the gateway auth token and not the bot token.",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "env"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "file"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "exec"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "webhookPath": {
+                  "description": "Local webhook route path served by the gateway listener. Defaults to /telegram-webhook.",
+                  "type": "string"
+                },
+                "webhookHost": {
+                  "description": "Local bind host for the webhook listener. Defaults to 127.0.0.1; keep loopback unless you intentionally expose direct ingress.",
+                  "type": "string"
+                },
+                "webhookPort": {
+                  "description": "Local bind port for the webhook listener. Defaults to 8787; set to 0 to let the OS assign an ephemeral port.",
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "webhookCertPath": {
+                  "description": "Path to the self-signed certificate (PEM) to upload to Telegram during webhook registration. Required for self-signed certs (direct IP or no domain).",
+                  "type": "string"
+                },
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "reactions": {
+                      "type": "boolean"
+                    },
+                    "sendMessage": {
+                      "type": "boolean"
+                    },
+                    "poll": {
+                      "type": "boolean"
+                    },
+                    "deleteMessage": {
+                      "type": "boolean"
+                    },
+                    "editMessage": {
+                      "type": "boolean"
+                    },
+                    "sticker": {
+                      "type": "boolean"
+                    },
+                    "createForumTopic": {
+                      "type": "boolean"
+                    },
+                    "editForumTopic": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "threadBindings": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "idleHours": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "maxAgeHours": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "spawnSubagentSessions": {
+                      "type": "boolean"
+                    },
+                    "spawnAcpSessions": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reactionNotifications": {
+                  "type": "string",
+                  "enum": ["off", "own", "all"]
+                },
+                "reactionLevel": {
+                  "type": "string",
+                  "enum": ["off", "ack", "minimal", "extensive"]
+                },
+                "heartbeat": {
+                  "type": "object",
+                  "properties": {
+                    "showOk": {
+                      "type": "boolean"
+                    },
+                    "showAlerts": {
+                      "type": "boolean"
+                    },
+                    "useIndicator": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "healthMonitor": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "linkPreview": {
+                  "type": "boolean"
+                },
+                "silentErrorReplies": {
+                  "type": "boolean"
+                },
+                "responsePrefix": {
+                  "type": "string"
+                },
+                "ackReaction": {
+                  "type": "string"
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "apiRoot": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "trustedLocalFileRoots": {
+                  "description": "Trusted local filesystem roots for self-hosted Telegram Bot API absolute file_path values. Only absolute paths under these roots are read directly; all other absolute paths are rejected.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "autoTopicLabel": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "prompt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "required": ["dmPolicy", "groupPolicy"],
+              "additionalProperties": false
+            }
+          },
+          "defaultAccount": {
+            "type": "string"
+          }
+        },
+        "required": ["dmPolicy", "groupPolicy"],
+        "additionalProperties": false
+      }
+    }
   }
 }

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -7,6 +7,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-core";
 import type {
+  ReplyToMode,
   TelegramAccountConfig,
   TelegramActionConfig,
 } from "openclaw/plugin-sdk/config-runtime";
@@ -183,4 +184,21 @@ export function listEnabledTelegramAccounts(cfg: OpenClawConfig): ResolvedTelegr
   return listTelegramAccountIds(cfg)
     .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
+}
+
+export function resolveTelegramReplyToMode(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+  chatType?: string | null,
+): ReplyToMode {
+  const account = mergeTelegramAccountConfig(cfg, normalizeAccountId(accountId));
+  const normalized =
+    chatType === "direct" || chatType === "group" || chatType === "channel" ? chatType : undefined;
+  if (normalized && account.replyToModeByChatType?.[normalized] !== undefined) {
+    return account.replyToModeByChatType[normalized];
+  }
+  if (account.replyToMode !== undefined) {
+    return account.replyToMode;
+  }
+  return normalized && normalized !== "direct" ? "all" : "off";
 }

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -112,7 +112,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       const effectiveReplyToMode = resolveTelegramReplyToMode(
         cfg,
         context.route?.accountId,
-        context.isGroup ? "group" : "direct",
+        context.msg.chat.type === "channel" ? "channel" : context.isGroup ? "group" : "direct",
       );
       await dispatchTelegramMessage({
         context,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -2,6 +2,7 @@ import type { ReplyToMode } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramReplyToMode } from "./accounts.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   buildTelegramMessageContext,
@@ -47,7 +48,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     loadFreshConfig,
     sendChatActionHandler,
     runtime,
-    replyToMode,
+    replyToMode: _replyToMode,
     streamMode,
     textLimit,
     telegramDeps,
@@ -108,12 +109,17 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       );
     }
     try {
+      const effectiveReplyToMode = resolveTelegramReplyToMode(
+        cfg,
+        context.route?.accountId,
+        context.isGroup ? "group" : "direct",
+      );
       await dispatchTelegramMessage({
         context,
         bot,
         cfg,
         runtime,
-        replyToMode,
+        replyToMode: effectiveReplyToMode,
         streamMode,
         textLimit,
         telegramCfg,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -31,6 +31,7 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
+import { resolveTelegramReplyToMode } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -469,7 +470,7 @@ export const registerTelegramNativeCommands = ({
   telegramCfg,
   allowFrom,
   groupAllowFrom,
-  replyToMode,
+  replyToMode: _replyToMode,
   textLimit,
   useAccessGroups,
   nativeEnabled,
@@ -694,6 +695,7 @@ export const registerTelegramNativeCommands = ({
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: TelegramChunkMode;
     linkPreview?: boolean;
+    chatType: "direct" | "group";
   }) => ({
     chatId: String(params.chatId),
     currentMessageId: params.currentMessageId,
@@ -705,7 +707,7 @@ export const registerTelegramNativeCommands = ({
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode,
+    replyToMode: resolveTelegramReplyToMode(cfg, params.accountId, params.chatType),
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -864,6 +866,7 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          chatType: isGroup ? "group" : "direct",
         });
         const conversationLabel = isGroup
           ? msg.chat.title
@@ -1050,6 +1053,7 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          chatType: isGroup ? "group" : "direct",
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -230,7 +230,7 @@ export type RegisterTelegramNativeCommandsParams = {
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
-  replyToMode: ReplyToMode;
+  replyToMode?: ReplyToMode;
   textLimit: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
@@ -684,6 +684,7 @@ export const registerTelegramNativeCommands = ({
   };
   const buildCommandDeliveryBaseOptions = (params: {
     chatId: string | number;
+    currentMessageId?: string;
     accountId: string;
     sessionKeyForInternalHooks?: string;
     mirrorIsGroup?: boolean;
@@ -695,6 +696,7 @@ export const registerTelegramNativeCommands = ({
     linkPreview?: boolean;
   }) => ({
     chatId: String(params.chatId),
+    currentMessageId: params.currentMessageId,
     accountId: params.accountId,
     sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
     mirrorIsGroup: params.mirrorIsGroup,
@@ -852,6 +854,7 @@ export const registerTelegramNativeCommands = ({
           });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: commandSessionKey,
           mirrorIsGroup: isGroup,
@@ -1037,6 +1040,7 @@ export const registerTelegramNativeCommands = ({
         const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: route.sessionKey,
           mirrorIsGroup: isGroup,

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -440,7 +440,8 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
   const allowFrom = opts.allowFrom ?? telegramCfg.allowFrom;
   const groupAllowFrom =
     opts.groupAllowFrom ?? telegramCfg.groupAllowFrom ?? telegramCfg.allowFrom ?? allowFrom;
-  const replyToMode = opts.replyToMode ?? telegramCfg.replyToMode ?? "off";
+  const replyToMode = opts.replyToMode ?? telegramCfg.replyToMode;
+  const processorReplyToMode = replyToMode ?? "off";
   const nativeEnabled = resolveNativeCommandsEnabled({
     providerId: "telegram",
     providerSetting: telegramCfg.commands?.native,
@@ -573,7 +574,7 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
     loadFreshConfig: () => telegramDeps.loadConfig(),
     sendChatActionHandler,
     runtime,
-    replyToMode,
+    replyToMode: processorReplyToMode,
     streamMode,
     textLimit,
     opts,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -18,6 +18,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
+import { normalizeReplyPayloadsForDelivery } from "../../../../src/infra/outbound/payloads.js";
 import type { TelegramInlineButtons } from "../button-types.js";
 import { splitTelegramCaption } from "../caption.js";
 import {
@@ -581,6 +582,7 @@ export function emitTelegramMessageSentHooks(params: EmitMessageSentHookParams):
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
+  currentMessageId?: string;
   chatId: string;
   accountId?: string;
   sessionKeyForInternalHooks?: string;
@@ -590,7 +592,7 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   bot: Bot;
   mediaLocalRoots?: readonly string[];
-  replyToMode: ReplyToMode;
+  replyToMode?: ReplyToMode;
   textLimit: number;
   thread?: TelegramThreadSpec | null;
   tableMode?: MarkdownTableMode;
@@ -615,12 +617,16 @@ export async function deliverReplies(params: {
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  const effectiveReplyToMode =
+    params.replyToMode ?? (params.thread?.scope === "dm" ? "off" : "all");
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
-  for (const originalReply of params.replies) {
+  for (const originalReply of normalizeReplyPayloadsForDelivery(params.replies, {
+    currentMessageId: params.currentMessageId,
+  })) {
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls
@@ -667,8 +673,11 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
+      const explicitReplyOverride = Boolean(reply.replyToTag) || Boolean(reply.replyToCurrent);
       const replyToId =
-        params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+        effectiveReplyToMode === "off" && !explicitReplyOverride
+          ? undefined
+          : resolveTelegramReplyId(reply.replyToId);
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
@@ -686,7 +695,7 @@ export async function deliverReplies(params: {
           linkPreview: params.linkPreview,
           silent: params.silent,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       } else {
@@ -707,7 +716,7 @@ export async function deliverReplies(params: {
           replyQuoteText: params.replyQuoteText,
           replyMarkup,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       }

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -15,6 +15,7 @@ import {
   resolveConfiguredFromCredentialStatuses,
 } from "openclaw/plugin-sdk/channel-status";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { createScopedAccountReplyToModeResolver } from "openclaw/plugin-sdk/conversation-runtime";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -35,7 +36,11 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
-import { resolveTelegramAccount, type ResolvedTelegramAccount } from "./accounts.js";
+import {
+  resolveTelegramAccount,
+  resolveTelegramReplyToMode,
+  type ResolvedTelegramAccount,
+} from "./accounts.js";
 import { resolveTelegramAutoThreadId } from "./action-threading.js";
 import { lookupTelegramChatId } from "./api-fetch.js";
 import { telegramApprovalCapability } from "./approval-native.js";
@@ -1000,6 +1005,23 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   threading: {
     topLevelReplyToMode: "telegram",
+    resolveReplyToMode: createScopedAccountReplyToModeResolver<ResolvedTelegramAccount>({
+      resolveAccount: (cfg, accountId) => resolveTelegramAccount({ cfg, accountId }),
+      resolveReplyToMode: (account, chatType) => {
+        const normalizedChatType =
+          chatType === "direct" || chatType === "group" || chatType === "channel"
+            ? chatType
+            : undefined;
+        if (normalizedChatType && account.config.replyToModeByChatType?.[normalizedChatType]) {
+          return account.config.replyToModeByChatType[normalizedChatType];
+        }
+        return resolveTelegramReplyToMode(
+          { channels: { telegram: account.config } } as OpenClawConfig,
+          account.accountId,
+          normalizedChatType,
+        );
+      },
+    }),
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
   },

--- a/src/auto-reply/reply/reply-threading.test.ts
+++ b/src/auto-reply/reply/reply-threading.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import {
+  createReplyToModeFilter,
   resolveConfiguredReplyToMode,
   resolveReplyToMode,
   resolveReplyToModeWithThreading,
@@ -58,6 +59,8 @@ describe("resolveReplyToMode", () => {
       expected: "off" | "all" | "first";
     }> = [
       { cfg: emptyCfg, channel: "telegram", expected: "all" },
+      { cfg: emptyCfg, channel: "telegram", chatType: "direct", expected: "off" },
+      { cfg: emptyCfg, channel: "telegram", chatType: "group", expected: "all" },
       { cfg: emptyCfg, channel: "discord", expected: "all" },
       { cfg: emptyCfg, channel: "slack", expected: "all" },
       { cfg: emptyCfg, channel: undefined, expected: "all" },
@@ -127,5 +130,31 @@ describe("resolveConfiguredReplyToMode", () => {
     expect(resolveConfiguredReplyToMode(cfg, "slack", "group")).toBe("first");
     expect(resolveConfiguredReplyToMode(cfg, "slack", "channel")).toBe("off");
     expect(resolveConfiguredReplyToMode(cfg, "slack", undefined)).toBe("off");
+  });
+
+  it("uses Telegram per-chat-type replyToMode overrides", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          replyToMode: "off",
+          replyToModeByChatType: { direct: "off", group: "all", channel: "first" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "direct")).toBe("off");
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "group")).toBe("all");
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "channel")).toBe("first");
+  });
+});
+
+describe("createReplyToModeFilter", () => {
+  it("applies first-mode per distinct replyToId", () => {
+    const filter = createReplyToModeFilter("first");
+
+    expect(filter({ text: "a1", replyToId: "a" }).replyToId).toBe("a");
+    expect(filter({ text: "a2", replyToId: "a" }).replyToId).toBeUndefined();
+    expect(filter({ text: "b1", replyToId: "b" }).replyToId).toBe("b");
+    expect(filter({ text: "b2", replyToId: "b" }).replyToId).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -31,7 +31,13 @@ export function resolveConfiguredReplyToMode(
   const provider = normalizeAnyChannelId(channel) ?? normalizeOptionalLowercaseString(channel);
   const normalizedChatType = normalizeReplyToModeChatType(chatType);
   const defaultMode: ReplyToMode =
-    normalizedChatType == null ? "all" : normalizedChatType !== "direct" ? "all" : "off";
+    normalizedChatType == null
+      ? "all"
+      : provider === "telegram"
+        ? normalizedChatType !== "direct"
+          ? "all"
+          : "off"
+        : "all";
   if (!provider) {
     return defaultMode;
   }

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -29,13 +29,15 @@ export function resolveConfiguredReplyToMode(
   chatType?: string | null,
 ): ReplyToMode {
   const provider = normalizeAnyChannelId(channel) ?? normalizeOptionalLowercaseString(channel);
+  const normalizedChatType = normalizeReplyToModeChatType(chatType);
+  const defaultMode: ReplyToMode =
+    normalizedChatType == null ? "all" : normalizedChatType !== "direct" ? "all" : "off";
   if (!provider) {
-    return "all";
+    return defaultMode;
   }
   const channelConfig = (cfg.channels as Record<string, ReplyToModeChannelConfig> | undefined)?.[
     provider
   ];
-  const normalizedChatType = normalizeReplyToModeChatType(chatType);
   if (normalizedChatType) {
     const scopedMode = channelConfig?.replyToModeByChatType?.[normalizedChatType];
     if (scopedMode !== undefined) {
@@ -48,7 +50,7 @@ export function resolveConfiguredReplyToMode(
       return legacyDirectMode;
     }
   }
-  return channelConfig?.replyToMode ?? "all";
+  return channelConfig?.replyToMode ?? defaultMode;
 }
 
 export function resolveReplyToModeWithThreading(
@@ -82,7 +84,7 @@ export function createReplyToModeFilter(
   mode: ReplyToMode,
   opts: { allowExplicitReplyTagsWhenOff?: boolean } = {},
 ) {
-  let hasThreaded = false;
+  const threadedIds = new Set<string>();
   return (payload: ReplyPayload): ReplyPayload => {
     if (!payload.replyToId) {
       return payload;
@@ -102,7 +104,7 @@ export function createReplyToModeFilter(
     if (mode === "all") {
       return payload;
     }
-    if (isSingleUseReplyToMode(mode) && hasThreaded) {
+    if (isSingleUseReplyToMode(mode) && threadedIds.has(payload.replyToId)) {
       // Compaction notices are transient status messages that should always
       // appear in-thread, even after the first assistant block has already
       // consumed the "first" slot.  Let them keep their replyToId.
@@ -116,7 +118,7 @@ export function createReplyToModeFilter(
     // "first" slot of the replyToMode=first|batched filter.  Skip advancing
     // hasThreaded so the real assistant reply still gets replyToId.
     if (isSingleUseReplyToMode(mode) && !payload.isCompactionNotice) {
-      hasThreaded = true;
+      threadedIds.add(payload.replyToId);
     }
     return payload;
   };

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -1,3 +1,4 @@
+import type { ChatType } from "../channels/chat-type.js";
 import type {
   ChannelPreviewStreamingConfig,
   ContextVisibilityMode,
@@ -121,6 +122,8 @@ export type TelegramAccountConfig = {
   tokenFile?: string;
   /** Control reply threading when reply tags are present (off|first|all|batched). */
   replyToMode?: ReplyToMode;
+  /** Optional per-chat-type reply threading overrides. */
+  replyToModeByChatType?: Partial<Record<ChatType, ReplyToMode>>;
   groups?: Record<string, TelegramGroupConfig>;
   /** Per-DM configuration for Telegram DM topics (key is chat ID). */
   direct?: Record<string, TelegramDirectConfig>;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -181,6 +181,14 @@ const TelegramCustomCommandSchema = z
   })
   .strict();
 
+const TelegramReplyToModeByChatTypeSchema = z
+  .object({
+    direct: ReplyToModeSchema.optional(),
+    group: ReplyToModeSchema.optional(),
+    channel: ReplyToModeSchema.optional(),
+  })
+  .strict();
+
 const validateTelegramCustomCommands = (
   value: { customCommands?: Array<{ command?: string; description?: string }> },
   ctx: z.RefinementCtx,
@@ -225,6 +233,7 @@ export const TelegramAccountSchemaBase = z
     dmPolicy: DmPolicySchema.optional().default("pairing"),
     botToken: SecretInputSchema.optional().register(sensitive),
     tokenFile: z.string().optional(),
+    replyToModeByChatType: TelegramReplyToModeByChatTypeSchema.optional(),
     replyToMode: ReplyToModeSchema.optional(),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -311,6 +311,29 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       },
     ]);
   });
+
+  it("resolves [[reply_to_current]] into replyToId when currentMessageId is provided", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery(
+        [
+          {
+            text: "[[reply_to_current]] hello",
+          },
+        ],
+        { currentMessageId: "12345" },
+      ),
+    ).toEqual([
+      {
+        text: "hello",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToCurrent: true,
+        replyToId: "12345",
+        replyToTag: true,
+        audioAsVoice: false,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloadsForJson", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -89,11 +89,16 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
-function createOutboundPayloadPlanEntry(payload: ReplyPayload): OutboundPayloadPlan | null {
+function createOutboundPayloadPlanEntry(
+  payload: ReplyPayload,
+  options: { currentMessageId?: string } = {},
+): OutboundPayloadPlan | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
-  const parsed = parseReplyDirectives(payload.text ?? "");
+  const parsed = parseReplyDirectives(payload.text ?? "", {
+    currentMessageId: options.currentMessageId,
+  });
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
   const mergedMedia = mergeMediaUrls(
@@ -138,13 +143,14 @@ function createOutboundPayloadPlanEntry(payload: ReplyPayload): OutboundPayloadP
 
 export function createOutboundPayloadPlan(
   payloads: readonly ReplyPayload[],
+  options: { currentMessageId?: string } = {},
 ): OutboundPayloadPlan[] {
   // Intentionally scoped to channel-agnostic normalization and projection inputs.
   // Transport concerns (queueing, hooks, retries), channel transforms, and
   // heartbeat-specific token semantics remain outside this plan boundary.
   const plan: OutboundPayloadPlan[] = [];
   for (const payload of payloads) {
-    const entry = createOutboundPayloadPlanEntry(payload);
+    const entry = createOutboundPayloadPlanEntry(payload, options);
     if (!entry) {
       continue;
     }
@@ -230,8 +236,9 @@ export function summarizeOutboundPayloadForTransport(
 
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
+  options: { currentMessageId?: string } = {},
 ): ReplyPayload[] {
-  return projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan(payloads));
+  return projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan(payloads, options));
 }
 
 export function normalizeOutboundPayloads(


### PR DESCRIPTION
## Summary
- add `channels.telegram.replyToModeByChatType`, matching the already-supported Slack shape
- apply the per-chat-type reply mode in Telegram reply-threading and delivery paths
- wire Telegram config/schema/plugin metadata so CLI validation and startup accept the new field

## Why
Slack already supports chat-type-scoped reply mode config. This PR ports the same idea to Telegram so DMs and groups can use different native reply behavior, for example `direct=off` and `group=all`, without relying on a single global Telegram reply mode.