### PR TITLE
fix(agents): skip sessions_send A2A flow for parent-owned ACP children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/ACP: skip the `sessions_send` A2A ping-pong flow when a parent sends to its own background oneshot ACP child, preventing parent/child echo loops while preserving normal A2A delivery for non-parent senders. (#69817) Thanks @scotthuang.
 - Agents/subagents: stop terminal failed subagent runs from freezing or announcing captured reply text, so failover-exhausted runs report a clean failure instead of replaying stale assistant/tool output.
 - Security/external content: strip common self-hosted LLM chat-template special-token literals, including Qwen/ChatML, Llama, Gemma, Mistral, Phi, and GPT-OSS markers, from wrapped external content and metadata, preventing tokenizer-layer role-boundary spoofing against OpenAI-compatible backends that preserve special tokens in user text.
 - Auth/commands: require owner identity (an owner-candidate match or internal `operator.admin`) for owner-enforced commands instead of treating wildcard channel `allowFrom` or empty owner-candidate lists as sufficient, so non-owner senders can no longer reach owner-only commands through a permissive fallback when `enforceOwnerForCommands=true` and `commands.ownerAllowFrom` is unset. (#69774) Thanks @drobison00.

--- a/src/acp/session-interaction-mode.test.ts
+++ b/src/acp/session-interaction-mode.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  isParentOwnedBackgroundAcpSession,
+  isRequesterParentOfBackgroundAcpSession,
+  resolveAcpSessionInteractionMode,
+} from "./session-interaction-mode.js";
+
+const parentKey = "agent:main:main";
+const otherKey = "agent:peer:some-other";
+
+describe("resolveAcpSessionInteractionMode", () => {
+  it("returns interactive when entry is undefined", () => {
+    expect(resolveAcpSessionInteractionMode(undefined)).toBe("interactive");
+  });
+
+  it("returns interactive for non-oneshot ACP sessions", () => {
+    expect(
+      resolveAcpSessionInteractionMode({
+        acp: { mode: "persistent" } as never,
+        spawnedBy: parentKey,
+      }),
+    ).toBe("interactive");
+  });
+
+  it("returns parent-owned-background for oneshot sessions with spawnedBy set", () => {
+    expect(
+      resolveAcpSessionInteractionMode({
+        acp: { mode: "oneshot" } as never,
+        spawnedBy: parentKey,
+      }),
+    ).toBe("parent-owned-background");
+  });
+
+  it("returns parent-owned-background for oneshot sessions with parentSessionKey set", () => {
+    expect(
+      resolveAcpSessionInteractionMode({
+        acp: { mode: "oneshot" } as never,
+        parentSessionKey: parentKey,
+      }),
+    ).toBe("parent-owned-background");
+  });
+
+  it("returns interactive for a oneshot session without any parent linkage", () => {
+    expect(
+      resolveAcpSessionInteractionMode({
+        acp: { mode: "oneshot" } as never,
+      }),
+    ).toBe("interactive");
+  });
+});
+
+describe("isRequesterParentOfBackgroundAcpSession", () => {
+  const backgroundEntry = {
+    acp: { mode: "oneshot" } as never,
+    spawnedBy: parentKey,
+    parentSessionKey: parentKey,
+  };
+
+  it("returns true when requester matches spawnedBy", () => {
+    expect(
+      isRequesterParentOfBackgroundAcpSession(
+        { acp: { mode: "oneshot" } as never, spawnedBy: parentKey },
+        parentKey,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when requester matches parentSessionKey", () => {
+    expect(
+      isRequesterParentOfBackgroundAcpSession(
+        { acp: { mode: "oneshot" } as never, parentSessionKey: parentKey },
+        parentKey,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when requester is a different session (not the parent)", () => {
+    expect(isRequesterParentOfBackgroundAcpSession(backgroundEntry, otherKey)).toBe(false);
+  });
+
+  it("returns false when requester key is missing", () => {
+    expect(isRequesterParentOfBackgroundAcpSession(backgroundEntry, undefined)).toBe(false);
+    expect(isRequesterParentOfBackgroundAcpSession(backgroundEntry, "")).toBe(false);
+  });
+
+  it("returns false when target is not a parent-owned background ACP session", () => {
+    expect(
+      isRequesterParentOfBackgroundAcpSession(
+        { acp: { mode: "persistent" } as never, spawnedBy: parentKey },
+        parentKey,
+      ),
+    ).toBe(false);
+  });
+
+  it("delegates to isParentOwnedBackgroundAcpSession for target-only checks", () => {
+    expect(isParentOwnedBackgroundAcpSession(backgroundEntry)).toBe(true);
+  });
+});

--- a/src/acp/session-interaction-mode.ts
+++ b/src/acp/session-interaction-mode.ts
@@ -23,3 +23,30 @@ export function resolveAcpSessionInteractionMode(
 export function isParentOwnedBackgroundAcpSession(entry?: SessionInteractionEntry | null): boolean {
   return resolveAcpSessionInteractionMode(entry) === "parent-owned-background";
 }
+
+/**
+ * Returns true when `entry` is a parent-owned background ACP session AND the
+ * given `requesterSessionKey` is the session that spawned/owns it. This is a
+ * strictly narrower check than {@link isParentOwnedBackgroundAcpSession}: the
+ * target must match *and* the caller must be the parent.
+ *
+ * Used to gate behaviors that only make sense for the parent↔own-child pair
+ * (e.g. skipping the A2A ping-pong flow in `sessions_send`), so that an
+ * unrelated session with broad visibility (e.g. `tools.sessions.visibility=all`)
+ * sending to the same target is still routed through the normal A2A path.
+ */
+export function isRequesterParentOfBackgroundAcpSession(
+  entry: SessionInteractionEntry | null | undefined,
+  requesterSessionKey: string | null | undefined,
+): boolean {
+  if (!isParentOwnedBackgroundAcpSession(entry)) {
+    return false;
+  }
+  const requester = normalizeOptionalString(requesterSessionKey);
+  if (!requester) {
+    return false;
+  }
+  const spawnedBy = normalizeOptionalString(entry?.spawnedBy);
+  const parentSessionKey = normalizeOptionalString(entry?.parentSessionKey);
+  return requester === spawnedBy || requester === parentSessionKey;
+}

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
-import { isParentOwnedBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
+import { isRequesterParentOfBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -290,18 +290,33 @@ export function createSessionsSendTool(opts?: {
       const requesterSessionKey = opts?.agentSessionKey;
       const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
-      const delivery = { status: "pending", mode: "announce" as const };
 
-      // Skip the A2A ping-pong + announce flow when the target is a
-      // parent-owned background ACP subagent. Such sessions already report
-      // their results back to the parent through the
-      // `[Internal task completion event]` announcement path, and treating
+      // Skip the A2A ping-pong + announce flow when the current caller is the
+      // parent of a parent-owned background ACP subagent it spawned itself.
+      // Such sessions already report their results back to the parent through
+      // the `[Internal task completion event]` announcement path, and treating
       // them as a peer agent causes the parent to be woken with the child's
       // reply, generate a user-facing response, and have that response
-      // forwarded back to the child as a new message — producing an infinite
-      // ping-pong loop between parent and ACP child.
+      // forwarded back to the child as a new message — producing a
+      // ping-pong loop between parent and ACP child (bounded by
+      // maxPingPongTurns, but user-visible as a runaway conversation).
+      //
+      // The skip is gated on requester ownership, not just target type: an
+      // unrelated sender that can see the same target (e.g. under
+      // `tools.sessions.visibility=all`) must still go through the normal A2A
+      // path so it actually receives a follow-up delivery.
       const targetSessionEntry = loadSessionEntryByKey(resolvedKey);
-      const skipA2AFlow = isParentOwnedBackgroundAcpSession(targetSessionEntry);
+      const skipA2AFlow = isRequesterParentOfBackgroundAcpSession(
+        targetSessionEntry,
+        effectiveRequesterKey,
+      );
+      // When the A2A flow is skipped, no follow-up announcement will fire and
+      // the reply (when present) is returned inline via the `reply` field.
+      // Reflect that in the metadata so the parent LLM does not wait for a
+      // second result that will never arrive.
+      const delivery = skipA2AFlow
+        ? ({ status: "skipped", mode: "announce" } as const)
+        : ({ status: "pending", mode: "announce" } as const);
 
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
         if (skipA2AFlow) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
+import { isParentOwnedBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -15,6 +16,7 @@ import {
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
 } from "../run-wait.js";
+import { loadSessionEntryByKey } from "../subagent-announce-delivery.js";
 import {
   describeSessionsSendTool,
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
@@ -289,7 +291,22 @@ export function createSessionsSendTool(opts?: {
       const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
       const delivery = { status: "pending", mode: "announce" as const };
+
+      // Skip the A2A ping-pong + announce flow when the target is a
+      // parent-owned background ACP subagent. Such sessions already report
+      // their results back to the parent through the
+      // `[Internal task completion event]` announcement path, and treating
+      // them as a peer agent causes the parent to be woken with the child's
+      // reply, generate a user-facing response, and have that response
+      // forwarded back to the child as a new message — producing an infinite
+      // ping-pong loop between parent and ACP child.
+      const targetSessionEntry = loadSessionEntryByKey(resolvedKey);
+      const skipA2AFlow = isParentOwnedBackgroundAcpSession(targetSessionEntry);
+
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+        if (skipA2AFlow) {
+          return;
+        }
         void runSessionsSendA2AFlow({
           targetSessionKey: resolvedKey,
           displayKey,


### PR DESCRIPTION
## Summary

- **Problem**: `sessions_send` to a parent-owned background ACP child enters an A2A ping-pong: the child's reply is forwarded to the parent as a user message, the parent replies, that reply is forwarded back to the child, repeat. The loop is bounded by `maxPingPongTurns` (defaults to 5), so it always terminates — but from the user's point of view the conversation keeps producing turns on its own for several rounds before stopping.
- **Why it matters**: The child has no `sessions_send` tool but effectively gets one via A2A echo — an implicit capability leak. It also pollutes the parent's context and wastes turns/tokens. Results already reach the parent via `[Internal task completion event]`.
- **UX impact**: Even though the `maxPingPongTurns` guardrail prevents a truly infinite loop, the user-visible behavior is that the chat keeps auto-replying to itself without any user input. To anyone not familiar with the A2A internals this looks like a runaway agent that "won't stop talking" — a bug-class experience, not a graceful bounded handshake.
- **What changed**: In `sessions-send-tool.ts`, detect parent-owned background ACP targets via `isParentOwnedBackgroundAcpSession` and skip `startA2AFlow`.
- **Scope of the skip**: strictly ACP sessions spawned with `mode=run` (oneshot background children spawned by the current parent). `mode=session` (persistent) ACP targets, externally-opened ACP sessions that are not parent-owned, non-ACP peer targets, and any other `sessions_send` path are **not** touched.
- **What did NOT change**: Completion announcement path; A2A flow for all other targets (including `mode=session` ACP sessions and peer agents); ACP protocol, session binding, inline delivery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #55981 — announce posts to wrong chat in multi-agent setup. ACP-child slice is resolved; non-ACP worker agents are out of scope here.
- Related #62872 — A2A ping-pong duplicate messages in persistent sessions. ACP-child slice resolved; non-ACP persistent sessions would need the broader `maxPingPongTurns` API surface the issue suggests.
- Related #62814 — duplicate of #62872.

## Root Cause (if applicable)

- **Root cause**: `runSessionsSendA2AFlow` treats the target as a peer and echoes replies in both directions for up to `maxPingPongTurns`. For parent-owned background ACP children, this path coexists with `[Internal task completion event]`, so the parent is both notified *and* fed the child's reply as a user message — creating the loop.
- **Missing guardrail**: No check on target session type before entering A2A flow.
- **Context**: A2A was designed for same-tier peer conversations; ACP spawn is a parent/child hierarchy where the child is a task executor, not a peer.

## Regression Test Plan (if applicable)

- **Coverage level**: Seam / integration test
- **Target**: `src/agents/tools/sessions-send-tool.a2a.test.ts`
- **Scenario**: `startA2AFlow` is skipped when the target entry is a parent-owned background ACP session (spawned with `mode=run`); still runs for `mode=session` ACP targets and peer targets.
- **Why smallest**: Pure control-flow decision at the tool entry — a parameterized test on target entry kind is enough; no full ACP spawn needed.
- **Existing coverage**: None (existing A2A tests cover peer scenarios only).
- **If not added**: Deferred to keep the fix PR minimal; follow-up recommended.

## User-visible / Behavior Changes

Background ACP children spawned with `mode=run` by the current requester no longer participate in A2A ping-pong. Their results still reach the parent via `[Internal task completion event]`. `mode=session` (persistent) ACP targets and all other `sessions_send` targets are unchanged.

## Diagram (if applicable)

```text
Before (ACP child target):
  parent --sessions_send--> child
     ^                        |
     |                   child replies
     |                        |
     +---- A2A forwards reply as user message to parent
     |
     v
  parent responds
     |
     +---- A2A forwards response as user message to child
  ...loop continues until maxPingPongTurns (default 5) caps it...

After:
  parent --sessions_send--> child --replies--> [Internal task completion event] --> parent
  (A2A flow is skipped; nothing is echoed back to the child)
```

## Security Impact (required)

- New permissions/capabilities? `No` — actually **removes** an unintended implicit capability (ACP child gaining de-facto `sessions_send` via A2A echo).
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: closes an implicit privilege escalation for ACP children; legitimate peer A2A is unaffected because the check is strictly a target-type filter.

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime: Node 22+, local `pnpm openclaw gateway`
- Model/provider: Claude via ACP (claude-cli)
- Channel: openclaw-control-ui (webchat)
- Config: default

### Steps

1. Start main agent (`agent:main:main`) in webchat.
2. Main agent spawns a background ACP child (`mode=run`, Claude) via `sessions_spawn`.
3. Main agent calls `sessions_send` to that child with a short greeting.

### Expected

- One `[Internal task completion event]` reaches the parent.
- Child's raw reply is not rendered into the main conversation.
- No further turns triggered by the child's reply.

### Actual

- Before fix: child's reply enters the main conversation as a user message, main agent replies, reply is forwarded to the child, the child replies again — repeated turns observed.
- After fix: exactly one completion event; no further main-session turn; no ping-pong.

## Evidence

- [x] Screenshots (before / after)

Same repro in both runs, captured from the webchat UI against a local `pnpm openclaw gateway` (v2026.4.20):

1. Main agent spawns a background ACP Claude child via `sessions_spawn`.
2. Main agent calls `sessions_send` to that child with a short greeting.
3. Observe the main conversation for subsequent turns.

### Before fix — A2A ping-pong

<img width="1183" height="373" alt="主session-ping-pong1" src="https://github.com/user-attachments/assets/d91e48c4-4e90-4ff6-88c2-497192a48434" />

What the screenshot shows:

- After `sessions_send`, the ACP child's raw reply appears in the main conversation as a new user message (A2A echo).
- The main agent responds to that echoed message, which is then forwarded back to the child, producing another child turn.
- Multiple back-and-forth turns are visible after a single `sessions_send` call — the ping-pong loop. The loop eventually stops on its own because `maxPingPongTurns` caps it, but during those intermediate turns the UI looks like an agent that has gone runaway: messages keep appearing without any user input, and there is no signal to the user that a bounded guardrail will eventually end it.

### After fix — single completion event, no loop

<img width="1176" height="594" alt="after" src="https://github.com/user-attachments/assets/c30c3249-99fa-44ed-8c18-2d3c08305594" />

What the screenshot shows:

- `sessions_send` resolves with exactly one `[Internal task completion event]` reaching the main agent.
- The child's raw reply does not appear as a user message in the main conversation.
- No additional main-session turn is triggered; no further child turn is observed — the loop is gone.

Net effect: the only path by which the child's result reaches the parent is the existing completion-announcement channel, matching the "After" branch of the diagram above.

## Human Verification (required)

- Verified: main (`agent:main:main`) → ACP Claude child via `sessions_send`; single completion event; no ping-pong; no echo back to child. Repeated sends behave consistently.
- Not verified: non-ACP peer A2A (cross-channel human bridging) — reasoned about by code only. Remote/production environments — local verification only.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: a valid non-loop A2A scenario targeting a parent-owned background ACP session is unintentionally suppressed.
  - Mitigation: `isParentOwnedBackgroundAcpSession` matches only `acp.mode === "oneshot"` sessions with `spawnedBy`/`parentSessionKey` set — exactly the subset that uses the announcement path for result delivery. Persistent (`acp.mode === "persistent"`) sessions and ACP sessions that are not owned by the current parent are not matched.
- Risk: callers that relied on the child's reply appearing inline in the parent conversation lose that behavior.
  - Mitigation: that inline echo was the source of the bug (implicit capability leak). The official channel remains the completion announcement, which already contains the child's result wrapped as untrusted content.
