### PR TITLE
fix(agents): normalize malformed assistant replay content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Usage/providers: keep plugin-owned usage auth enabled when manifest-declared provider auth env vars such as `MINIMAX_CODE_PLAN_KEY` are present, so `/usage` can resolve MiniMax billing credentials through the provider plugin.
 - Tlon/uploads: route both hosted Memex upload targets and custom-S3 presigned upload URLs through the shared SSRF guard so blocked private or loopback destinations fail before upload, while public upload URLs continue through the existing hosted upload flow. (#69794) Thanks @drobison00.
 - Channels/thread routing: keep outbound replies in existing Slack, Mattermost, Matrix, Telegram, Discord, and QA-channel thread sessions by sharing the Plugin SDK thread-aware route builder across bundled plugins.
+- Agents/replay: normalize restored assistant text content before provider replay and prompt submission, so legacy or repaired sessions no longer crash on `assistantMsg.content.flatMap`. (#69850) Thanks @fuller-stack-dev.
 
 ## 2026.4.20
 

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -40,7 +40,6 @@ import {
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
-import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 
 const INTER_SESSION_PREFIX_BASE = "[Inter-session message]";
@@ -232,23 +231,15 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
   let touched = false;
   const out = [...messages];
   for (let i = 0; i < out.length; i += 1) {
-    const message = out[i] as (AgentMessage & { role?: unknown; content?: unknown }) | undefined;
-    if (!message || message.role !== "assistant" || Array.isArray(message.content)) {
+    const message = out[i];
+    const replayContent = (message as { content?: unknown } | undefined)?.content;
+    if (!message || message.role !== "assistant" || typeof replayContent !== "string") {
       continue;
     }
-    if (typeof message.content !== "string") {
-      log.warn(
-        `normalizeAssistantReplayContent: repairing malformed assistant content ` +
-          `(index=${i}, type=${typeof message.content})`,
-      );
-    }
     out[i] = {
-      ...(message as unknown as Record<string, unknown>),
-      content:
-        typeof message.content === "string"
-          ? [{ type: "text", text: message.content }]
-          : [{ type: "text", text: "" }],
-    } as AgentMessage;
+      ...message,
+      content: [{ type: "text", text: replayContent }],
+    };
     touched = true;
   }
   return touched ? out : messages;

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -227,6 +227,26 @@ function stripStaleAssistantUsageBeforeLatestCompaction(messages: AgentMessage[]
   return touched ? out : messages;
 }
 
+export function normalizeAssistantReplayContent(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out = [...messages];
+  for (let i = 0; i < out.length; i += 1) {
+    const message = out[i] as (AgentMessage & { role?: unknown; content?: unknown }) | undefined;
+    if (!message || message.role !== "assistant" || Array.isArray(message.content)) {
+      continue;
+    }
+    out[i] = {
+      ...(message as unknown as Record<string, unknown>),
+      content:
+        typeof message.content === "string"
+          ? [{ type: "text", text: message.content }]
+          : [{ type: "text", text: "" }],
+    } as AgentMessage;
+    touched = true;
+  }
+  return touched ? out : messages;
+}
+
 function normalizeAssistantUsageSnapshot(usage: unknown) {
   const normalized = normalizeUsage((usage ?? undefined) as UsageLike | undefined);
   if (!normalized) {
@@ -443,8 +463,9 @@ export async function sanitizeSessionHistory(params: {
     params.modelApi === "openai-responses" ||
     params.modelApi === "openai-codex-responses" ||
     params.modelApi === "azure-openai-responses";
+  const normalizedAssistantReplay = normalizeAssistantReplayContent(withInterSessionMarkers);
   const sanitizedImages = await sanitizeSessionMessagesImages(
-    withInterSessionMarkers,
+    normalizedAssistantReplay,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -40,6 +40,7 @@ import {
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
+import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 
 const INTER_SESSION_PREFIX_BASE = "[Inter-session message]";
@@ -234,6 +235,12 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
     const message = out[i] as (AgentMessage & { role?: unknown; content?: unknown }) | undefined;
     if (!message || message.role !== "assistant" || Array.isArray(message.content)) {
       continue;
+    }
+    if (typeof message.content !== "string") {
+      log.warn(
+        `normalizeAssistantReplayContent: repairing malformed assistant content ` +
+          `(index=${i}, type=${typeof message.content})`,
+      );
     }
     out[i] = {
       ...(message as unknown as Record<string, unknown>),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1144,11 +1144,9 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
-      if (typeof activeSession.agent.convertToLlm === "function") {
-        const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
-        activeSession.agent.convertToLlm = async (messages) =>
-          await baseConvertToLlm(normalizeAssistantReplayContent(messages));
-      }
+      const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
+      activeSession.agent.convertToLlm = async (messages) =>
+        await baseConvertToLlm(normalizeAssistantReplayContent(messages));
       let prePromptMessageCount = activeSession.messages.length;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1144,9 +1144,11 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
-      const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
-      activeSession.agent.convertToLlm = async (messages) =>
-        await baseConvertToLlm(normalizeAssistantReplayContent(messages));
+      if (typeof activeSession.agent.convertToLlm === "function") {
+        const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
+        activeSession.agent.convertToLlm = async (messages) =>
+          await baseConvertToLlm(normalizeAssistantReplayContent(messages));
+      }
       let prePromptMessageCount = activeSession.messages.length;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
@@ -2193,7 +2195,7 @@ export async function runEmbeddedAttempt(
               activeSession.agent.state.messages = normalizedReplayMessages;
             }
             finalPromptText = effectivePrompt;
-            const btwSnapshotMessages = activeSession.messages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);
+            const btwSnapshotMessages = normalizedReplayMessages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);
             updateActiveEmbeddedRunSnapshot(params.sessionId, {
               transcriptLeafId,
               messages: btwSnapshotMessages,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -138,7 +138,11 @@ import {
   type PromptCacheChange,
 } from "../prompt-cache-observability.js";
 import { resolveCacheRetention } from "../prompt-cache-retention.js";
-import { sanitizeSessionHistory, validateReplayTurns } from "../replay-history.js";
+import {
+  normalizeAssistantReplayContent,
+  sanitizeSessionHistory,
+  validateReplayTurns,
+} from "../replay-history.js";
 import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
 import {
   clearActiveEmbeddedRun,
@@ -1140,6 +1144,9 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
+      activeSession.agent.convertToLlm = async (messages) =>
+        await baseConvertToLlm(normalizeAssistantReplayContent(messages));
       let prePromptMessageCount = activeSession.messages.length;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
@@ -2179,6 +2186,12 @@ export async function runEmbeddedAttempt(
           }
 
           if (!skipPromptSubmission) {
+            const normalizedReplayMessages = normalizeAssistantReplayContent(
+              activeSession.messages,
+            );
+            if (normalizedReplayMessages !== activeSession.messages) {
+              activeSession.agent.state.messages = normalizedReplayMessages;
+            }
             finalPromptText = effectivePrompt;
             const btwSnapshotMessages = activeSession.messages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);
             updateActiveEmbeddedRunSnapshot(params.sessionId, {

--- a/src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts
+++ b/src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts
@@ -60,4 +60,25 @@ describe("sanitizeSessionHistory toolResult details stripping", () => {
     const serialized = JSON.stringify(sanitized);
     expect(serialized).not.toContain("Ignore previous instructions");
   });
+
+  it("normalizes malformed assistant string content before replay sanitization", async () => {
+    const sm = SessionManager.inMemory();
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: [
+        { role: "assistant", content: "plain reply", timestamp: 1 } as unknown as AgentMessage,
+        { role: "user", content: "continue", timestamp: 2 } satisfies UserMessage,
+      ],
+      modelApi: "openai-responses",
+      provider: "github-copilot",
+      modelId: "gpt-5-mini",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    expect(sanitized[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "plain reply" }],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- normalize malformed assistant replay content into block arrays during session-history sanitization and again at the embedded prompt handoff
- wrap the embedded agent's `convertToLlm` path so provider replay never receives string-backed assistant content from live in-memory session state
- add a regression test for assistant string-content replay normalization

## Testing
- `pnpm test src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts`
- `pnpm build`
- `pnpm check:changed --staged`

## Validation
- local two-turn `github-copilot/gpt-5-mini` smoke session no longer reproduced `assistantMsg.content.flatMap is not a function` after deploying the patch into the live runtime