### PR TITLE
onboard: plain-prose security disclaimer + searchable pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Onboard/wizard: simplify the security disclaimer copy (drop the yellow banner and warning icon in favor of plain-prose paragraphs), and flip remaining onboarding pickers with long dynamic option lists to searchable autocompletes (search provider, plugin configure, model provider filter).
 - Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
 
 ## 2026.4.20

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -284,6 +284,7 @@ async function maybeFilterModelsByProvider(params: {
     const selection = await params.prompter.select({
       message: "Filter models by provider",
       options: [{ value: "*", label: "All providers" }, ...buildModelProviderFilterOptions(next)],
+      searchable: true,
     });
     if (selection !== "*") {
       next = next.filter((entry) => entry.provider === selection);

--- a/src/flows/search-setup.ts
+++ b/src/flows/search-setup.ts
@@ -390,6 +390,7 @@ export async function runSearchSetupFlow(
       },
     ],
     initialValue: defaultProvider,
+    searchable: true,
   });
 
   if (choice === "__skip__") {

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -396,6 +396,7 @@ export async function configurePluginConfig(params: {
       }),
       { value: "__skip__", label: "Back", hint: "Return to section menu" },
     ],
+    searchable: true,
   });
 
   if (selected === "__skip__") {

--- a/src/wizard/setup.security-note.ts
+++ b/src/wizard/setup.security-note.ts
@@ -1,6 +1,5 @@
 import chalk from "chalk";
 import { formatCliCommand } from "../cli/command-format.js";
-import { theme } from "../terminal/theme.js";
 
 export const SECURITY_NOTE_TITLE = "Security disclaimer";
 
@@ -10,18 +9,16 @@ export const SECURITY_CONFIRM_MESSAGE =
 const heading = (text: string) => chalk.bold(text);
 
 export const SECURITY_NOTE_MESSAGE = [
-  theme.warn("⚠ OpenClaw is in Beta - expect sharp edges"),
-  "- By default, OpenClaw is a personal agent: one trusted operator boundary.",
-  "- This bot can read files and run actions if tools are enabled.",
-  "- A bad prompt can trick it into doing unsafe things.",
+  "OpenClaw is a hobby project and still in beta. Expect sharp edges.",
+  "By default, OpenClaw is a personal agent: one trusted operator boundary.",
+  "This bot can read files and run actions if tools are enabled.",
+  "A bad prompt can trick it into doing unsafe things.",
   "",
-  heading("How OpenClaw treats trust"),
-  "- OpenClaw is not a hostile multi-tenant boundary by default.",
-  "- If multiple users can message one tool-enabled agent, they share that delegated tool authority.",
+  "OpenClaw is not a hostile multi-tenant boundary by default.",
+  "If multiple users can message one tool-enabled agent, they share that delegated tool authority.",
   "",
-  heading("When not to run OpenClaw"),
-  "- If you’re not comfortable with security hardening and access control, don’t run OpenClaw.",
-  "- Ask someone experienced to help before enabling tools or exposing it to the internet.",
+  "If you’re not comfortable with security hardening and access control, don’t run OpenClaw.",
+  "Ask someone experienced to help before enabling tools or exposing it to the internet.",
   "",
   heading("Recommended baseline"),
   "- Pairing/allowlists + mention gating.",


### PR DESCRIPTION
## Summary

Two small follow-ups to #69553:

- **Security disclaimer**: drop the yellow warning banner and ⚠ icon, go back to original text.
- **Searchable autocompletes** on the remaining onboarding pickers with long dynamic option lists:
  - Search provider (`src/flows/search-setup.ts`) 
  - Plugin configure (`src/wizard/setup.plugin-config.ts`)
  - Model provider filter (`src/flows/model-picker.ts`) 

## Test plan

- [x] `pnpm check:changed` — 802 tests across 70 shards, all green.
- [x] Walked through `pnpm openclaw onboard --reset --reset-scope full`; pickers typeahead-filter correctly.

AI-assisted (Claude Code, Opus 4.7 1M). Lightly tested.