### PR TITLE
feat: add `openclaw diagnose` CLI for AI-powered gateway diagnostics

### DIFF
--- a/docs/cli/diagnose.md
+++ b/docs/cli/diagnose.md
@@ -31,6 +31,10 @@ openclaw diagnose --output diagnostics.md   # save report to file
 openclaw diagnose --json                    # structured JSON output
 openclaw diagnose --model claude-haiku-4-5  # use a specific model
 openclaw diagnose --max-log-entries 50      # limit log entries (faster, cheaper)
+openclaw diagnose --last 2h                 # analyze only the last 2 hours
+openclaw diagnose --last 7d                 # analyze the last 7 days (reads daily log files)
+openclaw diagnose --since 2026-04-20        # analyze since a specific date
+openclaw diagnose --since 2026-04-20T10:00:00  # analyze since a precise timestamp
 ```
 
 ## Options
@@ -40,6 +44,8 @@ openclaw diagnose --max-log-entries 50      # limit log entries (faster, cheaper
 - `--json`: Output result as structured JSON (includes raw context and report)
 - `--model <id>`: Override the model used for analysis (default: user's configured primary model)
 - `--max-log-entries <n>`: Maximum WARN/ERROR/FATAL log entries to include (default: 200)
+- `--since <value>`: Only include log entries from this point onward. Accepts an ISO timestamp (e.g. `2026-04-20`, `2026-04-20T10:00:00`) **or** a duration (e.g. `2h`, `7d`). When the window extends across day boundaries, `diagnose` reads every dated daily log file (`openclaw-YYYY-MM-DD.log`) that falls within it.
+- `--last <duration>`: Shorthand for `--since` with a duration relative to now. Units: `ms`, `s`, `m`, `h`, `d`, `w`. Mutually exclusive with `--since`.
 
 ## What gets analyzed
 

--- a/docs/cli/diagnose.md
+++ b/docs/cli/diagnose.md
@@ -1,0 +1,79 @@
+---
+summary: "CLI reference for `openclaw diagnose` (AI-powered gateway diagnostic analysis)"
+read_when:
+  - The gateway is misbehaving and you want a structured diagnostic report
+  - You want an AI analysis of gateway logs, config, and health data
+  - You need to generate a diagnostic report for sharing or archival
+title: "diagnose"
+---
+
+# `openclaw diagnose`
+
+AI-powered diagnostic analysis of gateway logs and configuration.
+
+Assembles diagnostic context from the gateway log, configuration, health data,
+version info, auth events, and system memory, then sends it to an AI model for
+structured analysis. The resulting report identifies issues, likely root causes,
+and recommended fixes.
+
+Related:
+
+- Health checks: [doctor](/cli/doctor)
+- Gateway status: [gateway](/cli/gateway)
+- Logs: [logs](/cli/logs)
+
+## Examples
+
+```bash
+openclaw diagnose                           # stream report to stdout
+openclaw diagnose --canvas                  # also save HTML to canvas for browser viewing
+openclaw diagnose --output diagnostics.md   # save report to file
+openclaw diagnose --json                    # structured JSON output
+openclaw diagnose --model claude-haiku-4-5  # use a specific model
+openclaw diagnose --max-log-entries 50      # limit log entries (faster, cheaper)
+```
+
+## Options
+
+- `--output <path>`: Save the Markdown report to a file
+- `--canvas`: Save an HTML report to `~/.openclaw/canvas/diagnostics.html` for browser viewing
+- `--json`: Output result as structured JSON (includes raw context and report)
+- `--model <id>`: Override the model used for analysis (default: user's configured primary model)
+- `--max-log-entries <n>`: Maximum WARN/ERROR/FATAL log entries to include (default: 200)
+
+## What gets analyzed
+
+The diagnostic context includes six sections, assembled automatically:
+
+1. **Gateway log** — today's WARN/ERROR/FATAL entries, capped to fit the model's token limit
+2. **Configuration** — `openclaw.json` with secrets redacted
+3. **Health data** — `health.json` from the workspace watchdog
+4. **Version** — installed OpenClaw version
+5. **Auth events** — count and IP summary of authentication rejections
+6. **System memory** — RAM and platform info at time of analysis
+
+## Report structure
+
+The AI model produces a structured Markdown report with:
+
+- **Executive Summary** — one-paragraph health assessment plus an alphabetically enumerated list of every issue found
+- **Findings** — one subsection per issue with: what it means, relevant log entries with timestamps, likely root cause, and recommended fix
+
+## Canvas output
+
+When `--canvas` is used, the report is also saved as a self-contained HTML page at
+`~/.openclaw/canvas/diagnostics.html`. This page includes a dark-theme stylesheet
+and can be viewed in any browser. If the gateway is running, it is also accessible
+via the Control UI's canvas serving mechanism.
+
+## Notes
+
+- The gateway must be running for the AI analysis (the command uses the gateway's
+  model routing). If the gateway is down, use `--json` to get the raw diagnostic
+  context and feed it to your own LLM.
+- The command reads log files directly from disk, so log data is available even
+  when the gateway is unresponsive.
+- Secrets in `openclaw.json` (API keys, tokens, passwords) are replaced with
+  `[REDACTED]` before being sent to the model.
+- Use `--max-log-entries` to reduce token usage and cost when a full log scan
+  is not needed.

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -77,7 +77,7 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerBackupCommand",
       },
       {
-        commandNames: ["doctor", "dashboard", "reset", "uninstall"],
+        commandNames: ["diagnose", "doctor", "dashboard", "reset", "uninstall"],
         loadModule: () => import("./register.maintenance.js"),
         exportName: "registerMaintenanceCommands",
       },

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -31,6 +31,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "diagnose",
+    description: "AI-powered diagnostic analysis of gateway logs and configuration",
+    hasSubcommands: false,
+  },
+  {
     name: "doctor",
     description: "Health checks + quick fixes for the gateway and channels",
     hasSubcommands: false,

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { dashboardCommand } from "../../commands/dashboard.js";
 import { diagnoseCommand } from "../../commands/diagnose.js";
+import { parseTimeFilter } from "../../commands/diagnose/parse-time-filter.js";
 import { doctorCommand } from "../../commands/doctor.js";
 import { resetCommand } from "../../commands/reset.js";
 import { uninstallCommand } from "../../commands/uninstall.js";
@@ -27,6 +28,8 @@ ${theme.heading("Examples:")}
   ${theme.command("openclaw diagnose --output r.md")} ${theme.muted("# save report to file")}
   ${theme.command("openclaw diagnose --json")}        ${theme.muted("# structured JSON output")}
   ${theme.command("openclaw diagnose --model claude-haiku-4-5")} ${theme.muted("# override model")}
+  ${theme.command("openclaw diagnose --last 2h")}     ${theme.muted("# only analyze the last 2 hours")}
+  ${theme.command("openclaw diagnose --since 2026-04-20")} ${theme.muted("# only analyze since a date")}
 
 ${theme.muted("Docs:")} ${formatDocsLink("/cli/diagnose", "docs.openclaw.ai/cli/diagnose")}\n`,
     )
@@ -39,14 +42,41 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/diagnose", "docs.openclaw.ai/cli/
       "Maximum WARN/ERROR/FATAL log entries to include (default: 200)",
       "200",
     )
+    .option(
+      "--since <value>",
+      "Only include log entries from this point onward. Accepts an ISO timestamp (e.g. 2026-04-20, 2026-04-20T10:00:00) or a duration (e.g. 2h, 7d).",
+    )
+    .option(
+      "--last <duration>",
+      "Only include log entries from the last N duration (e.g. 30m, 2h, 7d). Mutually exclusive with --since.",
+    )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        let sinceMs: number | undefined;
+        let sinceLabel: string | undefined;
+        try {
+          const filter = parseTimeFilter({
+            since: opts.since as string | undefined,
+            last: opts.last as string | undefined,
+          });
+          if (filter) {
+            sinceMs = filter.sinceMs;
+            sinceLabel = filter.label;
+          }
+        } catch (err) {
+          defaultRuntime.error(err instanceof Error ? err.message : String(err));
+          defaultRuntime.exit(1);
+          return;
+        }
+
         await diagnoseCommand(defaultRuntime, {
           output: opts.output as string | undefined,
           canvas: Boolean(opts.canvas),
           json: Boolean(opts.json),
           model: opts.model as string | undefined,
           maxLogEntries: Number.parseInt(opts.maxLogEntries as string, 10) || 200,
+          sinceMs,
+          sinceLabel,
         });
         defaultRuntime.exit(0);
       });

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { dashboardCommand } from "../../commands/dashboard.js";
+import { diagnoseCommand } from "../../commands/diagnose.js";
 import { doctorCommand } from "../../commands/doctor.js";
 import { resetCommand } from "../../commands/reset.js";
 import { uninstallCommand } from "../../commands/uninstall.js";
@@ -9,6 +10,48 @@ import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 
 export function registerMaintenanceCommands(program: Command) {
+  program
+    .command("diagnose")
+    .description("AI-powered diagnostic analysis of gateway logs and configuration")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("What this does:")}
+  Assembles diagnostic context (gateway log, redacted config, health data,
+  version info, auth events, system memory) and sends it to an AI model for
+  structured analysis. The report identifies issues, root causes, and fixes.
+
+${theme.heading("Examples:")}
+  ${theme.command("openclaw diagnose")}              ${theme.muted("# stream Markdown report to stdout")}
+  ${theme.command("openclaw diagnose --canvas")}      ${theme.muted("# also save HTML to canvas for browser viewing")}
+  ${theme.command("openclaw diagnose --output r.md")} ${theme.muted("# save report to file")}
+  ${theme.command("openclaw diagnose --json")}        ${theme.muted("# structured JSON output")}
+  ${theme.command("openclaw diagnose --model claude-haiku-4-5")} ${theme.muted("# override model")}
+
+${theme.muted("Docs:")} ${formatDocsLink("/cli/diagnose", "docs.openclaw.ai/cli/diagnose")}\n`,
+    )
+    .option("--output <path>", "Save the Markdown report to a file")
+    .option("--canvas", "Save an HTML report to ~/.openclaw/canvas/ for browser viewing", false)
+    .option("--json", "Output result as JSON", false)
+    .option("--model <id>", "Override the model used for analysis")
+    .option(
+      "--max-log-entries <n>",
+      "Maximum WARN/ERROR/FATAL log entries to include (default: 200)",
+      "200",
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await diagnoseCommand(defaultRuntime, {
+          output: opts.output as string | undefined,
+          canvas: Boolean(opts.canvas),
+          json: Boolean(opts.json),
+          model: opts.model as string | undefined,
+          maxLogEntries: Number.parseInt(opts.maxLogEntries as string, 10) || 200,
+        });
+        defaultRuntime.exit(0);
+      });
+    });
+
   program
     .command("doctor")
     .description("Health checks + quick fixes for the gateway and channels")

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -56,8 +56,8 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/diagnose", "docs.openclaw.ai/cli/
         let sinceLabel: string | undefined;
         try {
           const filter = parseTimeFilter({
-            since: opts.since as string | undefined,
-            last: opts.last as string | undefined,
+            since: opts.since,
+            last: opts.last,
           });
           if (filter) {
             sinceMs = filter.sinceMs;

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -69,12 +69,21 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/diagnose", "docs.openclaw.ai/cli/
           return;
         }
 
+        const maxLogEntriesRaw = Number.parseInt(opts.maxLogEntries as string, 10);
+        if (Number.isNaN(maxLogEntriesRaw) || maxLogEntriesRaw <= 0) {
+          defaultRuntime.error(
+            `Invalid --max-log-entries value "${opts.maxLogEntries}" — expected a positive integer.`,
+          );
+          defaultRuntime.exit(1);
+          return;
+        }
+
         await diagnoseCommand(defaultRuntime, {
           output: opts.output as string | undefined,
           canvas: Boolean(opts.canvas),
           json: Boolean(opts.json),
           model: opts.model as string | undefined,
-          maxLogEntries: Number.parseInt(opts.maxLogEntries as string, 10) || 200,
+          maxLogEntries: maxLogEntriesRaw,
           sinceMs,
           sinceLabel,
         });

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
-import path from "node:path";
-import type { Runtime } from "../runtime.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 import { assembleDiagnosticContext } from "./diagnose/assemble-context.js";
 import { KNOWN_ISSUES_PROMPT } from "./diagnose/known-issues.js";
@@ -16,7 +15,7 @@ export interface DiagnoseCommandOptions {
 }
 
 export async function diagnoseCommand(
-  runtime: Runtime,
+  runtime: RuntimeEnv,
   opts: DiagnoseCommandOptions,
 ): Promise<void> {
   if (!opts.json) {

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import type { RuntimeEnv } from "../runtime.js";
+import { writeRuntimeJson } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 import { assembleDiagnosticContext } from "./diagnose/assemble-context.js";
 import { KNOWN_ISSUES_PROMPT } from "./diagnose/known-issues.js";
@@ -66,7 +67,7 @@ export async function diagnoseCommand(
     if (opts.json) {
       // Return raw context as fallback so --json is usable even when the
       // gateway is down — the documented offline analysis workflow.
-      runtime.writeJson({
+      writeRuntimeJson(runtime, {
         status: "context-only",
         error: String(err),
         context: context.text,
@@ -112,7 +113,7 @@ export async function diagnoseCommand(
 
   // JSON output.
   if (opts.json) {
-    runtime.writeJson({
+    writeRuntimeJson(runtime, {
       status: "ok",
       markdown: report.markdown,
       inputTokens: report.inputTokens,

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Runtime } from "../runtime.js";
+import { theme } from "../terminal/theme.js";
+import { assembleDiagnosticContext } from "./diagnose/assemble-context.js";
+import { KNOWN_ISSUES_PROMPT } from "./diagnose/known-issues.js";
+import { renderCanvasHtml } from "./diagnose/render-canvas.js";
+import { streamDiagnosticReport } from "./diagnose/stream-report.js";
+
+export interface DiagnoseCommandOptions {
+  output?: string;
+  canvas: boolean;
+  json: boolean;
+  model?: string;
+  maxLogEntries: number;
+}
+
+export async function diagnoseCommand(
+  runtime: Runtime,
+  opts: DiagnoseCommandOptions,
+): Promise<void> {
+  if (!opts.json) {
+    runtime.log(theme.heading("OpenClaw Gateway Diagnostic Report"));
+    runtime.log(theme.muted("Assembling diagnostic context..."));
+    runtime.log("");
+  }
+
+  // Phase 2: assemble context from log, config, health, version, auth, memory.
+  const context = await assembleDiagnosticContext({
+    maxLogEntries: opts.maxLogEntries,
+  });
+
+  if (!opts.json) {
+    runtime.log(
+      theme.muted(
+        `Context: ${context.logEntryCount} log entries, ` +
+          `${context.authRejectCount} auth events, ` +
+          `version ${context.version ?? "unknown"}`,
+      ),
+    );
+    runtime.log("");
+  }
+
+  // Phase 3: stream report from LLM.
+  const report = await streamDiagnosticReport({
+    context: context.text,
+    knownIssues: KNOWN_ISSUES_PROMPT,
+    modelOverride: opts.model,
+    json: opts.json,
+    onChunk: opts.json
+      ? undefined
+      : (chunk: string) => {
+          process.stdout.write(chunk);
+        },
+  });
+
+  if (!opts.json) {
+    // Ensure final newline after streaming.
+    process.stdout.write("\n\n");
+    runtime.log(
+      theme.muted(
+        `Tokens: ${report.inputTokens.toLocaleString()} input, ` +
+          `${report.outputTokens.toLocaleString()} output` +
+          (report.costUsd > 0 ? ` (~$${report.costUsd.toFixed(4)})` : ""),
+      ),
+    );
+  }
+
+  // Save to file if --output specified.
+  if (opts.output) {
+    await fs.writeFile(opts.output, report.markdown, "utf-8");
+    if (!opts.json) {
+      runtime.log(theme.muted(`Report saved to ${opts.output}`));
+    }
+  }
+
+  // Phase 4: save canvas HTML if --canvas specified.
+  if (opts.canvas) {
+    const canvasPath = await renderCanvasHtml(report.markdown);
+    if (!opts.json) {
+      runtime.log(theme.muted(`Canvas report saved to ${canvasPath}`));
+      runtime.log(
+        theme.muted("View at: http://127.0.0.1:18789/__openclaw__/canvas/diagnostics.html"),
+      );
+    }
+  }
+
+  // JSON output.
+  if (opts.json) {
+    runtime.writeJson({
+      status: "ok",
+      markdown: report.markdown,
+      inputTokens: report.inputTokens,
+      outputTokens: report.outputTokens,
+      costUsd: report.costUsd,
+      logEntryCount: context.logEntryCount,
+      authRejectCount: context.authRejectCount,
+      version: context.version,
+    });
+  }
+}

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -12,6 +12,10 @@ export interface DiagnoseCommandOptions {
   json: boolean;
   model?: string;
   maxLogEntries: number;
+  /** Optional cutoff (epoch ms); log entries older than this are excluded. */
+  sinceMs?: number;
+  /** Human-readable label for the time filter (e.g. "last 2h"). */
+  sinceLabel?: string;
 }
 
 export async function diagnoseCommand(
@@ -27,6 +31,8 @@ export async function diagnoseCommand(
   // Phase 2: assemble context from log, config, health, version, auth, memory.
   const context = await assembleDiagnosticContext({
     maxLogEntries: opts.maxLogEntries,
+    sinceMs: opts.sinceMs,
+    sinceLabel: opts.sinceLabel,
   });
 
   if (!opts.json) {

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -42,17 +42,37 @@ export async function diagnoseCommand(
   }
 
   // Phase 3: stream report from LLM.
-  const report = await streamDiagnosticReport({
-    context: context.text,
-    knownIssues: KNOWN_ISSUES_PROMPT,
-    modelOverride: opts.model,
-    json: opts.json,
-    onChunk: opts.json
-      ? undefined
-      : (chunk: string) => {
-          process.stdout.write(chunk);
-        },
-  });
+  // When --json is used and the gateway is unreachable, return the raw context
+  // without AI analysis so the user can feed it to their own LLM offline.
+  let report: { markdown: string; inputTokens: number; outputTokens: number; costUsd: number };
+  try {
+    report = await streamDiagnosticReport({
+      context: context.text,
+      knownIssues: KNOWN_ISSUES_PROMPT,
+      modelOverride: opts.model,
+      json: opts.json,
+      onChunk: opts.json
+        ? undefined
+        : (chunk: string) => {
+            process.stdout.write(chunk);
+          },
+    });
+  } catch (err) {
+    if (opts.json) {
+      // Return raw context as fallback so --json is usable even when the
+      // gateway is down — the documented offline analysis workflow.
+      runtime.writeJson({
+        status: "context-only",
+        error: String(err),
+        context: context.text,
+        logEntryCount: context.logEntryCount,
+        authRejectCount: context.authRejectCount,
+        version: context.version,
+      });
+      return;
+    }
+    throw err;
+  }
 
   if (!opts.json) {
     // Ensure final newline after streaming.

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { readConfigFileSnapshot } from "../../config/io.js";
+import JSON5 from "json5";
 import { resolveStateDir } from "../../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
@@ -25,14 +25,14 @@ interface AssembleOptions {
 
 const RE_ANSI = /\x1b\[[0-9;]*[mGKHF]/g;
 const RE_IP = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
-const SECRET_KEYS = new Set([
-  "token",
-  "apikey",
-  "api_key",
-  "secret",
-  "password",
-  "authorization",
-]);
+// Suffix-based matching catches botToken, appToken, webhookSecret, accessToken,
+// apiKey, etc. — not just exact key names.
+const SECRET_SUFFIXES = ["token", "secret", "password", "apikey", "api_key", "authorization"];
+
+function isSecretKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SECRET_SUFFIXES.some((suffix) => lower === suffix || lower.endsWith(suffix));
+}
 
 function stripAnsi(text: string): string {
   return text.replace(RE_ANSI, "");
@@ -46,7 +46,7 @@ function redactSecrets(obj: unknown, depth = 0): unknown {
   if (typeof obj === "object" && obj !== null) {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      if (SECRET_KEYS.has(key.toLowerCase()) && typeof value === "string" && value.length > 0) {
+      if (isSecretKey(key) && typeof value === "string" && value.length > 0) {
         result[key] = "[REDACTED]";
       } else {
         result[key] = redactSecrets(value, depth + 1);
@@ -77,18 +77,50 @@ interface ParsedLogEntry {
   raw: string;
 }
 
-const RE_LOG_LINE =
+// OpenClaw gateway logs are JSON lines. Each line is a JSON object with:
+//   "0": subsystem info (JSON string like '{"subsystem":"gateway/ws"}')
+//   "1": message text
+//   "_meta": { "logLevelName": "INFO"|"WARN"|"ERROR"|"FATAL", "date": "..." }
+//   "time": local ISO timestamp
+// Fallback regex handles any non-JSON log lines (older versions, plain text).
+const RE_LOG_LINE_FALLBACK =
   /^(\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:\d{2}|Z)?)\s+\[(\w+)]\s+\[([^\]]*?)]\s+(.*)/;
 
 function parseLogLine(line: string): ParsedLogEntry | null {
-  const match = RE_LOG_LINE.exec(line.trim());
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  // Try JSON parse first (primary format).
+  if (trimmed.startsWith("{")) {
+    try {
+      const obj = JSON.parse(trimmed);
+      const meta = obj._meta ?? {};
+      const level = meta.logLevelName ?? "";
+      const timestamp = obj.time ?? meta.date ?? "";
+      let subsystem = "";
+      try {
+        const sub = JSON.parse(obj["0"] ?? "{}");
+        subsystem = sub.subsystem ?? "";
+      } catch {
+        subsystem = String(obj["0"] ?? "");
+      }
+      const message = String(obj["1"] ?? "");
+      if (!level && !message) return null;
+      return { timestamp, level, subsystem, message, raw: trimmed };
+    } catch {
+      // Fall through to regex.
+    }
+  }
+
+  // Fallback: plain-text log format.
+  const match = RE_LOG_LINE_FALLBACK.exec(trimmed);
   if (!match) return null;
   return {
     timestamp: match[1],
     level: match[2],
     subsystem: match[3],
     message: match[4],
-    raw: line.trim(),
+    raw: trimmed,
   };
 }
 
@@ -168,7 +200,7 @@ function assembleRedactedConfig(): string {
 
   try {
     const raw = fs.readFileSync(configPath, { encoding: "utf-8" });
-    const parsed = JSON.parse(raw);
+    const parsed = JSON5.parse(raw);
     const redacted = redactSecrets(parsed);
     return (
       "## OpenClaw Configuration (openclaw.json, secrets redacted)\n" +

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -95,7 +95,7 @@ function dailyLogFileNamesInRange(startDate: Date, endDate: Date): string[] {
   return names;
 }
 
-interface ParsedLogEntry {
+export interface ParsedLogEntry {
   timestamp: string;
   level: string;
   subsystem: string;
@@ -120,7 +120,7 @@ function parseEntryTimestampMs(entry: ParsedLogEntry): number | null {
 const RE_LOG_LINE_FALLBACK =
   /^(\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:\d{2}|Z)?)\s+\[(\w+)]\s+\[([^\]]*?)]\s+(.*)/;
 
-function parseLogLine(line: string): ParsedLogEntry | null {
+export function parseLogLine(line: string): ParsedLogEntry | null {
   const trimmed = line.trim();
   if (!trimmed) {
     return null;
@@ -133,14 +133,48 @@ function parseLogLine(line: string): ParsedLogEntry | null {
       const meta = obj._meta ?? {};
       const level = meta.logLevelName ?? "";
       const timestamp = obj.time ?? meta.date ?? "";
+
+      // tslog stores positional call arguments under numeric string keys
+      // ("0", "1", "2", ...). Any of them may be:
+      //   - a JSON string describing a bindings object (e.g. '{"subsystem":"x"}')
+      //   - a plain string message
+      //   - an already-serialised object
+      // We walk the numeric keys in order, pull out the first subsystem we
+      // find, and join everything else into the message.
       let subsystem = "";
-      try {
-        const sub = JSON.parse(obj["0"] ?? "{}");
-        subsystem = sub.subsystem ?? "";
-      } catch {
-        subsystem = String(obj["0"] ?? "");
+      const messageParts: string[] = [];
+      let idx = 0;
+      while (Object.hasOwn(obj, String(idx))) {
+        const value = obj[String(idx)];
+        if (typeof value === "string") {
+          const looksLikeJson = value.startsWith("{") && value.endsWith("}");
+          if (looksLikeJson) {
+            try {
+              const parsed = JSON.parse(value);
+              if (!subsystem && typeof parsed?.subsystem === "string") {
+                subsystem = parsed.subsystem;
+              } else {
+                messageParts.push(value);
+              }
+            } catch {
+              messageParts.push(value);
+            }
+          } else {
+            messageParts.push(value);
+          }
+        } else if (value && typeof value === "object") {
+          const maybeSub = (value as { subsystem?: unknown }).subsystem;
+          if (!subsystem && typeof maybeSub === "string") {
+            subsystem = maybeSub;
+          } else {
+            messageParts.push(JSON.stringify(value));
+          }
+        } else if (value !== undefined) {
+          messageParts.push(String(value));
+        }
+        idx++;
       }
-      const message = String(obj["1"] ?? "");
+      const message = messageParts.join(" ");
       if (!level && !message) {
         return null;
       }
@@ -309,17 +343,28 @@ function assembleRedactedConfig(): string {
 
 function assembleHealthData(): string {
   const stateDir = resolveStateDir();
-  const healthPath = path.join(stateDir, "workspace", "memory", "health.json");
+  // Authoritative location used by src/config/io.observe-recovery.ts.
+  // The file is written by the config-observe recovery path and is JSON5.
+  const healthPath = path.join(stateDir, "logs", "config-health.json");
 
   if (!fs.existsSync(healthPath)) {
-    return "## Watchdog Health Data\nhealth.json not found — watchdog may not have run.\n";
+    return "## Config Health Data\nconfig-health.json not found — observe-recovery may not have run.\n";
   }
 
   try {
     const raw = fs.readFileSync(healthPath, { encoding: "utf-8" });
-    return "## Watchdog Health Data (health.json)\n" + raw + "\n";
+    // Parse with JSON5 then re-serialise as strict JSON so the model sees a
+    // canonical shape. Fall back to the raw text if parsing fails.
+    let body = raw;
+    try {
+      const parsed = JSON5.parse(raw);
+      body = JSON.stringify(parsed, null, 2);
+    } catch {
+      // keep raw text
+    }
+    return "## Config Health Data (logs/config-health.json)\n" + body + "\n";
   } catch (err) {
-    return `## Watchdog Health Data\nError reading health.json: ${String(err)}\n`;
+    return `## Config Health Data\nError reading config-health.json: ${String(err)}\n`;
   }
 }
 

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -100,23 +100,20 @@ function assembleGatewayLog(maxEntries: number): {
   allParsed: ParsedLogEntry[];
 } {
   const logDir = resolveLogDir();
-  const logPath = path.join(logDir, todayLogFileName());
+  const datedPath = path.join(logDir, todayLogFileName());
+  const fallbackPath = path.join(logDir, "openclaw.log");
+  const datedExists = fs.existsSync(datedPath);
+  const fallbackExists = fs.existsSync(fallbackPath);
 
-  if (!fs.existsSync(logPath)) {
-    // Fall back to the non-dated log file.
-    const fallback = path.join(logDir, "openclaw.log");
-    if (!fs.existsSync(fallback)) {
-      return {
-        section: "## Gateway Log\nLog file not found — gateway may not have run today.\n",
-        entryCount: 0,
-        allParsed: [],
-      };
-    }
+  if (!datedExists && !fallbackExists) {
+    return {
+      section: "## Gateway Log\nLog file not found — gateway may not have run today.\n",
+      entryCount: 0,
+      allParsed: [],
+    };
   }
 
-  const actualPath = fs.existsSync(path.join(logDir, todayLogFileName()))
-    ? path.join(logDir, todayLogFileName())
-    : path.join(logDir, "openclaw.log");
+  const actualPath = datedExists ? datedPath : fallbackPath;
 
   try {
     const content = fs.readFileSync(actualPath, { encoding: "utf-8" });

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -19,6 +19,10 @@ export interface DiagnosticContext {
 
 interface AssembleOptions {
   maxLogEntries: number;
+  /** When set, only include log entries with timestamp >= sinceMs (epoch ms). */
+  sinceMs?: number;
+  /** Human-readable label for the time filter, embedded in section headings. */
+  sinceLabel?: string;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -64,12 +68,31 @@ function resolveLogDir(): string {
   return resolvePreferredOpenClawTmpDir();
 }
 
-function todayLogFileName(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
+function dailyLogFileName(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
   return `openclaw-${year}-${month}-${day}.log`;
+}
+
+function todayLogFileName(): string {
+  return dailyLogFileName(new Date());
+}
+
+/**
+ * Enumerate each daily log file name from startDate through endDate (inclusive,
+ * at local midnight boundaries). Used when a --since / --last filter widens the
+ * window beyond today.
+ */
+function dailyLogFileNamesInRange(startDate: Date, endDate: Date): string[] {
+  const names: string[] = [];
+  const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+  while (cursor.getTime() <= end.getTime()) {
+    names.push(dailyLogFileName(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return names;
 }
 
 interface ParsedLogEntry {
@@ -78,6 +101,14 @@ interface ParsedLogEntry {
   subsystem: string;
   message: string;
   raw: string;
+}
+
+function parseEntryTimestampMs(entry: ParsedLogEntry): number | null {
+  if (!entry.timestamp) {
+    return null;
+  }
+  const ms = Date.parse(entry.timestamp);
+  return Number.isNaN(ms) ? null : ms;
 }
 
 // OpenClaw gateway logs are JSON lines. Each line is a JSON object with:
@@ -135,49 +166,102 @@ function parseLogLine(line: string): ParsedLogEntry | null {
 
 // ── Section assemblers ───────────────────────────────────────────────────
 
-function assembleGatewayLog(maxEntries: number): {
+function assembleGatewayLog(
+  maxEntries: number,
+  sinceMs?: number,
+  sinceLabel?: string,
+): {
   section: string;
   entryCount: number;
   allParsed: ParsedLogEntry[];
 } {
   const logDir = resolveLogDir();
-  const datedPath = path.join(logDir, todayLogFileName());
-  const fallbackPath = path.join(logDir, "openclaw.log");
-  const datedExists = fs.existsSync(datedPath);
-  const fallbackExists = fs.existsSync(fallbackPath);
 
-  if (!datedExists && !fallbackExists) {
+  // Decide which log files to read.
+  //   - Default (no time filter): today's dated log, or openclaw.log as fallback.
+  //   - With time filter: every daily file in the [sinceMs, now] window that exists,
+  //     falling back to openclaw.log only if no dated files are found.
+  const filesToRead: string[] = [];
+  let sourceLabel: string;
+
+  if (sinceMs !== undefined) {
+    const candidates = dailyLogFileNamesInRange(new Date(sinceMs), new Date());
+    for (const name of candidates) {
+      const p = path.join(logDir, name);
+      if (fs.existsSync(p)) {
+        filesToRead.push(p);
+      }
+    }
+    if (filesToRead.length === 0) {
+      const fallbackPath = path.join(logDir, "openclaw.log");
+      if (fs.existsSync(fallbackPath)) {
+        filesToRead.push(fallbackPath);
+      }
+    }
+    sourceLabel =
+      filesToRead.length === 0
+        ? "(no log files found in range)"
+        : filesToRead.map((p) => path.basename(p)).join(", ");
+  } else {
+    const datedPath = path.join(logDir, todayLogFileName());
+    const fallbackPath = path.join(logDir, "openclaw.log");
+    if (fs.existsSync(datedPath)) {
+      filesToRead.push(datedPath);
+    } else if (fs.existsSync(fallbackPath)) {
+      filesToRead.push(fallbackPath);
+    }
+    sourceLabel = todayLogFileName();
+  }
+
+  if (filesToRead.length === 0) {
+    const filterSuffix = sinceLabel ? ` (${sinceLabel})` : "";
     return {
-      section: "## Gateway Log\nLog file not found — gateway may not have run today.\n",
+      section: `## Gateway Log${filterSuffix}\nLog file not found — gateway may not have run in this window.\n`,
       entryCount: 0,
       allParsed: [],
     };
   }
 
-  const actualPath = datedExists ? datedPath : fallbackPath;
-
   try {
-    const content = fs.readFileSync(actualPath, { encoding: "utf-8" });
-    const lines = content.split("\n");
-    const totalLines = lines.length;
+    let totalLines = 0;
     const allParsed: ParsedLogEntry[] = [];
     const issueEntries: ParsedLogEntry[] = [];
+    let droppedByTimeFilter = 0;
 
-    for (const line of lines) {
-      const entry = parseLogLine(line);
-      if (!entry) {
-        continue;
-      }
-      allParsed.push(entry);
-      if (["WARN", "WARNING", "ERROR", "FATAL"].includes(entry.level)) {
-        issueEntries.push(entry);
+    for (const filePath of filesToRead) {
+      const content = fs.readFileSync(filePath, { encoding: "utf-8" });
+      const lines = content.split("\n");
+      totalLines += lines.length;
+
+      for (const line of lines) {
+        const entry = parseLogLine(line);
+        if (!entry) {
+          continue;
+        }
+        if (sinceMs !== undefined) {
+          const ts = parseEntryTimestampMs(entry);
+          // When the timestamp is unparseable we keep the entry rather than
+          // silently dropping it — safer than hiding potentially relevant noise.
+          if (ts !== null && ts < sinceMs) {
+            droppedByTimeFilter++;
+            continue;
+          }
+        }
+        allParsed.push(entry);
+        if (["WARN", "WARNING", "ERROR", "FATAL"].includes(entry.level)) {
+          issueEntries.push(entry);
+        }
       }
     }
 
     const totalIssues = issueEntries.length;
     const shown = issueEntries.slice(-maxEntries);
-    let section = `## Gateway Log (${todayLogFileName()}) — WARN/ERROR/FATAL entries\n`;
-    section += `Total log lines: ${totalLines}. Total issues: ${totalIssues}.`;
+    const filterSuffix = sinceLabel ? ` — filtered: ${sinceLabel}` : "";
+    let section = `## Gateway Log (${sourceLabel})${filterSuffix} — WARN/ERROR/FATAL entries\n`;
+    section += `Total log lines scanned: ${totalLines}. Total issues in window: ${totalIssues}.`;
+    if (droppedByTimeFilter > 0) {
+      section += ` ${droppedByTimeFilter} entries excluded by time filter.`;
+    }
     if (totalIssues > shown.length) {
       section += ` Showing most recent ${shown.length} (truncated to fit token limit).`;
     }
@@ -188,7 +272,7 @@ function assembleGatewayLog(maxEntries: number): {
         section += `[${entry.timestamp}] [${entry.level}] [${entry.subsystem}] ${entry.message}\n`;
       }
     } else {
-      section += "(No WARN/ERROR/FATAL entries found — gateway log appears clean.)\n";
+      section += "(No WARN/ERROR/FATAL entries found in window — gateway log appears clean.)\n";
     }
 
     return { section, entryCount: shown.length, allParsed };
@@ -257,7 +341,10 @@ async function assembleVersionInfo(): Promise<{ section: string; version: string
   }
 }
 
-function assembleAuthSummary(allParsed: ParsedLogEntry[]): {
+function assembleAuthSummary(
+  allParsed: ParsedLogEntry[],
+  sinceLabel?: string,
+): {
   section: string;
   count: number;
 } {
@@ -279,9 +366,10 @@ function assembleAuthSummary(allParsed: ParsedLogEntry[]): {
     if (match) sourceIps.add(match[0]);
   }
 
-  let section = "## Security Events — Auth Rejections\n";
+  const windowLabel = sinceLabel ?? "today's log";
+  let section = `## Security Events — Auth Rejections (${windowLabel})\n`;
   if (rejects.length === 0) {
-    section += "No auth rejection events found in today's log.\n";
+    section += `No auth rejection events found in ${windowLabel}.\n`;
   } else {
     section += `${rejects.length} auth rejection event(s) detected.`;
     if (rejects.length >= 2) {
@@ -314,11 +402,11 @@ function assembleSystemMemory(): string {
 export async function assembleDiagnosticContext(
   opts: AssembleOptions,
 ): Promise<DiagnosticContext> {
-  const logResult = assembleGatewayLog(opts.maxLogEntries);
+  const logResult = assembleGatewayLog(opts.maxLogEntries, opts.sinceMs, opts.sinceLabel);
   const configSection = assembleRedactedConfig();
   const healthSection = assembleHealthData();
   const versionResult = await assembleVersionInfo();
-  const authResult = assembleAuthSummary(logResult.allParsed);
+  const authResult = assembleAuthSummary(logResult.allParsed, opts.sinceLabel);
   const memorySection = assembleSystemMemory();
 
   const text = [

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -363,7 +363,9 @@ function assembleAuthSummary(
   const sourceIps = new Set<string>();
   for (const entry of rejects) {
     const match = RE_IP.exec(entry.message);
-    if (match) sourceIps.add(match[0]);
+    if (match) {
+      sourceIps.add(match[0]);
+    }
   }
 
   const windowLabel = sinceLabel ?? "today's log";

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -1,0 +1,299 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readConfigFileSnapshot } from "../../config/io.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+
+export interface DiagnosticContext {
+  /** Combined Markdown text of all context sections. */
+  text: string;
+  /** Number of WARN/ERROR/FATAL log entries included. */
+  logEntryCount: number;
+  /** Number of auth rejection events found. */
+  authRejectCount: number;
+  /** Installed OpenClaw version string, or null. */
+  version: string | null;
+}
+
+interface AssembleOptions {
+  maxLogEntries: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+const RE_ANSI = /\x1b\[[0-9;]*[mGKHF]/g;
+const RE_IP = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
+const SECRET_KEYS = new Set([
+  "token",
+  "apikey",
+  "api_key",
+  "secret",
+  "password",
+  "authorization",
+]);
+
+function stripAnsi(text: string): string {
+  return text.replace(RE_ANSI, "");
+}
+
+function redactSecrets(obj: unknown, depth = 0): unknown {
+  if (depth > 10) return obj;
+  if (Array.isArray(obj)) {
+    return obj.map((item) => redactSecrets(item, depth + 1));
+  }
+  if (typeof obj === "object" && obj !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (SECRET_KEYS.has(key.toLowerCase()) && typeof value === "string" && value.length > 0) {
+        result[key] = "[REDACTED]";
+      } else {
+        result[key] = redactSecrets(value, depth + 1);
+      }
+    }
+    return result;
+  }
+  return obj;
+}
+
+function resolveLogDir(): string {
+  return resolvePreferredOpenClawTmpDir();
+}
+
+function todayLogFileName(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `openclaw-${year}-${month}-${day}.log`;
+}
+
+interface ParsedLogEntry {
+  timestamp: string;
+  level: string;
+  subsystem: string;
+  message: string;
+  raw: string;
+}
+
+const RE_LOG_LINE =
+  /^(\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:\d{2}|Z)?)\s+\[(\w+)]\s+\[([^\]]*?)]\s+(.*)/;
+
+function parseLogLine(line: string): ParsedLogEntry | null {
+  const match = RE_LOG_LINE.exec(line.trim());
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    level: match[2],
+    subsystem: match[3],
+    message: match[4],
+    raw: line.trim(),
+  };
+}
+
+// ── Section assemblers ───────────────────────────────────────────────────
+
+function assembleGatewayLog(maxEntries: number): {
+  section: string;
+  entryCount: number;
+  allParsed: ParsedLogEntry[];
+} {
+  const logDir = resolveLogDir();
+  const logPath = path.join(logDir, todayLogFileName());
+
+  if (!fs.existsSync(logPath)) {
+    // Fall back to the non-dated log file.
+    const fallback = path.join(logDir, "openclaw.log");
+    if (!fs.existsSync(fallback)) {
+      return {
+        section: "## Gateway Log\nLog file not found — gateway may not have run today.\n",
+        entryCount: 0,
+        allParsed: [],
+      };
+    }
+  }
+
+  const actualPath = fs.existsSync(path.join(logDir, todayLogFileName()))
+    ? path.join(logDir, todayLogFileName())
+    : path.join(logDir, "openclaw.log");
+
+  try {
+    const content = fs.readFileSync(actualPath, { encoding: "utf-8" });
+    const lines = content.split("\n");
+    const totalLines = lines.length;
+    const allParsed: ParsedLogEntry[] = [];
+    const issueEntries: ParsedLogEntry[] = [];
+
+    for (const line of lines) {
+      const entry = parseLogLine(line);
+      if (!entry) continue;
+      allParsed.push(entry);
+      if (["WARN", "WARNING", "ERROR", "FATAL"].includes(entry.level)) {
+        issueEntries.push(entry);
+      }
+    }
+
+    const totalIssues = issueEntries.length;
+    const shown = issueEntries.slice(-maxEntries);
+    let section = `## Gateway Log (${todayLogFileName()}) — WARN/ERROR/FATAL entries\n`;
+    section += `Total log lines: ${totalLines}. Total issues: ${totalIssues}.`;
+    if (totalIssues > shown.length) {
+      section += ` Showing most recent ${shown.length} (truncated to fit token limit).`;
+    }
+    section += "\n\n";
+
+    if (shown.length > 0) {
+      for (const entry of shown) {
+        section += `[${entry.timestamp}] [${entry.level}] [${entry.subsystem}] ${entry.message}\n`;
+      }
+    } else {
+      section += "(No WARN/ERROR/FATAL entries found — gateway log appears clean.)\n";
+    }
+
+    return { section, entryCount: shown.length, allParsed };
+  } catch (err) {
+    return {
+      section: `## Gateway Log\nError reading log file: ${String(err)}\n`,
+      entryCount: 0,
+      allParsed: [],
+    };
+  }
+}
+
+function assembleRedactedConfig(): string {
+  const stateDir = resolveStateDir();
+  const configPath = path.join(stateDir, "openclaw.json");
+
+  if (!fs.existsSync(configPath)) {
+    return "## OpenClaw Configuration\nopenclaw.json not found.\n";
+  }
+
+  try {
+    const raw = fs.readFileSync(configPath, { encoding: "utf-8" });
+    const parsed = JSON.parse(raw);
+    const redacted = redactSecrets(parsed);
+    return (
+      "## OpenClaw Configuration (openclaw.json, secrets redacted)\n" +
+      JSON.stringify(redacted, null, 2) +
+      "\n"
+    );
+  } catch (err) {
+    return `## OpenClaw Configuration\nError reading openclaw.json: ${String(err)}\n`;
+  }
+}
+
+function assembleHealthData(): string {
+  const stateDir = resolveStateDir();
+  const healthPath = path.join(stateDir, "workspace", "memory", "health.json");
+
+  if (!fs.existsSync(healthPath)) {
+    return "## Watchdog Health Data\nhealth.json not found — watchdog may not have run.\n";
+  }
+
+  try {
+    const raw = fs.readFileSync(healthPath, { encoding: "utf-8" });
+    return "## Watchdog Health Data (health.json)\n" + raw + "\n";
+  } catch (err) {
+    return `## Watchdog Health Data\nError reading health.json: ${String(err)}\n`;
+  }
+}
+
+async function assembleVersionInfo(): Promise<{ section: string; version: string | null }> {
+  try {
+    const result = await runCommandWithTimeout(["openclaw", "--version"], {
+      timeoutMs: 15_000,
+    });
+    const version = stripAnsi(result.stdout).trim() || null;
+    return {
+      section: `## OpenClaw Version\n${version ?? "Unknown"}\n`,
+      version,
+    };
+  } catch (err) {
+    return {
+      section: `## OpenClaw Version\nError: ${String(err)}\n`,
+      version: null,
+    };
+  }
+}
+
+function assembleAuthSummary(allParsed: ParsedLogEntry[]): {
+  section: string;
+  count: number;
+} {
+  const rejects = allParsed.filter((entry) => {
+    const sub = (entry.subsystem || "").toLowerCase();
+    const msg = (entry.message || "").toLowerCase();
+    return (
+      sub.includes("auth") &&
+      (msg.includes("rejected") ||
+        msg.includes("denied") ||
+        msg.includes("invalid token") ||
+        msg.includes("unauthorized"))
+    );
+  });
+
+  const sourceIps = new Set<string>();
+  for (const entry of rejects) {
+    const match = RE_IP.exec(entry.message);
+    if (match) sourceIps.add(match[0]);
+  }
+
+  let section = "## Security Events — Auth Rejections\n";
+  if (rejects.length === 0) {
+    section += "No auth rejection events found in today's log.\n";
+  } else {
+    section += `${rejects.length} auth rejection event(s) detected.`;
+    if (rejects.length >= 2) {
+      section += ` First: ${rejects[0].timestamp}, Last: ${rejects[rejects.length - 1].timestamp}.`;
+    }
+    section += "\n";
+    if (sourceIps.size > 0) {
+      section += `Source IPs: ${[...sourceIps].sort().join(", ")}\n`;
+    }
+  }
+
+  return { section, count: rejects.length };
+}
+
+function assembleSystemMemory(): string {
+  const totalMb = Math.round(os.totalmem() / 1024 / 1024);
+  const freeMb = Math.round(os.freemem() / 1024 / 1024);
+  const usedMb = totalMb - freeMb;
+  const pctUsed = totalMb > 0 ? Math.round((usedMb / totalMb) * 100) : 0;
+
+  return (
+    "## System Memory (at time of diagnostic run)\n" +
+    `Total: ${totalMb} MB, Used: ${usedMb} MB (${pctUsed}%), Free: ${freeMb} MB\n` +
+    `Platform: ${os.platform()} ${os.arch()}, Node: ${process.versions.node}\n`
+  );
+}
+
+// ── Main assembler ───────────────────────────────────────────────────────
+
+export async function assembleDiagnosticContext(
+  opts: AssembleOptions,
+): Promise<DiagnosticContext> {
+  const logResult = assembleGatewayLog(opts.maxLogEntries);
+  const configSection = assembleRedactedConfig();
+  const healthSection = assembleHealthData();
+  const versionResult = await assembleVersionInfo();
+  const authResult = assembleAuthSummary(logResult.allParsed);
+  const memorySection = assembleSystemMemory();
+
+  const text = [
+    logResult.section,
+    configSection,
+    healthSection,
+    versionResult.section,
+    authResult.section,
+    memorySection,
+  ].join("\n\n");
+
+  return {
+    text,
+    logEntryCount: logResult.entryCount,
+    authRejectCount: authResult.count,
+    version: versionResult.version,
+  };
+}

--- a/src/commands/diagnose/assemble-context.ts
+++ b/src/commands/diagnose/assemble-context.ts
@@ -23,7 +23,8 @@ interface AssembleOptions {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-const RE_ANSI = /\x1b\[[0-9;]*[mGKHF]/g;
+// eslint-disable-next-line no-control-regex
+const RE_ANSI = /\u001b\[[0-9;]*[mGKHF]/g;
 const RE_IP = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
 // Suffix-based matching catches botToken, appToken, webhookSecret, accessToken,
 // apiKey, etc. — not just exact key names.
@@ -39,7 +40,9 @@ function stripAnsi(text: string): string {
 }
 
 function redactSecrets(obj: unknown, depth = 0): unknown {
-  if (depth > 10) return obj;
+  if (depth > 10) {
+    return obj;
+  }
   if (Array.isArray(obj)) {
     return obj.map((item) => redactSecrets(item, depth + 1));
   }
@@ -88,7 +91,9 @@ const RE_LOG_LINE_FALLBACK =
 
 function parseLogLine(line: string): ParsedLogEntry | null {
   const trimmed = line.trim();
-  if (!trimmed) return null;
+  if (!trimmed) {
+    return null;
+  }
 
   // Try JSON parse first (primary format).
   if (trimmed.startsWith("{")) {
@@ -105,7 +110,9 @@ function parseLogLine(line: string): ParsedLogEntry | null {
         subsystem = String(obj["0"] ?? "");
       }
       const message = String(obj["1"] ?? "");
-      if (!level && !message) return null;
+      if (!level && !message) {
+        return null;
+      }
       return { timestamp, level, subsystem, message, raw: trimmed };
     } catch {
       // Fall through to regex.
@@ -114,7 +121,9 @@ function parseLogLine(line: string): ParsedLogEntry | null {
 
   // Fallback: plain-text log format.
   const match = RE_LOG_LINE_FALLBACK.exec(trimmed);
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   return {
     timestamp: match[1],
     level: match[2],
@@ -156,7 +165,9 @@ function assembleGatewayLog(maxEntries: number): {
 
     for (const line of lines) {
       const entry = parseLogLine(line);
-      if (!entry) continue;
+      if (!entry) {
+        continue;
+      }
       allParsed.push(entry);
       if (["WARN", "WARNING", "ERROR", "FATAL"].includes(entry.level)) {
         issueEntries.push(entry);
@@ -278,7 +289,7 @@ function assembleAuthSummary(allParsed: ParsedLogEntry[]): {
     }
     section += "\n";
     if (sourceIps.size > 0) {
-      section += `Source IPs: ${[...sourceIps].sort().join(", ")}\n`;
+      section += `Source IPs: ${[...sourceIps].toSorted().join(", ")}\n`;
     }
   }
 

--- a/src/commands/diagnose/known-issues.ts
+++ b/src/commands/diagnose/known-issues.ts
@@ -1,0 +1,62 @@
+/**
+ * Curated table of known OpenClaw gateway log patterns.
+ *
+ * This is injected into the system prompt so the AI model can reference
+ * authoritative explanations and fixes rather than guessing. Patterns are
+ * maintained from real-world operational experience.
+ */
+
+export const KNOWN_ISSUES_PROMPT = `\
+## Known Gateway Issue Patterns
+
+When you encounter any of these patterns in the diagnostic data, use the
+explanation and fix provided here rather than speculating.
+
+- \`[auth] rejected request: invalid token\` — the gateway received a request
+  with the wrong auth token. Check that \`gateway.auth.token\` in
+  \`openclaw.json\` matches the token used by the client. If the token
+  references an environment variable (\`\${OPENCLAW_GATEWAY_TOKEN}\`), verify
+  the variable is set in \`~/.openclaw/.env\`.
+
+- \`[ws] client disconnected unexpectedly\` — the browser client lost the
+  WebSocket connection. Usually transient. Persistent occurrences indicate
+  network instability, a reverse-proxy timeout, or the gateway process
+  crashing and restarting.
+
+- \`[agent] context limit approaching\` — the agent's conversation is near the
+  model's context window limit. The user should start a new session or the
+  gateway will compact the context (which may lose earlier instructions).
+
+- \`[startup] workspace not found\` — the \`agents.list[main].workspace\` path
+  in \`openclaw.json\` does not exist on disk. Create the directory or correct
+  the path.
+
+- \`[health] check failed: ECONNREFUSED\` — the watchdog ping to the gateway
+  health endpoint was refused. The gateway process may have crashed. Check
+  \`openclaw gateway status\` and restart if needed.
+
+- \`Invalid config at ... Unrecognized key:\` — a top-level key in
+  \`openclaw.json\` is not recognized by the installed OpenClaw version. This
+  usually happens after an upgrade that moves or removes config keys. Back up
+  the file and run \`openclaw doctor --fix\`, or manually remove the
+  unrecognized key.
+
+- \`ERR_MODULE_NOT_FOUND ... commands.runtime-*.js\` — the gateway is trying to
+  load a dynamic import chunk from a previous version's build. This happens
+  when the npm package was updated but the gateway process was not restarted.
+  Fix: \`openclaw gateway restart\`.
+
+- \`tools.web.search: ... provider-owned config moved to plugins\` — a legacy
+  \`tools.web.search\` configuration is present that was moved to the plugin
+  system. Run \`openclaw doctor --fix\` to migrate automatically.
+
+- \`channels.telegram.streamMode\` / \`streaming (scalar)\` / \`chunkMode\` /
+  \`blockStreaming\` — legacy scalar streaming configuration. The current
+  schema uses \`channels.telegram.streaming.{mode,chunkMode,...}\`. Run
+  \`openclaw doctor --fix\` to migrate.
+
+- \`[agent/embedded] incomplete turn detected: ... payloads=0\` — the model
+  returned a stop signal but produced no content. This is a model-level or
+  provider-level issue (not an OpenClaw bug). Try a different model or check
+  the provider's status page.
+`;

--- a/src/commands/diagnose/parse-log-line.test.ts
+++ b/src/commands/diagnose/parse-log-line.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { parseLogLine } from "./assemble-context.js";
+
+describe("parseLogLine", () => {
+  it("returns null for blank input", () => {
+    expect(parseLogLine("")).toBeNull();
+    expect(parseLogLine("   ")).toBeNull();
+  });
+
+  it("extracts message from tslog string-only argument form", () => {
+    const line = JSON.stringify({
+      "0": "starting gateway on port 18789",
+      _meta: { logLevelName: "INFO", date: "2026-04-21T10:00:00.000Z" },
+      time: "2026-04-21 10:00:00.000",
+    });
+    const entry = parseLogLine(line);
+    expect(entry).not.toBeNull();
+    expect(entry?.level).toBe("INFO");
+    expect(entry?.subsystem).toBe("");
+    expect(entry?.message).toBe("starting gateway on port 18789");
+    expect(entry?.timestamp).toBe("2026-04-21 10:00:00.000");
+  });
+
+  it("extracts subsystem + message from tslog bindings-object form", () => {
+    const line = JSON.stringify({
+      "0": '{"subsystem":"gateway/ws"}',
+      "1": "incoming connection accepted",
+      _meta: { logLevelName: "WARN" },
+      time: "2026-04-21 10:05:00.000",
+    });
+    const entry = parseLogLine(line);
+    expect(entry?.level).toBe("WARN");
+    expect(entry?.subsystem).toBe("gateway/ws");
+    expect(entry?.message).toBe("incoming connection accepted");
+  });
+
+  it("joins multiple positional message parts with spaces", () => {
+    const line = JSON.stringify({
+      "0": "part one",
+      "1": "part two",
+      "2": "part three",
+      _meta: { logLevelName: "ERROR" },
+      time: "2026-04-21",
+    });
+    const entry = parseLogLine(line);
+    expect(entry?.message).toBe("part one part two part three");
+  });
+
+  it("keeps JSON-looking strings without a subsystem field as message text", () => {
+    const line = JSON.stringify({
+      "0": '{"foo":"bar"}',
+      _meta: { logLevelName: "INFO" },
+      time: "2026-04-21",
+    });
+    const entry = parseLogLine(line);
+    expect(entry?.subsystem).toBe("");
+    expect(entry?.message).toBe('{"foo":"bar"}');
+  });
+
+  it("falls back to regex for plain-text lines", () => {
+    const line = "2026-04-21T10:00:00.000Z [WARN] [gateway] restart triggered";
+    const entry = parseLogLine(line);
+    expect(entry?.level).toBe("WARN");
+    expect(entry?.subsystem).toBe("gateway");
+    expect(entry?.message).toBe("restart triggered");
+  });
+
+  it("returns null for unparseable lines", () => {
+    expect(parseLogLine("not a log line")).toBeNull();
+    expect(parseLogLine("{ broken json")).toBeNull();
+  });
+});

--- a/src/commands/diagnose/parse-time-filter.test.ts
+++ b/src/commands/diagnose/parse-time-filter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseDurationMs, parseTimeFilter } from "./parse-time-filter.js";
+
+describe("parseDurationMs", () => {
+  it("parses each supported unit", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("2h")).toBe(7_200_000);
+    expect(parseDurationMs("7d")).toBe(7 * 86_400_000);
+    expect(parseDurationMs("1w")).toBe(604_800_000);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseDurationMs("  2h  ")).toBe(7_200_000);
+  });
+
+  it("rejects unknown or malformed input", () => {
+    expect(parseDurationMs("2x")).toBeNull();
+    expect(parseDurationMs("abc")).toBeNull();
+    expect(parseDurationMs("")).toBeNull();
+    expect(parseDurationMs("2.5h")).toBeNull();
+    expect(parseDurationMs("-2h")).toBeNull();
+  });
+});
+
+describe("parseTimeFilter", () => {
+  const now = Date.UTC(2026, 3, 21, 12, 0, 0);
+
+  it("returns null when neither option is given", () => {
+    expect(parseTimeFilter({}, now)).toBeNull();
+  });
+
+  it("treats --last as now minus duration", () => {
+    const filter = parseTimeFilter({ last: "2h" }, now);
+    expect(filter).toEqual({ sinceMs: now - 7_200_000, label: "last 2h" });
+  });
+
+  it("treats --since duration-form as now minus duration", () => {
+    const filter = parseTimeFilter({ since: "7d" }, now);
+    expect(filter).toEqual({ sinceMs: now - 7 * 86_400_000, label: "last 7d" });
+  });
+
+  it("parses --since ISO date", () => {
+    const filter = parseTimeFilter({ since: "2026-04-20" }, now);
+    expect(filter?.sinceMs).toBe(Date.parse("2026-04-20"));
+    expect(filter?.label).toContain("since ");
+  });
+
+  it("parses --since ISO timestamp", () => {
+    const filter = parseTimeFilter({ since: "2026-04-20T10:30:00Z" }, now);
+    expect(filter?.sinceMs).toBe(Date.parse("2026-04-20T10:30:00Z"));
+  });
+
+  it("throws when both --since and --last are given", () => {
+    expect(() => parseTimeFilter({ since: "2h", last: "1h" }, now)).toThrow(
+      /cannot both be specified/,
+    );
+  });
+
+  it("throws on invalid --last", () => {
+    expect(() => parseTimeFilter({ last: "nonsense" }, now)).toThrow(/Invalid --last duration/);
+  });
+
+  it("throws on invalid --since", () => {
+    expect(() => parseTimeFilter({ since: "not-a-date" }, now)).toThrow(/Invalid --since value/);
+  });
+});

--- a/src/commands/diagnose/parse-time-filter.ts
+++ b/src/commands/diagnose/parse-time-filter.ts
@@ -1,0 +1,84 @@
+// Duration suffix → multiplier in milliseconds.
+// Accepts: ms (millisecond), s (second), m (minute), h (hour), d (day), w (week).
+const DURATION_MULTIPLIERS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+const DURATION_RE = /^(\d+)(ms|s|m|h|d|w)$/;
+
+export interface TimeFilter {
+  /** Absolute epoch milliseconds — include entries with timestamp >= sinceMs. */
+  sinceMs: number;
+  /** Human-readable label (e.g. "last 2h", "since 2026-04-20T00:00:00.000Z") for the diagnostic context. */
+  label: string;
+}
+
+/**
+ * Parse a duration string like "30m", "2h", "7d" into milliseconds.
+ * Returns null if the string is not a valid duration.
+ */
+export function parseDurationMs(value: string): number | null {
+  const match = DURATION_RE.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const n = Number.parseInt(match[1] ?? "0", 10);
+  const unit = match[2] ?? "";
+  const multiplier = DURATION_MULTIPLIERS[unit];
+  if (multiplier === undefined) {
+    return null;
+  }
+  return n * multiplier;
+}
+
+/**
+ * Resolve --since / --last options into an absolute epoch ms cutoff plus a
+ * display label. Throws on invalid input or when both options are set.
+ *
+ *   --last <duration>  → sinceMs = now - duration
+ *   --since <duration> → sinceMs = now - duration  (same as --last)
+ *   --since <iso-date> → sinceMs = Date.parse(iso-date)
+ *
+ * Returns null when neither option is provided (no filter).
+ */
+export function parseTimeFilter(
+  opts: { since?: string; last?: string },
+  nowMs: number = Date.now(),
+): TimeFilter | null {
+  if (opts.since !== undefined && opts.last !== undefined) {
+    throw new Error("--since and --last cannot both be specified. Choose one.");
+  }
+
+  if (opts.last !== undefined) {
+    const durationMs = parseDurationMs(opts.last);
+    if (durationMs === null) {
+      throw new Error(
+        `Invalid --last duration: "${opts.last}". Expected format like "30m", "2h", "7d" (units: ms, s, m, h, d, w).`,
+      );
+    }
+    return { sinceMs: nowMs - durationMs, label: `last ${opts.last}` };
+  }
+
+  if (opts.since !== undefined) {
+    // Try duration first (e.g. "--since 2h" behaves like "--last 2h").
+    const durationMs = parseDurationMs(opts.since);
+    if (durationMs !== null) {
+      return { sinceMs: nowMs - durationMs, label: `last ${opts.since}` };
+    }
+    // Otherwise parse as an absolute timestamp.
+    const parsed = Date.parse(opts.since);
+    if (Number.isNaN(parsed)) {
+      throw new Error(
+        `Invalid --since value: "${opts.since}". Expected an ISO timestamp (e.g. "2026-04-20", "2026-04-20T10:00:00") or a duration (e.g. "2h", "7d").`,
+      );
+    }
+    return { sinceMs: parsed, label: `since ${new Date(parsed).toISOString()}` };
+  }
+
+  return null;
+}

--- a/src/commands/diagnose/render-canvas.ts
+++ b/src/commands/diagnose/render-canvas.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+
+const CANVAS_FILENAME = "diagnostics.html";
+
+/**
+ * Wrap a Markdown report in a self-contained HTML page and write it to the
+ * OpenClaw canvas directory (~/.openclaw/canvas/).
+ *
+ * Returns the absolute path of the written file.
+ */
+export async function renderCanvasHtml(markdown: string): Promise<string> {
+  const stateDir = resolveStateDir();
+  const canvasDir = path.join(stateDir, "canvas");
+  await fs.mkdir(canvasDir, { recursive: true });
+
+  const outputPath = path.join(canvasDir, CANVAS_FILENAME);
+  const html = buildHtmlPage(markdown);
+  await fs.writeFile(outputPath, html, "utf-8");
+  return outputPath;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildHtmlPage(markdown: string): string {
+  // The page includes a minimal Markdown-to-HTML renderer (inline JS) so it
+  // is fully self-contained — no external dependencies required.
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenClaw Gateway Diagnostic Report</title>
+<style>
+  :root {
+    --bg: #1a1a2e;
+    --surface: #16213e;
+    --text: #e0e0e0;
+    --text-muted: #8888aa;
+    --accent: #0f3460;
+    --green: #4caf50;
+    --yellow: #ffc107;
+    --red: #f44336;
+    --blue: #2196f3;
+    --code-bg: #0d1117;
+    --border: #2a2a4a;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 24px 40px;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+  h1 { color: var(--blue); margin-bottom: 16px; font-size: 1.6em; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+  h2 { color: var(--green); margin-top: 28px; margin-bottom: 12px; font-size: 1.3em; }
+  h3 { color: var(--yellow); margin-top: 20px; margin-bottom: 8px; font-size: 1.1em; }
+  p { margin-bottom: 12px; }
+  ul, ol { margin-bottom: 12px; padding-left: 24px; }
+  li { margin-bottom: 4px; }
+  code {
+    background: var(--code-bg);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.9em;
+    font-family: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+  }
+  pre {
+    background: var(--code-bg);
+    padding: 12px 16px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin-bottom: 16px;
+    border: 1px solid var(--border);
+  }
+  pre code { background: none; padding: 0; }
+  strong { color: #fff; }
+  .toolbar {
+    position: fixed;
+    top: 12px;
+    right: 24px;
+    display: flex;
+    gap: 8px;
+    z-index: 100;
+  }
+  .toolbar button {
+    background: var(--accent);
+    color: var(--text);
+    border: 1px solid var(--border);
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+  }
+  .toolbar button:hover { background: var(--blue); color: #fff; }
+  .timestamp { color: var(--text-muted); font-size: 0.85em; }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <button onclick="copyReport()">Copy Markdown</button>
+  <button onclick="window.print()">Print</button>
+</div>
+
+<div id="report"></div>
+
+<script>
+// Minimal Markdown-to-HTML (covers headings, bold, code, lists, paragraphs).
+function md2html(md) {
+  var lines = md.split('\\n');
+  var html = [];
+  var inList = false;
+  var inCode = false;
+  var codeLang = '';
+  var codeLines = [];
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+    if (inCode) {
+      if (line.trimEnd() === '\`\`\`') {
+        html.push('<pre><code>' + esc(codeLines.join('\\n')) + '</code></pre>');
+        inCode = false;
+        codeLines = [];
+      } else {
+        codeLines.push(line);
+      }
+      continue;
+    }
+    if (line.startsWith('\`\`\`')) {
+      if (inList) { html.push('</ul>'); inList = false; }
+      inCode = true;
+      codeLang = line.slice(3).trim();
+      continue;
+    }
+    if (/^#{1,3} /.test(line)) {
+      if (inList) { html.push('</ul>'); inList = false; }
+      var level = line.match(/^(#+)/)[1].length;
+      html.push('<h' + level + '>' + inline(line.replace(/^#+\\s*/, '')) + '</h' + level + '>');
+    } else if (/^[-*] /.test(line.trim())) {
+      if (!inList) { html.push('<ul>'); inList = true; }
+      html.push('<li>' + inline(line.replace(/^\\s*[-*]\\s*/, '')) + '</li>');
+    } else if (line.trim() === '') {
+      if (inList) { html.push('</ul>'); inList = false; }
+    } else {
+      if (inList) { html.push('</ul>'); inList = false; }
+      html.push('<p>' + inline(line) + '</p>');
+    }
+  }
+  if (inList) html.push('</ul>');
+  if (inCode) html.push('<pre><code>' + esc(codeLines.join('\\n')) + '</code></pre>');
+  return html.join('\\n');
+}
+function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function inline(s) {
+  s = s.replace(/\`([^\`]+)\`/g, '<code>$1</code>');
+  s = s.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+  s = s.replace(/\\*([^*]+)\\*/g, '<em>$1</em>');
+  return s;
+}
+
+var rawMarkdown = ${JSON.stringify(markdown)};
+document.getElementById('report').innerHTML = md2html(rawMarkdown);
+
+function copyReport() {
+  navigator.clipboard.writeText(rawMarkdown).then(function() {
+    event.target.textContent = 'Copied!';
+    setTimeout(function() { event.target.textContent = 'Copy Markdown'; }, 1500);
+  });
+}
+</script>
+</body>
+</html>`;
+}

--- a/src/commands/diagnose/render-canvas.ts
+++ b/src/commands/diagnose/render-canvas.ts
@@ -21,13 +21,7 @@ export async function renderCanvasHtml(markdown: string): Promise<string> {
   return outputPath;
 }
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+
 
 function buildHtmlPage(markdown: string): string {
   // The page includes a minimal Markdown-to-HTML renderer (inline JS) so it

--- a/src/commands/diagnose/render-canvas.ts
+++ b/src/commands/diagnose/render-canvas.ts
@@ -161,6 +161,9 @@ function md2html(md) {
 }
 function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 function inline(s) {
+  // Escape HTML FIRST to prevent script injection from log/config content,
+  // then apply markdown formatting on the safe escaped text.
+  s = esc(s);
   s = s.replace(/\`([^\`]+)\`/g, '<code>$1</code>');
   s = s.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
   s = s.replace(/\\*([^*]+)\\*/g, '<em>$1</em>');

--- a/src/commands/diagnose/render-canvas.ts
+++ b/src/commands/diagnose/render-canvas.ts
@@ -174,9 +174,10 @@ var rawMarkdown = ${JSON.stringify(markdown)};
 document.getElementById('report').innerHTML = md2html(rawMarkdown);
 
 function copyReport() {
+  var btn = document.querySelector('.toolbar button');
   navigator.clipboard.writeText(rawMarkdown).then(function() {
-    event.target.textContent = 'Copied!';
-    setTimeout(function() { event.target.textContent = 'Copy Markdown'; }, 1500);
+    btn.textContent = 'Copied!';
+    setTimeout(function() { btn.textContent = 'Copy Markdown'; }, 1500);
   });
 }
 </script>

--- a/src/commands/diagnose/stream-report.ts
+++ b/src/commands/diagnose/stream-report.ts
@@ -107,6 +107,7 @@ export async function streamDiagnosticReport(
           "Start the gateway with: openclaw gateway\n" +
           "Or use: openclaw diagnose --json  to get the raw diagnostic context " +
           "without AI analysis.",
+        { cause: err },
       );
     }
     throw err;

--- a/src/commands/diagnose/stream-report.ts
+++ b/src/commands/diagnose/stream-report.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { callGatewayFromCli } from "../../cli/gateway-rpc.js";
 import type { GatewayRpcOpts } from "../../cli/gateway-rpc.types.js";
 
@@ -64,6 +65,7 @@ export async function streamDiagnosticReport(
 
   const agentParams: Record<string, unknown> = {
     message: prompt,
+    idempotencyKey: crypto.randomUUID(),
   };
   if (opts.modelOverride) {
     agentParams.model = opts.modelOverride;

--- a/src/commands/diagnose/stream-report.ts
+++ b/src/commands/diagnose/stream-report.ts
@@ -76,8 +76,10 @@ export async function streamDiagnosticReport(
       expectFinal: true,
     });
 
-    // Extract text from the agent response payloads.
-    const payloads = (response as Record<string, unknown>)?.result as
+    // Extract text from the agent response payloads. callGateway defaults its
+    // generic to Record<string, unknown>, so response is already that shape —
+    // no redundant cast on response itself, just narrow `.result`.
+    const payloads = response.result as
       | { payloads?: Array<{ text?: string }>; meta?: Record<string, unknown> }
       | undefined;
     const textParts = (payloads?.payloads ?? [])

--- a/src/commands/diagnose/stream-report.ts
+++ b/src/commands/diagnose/stream-report.ts
@@ -1,0 +1,112 @@
+import { callGatewayFromCli } from "../../cli/gateway-rpc.js";
+import type { GatewayRpcOpts } from "../../cli/gateway-rpc.types.js";
+
+export interface StreamReportOptions {
+  /** Assembled diagnostic context (Markdown). */
+  context: string;
+  /** Known-issues reference prompt. */
+  knownIssues: string;
+  /** Model override (e.g. "claude-haiku-4-5"). */
+  modelOverride?: string;
+  /** JSON mode — suppress streaming output. */
+  json: boolean;
+  /** Callback for each streamed chunk (undefined in JSON mode). */
+  onChunk?: (chunk: string) => void;
+}
+
+export interface DiagnosticReport {
+  markdown: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+function buildDiagnosticPrompt(context: string, knownIssues: string): string {
+  const now = new Date().toLocaleString();
+  return (
+    knownIssues +
+    "\n\n---\n\n" +
+    context +
+    "\n\n---\n\n" +
+    `Current date and time: ${now}\n\n` +
+    "Based on the diagnostic data above, produce a structured report of all issues found. " +
+    `Begin the report with the exact H1 heading: '# OpenClaw Gateway Diagnostic Report — ${now}'\n\n` +
+    "Use the following exact two-section structure:\n\n" +
+    "## 1) Executive Summary\n" +
+    "One paragraph of overall health assessment, followed by an alphabetically enumerated list " +
+    "of every distinct issue found — one line each — using this format:\n" +
+    "- Issue A — [one-sentence summary]\n" +
+    "- Issue B — [one-sentence summary]\n" +
+    "(and so on)\n\n" +
+    "## 2) Findings\n" +
+    "One subsection per issue, labeled with the SAME letter used in the Executive Summary:\n" +
+    "### Issue A — [same title]\n" +
+    "- **What it means**: ...\n" +
+    "- **Log entries**: list every log entry timestamp that relates to this issue, one per line, " +
+    "in the format `HH:MM:SS — [log text]`. If there are many identical entries, list the first " +
+    "and last timestamp and note the count in between.\n" +
+    "- **Likely root cause**: ...\n" +
+    "- **Fix**: ...\n\n" +
+    "Group identical or closely related log patterns under a single issue letter. " +
+    "If no issues were found, state that clearly in the Executive Summary and omit the Findings section. " +
+    "Focus on actionable findings only — do not pad the report with caveats."
+  );
+}
+
+export async function streamDiagnosticReport(
+  opts: StreamReportOptions,
+): Promise<DiagnosticReport> {
+  const prompt = buildDiagnosticPrompt(opts.context, opts.knownIssues);
+
+  const gatewayOpts: GatewayRpcOpts = {
+    timeout: "120000",
+  };
+
+  const agentParams: Record<string, unknown> = {
+    message: prompt,
+  };
+  if (opts.modelOverride) {
+    agentParams.model = opts.modelOverride;
+  }
+
+  try {
+    const response = await callGatewayFromCli("agent", gatewayOpts, agentParams, {
+      expectFinal: true,
+    });
+
+    // Extract text from the agent response payloads.
+    const payloads = (response as Record<string, unknown>)?.result as
+      | { payloads?: Array<{ text?: string }>; meta?: Record<string, unknown> }
+      | undefined;
+    const textParts = (payloads?.payloads ?? [])
+      .map((p) => p.text ?? "")
+      .filter(Boolean);
+    const markdown = textParts.join("\n");
+
+    // Emit the full report via callback (non-streaming, but matches the interface).
+    if (opts.onChunk && markdown) {
+      opts.onChunk(markdown);
+    }
+
+    // Token usage is not directly available from the gateway RPC response;
+    // return zeros. A future enhancement could parse usage from the agent meta.
+    return {
+      markdown,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    };
+  } catch (err) {
+    const message = String(err);
+    if (message.includes("ECONNREFUSED") || message.includes("connect")) {
+      throw new Error(
+        "Could not connect to the OpenClaw gateway. The gateway must be running " +
+          "to perform AI-powered diagnostics.\n\n" +
+          "Start the gateway with: openclaw gateway\n" +
+          "Or use: openclaw diagnose --json  to get the raw diagnostic context " +
+          "without AI analysis.",
+      );
+    }
+    throw err;
+  }
+}

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -103,6 +103,7 @@ describe("production lint suppressions", () => {
       "src/cli/command-options.ts|typescript/no-unnecessary-type-parameters|1",
       "src/cli/plugins-cli-test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
       "src/cli/test-runtime-capture.ts|typescript/no-unnecessary-type-parameters|1",
+      "src/commands/diagnose/assemble-context.ts|no-control-regex|1",
       "src/config/types.channels.ts|@typescript-eslint/no-explicit-any|1",
       "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
       "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary

Adds a new `openclaw diagnose` command that assembles diagnostic context from the gateway's operational data and sends it to an AI model for structured analysis. The command produces a Markdown report with an Executive Summary and per-issue Findings (root cause, log entries, fix).

This feature originated from a management UI for OpenClaw ([App-Scaffold.com](https://github.com/DanWebb1949/App-Scaffold.com)) where it has been in daily operational use since March 2026, diagnosing real gateway issues across multiple OpenClaw installations.

**What gets analyzed (assembled automatically):**
- Gateway log — today's WARN/ERROR/FATAL entries
- Configuration — `openclaw.json` with secrets redacted
- Health data — watchdog `health.json`
- Version — installed OpenClaw version
- Auth events — rejection count and source IP summary
- System memory — RAM and platform info

**Options:**
```
openclaw diagnose                           # stream report to stdout
openclaw diagnose --canvas                  # save HTML to canvas for browser viewing
openclaw diagnose --output diagnostics.md   # save to file
openclaw diagnose --json                    # structured JSON output
openclaw diagnose --model claude-haiku-4-5  # override model
openclaw diagnose --max-log-entries 50      # limit entries (faster, cheaper)
```

**Known-issues knowledge base:** A curated table of common gateway log patterns (auth failures, stale chunks, config schema drift, incomplete turns, etc.) is injected into the system prompt so the AI references authoritative explanations rather than guessing.

**Canvas output:** `--canvas` writes a self-contained HTML page to `~/.openclaw/canvas/diagnostics.html` with a dark theme, Copy button, and Print button — viewable in any browser or via the Control UI's canvas serving.

## Files

| File | Change |
|------|--------|
| `src/commands/diagnose.ts` | NEW — command entry point |
| `src/commands/diagnose/assemble-context.ts` | NEW — 6-section context assembly |
| `src/commands/diagnose/stream-report.ts` | NEW — LLM call via gateway RPC |
| `src/commands/diagnose/render-canvas.ts` | NEW — self-contained HTML output |
| `src/commands/diagnose/known-issues.ts` | NEW — curated issue pattern reference |
| `src/cli/program/command-registry-core.ts` | EDIT — register in maintenance group |
| `src/cli/program/register.maintenance.ts` | EDIT — command options and action |
| `docs/cli/diagnose.md` | NEW — CLI reference documentation |

## Test plan

- [ ] `openclaw diagnose --help` — verify command registered with all options
- [ ] `openclaw diagnose` — run against live gateway, verify streamed Markdown report
- [ ] `openclaw diagnose --canvas` — verify HTML file written to `~/.openclaw/canvas/`
- [ ] `openclaw diagnose --output report.md` — verify file written
- [ ] `openclaw diagnose --json` — verify structured JSON with context and report
- [ ] `openclaw diagnose --model claude-haiku-4-5` — verify model override
- [ ] Gateway offline + `openclaw diagnose` — verify clear error with `--json` suggestion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)