### PR TITLE
fix(slack): preserve gateway thread continuations [AI-assisted]

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -91,6 +91,14 @@ function requireSlackListPeers() {
   return listPeers;
 }
 
+function requireSlackResolveOutboundSessionRoute() {
+  const resolveRoute = slackPlugin.messaging?.resolveOutboundSessionRoute;
+  if (!resolveRoute) {
+    throw new Error("slack messaging.resolveOutboundSessionRoute unavailable");
+  }
+  return resolveRoute;
+}
+
 describe("slackPlugin actions", () => {
   it("prefers session lookup for announce target routing", () => {
     expect(slackPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
@@ -390,6 +398,45 @@ describe("slackPlugin outbound", () => {
   it("advertises the 8000-character Slack default chunk limit", () => {
     expect(slackOutbound.textChunkLimit).toBe(8000);
     expect(slackPlugin.outbound?.textChunkLimit).toBe(8000);
+  });
+
+  it("recovers thread route from currentSessionKey when no explicit thread target is provided", async () => {
+    const resolveRoute = requireSlackResolveOutboundSessionRoute();
+
+    const route = await resolveRoute({
+      cfg,
+      agentId: "main",
+      target: "channel:c123",
+      currentSessionKey: "agent:main:slack:channel:c123:thread:1712345678.123456",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:channel:c123:thread:1712345678.123456",
+      baseSessionKey: "agent:main:slack:channel:c123",
+      peer: { kind: "channel", id: "c123" },
+      chatType: "channel",
+      from: "slack:channel:c123",
+      to: "channel:c123",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("prefers replyToId over threadId for outbound route derivation", async () => {
+    const resolveRoute = requireSlackResolveOutboundSessionRoute();
+
+    const route = await resolveRoute({
+      cfg,
+      agentId: "main",
+      target: "channel:c123",
+      replyToId: "1712000000.000001",
+      threadId: "1712345678.123456",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:channel:c123:thread:1712000000.000001",
+      baseSessionKey: "agent:main:slack:channel:c123",
+      threadId: "1712000000.000001",
+    });
   });
 
   it("uses threadId as threadTs fallback for sendText", async () => {

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -421,6 +421,51 @@ describe("slackPlugin outbound", () => {
     });
   });
 
+  it('does not recover a thread from currentSessionKey for shared dmScope "main" DMs', async () => {
+    const resolveRoute = requireSlackResolveOutboundSessionRoute();
+
+    const route = await resolveRoute({
+      cfg,
+      agentId: "main",
+      target: "user:U999",
+      currentSessionKey: "agent:main:main:thread:1712345678.123456",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:main",
+      baseSessionKey: "agent:main:main",
+      peer: { kind: "direct", id: "U999" },
+      chatType: "direct",
+      from: "slack:U999",
+      to: "user:U999",
+    });
+    expect(route?.threadId).toBeUndefined();
+  });
+
+  it("recovers a DM thread from currentSessionKey when dmScope isolates DM peers", async () => {
+    const resolveRoute = requireSlackResolveOutboundSessionRoute();
+
+    const route = await resolveRoute({
+      cfg: {
+        ...cfg,
+        session: { dmScope: "per-channel-peer" },
+      },
+      agentId: "main",
+      target: "user:U123",
+      currentSessionKey: "agent:main:slack:direct:u123:thread:1712345678.123456",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:slack:direct:u123:thread:1712345678.123456",
+      baseSessionKey: "agent:main:slack:direct:u123",
+      peer: { kind: "direct", id: "U123" },
+      chatType: "direct",
+      from: "slack:U123",
+      to: "user:U123",
+      threadId: "1712345678.123456",
+    });
+  });
+
   it("prefers replyToId over threadId for outbound route derivation", async () => {
     const resolveRoute = requireSlackResolveOutboundSessionRoute();
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -28,7 +28,10 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveTargetsWithOptionalToken } from "openclaw/plugin-sdk/target-resolver-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/text-runtime";
 import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
@@ -202,11 +205,31 @@ function buildSlackBaseSessionKey(params: {
   return buildOutboundBaseSessionKey({ ...params, channel: "slack" });
 }
 
+function parseSlackThreadSessionKey(sessionKey?: string | null): {
+  baseSessionKey?: string;
+  threadId?: string;
+} {
+  const raw = normalizeOptionalString(sessionKey);
+  if (!raw) {
+    return {};
+  }
+  const marker = ":thread:";
+  const index = raw.toLowerCase().lastIndexOf(marker);
+  if (index === -1) {
+    return {};
+  }
+  return {
+    baseSessionKey: raw.slice(0, index),
+    threadId: normalizeOutboundThreadId(raw.slice(index + marker.length)),
+  };
+}
+
 async function resolveSlackOutboundSessionRoute(params: {
   cfg: OpenClawConfig;
   agentId: string;
   accountId?: string | null;
   target: string;
+  currentSessionKey?: string | null;
   replyToId?: string | null;
   threadId?: string | number | null;
 }) {
@@ -239,7 +262,15 @@ async function resolveSlackOutboundSessionRoute(params: {
     accountId: params.accountId,
     peer,
   });
-  const threadId = normalizeOutboundThreadId(params.threadId ?? params.replyToId);
+  const currentSessionThread = parseSlackThreadSessionKey(params.currentSessionKey);
+  const recoveredThreadId =
+    normalizeOptionalLowercaseString(currentSessionThread.baseSessionKey) ===
+    normalizeOptionalLowercaseString(baseSessionKey)
+      ? currentSessionThread.threadId
+      : undefined;
+  const threadId = normalizeOutboundThreadId(
+    params.replyToId ?? params.threadId ?? recoveredThreadId,
+  );
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey,
     threadId,

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -224,6 +224,26 @@ function parseSlackThreadSessionKey(sessionKey?: string | null): {
   };
 }
 
+function shouldRecoverSlackThreadFromCurrentSession(params: {
+  cfg: OpenClawConfig;
+  peerKind: RoutePeer["kind"];
+  currentBaseSessionKey?: string;
+  nextBaseSessionKey: string;
+}): boolean {
+  if (
+    normalizeOptionalLowercaseString(params.currentBaseSessionKey) !==
+    normalizeOptionalLowercaseString(params.nextBaseSessionKey)
+  ) {
+    return false;
+  }
+  // Shared DM sessions (dmScope="main") do not encode the DM peer in the base key,
+  // so inheriting a prior thread can bleed across unrelated direct-message targets.
+  if (params.peerKind === "direct" && (params.cfg.session?.dmScope ?? "main") === "main") {
+    return false;
+  }
+  return true;
+}
+
 async function resolveSlackOutboundSessionRoute(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -263,11 +283,14 @@ async function resolveSlackOutboundSessionRoute(params: {
     peer,
   });
   const currentSessionThread = parseSlackThreadSessionKey(params.currentSessionKey);
-  const recoveredThreadId =
-    normalizeOptionalLowercaseString(currentSessionThread.baseSessionKey) ===
-    normalizeOptionalLowercaseString(baseSessionKey)
-      ? currentSessionThread.threadId
-      : undefined;
+  const recoveredThreadId = shouldRecoverSlackThreadFromCurrentSession({
+    cfg: params.cfg,
+    peerKind,
+    currentBaseSessionKey: currentSessionThread.baseSessionKey,
+    nextBaseSessionKey: baseSessionKey,
+  })
+    ? currentSessionThread.threadId
+    : undefined;
   const threadId = normalizeOutboundThreadId(
     params.replyToId ?? params.threadId ?? recoveredThreadId,
   );

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -728,6 +728,211 @@ describe("gateway send mirroring", () => {
     });
   });
 
+  it("uses the derived thread session and derived thread delivery when route refines the provided base session", async () => {
+    mockDeliverySuccess("m-derived-thread");
+    const derivedThreadRoute = {
+      sessionKey: "agent:main:slack:channel:resolved:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: "1710000000.9999",
+    };
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(derivedThreadRoute);
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      sessionKey: "agent:main:slack:channel:resolved",
+      idempotencyKey: "idem-derived-thread",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining(derivedThreadRoute),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: derivedThreadRoute.sessionKey,
+        }),
+        threadId: derivedThreadRoute.threadId,
+        mirror: expect.objectContaining({
+          sessionKey: derivedThreadRoute.sessionKey,
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
+  it("uses the derived thread session and derived thread delivery when no sessionKey is provided", async () => {
+    mockDeliverySuccess("m-derived-thread-no-session");
+    const derivedThreadRoute = {
+      sessionKey: "agent:main:slack:channel:resolved:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: "1710000000.9999",
+    };
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(derivedThreadRoute);
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      idempotencyKey: "idem-derived-thread-no-session",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining(derivedThreadRoute),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: derivedThreadRoute.sessionKey,
+        }),
+        threadId: derivedThreadRoute.threadId,
+        mirror: expect.objectContaining({
+          sessionKey: derivedThreadRoute.sessionKey,
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
+  it("keeps the provided thread session but still delivers to the derived thread", async () => {
+    mockDeliverySuccess("m-thread-session");
+    const derivedThreadRoute = {
+      sessionKey: "agent:main:slack:channel:resolved:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: "1710000000.9999",
+    };
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(derivedThreadRoute);
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      sessionKey: derivedThreadRoute.sessionKey,
+      idempotencyKey: "idem-thread-session",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining(derivedThreadRoute),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: derivedThreadRoute.sessionKey,
+        }),
+        threadId: derivedThreadRoute.threadId,
+        mirror: expect.objectContaining({
+          sessionKey: derivedThreadRoute.sessionKey,
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
+  it("keeps an unrelated provided session key and does not inherit the derived thread id", async () => {
+    mockDeliverySuccess("m-unrelated-session");
+    const providedSessionKey = "agent:main:matrix:channel:!dm:example.org";
+    const derivedThreadRoute = {
+      sessionKey: "agent:main:slack:channel:resolved:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: "1710000000.9999",
+    };
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(derivedThreadRoute);
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      sessionKey: providedSessionKey,
+      idempotencyKey: "idem-unrelated-session",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining(derivedThreadRoute),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: providedSessionKey,
+        }),
+        threadId: null,
+        mirror: expect.objectContaining({
+          sessionKey: providedSessionKey,
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
+  it("prefers an explicit request threadId over any derived thread id", async () => {
+    mockDeliverySuccess("m-explicit-thread");
+    const derivedThreadRoute = {
+      sessionKey: "agent:main:slack:channel:resolved:thread:1710000000.9999",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: "1710000000.9999",
+    };
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(derivedThreadRoute);
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      threadId: "1711111111.111111",
+      idempotencyKey: "idem-explicit-thread",
+    });
+
+    expect(mocks.ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining(derivedThreadRoute),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: derivedThreadRoute.sessionKey,
+        }),
+        threadId: "1711111111.111111",
+        mirror: expect.objectContaining({
+          sessionKey: derivedThreadRoute.sessionKey,
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
   it("falls back to the provided sessionKey when outbound route lookup returns null", async () => {
     mockDeliverySuccess("m-session-fallback");
     mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(null);

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -809,6 +809,41 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("stringifies numeric derived thread ids before classifying and delivering them", async () => {
+    mockDeliverySuccess("m-derived-thread-numeric");
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
+      sessionKey: "agent:main:slack:channel:resolved:thread:42",
+      baseSessionKey: "agent:main:slack:channel:resolved",
+      peer: { kind: "channel" as const, id: "resolved" },
+      chatType: "channel" as const,
+      from: "slack:channel:resolved",
+      to: "channel:resolved",
+      threadId: 42,
+    });
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      sessionKey: "agent:main:slack:channel:resolved",
+      idempotencyKey: "idem-derived-thread-numeric",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          agentId: "main",
+          key: "agent:main:slack:channel:resolved:thread:42",
+        }),
+        threadId: "42",
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:slack:channel:resolved:thread:42",
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
   it("keeps the provided thread session but still delivers to the derived thread", async () => {
     mockDeliverySuccess("m-thread-session");
     const derivedThreadRoute = {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -260,6 +260,77 @@ function createGatewayInflightUnavailableFailure(params: {
   };
 }
 
+type GatewayDerivedRoute = {
+  sessionKey: string;
+  baseSessionKey: string;
+  threadId?: string | number;
+};
+
+function classifyDerivedThreadRelationship(params: {
+  providedSessionKey?: string;
+  derivedRoute?: GatewayDerivedRoute | null;
+}): "none" | "base_refinement" | "same_thread" {
+  const providedSessionKey = normalizeOptionalLowercaseString(params.providedSessionKey);
+  const derivedThreadId = normalizeOptionalString(params.derivedRoute?.threadId);
+  if (!providedSessionKey || !params.derivedRoute || !derivedThreadId) {
+    return "none";
+  }
+  const derivedSessionKey = normalizeOptionalLowercaseString(params.derivedRoute.sessionKey);
+  const derivedBaseSessionKey = normalizeOptionalLowercaseString(
+    params.derivedRoute.baseSessionKey,
+  );
+  if (derivedSessionKey && providedSessionKey === derivedSessionKey) {
+    return "same_thread";
+  }
+  if (
+    derivedBaseSessionKey &&
+    providedSessionKey === derivedBaseSessionKey &&
+    providedSessionKey !== derivedSessionKey
+  ) {
+    return "base_refinement";
+  }
+  return "none";
+}
+
+function resolveGatewayTranscriptSessionKey(params: {
+  providedSessionKey?: string;
+  derivedRoute?: GatewayDerivedRoute | null;
+}): string | undefined {
+  const providedSessionKey = normalizeOptionalLowercaseString(params.providedSessionKey);
+  const derivedSessionKey = normalizeOptionalLowercaseString(params.derivedRoute?.sessionKey);
+  if (!providedSessionKey) {
+    return derivedSessionKey;
+  }
+  return classifyDerivedThreadRelationship(params) === "base_refinement"
+    ? (derivedSessionKey ?? providedSessionKey)
+    : providedSessionKey;
+}
+
+function resolveGatewayDeliveryThreadId(params: {
+  explicitThreadId?: string;
+  providedSessionKey?: string;
+  derivedRoute?: GatewayDerivedRoute | null;
+}): string | null {
+  const explicitThreadId = normalizeOptionalString(params.explicitThreadId);
+  if (explicitThreadId) {
+    return explicitThreadId;
+  }
+  const derivedThreadId = normalizeOptionalString(params.derivedRoute?.threadId);
+  if (!derivedThreadId) {
+    return null;
+  }
+  if (!normalizeOptionalLowercaseString(params.providedSessionKey)) {
+    return derivedThreadId;
+  }
+  const relationship = classifyDerivedThreadRelationship({
+    providedSessionKey: params.providedSessionKey,
+    derivedRoute: params.derivedRoute,
+  });
+  return relationship === "base_refinement" || relationship === "same_thread"
+    ? derivedThreadId
+    : null;
+}
+
 export const sendHandlers: GatewayRequestHandlers = {
   "message.action": async ({ params, respond, context, client }) => {
     const p = params;
@@ -486,24 +557,23 @@ export const sendHandlers: GatewayRequestHandlers = {
           resolvedTarget: idLikeTarget,
           threadId,
         });
-        const outboundRoute = derivedRoute
-          ? providedSessionKey
-            ? {
-                ...derivedRoute,
-                sessionKey: providedSessionKey,
-                baseSessionKey: providedSessionKey,
-              }
-            : derivedRoute
-          : null;
-        if (outboundRoute) {
+        if (derivedRoute) {
           await ensureOutboundSessionEntry({
             cfg,
             channel,
             accountId,
-            route: outboundRoute,
+            route: derivedRoute,
           });
         }
-        const outboundSessionKey = outboundRoute?.sessionKey ?? providedSessionKey;
+        const outboundSessionKey = resolveGatewayTranscriptSessionKey({
+          providedSessionKey,
+          derivedRoute,
+        });
+        const deliveryThreadId = resolveGatewayDeliveryThreadId({
+          explicitThreadId: threadId,
+          providedSessionKey,
+          derivedRoute,
+        });
         const outboundSession = buildOutboundSessionContext({
           cfg,
           agentId: effectiveAgentId,
@@ -517,7 +587,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           payloads: outboundPayloads,
           session: outboundSession,
           gifPlayback: request.gifPlayback,
-          threadId: threadId ?? null,
+          threadId: deliveryThreadId,
           deps: outboundDeps,
           gatewayClientScopes: client?.connect?.scopes ?? [],
           mirror: outboundSessionKey

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -19,6 +19,7 @@ import {
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
+import { normalizeOutboundThreadId } from "../../infra/outbound/thread-id.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
 import { normalizePollInput } from "../../polls.js";
 import {
@@ -271,7 +272,7 @@ function classifyDerivedThreadRelationship(params: {
   derivedRoute?: GatewayDerivedRoute | null;
 }): "none" | "base_refinement" | "same_thread" {
   const providedSessionKey = normalizeOptionalLowercaseString(params.providedSessionKey);
-  const derivedThreadId = normalizeOptionalString(params.derivedRoute?.threadId);
+  const derivedThreadId = normalizeOutboundThreadId(params.derivedRoute?.threadId);
   if (!providedSessionKey || !params.derivedRoute || !derivedThreadId) {
     return "none";
   }
@@ -315,7 +316,7 @@ function resolveGatewayDeliveryThreadId(params: {
   if (explicitThreadId) {
     return explicitThreadId;
   }
-  const derivedThreadId = normalizeOptionalString(params.derivedRoute?.threadId);
+  const derivedThreadId = normalizeOutboundThreadId(params.derivedRoute?.threadId);
   if (!derivedThreadId) {
     return null;
   }


### PR DESCRIPTION
## Summary
- preserve derived thread-scoped routing when gateway send receives a broader or thread-scoped `sessionKey`
- separate transcript/mirror session selection from delivery-thread selection in gateway send
- recover Slack thread scope from `currentSessionKey` and align Slack route derivation with final send precedence
- add regression coverage for base-session, thread-session, unrelated-session, explicit-thread, and sessionKey-only continuation cases

## Root Cause
`#69741` comes from two related gaps in the Slack continuation path:

1. `src/gateway/server-methods/send.ts` flattened derived thread routes back onto the caller-provided `sessionKey`, which coupled transcript/mirror session choice to delivery-thread choice.
2. `extensions/slack/src/channel.ts` could not recover thread scope when only a thread-scoped `sessionKey` survived the gateway hop, and route derivation could disagree with final Slack send behavior.

Together, those gaps could flatten threaded continuations to the channel level or attach mirror/transcript behavior to the wrong session.

## User Impact
Slack continuation replies now stay bound to the correct thread when gateway send only has a forwarded `sessionKey`, while preserving the existing mirror/transcript contract for unrelated provided sessions.

## Testing
Fully tested.

- `codex review --base origin/main`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/send.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts slack/src/channel.test.ts`
- `pnpm test:extensions:package-boundary`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## AI Assistance
AI-assisted: implemented with Codex, with all code and validation reviewed locally before submission.
