### PR TITLE
fix: update GitHub Copilot Opus default to 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
 - Telegram/media: parse lowercase media directives in block replies and preserve outbound attachment filenames, so generated files send once with their original names. (#69641) Thanks @obviyus.
 - Agents/Anthropic: honor explicit `cacheRetention: "long"` for custom `anthropic-messages` endpoints by applying the 1-hour ephemeral cache TTL independently of the Anthropic/Vertex hostname allowlist. Implicit and env-driven long retention still require an allowlisted host. (#67800) Thanks @MonkeyLeeT.
+- GitHub Copilot: update the default Opus model from `claude-opus-4.6` to `claude-opus-4.7` after GitHub removed Copilot support for 4.6. (#69818) Thanks @shakkernerd.
 
 ## 2026.4.19-beta.2
 

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -31,7 +31,7 @@ provider in two different ways.
       </Step>
       <Step title="Set a default model">
         ```bash
-        openclaw models set github-copilot/claude-opus-4.6
+        openclaw models set github-copilot/claude-opus-4.7
         ```
 
         Or in config:
@@ -39,7 +39,7 @@ provider in two different ways.
         ```json5
         {
           agents: {
-            defaults: { model: { primary: "github-copilot/claude-opus-4.6" } },
+            defaults: { model: { primary: "github-copilot/claude-opus-4.7" } },
           },
         }
         ```

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -69,7 +69,7 @@ export default definePluginEntry({
             credential,
           },
         ],
-        defaultModel: "github-copilot/claude-opus-4.6",
+        defaultModel: "github-copilot/claude-opus-4.7",
       };
     }
 

--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -8,7 +8,7 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
-  "claude-opus-4.6",
+  "claude-opus-4.7",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
   "gpt-4o",

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -63,8 +63,9 @@ function requireResolvedModel(ctx: ProviderResolveDynamicModelContext) {
 
 describe("github-copilot model defaults", () => {
   describe("getDefaultCopilotModelIds", () => {
-    it("includes claude-opus-4.6", () => {
-      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.6");
+    it("includes claude-opus-4.7", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.7");
+      expect(getDefaultCopilotModelIds()).not.toContain("claude-opus-4.6");
     });
 
     it("includes claude-sonnet-4.6", () => {

--- a/test/helpers/plugins/provider-auth-contract.ts
+++ b/test/helpers/plugins/provider-auth-contract.ts
@@ -347,7 +347,7 @@ export function describeGithubCopilotProviderAuthContract(load: ProviderAuthCont
               },
             },
           ],
-          defaultModel: "github-copilot/claude-opus-4.6",
+          defaultModel: "github-copilot/claude-opus-4.7",
         });
       } finally {
         if (previousIsTTYDescriptor) {


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot's bundled model defaults still preferred `claude-opus-4.6` for Copilot setup/docs even though GitHub has started replacing Opus 4.6 with Opus 4.7.
- Why it matters: new Copilot auth/setup flows can leave users on a model that is being removed from the Copilot picker and may fail for accounts where 4.6 is no longer available.
- What changed: replaced Copilot's static Opus default, auth setup default, docs, and provider auth/default-model tests with `github-copilot/claude-opus-4.7`.
- What did NOT change (scope boundary): no changes to Anthropic direct defaults, Copilot dynamic model passthrough, tokens, streaming behavior, or non-Copilot provider examples.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: GitHub Copilot's bundled provider defaults were not updated after GitHub announced Claude Opus 4.7 and started replacing Opus 4.5/4.6 in the Copilot model picker.
- Missing detection / guardrail: provider default tests asserted the old model but did not track upstream Copilot model retirement/replacement announcements.
- Contributing context (if known): GitHub announced Opus 4.7 availability and noted it will replace Opus 4.5 and 4.6 over the coming weeks: https://github.blog/changelog/2026-04-16-claude-opus-4-7-is-generally-available/. GitHub's April 20 plan update also says Opus 4.5 and 4.6 will be removed from Pro+: https://github.blog/changelog/2026-04-20-changes-to-github-copilot-plans-for-individuals/.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/github-copilot/models.test.ts`, `extensions/github-copilot/provider-auth.contract.test.ts`
- Scenario the test should lock in: Copilot default model IDs and provider auth setup return `github-copilot/claude-opus-4.7`, not `github-copilot/claude-opus-4.6`.
- Why this is the smallest reliable guardrail: the changed behavior is provider catalog/default selection, so provider-level tests catch it without requiring a live Copilot account.
- Existing test that already covers this (if any): updated existing Copilot model default and provider auth contract tests.
- If no new test is added, why not: existing focused tests were updated instead of adding duplicate coverage.

## User-visible / Behavior Changes

- GitHub Copilot onboarding/auth setup now uses `github-copilot/claude-opus-4.7` as the default model.
- GitHub Copilot docs now recommend `github-copilot/claude-opus-4.7`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: GitHub Copilot provider defaults
- Integration/channel (if any): `github-copilot`
- Relevant config (redacted): N/A

### Steps

1. Inspect GitHub Copilot bundled default model IDs and provider auth default model.
2. Update the Copilot Opus default from `claude-opus-4.6` to `claude-opus-4.7`.
3. Run focused provider tests and the repo check gate.

### Expected

- Copilot defaults and docs point to `github-copilot/claude-opus-4.7`.
- Tests pass.

### Actual

- Copilot defaults and docs point to `github-copilot/claude-opus-4.7`.
- Tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/github-copilot/models.test.ts extensions/github-copilot/index.test.ts extensions/github-copilot/provider-auth.contract.test.ts`
  - `pnpm check`
  - `scripts/committer` changed-file gate, including broad changed tests, passed before commit.
- Edge cases checked: stale `github-copilot/claude-opus-4.6` references under `extensions/github-copilot`, the GitHub Copilot provider docs, and the provider auth contract helper.
- What you did **not** verify: live Copilot API access in CI; this was manually reported as responding when configured as `github-copilot/claude-opus-4.7`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: existing configs pinned to `github-copilot/claude-opus-4.6` are not rewritten; users can run `openclaw models set github-copilot/claude-opus-4.7` if they already pinned the old model.

## Risks and Mitigations

- Risk: Copilot model availability varies by plan/org and rollout stage.
  - Mitigation: the provider already supports forward-compatible dynamic model refs, and GitHub's changelog states rollout is gradual and administrators may need to enable Opus 4.7 policy access.
