### PR TITLE
Ollama: gate synthetic auth on local baseUrl classification (realigns #59954)

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -495,4 +495,65 @@ describe("ollama plugin", () => {
     expect(baseStreamFn).toHaveBeenCalledTimes(1);
     expect(payloadSeen?.think).toBeUndefined();
   });
+
+  it("mints synthetic auth for explicit LAN ollama config", () => {
+    const provider = registerProvider();
+
+    const auth = provider.resolveSyntheticAuth?.({
+      providerConfig: {
+        baseUrl: "http://192.168.1.50:11434",
+        api: "ollama",
+        models: [],
+      },
+    });
+
+    expect(auth).toEqual({
+      apiKey: "ollama-local",
+      source: "models.providers.ollama (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
+  it("does not mint synthetic auth for remote Ollama Cloud baseUrl", () => {
+    const provider = registerProvider();
+
+    const auth = provider.resolveSyntheticAuth?.({
+      providerConfig: {
+        baseUrl: "https://ollama.com",
+        api: "ollama",
+        models: [],
+      },
+    });
+
+    expect(auth).toBeUndefined();
+  });
+
+  it("does not mint synthetic auth for public IPv4 baseUrl outside LAN ranges", () => {
+    const provider = registerProvider();
+
+    const auth = provider.resolveSyntheticAuth?.({
+      providerConfig: {
+        baseUrl: "http://8.8.8.8:11434",
+        api: "ollama",
+        models: [],
+      },
+    });
+
+    expect(auth).toBeUndefined();
+  });
+
+  it("does not mint synthetic auth for remote baseUrl even when explicit apiKey is present", () => {
+    const provider = registerProvider();
+
+    const auth = provider.resolveSyntheticAuth?.({
+      providerConfig: {
+        baseUrl: "https://ollama.com",
+        apiKey: "some-real-key",
+        api: "ollama",
+        models: [],
+      },
+    });
+
+    expect(auth).toBeUndefined();
+  });
 });

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -18,6 +18,7 @@ import {
   OLLAMA_DEFAULT_API_KEY,
   OLLAMA_PROVIDER_ID,
   hasMeaningfulExplicitOllamaConfig,
+  isLocalOllamaBaseUrl,
   resolveOllamaDiscoveryResult,
   type OllamaPluginConfig,
 } from "./src/discovery-shared.js";
@@ -173,6 +174,9 @@ export default definePluginEntry({
         /\btruncating input\b.*\btoo long\b/i.test(errorMessage),
       resolveSyntheticAuth: ({ providerConfig }) => {
         if (!hasMeaningfulExplicitOllamaConfig(providerConfig)) {
+          return undefined;
+        }
+        if (!isLocalOllamaBaseUrl(providerConfig?.baseUrl)) {
           return undefined;
         }
         return {

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { isLocalOllamaBaseUrl } from "./discovery-shared.js";
+
+describe("isLocalOllamaBaseUrl", () => {
+  describe("local (returns true)", () => {
+    it.each([
+      "http://localhost:11434",
+      "http://127.0.0.1:11434",
+      "http://0.0.0.0:11434",
+      "http://[::1]:11434",
+      "http://[::]:11434",
+      "http://10.0.0.5:11434",
+      "http://172.16.0.10:11434",
+      "http://172.31.255.254:11434",
+      "http://192.168.1.100:11434",
+      "http://gpu-node-1:11434",
+      "http://mac-studio.local:11434",
+      "http://MAC-STUDIO.LOCAL:11434",
+      "http://[fd00::1]:11434",
+      "http://[fc00::1]:11434",
+      "http://[fe80::1]:11434",
+    ])("classifies %s as local", (url) => {
+      expect(isLocalOllamaBaseUrl(url)).toBe(true);
+    });
+
+    it("classifies undefined baseUrl as local (ambient discovery)", () => {
+      expect(isLocalOllamaBaseUrl(undefined)).toBe(true);
+      expect(isLocalOllamaBaseUrl(null)).toBe(true);
+    });
+
+    it("classifies empty string baseUrl as local", () => {
+      expect(isLocalOllamaBaseUrl("")).toBe(true);
+    });
+  });
+
+  describe("remote (returns false)", () => {
+    it.each([
+      "https://ollama.com",
+      "https://api.ollama.com/v1",
+      "https://ollama.example.com:11434",
+      "http://8.8.8.8:11434",
+      "http://172.15.255.254:11434",
+      "http://172.32.0.1:11434",
+      "http://193.168.1.1:11434",
+      "http://[2001:4860:4860::8888]:11434",
+      "http://10.example.com:11434",
+      "http://192.168.example.com:11434",
+      "http://172.20.company.net:11434",
+    ])("classifies %s as remote", (url) => {
+      expect(isLocalOllamaBaseUrl(url)).toBe(false);
+    });
+
+    it("classifies unparseable URL as remote (conservative)", () => {
+      expect(isLocalOllamaBaseUrl("not a url")).toBe(false);
+    });
+  });
+});

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -54,6 +54,71 @@ function shouldSkipAmbientOllamaDiscovery(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.VITEST) || env.NODE_ENV === "test";
 }
 
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
+
+function isIpv4LanRange(host: string): boolean {
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    return false;
+  }
+  const [a, b] = host.split(".").map(Number);
+  if (a === 10) {
+    return true;
+  }
+  if (a === 172 && b >= 16 && b <= 31) {
+    return true;
+  }
+  if (a === 192 && b === 168) {
+    return true;
+  }
+  return false;
+}
+
+function isIpv6LocalRange(host: string): boolean {
+  const lower = host.toLowerCase();
+  if (lower === "::1") {
+    return true;
+  }
+  if (lower.startsWith("fe80:")) {
+    return true;
+  }
+  if (/^f[cd][0-9a-f]{2}:/.test(lower)) {
+    return true;
+  }
+  return false;
+}
+
+export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolean {
+  if (!baseUrl) {
+    return true;
+  }
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return false;
+  }
+  let host = url.hostname.toLowerCase();
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  if (LOCAL_HOSTNAMES.has(host)) {
+    return true;
+  }
+  if (host.endsWith(".local")) {
+    return true;
+  }
+  if (isIpv4LanRange(host)) {
+    return true;
+  }
+  if (isIpv6LocalRange(host)) {
+    return true;
+  }
+  if (!host.includes(".") && !host.includes(":")) {
+    return true;
+  }
+  return false;
+}
+
 export function hasMeaningfulExplicitOllamaConfig(
   providerConfig: ModelProviderConfig | undefined,
 ): boolean {


### PR DESCRIPTION
## Summary

Tightens `resolveSyntheticAuth` in the Ollama extension so that the synthetic local API key (`"ollama-local"`) is only applied when the configured `baseUrl` points at a local/LAN endpoint. Remote URLs (Ollama Cloud, publicly-hosted Ollama behind a TLS proxy, etc.) must now supply real credentials via env var, auth profile, or explicit config — the synthetic key no longer papers over misconfiguration or routes to endpoints that will reject it.

Partially addresses #43945 (for the Cloud-auth-specific path; the broader subagent credential lookup issue still needs the fix proposed by @Meli73).

Supersedes #59954.

## What changes

- New `isLocalOllamaBaseUrl(baseUrl)` helper in `extensions/ollama/src/discovery-shared.ts` with RFC1918 IPv4, IPv6 ULA/link-local, `.local` mDNS, bare hostname, and loopback classification.
- `resolveSyntheticAuth` now checks this classifier before returning the synthetic key. Undefined return means the auth pipeline falls through to real-credential resolution (env, profile, or explicit).
- Test coverage for the classifier (11 positive + 8 negative URL cases) and hook integration (3 new scenarios).

## What does NOT change

- Local Ollama (`localhost`, `127.0.0.1`, `::1`) — synthetic auth applies as before.
- LAN Ollama (`192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`) — synthetic auth applies as before.
- `.local` mDNS hosts — synthetic auth applies as before.
- Missing `baseUrl` (ambient discovery) — synthetic auth applies as before.
- Bare hostnames (homelab pattern `gpu-node-1`) — synthetic auth applies as before.
- Any other hook or pipeline logic — minimal surgical change.

## Backwards compatibility

Breaking for users who were configuring a remote Ollama endpoint with `"apiKey": "ollama-local"` and expecting it to work. This was never correct behavior (remote Ollama endpoints reject the synthetic marker with 401 anyway) — it just failed silently and cascaded to a different provider. After this change the failure is explicit: "Ollama remote endpoint requires real credentials — set OLLAMA_API_KEY or configure an auth profile."

## Related

- #43945 — subagent credential lookup regression, partially addressed by this change for the remote-Cloud path.
- #69855 — session-level provider drift after fallback, filed separately as a distinct bug in the same "silent cloud fallback" family.
