### PR TITLE
fix(openshell): pin sandbox file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: require the same `/models` authorization for group model-picker callbacks, so unauthorized participants can no longer browse or change the session model through inline buttons. (#70235) Thanks @drobison00.
 - Agents/Pi: keep the filtered tool-name allowlist active for embedded OpenAI/OpenAI Codex GPT-5 runs and compaction sessions, so bundled and client tools still execute after the Pi `0.68.1` session-tool allowlist change instead of stopping at plan-only replies with no tool call. (#70281) Thanks @jalehman.
 - Agents/Pi: honor explicit `strict-agentic` execution contracts for incomplete-turn retry guards across providers, so manually opted-in local or compatible models get the same retry behavior without relying on OpenAI model inference. (#66750) Thanks @ziomancer.
+- OpenShell/sandbox: pin verified file reads to an already-opened descriptor, walk the ancestor chain for symlinked parents on platforms without fd-path readlink, and re-check file identity so parent symlink swaps cannot redirect in-sandbox reads to host files outside the allowed mount root. (#69798) Thanks @drobison00.
 
 ## 2026.4.21
 

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -377,11 +377,7 @@ async function openPinnedReadableFile(params: {
   if (!isPathInside(literalRoot, literalPath)) {
     throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.containerPath}`);
   }
-  const openCloseOnExecFlag = (fs.constants as Record<string, number>).O_CLOEXEC ?? 0;
-  const openReadFlags =
-    fs.constants.O_RDONLY |
-    (typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0) |
-    openCloseOnExecFlag;
+  const { flags: openReadFlags, supportsNoFollow } = resolveOpenReadFlags();
   // Open first so every later check runs against an fd that is already pinned
   // to one specific inode. `O_NOFOLLOW` prevents the final path component from
   // being a symlink; the ancestor walk below handles parent-directory symlink
@@ -421,7 +417,7 @@ async function openPinnedReadableFile(params: {
       // On platforms where `O_NOFOLLOW` is unavailable (Windows), the open
       // call would have transparently followed a final-component symlink, so
       // the ancestor walk has to lstat the leaf as well.
-      includeLeaf: typeof fs.constants.O_NOFOLLOW !== "number",
+      includeLeaf: !supportsNoFollow,
     });
     const currentResolvedStat = await fsPromises.stat(literalPath);
     if (!sameFileIdentity(currentResolvedStat, openedStat)) {
@@ -477,6 +473,37 @@ async function assertAncestorChainHasNoSymlinks(
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
     }
   }
+}
+
+type ReadOpenFlagsResolution = { flags: number; supportsNoFollow: boolean };
+
+let readOpenFlagsResolverForTest: (() => ReadOpenFlagsResolution) | undefined;
+
+function resolveOpenReadFlags(): ReadOpenFlagsResolution {
+  if (readOpenFlagsResolverForTest) {
+    return readOpenFlagsResolverForTest();
+  }
+  const closeOnExec = (fs.constants as Record<string, number>).O_CLOEXEC ?? 0;
+  const supportsNoFollow = typeof fs.constants.O_NOFOLLOW === "number";
+  const noFollow = supportsNoFollow ? fs.constants.O_NOFOLLOW : 0;
+  return {
+    flags: fs.constants.O_RDONLY | noFollow | closeOnExec,
+    supportsNoFollow,
+  };
+}
+
+/**
+ * Test-only seam for forcing the open-flag/`O_NOFOLLOW` resolution. Used to
+ * exercise the Windows-style fallback (no `O_NOFOLLOW`, ancestor walk
+ * includes the leaf) on platforms where `fs.constants.O_NOFOLLOW` is a
+ * non-configurable native data property and cannot be patched directly.
+ *
+ * @internal
+ */
+export function setReadOpenFlagsResolverForTest(
+  resolver: (() => ReadOpenFlagsResolution) | undefined,
+): void {
+  readOpenFlagsResolverForTest = resolver;
 }
 
 // Resolves the absolute path associated with an open fd via the kernel-backed

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { sameFileIdentity } from "../../../src/infra/file-identity.js";
 import { writeFileWithinRoot } from "openclaw/plugin-sdk/infra-runtime";
 import type {
   SandboxFsBridge,
@@ -364,14 +363,18 @@ async function openPinnedReadableFile(params: {
   rootPath: string;
   containerPath: string;
 }): Promise<FileHandle> {
-  const canonicalRoot = await fsPromises
-    .realpath(params.rootPath)
-    .catch(() => path.resolve(params.rootPath));
+  // The literal root is what `resolveTarget` joins caller-provided relative
+  // paths against, so pre-open containment must be checked in literal form.
+  // The canonical root is derived separately and used for the post-open
+  // path checks (fd-path readlink and realpath cross-check), so a workspace
+  // that is itself configured as a symlink still works.
+  const literalRoot = path.resolve(params.rootPath);
+  const canonicalRoot = await fsPromises.realpath(literalRoot).catch(() => literalRoot);
   const literalPath = path.resolve(params.absolutePath);
   // Cheap string-prefix check on the caller-provided absolute path; no
   // filesystem state is read here, so there is no TOCTOU window. Deeper
   // checks run after the fd is pinned.
-  if (!isPathInside(canonicalRoot, literalPath)) {
+  if (!isPathInside(literalRoot, literalPath)) {
     throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.containerPath}`);
   }
   const openCloseOnExecFlag = (fs.constants as Record<string, number>).O_CLOEXEC ?? 0;
@@ -408,10 +411,11 @@ async function openPinnedReadableFile(params: {
     // there is no `/proc` equivalent. With no kernel-backed path readback we
     // must prove the pinned fd is in-root without trusting a separate
     // `realpath` lookup of the caller-provided path (that pair races). Walk
-    // every ancestor between `canonicalRoot` and `literalPath` and reject if
-    // any ancestor is a symlink; then realpath the path and cross-check the
-    // resolved path and file identity against the pinned fd.
-    await assertAncestorChainHasNoSymlinks(canonicalRoot, literalPath, params.containerPath);
+    // every ancestor between `literalRoot` and `literalPath` — the actual
+    // on-disk chain — and reject if any ancestor is a symlink; then realpath
+    // the path and cross-check the canonical resolved path and file identity
+    // against the pinned fd.
+    await assertAncestorChainHasNoSymlinks(literalRoot, literalPath, params.containerPath);
     const currentResolvedPath = await fsPromises.realpath(literalPath);
     if (!isPathInside(canonicalRoot, currentResolvedPath)) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
@@ -477,4 +481,31 @@ function normalizeOpenedReadablePath(openedPath: string): string {
     ? openedPath.slice(0, -deletedSuffix.length)
     : openedPath;
   return path.resolve(withoutDeletedSuffix);
+}
+
+// File identity comparison with win32-aware `dev=0` handling, matching the
+// shared `src/infra/file-identity.ts` contract. Kept local because extension
+// production code is not allowed to reach into core `src/**` by relative
+// import, and this helper is not yet part of the `openclaw/plugin-sdk/*`
+// public surface.
+function isZeroStatField(value: number | bigint): boolean {
+  return value === 0 || value === 0n;
+}
+
+function sameFileIdentity(
+  left: { dev: number | bigint; ino: number | bigint },
+  right: { dev: number | bigint; ino: number | bigint },
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (left.ino !== right.ino) {
+    return false;
+  }
+  if (left.dev === right.dev) {
+    return true;
+  }
+  // On Windows, path-based stat can report `dev=0` while fd-based stat reports
+  // a real volume serial. Treat either side `dev=0` as "unknown device"
+  // rather than a mismatch so legitimate Windows fallback reads are not
+  // rejected.
+  return platform === "win32" && (isZeroStatField(left.dev) || isZeroStatField(right.dev));
 }

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -422,6 +422,16 @@ async function openPinnedReadableFile(params: {
     if (!sameFileIdentity(currentResolvedStat, openedStat)) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
     }
+    // Belt-and-suspenders: re-fstat the pinned fd after the identity check and
+    // confirm the file type and link count are still trustworthy. A hardlink
+    // that appeared between the initial fstat and here is not exploitable for
+    // the read (the fd is already pinned to the original inode), but failing
+    // closed here keeps the guarantee simple: the bytes we return always come
+    // from a file that was a single-linked regular file at verification time.
+    const postCheckStat = await handle.stat();
+    if (!postCheckStat.isFile() || postCheckStat.nlink > 1) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
+    }
     return handle;
   } catch (error) {
     await handle.close();

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -417,7 +417,12 @@ async function openPinnedReadableFile(params: {
     // same file the fd has pinned. `fs.promises.stat` resolves the path and
     // returns the final file's identity in one syscall, so there is no
     // between-await window for an attacker to race.
-    await assertAncestorChainHasNoSymlinks(literalRoot, literalPath, params.containerPath);
+    await assertAncestorChainHasNoSymlinks(literalRoot, literalPath, params.containerPath, {
+      // On platforms where `O_NOFOLLOW` is unavailable (Windows), the open
+      // call would have transparently followed a final-component symlink, so
+      // the ancestor walk has to lstat the leaf as well.
+      includeLeaf: typeof fs.constants.O_NOFOLLOW !== "number",
+    });
     const currentResolvedStat = await fsPromises.stat(literalPath);
     if (!sameFileIdentity(currentResolvedStat, openedStat)) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
@@ -440,27 +445,35 @@ async function openPinnedReadableFile(params: {
 }
 
 // Walks each directory between canonicalRoot (exclusive) and
-// targetAbsolutePath (exclusive), `lstat`'ing each segment. Rejects if any
-// intermediate segment is a symlink or a non-directory. The final component
-// is not walked because `O_NOFOLLOW` already protects it on the open call.
+// targetAbsolutePath, `lstat`'ing each segment. Rejects if any intermediate
+// segment is a symlink or a non-directory. By default the final component is
+// not walked because `O_NOFOLLOW` already protects it on the open call. Pass
+// `includeLeaf: true` on platforms where `O_NOFOLLOW` is unavailable
+// (Windows) so a symlinked leaf cannot be followed silently by `open`.
 async function assertAncestorChainHasNoSymlinks(
   canonicalRoot: string,
   targetAbsolutePath: string,
   containerPath: string,
+  options: { includeLeaf?: boolean } = {},
 ): Promise<void> {
   const relative = path.relative(canonicalRoot, targetAbsolutePath);
   if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
     return;
   }
   const segments = relative.split(path.sep).filter((segment) => segment.length > 0);
+  const lastIndex = options.includeLeaf ? segments.length : segments.length - 1;
   let cursor = canonicalRoot;
-  for (let i = 0; i < segments.length - 1; i += 1) {
+  for (let i = 0; i < lastIndex; i += 1) {
     cursor = path.join(cursor, segments[i]);
     const stat = await fsPromises.lstat(cursor).catch(() => null);
     if (!stat) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
     }
-    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    const isLeaf = i === segments.length - 1;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
+    }
+    if (!isLeaf && !stat.isDirectory()) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
     }
   }

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs";
 import fsPromises from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
+import { sameFileIdentity } from "../../../src/infra/file-identity.js";
 import { writeFileWithinRoot } from "openclaw/plugin-sdk/infra-runtime";
 import type {
   SandboxFsBridge,
@@ -50,13 +53,16 @@ class OpenShellFsBridge implements SandboxFsBridge {
   }): Promise<Buffer> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
-    await assertLocalPathSafety({
-      target,
-      root: target.mountHostRoot,
-      allowMissingLeaf: false,
-      allowFinalSymlinkForUnlink: false,
+    const handle = await openPinnedReadableFile({
+      absolutePath: hostPath,
+      rootPath: target.mountHostRoot,
+      containerPath: target.containerPath,
     });
-    return await fsPromises.readFile(hostPath);
+    try {
+      return (await handle.readFile()) as Buffer;
+    } finally {
+      await handle.close();
+    }
   }
 
   async writeFile(params: {
@@ -351,4 +357,124 @@ async function resolveCanonicalCandidate(targetPath: string): Promise<string> {
     missing.unshift(path.basename(cursor));
     cursor = parent;
   }
+}
+
+async function openPinnedReadableFile(params: {
+  absolutePath: string;
+  rootPath: string;
+  containerPath: string;
+}): Promise<FileHandle> {
+  const canonicalRoot = await fsPromises
+    .realpath(params.rootPath)
+    .catch(() => path.resolve(params.rootPath));
+  const literalPath = path.resolve(params.absolutePath);
+  // Cheap string-prefix check on the caller-provided absolute path; no
+  // filesystem state is read here, so there is no TOCTOU window. Deeper
+  // checks run after the fd is pinned.
+  if (!isPathInside(canonicalRoot, literalPath)) {
+    throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.containerPath}`);
+  }
+  const openCloseOnExecFlag = (fs.constants as Record<string, number>).O_CLOEXEC ?? 0;
+  const openReadFlags =
+    fs.constants.O_RDONLY |
+    (typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0) |
+    openCloseOnExecFlag;
+  // Open first so every later check runs against an fd that is already pinned
+  // to one specific inode. `O_NOFOLLOW` prevents the final path component from
+  // being a symlink; the ancestor walk below handles parent-directory symlink
+  // swaps on platforms where fd-path readlink is not available.
+  const handle = await fsPromises.open(literalPath, openReadFlags);
+  try {
+    const openedStat = await handle.stat();
+    if (!openedStat.isFile()) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
+    }
+    if (openedStat.nlink > 1) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
+    }
+    const resolvedPath = await resolveOpenedReadablePath(handle.fd);
+    if (resolvedPath !== null) {
+      // Primary guarantee on Linux: the fd's resolved path is derived from the
+      // kernel, so a parent-directory swap cannot make this return a stale path.
+      if (!isPathInside(canonicalRoot, resolvedPath)) {
+        throw new Error(
+          `Sandbox boundary checks failed; cannot read files: ${params.containerPath}`,
+        );
+      }
+      return handle;
+    }
+    // Fallback for platforms where fd-path readlink is unavailable. On macOS,
+    // `/dev/fd/N` is a character device so readlink returns EINVAL; on Windows
+    // there is no `/proc` equivalent. With no kernel-backed path readback we
+    // must prove the pinned fd is in-root without trusting a separate
+    // `realpath` lookup of the caller-provided path (that pair races). Walk
+    // every ancestor between `canonicalRoot` and `literalPath` and reject if
+    // any ancestor is a symlink; then realpath the path and cross-check the
+    // resolved path and file identity against the pinned fd.
+    await assertAncestorChainHasNoSymlinks(canonicalRoot, literalPath, params.containerPath);
+    const currentResolvedPath = await fsPromises.realpath(literalPath);
+    if (!isPathInside(canonicalRoot, currentResolvedPath)) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
+    }
+    const currentLstat = await fsPromises.lstat(currentResolvedPath);
+    if (!sameFileIdentity(currentLstat, openedStat)) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
+    }
+    return handle;
+  } catch (error) {
+    await handle.close();
+    throw error;
+  }
+}
+
+// Walks each directory between canonicalRoot (exclusive) and
+// targetAbsolutePath (exclusive), `lstat`'ing each segment. Rejects if any
+// intermediate segment is a symlink or a non-directory. The final component
+// is not walked because `O_NOFOLLOW` already protects it on the open call.
+async function assertAncestorChainHasNoSymlinks(
+  canonicalRoot: string,
+  targetAbsolutePath: string,
+  containerPath: string,
+): Promise<void> {
+  const relative = path.relative(canonicalRoot, targetAbsolutePath);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return;
+  }
+  const segments = relative.split(path.sep).filter((segment) => segment.length > 0);
+  let cursor = canonicalRoot;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    cursor = path.join(cursor, segments[i]);
+    const stat = await fsPromises.lstat(cursor).catch(() => null);
+    if (!stat) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error(`Sandbox boundary checks failed; cannot read files: ${containerPath}`);
+    }
+  }
+}
+
+// Resolves the absolute path associated with an open fd via the kernel-backed
+// `/proc/self/fd/<fd>` (Linux) or `/dev/fd/<fd>` (some BSDs). Returns null
+// when no fd-path endpoint is available. Note: on macOS `/dev/fd/N` is a
+// character device rather than a symlink, so `readlink` fails with EINVAL
+// there and the caller must use the ancestor-walk fallback instead.
+async function resolveOpenedReadablePath(fd: number): Promise<string | null> {
+  for (const fdPath of [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]) {
+    try {
+      const openedPath = await fsPromises.readlink(fdPath);
+      return normalizeOpenedReadablePath(openedPath);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function normalizeOpenedReadablePath(openedPath: string): string {
+  const deletedSuffix = " (deleted)";
+  const withoutDeletedSuffix = openedPath.endsWith(deletedSuffix)
+    ? openedPath.slice(0, -deletedSuffix.length)
+    : openedPath;
+  return path.resolve(withoutDeletedSuffix);
 }

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -410,18 +410,16 @@ async function openPinnedReadableFile(params: {
     // `/dev/fd/N` is a character device so readlink returns EINVAL; on Windows
     // there is no `/proc` equivalent. With no kernel-backed path readback we
     // must prove the pinned fd is in-root without trusting a separate
-    // `realpath` lookup of the caller-provided path (that pair races). Walk
+    // `realpath` + `lstat` pair that would race between the two awaits. Walk
     // every ancestor between `literalRoot` and `literalPath` — the actual
-    // on-disk chain — and reject if any ancestor is a symlink; then realpath
-    // the path and cross-check the canonical resolved path and file identity
-    // against the pinned fd.
+    // on-disk chain — and reject if any ancestor is a symlink, then use a
+    // single `stat` call to confirm that the path still resolves to the
+    // same file the fd has pinned. `fs.promises.stat` resolves the path and
+    // returns the final file's identity in one syscall, so there is no
+    // between-await window for an attacker to race.
     await assertAncestorChainHasNoSymlinks(literalRoot, literalPath, params.containerPath);
-    const currentResolvedPath = await fsPromises.realpath(literalPath);
-    if (!isPathInside(canonicalRoot, currentResolvedPath)) {
-      throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
-    }
-    const currentLstat = await fsPromises.lstat(currentResolvedPath);
-    if (!sameFileIdentity(currentLstat, openedStat)) {
+    const currentResolvedStat = await fsPromises.stat(literalPath);
+    if (!sameFileIdentity(currentResolvedStat, openedStat)) {
       throw new Error(`Sandbox boundary checks failed; cannot read files: ${params.containerPath}`);
     }
     return handle;
@@ -487,14 +485,11 @@ function normalizeOpenedReadablePath(openedPath: string): string {
 // shared `src/infra/file-identity.ts` contract. Kept local because extension
 // production code is not allowed to reach into core `src/**` by relative
 // import, and this helper is not yet part of the `openclaw/plugin-sdk/*`
-// public surface.
-function isZeroStatField(value: number | bigint): boolean {
-  return value === 0 || value === 0n;
-}
-
+// public surface. Stats here come from `FileHandle.stat()` / `fs.promises.stat()`
+// with no `{ bigint: true }` option, so all fields are numbers.
 function sameFileIdentity(
-  left: { dev: number | bigint; ino: number | bigint },
-  right: { dev: number | bigint; ino: number | bigint },
+  left: { dev: number; ino: number },
+  right: { dev: number; ino: number },
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (left.ino !== right.ino) {
@@ -507,5 +502,5 @@ function sameFileIdentity(
   // a real volume serial. Treat either side `dev=0` as "unknown device"
   // rather than a mismatch so legitimate Windows fallback reads are not
   // rejected.
-  return platform === "win32" && (isZeroStatField(left.dev) || isZeroStatField(right.dev));
+  return platform === "win32" && (left.dev === 0 || right.dev === 0);
 }

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -419,9 +419,9 @@ describe("openshell fs bridges", () => {
     const { createOpenShellFsBridge } = await import("./fs-bridge.js");
     const bridge = createOpenShellFsBridge({ sandbox, backend });
     const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
-    const originalLstat = fs.lstat.bind(fs);
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await originalLstat(...args);
+    const originalStat = fs.stat.bind(fs);
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+      const stat = await originalStat(...args);
       if (args[0] === targetPath) {
         return cloneStatWithDev(stat, 0);
       }
@@ -433,9 +433,9 @@ describe("openshell fs bridges", () => {
         "Sandbox boundary checks failed",
       );
       expect(readlinkSpy).toHaveBeenCalled();
-      expect(lstatSpy).toHaveBeenCalledWith(targetPath);
+      expect(statSpy).toHaveBeenCalledWith(targetPath);
     } finally {
-      lstatSpy.mockRestore();
+      statSpy.mockRestore();
       readlinkSpy.mockRestore();
     }
     },

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -512,18 +512,19 @@ describe("openshell fs bridges", () => {
       },
     });
 
-    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const { createOpenShellFsBridge, setReadOpenFlagsResolverForTest } = await import(
+      "./fs-bridge.js"
+    );
     const bridge = createOpenShellFsBridge({ sandbox, backend });
     // Force the fallback path so the leaf-lstat guard is exercised.
     const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
-    // Simulate a host that lacks `O_NOFOLLOW` (e.g. Windows) by making
-    // `fs.constants.O_NOFOLLOW` look undefined to the bridge.
-    const originalNoFollow = (nodeFs.constants as Record<string, number | undefined>).O_NOFOLLOW;
-    Object.defineProperty(nodeFs.constants, "O_NOFOLLOW", {
-      configurable: true,
-      writable: true,
-      value: undefined,
-    });
+    // Simulate a host that lacks `O_NOFOLLOW` (e.g. Windows) without touching
+    // the non-configurable native `fs.constants` data property. The bridge
+    // exposes a test-only seam for exactly this case.
+    setReadOpenFlagsResolverForTest(() => ({
+      flags: nodeFs.constants.O_RDONLY,
+      supportsNoFollow: false,
+    }));
 
     try {
       await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
@@ -531,11 +532,7 @@ describe("openshell fs bridges", () => {
       );
       expect(readlinkSpy).toHaveBeenCalled();
     } finally {
-      Object.defineProperty(nodeFs.constants, "O_NOFOLLOW", {
-        configurable: true,
-        writable: true,
-        value: originalNoFollow,
-      });
+      setReadOpenFlagsResolverForTest(undefined);
       readlinkSpy.mockRestore();
     }
   });

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -347,14 +347,15 @@ describe("openshell fs bridges", () => {
     let swapped = false;
     const openSpy = vi
       .spyOn(nodeFs, "open")
-      .mockImplementation((filePath, flags, mode, cb) => {
+      .mockImplementation(((...args: unknown[]) => {
+        const filePath = args[0];
         if (!swapped && filePath === targetPath) {
           swapped = true;
           nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
           nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
         }
-        return (originalOpen as (...args: unknown[]) => unknown)(filePath, flags, mode, cb);
-      });
+        return (originalOpen as (...delegated: unknown[]) => unknown)(...args);
+      }) as unknown as typeof nodeFs.open);
 
     try {
       await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
@@ -459,14 +460,15 @@ describe("openshell fs bridges", () => {
     let swapped = false;
     const openSpy = vi
       .spyOn(nodeFs, "open")
-      .mockImplementation((filePath, flags, mode, cb) => {
+      .mockImplementation(((...args: unknown[]) => {
+        const filePath = args[0];
         if (!swapped && filePath === targetPath) {
           swapped = true;
           nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
           nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
         }
-        return (originalOpen as (...args: unknown[]) => unknown)(filePath, flags, mode, cb);
-      });
+        return (originalOpen as (...delegated: unknown[]) => unknown)(...args);
+      }) as unknown as typeof nodeFs.open);
     // Force the fallback verification path even on Linux so the ancestor-walk
     // guard is exercised directly.
     const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -1,3 +1,4 @@
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -200,6 +201,22 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
+function cloneStatWithDev<T extends nodeFs.Stats | nodeFs.BigIntStats>(
+  stat: T,
+  dev: number | bigint,
+): T {
+  return Object.defineProperty(
+    Object.create(Object.getPrototypeOf(stat), Object.getOwnPropertyDescriptors(stat)),
+    "dev",
+    {
+      value: dev,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    },
+  ) as T;
+}
+
 function createMirrorBackendMock(): OpenShellSandboxBackend {
   return {
     id: "openshell",
@@ -305,6 +322,193 @@ describe("openshell fs bridges", () => {
     await expect(fs.readlink(path.join(workspaceDir, "link.txt"))).resolves.toBe("existing.txt");
     await expect(fs.readFile(linkedTarget, "utf8")).resolves.toBe("keep");
     expect(backend.syncLocalPathToRemote).not.toHaveBeenCalled();
+  });
+
+  it("rejects a parent symlink swap that lands outside the sandbox root", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "subdir", "secret.txt"), "inside", "utf8");
+    await fs.writeFile(path.join(outsideDir, "secret.txt"), "outside", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    const originalOpen = nodeFs.open.bind(nodeFs);
+    const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
+    let swapped = false;
+    const openSpy = vi
+      .spyOn(nodeFs, "open")
+      .mockImplementation((filePath, flags, mode, cb) => {
+        if (!swapped && filePath === targetPath) {
+          swapped = true;
+          nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
+          nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
+        }
+        return (originalOpen as (...args: unknown[]) => unknown)(filePath, flags, mode, cb);
+      });
+
+    try {
+      await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
+        "Sandbox boundary checks failed",
+      );
+      expect(openSpy).toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("falls back to inode checks when fd path resolution is unavailable", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "subdir", "secret.txt"), "inside", "utf8");
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
+
+    try {
+      await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).resolves.toEqual(
+        Buffer.from("inside"),
+      );
+      expect(readlinkSpy).toHaveBeenCalled();
+    } finally {
+      readlinkSpy.mockRestore();
+    }
+  });
+
+  it("rejects fallback reads when path stats report an unknown device id", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(targetPath, "inside", "utf8");
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
+    const originalLstat = fs.lstat.bind(fs);
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const stat = await originalLstat(...args);
+      if (args[0] === targetPath) {
+        return cloneStatWithDev(stat, 0);
+      }
+      return stat;
+    });
+
+    try {
+      await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
+        "Sandbox boundary checks failed",
+      );
+      expect(readlinkSpy).toHaveBeenCalled();
+      expect(lstatSpy).toHaveBeenCalledWith(targetPath);
+    } finally {
+      lstatSpy.mockRestore();
+      readlinkSpy.mockRestore();
+    }
+  });
+
+  it("rejects fallback reads when an ancestor directory is swapped to a symlink", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "subdir", "secret.txt"), "inside", "utf8");
+    await fs.writeFile(path.join(outsideDir, "secret.txt"), "outside", "utf8");
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    const originalOpen = nodeFs.open.bind(nodeFs);
+    const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
+    let swapped = false;
+    const openSpy = vi
+      .spyOn(nodeFs, "open")
+      .mockImplementation((filePath, flags, mode, cb) => {
+        if (!swapped && filePath === targetPath) {
+          swapped = true;
+          nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
+          nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
+        }
+        return (originalOpen as (...args: unknown[]) => unknown)(filePath, flags, mode, cb);
+      });
+    // Force the fallback verification path even on Linux so the ancestor-walk
+    // guard is exercised directly.
+    const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
+
+    try {
+      await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
+        "Sandbox boundary checks failed",
+      );
+      expect(openSpy).toHaveBeenCalled();
+      expect(readlinkSpy).toHaveBeenCalled();
+    } finally {
+      readlinkSpy.mockRestore();
+      openSpy.mockRestore();
+    }
+  });
+
+  it("rejects hardlinked files inside the sandbox root", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "secret.txt"), "outside", "utf8");
+    await fs.link(
+      path.join(outsideDir, "secret.txt"),
+      path.join(workspaceDir, "subdir", "secret.txt"),
+    );
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
+      "Sandbox boundary checks failed",
+    );
   });
 
   it("maps agent mount paths when the sandbox workspace is read-only", async () => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -342,20 +342,18 @@ describe("openshell fs bridges", () => {
 
     const { createOpenShellFsBridge } = await import("./fs-bridge.js");
     const bridge = createOpenShellFsBridge({ sandbox, backend });
-    const originalOpen = nodeFs.open.bind(nodeFs);
+    const originalOpen = fs.open.bind(fs);
     const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
     let swapped = false;
-    const openSpy = vi
-      .spyOn(nodeFs, "open")
-      .mockImplementation(((...args: unknown[]) => {
-        const filePath = args[0];
-        if (!swapped && filePath === targetPath) {
-          swapped = true;
-          nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
-          nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
-        }
-        return (originalOpen as (...delegated: unknown[]) => unknown)(...args);
-      }) as unknown as typeof nodeFs.open);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation((async (...args: unknown[]) => {
+      const filePath = args[0];
+      if (!swapped && filePath === targetPath) {
+        swapped = true;
+        nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
+        nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
+      }
+      return await (originalOpen as (...delegated: unknown[]) => Promise<unknown>)(...args);
+    }) as unknown as typeof fs.open);
 
     try {
       await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
@@ -396,7 +394,13 @@ describe("openshell fs bridges", () => {
     }
   });
 
-  it("rejects fallback reads when path stats report an unknown device id", async () => {
+  // The shared `sameFileIdentity` contract intentionally treats either-side
+  // `dev=0` as "unknown device" on win32 (path-based stat can legitimately
+  // report `dev=0` there) and only fails closed on other platforms. Skip the
+  // Linux/macOS rejection expectation on Windows runners.
+  it.skipIf(process.platform === "win32")(
+    "rejects fallback reads when path stats report an unknown device id",
+    async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
     await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
@@ -434,7 +438,8 @@ describe("openshell fs bridges", () => {
       lstatSpy.mockRestore();
       readlinkSpy.mockRestore();
     }
-  });
+    },
+  );
 
   it("rejects fallback reads when an ancestor directory is swapped to a symlink", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
@@ -455,20 +460,18 @@ describe("openshell fs bridges", () => {
 
     const { createOpenShellFsBridge } = await import("./fs-bridge.js");
     const bridge = createOpenShellFsBridge({ sandbox, backend });
-    const originalOpen = nodeFs.open.bind(nodeFs);
+    const originalOpen = fs.open.bind(fs);
     const targetPath = path.join(workspaceDir, "subdir", "secret.txt");
     let swapped = false;
-    const openSpy = vi
-      .spyOn(nodeFs, "open")
-      .mockImplementation(((...args: unknown[]) => {
-        const filePath = args[0];
-        if (!swapped && filePath === targetPath) {
-          swapped = true;
-          nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
-          nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
-        }
-        return (originalOpen as (...delegated: unknown[]) => unknown)(...args);
-      }) as unknown as typeof nodeFs.open);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation((async (...args: unknown[]) => {
+      const filePath = args[0];
+      if (!swapped && filePath === targetPath) {
+        swapped = true;
+        nodeFs.rmSync(path.join(workspaceDir, "subdir"), { recursive: true, force: true });
+        nodeFs.symlinkSync(outsideDir, path.join(workspaceDir, "subdir"));
+      }
+      return await (originalOpen as (...delegated: unknown[]) => Promise<unknown>)(...args);
+    }) as unknown as typeof fs.open);
     // Force the fallback verification path even on Linux so the ancestor-walk
     // guard is exercised directly.
     const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -488,6 +488,58 @@ describe("openshell fs bridges", () => {
     }
   });
 
+  it("rejects fallback reads of a symlinked leaf when O_NOFOLLOW is unavailable", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const outsideDir = await makeTempDir("openclaw-openshell-outside-");
+    await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "secret.txt"), "outside", "utf8");
+    // The workspace contains a symlink as the FINAL path component pointing
+    // out-of-root. On Windows `O_NOFOLLOW` is `undefined`, so `open` would
+    // silently traverse the symlink to the outside file; the ancestor walk
+    // must lstat the leaf in that case to fail closed.
+    await fs.symlink(
+      path.join(outsideDir, "secret.txt"),
+      path.join(workspaceDir, "subdir", "secret.txt"),
+    );
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    // Force the fallback path so the leaf-lstat guard is exercised.
+    const readlinkSpy = vi.spyOn(fs, "readlink").mockRejectedValue(new Error("fd path unavailable"));
+    // Simulate a host that lacks `O_NOFOLLOW` (e.g. Windows) by making
+    // `fs.constants.O_NOFOLLOW` look undefined to the bridge.
+    const originalNoFollow = (nodeFs.constants as Record<string, number | undefined>).O_NOFOLLOW;
+    Object.defineProperty(nodeFs.constants, "O_NOFOLLOW", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    try {
+      await expect(bridge.readFile({ filePath: "subdir/secret.txt" })).rejects.toThrow(
+        "Sandbox boundary checks failed",
+      );
+      expect(readlinkSpy).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(nodeFs.constants, "O_NOFOLLOW", {
+        configurable: true,
+        writable: true,
+        value: originalNoFollow,
+      });
+      readlinkSpy.mockRestore();
+    }
+  });
+
   it("rejects hardlinked files inside the sandbox root", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const outsideDir = await makeTempDir("openclaw-openshell-outside-");


### PR DESCRIPTION
# fix(openshell): pin sandbox file reads

## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: OpenShell sandbox reads validated the requested path and then reread the unresolved host path, leaving a race window where a swapped parent symlink could redirect the read outside the sandbox root.
- Why it matters: A sandboxed attacker could win that race and disclose host files reachable by the OpenClaw process user.
- What changed: `OpenShellFsBridge.readFile` now resolves and opens the verified in-boundary file before reading, and it checks the opened file identity before returning bytes.
- What did NOT change (scope boundary): This patch does not change OpenShell write, mkdir, remove, or rename paths, and it does not modify shared sandbox infrastructure or workflow files.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related NVIDIA-dev/openclaw-tracking#491
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `OpenShellFsBridge.readFile` performed async path validation and then called `fsPromises.readFile(hostPath)` on the original unresolved path string.
- Missing detection / guardrail: There was no regression test that forced a symlink swap between validation and the final read call.
- Contributing context (if known): The main sandbox bridge already used fd-pinned reads, but the OpenShell bridge still used the older check-then-read pattern.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openshell/src/openshell-core.test.ts`
- Scenario the test should lock in: A parent directory swap to a symlink after validation must not redirect a read outside the sandbox root.
- Why this is the smallest reliable guardrail: The failure mode is local to the OpenShell bridge read path and can be simulated with a targeted filesystem swap without booting a full sandbox runtime.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenShell sandbox reads now stay pinned to the verified in-boundary file. Malicious parent symlink swaps should no longer redirect reads outside the sandbox root. No intended behavior change for legitimate in-sandbox file reads.

## Diagram (if applicable)

```text
Before:
[validate path] -> [read unresolved host path] -> [race can redirect read outside root]

After:
[resolve verified in-boundary file] -> [open pinned fd] -> [read fd bytes] -> [race does not redirect read]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: OpenShell reads are now constrained to the file that was resolved and opened inside the sandbox boundary, which removes the prior parent-symlink race for host-file disclosure.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Codex task workspace checkout
- Model/provider: <operator to fill>
- Integration/channel (if any): OpenShell sandbox backend
- Relevant config (redacted): no `node_modules/` present in this workspace checkout; repo helper scripts needed for the usual Vitest path were also absent

### Steps

1. Inspected `extensions/openshell/src/fs-bridge.ts` and confirmed the old read path validated the target and then read the unresolved host path.
2. Updated the read path to resolve and open the verified in-boundary file before reading, then added a regression test that swaps the parent directory to a symlink if `fs.promises.readFile` is used.
3. Attempted targeted test execution with `pnpm exec vitest run extensions/openshell/src/openshell-core.test.ts` and `node scripts/run-vitest.mjs run extensions/openshell/src/openshell-core.test.ts`, then ran `git diff --check` after the checkout proved incomplete for normal test execution.

### Expected

- The OpenShell read path no longer rereads the unresolved host path after validation.
- The targeted regression test passes in a full repo checkout.

### Actual

- The code change is limited to the OpenShell read path and one regression test, and `git diff --check` passed cleanly.
- Targeted automated test execution was not possible in this workspace because `vitest`, `scripts/run-vitest.mjs`, and `node_modules/` were missing from the checkout.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippets captured:
- `pnpm exec vitest run extensions/openshell/src/openshell-core.test.ts` -> `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "vitest" not found`
- `node scripts/run-vitest.mjs run extensions/openshell/src/openshell-core.test.ts` -> `MODULE_NOT_FOUND` for `scripts/run-vitest.mjs`
- `git diff --check` -> clean

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the final diff to confirm `readFile` no longer calls `fsPromises.readFile(hostPath)` and now reads from an already-opened file descriptor; confirmed the added regression test encodes the symlink-swap attack pattern.
- Edge cases checked: the opened file must remain inside the canonical sandbox root and must match the pre-open file identity before bytes are returned.
- What you did **not** verify: I could not run the targeted Vitest file or broader test suite in this workspace because the checkout lacked repo dependencies and the usual test runner script.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - The new regression test was added but could not be executed in this workspace checkout.
- Mitigation:
  - The change is narrowly scoped to one read path, `git diff --check` passed, and the added test is ready to run in a full checkout with dependencies installed.

- Risk:
  - The pinned-read helper is local to the OpenShell bridge rather than shared infrastructure.
- Mitigation:
  - The helper is intentionally small and scoped to this one read path so the branch stays surgical and does not broaden into the separate OpenShell write-path issue.