### PR TITLE
fix(cron): validate delivery.channel ambiguity at add/edit time

### DIFF
--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -25,8 +25,15 @@ export interface CronServiceContract {
   status(): Promise<CronStatusSummary>;
   list(opts?: { includeDisabled?: boolean }): Promise<CronListResult>;
   listPage(opts?: CronListPageOptions): Promise<CronListPageResult>;
-  add(input: CronAddInput): Promise<CronAddResult>;
-  update(id: string, patch: CronUpdateInput): Promise<CronUpdateResult>;
+  add(
+    input: CronAddInput,
+    opts?: { configuredChannels?: readonly string[] },
+  ): Promise<CronAddResult>;
+  update(
+    id: string,
+    patch: CronUpdateInput,
+    opts?: { configuredChannels?: readonly string[] },
+  ): Promise<CronUpdateResult>;
   remove(id: string): Promise<CronRemoveResult>;
   run(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;
   enqueueRun(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -420,7 +420,7 @@ describe("applyJobPatch", () => {
 
   describe("channel ambiguity with configuredChannels", () => {
     const expectedError =
-      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set --channel explicitly.";
+      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set delivery.channel explicitly.";
 
     it("rejects a delivery patch that omits channel when 2+ channels are configured", () => {
       const job = createIsolatedAgentTurnJob("job-ambiguous-patch", {
@@ -602,7 +602,7 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
         { configuredChannels: ["telegram", "signal"] },
       ),
     ).toThrow(
-      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set --channel explicitly.",
+      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set delivery.channel explicitly.",
     );
   });
 });

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -417,6 +417,83 @@ describe("applyJobPatch", () => {
 
     expect(() => applyJobPatch(job, { enabled: true })).not.toThrow();
   });
+
+  describe("channel ambiguity with configuredChannels", () => {
+    const expectedError =
+      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set --channel explicitly.";
+
+    it("rejects a delivery patch that omits channel when 2+ channels are configured", () => {
+      const job = createIsolatedAgentTurnJob("job-ambiguous-patch", {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+      });
+
+      expect(() =>
+        applyJobPatch(
+          job,
+          { delivery: { mode: "announce", channel: "", to: "999" } },
+          { configuredChannels: ["telegram", "signal"] },
+        ),
+      ).toThrow(expectedError);
+    });
+
+    it("allows a delivery patch that sets channel explicitly", () => {
+      const job = createIsolatedAgentTurnJob("job-explicit-channel", {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+      });
+
+      expect(() =>
+        applyJobPatch(
+          job,
+          { delivery: { mode: "announce", channel: "signal", to: "+15551234567" } },
+          { configuredChannels: ["telegram", "signal"] },
+        ),
+      ).not.toThrow();
+    });
+
+    it("allows non-delivery updates on a legacy ambiguous job", () => {
+      // Regression: a legacy job with pre-existing ambiguous announce delivery
+      // must still be renameable / disableable / reschedulable once multiple
+      // channels are configured, since its delivery was not part of the patch.
+      const job = createIsolatedAgentTurnJob("job-legacy-ambiguous", {
+        mode: "announce",
+        to: "123",
+      });
+
+      expect(() =>
+        applyJobPatch(job, { enabled: false }, { configuredChannels: ["telegram", "signal"] }),
+      ).not.toThrow();
+      expect(() =>
+        applyJobPatch(job, { name: "renamed" }, { configuredChannels: ["telegram", "signal"] }),
+      ).not.toThrow();
+      expect(() =>
+        applyJobPatch(
+          job,
+          { schedule: { kind: "every", everyMs: 120_000 } },
+          { configuredChannels: ["telegram", "signal"] },
+        ),
+      ).not.toThrow();
+    });
+
+    it("skips the check when only one channel is configured", () => {
+      const job = createIsolatedAgentTurnJob("job-single-channel", {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+      });
+
+      expect(() =>
+        applyJobPatch(
+          job,
+          { delivery: { mode: "announce", channel: "", to: "999" } },
+          { configuredChannels: ["telegram"] },
+        ),
+      ).not.toThrow();
+    });
+  });
 });
 
 function createMockState(now: number, opts?: { defaultAgentId?: string }): CronServiceState {
@@ -506,6 +583,27 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
         },
       }),
     ).toThrow('cron channel delivery config is only supported for sessionTarget="isolated"');
+  });
+
+  it("rejects isolated announce delivery without channel when 2+ channels are configured", () => {
+    const state = createMockState(now, { defaultAgentId: "main" });
+    expect(() =>
+      createJob(
+        state,
+        {
+          name: "ambiguous-announce",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "now",
+          payload: { kind: "agentTurn", message: "do it" },
+          delivery: { mode: "announce", to: "123" },
+        },
+        { configuredChannels: ["telegram", "signal"] },
+      ),
+    ).toThrow(
+      "delivery.channel is required when multiple channels are configured. Active channels: telegram, signal. Set --channel explicitly.",
+    );
   });
 });
 

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -42,12 +42,12 @@ export class CronService implements CronServiceContract {
     return await ops.listPage(this.state, opts);
   }
 
-  async add(input: CronJobCreate) {
-    return await ops.add(this.state, input);
+  async add(input: CronJobCreate, opts?: { configuredChannels?: readonly string[] }) {
+    return await ops.add(this.state, input, opts);
   }
 
-  async update(id: string, patch: CronJobPatch) {
-    return await ops.update(this.state, id, patch);
+  async update(id: string, patch: CronJobPatch, opts?: { configuredChannels?: readonly string[] }) {
+    return await ops.update(this.state, id, patch, opts);
   }
 
   async remove(id: string) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -216,7 +216,7 @@ function assertDeliverySupport(
   // With a single configured channel, the runtime safely defaults to it.
   if (configuredChannels && !job.delivery.channel && configuredChannels.length >= 2) {
     throw new Error(
-      `delivery.channel is required when multiple channels are configured. Active channels: ${configuredChannels.join(", ")}. Set --channel explicitly.`,
+      `delivery.channel is required when multiple channels are configured. Active channels: ${configuredChannels.join(", ")}. Set delivery.channel explicitly.`,
     );
   }
 }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -188,7 +188,10 @@ function assertMainSessionAgentId(
   }
 }
 
-function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
+function assertDeliverySupport(
+  job: Pick<CronJob, "sessionTarget" | "delivery">,
+  configuredChannels?: readonly string[],
+) {
   // No delivery object or mode is "none" -- nothing to validate.
   if (!job.delivery || job.delivery.mode === "none") {
     return;
@@ -208,6 +211,13 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     job.sessionTarget.startsWith("session:");
   if (!isIsolatedLike) {
     throw new Error('cron channel delivery config is only supported for sessionTarget="isolated"');
+  }
+  // Surface ambiguous channel selection at add/edit time instead of at run time.
+  // With a single configured channel, the runtime safely defaults to it.
+  if (configuredChannels && !job.delivery.channel && configuredChannels.length >= 2) {
+    throw new Error(
+      `delivery.channel is required when multiple channels are configured. Active channels: ${configuredChannels.join(", ")}. Set --channel explicitly.`,
+    );
   }
 }
 
@@ -548,7 +558,11 @@ export function nextWakeAtMs(state: CronServiceState) {
   }, first);
 }
 
-export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
+export function createJob(
+  state: CronServiceState,
+  input: CronJobCreate,
+  opts?: { configuredChannels?: readonly string[] },
+): CronJob {
   const now = state.deps.nowMs();
   const id = crypto.randomUUID();
   const schedule =
@@ -601,7 +615,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   };
   assertSupportedJobSpec(job);
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
-  assertDeliverySupport(job);
+  assertDeliverySupport(job, opts?.configuredChannels);
   assertFailureDestinationSupport(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
   return job;
@@ -610,7 +624,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
 export function applyJobPatch(
   job: CronJob,
   patch: CronJobPatch,
-  opts?: { defaultAgentId?: string },
+  opts?: { defaultAgentId?: string; configuredChannels?: readonly string[] },
 ) {
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
@@ -680,7 +694,10 @@ export function applyJobPatch(
   }
   assertSupportedJobSpec(job);
   assertMainSessionAgentId(job, opts?.defaultAgentId);
-  assertDeliverySupport(job);
+  // Only validate channel ambiguity when the patch touches delivery. Otherwise
+  // legacy jobs with pre-existing ambiguous delivery couldn't be renamed,
+  // disabled, or rescheduled once a second channel is configured.
+  assertDeliverySupport(job, patch.delivery ? opts?.configuredChannels : undefined);
   assertFailureDestinationSupport(job);
 }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -246,11 +246,15 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
-export async function add(state: CronServiceState, input: CronJobCreate) {
+export async function add(
+  state: CronServiceState,
+  input: CronJobCreate,
+  opts?: { configuredChannels?: readonly string[] },
+) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state);
-    const job = createJob(state, input);
+    const job = createJob(state, input, { configuredChannels: opts?.configuredChannels });
     state.store?.jobs.push(job);
 
     // Defensive: recompute all next-run times to ensure consistency
@@ -280,13 +284,21 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
   });
 }
 
-export async function update(state: CronServiceState, id: string, patch: CronJobPatch) {
+export async function update(
+  state: CronServiceState,
+  id: string,
+  patch: CronJobPatch,
+  opts?: { configuredChannels?: readonly string[] },
+) {
   return await locked(state, async () => {
     warnIfDisabled(state, "update");
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
     const now = state.deps.nowMs();
-    applyJobPatch(job, patch, { defaultAgentId: state.deps.defaultAgentId });
+    applyJobPatch(job, patch, {
+      defaultAgentId: state.deps.defaultAgentId,
+      configuredChannels: opts?.configuredChannels,
+    });
     if (job.schedule.kind === "every") {
       const anchor = job.schedule.anchorMs;
       if (typeof anchor !== "number" || !Number.isFinite(anchor)) {

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -51,7 +51,7 @@ function assertConfiguredAnnounceChannel(params: {
       return;
     }
     throw new Error(
-      `${params.field} is required when multiple channels are configured: ${configuredChannels.join(", ")}`,
+      `${params.field} is required when multiple channels are configured. Active channels: ${configuredChannels.join(", ")}. Set ${params.field} explicitly.`,
     );
   }
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -97,6 +97,7 @@ function assertValidCronUpdateDelivery(params: {
   defaultAgentId?: string;
   currentJob: CronJob | undefined;
   patch: CronJobPatch;
+  configuredChannels: readonly string[];
 }) {
   if (!params.currentJob || !("delivery" in params.patch)) {
     return;
@@ -105,6 +106,7 @@ function assertValidCronUpdateDelivery(params: {
   const nextJob = structuredClone(params.currentJob);
   applyJobPatch(nextJob, params.patch, {
     defaultAgentId: params.defaultAgentId,
+    configuredChannels: params.configuredChannels,
   });
   assertValidCronAnnounceDelivery({
     cfg: params.cfg,
@@ -219,6 +221,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     const jobCreate = normalized as unknown as CronJobCreate;
     const cfg = loadConfig();
+    const configuredChannels = listConfiguredAnnounceChannelIds(cfg);
     const timestampValidation = validateScheduleTimestamp(jobCreate.schedule);
     if (!timestampValidation.ok) {
       respond(
@@ -241,7 +244,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate);
+    const job = await context.cron.add(jobCreate, { configuredChannels });
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -291,6 +294,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     const patch = p.patch as unknown as CronJobPatch;
     const cfg = loadConfig();
+    const configuredChannels = listConfiguredAnnounceChannelIds(cfg);
     if (patch.schedule) {
       const timestampValidation = validateScheduleTimestamp(patch.schedule);
       if (!timestampValidation.ok) {
@@ -308,6 +312,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         defaultAgentId: context.cron.getDefaultAgentId(),
         currentJob: context.cron.getJob(jobId),
         patch,
+        configuredChannels,
       });
     } catch (err) {
       respond(
@@ -320,7 +325,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.update(jobId, patch);
+    const job = await context.cron.update(jobId, patch, { configuredChannels });
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);
   },


### PR DESCRIPTION
## Summary

## Summary
- Problem: Cron jobs with `delivery.mode="announce"` and no explicit `channel` are accepted at create/update time but fail at runtime with `"Channel is required when multiple channels are configured"`. Invalid config survives until execution.
- Why it matters: Users create crons that look valid, then silently fail on first run. No feedback until they check run history or notice missing deliveries. Hit in production on a Weekly Obsidian Vault Sync cron.
- What changed: Moved the multi-channel ambiguity check from the runtime send path into `assertDeliverySupport` (called by `createJob`/`applyJobPatch`). Gateway handler resolves configured channels via existing `listConfiguredAnnounceChannelIds(cfg)` and passes them through. Users now get an actionable error at create/update time listing available channels.
- What did NOT change (scope boundary): Runtime channel resolution untouched. Legacy jobs with pre-existing ambiguous delivery can still be renamed, disabled, or rescheduled — validation only fires on delivery-touching patches. No new channel-resolution code paths. Webhook/none delivery modes unaffected.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: `assertDeliverySupport` in `jobs.ts` validated webhook URLs and session target constraints but did not check whether `delivery.channel` is required given the number of configured channels. That check only existed in the runtime send path (`channel-selection.ts:204`).
- Missing detection / guardrail: No upfront validation at job create/update time for channel ambiguity.
- Contributing context (if known): The gateway handler (`server-methods/cron.ts`) had a partial check via `listPotentialConfiguredChannelIds` but it only ran on the gateway RPC path, not the CLI/tool path that calls `createJob`/`applyJobPatch` directly.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/service.jobs.test.ts`, `src/cron/service/jobs.apply-patch.test.ts`
- Scenario the test should lock in: Creating or updating a cron with `delivery.mode="announce"`, no `delivery.channel`, and 2+ configured channels → throws validation error at create/update time.
- Why this is the smallest reliable guardrail: Unit test on `assertDeliverySupport` catches the exact gap without needing a running gateway.
- Existing test that already covers this (if any): None for this specific validation.
- If no new test is added, why not: Tests were added — 60/60 in jobs tests, 24/24 in gateway cron tests.

## User-visible / Behavior Changes
Cron create/update now rejects jobs with ambiguous delivery channel when multiple channels are configured. Error message includes the list of available channels. Previously this only failed silently at runtime.

## Diagram (if applicable)
```text
Before:
[cron add --announce --to user:X] -> [job accepted] -> [runtime: "Channel is required when multiple channels are configured"] -> [delivery silently fails]

After:
[cron add --announce --to user:X] -> [validation: "delivery.channel is required when multiple channels are configured: discord, telegram. Set --channel explicitly."] -> [job rejected immediately]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS 15.4
- Runtime/container: Node 22 / npm global
- Model/provider: N/A — affects cron delivery validation
- Integration/channel (if any): Discord + Telegram (any multi-channel setup)
- Relevant config (redacted): Two or more channels configured

### Steps
1. Configure OpenClaw with 2+ channels (e.g., Discord + Telegram)
2. `openclaw cron add --name "Test" --cron "0 9 * * *" --session isolated --message "Test" --announce --to "user:XXX"` (no `--channel` flag)
3. Observe behavior

### Expected
- Validation error at create time: `delivery.channel is required when multiple channels are configured`

### Actual
- Job accepted, fails silently at runtime

## Evidence
- [x] Failing test/log before + passing after

Production incident: Weekly Obsidian Vault Sync cron accepted without `delivery.channel`, failed at runtime with `"Channel is required when multiple channels are configured: discord, telegram"`. Scoped tests: 60/60 jobs tests, 24/24 gateway cron tests, 451+657 pre-commit tests all passing.

## Human Verification (required)
- Verified scenarios: Confirmed `assertDeliverySupport` now throws when 2+ channels and no `delivery.channel`. Confirmed single-channel setups skip the check. Confirmed webhook/none modes unaffected. Confirmed legacy jobs without delivery patches are not rejected on rename/disable/reschedule.
- Edge cases checked: 0 channels configured (skipped), 1 channel (skipped, safe to default), delivery-touching vs non-delivery patches (gated correctly).
- What you did **not** verify: CLI `cron add` path end-to-end against a running multi-channel gateway. Service-layer throws surface as generic handler errors rather than `INVALID_REQUEST` on non-gateway callers (noted as follow-up).

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Legacy crons with pre-existing ambiguous delivery could be rejected on unrelated edits (rename, reschedule).
  - Mitigation: Validation is gated to delivery-touching patches only. Non-delivery edits skip the check.
- Risk: Service-layer throws surface as generic errors on non-gateway callers.
  - Mitigation: Gateway preflight already catches this on the RPC path. Noted as follow-up for non-gateway callers.



## Test plan

- [x] `pnpm tsgo:core`
- [x] `pnpm test src/cron/service.jobs.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/service/jobs.schedule-error-isolation.test.ts` (60/60)
- [x] `pnpm test src/gateway/server.cron.test.ts src/gateway/server-cron.test.ts` (24/24)
- [x] Pre-commit scoped gates green (451 + 657 tests)

## Follow-up

- Service-layer throws from `context.cron.add/update` currently surface as generic handler errors rather than `INVALID_REQUEST`. In practice the gateway preflight already catches ambiguous delivery on the RPC path, so this only affects direct/non-gateway callers — left as a follow-up.
