### PR TITLE
fix(discord): keep slash follow-ups ephemeral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Docs: https://docs.openclaw.ai
 - CLI/doctor plugins: lazy-load doctor plugin paths and prefer installed plugin `dist/*` runtime entries over source-adjacent JavaScript fallbacks, reducing the measured `doctor --non-interactive` runtime by about 74% while keeping cold doctor startup on built plugin artifacts. (#69840) Thanks @gumadeiras.
 - WhatsApp/groups+direct: forward per-group and per-direct `systemPrompt` config into inbound context `GroupSystemPrompt` so configured per-chat behavioral instructions are injected on every turn. Supports `"*"` wildcard fallback and account-scoped overrides under `channels.whatsapp.accounts.<id>.{groups,direct}`; account maps fully replace root maps (no deep merge), matching the existing `requireMention` pattern. Closes #7011. (#59553) Thanks @Bluetegu.
 
+### Fixes
+
+- Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel.
+
 ## 2026.4.21
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel.
+- Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel. (#69869) thanks @gumadeiras.
 
 ## 2026.4.21
 

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -35,6 +35,7 @@ import {
   withTimeout,
 } from "openclaw/plugin-sdk/text-runtime";
 import { resolveDiscordChannelNameSafe } from "./channel-access.js";
+import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
 import {
   readDiscordModelPickerRecentModels,
@@ -919,7 +920,7 @@ export async function handleDiscordCommandArgInteraction(params: {
     sessionPrefix: ctx.sessionPrefix,
     preferFollowUp: true,
     threadBindings: ctx.threadBindings,
-    responseEphemeral: true,
+    responseEphemeral: resolveDiscordSlashCommandConfig(ctx.discordConfig?.slashCommand).ephemeral,
   });
 }
 

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -80,6 +80,7 @@ export type DispatchDiscordCommandInteractionParams = {
   sessionPrefix: string;
   preferFollowUp: boolean;
   threadBindings: ThreadBindingManager;
+  responseEphemeral?: boolean;
   suppressReplies?: boolean;
 };
 
@@ -918,6 +919,7 @@ export async function handleDiscordCommandArgInteraction(params: {
     sessionPrefix: ctx.sessionPrefix,
     preferFollowUp: true,
     threadBindings: ctx.threadBindings,
+    responseEphemeral: true,
   });
 }
 

--- a/extensions/discord/src/monitor/native-command.command-arg.test.ts
+++ b/extensions/discord/src/monitor/native-command.command-arg.test.ts
@@ -1,0 +1,97 @@
+import type { ChatCommandDefinition } from "openclaw/plugin-sdk/command-auth";
+import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDiscordCommandArgFallbackButton,
+  type DispatchDiscordCommandInteraction,
+} from "./native-command-ui.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+type CommandArgContext = Parameters<typeof createDiscordCommandArgFallbackButton>[0]["ctx"];
+type CommandArgButton = ReturnType<typeof createDiscordCommandArgFallbackButton>;
+type CommandArgInteraction = Parameters<CommandArgButton["run"]>[0];
+type CommandArgData = Parameters<CommandArgButton["run"]>[1];
+
+function createCommandDefinition(): ChatCommandDefinition {
+  return {
+    key: "think",
+    nativeName: "think",
+    description: "Set thinking level",
+    textAliases: ["/think"],
+    acceptsArgs: true,
+    args: [
+      {
+        name: "level",
+        description: "Thinking level",
+        type: "string",
+        required: true,
+      },
+    ],
+    argsParsing: "none",
+    scope: "native",
+  };
+}
+
+function createContext(
+  discordConfig: NonNullable<OpenClawConfig["channels"]>["discord"],
+): CommandArgContext {
+  const cfg = {
+    channels: {
+      discord: discordConfig,
+    },
+  } as OpenClawConfig;
+  return {
+    cfg,
+    discordConfig,
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    threadBindings: createNoopThreadBindingManager("default"),
+  };
+}
+
+function createInteraction(): CommandArgInteraction {
+  return {
+    user: {
+      id: "owner",
+      username: "tester",
+      globalName: "Tester",
+    },
+    update: vi.fn().mockResolvedValue({ ok: true }),
+  } as unknown as CommandArgInteraction;
+}
+
+async function safeInteractionCall<T>(_label: string, fn: () => Promise<T>): Promise<T | null> {
+  return await fn();
+}
+
+describe("discord command argument fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves public slash command visibility for selected argument follow-ups", async () => {
+    const commandDefinition = createCommandDefinition();
+    vi.spyOn(commandRegistryModule, "findCommandByNativeName").mockReturnValue(commandDefinition);
+    const dispatchSpy = vi.fn<DispatchDiscordCommandInteraction>().mockResolvedValue();
+    const button = createDiscordCommandArgFallbackButton({
+      ctx: createContext({ slashCommand: { ephemeral: false } }),
+      safeInteractionCall,
+      dispatchCommandInteraction: dispatchSpy,
+    });
+
+    await button.run(createInteraction(), {
+      command: "think",
+      arg: "level",
+      value: "high",
+      user: "owner",
+    } satisfies CommandArgData);
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "/think high",
+        responseEphemeral: false,
+      }),
+    );
+  });
+});

--- a/extensions/discord/src/monitor/native-command.status-direct.test.ts
+++ b/extensions/discord/src/monitor/native-command.status-direct.test.ts
@@ -152,9 +152,30 @@ describe("discord native /status", () => {
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({
         content: "status reply",
+        ephemeral: true,
       }),
     );
     expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("keeps every direct status chunk ephemeral", async () => {
+    runtimeModuleMocks.resolveDirectStatusReplyForSession.mockResolvedValue({
+      text: `fallback models\nruntime info\n${"x".repeat(2200)}`,
+    });
+    const cfg = createConfig();
+    const command = await createStatusCommand(cfg);
+    const interaction = createInteraction();
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp.mock.calls.length).toBeGreaterThan(1);
+    for (const [payload] of interaction.followUp.mock.calls) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          ephemeral: true,
+        }),
+      );
+    }
   });
 
   it("passes through the effective guild activation when requireMention is disabled", async () => {

--- a/extensions/discord/src/monitor/native-command.status-direct.test.ts
+++ b/extensions/discord/src/monitor/native-command.status-direct.test.ts
@@ -6,6 +6,7 @@ import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
 const runtimeModuleMocks = vi.hoisted(() => ({
   dispatchReplyWithDispatcher: vi.fn(),
+  loadWebMedia: vi.fn(),
   resolveDirectStatusReplyForSession: vi.fn(),
 }));
 
@@ -23,6 +24,10 @@ vi.mock("openclaw/plugin-sdk/reply-dispatch-runtime", async () => {
 vi.mock("openclaw/plugin-sdk/command-status-runtime", () => ({
   resolveDirectStatusReplyForSession: (...args: unknown[]) =>
     runtimeModuleMocks.resolveDirectStatusReplyForSession(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/web-media", () => ({
+  loadWebMedia: (...args: unknown[]) => runtimeModuleMocks.loadWebMedia(...args),
 }));
 
 let createDiscordNativeCommand: typeof import("./native-command.js").createDiscordNativeCommand;
@@ -134,6 +139,10 @@ describe("discord native /status", () => {
     runtimeModuleMocks.resolveDirectStatusReplyForSession.mockResolvedValue({
       text: "status reply",
     });
+    runtimeModuleMocks.loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      fileName: "status.png",
+    });
     discordNativeCommandTesting.setDispatchReplyWithDispatcher(
       runtimeModuleMocks.dispatchReplyWithDispatcher as typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").dispatchReplyWithDispatcher,
     );
@@ -176,6 +185,37 @@ describe("discord native /status", () => {
         }),
       );
     }
+  });
+
+  it("keeps direct status media follow-up chunks ephemeral", async () => {
+    runtimeModuleMocks.resolveDirectStatusReplyForSession.mockResolvedValue({
+      text: `status image\n${"x".repeat(2200)}`,
+      mediaUrls: ["https://example.com/status.png"],
+    });
+    const cfg = createConfig();
+    const command = await createStatusCommand(cfg);
+    const interaction = createInteraction();
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(runtimeModuleMocks.loadWebMedia).toHaveBeenCalledWith("https://example.com/status.png", {
+      localRoots: expect.any(Array),
+    });
+    expect(interaction.followUp.mock.calls.length).toBeGreaterThan(1);
+    expect(interaction.followUp.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        ephemeral: true,
+        files: expect.arrayContaining([expect.objectContaining({ name: "status.png" })]),
+      }),
+    );
+    for (const [payload] of interaction.followUp.mock.calls) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          ephemeral: true,
+        }),
+      );
+    }
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it("passes through the effective guild activation when requireMention is disabled", async () => {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -33,7 +33,6 @@ import {
   type ChatCommandDefinition,
   type CommandArgDefinition,
   type CommandArgValues,
-  type CommandArgs,
   type NativeCommandSpec,
 } from "openclaw/plugin-sdk/native-command-registry";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
@@ -88,6 +87,10 @@ import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
+type DiscordCommandArgs = {
+  raw?: string;
+  values?: CommandArgValues;
+};
 const log = createSubsystemLogger("discord/native-command");
 // Discord application command and option descriptions are limited to 1-100 chars.
 // https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
@@ -559,7 +562,7 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
 function readDiscordCommandArgs(
   interaction: CommandInteraction,
   definitions?: CommandArgDefinition[],
-): CommandArgs | undefined {
+): DiscordCommandArgs | undefined {
   if (!definitions || definitions.length === 0) {
     return undefined;
   }
@@ -726,7 +729,7 @@ export function createDiscordNativeCommand(params: {
         ? ({
             ...commandArgs,
             raw: serializeCommandArgs(commandDefinition, commandArgs) ?? commandArgs.raw,
-          } satisfies CommandArgs)
+          } satisfies DiscordCommandArgs)
         : undefined;
       const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
       await dispatchDiscordCommandInteraction({
@@ -752,7 +755,7 @@ async function dispatchDiscordCommandInteraction(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
   prompt: string;
   command: ChatCommandDefinition;
-  commandArgs?: CommandArgs;
+  commandArgs?: DiscordCommandArgs;
   cfg: ReturnType<typeof loadConfig>;
   discordConfig: DiscordConfig;
   accountId: string;
@@ -1402,10 +1405,7 @@ async function deliverDiscordInteractionReply(params: {
       if (!chunk.trim()) {
         continue;
       }
-      await interaction.followUp({
-        content: chunk,
-        ...(params.responseEphemeral !== undefined ? { ephemeral: params.responseEphemeral } : {}),
-      });
+      await sendMessage(chunk);
     }
     return;
   }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -742,6 +742,7 @@ export function createDiscordNativeCommand(params: {
         // follow-up/edit semantics instead of the initial reply endpoint.
         preferFollowUp: true,
         threadBindings,
+        responseEphemeral: ephemeralDefault,
       });
     }
   })();
@@ -758,6 +759,7 @@ async function dispatchDiscordCommandInteraction(params: {
   sessionPrefix: string;
   preferFollowUp: boolean;
   threadBindings: ThreadBindingManager;
+  responseEphemeral?: boolean;
   suppressReplies?: boolean;
 }) {
   const {
@@ -771,13 +773,15 @@ async function dispatchDiscordCommandInteraction(params: {
     sessionPrefix,
     preferFollowUp,
     threadBindings,
+    responseEphemeral,
     suppressReplies,
   } = params;
   const commandName = command.nativeName ?? command.key;
   const respond = async (content: string, options?: { ephemeral?: boolean }) => {
+    const ephemeral = options?.ephemeral ?? responseEphemeral;
     const payload = {
       content,
-      ...(options?.ephemeral !== undefined ? { ephemeral: options.ephemeral } : {}),
+      ...(ephemeral !== undefined ? { ephemeral } : {}),
     };
     await safeDiscordInteractionCall("interaction reply", async () => {
       if (preferFollowUp) {
@@ -1099,6 +1103,7 @@ async function dispatchDiscordCommandInteraction(params: {
       }),
       maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
       preferFollowUp,
+      responseEphemeral,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
     return;
@@ -1168,6 +1173,7 @@ async function dispatchDiscordCommandInteraction(params: {
         }),
         maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
         preferFollowUp,
+        responseEphemeral,
         chunkMode: resolveChunkMode(cfg, "discord", accountId),
       });
       return;
@@ -1233,6 +1239,7 @@ async function dispatchDiscordCommandInteraction(params: {
             }),
             maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
             preferFollowUp: preferFollowUp || didReply,
+            responseEphemeral,
             chunkMode: resolveChunkMode(cfg, "discord", accountId),
           });
         } catch (error) {
@@ -1314,6 +1321,7 @@ async function deliverDiscordInteractionReply(params: {
   textLimit: number;
   maxLinesPerMessage?: number;
   preferFollowUp: boolean;
+  responseEphemeral?: boolean;
   chunkMode: "length" | "newline";
 }) {
   const { interaction, payload, textLimit, maxLinesPerMessage, preferFollowUp, chunkMode } = params;
@@ -1337,6 +1345,9 @@ async function deliverDiscordInteractionReply(params: {
         ? {
             content,
             ...(components ? { components } : {}),
+            ...(params.responseEphemeral !== undefined
+              ? { ephemeral: params.responseEphemeral }
+              : {}),
             files: files.map((file) => {
               if (file.data instanceof Blob) {
                 return { name: file.name, data: file.data };
@@ -1348,6 +1359,9 @@ async function deliverDiscordInteractionReply(params: {
         : {
             content,
             ...(components ? { components } : {}),
+            ...(params.responseEphemeral !== undefined
+              ? { ephemeral: params.responseEphemeral }
+              : {}),
           };
     await safeDiscordInteractionCall("interaction send", async () => {
       if (!preferFollowUp && !hasReplied) {
@@ -1388,7 +1402,10 @@ async function deliverDiscordInteractionReply(params: {
       if (!chunk.trim()) {
         continue;
       }
-      await interaction.followUp({ content: chunk });
+      await interaction.followUp({
+        content: chunk,
+        ...(params.responseEphemeral !== undefined ? { ephemeral: params.responseEphemeral } : {}),
+      });
     }
     return;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord slash command replies can be chunked into multiple follow-ups, but follow-up payloads did not preserve the command's ephemeral visibility.
- Why it matters: long `/status` replies could expose fallback model/runtime details publicly after the initial ephemeral response.
- What changed: thread the native command ephemeral policy through Discord interaction reply delivery, including chunked text and media follow-up chunks.
- What did NOT change (scope boundary): no Discord gateway startup, doctor, command routing, or model status content changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69841
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Discord native slash commands set an ephemeral command policy and defer the interaction, but `deliverDiscordInteractionReply` built subsequent `followUp()` payloads without the `ephemeral` flag.
- Missing detection / guardrail: direct `/status` coverage asserted the reply text but not visibility across chunked follow-ups.
- Contributing context (if known): `/status` can exceed Discord chunk limits when fallback models/runtime details are included.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/native-command.status-direct.test.ts`
- Scenario the test should lock in: long direct `/status` output sends multiple follow-ups, and every follow-up remains ephemeral.
- Why this is the smallest reliable guardrail: it exercises the Discord native command delivery helper directly without live Discord.
- Existing test that already covers this (if any): existing direct `/status` test covered dispatcher bypass but not chunk visibility.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord slash-command follow-up chunks now stay ephemeral when the command is configured for ephemeral replies.

## Diagram (if applicable)

```text
Before:
/status -> ephemeral defer -> first follow-up -> later chunks public

After:
/status -> ephemeral defer -> all follow-up chunks ephemeral
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local dev
- Runtime/container: Node repo runtime via pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord native slash commands with ephemeral replies enabled

### Steps

1. Configure Discord slash commands for ephemeral replies.
2. Run `/status` with enough status content to require multiple Discord follow-up messages.
3. Inspect follow-up payload visibility.

### Expected

- Every `/status` follow-up remains ephemeral.

### Actual

- Before this fix, later follow-up chunks could be sent without `ephemeral` and become public.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Regression coverage added in `native-command.status-direct.test.ts`; local changed gate passes.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: long direct `/status` output produces multiple follow-ups and all follow-up payloads contain `ephemeral: true`.
- Edge cases checked: shared Discord changed-surface gate, including extension typecheck, lint, import cycles, and 54 Discord extension test files.
- What you did **not** verify: live Discord API behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some non-status slash-command follow-ups now explicitly inherit the configured ephemeral policy.
  - Mitigation: this matches the existing command-level `ephemeralDefault` and preserves explicit overrides where call sites pass one.
