### PR TITLE
fix: validate plugin source entries before runtime inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel. (#69869) thanks @gumadeiras.
+- Plugins/discovery: reject package plugin source entries that escape the package directory before explicit runtime entries or inferred built JavaScript peers can be used. (#69868) thanks @gumadeiras.
 
 ## 2026.4.21
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -507,18 +507,20 @@ Some pre-runtime plugin metadata intentionally lives in `package.json` under the
 
 Important examples:
 
-| Field                                                             | What it means                                                                                                                                |
-| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openclaw.extensions`                                             | Declares native plugin entrypoints.                                                                                                          |
-| `openclaw.setupEntry`                                             | Lightweight setup-only entrypoint used during onboarding, deferred channel startup, and read-only channel status/SecretRef discovery.        |
-| `openclaw.channel`                                                | Cheap channel catalog metadata like labels, docs paths, aliases, and selection copy.                                                         |
-| `openclaw.channel.configuredState`                                | Lightweight configured-state checker metadata that can answer "does env-only setup already exist?" without loading the full channel runtime. |
-| `openclaw.channel.persistedAuthState`                             | Lightweight persisted-auth checker metadata that can answer "is anything already signed in?" without loading the full channel runtime.       |
-| `openclaw.install.npmSpec` / `openclaw.install.localPath`         | Install/update hints for bundled and externally published plugins.                                                                           |
-| `openclaw.install.defaultChoice`                                  | Preferred install path when multiple install sources are available.                                                                          |
-| `openclaw.install.minHostVersion`                                 | Minimum supported OpenClaw host version, using a semver floor like `>=2026.3.22`.                                                            |
-| `openclaw.install.allowInvalidConfigRecovery`                     | Allows a narrow bundled-plugin reinstall recovery path when config is invalid.                                                               |
-| `openclaw.startup.deferConfiguredChannelFullLoadUntilAfterListen` | Lets setup-only channel surfaces load before the full channel plugin during startup.                                                         |
+| Field                                                             | What it means                                                                                                                                                                        |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openclaw.extensions`                                             | Declares native plugin entrypoints. Must stay inside the plugin package directory.                                                                                                   |
+| `openclaw.runtimeExtensions`                                      | Declares built JavaScript runtime entrypoints for installed packages. Must stay inside the plugin package directory.                                                                 |
+| `openclaw.setupEntry`                                             | Lightweight setup-only entrypoint used during onboarding, deferred channel startup, and read-only channel status/SecretRef discovery. Must stay inside the plugin package directory. |
+| `openclaw.runtimeSetupEntry`                                      | Declares the built JavaScript setup entrypoint for installed packages. Must stay inside the plugin package directory.                                                                |
+| `openclaw.channel`                                                | Cheap channel catalog metadata like labels, docs paths, aliases, and selection copy.                                                                                                 |
+| `openclaw.channel.configuredState`                                | Lightweight configured-state checker metadata that can answer "does env-only setup already exist?" without loading the full channel runtime.                                         |
+| `openclaw.channel.persistedAuthState`                             | Lightweight persisted-auth checker metadata that can answer "is anything already signed in?" without loading the full channel runtime.                                               |
+| `openclaw.install.npmSpec` / `openclaw.install.localPath`         | Install/update hints for bundled and externally published plugins.                                                                                                                   |
+| `openclaw.install.defaultChoice`                                  | Preferred install path when multiple install sources are available.                                                                                                                  |
+| `openclaw.install.minHostVersion`                                 | Minimum supported OpenClaw host version, using a semver floor like `>=2026.3.22`.                                                                                                    |
+| `openclaw.install.allowInvalidConfigRecovery`                     | Allows a narrow bundled-plugin reinstall recovery path when config is invalid.                                                                                                       |
+| `openclaw.startup.deferConfiguredChannelFullLoadUntilAfterListen` | Lets setup-only channel surfaces load before the full channel plugin during startup.                                                                                                 |
 
 `openclaw.install.minHostVersion` is enforced during install and manifest
 registry loading. Invalid values are rejected; newer-but-valid values skip the
@@ -529,6 +531,10 @@ or SecretRef scans need to identify configured accounts without loading the full
 runtime. The setup entry should expose channel metadata plus setup-safe config,
 status, and secrets adapters; keep network clients, gateway listeners, and
 transport runtimes in the main extension entrypoint.
+
+Runtime entrypoint fields do not override package-boundary checks for source
+entrypoint fields. For example, `openclaw.runtimeExtensions` cannot make an
+escaping `openclaw.extensions` path loadable.
 
 `openclaw.install.allowInvalidConfigRecovery` is intentionally narrow. It does
 not make arbitrary broken configs installable. Today it only allows install

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -34,6 +34,10 @@ TypeScript compilation. If an installed package only declares a TypeScript
 source entry, OpenClaw will use a matching built `dist/*.js` peer when one
 exists, then fall back to the TypeScript source.
 
+All entry paths must stay inside the plugin package directory. Runtime entries
+and inferred built JavaScript peers do not make an escaping `extensions` or
+`setupEntry` source path valid.
+
 <Tip>
   **Looking for a walkthrough?** See [Channel Plugins](/plugins/sdk-channel-plugins)
   or [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -767,6 +767,35 @@ describe("discoverOpenClawPlugins", () => {
       },
     },
     {
+      name: "blocks parent-segment TypeScript entries before built runtime inference",
+      expectedDiagnostic: "escapes" as const,
+      setup: (stateDir: string) => {
+        const globalExt = path.join(stateDir, "extensions", "escape-pack");
+        mkdirSafe(path.join(globalExt, "src"));
+        writePluginPackageManifest({
+          packageDir: globalExt,
+          packageName: "@openclaw/escape-pack",
+          extensions: ["../src/index.ts"],
+        });
+        fs.writeFileSync(path.join(globalExt, "src", "index.js"), "export default {}", "utf-8");
+      },
+    },
+    {
+      name: "blocks escaping source entries before explicit runtime entries",
+      expectedDiagnostic: "escapes" as const,
+      setup: (stateDir: string) => {
+        const globalExt = path.join(stateDir, "extensions", "escape-pack");
+        mkdirSafe(path.join(globalExt, "dist"));
+        writePluginPackageManifest({
+          packageDir: globalExt,
+          packageName: "@openclaw/escape-pack",
+          extensions: ["../src/index.ts"],
+          runtimeExtensions: ["./dist/index.js"],
+        });
+        fs.writeFileSync(path.join(globalExt, "dist", "index.js"), "export default {}", "utf-8");
+      },
+    },
+    {
       name: "skips missing package extension entries without escape diagnostics",
       expectedDiagnostic: "none" as const,
       setup: (stateDir: string) => {
@@ -835,6 +864,38 @@ describe("discoverOpenClawPlugins", () => {
         return true;
       },
     },
+    {
+      name: "rejects hardlinked TypeScript entries before built runtime inference",
+      expectedDiagnostic: "escapes" as const,
+      expectedId: "pack",
+      setup: (stateDir: string) => {
+        if (process.platform === "win32") {
+          return false;
+        }
+        const globalExt = path.join(stateDir, "extensions", "pack");
+        const outsideDir = path.join(stateDir, "outside");
+        const outsideFile = path.join(outsideDir, "escape.ts");
+        const linkedFile = path.join(globalExt, "escape.ts");
+        mkdirSafe(path.join(globalExt, "dist"));
+        mkdirSafe(outsideDir);
+        fs.writeFileSync(outsideFile, "export default {}", "utf-8");
+        fs.writeFileSync(path.join(globalExt, "dist", "escape.js"), "export default {}", "utf-8");
+        try {
+          fs.linkSync(outsideFile, linkedFile);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+            return false;
+          }
+          throw err;
+        }
+        writePluginPackageManifest({
+          packageDir: globalExt,
+          packageName: "@openclaw/pack",
+          extensions: ["./escape.ts"],
+        });
+        return true;
+      },
+    },
   ] as const)("$name", async ({ setup, expectedDiagnostic, expectedId }) => {
     const stateDir = makeTempDir();
     await expectRejectedPackageExtensionEntry({
@@ -843,6 +904,28 @@ describe("discoverOpenClawPlugins", () => {
       expectedDiagnostic,
       ...(expectedId ? { expectedId } : {}),
     });
+  });
+
+  it("blocks escaping setup entries before explicit runtime setup entries", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "escape-pack");
+    mkdirSafe(path.join(globalExt, "dist"));
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@openclaw/escape-pack",
+      extensions: ["./dist/index.js"],
+      setupEntry: "../src/setup-entry.ts",
+      runtimeSetupEntry: "./dist/setup-entry.js",
+    });
+    fs.writeFileSync(path.join(globalExt, "dist", "index.js"), "export default {}", "utf-8");
+    fs.writeFileSync(path.join(globalExt, "dist", "setup-entry.js"), "export default {}", "utf-8");
+
+    const result = await discoverWithStateDir(stateDir, {});
+    const candidate = findCandidateById(result.candidates, "escape-pack");
+
+    expect(candidate).toBeDefined();
+    expect(candidate?.setupSource).toBeUndefined();
+    expectEscapesPackageDiagnostic(result.diagnostics);
   });
 
   it("ignores package manifests that are hardlinked aliases", async () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import { resolveBoundaryPathSync } from "../infra/boundary-path.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -619,6 +620,48 @@ function shouldInferBuiltRuntimeEntry(origin: PluginOrigin): boolean {
   return origin === "config" || origin === "global";
 }
 
+function resolveSafePackageEntry(params: {
+  packageDir: string;
+  entryPath: string;
+  sourceLabel: string;
+  diagnostics: PluginDiagnostic[];
+  rejectHardlinks?: boolean;
+}): { relativePath: string; existingSource?: string } | null {
+  const absolutePath = path.resolve(params.packageDir, params.entryPath);
+  if (fs.existsSync(absolutePath)) {
+    const existingSource = resolvePackageEntrySource({
+      packageDir: params.packageDir,
+      entryPath: params.entryPath,
+      sourceLabel: params.sourceLabel,
+      diagnostics: params.diagnostics,
+      rejectHardlinks: params.rejectHardlinks,
+    });
+    if (!existingSource) {
+      return null;
+    }
+    return {
+      relativePath: path.relative(params.packageDir, absolutePath).replace(/\\/g, "/"),
+      existingSource,
+    };
+  }
+
+  try {
+    resolveBoundaryPathSync({
+      absolutePath,
+      rootPath: params.packageDir,
+      boundaryLabel: "plugin package directory",
+    });
+  } catch {
+    params.diagnostics.push({
+      level: "error",
+      message: `extension entry escapes package directory: ${params.entryPath}`,
+      source: params.sourceLabel,
+    });
+    return null;
+  }
+  return { relativePath: path.relative(params.packageDir, absolutePath).replace(/\\/g, "/") };
+}
+
 function listBuiltRuntimeEntryCandidates(entryPath: string): string[] {
   if (!isTypeScriptPackageEntry(entryPath)) {
     return [];
@@ -671,6 +714,17 @@ function resolvePackageRuntimeEntrySource(params: {
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
 }): string | null {
+  const safeEntry = resolveSafePackageEntry({
+    packageDir: params.packageDir,
+    entryPath: params.entryPath,
+    sourceLabel: params.sourceLabel,
+    diagnostics: params.diagnostics,
+    rejectHardlinks: params.rejectHardlinks,
+  });
+  if (!safeEntry) {
+    return null;
+  }
+
   if (params.runtimeEntryPath) {
     const runtimeSource = resolvePackageEntrySource({
       packageDir: params.packageDir,
@@ -685,7 +739,7 @@ function resolvePackageRuntimeEntrySource(params: {
   }
 
   if (shouldInferBuiltRuntimeEntry(params.origin)) {
-    for (const candidate of listBuiltRuntimeEntryCandidates(params.entryPath)) {
+    for (const candidate of listBuiltRuntimeEntryCandidates(safeEntry.relativePath)) {
       const runtimeSource = resolveExistingPackageEntrySource({
         packageDir: params.packageDir,
         entryPath: candidate,
@@ -697,6 +751,10 @@ function resolvePackageRuntimeEntrySource(params: {
         return runtimeSource;
       }
     }
+  }
+
+  if (safeEntry.existingSource) {
+    return safeEntry.existingSource;
   }
 
   return resolvePackageEntrySource({


### PR DESCRIPTION
## Summary

- Problem: package plugin discovery could infer or accept built runtime entries before validating the declared source entry path.
- Why it matters: an escaping `openclaw.extensions` or `openclaw.setupEntry` path could be made to load an in-package runtime file instead of being rejected by package-boundary validation.
- What changed: validate declared package source entries before explicit runtime entries or inferred built JavaScript peers, and document the package-local entrypoint contract.
- What did NOT change (scope boundary): plugin runtime execution, manifest parsing shape, bundled plugin APIs, and external plugin ownership boundaries.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: built runtime inference used the raw manifest source path to create runtime candidates, then boundary-validated only the rewritten runtime candidate.
- Missing detection / guardrail: tests covered direct escaping package entries, but not TypeScript source entries that could be rewritten to in-package runtime files.
- Contributing context (if known): installed package support allows missing TypeScript source entries to resolve to built JavaScript peers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/discovery.test.ts`
- Scenario the test should lock in: escaping source entries are rejected before inferred runtime entries, explicit runtime entries, and setup runtime entries can be considered.
- Why this is the smallest reliable guardrail: discovery owns package entry resolution and can exercise the manifest-to-candidate routing without loading plugin runtime.
- Existing test that already covers this (if any): direct escaping, symlink, and hardlink package entry tests existed but did not cover runtime inference.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Invalid package plugin manifests with escaping `openclaw.extensions` or `openclaw.setupEntry` source paths are rejected even when runtime entry fields or inferred built JavaScript peers point inside the package.

## Diagram (if applicable)

```text
Before:
package manifest -> infer runtime candidate -> validate rewritten runtime path -> candidate accepted

After:
package manifest -> validate declared source path -> infer or load runtime path -> candidate accepted
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: plugin discovery now preserves package-directory boundary validation for declared source entries before runtime path selection.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ repo runtime via pnpm
- Model/provider: N/A
- Integration/channel (if any): Plugin discovery
- Relevant config (redacted): N/A

### Steps

1. Create a package plugin manifest with `openclaw.extensions: ["../src/index.ts"]`.
2. Add an in-package built JavaScript peer such as `src/index.js` or an explicit `runtimeExtensions` path.
3. Run plugin discovery.

### Expected

- Discovery rejects the escaping source entry and does not load it through runtime inference or runtime override.

### Actual

- Before this fix, discovery could accept the rewritten in-package runtime candidate. After this fix, discovery emits an escape diagnostic and skips the unsafe source route.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/plugins/discovery.test.ts`; docs formatting and markdown lint for touched docs; `git diff --check`.
- Edge cases checked: inferred runtime bypass, explicit runtime bypass, setup runtime bypass, hardlinked TypeScript source with inferred runtime peer.
- What you did **not** verify: full test suite, per request to keep verification targeted.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: installed packages with invalid escaping source entries but valid runtime entries stop loading.
  - Mitigation: this is intentional boundary enforcement; docs now state all entry paths must stay inside the plugin package directory.
