### PR TITLE
fix(slack): tolerate unresolved channel SecretRef in actions token resolution

### DIFF
--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -43,7 +43,21 @@ export type SlackPin = {
 
 function resolveToken(explicit?: string, accountId?: string) {
   const cfg = loadConfig();
-  const account = resolveSlackAccount({ cfg, accountId });
+  // Tolerate unresolved channel SecretRefs in the cfg snapshot here: the
+  // action path either receives an explicit `opts.token` (resolved by the
+  // caller) or surfaces the existing "missing bot token" error via the
+  // guard below. The runtime snapshot can legitimately retain unresolved
+  // `channels.slack.*` SecretRefs (see the inspect/strict separation
+  // introduced in #66818) when the active account's secrets were not part
+  // of the agent-runtime base target set; failing the strict resolver
+  // here would block Slack actions (edit, pin, read, reactions, etc.)
+  // even though inbound dispatch keeps working via the boot-resolved
+  // token. Mirrors the outbound-send fix from #68954. See #68237.
+  const account = resolveSlackAccount({
+    cfg,
+    accountId,
+    tolerateUnresolvedSecrets: true,
+  });
   const token = resolveSlackBotToken(explicit ?? account.botToken ?? undefined);
   if (!token) {
     logVerbose(


### PR DESCRIPTION
## Summary
- apply #68954's `tolerateUnresolvedSecrets` pattern to `resolveToken` in `extensions/slack/src/actions.ts`
- unblocks Slack actions (edit, pin, unpin, read, listReactions, listPins, delete, getMemberInfo, listEmojis) on deployments with unresolved `channels.slack.*` `SecretRef` entries in the cfg snapshot

## Root cause
`resolveToken` at `extensions/slack/src/actions.ts:44-57` calls `resolveSlackAccount({ cfg, accountId })` in strict mode, mirroring the pre-#68954 `send.ts` shape. When the operator configures `channels.slack.accounts.*.botToken` as a `SecretRef` (`exec`/`file` source), the runtime snapshot can legitimately retain the unresolved ref (inspect/strict separation introduced in #66818) even when a working bot token has been boot-resolved. Strict mode throws on the `SecretRef`, blocking the 9 exported action functions that share this code path — identical symptom class to #68237, different call site.

## Fix
Pass `tolerateUnresolvedSecrets: true` to the inner `resolveSlackAccount` call, matching the `send.ts:335` pattern landed in #68954. The existing `if (!token)` guard at `actions.ts:48-55` continues to surface the clean "missing bot token" error when no explicit override or resolved account token is available.

## Validation
- `pnpm oxlint extensions/slack/src/actions.ts` — 0 warnings / 0 errors
- `pnpm tsgo --project tsconfig.core.json` — clean
- `pnpm test -- extensions/slack/src/{actions.blocks,actions.download-file,actions.read,accounts}.test.ts` — 25/25 pass, zero regressions

## Test coverage
The `resolveSlackAccount({ tolerateUnresolvedSecrets: true })` contract (SecretRef credentials silently become `undefined` + CWE-287 env-fallback gating) is locked by the suite added in #68954 at `extensions/slack/src/accounts.test.ts:112-319`. Same coverage model the merging reviewer accepted for the `send.ts` call site.

## Notes
Pre-commit hook (`pnpm check`) fails on current `upstream/main` due to pre-existing TS errors in unrelated extensions (`extensions/discord/src/monitor/gateway-plugin.ts` `firstHeartbeatTimeout` TS2339 ×3, `extensions/qa-lab/src/providers/aimock/server.ts` TS2307/TS7006, `extensions/qqbot/src/bridge/setup/finalize.ts` TS2307). Reproducible on a clean `upstream/main` checkout, not introduced by this commit. Related to prior #62014 tsgo hook breakage. CI is the real gate.