### PR TITLE
perf: speed up discord channel registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`. (#69782) Thanks @gumadeiras.
 - QQBot: extract a self-contained `engine/` architecture with QR-code onboarding, native approval handling via `/bot-approve`, per-account isolated resource stacks and multi-account logger, credential backup/restore, shared `~/.openclaw/media` payload root, and unified API/bridge/gateway modules. (#67960) Thanks @cxyhhhhh.
 - Telegram/plugin startup: load Telegram's bundled runtime setter through a narrow sidecar and let built sidecars use native loading before falling back to jiti, cutting the measured setup-runtime registration path by about 14s while preserving runtime API compatibility. (#69786) thanks @gumadeiras.
+- Discord/plugin startup: load Discord's bundled runtime setter through a narrow sidecar so setup-runtime registration avoids the broad runtime barrel while preserving runtime API compatibility. (#69791) thanks @gumadeiras.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/startup: narrow Matrix runtime registration and defer setup/doctor surfaces so cold plugin registration spends about 1.8s less in `setChannelRuntime`. (#69782) Thanks @gumadeiras.
 - QQBot: extract a self-contained `engine/` architecture with QR-code onboarding, native approval handling via `/bot-approve`, per-account isolated resource stacks and multi-account logger, credential backup/restore, shared `~/.openclaw/media` payload root, and unified API/bridge/gateway modules. (#67960) Thanks @cxyhhhhh.
 - Telegram/plugin startup: load Telegram's bundled runtime setter through a narrow sidecar and let built sidecars use native loading before falling back to jiti, cutting the measured setup-runtime registration path by about 14s while preserving runtime API compatibility. (#69786) thanks @gumadeiras.
-- Discord/plugin startup: load Discord's bundled runtime setter through a narrow sidecar so setup-runtime registration avoids the broad runtime barrel while preserving runtime API compatibility. (#69791) thanks @gumadeiras.
+- Discord/plugin startup: load Discord's bundled runtime setter through a narrow sidecar so setup-runtime registration avoids the broad runtime barrel, cutting measured registration time by about 98% (18.5s to 0.44s) while preserving runtime API compatibility. (#69791) thanks @gumadeiras.
 
 ### Fixes
 

--- a/extensions/discord/index.ts
+++ b/extensions/discord/index.ts
@@ -19,7 +19,7 @@ export default defineBundledChannelEntry({
     exportName: "discordPlugin",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setDiscordRuntime",
   },
   accountInspect: {

--- a/extensions/discord/runtime-setter-api.ts
+++ b/extensions/discord/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled registration fast: runtime wiring only needs the store setter,
+// while runtime-api.js remains the broad compatibility barrel.
+export { setDiscordRuntime } from "./src/runtime.js";

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -5,6 +5,7 @@
   "dist/extensions/copilot-proxy/runtime-api.js",
   "dist/extensions/diffs/runtime-api.js",
   "dist/extensions/discord/runtime-api.js",
+  "dist/extensions/discord/runtime-setter-api.js",
   "dist/extensions/feishu/runtime-api.js",
   "dist/extensions/google/runtime-api.js",
   "dist/extensions/googlechat/runtime-api.js",

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -175,6 +175,16 @@ describe("bundled plugin metadata", () => {
     });
   });
 
+  it("keeps Discord's narrow runtime setter on the bundled runtime sidecar surface", () => {
+    const discord = listRepoBundledPluginMetadata().find((entry) => entry.dirName === "discord");
+    expectArtifactPresence(discord?.publicSurfaceArtifacts, {
+      contains: ["runtime-setter-api.js"],
+    });
+    expectArtifactPresence(discord?.runtimeSidecarArtifacts, {
+      contains: ["runtime-setter-api.js"],
+    });
+  });
+
   it("loads tlon channel config metadata from the lightweight schema surface", () => {
     expect(collectRepoBundledChannelConfigsForTest("tlon")?.tlon).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- Problem: Discord bundled registration pays a broad runtime barrel load during runtime wiring, and built bundled sidecars still pay jiti overhead on non-Windows platforms.
- Why it matters: setup-runtime registration is on lightweight startup/plugin discovery paths; Discord measured at ~18s before this change.
- What changed: add a narrow Discord runtime setter sidecar, package that sidecar, and let built bundled sidecars try native `require` before falling back to jiti.
- What did NOT change (scope boundary): no Discord behavior/config changes, no source `.ts` sidecar loading changes, no full-suite gate.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69786
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: bundled runtime sidecar coverage did not include narrow setter sidecars yet.
- Contributing context (if known): `runtime-api.js` remains a compatibility barrel and imports much more than runtime wiring needs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/channel-entry-contract.test.ts`, `src/plugins/bundled-plugin-metadata.test.ts`
- Scenario the test should lock in: built sidecars can use the native fast path, Win32 remains covered, and Discord's narrow setter sidecar stays on the packaged runtime sidecar surface.
- Why this is the smallest reliable guardrail: these tests pin the loader and packaging seams directly.
- Existing test that already covers this (if any): runtime API export guardrail remains unchanged for broad compatibility barrels.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None. Installed npm packages after release should spend less time in bundled Discord setup-runtime registration.

## Diagram (if applicable)

```text
Before:
register discord -> runtime-api.js barrel -> broad graph load -> channel plugin load

After:
register discord -> runtime-setter-api.js -> runtime store only
                 -> built sidecar native load, with jiti fallback
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo build
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Build the repo.
2. Benchmark Discord bundled registration for `setup-runtime` mode with 7 measured runs and 1 warmup.
3. Compare `bundled-register:setChannelRuntime`, `bundled-register:loadChannelPlugin`, and total registration timings.

### Expected

- Discord runtime wiring loads the narrow setter sidecar.
- Built bundled sidecars try native loading and keep jiti fallback.
- Discord setup-runtime registration is materially faster.

### Actual

- `setChannelRuntime` avg: 17801.2ms -> 3.3ms
- `loadChannelPlugin` avg: 562.3ms -> 370.7ms
- `register` avg: 18363.6ms -> 374.1ms
- `total` avg: 18496.2ms -> 439.4ms

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm build`
  - `pnpm runtime-sidecars:check`
  - `pnpm test src/plugin-sdk/channel-entry-contract.test.ts src/plugins/bundled-plugin-metadata.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts extensions/discord/index.test.ts`
  - `git diff --check`
- Edge cases checked: jiti fallback remains in the loader; explicit Win32 fast-path regression coverage remains.
- What you did **not** verify: full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Native load might fail for some built sidecars.
  - Mitigation: the loader catches native failures and falls back to the existing jiti path.
