### PR TITLE
Fix cron message trace channel

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -455,6 +455,41 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
+  it("records generic message tool sends with the resolved channel", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [{ tool: "message", provider: "message", to: "123" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
+        id: "message-tool-generic-target",
+        name: "Message Tool Generic Target",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send a message" },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      } as never,
+    });
+
+    expect(result.delivery).toEqual(
+      expect.objectContaining({
+        resolved: { ok: true, channel: "telegram", to: "123", source: "explicit" },
+        messageToolSentTo: [{ channel: "telegram", to: "123" }],
+      }),
+    );
+  });
+
   it("does not mark message tool delivery as matched when cron target resolution failed", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -142,15 +142,32 @@ function normalizeCronTraceTarget(
   };
 }
 
+type MessagingToolTargetMatcher = (
+  target: { provider?: string; to?: string; accountId?: string },
+  delivery: { channel?: string; to?: string; accountId?: string },
+) => boolean;
+
 function normalizeMessagingToolTarget(
   target: MessagingToolSend,
+  resolvedDelivery: ResolvedCronDeliveryTarget,
+  matchesMessagingToolDeliveryTarget: MessagingToolTargetMatcher,
 ): CronDeliveryTraceMessageTarget | undefined {
   const channel = target.provider?.trim();
   if (!channel) {
     return undefined;
   }
+  const traceChannel =
+    channel === "message" &&
+    resolvedDelivery.ok &&
+    matchesMessagingToolDeliveryTarget(target, {
+      channel: resolvedDelivery.channel,
+      to: resolvedDelivery.to,
+      accountId: resolvedDelivery.accountId,
+    })
+      ? resolvedDelivery.channel
+      : channel;
   return {
-    channel,
+    channel: traceChannel,
     ...(target.to ? { to: target.to } : {}),
     ...(target.accountId ? { accountId: target.accountId } : {}),
     ...(target.threadId ? { threadId: target.threadId } : {}),
@@ -161,6 +178,7 @@ function buildCronDeliveryTrace(params: {
   deliveryPlan: CronDeliveryPlan;
   resolvedDelivery: ResolvedCronDeliveryTarget;
   messagingToolSentTargets: MessagingToolSend[];
+  matchesMessagingToolDeliveryTarget: MessagingToolTargetMatcher;
   fallbackUsed: boolean;
   delivered: boolean;
 }): CronDeliveryTrace {
@@ -195,7 +213,13 @@ function buildCronDeliveryTrace(params: {
         error: params.resolvedDelivery.error.message,
       };
   const messageToolSentTo = params.messagingToolSentTargets
-    .map((target) => normalizeMessagingToolTarget(target))
+    .map((target) =>
+      normalizeMessagingToolTarget(
+        target,
+        params.resolvedDelivery,
+        params.matchesMessagingToolDeliveryTarget,
+      ),
+    )
     .filter((target): target is CronDeliveryTraceMessageTarget => Boolean(target));
   return {
     ...(intended ? { intended } : {}),
@@ -836,6 +860,7 @@ async function finalizeCronRun(params: {
     deliveryPlan: prepared.deliveryPlan,
     resolvedDelivery: prepared.resolvedDelivery,
     messagingToolSentTargets,
+    matchesMessagingToolDeliveryTarget,
     fallbackUsed: deliveryResult.deliveryAttempted && !skipMessagingToolDelivery,
     delivered: deliveryResult.delivered,
   });


### PR DESCRIPTION
Normalize generic `message` tool trace entries to the resolved cron channel when they match the resolved delivery target. This keeps run-log audits readable without changing delivery behavior.

Tests:
- `pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `pnpm check:changed`
