### PR TITLE
[codex] Add mailbox previews to the Sessions Control UI

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -93,7 +93,7 @@ locale picker lives in the Gateway Access card, not under Appearance.
 - Stream tool calls + live tool output cards in Chat (agent events)
 - Channels: built-in plus bundled/external plugin channels status, QR login, and per-channel config (`channels.status`, `web.login.*`, `config.patch`)
 - Instances: presence list + refresh (`system-presence`)
-- Sessions: list + per-session model/thinking/fast/verbose/trace/reasoning overrides (`sessions.list`, `sessions.patch`)
+- Sessions: mailbox-style list with recent preview text plus per-session model/thinking/fast/verbose/trace/reasoning overrides (`sessions.list`, `sessions.preview`, `sessions.patch`)
 - Dreams: dreaming status, enable/disable toggle, and Dream Diary reader (`doctor.memory.status`, `doctor.memory.dreamDiary`, `config.patch`)
 - Cron jobs: list/add/edit/run/enable/disable + run history (`cron.*`)
 - Skills: status, enable/disable, install, API key updates (`skills.*`)

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -101,6 +101,7 @@ import {
   branchSessionFromCheckpoint,
   deleteSessionsAndRefresh,
   loadSessions,
+  loadVisibleSessionPreviews,
   patchSession,
   restoreSessionFromCheckpoint,
   toggleSessionCompactionCheckpoints,
@@ -1562,6 +1563,7 @@ export function renderApp(state: AppViewState) {
                 sortDir: state.sessionsSortDir,
                 page: state.sessionsPage,
                 pageSize: state.sessionsPageSize,
+                previewTextByKey: state.sessionsPreviewTextByKey,
                 selectedKeys: state.sessionsSelectedKeys,
                 expandedCheckpointKey: state.sessionsExpandedCheckpointKey,
                 checkpointItemsByKey: state.sessionsCheckpointItemsByKey,
@@ -1577,18 +1579,22 @@ export function renderApp(state: AppViewState) {
                 onSearchChange: (q) => {
                   state.sessionsSearchQuery = q;
                   state.sessionsPage = 0;
+                  void loadVisibleSessionPreviews(state);
                 },
                 onSortChange: (col, dir) => {
                   state.sessionsSortColumn = col;
                   state.sessionsSortDir = dir;
                   state.sessionsPage = 0;
+                  void loadVisibleSessionPreviews(state);
                 },
                 onPageChange: (p) => {
                   state.sessionsPage = p;
+                  void loadVisibleSessionPreviews(state);
                 },
                 onPageSizeChange: (s) => {
                   state.sessionsPageSize = s;
                   state.sessionsPage = 0;
+                  void loadVisibleSessionPreviews(state);
                 },
                 onRefresh: () => loadSessions(state),
                 onPatch: (key, patch) => patchSession(state, key, patch),

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -231,6 +231,7 @@ export type AppViewState = {
   sessionsSortDir: "asc" | "desc";
   sessionsPage: number;
   sessionsPageSize: number;
+  sessionsPreviewTextByKey: Record<string, string>;
   sessionsSelectedKeys: Set<string>;
   sessionsExpandedCheckpointKey: string | null;
   sessionsCheckpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -334,6 +334,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionsSortDir: "asc" | "desc" = "desc";
   @state() sessionsPage = 0;
   @state() sessionsPageSize = 25;
+  @state() sessionsPreviewTextByKey: Record<string, string> = {};
   @state() sessionsSelectedKeys: Set<string> = new Set();
   @state() sessionsExpandedCheckpointKey: string | null = null;
   @state() sessionsCheckpointItemsByKey: Record<string, SessionCompactionCheckpoint[]> = {};

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -27,6 +27,12 @@ function createState(request: RequestFn, overrides: Partial<SessionsState> = {})
     sessionsFilterLimit: "0",
     sessionsIncludeGlobal: true,
     sessionsIncludeUnknown: true,
+    sessionsSearchQuery: "",
+    sessionsSortColumn: "updated",
+    sessionsSortDir: "desc",
+    sessionsPage: 0,
+    sessionsPageSize: 25,
+    sessionsPreviewTextByKey: {},
     sessionsExpandedCheckpointKey: null,
     sessionsCheckpointItemsByKey: {},
     sessionsCheckpointLoadingKey: null,
@@ -132,6 +138,61 @@ describe("deleteSessionsAndRefresh", () => {
 });
 
 describe("loadSessions", () => {
+  it("loads preview text for the visible sessions page on the sessions tab", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: 1,
+          path: "(multiple)",
+          count: 2,
+          defaults: {},
+          sessions: [
+            {
+              key: "agent:main:main",
+              kind: "direct",
+              updatedAt: 20,
+            },
+            {
+              key: "agent:main:other",
+              kind: "direct",
+              updatedAt: 10,
+            },
+          ],
+        };
+      }
+      if (method === "sessions.preview") {
+        return {
+          ts: 2,
+          previews: [
+            {
+              key: "agent:main:main",
+              status: "ok",
+              items: [{ role: "assistant", text: "Most recent reply" }],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request, {
+      tab: "sessions",
+      sessionsPageSize: 1,
+    });
+
+    await loadSessions(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.preview", {
+      keys: ["agent:main:main"],
+      limit: 1,
+      maxChars: 120,
+    });
+    expect(state.sessionsPreviewTextByKey["agent:main:main"]).toBe("Most recent reply");
+  });
+
   it("refreshes expanded checkpoint cards when the row summary changes", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.list") {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,6 +1,8 @@
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type {
+  GatewaySessionRow,
   SessionCompactionCheckpoint,
   SessionsCompactionBranchResult,
   SessionsCompactionListResult,
@@ -13,6 +15,7 @@ import {
 } from "./scope-errors.ts";
 
 export type SessionsState = {
+  tab?: string;
   client: GatewayBrowserClient | null;
   connected: boolean;
   sessionsLoading: boolean;
@@ -22,12 +25,112 @@ export type SessionsState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionsSearchQuery: string;
+  sessionsSortColumn: "key" | "kind" | "updated" | "tokens";
+  sessionsSortDir: "asc" | "desc";
+  sessionsPage: number;
+  sessionsPageSize: number;
+  sessionsPreviewTextByKey: Record<string, string>;
   sessionsExpandedCheckpointKey: string | null;
   sessionsCheckpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;
   sessionsCheckpointLoadingKey: string | null;
   sessionsCheckpointBusyKey: string | null;
   sessionsCheckpointErrorByKey: Record<string, string>;
 };
+
+function filterSessionRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
+  const q = normalizeLowercaseStringOrEmpty(query);
+  if (!q) {
+    return rows;
+  }
+  return rows.filter((row) => {
+    const key = normalizeLowercaseStringOrEmpty(row.key);
+    const label = normalizeLowercaseStringOrEmpty(row.label);
+    const kind = normalizeLowercaseStringOrEmpty(row.kind);
+    const displayName = normalizeLowercaseStringOrEmpty(row.displayName);
+    return key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q);
+  });
+}
+
+function sortSessionRows(
+  rows: GatewaySessionRow[],
+  column: "key" | "kind" | "updated" | "tokens",
+  dir: "asc" | "desc",
+): GatewaySessionRow[] {
+  const cmp = dir === "asc" ? 1 : -1;
+  return [...rows].toSorted((a, b) => {
+    let diff = 0;
+    switch (column) {
+      case "key":
+        diff = (a.key ?? "").localeCompare(b.key ?? "");
+        break;
+      case "kind":
+        diff = (a.kind ?? "").localeCompare(b.kind ?? "");
+        break;
+      case "updated":
+        diff = (a.updatedAt ?? 0) - (b.updatedAt ?? 0);
+        break;
+      case "tokens":
+        diff =
+          (a.totalTokens ?? a.inputTokens ?? a.outputTokens ?? 0) -
+          (b.totalTokens ?? b.inputTokens ?? b.outputTokens ?? 0);
+        break;
+    }
+    return diff * cmp;
+  });
+}
+
+function getVisibleSessionPreviewKeys(state: SessionsState): string[] {
+  const rows = state.sessionsResult?.sessions ?? [];
+  const filtered = filterSessionRows(rows, state.sessionsSearchQuery);
+  const sorted = sortSessionRows(filtered, state.sessionsSortColumn, state.sessionsSortDir);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / state.sessionsPageSize));
+  const page = Math.min(state.sessionsPage, totalPages - 1);
+  const start = page * state.sessionsPageSize;
+  return sorted
+    .slice(start, start + state.sessionsPageSize)
+    .map((row) => row.key)
+    .filter(Boolean)
+    .slice(0, 64);
+}
+
+export async function loadVisibleSessionPreviews(state: SessionsState) {
+  if (state.tab !== "sessions" || !state.client || !state.connected) {
+    return;
+  }
+  const keys = getVisibleSessionPreviewKeys(state);
+  if (keys.length === 0) {
+    return;
+  }
+  try {
+    const result = await state.client.request<{
+      previews?: Array<{
+        key?: string;
+        items?: Array<{ text?: string }>;
+      }>;
+    }>("sessions.preview", {
+      keys,
+      limit: 1,
+      maxChars: 120,
+    });
+    const next = { ...state.sessionsPreviewTextByKey };
+    for (const key of keys) {
+      delete next[key];
+    }
+    for (const preview of result?.previews ?? []) {
+      if (!preview || typeof preview.key !== "string") {
+        continue;
+      }
+      const text = preview.items?.at(-1)?.text?.trim();
+      if (text) {
+        next[preview.key] = text;
+      }
+    }
+    state.sessionsPreviewTextByKey = next;
+  } catch {
+    // Keep preview fetch failures non-fatal for the sessions table.
+  }
+}
 
 function checkpointSummarySignature(
   row:
@@ -171,6 +274,9 @@ export async function loadSessions(
     if (res) {
       state.sessionsResult = res;
       const nextKeys = new Set(res.sessions.map((row) => row.key));
+      state.sessionsPreviewTextByKey = Object.fromEntries(
+        Object.entries(state.sessionsPreviewTextByKey).filter(([key]) => nextKeys.has(key)),
+      );
       for (const key of Object.keys(state.sessionsCheckpointItemsByKey)) {
         if (!nextKeys.has(key)) {
           invalidateCheckpointCacheForKey(state, key);
@@ -194,6 +300,7 @@ export async function loadSessions(
       ) {
         await fetchSessionCompactionCheckpoints(state, expandedKey);
       }
+      await loadVisibleSessionPreviews(state);
     }
   }).catch((err: unknown) => {
     if (!isMissingOperatorReadScopeError(err)) {

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -40,6 +40,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     sortDir: "desc",
     page: 0,
     pageSize: 10,
+    previewTextByKey: {},
     selectedKeys: new Set<string>(),
     expandedCheckpointKey: null,
     checkpointItemsByKey: {},
@@ -65,6 +66,28 @@ function buildProps(result: SessionsListResult): SessionsProps {
 }
 
 describe("sessions view", () => {
+  it("renders mailbox-style preview text under the session key", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        previewTextByKey: {
+          "agent:main:main": "Need review on the patch",
+        },
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Need review on the patch");
+  });
+
   it("keeps session selects stable and deselects only the current page", async () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -25,6 +25,7 @@ export type SessionsProps = {
   sortDir: "asc" | "desc";
   page: number;
   pageSize: number;
+  previewTextByKey: Record<string, string>;
   selectedKeys: Set<string>;
   expandedCheckpointKey: string | null;
   checkpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;
@@ -461,6 +462,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
   const showDisplayName = Boolean(
     displayName && displayName !== row.key && displayName !== trimmedLabel,
   );
+  const previewText = normalizeOptionalString(props.previewTextByKey[row.key]) ?? null;
   const canLink = row.kind !== "global";
   const chatUrl = canLink
     ? `${pathForTab("chat", props.basePath)}?session=${encodeURIComponent(row.key)}`
@@ -485,32 +487,39 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
         />
       </td>
       <td class="data-table-key-col">
-        <div class="mono session-key-cell">
-          ${canLink
-            ? html`<a
-                href=${chatUrl}
-                class="session-link"
-                @click=${(e: MouseEvent) => {
-                  if (
-                    e.defaultPrevented ||
-                    e.button !== 0 ||
-                    e.metaKey ||
-                    e.ctrlKey ||
-                    e.shiftKey ||
-                    e.altKey
-                  ) {
-                    return;
-                  }
-                  if (props.onNavigateToChat) {
-                    e.preventDefault();
-                    props.onNavigateToChat(row.key);
-                  }
-                }}
-                >${row.key}</a
-              >`
-            : row.key}
-          ${showDisplayName
-            ? html`<span class="muted session-key-display-name">${displayName}</span>`
+        <div style="display: grid; gap: 4px;">
+          <div class="mono session-key-cell">
+            ${canLink
+              ? html`<a
+                  href=${chatUrl}
+                  class="session-link"
+                  @click=${(e: MouseEvent) => {
+                    if (
+                      e.defaultPrevented ||
+                      e.button !== 0 ||
+                      e.metaKey ||
+                      e.ctrlKey ||
+                      e.shiftKey ||
+                      e.altKey
+                    ) {
+                      return;
+                    }
+                    if (props.onNavigateToChat) {
+                      e.preventDefault();
+                      props.onNavigateToChat(row.key);
+                    }
+                  }}
+                  >${row.key}</a
+                >`
+              : row.key}
+            ${showDisplayName
+              ? html`<span class="muted session-key-display-name">${displayName}</span>`
+              : nothing}
+          </div>
+          ${previewText
+            ? html`<div class="muted" style="font-size: 12px; line-height: 1.35;">
+                ${previewText}
+              </div>`
             : nothing}
         </div>
       </td>


### PR DESCRIPTION
Closes #47120

## Summary
- load lightweight preview text for the visible Sessions page rows through the existing `sessions.preview` RPC
- render mailbox-style preview snippets under each session key without changing the broader session management surface
- document and test the new Sessions preview behavior in Control UI

## Testing
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/sessions.test.ts ui/src/ui/app-gateway.sessions.node.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm build`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm check:changed`