### PR TITLE
fix(openshell): pin host writes to sandbox root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Exec/allowlist: reject POSIX parameter expansion forms such as `$VAR`, `$?`, `$$`, `$1`, and `$@` inside unquoted heredocs during shell approval analysis, so these heredocs no longer pass allowlist review as plain text. (#69795) Thanks @drobison00.
 - Gateway/MCP loopback: derive owner-only tool visibility from distinct authenticated owner vs non-owner loopback bearers instead of the caller-controlled owner header, so non-owner MCP child processes cannot recover owner access by spoofing request metadata. (#69796)
 - GitHub Copilot: update the default Opus model from `claude-opus-4.6` to `claude-opus-4.7` after GitHub removed Copilot support for 4.6. (#69818) Thanks @shakkernerd.
+- OpenShell: pin host-side sandbox writes under the mounted root so symlink-parent rebinds cannot redirect `writeFile` outside the workspace during local mirror updates. (#69797) Thanks @drobison00.
 
 ## 2026.4.20
 

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -70,6 +70,12 @@ class OpenShellFsBridge implements SandboxFsBridge {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     this.ensureWritable(target, "write files");
+    await assertLocalPathSafety({
+      target,
+      root: target.mountHostRoot,
+      allowMissingLeaf: true,
+      allowFinalSymlinkForUnlink: false,
+    });
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -6,7 +6,7 @@ import type {
   SandboxResolvedPath,
 } from "openclaw/plugin-sdk/sandbox";
 import { createWritableRenameTargetResolver } from "openclaw/plugin-sdk/sandbox";
-import { writeFileWithinRoot } from "../../../src/infra/fs-safe.js";
+import { writeFileWithinRoot } from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenShellFsBridgeContext, OpenShellSandboxBackend } from "./backend.types.js";
 import { movePathWithCopyFallback } from "./mirror.js";
 

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -6,6 +6,7 @@ import type {
   SandboxResolvedPath,
 } from "openclaw/plugin-sdk/sandbox";
 import { createWritableRenameTargetResolver } from "openclaw/plugin-sdk/sandbox";
+import { writeFileWithinRoot } from "../../../src/infra/fs-safe.js";
 import type { OpenShellFsBridgeContext, OpenShellSandboxBackend } from "./backend.types.js";
 import { movePathWithCopyFallback } from "./mirror.js";
 
@@ -69,25 +70,15 @@ class OpenShellFsBridge implements SandboxFsBridge {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     this.ensureWritable(target, "write files");
-    await assertLocalPathSafety({
-      target,
-      root: target.mountHostRoot,
-      allowMissingLeaf: true,
-      allowFinalSymlinkForUnlink: false,
-    });
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
-    const parentDir = path.dirname(hostPath);
-    if (params.mkdir !== false) {
-      await fsPromises.mkdir(parentDir, { recursive: true });
-    }
-    const tempPath = path.join(
-      parentDir,
-      `.openclaw-openshell-write-${path.basename(hostPath)}-${process.pid}-${Date.now()}`,
-    );
-    await fsPromises.writeFile(tempPath, buffer);
-    await fsPromises.rename(tempPath, hostPath);
+    await writeFileWithinRoot({
+      rootDir: target.mountHostRoot,
+      relativePath: path.relative(target.mountHostRoot, hostPath),
+      data: buffer,
+      mkdir: params.mkdir,
+    });
     await this.backend.syncLocalPathToRemote(hostPath, target.containerPath);
   }
 

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -277,6 +277,36 @@ describe("openshell fs bridges", () => {
     expect(backend.syncLocalPathToRemote).not.toHaveBeenCalled();
   });
 
+  it("rejects writes whose final target is a symlink inside the local mount root", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const linkedTarget = path.join(workspaceDir, "existing.txt");
+    await fs.writeFile(linkedTarget, "keep", "utf8");
+    await fs.symlink("existing.txt", path.join(workspaceDir, "link.txt"));
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(
+      bridge.writeFile({
+        filePath: "link.txt",
+        data: "owned",
+        mkdir: true,
+      }),
+    ).rejects.toThrow();
+    await expect(fs.readlink(path.join(workspaceDir, "link.txt"))).resolves.toBe("existing.txt");
+    await expect(fs.readFile(linkedTarget, "utf8")).resolves.toBe("keep");
+    expect(backend.syncLocalPathToRemote).not.toHaveBeenCalled();
+  });
+
   it("maps agent mount paths when the sandbox workspace is read-only", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -248,6 +248,35 @@ describe("openshell fs bridges", () => {
     );
   });
 
+  it("rejects symlink-parent writes instead of escaping the local mount root", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+    await fs.symlink(outsideDir, path.join(workspaceDir, "alias"));
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(
+      bridge.writeFile({
+        filePath: "alias/escape.txt",
+        data: "owned",
+        mkdir: true,
+      }),
+    ).rejects.toThrow();
+    await expect(fs.stat(path.join(outsideDir, "escape.txt"))).rejects.toThrow();
+    await expect(fs.readdir(outsideDir)).resolves.toEqual([]);
+    expect(backend.syncLocalPathToRemote).not.toHaveBeenCalled();
+  });
+
   it("maps agent mount paths when the sandbox workspace is read-only", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const agentWorkspaceDir = await makeTempDir("openclaw-openshell-agent-");


### PR DESCRIPTION
# fix(openshell): pin host writes to sandbox root

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `OpenShellFsBridge.writeFile` validated a target path and then performed `mkdir`, temp-file creation, and rename through the unresolved host path, leaving a symlink-parent race that could escape the mounted root.
- Why it matters: a sandboxed OpenShell session could create or overwrite host files outside the intended workspace mount if a parent path component was rebound during the write sequence.
- What changed: the OpenShell write path now delegates to `writeFileWithinRoot`, which uses the existing root-scoped atomic write helper, and a regression test now asserts that symlink-parent writes are rejected.
- What did NOT change (scope boundary): this change does not alter OpenShell read/remove/rename behavior, remote command handling, or any CI/workflow/configuration files.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #490 in `NVIDIA-dev/openclaw-tracking`
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the OpenShell bridge performed a check-then-use write flow, reusing an unresolved host path after async path validation instead of pinning the destination under the mount root for the actual write.
- Missing detection / guardrail: the OpenShell bridge did not reuse the existing `fs-safe` pinned write helper and had no regression test covering a symlink-parent write escape.
- Contributing context (if known): the vulnerable sequence combined `assertLocalPathSafety`, `mkdir`, temp-file creation, and rename across separate filesystem operations.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openshell/src/openshell-core.test.ts`
- Scenario the test should lock in: a write to `alias/escape.txt` must fail when `alias` is a symlinked parent path, and no file may be created outside the local mount root.
- Why this is the smallest reliable guardrail: it exercises the exact `OpenShellFsBridge.writeFile` path with a controlled local filesystem layout and verifies both rejection and no out-of-root write.
- Existing test that already covers this (if any): the same file already covered the normal local write-and-sync path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Writes through symlinked parent paths in the OpenShell sandbox backend now fail instead of creating files outside the mounted workspace root.

## Diagram (if applicable)

```text
Before:
[sandbox write to alias/file] -> [path validated lexically] -> [parent rebound to symlink] -> [host file written outside root]

After:
[sandbox write to alias/file] -> [root-scoped pinned write helper] -> [write rejected] -> [no outside file created]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: local workspace shell
- Model/provider: N/A
- Integration/channel (if any): OpenShell sandbox backend
- Relevant config (redacted): default test configuration for `test/vitest/vitest.extension-misc.config.ts`

### Steps

1. Create a temporary workspace root and an outside directory, then symlink a path inside the workspace to the outside directory.
2. Call `OpenShellFsBridge.writeFile` with a target under the symlinked parent path.
3. Verify the write rejects, no outside file is created, and the backend does not sync a host path to the remote workspace.

### Expected

- The write is rejected and no file is created outside the mounted root.

### Actual

- `pnpm exec vitest run --config test/vitest/vitest.extension-misc.config.ts openshell/src/openshell-core.test.ts --reporter=verbose` passed with `1` test file and `10` tests passing, including the new symlink-parent regression case.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: the targeted `openshell` unit test file passed on the current `upstream/main` base; the existing normal write-and-sync path still passed alongside the new rejection case.
- Edge cases checked: symlink-parent write rejection, no out-of-root file creation, and no remote sync on rejected writes.
- What you did **not** verify: live OpenShell end-to-end behavior against a real sandbox runtime.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: OpenShell writes that rely on symlinked parent aliases now fail where they may previously have succeeded.
  - Mitigation: the new path is intentionally constrained to the mounted root, and the regression test locks in the rejection behavior for out-of-root aliases.