### PR TITLE
fix(ollama): register media-understanding provider so image tool routes ollama/* vision models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/MCP loopback: derive owner-only tool visibility from distinct authenticated owner vs non-owner loopback bearers instead of the caller-controlled owner header, so non-owner MCP child processes cannot recover owner access by spoofing request metadata. (#69796)
 - GitHub Copilot: update the default Opus model from `claude-opus-4.6` to `claude-opus-4.7` after GitHub removed Copilot support for 4.6. (#69818) Thanks @shakkernerd.
 - OpenShell: pin host-side sandbox writes under the mounted root so symlink-parent rebinds cannot redirect `writeFile` outside the workspace during local mirror updates. (#69797) Thanks @drobison00.
+- Ollama/media understanding: register Ollama as an image-capable media-understanding provider so `agents.defaults.imageModel.primary` values like `ollama/qwen2.5vl:7b` route through the Ollama plugin instead of failing as unknown models. (#69816) Thanks @soloclz.
+- CLI/media understanding: make `openclaw infer image describe --model <provider/model>` execute the explicit image model instead of skipping description when that model supports native vision.
 
 ## 2026.4.20
 

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -495,4 +495,42 @@ describe("ollama plugin", () => {
     expect(baseStreamFn).toHaveBeenCalledTimes(1);
     expect(payloadSeen?.think).toBeUndefined();
   });
+
+  it("registers an image-capable media understanding provider so image tool can route ollama/*", () => {
+    const mediaProviders: Array<{
+      id: string;
+      capabilities?: string[];
+      defaultModels?: Record<string, string>;
+      autoPriority?: Record<string, number>;
+      describeImage?: unknown;
+      describeImages?: unknown;
+    }> = [];
+
+    plugin.register(
+      createTestPluginApi({
+        id: "ollama",
+        name: "Ollama",
+        source: "test",
+        config: {},
+        pluginConfig: {},
+        runtime: {} as never,
+        registerProvider() {},
+        registerMediaUnderstandingProvider(provider) {
+          mediaProviders.push(provider);
+        },
+      }),
+    );
+
+    expect(mediaProviders).toHaveLength(1);
+    const [ollamaMedia] = mediaProviders;
+    expect(ollamaMedia.id).toBe("ollama");
+    expect(ollamaMedia.capabilities).toEqual(["image"]);
+    expect(typeof ollamaMedia.describeImage).toBe("function");
+    expect(typeof ollamaMedia.describeImages).toBe("function");
+    // Intentional: no defaultModels or autoPriority. Ollama vision models are
+    // user-installed (llava, qwen2.5vl, …) with no universal default, and we
+    // don't want Ollama to auto-steal image duty from configured providers.
+    expect(ollamaMedia.defaultModels).toBeUndefined();
+    expect(ollamaMedia.autoPriority).toBeUndefined();
+  });
 });

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
 } from "./src/embedding-provider.js";
+import { ollamaMediaUnderstandingProvider } from "./src/media-understanding-provider.js";
 import { ollamaMemoryEmbeddingProviderAdapter } from "./src/memory-embedding-adapter.js";
 import {
   createConfiguredOllamaCompatStreamWrapper,
@@ -55,6 +56,7 @@ export default definePluginEntry({
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
     api.registerMemoryEmbeddingProvider(ollamaMemoryEmbeddingProviderAdapter);
+    api.registerMediaUnderstandingProvider(ollamaMediaUnderstandingProvider);
     const pluginConfig = (api.pluginConfig ?? {}) as OllamaPluginConfig;
     api.registerWebSearchProvider(createOllamaWebSearchProvider());
     api.registerProvider({

--- a/extensions/ollama/src/media-understanding-provider.ts
+++ b/extensions/ollama/src/media-understanding-provider.ts
@@ -1,0 +1,18 @@
+import {
+  describeImageWithModel,
+  describeImagesWithModel,
+  type MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+import { OLLAMA_PROVIDER_ID } from "./discovery-shared.js";
+
+// Ollama vision support depends on which models the user has pulled (llava,
+// qwen2.5vl, llama3.2-vision, …) — there is no single canonical default. We
+// register the provider so the image tool can route `ollama/<vision-model>`
+// requests, but leave `defaultModels` and `autoPriority` unset so Ollama
+// only participates when the user explicitly configures an image model.
+export const ollamaMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: OLLAMA_PROVIDER_ID,
+  capabilities: ["image"],
+  describeImage: describeImageWithModel,
+  describeImages: describeImagesWithModel,
+};

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -57,6 +57,10 @@ const mocks = vi.hoisted(() => ({
     provider: "openai",
     model: "gpt-4.1-mini",
   })),
+  describeImageFileWithModel: vi.fn(async () => ({
+    text: "friendly lobster",
+    model: "gpt-4.1-mini",
+  })),
   generateImage: vi.fn(),
   generateVideo: vi.fn(),
   transcribeAudioFile: vi.fn(async () => ({ text: "meeting notes" })),
@@ -179,6 +183,8 @@ vi.mock("../gateway/connection-details.js", () => ({
 vi.mock("../media-understanding/runtime.js", () => ({
   describeImageFile:
     mocks.describeImageFile as typeof import("../media-understanding/runtime.js").describeImageFile,
+  describeImageFileWithModel:
+    mocks.describeImageFileWithModel as typeof import("../media-understanding/runtime.js").describeImageFileWithModel,
   describeVideoFile: vi.fn(),
   transcribeAudioFile:
     mocks.transcribeAudioFile as typeof import("../media-understanding/runtime.js").transcribeAudioFile,
@@ -289,6 +295,7 @@ describe("capability cli", () => {
       return {};
     }) as never);
     mocks.describeImageFile.mockClear();
+    mocks.describeImageFileWithModel.mockClear();
     mocks.generateImage.mockReset();
     mocks.generateVideo.mockReset();
     mocks.transcribeAudioFile.mockClear();
@@ -380,6 +387,37 @@ describe("capability cli", () => {
       expect.objectContaining({
         capability: "image.describe",
         outputs: [expect.objectContaining({ kind: "image.description" })],
+      }),
+    );
+  });
+
+  it("uses the explicit media-understanding provider for image describe model overrides", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        "photo.jpg",
+        "--model",
+        "ollama/qwen2.5vl:7b",
+        "--json",
+      ],
+    });
+
+    expect(mocks.describeImageFileWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: expect.stringMatching(/photo\.jpg$/),
+        provider: "ollama",
+        model: "qwen2.5vl:7b",
+      }),
+    );
+    expect(mocks.describeImageFile).not.toHaveBeenCalled();
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "ollama",
+        model: "gpt-4.1-mini",
       }),
     );
   });

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -25,6 +25,7 @@ import { generateImage, listRuntimeImageGenerationProviders } from "../image-gen
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
 import {
   describeImageFile,
+  describeImageFileWithModel,
   describeVideoFile,
   transcribeAudioFile,
 } from "../media-understanding/runtime.js";
@@ -749,21 +750,32 @@ async function runImageDescribe(params: {
   model?: string;
 }) {
   const cfg = loadConfig();
+  const agentDir = resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
   const activeModel = requireProviderModelOverride(params.model);
   const outputs = await Promise.all(
     params.files.map(async (filePath) => {
-      const result = await describeImageFile({
-        filePath: path.resolve(filePath),
-        cfg,
-        activeModel,
-      });
+      const resolvedPath = path.resolve(filePath);
+      const result = activeModel
+        ? await describeImageFileWithModel({
+            filePath: resolvedPath,
+            cfg,
+            agentDir,
+            provider: activeModel.provider,
+            model: activeModel.model,
+            prompt: "Describe the image.",
+          })
+        : await describeImageFile({
+            filePath: resolvedPath,
+            cfg,
+            agentDir,
+          });
       if (!result.text) {
-        throw new Error(`No description returned for image: ${path.resolve(filePath)}`);
+        throw new Error(`No description returned for image: ${resolvedPath}`);
       }
       return {
-        path: path.resolve(filePath),
+        path: resolvedPath,
         text: result.text,
-        provider: result.provider,
+        provider: activeModel?.provider ?? ("provider" in result ? result.provider : undefined),
         model: result.model,
         kind: "image.description",
       };

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -17,6 +17,7 @@ const hoisted = vi.hoisted(() => ({
   setRuntimeApiKeyMock: vi.fn(),
   discoverModelsMock: vi.fn(),
   fetchMock: vi.fn(),
+  registerProviderStreamForModelMock: vi.fn(),
 }));
 const {
   completeMock,
@@ -27,6 +28,7 @@ const {
   setRuntimeApiKeyMock,
   discoverModelsMock,
   fetchMock,
+  registerProviderStreamForModelMock,
 } = hoisted;
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -48,6 +50,10 @@ vi.mock("../agents/model-auth.js", () => ({
   getApiKeyForModel: getApiKeyForModelMock,
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
   requireApiKey: requireApiKeyMock,
+}));
+
+vi.mock("../agents/provider-stream.js", () => ({
+  registerProviderStreamForModel: registerProviderStreamForModelMock,
 }));
 
 vi.mock("../agents/pi-model-discovery-runtime.js", () => ({
@@ -168,6 +174,16 @@ describe("describeImageWithModel", () => {
       text: "generic ok",
       model: "custom-vision",
     });
+    expect(registerProviderStreamForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "minimax-portal",
+          id: "custom-vision",
+        }),
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+      }),
+    );
     expect(completeMock).toHaveBeenCalledOnce();
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
+import { registerProviderStreamForModel } from "../agents/provider-stream.js";
 import {
   coerceImageAssistantText,
   hasImageReasoningOnlyResponse,
@@ -244,6 +245,12 @@ export async function describeImagesWithModel(
       images: params.images,
     });
   }
+
+  registerProviderStreamForModel({
+    model,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+  });
 
   const context = buildImageContext(prompt, params.images);
   const controller = new AbortController();


### PR DESCRIPTION
## Summary

The Ollama plugin registered providers for chat, embeddings, and web search but
not for media understanding. As a result, the image tool's provider registry
had no `ollama` entry, and `agents.defaults.imageModel.primary = "ollama/..."`
configs failed to resolve — users saw `Unknown model` errors or the tool fell
back to unrelated providers.

This wires up `ollamaMediaUnderstandingProvider` using the shared
`describeImageWithModel` / `describeImagesWithModel` helpers from the plugin
SDK. Ollama's chat stream (`extensions/ollama/src/stream.ts`) already extracts
image parts from user messages and forwards them via the `images[]` field, so
the shared helpers route through the same pi-ai `complete()` path Ollama chat
already uses. Vision-capable Ollama models are already marked with
`input: ["text", "image"]` during discovery
(`extensions/ollama/src/provider-models.ts:220`), so the image-capability check
in `src/media-understanding/image.ts` passes.

### Why no defaults

Ollama vision support depends on whichever model the user has pulled (`llava`,
`qwen2.5vl`, `llama3.2-vision`, `gemma3`, …). There is no single canonical
default, so `defaultModels.image` is intentionally left unset — users must
specify the model via `imageModel.primary`. `autoPriority` is also omitted so
Ollama does not auto-steal image duty from configured providers.

## Issue

- Fixes https://github.com/openclaw/openclaw/issues/69071
- Supersedes https://github.com/openclaw/openclaw/issues/60280

## Test Plan

- [x] `pnpm test extensions/ollama/index.test.ts` (new registration test asserts shape + capabilities)
- [x] `pnpm check:changed`
- [x] `pnpm test src/agents/tools/image-tool.test.ts`
- [x] `pnpm test src/media-understanding/defaults.test.ts src/media-understanding/provider-registry.test.ts`