### PR TITLE
fix: honor resolved session maintenance config on load

### DIFF
--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -8,10 +8,10 @@ import {
   setSerializedSessionStore,
   writeSessionStoreCache,
 } from "./store-cache.js";
+import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
   pruneStaleEntries,
-  resolveMaintenanceConfigFromInput,
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
 import { applySessionStoreMigrations } from "./store-migrations.js";
@@ -128,7 +128,7 @@ export function loadSessionStore(
 
   applySessionStoreMigrations(store);
   normalizeSessionStore(store);
-  const maintenance = opts.maintenanceConfig ?? resolveMaintenanceConfigFromInput();
+  const maintenance = opts.maintenanceConfig ?? resolveMaintenanceConfig();
   if (maintenance.mode === "enforce" && Object.keys(store).length > maintenance.maxEntries) {
     const beforeCount = Object.keys(store).length;
     const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, { log: false });

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -15,6 +15,7 @@ let loadConfig: typeof import("../config.js").loadConfig;
 let clearSessionStoreCacheForTest: typeof import("./store.js").clearSessionStoreCacheForTest;
 let loadSessionStore: typeof import("./store.js").loadSessionStore;
 let saveSessionStore: typeof import("./store.js").saveSessionStore;
+let updateLastRoute: typeof import("./store.js").updateLastRoute;
 
 let mockLoadConfig: ReturnType<typeof vi.fn>;
 
@@ -37,29 +38,44 @@ function makeEntry(updatedAt: number): SessionEntry {
   return { sessionId: crypto.randomUUID(), updatedAt };
 }
 
-function applyEnforcedMaintenanceConfig(mockLoadConfig: ReturnType<typeof vi.fn>) {
+function createStoreWithEntryCount(
+  entryCount: number,
+  now = Date.now(),
+): Record<string, SessionEntry> {
+  return Object.fromEntries(
+    Array.from({ length: entryCount }, (_, index) => [
+      `session-${String(index).padStart(4, "0")}`,
+      makeEntry(now - index),
+    ]),
+  );
+}
+
+function applyMaintenanceConfig(
+  mockLoadConfig: ReturnType<typeof vi.fn>,
+  maintenance: Record<string, unknown>,
+) {
   mockLoadConfig.mockReturnValue({
     session: {
-      maintenance: {
-        mode: "enforce",
-        pruneAfter: "7d",
-        maxEntries: 500,
-        rotateBytes: 10_485_760,
-      },
+      maintenance,
     },
   });
 }
 
+function applyEnforcedMaintenanceConfig(mockLoadConfig: ReturnType<typeof vi.fn>) {
+  applyMaintenanceConfig(mockLoadConfig, {
+    mode: "enforce",
+    pruneAfter: "7d",
+    maxEntries: 500,
+    rotateBytes: 10_485_760,
+  });
+}
+
 function applyCappedMaintenanceConfig(mockLoadConfig: ReturnType<typeof vi.fn>) {
-  mockLoadConfig.mockReturnValue({
-    session: {
-      maintenance: {
-        mode: "enforce",
-        pruneAfter: "365d",
-        maxEntries: 1,
-        rotateBytes: 10_485_760,
-      },
-    },
+  applyMaintenanceConfig(mockLoadConfig, {
+    mode: "enforce",
+    pruneAfter: "365d",
+    maxEntries: 1,
+    rotateBytes: 10_485_760,
   });
 }
 
@@ -90,7 +106,7 @@ describe("Integration: saveSessionStore with pruning", () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ loadConfig } = await import("../config.js"));
-    ({ clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore } =
+    ({ clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore, updateLastRoute } =
       await import("./store.js"));
     mockLoadConfig = vi.mocked(loadConfig) as ReturnType<typeof vi.fn>;
     testDir = await createCaseDir("pruning-integ");
@@ -225,15 +241,11 @@ describe("Integration: saveSessionStore with pruning", () => {
   });
 
   it("saveSessionStore skips enforcement when maintenance mode is warn", async () => {
-    mockLoadConfig.mockReturnValue({
-      session: {
-        maintenance: {
-          mode: "warn",
-          pruneAfter: "7d",
-          maxEntries: 1,
-          rotateBytes: 10_485_760,
-        },
-      },
+    applyMaintenanceConfig(mockLoadConfig, {
+      mode: "warn",
+      pruneAfter: "7d",
+      maxEntries: 1,
+      rotateBytes: 10_485_760,
     });
 
     const store = createStaleAndFreshStore();
@@ -244,6 +256,104 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(loaded.stale).toBeDefined();
     expect(loaded.fresh).toBeDefined();
     expect(Object.keys(loaded)).toHaveLength(2);
+  });
+
+  it("loadSessionStore does not trim on load when the resolved config mode is warn", async () => {
+    applyMaintenanceConfig(mockLoadConfig, {
+      mode: "warn",
+      pruneAfter: "7d",
+      maxEntries: 1,
+      rotateBytes: 10_485_760,
+      resetArchiveRetention: false,
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      oldest: makeEntry(now - 2 * DAY_MS),
+      recent: makeEntry(now - DAY_MS),
+      newest: makeEntry(now),
+    };
+    await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+
+    expect(Object.keys(loaded)).toHaveLength(3);
+    expect(loaded.oldest).toBeDefined();
+    expect(loaded.recent).toBeDefined();
+    expect(loaded.newest).toBeDefined();
+  });
+
+  it("loadSessionStore honors the resolved maxEntries config on load", async () => {
+    applyMaintenanceConfig(mockLoadConfig, {
+      mode: "enforce",
+      pruneAfter: "99999d",
+      maxEntries: 999_999,
+      rotateBytes: 10_485_760,
+      resetArchiveRetention: false,
+    });
+
+    const oversizedStore = createStoreWithEntryCount(536);
+    await fs.writeFile(storePath, JSON.stringify(oversizedStore), "utf-8");
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+
+    expect(Object.keys(loaded)).toHaveLength(536);
+    expect(loaded["session-0000"]).toBeDefined();
+    expect(loaded["session-0535"]).toBeDefined();
+  });
+
+  it("does not trim stores above 500 entries when config allows more", async () => {
+    applyMaintenanceConfig(mockLoadConfig, {
+      mode: "enforce",
+      pruneAfter: "99999d",
+      maxEntries: 600,
+      rotateBytes: 10_485_760,
+      resetArchiveRetention: false,
+    });
+
+    const oversizedStore = createStoreWithEntryCount(536);
+    await fs.writeFile(storePath, JSON.stringify(oversizedStore), "utf-8");
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+
+    expect(Object.keys(loaded)).toHaveLength(536);
+    expect(loaded["session-0500"]).toBeDefined();
+    expect(loaded["session-0535"]).toBeDefined();
+  });
+
+  it("does not persist cached load-time trimming into later writes", async () => {
+    applyMaintenanceConfig(mockLoadConfig, {
+      mode: "warn",
+      pruneAfter: "99999d",
+      maxEntries: 999_999,
+      rotateBytes: 10_485_760,
+      resetArchiveRetention: false,
+    });
+
+    const oversizedStore = createStoreWithEntryCount(536);
+    await fs.writeFile(storePath, JSON.stringify(oversizedStore), "utf-8");
+
+    const inspected = loadSessionStore(storePath, {
+      maintenanceConfig: {
+        ...ENFORCED_MAINTENANCE_OVERRIDE,
+        pruneAfterMs: 99999 * DAY_MS,
+        maxEntries: 500,
+        resetArchiveRetentionMs: null,
+      },
+    });
+    expect(Object.keys(inspected)).toHaveLength(500);
+
+    await updateLastRoute({
+      storePath,
+      sessionKey: "session-0000",
+      channel: "telegram",
+      to: "12345",
+    });
+
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(persisted)).toHaveLength(536);
+    expect(persisted["session-0500"]).toBeDefined();
+    expect(persisted["session-0535"]).toBeDefined();
   });
 
   it("loadSessionStore prunes stale entries from oversized stores by default", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -723,7 +723,7 @@ export async function updateLastRoute(params: {
 }) {
   const { storePath, sessionKey, channel, to, accountId, threadId, ctx } = params;
   return await withSessionStoreLock(storePath, async () => {
-    const store = loadSessionStore(storePath);
+    const store = loadSessionStore(storePath, { skipCache: true });
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
     const now = Date.now();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `loadSessionStore()` fell back to helper defaults when callers did not pass `opts.maintenanceConfig`, so load-time maintenance could ignore the real resolved `session.maintenance` config.
- Why it matters: a store with more than 500 entries could be trimmed on read even when config was effectively `mode: "warn"` with a much larger `maxEntries`, and a later normal write could persist that truncated `sessions.json`.
- What changed: the load path now resolves maintenance through the runtime config layer, `updateLastRoute()` re-reads `sessions.json` from disk inside the write lock, and regression tests cover warn mode, large configured caps, >500-entry stores, and the cached-trim persistence path.
- What did NOT change (scope boundary): no new settings, no health-command special case, and no intentional global change to maintenance semantics beyond honoring the resolved config already in effect.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `src/config/sessions/store-load.ts` called `resolveMaintenanceConfigFromInput()` with no input when no explicit override was passed, so it used helper defaults instead of the resolved runtime `session.maintenance` config.
- Missing detection / guardrail: there was no regression coverage for load-time maintenance honoring resolved warn-mode and large `maxEntries` settings, and no coverage for cached load-time trimming being persisted by a later write.
- Contributing context (if known): load-time maintenance mutates the in-memory store and seeds the session-store cache, so a later write path could persist the wrong cached state back to `sessions.json`.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions/store.pruning.integration.test.ts`
- Scenario the test should lock in: load-time maintenance must honor resolved warn-mode and large-cap config, and a read that trims in memory must not let a later write persist truncated `sessions.json`.
- Why this is the smallest reliable guardrail: the regression depends on the interaction between config resolution, load-time maintenance, the session-store cache, and a subsequent write path.
- Existing test that already covers this (if any): existing load/save maintenance integration coverage in `src/config/sessions/store.pruning.integration.test.ts`.
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `loadSessionStore()` now honors the resolved `session.maintenance` config when no explicit maintenance override is passed.
- Read-only inspection flows no longer risk causing a later normal write to persist an incorrectly trimmed `sessions.json` from cached load-time state.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
read sessions.json -> load path uses helper defaults -> cache stores trimmed map -> later write saves trimmed sessions.json

After:
read sessions.json -> load path uses resolved runtime config -> cache keeps correct map -> later write re-reads disk and preserves full sessions.json
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local Linux workspace
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `session.maintenance.mode=warn`, `session.maintenance.maxEntries=999999`, `session.maintenance.pruneAfter=99999d`, `session.maintenance.resetArchiveRetention=false`

### Steps

1. Create a `sessions.json` store with more than 500 entries.
2. Resolve config so `session.maintenance` is effectively warn-only with a large `maxEntries` cap.
3. Load the store without passing an explicit maintenance override, then trigger a later normal write such as `updateLastRoute()`.

### Expected

- Load uses the resolved runtime maintenance config.
- The store is not trimmed on load under warn mode or a larger configured cap.
- A later write does not persist a truncated `sessions.json`.

### Actual

- Before this fix, load-time maintenance could behave as if `mode: "enforce"` and `maxEntries: 500`, then a later write could persist the trimmed store.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted regression suite for load-time warn mode, large configured caps, >500-entry stores, and cached-trim persistence.
- Edge cases checked: explicit load-time maintenance overrides still win; `updateLastRoute()` now bypasses cache inside the write lock.
- What you did **not** verify: full `pnpm check` / `pnpm test` on the whole repo, because the normal staged hook hit unrelated local typecheck failures in `src/gateway/server-restart-sentinel.test.ts`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: load-time maintenance now depends on the same runtime config resolution path as save-time maintenance, so future resolver regressions would affect both paths.
  - Mitigation: explicit regression coverage now locks in the resolved-config load behavior and the cache-to-write persistence path.
