### PR TITLE
perf: speed up telegram channel registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
 - Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`. (#69782) Thanks @gumadeiras.
 - QQBot: extract a self-contained `engine/` architecture with QR-code onboarding, native approval handling via `/bot-approve`, per-account isolated resource stacks and multi-account logger, credential backup/restore, shared `~/.openclaw/media` payload root, and unified API/bridge/gateway modules. (#67960) Thanks @cxyhhhhh.
+- Telegram/plugin startup: load Telegram's bundled runtime setter through a narrow sidecar and let built sidecars use native loading before falling back to jiti, reducing setup-runtime registration overhead while preserving runtime API compatibility. (#69786) thanks @gumadeiras.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 - Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
 - Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`. (#69782) Thanks @gumadeiras.
 - QQBot: extract a self-contained `engine/` architecture with QR-code onboarding, native approval handling via `/bot-approve`, per-account isolated resource stacks and multi-account logger, credential backup/restore, shared `~/.openclaw/media` payload root, and unified API/bridge/gateway modules. (#67960) Thanks @cxyhhhhh.
-- Telegram/plugin startup: load Telegram's bundled runtime setter through a narrow sidecar and let built sidecars use native loading before falling back to jiti, reducing setup-runtime registration overhead while preserving runtime API compatibility. (#69786) thanks @gumadeiras.
+- Telegram/plugin startup: load Telegram's bundled runtime setter through a narrow sidecar and let built sidecars use native loading before falling back to jiti, cutting the measured setup-runtime registration path by about 14s while preserving runtime API compatibility. (#69786) thanks @gumadeiras.
 
 ### Fixes
 

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -14,7 +14,7 @@ export default defineBundledChannelEntry({
     exportName: "channelSecrets",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setTelegramRuntime",
   },
   accountInspect: {

--- a/extensions/telegram/runtime-setter-api.ts
+++ b/extensions/telegram/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled registration fast: the runtime setter is needed during plugin
+// bootstrap, but the broad runtime-api barrel is only for compatibility callers.
+export { setTelegramRuntime } from "./src/runtime.js";

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -27,6 +27,7 @@
   "dist/extensions/signal/runtime-api.js",
   "dist/extensions/slack/runtime-api.js",
   "dist/extensions/telegram/runtime-api.js",
+  "dist/extensions/telegram/runtime-setter-api.js",
   "dist/extensions/tlon/runtime-api.js",
   "dist/extensions/twitch/runtime-api.js",
   "dist/extensions/voice-call/runtime-api.js",

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -15,6 +15,7 @@
   "dist/extensions/lobster/runtime-api.js",
   "dist/extensions/matrix/helper-api.js",
   "dist/extensions/matrix/runtime-api.js",
+  "dist/extensions/matrix/runtime-setter-api.js",
   "dist/extensions/matrix/thread-bindings-runtime.js",
   "dist/extensions/mattermost/runtime-api.js",
   "dist/extensions/memory-core/runtime-api.js",

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -17,7 +17,10 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-async function expectBuiltArtifactNodeRequireFastPath(scope: string): Promise<void> {
+async function expectBuiltArtifactNodeRequireFastPath(
+  scope: string,
+  artifactRoot = "dist",
+): Promise<void> {
   vi.stubEnv("OPENCLAW_PLUGIN_LOAD_PROFILE", "1");
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -29,7 +32,7 @@ async function expectBuiltArtifactNodeRequireFastPath(scope: string): Promise<vo
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);
 
-    const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
+    const pluginRoot = path.join(tempRoot, artifactRoot, "extensions", "telegram");
     fs.mkdirSync(pluginRoot, { recursive: true });
 
     const importerPath = path.join(pluginRoot, "index.js");
@@ -182,13 +185,8 @@ describe("loadBundledEntryExportSync", () => {
     await expectBuiltArtifactNodeRequireFastPath("built-artifact-profile-fast-path");
   });
 
-  it("keeps Win32 built sidecar loads on the nodeRequire fast-path", async () => {
-    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    try {
-      await expectBuiltArtifactNodeRequireFastPath("win32-profile-fast-path");
-    } finally {
-      platformSpy.mockRestore();
-    }
+  it("keeps dist-runtime built sidecar loads on the nodeRequire fast-path", async () => {
+    await expectBuiltArtifactNodeRequireFastPath("dist-runtime-profile-fast-path", "dist-runtime");
   });
 
   it("can disable source-tree fallback for dist bundled entry checks", () => {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -17,6 +17,47 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+async function expectBuiltArtifactNodeRequireFastPath(scope: string): Promise<void> {
+  vi.stubEnv("OPENCLAW_PLUGIN_LOAD_PROFILE", "1");
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  try {
+    const channelEntryContract = await importFreshModule<
+      typeof import("./channel-entry-contract.js")
+    >(import.meta.url, `./channel-entry-contract.js?scope=${scope}`);
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
+    tempDirs.push(tempRoot);
+
+    const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+
+    const importerPath = path.join(pluginRoot, "index.js");
+    const sidecarPath = path.join(pluginRoot, "fast-path-sidecar.js");
+    fs.writeFileSync(importerPath, "export default {};\n", "utf8");
+    // CommonJS so `nodeRequire` succeeds without falling back to jiti.
+    fs.writeFileSync(sidecarPath, "module.exports = { sentinel: 7 };\n", "utf8");
+
+    expect(
+      channelEntryContract.loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {
+        specifier: "./fast-path-sidecar.js",
+        exportName: "sentinel",
+      }),
+    ).toBe(7);
+
+    const profileLine = errorSpy.mock.calls
+      .map((args) => String(args[0] ?? ""))
+      .find((line) => line.startsWith("[plugin-load-profile] phase=bundled-entry-module-load"));
+    expect(profileLine, "expected a bundled-entry-module-load profile line").toBeDefined();
+    expect(profileLine).toContain("getJitiMs=0.0");
+    expect(profileLine).toContain("jitiCallMs=0.0");
+    expect(profileLine).not.toMatch(/getJitiMs=-/);
+    expect(profileLine).not.toMatch(/jitiCallMs=-/);
+  } finally {
+    errorSpy.mockRestore();
+  }
+}
+
 describe("loadBundledEntryExportSync", () => {
   it("includes importer and resolved path context when a bundled sidecar is missing", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
@@ -133,49 +174,19 @@ describe("loadBundledEntryExportSync", () => {
     });
   });
 
-  it("emits zero jiti sub-step timings on the Win32 nodeRequire fast-path", async () => {
-    // The Win32 fast-path goes through `nodeRequire` directly and never
+  it("emits zero jiti sub-step timings on the built-artifact nodeRequire fast-path", async () => {
+    // The built-artifact fast-path goes through `nodeRequire` directly and never
     // touches jiti. The plugin-load-profile line must reflect that with
     // `getJitiMs=0.0 jitiCallMs=0.0` rather than negative or full-elapsed
     // values that would mis-attribute nodeRequire time to jiti sub-steps.
+    await expectBuiltArtifactNodeRequireFastPath("built-artifact-profile-fast-path");
+  });
+
+  it("keeps Win32 built sidecar loads on the nodeRequire fast-path", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    vi.stubEnv("OPENCLAW_PLUGIN_LOAD_PROFILE", "1");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
     try {
-      const channelEntryContract = await importFreshModule<
-        typeof import("./channel-entry-contract.js")
-      >(import.meta.url, "./channel-entry-contract.js?scope=win32-profile-fast-path");
-
-      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
-      tempDirs.push(tempRoot);
-
-      const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
-      fs.mkdirSync(pluginRoot, { recursive: true });
-
-      const importerPath = path.join(pluginRoot, "index.js");
-      const sidecarPath = path.join(pluginRoot, "fast-path-sidecar.js");
-      fs.writeFileSync(importerPath, "export default {};\n", "utf8");
-      // CommonJS so `nodeRequire` succeeds without falling back to jiti.
-      fs.writeFileSync(sidecarPath, "module.exports = { sentinel: 7 };\n", "utf8");
-
-      expect(
-        channelEntryContract.loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {
-          specifier: "./fast-path-sidecar.js",
-          exportName: "sentinel",
-        }),
-      ).toBe(7);
-
-      const profileLine = errorSpy.mock.calls
-        .map((args) => String(args[0] ?? ""))
-        .find((line) => line.startsWith("[plugin-load-profile] phase=bundled-entry-module-load"));
-      expect(profileLine, "expected a bundled-entry-module-load profile line").toBeDefined();
-      expect(profileLine).toContain("getJitiMs=0.0");
-      expect(profileLine).toContain("jitiCallMs=0.0");
-      expect(profileLine).not.toMatch(/getJitiMs=-/);
-      expect(profileLine).not.toMatch(/jitiCallMs=-/);
+      await expectBuiltArtifactNodeRequireFastPath("win32-profile-fast-path");
     } finally {
-      errorSpy.mockRestore();
       platformSpy.mockRestore();
     }
   });

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -316,6 +316,13 @@ function getJiti(modulePath: string) {
   });
 }
 
+function canTryNodeRequireBuiltModule(modulePath: string): boolean {
+  return (
+    modulePath.includes(`${path.sep}dist${path.sep}`) &&
+    [".js", ".mjs", ".cjs"].includes(normalizeLowercaseStringOrEmpty(path.extname(modulePath)))
+  );
+}
+
 function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): unknown {
   const modulePath = resolveBundledEntryModulePath(importMetaUrl, specifier);
   const cached = loadedModuleExports.get(modulePath);
@@ -326,11 +333,7 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
   const profile = shouldProfilePluginLoader();
   const loadStartMs = profile ? performance.now() : 0;
   let getJitiEndMs = 0;
-  if (
-    process.platform === "win32" &&
-    modulePath.includes(`${path.sep}dist${path.sep}`) &&
-    [".js", ".mjs", ".cjs"].includes(normalizeLowercaseStringOrEmpty(path.extname(modulePath)))
-  ) {
+  if (canTryNodeRequireBuiltModule(modulePath)) {
     try {
       loaded = nodeRequire(modulePath);
     } catch {
@@ -355,7 +358,7 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
         pluginId: "(bundled-entry)",
         source: modulePath,
         elapsedMs: endMs - loadStartMs,
-        // When the Win32 fast-path resolves the module via `nodeRequire`,
+        // When the built-artifact fast-path resolves the module via `nodeRequire`,
         // `getJitiEndMs` stays `0` because the `catch` block (the only place
         // it gets stamped) never runs. Reporting `getJitiMs` /
         // `jitiCallMs` as `0` for that path keeps the breakdown honest:

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -317,8 +317,11 @@ function getJiti(modulePath: string) {
 }
 
 function canTryNodeRequireBuiltModule(modulePath: string): boolean {
+  const isBuiltBundledArtifact =
+    modulePath.includes(`${path.sep}dist${path.sep}`) ||
+    modulePath.includes(`${path.sep}dist-runtime${path.sep}`);
   return (
-    modulePath.includes(`${path.sep}dist${path.sep}`) &&
+    isBuiltBundledArtifact &&
     [".js", ".mjs", ".cjs"].includes(normalizeLowercaseStringOrEmpty(path.extname(modulePath)))
   );
 }

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -165,6 +165,16 @@ describe("bundled plugin metadata", () => {
     });
   });
 
+  it("keeps Telegram's narrow runtime setter on the bundled runtime sidecar surface", () => {
+    const telegram = listRepoBundledPluginMetadata().find((entry) => entry.dirName === "telegram");
+    expectArtifactPresence(telegram?.publicSurfaceArtifacts, {
+      contains: ["runtime-setter-api.js"],
+    });
+    expectArtifactPresence(telegram?.runtimeSidecarArtifacts, {
+      contains: ["runtime-setter-api.js"],
+    });
+  });
+
   it("loads tlon channel config metadata from the lightweight schema surface", () => {
     expect(collectRepoBundledChannelConfigsForTest("tlon")?.tlon).toEqual(
       expect.objectContaining({

--- a/src/plugins/bundled-plugin-scan.ts
+++ b/src/plugins/bundled-plugin-scan.ts
@@ -8,6 +8,7 @@ const RUNTIME_SIDECAR_ARTIFACTS = new Set([
   "helper-api.js",
   "light-runtime-api.js",
   "runtime-api.js",
+  "runtime-setter-api.js",
   "thread-bindings-runtime.js",
 ]);
 


### PR DESCRIPTION
## Summary

- Problem: Telegram bundled registration paid a broad runtime barrel load during runtime wiring and jiti overhead when loading built bundled sidecars.
- Why it matters: setup-runtime registration is on lightweight startup/plugin discovery paths; Telegram was taking ~14s in the measured path.
- What changed: add a narrow Telegram runtime setter sidecar, package that sidecar, and let built bundled sidecars try native `require` before falling back to jiti.
- What did NOT change (scope boundary): no Telegram behavior/config changes, no source `.ts` sidecar loading changes, no full-suite gate.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: bundled runtime sidecar coverage did not include narrow setter sidecars yet.
- Contributing context (if known): `runtime-api.js` remains a compatibility barrel and imports much more than runtime wiring needs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/channel-entry-contract.test.ts`, `src/plugins/bundled-plugin-metadata.test.ts`
- Scenario the test should lock in: built sidecars can use the native fast path, Win32 remains covered, and Telegram's narrow setter sidecar stays on the packaged runtime sidecar surface.
- Why this is the smallest reliable guardrail: these tests pin the loader and packaging seams directly.
- Existing test that already covers this (if any): runtime API export guardrail remains unchanged for broad compatibility barrels.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None. Installed npm packages after release should spend less time in bundled Telegram setup-runtime registration.

## Diagram (if applicable)

```text
Before:
register telegram -> runtime-api.js barrel -> broad graph load -> channel plugin load

After:
register telegram -> runtime-setter-api.js -> runtime store only
                  -> built sidecar native load, with jiti fallback
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.14.1, local repo build
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): N/A

### Steps

1. Build the repo.
2. Benchmark Telegram bundled registration for `setup-runtime` mode with 7 measured runs and 1 warmup.
3. Compare `bundled-register:setChannelRuntime`, `bundled-register:loadChannelPlugin`, and total registration timings.

### Expected

- Telegram runtime wiring loads the narrow setter sidecar.
- Built bundled sidecars try native loading and keep jiti fallback.
- Telegram setup-runtime registration is materially faster.

### Actual

- `setChannelRuntime` avg: 10521.0ms -> 3.4ms
- `loadChannelPlugin` avg: 3535.8ms -> 1127.5ms
- `register` avg: 14056.9ms -> 1131.1ms
- `total` avg: 14112.8ms -> 1188.6ms

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm build`
  - `pnpm runtime-sidecars:check`
  - `pnpm test src/plugin-sdk/channel-entry-contract.test.ts src/plugins/bundled-plugin-metadata.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts extensions/telegram/index.test.ts`
  - `pnpm test src/plugin-sdk/channel-entry-contract.test.ts`
  - `git diff --check`
- Edge cases checked: jiti fallback remains in the loader; explicit Win32 fast-path regression coverage remains.
- What you did **not** verify: full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Native load might fail for some built sidecars.
  - Mitigation: the loader catches native failures and falls back to the existing jiti path.
