### PR TITLE
fix: require owner identity for owner-enforced commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Docs: https://docs.openclaw.ai
 - Onboard/wizard: simplify the security disclaimer copy (drop the yellow banner and warning icon in favor of plain-prose paragraphs), and flip remaining onboarding pickers with long dynamic option lists to searchable autocompletes (search provider, plugin configure, model provider filter).
 - Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
 
+### Fixes
+
+- Auth/commands: require owner identity (an owner-candidate match or internal `operator.admin`) for owner-enforced commands instead of treating wildcard channel `allowFrom` or empty owner-candidate lists as sufficient, so non-owner senders can no longer reach owner-only commands through a permissive fallback when `enforceOwnerForCommands=true` and `commands.ownerAllowFrom` is unset. (#69774) Thanks @drobison00.
+
 ## 2026.4.20
 
 ### Changes

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -706,9 +706,7 @@ export function resolveCommandAuthorization(params: {
       ? true
       : ownerAllowlistConfigured
         ? senderIsOwner
-        : ownerState.allowAll ||
-          ownerState.ownerCandidatesForCommands.length === 0 ||
-          Boolean(matchedCommandOwner);
+        : senderIsOwnerByScope || Boolean(matchedCommandOwner);
   const isAuthorizedSender = resolveCommandSenderAuthorization({
     commandAuthorized,
     isOwnerForCommands,

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -159,6 +159,48 @@ describe("resolveCommandAuthorization", () => {
     expect(otherAuth.isAuthorizedSender).toBe(false);
   });
 
+  it("rejects wildcard channel senders when the plugin enforces owner-only commands", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "discord",
+              outbound: { deliveryMode: "direct" },
+            }),
+            commands: { enforceOwnerForCommands: true },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              resolveAllowFrom: () => ["*"],
+              formatAllowFrom,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const cfg = {
+      channels: { discord: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+
+    const auth = resolveCommandAuthorization({
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "direct",
+        From: "discord:123",
+        SenderId: "123",
+      } as MsgContext,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(false);
+  });
+
   it("uses explicit owner allowlist when allowFrom is empty", () => {
     const cfg = {
       commands: { ownerAllowFrom: ["whatsapp:+15551234567"] },


### PR DESCRIPTION
# fix: require owner identity for owner-enforced commands

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Channel plugins that require owner-only commands could still authorize non-owner senders when the channel inbound allowlist resolved to a wildcard or no owner candidates.
- Why it matters: Owner-only command surfaces could be reached by senders that the auth layer did not identify as owners.
- What changed: `resolveCommandAuthorization` now requires an actual owner candidate match, or internal `operator.admin` scope, when plugin-level owner enforcement is active without an explicit owner allowlist; a regression test covers the wildcard allowlist path.
- What did NOT change (scope boundary): Explicit `commands.ownerAllowFrom`, wildcard owner allowlists, and normal command authorization behavior for plugins that do not enforce owner-only commands.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill> (tracking: NVIDIA-dev/openclaw-tracking#484)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The owner-enforcement fallback treated wildcard channel access and empty owner-candidate lists as sufficient for owner authorization even when the plugin explicitly required an owner check.
- Missing detection / guardrail: There was no regression test for `enforceOwnerForCommands=true` combined with wildcard channel `allowFrom` and no explicit owner allowlist.
- Contributing context (if known): The owner-check branch reused general channel-allowlist state, which is correct for sender authorization but too permissive for owner identity.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/command-control.test.ts`
- Scenario the test should lock in: A non-owner direct sender stays unauthorized when the channel allowlist is wildcard and the plugin enforces owner-only commands.
- Why this is the smallest reliable guardrail: The regression lives entirely in `resolveCommandAuthorization`, so a focused unit test exercises the decision tree without requiring channel runtime setup.
- Existing test that already covers this (if any): The same file already covers explicit owner allowlists on wildcard channel `allowFrom`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Non-owner senders no longer pass owner-only command checks just because a channel allowlist is wildcard when that channel plugin enforces owner-only commands. Explicit owner allowlists and internal `operator.admin` authorization still work.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node.js workspace run with `pnpm` and `vitest`
- Model/provider: N/A
- Integration/channel (if any): Auto-reply command authorization; regression harness uses a stubbed channel plugin that exercises the shared owner-enforcement path
- Relevant config (redacted): `channels.<provider>.allowFrom=["*"]`; `plugin.commands.enforceOwnerForCommands=true`; `commands.ownerAllowFrom` unset

### Steps

1. Configure a channel allowlist to `["*"]` with plugin-level `enforceOwnerForCommands` enabled and no explicit `commands.ownerAllowFrom`.
2. Resolve command authorization for a non-owner direct sender with `commandAuthorized: true`.
3. Run `COREPACK_HOME=/tmp/corepack pnpm exec vitest run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/command-control.test.ts`.

### Expected

- The non-owner sender is not authorized for owner-only commands, and the focused auto-reply auth test suite passes.

### Actual

- `resolveCommandAuthorization` now only treats the sender as owner-authorized when they match an owner candidate or hold internal `operator.admin`; the targeted test run passed with `1` file and `42` tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run:

```text
Test Files  1 passed (1)
Tests      42 passed (42)
```

Commit-time validation (`node scripts/check-changed.mjs --staged`) also completed core typecheck, lint, import-cycle checks, and the auto-reply test shard:

```text
Test Files  113 passed (113)
Tests      1418 passed (1418)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the `resolveCommandAuthorization` owner-enforcement branch and confirmed the wildcard/empty-candidate fallback no longer authorizes non-owner senders; verified the new regression test exercises that path.
- Edge cases checked: Explicit owner allowlists on wildcard channel access still deny non-owner senders, and internal `operator.admin` remains allowed by the authorization branch.
- What you did **not** verify: Full channel-specific end-to-end behavior on a live WhatsApp runtime.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Plugins that depended on wildcard channel access to imply owner authorization under `enforceOwnerForCommands` will now reject those senders.
- Mitigation:
  - Configure explicit `commands.ownerAllowFrom` entries, or use internal `operator.admin`, when owner-only command access is intended.