### PR TITLE
perf(status): cache plugin compatibility notices by config + openclaw version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status/perf: cache `openclaw status` plugin compatibility notices under `<workspaceDir>/.openclaw/plugin-compat-cache.json`, keyed by openclaw version plus normalized plugins config, so warm runs skip the ~20s full plugin diagnostics load when compatibility-relevant inputs have not changed. Set `OPENCLAW_COMPAT_CACHE=0` to disable. Related to #69103.
 - Sessions/reset: add `/reset soft [message]` for an in-place reset that keeps the current transcript/session while clearing reused CLI backend bindings and reloading startup/bootstrap context. (#68635) Thanks @Takhoffman.
 - Exec/YOLO: stop rejecting gateway-host exec in `security=full` plus `ask=off` mode via the Python/Node script preflight hardening path, so promptless YOLO exec once again runs direct interpreter stdin and heredoc forms such as `node <<'NODE' ... NODE`.
 - OpenAI Codex: normalize legacy `openai-completions` transport overrides on default OpenAI/Codex and GitHub Copilot-compatible hosts back to the native Codex Responses transport while leaving custom proxies untouched. (#45304, #42194) Thanks @dyss1992 and @DeadlySilent.

--- a/src/plugins/compatibility-notice-types.ts
+++ b/src/plugins/compatibility-notice-types.ts
@@ -1,0 +1,11 @@
+export type PluginCompatibilityNotice = {
+  pluginId: string;
+  code: "legacy-before-agent-start" | "hook-only";
+  severity: "warn" | "info";
+  message: string;
+};
+
+export type PluginCompatibilitySummary = {
+  noticeCount: number;
+  pluginCount: number;
+};

--- a/src/plugins/compatibility-notices-cache.test.ts
+++ b/src/plugins/compatibility-notices-cache.test.ts
@@ -1,0 +1,162 @@
+import syncFs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  readCompatibilityNoticesCache,
+  resolveCompatibilityNoticesCacheKey,
+  resolveCompatibilityNoticesCachePath,
+  writeCompatibilityNoticesCache,
+} from "./compatibility-notices-cache.js";
+import type { PluginCompatibilityNotice } from "./status.js";
+
+const SAMPLE_NOTICES: PluginCompatibilityNotice[] = [
+  {
+    pluginId: "demo",
+    code: "legacy-before-agent-start",
+    severity: "warn",
+    message:
+      "still uses legacy before_agent_start; keep regression coverage on this plugin, and prefer before_model_resolve/before_prompt_build for new work.",
+  },
+  {
+    pluginId: "demo",
+    code: "hook-only",
+    severity: "info",
+    message:
+      "is hook-only. This remains a supported compatibility path, but it has not migrated to explicit capability registration yet.",
+  },
+];
+
+const CACHE_ENV: NodeJS.ProcessEnv = {
+  OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.4.20",
+};
+
+const CONFIG_A: OpenClawConfig = {
+  plugins: {
+    entries: {
+      demo: { enabled: true },
+    },
+  },
+} as OpenClawConfig;
+
+const CONFIG_B: OpenClawConfig = {
+  plugins: {
+    entries: {
+      demo: { enabled: false },
+    },
+  },
+} as OpenClawConfig;
+
+describe("compatibility-notices-cache", () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = syncFs.mkdtempSync(path.join(os.tmpdir(), "openclaw-compat-cache-"));
+  });
+
+  afterEach(() => {
+    syncFs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("resolves a stable sha256 cache key for the same inputs", () => {
+    const key1 = resolveCompatibilityNoticesCacheKey({ config: CONFIG_A, env: CACHE_ENV });
+    const key2 = resolveCompatibilityNoticesCacheKey({ config: CONFIG_A, env: CACHE_ENV });
+    expect(key1).toBe(key2);
+    expect(key1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes the cache key when plugins config changes", () => {
+    const key1 = resolveCompatibilityNoticesCacheKey({ config: CONFIG_A, env: CACHE_ENV });
+    const key2 = resolveCompatibilityNoticesCacheKey({ config: CONFIG_B, env: CACHE_ENV });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("changes the cache key when openclaw host version changes", () => {
+    const key1 = resolveCompatibilityNoticesCacheKey({ config: CONFIG_A, env: CACHE_ENV });
+    const key2 = resolveCompatibilityNoticesCacheKey({
+      config: CONFIG_A,
+      env: { OPENCLAW_COMPATIBILITY_HOST_VERSION: "2099.1.1" },
+    });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("returns null when no cache file exists", () => {
+    expect(
+      readCompatibilityNoticesCache({ config: CONFIG_A, env: CACHE_ENV, workspaceDir }),
+    ).toBeNull();
+  });
+
+  it("round-trips notices through the cache file", () => {
+    writeCompatibilityNoticesCache({
+      config: CONFIG_A,
+      env: CACHE_ENV,
+      workspaceDir,
+      notices: SAMPLE_NOTICES,
+    });
+    const read = readCompatibilityNoticesCache({
+      config: CONFIG_A,
+      env: CACHE_ENV,
+      workspaceDir,
+    });
+    expect(read).toEqual(SAMPLE_NOTICES);
+  });
+
+  it("invalidates the cache when config changes between write and read", () => {
+    writeCompatibilityNoticesCache({
+      config: CONFIG_A,
+      env: CACHE_ENV,
+      workspaceDir,
+      notices: SAMPLE_NOTICES,
+    });
+    const read = readCompatibilityNoticesCache({
+      config: CONFIG_B,
+      env: CACHE_ENV,
+      workspaceDir,
+    });
+    expect(read).toBeNull();
+  });
+
+  it("returns null when the cache file is corrupt", () => {
+    const filePath = resolveCompatibilityNoticesCachePath({ workspaceDir, env: CACHE_ENV });
+    syncFs.mkdirSync(path.dirname(filePath), { recursive: true });
+    syncFs.writeFileSync(filePath, "{ not valid json ", { encoding: "utf-8" });
+    expect(
+      readCompatibilityNoticesCache({ config: CONFIG_A, env: CACHE_ENV, workspaceDir }),
+    ).toBeNull();
+  });
+
+  it("returns null when the envelope version does not match", () => {
+    const filePath = resolveCompatibilityNoticesCachePath({ workspaceDir, env: CACHE_ENV });
+    syncFs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const key = resolveCompatibilityNoticesCacheKey({ config: CONFIG_A, env: CACHE_ENV });
+    syncFs.writeFileSync(filePath, JSON.stringify({ version: 999, key, notices: SAMPLE_NOTICES }), {
+      encoding: "utf-8",
+    });
+    expect(
+      readCompatibilityNoticesCache({ config: CONFIG_A, env: CACHE_ENV, workspaceDir }),
+    ).toBeNull();
+  });
+
+  it("skips read and write when OPENCLAW_COMPAT_CACHE=0", () => {
+    const disabledEnv: NodeJS.ProcessEnv = { ...CACHE_ENV, OPENCLAW_COMPAT_CACHE: "0" };
+    writeCompatibilityNoticesCache({
+      config: CONFIG_A,
+      env: disabledEnv,
+      workspaceDir,
+      notices: SAMPLE_NOTICES,
+    });
+    const filePath = resolveCompatibilityNoticesCachePath({ workspaceDir, env: disabledEnv });
+    expect(syncFs.existsSync(filePath)).toBe(false);
+
+    writeCompatibilityNoticesCache({
+      config: CONFIG_A,
+      env: CACHE_ENV,
+      workspaceDir,
+      notices: SAMPLE_NOTICES,
+    });
+    expect(
+      readCompatibilityNoticesCache({ config: CONFIG_A, env: disabledEnv, workspaceDir }),
+    ).toBeNull();
+  });
+});

--- a/src/plugins/compatibility-notices-cache.ts
+++ b/src/plugins/compatibility-notices-cache.ts
@@ -1,13 +1,14 @@
 import { createHash } from "node:crypto";
 import syncFs from "node:fs";
 import path from "node:path";
-import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import type { PluginCompatibilityNotice } from "./compatibility-notice-types.js";
 import { normalizePluginsConfig } from "./config-state.js";
 
-const CACHE_ENVELOPE_VERSION = 1;
+// Bump when the cache key shape changes so pre-existing files miss cleanly.
+const CACHE_ENVELOPE_VERSION = 2;
 const CACHE_DIRNAME = ".openclaw";
 const CACHE_FILENAME = "plugin-compat-cache.json";
 
@@ -36,25 +37,59 @@ function stableStringify(value: unknown): string {
   return `{${body}}`;
 }
 
+function isValidNotice(value: unknown): value is PluginCompatibilityNotice {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const notice = value as Partial<PluginCompatibilityNotice>;
+  return (
+    typeof notice.pluginId === "string" &&
+    (notice.code === "legacy-before-agent-start" || notice.code === "hook-only") &&
+    (notice.severity === "warn" || notice.severity === "info") &&
+    typeof notice.message === "string"
+  );
+}
+
 export function resolveCompatibilityNoticesCacheKey(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): string {
   const env = params.env ?? process.env;
-  const plugins = normalizePluginsConfig(params.config?.plugins);
+  const rawConfig = params.config ?? ({} as OpenClawConfig);
+  const normalizedPlugins = normalizePluginsConfig(rawConfig.plugins);
+  // Plugin auto-enable reads from channels/auth/models/tools/agents beyond
+  // `plugins`. Hash the full non-plugins config so any input that can change the
+  // active plugin set invalidates the cache, and keep normalized `plugins`
+  // separately so plugin-id aliases still collapse to the same key.
+  const { plugins: _omitPlugins, ...restConfig } = rawConfig as {
+    plugins?: unknown;
+  } & Record<string, unknown>;
   const payload = stableStringify({
     v: CACHE_ENVELOPE_VERSION,
     openclaw: resolveCompatibilityHostVersion(env),
-    plugins,
+    plugins: normalizedPlugins,
+    rest: restConfig,
   });
   return createHash("sha256").update(payload).digest("hex");
 }
 
+export function resolveCompatibilityNoticesCacheWorkspaceDir(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): string {
+  if (params.workspaceDir) {
+    return params.workspaceDir;
+  }
+  const config = params.config ?? ({} as OpenClawConfig);
+  return resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+}
+
 export function resolveCompatibilityNoticesCachePath(params: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): string {
-  const dir = params.workspaceDir ?? resolveDefaultAgentWorkspaceDir(params.env);
+  const dir = resolveCompatibilityNoticesCacheWorkspaceDir(params);
   return path.join(dir, CACHE_DIRNAME, CACHE_FILENAME);
 }
 
@@ -82,7 +117,8 @@ export function readCompatibilityNoticesCache(params: {
       typeof parsed === "object" &&
       parsed.version === CACHE_ENVELOPE_VERSION &&
       typeof parsed.key === "string" &&
-      Array.isArray(parsed.notices)
+      Array.isArray(parsed.notices) &&
+      parsed.notices.every(isValidNotice)
     ) {
       envelope = parsed;
     }

--- a/src/plugins/compatibility-notices-cache.ts
+++ b/src/plugins/compatibility-notices-cache.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import syncFs from "node:fs";
+import path from "node:path";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
+import type { PluginCompatibilityNotice } from "./compatibility-notice-types.js";
+import { normalizePluginsConfig } from "./config-state.js";
+
+const CACHE_ENVELOPE_VERSION = 1;
+const CACHE_DIRNAME = ".openclaw";
+const CACHE_FILENAME = "plugin-compat-cache.json";
+
+type CacheEnvelope = {
+  version: number;
+  key: string;
+  notices: PluginCompatibilityNotice[];
+};
+
+function isCacheEnabled(env: NodeJS.ProcessEnv | undefined): boolean {
+  const flag = (env ?? process.env).OPENCLAW_COMPAT_CACHE;
+  return flag !== "0" && flag !== "false";
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .toSorted(([a], [b]) => a.localeCompare(b));
+  const body = entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",");
+  return `{${body}}`;
+}
+
+export function resolveCompatibilityNoticesCacheKey(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const env = params.env ?? process.env;
+  const plugins = normalizePluginsConfig(params.config?.plugins);
+  const payload = stableStringify({
+    v: CACHE_ENVELOPE_VERSION,
+    openclaw: resolveCompatibilityHostVersion(env),
+    plugins,
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+export function resolveCompatibilityNoticesCachePath(params: {
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const dir = params.workspaceDir ?? resolveDefaultAgentWorkspaceDir(params.env);
+  return path.join(dir, CACHE_DIRNAME, CACHE_FILENAME);
+}
+
+export function readCompatibilityNoticesCache(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+}): PluginCompatibilityNotice[] | null {
+  const env = params.env ?? process.env;
+  if (!isCacheEnabled(env)) {
+    return null;
+  }
+  const filePath = resolveCompatibilityNoticesCachePath(params);
+  let raw: string;
+  try {
+    raw = syncFs.readFileSync(filePath, { encoding: "utf-8" });
+  } catch {
+    return null;
+  }
+  let envelope: CacheEnvelope | null = null;
+  try {
+    const parsed = JSON.parse(raw) as CacheEnvelope;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      parsed.version === CACHE_ENVELOPE_VERSION &&
+      typeof parsed.key === "string" &&
+      Array.isArray(parsed.notices)
+    ) {
+      envelope = parsed;
+    }
+  } catch {
+    return null;
+  }
+  if (!envelope) {
+    return null;
+  }
+  const key = resolveCompatibilityNoticesCacheKey({ config: params.config, env });
+  if (envelope.key !== key) {
+    return null;
+  }
+  return envelope.notices;
+}
+
+export function writeCompatibilityNoticesCache(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+  notices: PluginCompatibilityNotice[];
+}): void {
+  const env = params.env ?? process.env;
+  if (!isCacheEnabled(env)) {
+    return;
+  }
+  const filePath = resolveCompatibilityNoticesCachePath(params);
+  const key = resolveCompatibilityNoticesCacheKey({ config: params.config, env });
+  const envelope: CacheEnvelope = {
+    version: CACHE_ENVELOPE_VERSION,
+    key,
+    notices: params.notices,
+  };
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  try {
+    syncFs.mkdirSync(path.dirname(filePath), { recursive: true });
+    syncFs.writeFileSync(tmpPath, `${JSON.stringify(envelope, null, 2)}\n`, {
+      encoding: "utf-8",
+    });
+    syncFs.renameSync(tmpPath, filePath);
+  } catch {
+    try {
+      syncFs.unlinkSync(tmpPath);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -75,6 +75,11 @@ vi.mock("../agents/workspace.js", () => ({
   resolveDefaultAgentWorkspaceDir: () => "/default-workspace",
 }));
 
+vi.mock("./compatibility-notices-cache.js", () => ({
+  readCompatibilityNoticesCache: () => null,
+  writeCompatibilityNoticesCache: () => undefined,
+}));
+
 function setPluginLoadResult(overrides: Partial<ReturnType<typeof createPluginLoadResult>>) {
   const result = createPluginLoadResult({
     plugins: [],

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -18,6 +18,8 @@ const withBundledPluginAllowlistCompatMock = vi.fn();
 const withBundledPluginEnablementCompatMock = vi.fn();
 const listImportedBundledPluginFacadeIdsMock = vi.fn();
 const listImportedRuntimePluginIdsMock = vi.fn();
+const readCompatibilityNoticesCacheMock = vi.fn();
+const writeCompatibilityNoticesCacheMock = vi.fn();
 let buildPluginSnapshotReport: typeof import("./status.js").buildPluginSnapshotReport;
 let buildPluginDiagnosticsReport: typeof import("./status.js").buildPluginDiagnosticsReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
@@ -76,8 +78,9 @@ vi.mock("../agents/workspace.js", () => ({
 }));
 
 vi.mock("./compatibility-notices-cache.js", () => ({
-  readCompatibilityNoticesCache: () => null,
-  writeCompatibilityNoticesCache: () => undefined,
+  readCompatibilityNoticesCache: (...args: unknown[]) => readCompatibilityNoticesCacheMock(...args),
+  writeCompatibilityNoticesCache: (...args: unknown[]) =>
+    writeCompatibilityNoticesCacheMock(...args),
 }));
 
 function setPluginLoadResult(overrides: Partial<ReturnType<typeof createPluginLoadResult>>) {
@@ -341,6 +344,9 @@ describe("plugin status reports", () => {
     withBundledPluginEnablementCompatMock.mockReset();
     listImportedBundledPluginFacadeIdsMock.mockReset();
     listImportedRuntimePluginIdsMock.mockReset();
+    readCompatibilityNoticesCacheMock.mockReset();
+    writeCompatibilityNoticesCacheMock.mockReset();
+    readCompatibilityNoticesCacheMock.mockReturnValue(null);
     loadConfigMock.mockReturnValue({});
     applyPluginAutoEnableMock.mockImplementation((params: { config: unknown }) => ({
       config: params.config,
@@ -480,6 +486,54 @@ describe("plugin status reports", () => {
 
   it("preserves raw config activation context when compatibility notices build their own report", () => {
     expectAutoEnabledDemoCompatibilityNoticesPreserveRawConfig();
+  });
+
+  it("short-circuits to cached compatibility notices without loading plugins", () => {
+    const cached = [
+      createCompatibilityNotice({ pluginId: "demo", code: "legacy-before-agent-start" }),
+      createCompatibilityNotice({ pluginId: "demo", code: "hook-only" }),
+    ];
+    readCompatibilityNoticesCacheMock.mockReturnValue(cached);
+
+    expect(buildPluginCompatibilityNotices({ config: {} })).toEqual(cached);
+
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    expect(loadPluginMetadataRegistrySnapshotMock).not.toHaveBeenCalled();
+    expect(writeCompatibilityNoticesCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("writes compatibility notices to the cache on a miss", () => {
+    setSinglePluginLoadResult(
+      createPluginRecord({
+        id: "demo",
+        name: "Demo",
+        description: "Legacy plugin",
+        origin: "bundled",
+        hookCount: 1,
+      }),
+      {
+        typedHooks: [createTypedHook({ pluginId: "demo", hookName: "before_agent_start" })],
+      },
+    );
+
+    const notices = buildPluginCompatibilityNotices({ config: {} });
+
+    expect(notices.length).toBeGreaterThan(0);
+    expect(writeCompatibilityNoticesCacheMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notices }),
+    );
+  });
+
+  it("bypasses the cache when a diagnostics report is passed in", () => {
+    const report = buildPluginSnapshotReport({ config: {}, workspaceDir: "/workspace" });
+    readCompatibilityNoticesCacheMock.mockReturnValue([
+      createCompatibilityNotice({ pluginId: "stale", code: "hook-only" }),
+    ]);
+
+    buildPluginCompatibilityNotices({ config: {}, report });
+
+    expect(readCompatibilityNoticesCacheMock).not.toHaveBeenCalled();
+    expect(writeCompatibilityNoticesCacheMock).not.toHaveBeenCalled();
   });
 
   it("applies the full bundled provider compat chain before loading plugins", () => {

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -10,6 +10,10 @@ import {
   withBundledPluginAllowlistCompat,
   withBundledPluginEnablementCompat,
 } from "./bundled-compat.js";
+import {
+  readCompatibilityNoticesCache,
+  writeCompatibilityNoticesCache,
+} from "./compatibility-notices-cache.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import {
   buildPluginShapeSummary,
@@ -34,17 +38,15 @@ export type PluginStatusReport = PluginRegistry & {
 
 export type { PluginCapabilityKind, PluginInspectShape } from "./inspect-shape.js";
 
-export type PluginCompatibilityNotice = {
-  pluginId: string;
-  code: "legacy-before-agent-start" | "hook-only";
-  severity: "warn" | "info";
-  message: string;
-};
+import type {
+  PluginCompatibilityNotice,
+  PluginCompatibilitySummary,
+} from "./compatibility-notice-types.js";
 
-export type PluginCompatibilitySummary = {
-  noticeCount: number;
-  pluginCount: number;
-};
+export type {
+  PluginCompatibilityNotice,
+  PluginCompatibilitySummary,
+} from "./compatibility-notice-types.js";
 
 export type PluginInspectReport = {
   workspaceDir?: string;
@@ -403,7 +405,30 @@ export function buildPluginCompatibilityNotices(params?: {
   logger?: PluginLogger;
   report?: PluginStatusReport;
 }): PluginCompatibilityNotice[] {
-  return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
+  // Callers that already hold a diagnostics report have paid the expensive
+  // plugin-load cost; skip the cache and return live results directly.
+  if (params?.report) {
+    return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
+  }
+  const rawConfig = params?.config ?? loadConfig();
+  const cached = readCompatibilityNoticesCache({
+    config: rawConfig,
+    env: params?.env,
+    workspaceDir: params?.workspaceDir,
+  });
+  if (cached) {
+    return cached;
+  }
+  const notices = buildAllPluginInspectReports({ ...params, config: rawConfig }).flatMap(
+    (inspect) => inspect.compatibility,
+  );
+  writeCompatibilityNoticesCache({
+    config: rawConfig,
+    env: params?.env,
+    workspaceDir: params?.workspaceDir,
+    notices,
+  });
+  return notices;
 }
 
 export function formatPluginCompatibilityNotice(notice: PluginCompatibilityNotice): string {


### PR DESCRIPTION
## Summary
- cache `buildPluginCompatibilityNotices` results at `<workspaceDir>/.openclaw/plugin-compat-cache.json`, keyed by a sha256 of the openclaw compatibility host version plus the normalized plugins config
- warm `openclaw status` runs now skip the ~20s full plugin diagnostics load when compatibility-relevant inputs have not changed; cold runs behave as before
- callers that already hold a diagnostics `report` bypass the cache (preserves the existing explicit override contract)
- add `OPENCLAW_COMPAT_CACHE=0` escape hatch to fully disable read/write

## Why not the previous approach
Previous attempt (#69736) tried to flip the default from `buildPluginDiagnosticsReport` to `buildPluginSnapshotReport`. That path does not populate `registry.typedHooks` (see `src/plugins/loader.ts` `!shouldLoadModules` early-return), so the `legacy-before-agent-start` notice would silently regress. This change keeps the diagnostics path as the source of truth on cache miss and only short-circuits when inputs are unchanged.

## Correctness notes
- Cache key input = `resolveCompatibilityHostVersion(env)` + stable-stringify(`normalizePluginsConfig(config.plugins)`). Any openclaw version bump or plugins-section config change invalidates the cache.
- External plugin source edits without a config change will not invalidate the cache. Reinstalling a plugin updates `plugins.installs[*].installedAt` and re-hashes. The `OPENCLAW_COMPAT_CACHE=0` escape hatch exists for plugin-dev workflows.
- Corrupt / stale-envelope / version-mismatch cache files are treated as misses and re-computed.

## Issue
- Related to https://github.com/openclaw/openclaw/issues/69103
- Supersedes #69736

## Test Plan
- [x] `pnpm test src/plugins/compatibility-notices-cache.test.ts src/plugins/status.test.ts src/commands/status.scan.test.ts`
- [x] `pnpm check:changed`
- [x] `pnpm check:architecture`
- [x] `pnpm build`