### PR TITLE
perf(matrix): narrow register-time runtime surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Onboard/wizard: simplify the security disclaimer copy (drop the yellow banner and warning icon in favor of plain-prose paragraphs), and flip remaining onboarding pickers with long dynamic option lists to searchable autocompletes (search provider, plugin configure, model provider filter).
 - Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
+- Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`. (#69782) Thanks @gumadeiras.
 
 ### Fixes
 
@@ -23,7 +24,6 @@ Docs: https://docs.openclaw.ai
 - Models/costs: support tiered model pricing from cached catalogs and configured models, and include bundled Moonshot Kimi K2.6/K2.5 cost estimates for token-usage reports. (#67605) Thanks @sliverp.
 - Sessions/Maintenance: enforce the built-in entry cap and age prune by default, and prune oversized stores at load time so accumulated cron/executor session backlogs cannot OOM the gateway before the write path runs. (#69404) Thanks @bobrenze-bot.
 - Plugins/tests: reuse plugin loader alias and Jiti config resolution across repeated same-context loads, reducing import-heavy test overhead. (#69316) Thanks @amknight.
-- Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`.
 - Cron: split runtime execution state into `jobs-state.json` so `jobs.json` stays stable for git-tracked job definitions. (#63105) Thanks @Feelw00.
 - Agents/compaction: send opt-in start and completion notices during context compaction. (#67830) Thanks @feniix.
 - Moonshot/Kimi: default bundled Moonshot setup, web search, and media-understanding surfaces to `kimi-k2.6` while keeping `kimi-k2.5` available for compatibility. (#69477) Thanks @scoootscooob.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Models/costs: support tiered model pricing from cached catalogs and configured models, and include bundled Moonshot Kimi K2.6/K2.5 cost estimates for token-usage reports. (#67605) Thanks @sliverp.
 - Sessions/Maintenance: enforce the built-in entry cap and age prune by default, and prune oversized stores at load time so accumulated cron/executor session backlogs cannot OOM the gateway before the write path runs. (#69404) Thanks @bobrenze-bot.
 - Plugins/tests: reuse plugin loader alias and Jiti config resolution across repeated same-context loads, reducing import-heavy test overhead. (#69316) Thanks @amknight.
+- Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`.
 - Cron: split runtime execution state into `jobs-state.json` so `jobs.json` stays stable for git-tracked job definitions. (#63105) Thanks @Feelw00.
 - Agents/compaction: send opt-in start and completion notices during context compaction. (#67830) Thanks @feniix.
 - Moonshot/Kimi: default bundled Moonshot setup, web search, and media-understanding surfaces to `kimi-k2.6` while keeping `kimi-k2.5` available for compatibility. (#69477) Thanks @scoootscooob.

--- a/extensions/matrix/index.test.ts
+++ b/extensions/matrix/index.test.ts
@@ -22,7 +22,7 @@ vi.mock("./src/cli.js", () => {
 });
 
 vi.mock("./plugin-entry.handlers.runtime.js", () => runtimeMocks);
-vi.mock("./runtime-api.js", () => ({ setMatrixRuntime: runtimeMocks.setMatrixRuntime }));
+vi.mock("./runtime-setter-api.js", () => ({ setMatrixRuntime: runtimeMocks.setMatrixRuntime }));
 
 describe("matrix plugin", () => {
   it("registers matrix CLI through a descriptor-backed lazy registrar", async () => {
@@ -66,6 +66,7 @@ describe("matrix plugin", () => {
     expect(entry.kind).toBe("bundled-channel-entry");
     expect(entry.id).toBe("matrix");
     expect(entry.name).toBe("Matrix");
+    expect(entry.setChannelRuntime).toEqual(expect.any(Function));
   });
 
   it("registers subagent lifecycle hooks during full runtime registration", () => {

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -77,7 +77,7 @@ export default defineBundledChannelEntry({
     exportName: "channelSecrets",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setMatrixRuntime",
   },
   registerCliMetadata: registerMatrixCliMetadata,

--- a/extensions/matrix/runtime-setter-api.ts
+++ b/extensions/matrix/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Narrow entry point for setMatrixRuntime. The full runtime-api barrel is kept
+// for external/runtime callers, but bundled plugin register only needs this.
+export { setMatrixRuntime } from "./src/runtime.js";

--- a/extensions/matrix/setup-entry.ts
+++ b/extensions/matrix/setup-entry.ts
@@ -11,7 +11,7 @@ export default defineBundledChannelSetupEntry({
     exportName: "channelSecrets",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setMatrixRuntime",
   },
 });

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -1,18 +1,20 @@
 import { Type } from "@sinclair/typebox";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
-import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
-import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/accounts.js";
 import {
   createActionGate,
   readNumberParam,
   readStringParam,
   ToolAuthorizationError,
-  type ChannelMessageActionAdapter,
-  type ChannelMessageActionContext,
-  type ChannelMessageActionName,
-  type ChannelMessageToolDiscovery,
-} from "./runtime-api.js";
+} from "openclaw/plugin-sdk/channel-actions";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+  ChannelMessageActionName,
+  ChannelMessageToolDiscovery,
+} from "openclaw/plugin-sdk/channel-contract";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
+import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
+import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/accounts.js";
 import type { CoreConfig } from "./types.js";
 
 const MATRIX_PLUGIN_HANDLED_ACTIONS = new Set<ChannelMessageActionName>([

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -74,7 +74,7 @@ import type { CoreConfig } from "./types.js";
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
 let matrixStartupLock: Promise<void> = Promise.resolve();
 
-const loadMatrixSetupSurfaceModule = createLazyRuntimeNamedExport(
+const loadMatrixSetupWizard = createLazyRuntimeNamedExport(
   () => import("./setup-surface.js"),
   "matrixSetupWizard",
 );
@@ -326,7 +326,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
       id: "matrix",
       meta,
       setupWizard: createMatrixSetupWizardProxy(async () => ({
-        matrixSetupWizard: await loadMatrixSetupSurfaceModule(),
+        matrixSetupWizard: await loadMatrixSetupWizard(),
       })),
       capabilities: {
         chatTypes: ["direct", "group", "thread"],

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -4,6 +4,7 @@ import {
   createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-primitives";
+import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
   createAllowlistProviderOpenWarningCollector,
@@ -15,7 +16,6 @@ import {
   createResolvedDirectoryEntriesLister,
   createRuntimeDirectoryLiveAdapter,
 } from "openclaw/plugin-sdk/directory-runtime";
-import { buildTrafficStatusSummary } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/outbound-runtime";
 import {
@@ -34,7 +34,10 @@ import { matrixApprovalCapability } from "./approval-native.js";
 import { createMatrixPairingText, createMatrixProbeAccount } from "./channel-account-paths.js";
 import { DEFAULT_ACCOUNT_ID, matrixConfigAdapter } from "./config-adapter.js";
 import { MatrixConfigSchema } from "./config-schema.js";
-import { matrixDoctor } from "./doctor.js";
+import {
+  legacyConfigRules as MATRIX_LEGACY_CONFIG_RULES,
+  normalizeCompatibilityConfig as normalizeMatrixCompatibilityConfig,
+} from "./doctor-contract.js";
 import { shouldSuppressLocalMatrixExecApprovalPrompt } from "./exec-approvals.js";
 import {
   resolveMatrixGroupRequireMention,
@@ -64,14 +67,17 @@ import {
   resolveSingleAccountPromotionTarget,
   singleAccountKeysToMove,
 } from "./setup-contract.js";
-import { matrixSetupAdapter } from "./setup-core.js";
-import { matrixSetupWizard } from "./setup-surface.js";
+import { createMatrixSetupWizardProxy, matrixSetupAdapter } from "./setup-core.js";
 import { runMatrixStartupMaintenance } from "./startup-maintenance.js";
 import { resolveMatrixInboundConversation } from "./thread-binding-api.js";
 import type { CoreConfig } from "./types.js";
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
 let matrixStartupLock: Promise<void> = Promise.resolve();
 
+const loadMatrixSetupSurfaceModule = createLazyRuntimeNamedExport(
+  () => import("./setup-surface.js"),
+  "matrixSetupWizard",
+);
 const loadMatrixChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
   "matrixChannelRuntime",
@@ -86,6 +92,31 @@ const meta = {
   blurb: "open protocol; configure a homeserver + access token.",
   order: 70,
   quickstartAllowFrom: true,
+};
+
+function buildMatrixTrafficStatusSummary(
+  snapshot?: {
+    lastInboundAt?: number | null;
+    lastOutboundAt?: number | null;
+  } | null,
+) {
+  return {
+    lastInboundAt: snapshot?.lastInboundAt ?? null,
+    lastOutboundAt: snapshot?.lastOutboundAt ?? null,
+  };
+}
+
+const matrixDoctor: ChannelDoctorAdapter = {
+  dmAllowFromMode: "nestedOnly",
+  groupModel: "sender",
+  groupAllowFromFallbackToAllowFrom: false,
+  warnOnEmptyGroupSenderAllowlist: true,
+  legacyConfigRules: MATRIX_LEGACY_CONFIG_RULES,
+  normalizeCompatibilityConfig: normalizeMatrixCompatibilityConfig,
+  runConfigSequence: async ({ cfg, env, shouldRepair }) =>
+    await (await import("./doctor.js")).runMatrixDoctorSequence({ cfg, env, shouldRepair }),
+  cleanStaleConfig: async ({ cfg }) =>
+    await (await import("./doctor.js")).cleanStaleMatrixPluginConfig(cfg),
 };
 
 const listMatrixDirectoryPeersFromConfig =
@@ -294,7 +325,9 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
     base: {
       id: "matrix",
       meta,
-      setupWizard: matrixSetupWizard,
+      setupWizard: createMatrixSetupWizardProxy(async () => ({
+        matrixSetupWizard: await loadMatrixSetupSurfaceModule(),
+      })),
       capabilities: {
         chatTypes: ["direct", "group", "thread"],
         polls: true,
@@ -432,7 +465,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
           extra: {
             baseUrl: account.homeserver,
             lastProbeAt: runtime?.lastProbeAt ?? null,
-            ...buildTrafficStatusSummary(runtime),
+            ...buildMatrixTrafficStatusSummary(runtime),
           },
         }),
       }),

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -5,7 +5,6 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizardAdapter,
-  addWildcardAllowFrom,
   formatDocsLink,
   hasConfiguredSecretInput,
   mergeAllowFromEntries,
@@ -36,6 +35,7 @@ import {
 import { resolveMatrixConfigFieldPath, updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./matrix/deps.js";
 import { moveSingleMatrixAccountConfigToNamedAccount } from "./setup-config.js";
+import { resolveMatrixSetupDmAllowFrom } from "./setup-dm-policy.js";
 import type { CoreConfig, MatrixConfig } from "./types.js";
 
 const channel = "matrix" as const;
@@ -84,12 +84,12 @@ function setMatrixDmPolicy(cfg: CoreConfig, policy: DmPolicy, accountId?: string
     cfg,
     accountId: resolvedAccountId,
   });
-  const allowFrom = policy === "open" ? addWildcardAllowFrom(existing.dm?.allowFrom) : undefined;
+  const allowFrom = resolveMatrixSetupDmAllowFrom(policy, existing.dm?.allowFrom);
   return updateMatrixAccountConfig(cfg, resolvedAccountId, {
     dm: {
       ...existing.dm,
       policy,
-      ...(allowFrom ? { allowFrom } : {}),
+      allowFrom,
     },
   });
 }

--- a/extensions/matrix/src/setup-core.test.ts
+++ b/extensions/matrix/src/setup-core.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { matrixSetupAdapter } from "./setup-core.js";
+import type { ChannelSetupWizardAdapter } from "openclaw/plugin-sdk/setup";
+import { describe, expect, it, vi } from "vitest";
+import { createMatrixSetupWizardProxy, matrixSetupAdapter } from "./setup-core.js";
 import type { CoreConfig } from "./types.js";
 
 function applyOpsAccountConfig(cfg: CoreConfig): CoreConfig {
@@ -34,6 +35,85 @@ function expectOpsAccount(next: CoreConfig): void {
     accessToken: "ops-token",
   });
 }
+
+function makeFakeSetupWizard(
+  overrides: Partial<ChannelSetupWizardAdapter> = {},
+): ChannelSetupWizardAdapter {
+  return {
+    channel: "matrix",
+    getStatus: vi.fn(async () => ({
+      channel: "matrix",
+      configured: false,
+      statusLines: [],
+    })),
+    configure: vi.fn(async ({ cfg }) => ({ cfg })),
+    ...overrides,
+  } as ChannelSetupWizardAdapter;
+}
+
+describe("createMatrixSetupWizardProxy", () => {
+  it("does not load the setup surface when constructing the proxy", () => {
+    const loader = vi.fn(async () => ({ matrixSetupWizard: makeFakeSetupWizard() }));
+
+    const proxy = createMatrixSetupWizardProxy(loader);
+
+    expect(proxy.channel).toBe("matrix");
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("loads the setup surface when setup status is requested", async () => {
+    const status = {
+      channel: "matrix" as const,
+      configured: true,
+      statusLines: ["Matrix: configured"],
+    };
+    const getStatus = vi.fn(async () => status);
+    const loader = vi.fn(async () => ({
+      matrixSetupWizard: makeFakeSetupWizard({ getStatus }),
+    }));
+    const proxy = createMatrixSetupWizardProxy(loader);
+    const cfg = { channels: { matrix: {} } } as CoreConfig;
+
+    const result = await proxy.getStatus({ cfg, accountOverrides: {} });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenCalledWith({ cfg, accountOverrides: {} });
+    expect(result).toBe(status);
+  });
+
+  it("keeps sync dmPolicy helpers local and lazy-loads only promptAllowFrom", async () => {
+    const promptAllowFrom = vi.fn(async ({ cfg }) => cfg);
+    const loader = vi.fn(async () => ({
+      matrixSetupWizard: makeFakeSetupWizard({
+        dmPolicy: {
+          label: "Matrix",
+          channel: "matrix",
+          policyKey: "unused",
+          allowFromKey: "unused",
+          getCurrent: () => "pairing",
+          setPolicy: (cfg) => cfg,
+          promptAllowFrom,
+        },
+      }),
+    }));
+    const proxy = createMatrixSetupWizardProxy(loader);
+    const cfg = { channels: { matrix: {} } } as CoreConfig;
+
+    expect(proxy.dmPolicy?.getCurrent(cfg)).toBe("pairing");
+    const next = proxy.dmPolicy?.setPolicy(cfg, "open") as CoreConfig;
+
+    expect(next.channels?.matrix?.dm).toMatchObject({ policy: "open", allowFrom: ["*"] });
+    expect(loader).not.toHaveBeenCalled();
+
+    await proxy.dmPolicy?.promptAllowFrom?.({
+      cfg,
+      prompter: {} as never,
+    });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(promptAllowFrom).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("matrixSetupAdapter", () => {
   it("moves legacy default config before writing a named account", () => {

--- a/extensions/matrix/src/setup-core.test.ts
+++ b/extensions/matrix/src/setup-core.test.ts
@@ -139,6 +139,33 @@ describe("createMatrixSetupWizardProxy", () => {
     expect(loader).toHaveBeenCalledTimes(1);
     expect(promptAllowFrom).toHaveBeenCalledTimes(1);
   });
+
+  it("removes wildcard allowFrom when switching from open to a restrictive policy", () => {
+    const loader = vi.fn(async () => ({ matrixSetupWizard: makeFakeSetupWizard() }));
+    const proxy = createMatrixSetupWizardProxy(loader);
+    const cfg = {
+      channels: {
+        matrix: {
+          accounts: {
+            ops: {
+              dm: {
+                policy: "open",
+                allowFrom: ["*", "  @ops:example.org  "],
+              },
+            },
+          },
+        },
+      },
+    } as CoreConfig;
+
+    const next = proxy.dmPolicy?.setPolicy(cfg, "allowlist", "ops") as CoreConfig;
+
+    expect(next.channels?.matrix?.accounts?.ops?.dm).toMatchObject({
+      policy: "allowlist",
+      allowFrom: ["@ops:example.org"],
+    });
+    expect(loader).not.toHaveBeenCalled();
+  });
 });
 
 describe("matrixSetupAdapter", () => {

--- a/extensions/matrix/src/setup-core.test.ts
+++ b/extensions/matrix/src/setup-core.test.ts
@@ -97,12 +97,27 @@ describe("createMatrixSetupWizardProxy", () => {
       }),
     }));
     const proxy = createMatrixSetupWizardProxy(loader);
-    const cfg = { channels: { matrix: {} } } as CoreConfig;
+    const cfg = {
+      channels: {
+        matrix: {
+          accounts: {
+            ops: {
+              dm: {
+                allowFrom: ["  @ops:example.org  ", "", "*"],
+              },
+            },
+          },
+        },
+      },
+    } as CoreConfig;
 
-    expect(proxy.dmPolicy?.getCurrent(cfg)).toBe("pairing");
-    const next = proxy.dmPolicy?.setPolicy(cfg, "open") as CoreConfig;
+    expect(proxy.dmPolicy?.getCurrent(cfg, "ops")).toBe("pairing");
+    const next = proxy.dmPolicy?.setPolicy(cfg, "open", "ops") as CoreConfig;
 
-    expect(next.channels?.matrix?.dm).toMatchObject({ policy: "open", allowFrom: ["*"] });
+    expect(next.channels?.matrix?.accounts?.ops?.dm).toMatchObject({
+      policy: "open",
+      allowFrom: ["@ops:example.org", "*"],
+    });
     expect(loader).not.toHaveBeenCalled();
 
     await proxy.dmPolicy?.promptAllowFrom?.({

--- a/extensions/matrix/src/setup-core.test.ts
+++ b/extensions/matrix/src/setup-core.test.ts
@@ -68,17 +68,28 @@ describe("createMatrixSetupWizardProxy", () => {
       statusLines: ["Matrix: configured"],
     };
     const getStatus = vi.fn(async () => status);
+    const configure = vi.fn(async ({ cfg }) => ({ cfg }));
     const loader = vi.fn(async () => ({
-      matrixSetupWizard: makeFakeSetupWizard({ getStatus }),
+      matrixSetupWizard: makeFakeSetupWizard({ configure, getStatus }),
     }));
     const proxy = createMatrixSetupWizardProxy(loader);
     const cfg = { channels: { matrix: {} } } as CoreConfig;
 
     const result = await proxy.getStatus({ cfg, accountOverrides: {} });
+    const configured = await proxy.configure({
+      cfg,
+      runtime: {} as never,
+      prompter: {} as never,
+      forceAllowFrom: false,
+      accountOverrides: {},
+      shouldPromptAccountIds: false,
+    });
 
     expect(loader).toHaveBeenCalledTimes(1);
     expect(getStatus).toHaveBeenCalledWith({ cfg, accountOverrides: {} });
+    expect(configure).toHaveBeenCalledTimes(1);
     expect(result).toBe(status);
+    expect(configured).toEqual({ cfg });
   });
 
   it("keeps sync dmPolicy helpers local and lazy-loads only promptAllowFrom", async () => {

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -46,7 +46,11 @@ function setMatrixDmPolicy(cfg: CoreConfig, policy: DmPolicy, accountId?: string
 export function createMatrixSetupWizardProxy(
   loadWizardModule: () => Promise<MatrixSetupWizardModule>,
 ): ChannelSetupWizardAdapter {
-  const loadWizard = async () => (await loadWizardModule()).matrixSetupWizard;
+  let wizardPromise: Promise<ChannelSetupWizardAdapter> | null = null;
+  const loadWizard = () => {
+    wizardPromise ??= loadWizardModule().then((module) => module.matrixSetupWizard);
+    return wizardPromise;
+  };
   return {
     channel,
     getStatus: async (ctx) => await (await loadWizard()).getStatus(ctx),

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -1,16 +1,110 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   DEFAULT_ACCOUNT_ID,
+  type DmPolicy,
   normalizeAccountId,
   prepareScopedSetupConfig,
   type ChannelSetupAdapter,
+  type ChannelSetupWizardAdapter,
 } from "openclaw/plugin-sdk/setup";
+import { resolveDefaultMatrixAccountId, resolveMatrixAccountConfig } from "./matrix/accounts.js";
+import { resolveMatrixConfigFieldPath, updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { applyMatrixSetupAccountConfig, validateMatrixSetupInput } from "./setup-config.js";
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;
+type MatrixSetupWizardModule = { matrixSetupWizard: ChannelSetupWizardAdapter };
 
 function resolveMatrixSetupAccountId(params: { accountId?: string; name?: string }): string {
   return normalizeAccountId(params.accountId?.trim() || params.name?.trim() || DEFAULT_ACCOUNT_ID);
+}
+
+function resolveMatrixSetupWizardAccountId(cfg: CoreConfig, accountId?: string): string {
+  return normalizeAccountId(
+    accountId?.trim() || resolveDefaultMatrixAccountId(cfg) || DEFAULT_ACCOUNT_ID,
+  );
+}
+
+function setMatrixDmPolicy(cfg: CoreConfig, policy: DmPolicy, accountId?: string): CoreConfig {
+  const resolvedAccountId = resolveMatrixSetupWizardAccountId(cfg, accountId);
+  const existing = resolveMatrixAccountConfig({
+    cfg,
+    accountId: resolvedAccountId,
+  });
+  const allowFrom =
+    policy === "open"
+      ? [...new Set([...(existing.dm?.allowFrom ?? []), "*"])]
+      : existing.dm?.allowFrom;
+  return updateMatrixAccountConfig(cfg, resolvedAccountId, {
+    dm: {
+      ...existing.dm,
+      policy,
+      ...(allowFrom ? { allowFrom } : {}),
+    },
+  });
+}
+
+export function createMatrixSetupWizardProxy(
+  loadWizardModule: () => Promise<MatrixSetupWizardModule>,
+): ChannelSetupWizardAdapter {
+  const loadWizard = async () => (await loadWizardModule()).matrixSetupWizard;
+  return {
+    channel,
+    getStatus: async (ctx) => await (await loadWizard()).getStatus(ctx),
+    configure: async (ctx) => await (await loadWizard()).configure(ctx),
+    configureInteractive: async (ctx) => {
+      const wizard = await loadWizard();
+      return await (wizard.configureInteractive ?? wizard.configure)(ctx);
+    },
+    configureWhenConfigured: async (ctx) => {
+      const wizard = await loadWizard();
+      return await (
+        wizard.configureWhenConfigured ??
+        wizard.configureInteractive ??
+        wizard.configure
+      )(ctx);
+    },
+    afterConfigWritten: async (ctx) => await (await loadWizard()).afterConfigWritten?.(ctx),
+    dmPolicy: {
+      label: "Matrix",
+      channel,
+      policyKey: "channels.matrix.dm.policy",
+      allowFromKey: "channels.matrix.dm.allowFrom",
+      resolveConfigKeys: (cfg, accountId) => {
+        const resolvedAccountId = resolveMatrixSetupWizardAccountId(cfg as CoreConfig, accountId);
+        return {
+          policyKey: resolveMatrixConfigFieldPath(
+            cfg as CoreConfig,
+            resolvedAccountId,
+            "dm.policy",
+          ),
+          allowFromKey: resolveMatrixConfigFieldPath(
+            cfg as CoreConfig,
+            resolvedAccountId,
+            "dm.allowFrom",
+          ),
+        };
+      },
+      getCurrent: (cfg, accountId) =>
+        resolveMatrixAccountConfig({
+          cfg: cfg as CoreConfig,
+          accountId: resolveMatrixSetupWizardAccountId(cfg as CoreConfig, accountId),
+        }).dm?.policy ?? "pairing",
+      setPolicy: (cfg, policy, accountId) =>
+        setMatrixDmPolicy(cfg as CoreConfig, policy, accountId) as OpenClawConfig,
+      promptAllowFrom: async (params) => {
+        const promptAllowFrom = (await loadWizard()).dmPolicy?.promptAllowFrom;
+        return promptAllowFrom ? await promptAllowFrom(params) : params.cfg;
+      },
+    },
+    disable: (cfg) => ({
+      ...(cfg as CoreConfig),
+      channels: {
+        ...(cfg as CoreConfig).channels,
+        matrix: { ...(cfg as CoreConfig).channels?.matrix, enabled: false },
+      },
+    }),
+  };
 }
 
 export const matrixSetupAdapter: ChannelSetupAdapter = {

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -1,6 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
-  addWildcardAllowFrom,
   DEFAULT_ACCOUNT_ID,
   type DmPolicy,
   normalizeAccountId,
@@ -11,6 +10,7 @@ import {
 import { resolveDefaultMatrixAccountId, resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { resolveMatrixConfigFieldPath, updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { applyMatrixSetupAccountConfig, validateMatrixSetupInput } from "./setup-config.js";
+import { resolveMatrixSetupDmAllowFrom } from "./setup-dm-policy.js";
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;
@@ -32,13 +32,12 @@ function setMatrixDmPolicy(cfg: CoreConfig, policy: DmPolicy, accountId?: string
     cfg,
     accountId: resolvedAccountId,
   });
-  const allowFrom =
-    policy === "open" ? addWildcardAllowFrom(existing.dm?.allowFrom) : existing.dm?.allowFrom;
+  const allowFrom = resolveMatrixSetupDmAllowFrom(policy, existing.dm?.allowFrom);
   return updateMatrixAccountConfig(cfg, resolvedAccountId, {
     dm: {
       ...existing.dm,
       policy,
-      ...(allowFrom ? { allowFrom } : {}),
+      allowFrom,
     },
   });
 }

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
+  addWildcardAllowFrom,
   DEFAULT_ACCOUNT_ID,
   type DmPolicy,
   normalizeAccountId,
@@ -32,9 +33,7 @@ function setMatrixDmPolicy(cfg: CoreConfig, policy: DmPolicy, accountId?: string
     accountId: resolvedAccountId,
   });
   const allowFrom =
-    policy === "open"
-      ? [...new Set([...(existing.dm?.allowFrom ?? []), "*"])]
-      : existing.dm?.allowFrom;
+    policy === "open" ? addWildcardAllowFrom(existing.dm?.allowFrom) : existing.dm?.allowFrom;
   return updateMatrixAccountConfig(cfg, resolvedAccountId, {
     dm: {
       ...existing.dm,

--- a/extensions/matrix/src/setup-dm-policy.ts
+++ b/extensions/matrix/src/setup-dm-policy.ts
@@ -1,0 +1,15 @@
+import type { DmPolicy } from "openclaw/plugin-sdk/config-runtime";
+import { addWildcardAllowFrom, normalizeAllowFromEntries } from "openclaw/plugin-sdk/setup";
+import type { MatrixConfig } from "./types.js";
+
+type MatrixDmAllowFrom = NonNullable<MatrixConfig["dm"]>["allowFrom"];
+
+export function resolveMatrixSetupDmAllowFrom(
+  policy: DmPolicy,
+  allowFrom: MatrixDmAllowFrom,
+): string[] {
+  if (policy === "open") {
+    return addWildcardAllowFrom(allowFrom);
+  }
+  return normalizeAllowFromEntries(allowFrom ?? []).filter((entry) => entry !== "*");
+}

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -187,6 +187,13 @@ describe("bundled plugin metadata", () => {
     });
   });
 
+  it("keeps Matrix's narrow runtime-setter sidecar on the bundled public surface", () => {
+    const matrix = listRepoBundledPluginMetadata().find((entry) => entry.dirName === "matrix");
+    expectArtifactPresence(matrix?.publicSurfaceArtifacts, {
+      contains: ["runtime-setter-api.js"],
+    });
+  });
+
   it("keeps bundled configured-state metadata on channel package manifests", () => {
     const configuredChannels = listRepoBundledPluginMetadata()
       .filter((entry) => ["discord", "irc", "slack", "telegram"].includes(entry.dirName))

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -238,4 +238,15 @@ describe("runtime api guardrails", () => {
       );
     }
   });
+
+  it("keeps Matrix's narrow runtime-setter entrypoint pinned to a single export", () => {
+    const setterFile = bundledPluginFile({
+      rootDir: ROOT_DIR,
+      pluginId: "matrix",
+      relativePath: "runtime-setter-api.ts",
+    });
+    expect(readExportStatements(setterFile)).toEqual([
+      'export { setMatrixRuntime } from "./src/runtime.js";',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Matrix bundled channel registration was paying the broad `runtime-api.js` and setup/doctor surface import costs on the cold register path.
- Why it matters: Matrix plugin startup/registration is already dominated by Jiti/transpile work, so avoidable eager imports add seconds to gateway/channel startup.
- What changed: added a narrow `runtime-setter-api.ts` sidecar, pointed Matrix channel/setup entries at it, proxied Matrix setup wizard loading, lazy-loaded doctor execution, and replaced a couple of broad imports with narrow/local equivalents.
- What did NOT change (scope boundary): no Matrix runtime semantics, config schema, auth, messaging, encryption, or setup behavior intentionally changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69317
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: Matrix did not have a guardrail pinning a narrow runtime setter sidecar, so the bundled entry used the broader `runtime-api.js` path.
- Contributing context (if known): Slack recently got the same style of register-time deferral in #69317.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/setup-core.test.ts`, `src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`, `src/plugins/bundled-plugin-metadata.test.ts`
- Scenario the test should lock in: Matrix setup proxy stays lazy and Matrix runtime setter sidecar stays a single-export public surface.
- Why this is the smallest reliable guardrail: it pins the entrypoint contract and the lazy setup seam without exercising live Matrix.
- Existing test that already covers this (if any): existing Matrix plugin/index tests cover bundled entry shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Matrix cold plugin registration is faster. No config or feature behavior changed.

## Diagram (if applicable)

```text
Before:
register Matrix -> runtime-api.js barrel -> setup/doctor/shared surfaces -> channel plugin load

After:
register Matrix -> runtime-setter-api.js -> channel plugin load -> setup/doctor loaded only when used
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): N/A

### Steps

1. Build dist output with `pnpm build`.
2. Run cold Matrix register benchmark in fresh Node processes with `OPENCLAW_PLUGIN_LOAD_PROFILE=1` and `OPENCLAW_DISABLE_BUNDLED_ENTRY_SOURCE_FALLBACK=1`.
3. Run repo gates for touched surface.

### Expected

- Matrix `setChannelRuntime` no longer imports the broad runtime barrel.
- Matrix setup and doctor surfaces are deferred until actually used.
- Matrix tests and plugin contract guardrails pass.

### Actual

- `setChannelRuntime` dropped from 1938.1ms avg to 152.1ms avg in the local cold-register benchmark.
- `register()` total dropped from 11134.5ms avg to 9569.7ms avg.
- Gates passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Cold Matrix register benchmark, dist-mode, 7 measured runs, 1 warmup excluded, fresh Node process per sample:

| Metric | Baseline avg | Patched avg | Delta | Delta % | Baseline p50 | Patched p50 |
|---|---:|---:|---:|---:|---:|---:|
| `register()` total | 11134.5 ms | 9569.7 ms | -1564.8 ms | -14.1% | 10851.5 ms | 9528.9 ms |
| `setChannelRuntime` | 1938.1 ms | 152.1 ms | -1786.0 ms | -92.2% | 1774.6 ms | 151.8 ms |
| `loadChannelPlugin` | 9196.2 ms | 9417.4 ms | +221.2 ms | +2.4% | 9000.9 ms | 9377.0 ms |
| `registerChannel` | 0.0 ms | 0.0 ms | ~0 | n/a | 0.0 ms | 0.0 ms |

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/matrix/index.test.ts extensions/matrix/src/setup-core.test.ts src/plugins/bundled-plugin-metadata.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
  - `pnpm tsgo:extensions`
  - `pnpm tsgo:extensions:test`
  - `pnpm build`
  - `pnpm check:changed`
  - repeated after rebase onto current `origin/main`: `pnpm build`, `pnpm check:changed`
- Edge cases checked: setup proxy construction does not load setup surface; sync dmPolicy helpers remain local; promptAllowFrom still delegates lazily.
- What you did **not** verify: live Matrix login/send/encryption flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: setup wizard proxy could drift from the real Matrix onboarding adapter.
  - Mitigation: proxy tests cover lazy construction, setup status delegation, local dmPolicy helpers, and lazy promptAllowFrom delegation.
- Risk: future edits could broaden the runtime setter sidecar again.
  - Mitigation: plugin SDK runtime guardrail pins `runtime-setter-api.ts` to a single export.
