### PR TITLE
fix(config): preserve symlinked config writes and SecretRef markers

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1618,7 +1618,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       typeof snapshot.raw === "string" ? Buffer.byteLength(snapshot.raw, "utf-8") : null;
     const nextBytes = Buffer.byteLength(json, "utf-8");
     const previousStat = snapshot.exists
-      ? await deps.fs.promises.stat(configPath).catch(() => null)
+      ? await deps.fs.promises.stat(writePath).catch(() => null)
       : null;
     const hasMetaBefore = hasConfigMeta(snapshot.parsed);
     const hasMetaAfter = hasConfigMeta(stampedOutputConfig);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1588,6 +1588,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       homedir: deps.homedir,
       fsModule: deps.fs,
     });
+    const writePath = snapshot.exists
+      ? await deps.fs.promises.realpath(configPath).catch(() => configPath)
+      : configPath;
     const outputConfigBase =
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
@@ -1714,9 +1717,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       throw err;
     }
 
+    const writeDir = path.dirname(writePath);
     const tmp = path.join(
-      dir,
-      `${path.basename(configPath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+      writeDir,
+      `${path.basename(writePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
     );
 
     try {
@@ -1725,18 +1729,18 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         mode: 0o600,
       });
 
-      if (deps.fs.existsSync(configPath)) {
-        await maintainConfigBackups(configPath, deps.fs.promises);
+      if (deps.fs.existsSync(writePath)) {
+        await maintainConfigBackups(writePath, deps.fs.promises);
       }
 
       try {
-        await deps.fs.promises.rename(tmp, configPath);
+        await deps.fs.promises.rename(tmp, writePath);
       } catch (err) {
         const code = (err as { code?: string }).code;
         // Windows doesn't reliably support atomic replace via rename when dest exists.
         if (code === "EPERM" || code === "EEXIST") {
-          await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+          await deps.fs.promises.copyFile(tmp, writePath);
+          await deps.fs.promises.chmod(writePath, 0o600).catch(() => {
             // best-effort
           });
           await deps.fs.promises.unlink(tmp).catch(() => {
@@ -1747,7 +1751,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           await appendWriteAudit(
             "copy-fallback",
             undefined,
-            await deps.fs.promises.stat(configPath).catch(() => null),
+            await deps.fs.promises.stat(writePath).catch(() => null),
           );
           return { persistedHash: nextHash };
         }
@@ -1761,7 +1765,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       await appendWriteAudit(
         "rename",
         undefined,
-        await deps.fs.promises.stat(configPath).catch(() => null),
+        await deps.fs.promises.stat(writePath).catch(() => null),
       );
       return { persistedHash: nextHash };
     } catch (err) {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
-import { createConfigIO } from "./io.js";
+import {
+  createConfigIO,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  writeConfigFile,
+} from "./io.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
 // Mock the plugin manifest registry so we can register a fake channel whose
@@ -66,7 +71,12 @@ describe("config io write", () => {
     } satisfies PluginManifestRegistry);
   });
 
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
   afterAll(async () => {
+    resetConfigRuntimeState();
     await suiteRootTracker.cleanup();
   });
 
@@ -360,5 +370,131 @@ describe("config io write", () => {
       diagnostics: [],
       plugins: [],
     } satisfies PluginManifestRegistry);
+  });
+
+  it("preserves symlinked config files instead of renaming over the symlink path", async () => {
+    await withSuiteHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const trackedDir = path.join(home, "workspace", "config");
+      const targetPath = path.join(trackedDir, "openclaw.json");
+      const symlinkPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(trackedDir, { recursive: true });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        targetPath,
+        `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`,
+        "utf-8",
+      );
+      await fs.symlink(targetPath, symlinkPath);
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      await io.writeConfigFile({ gateway: { mode: "local", port: 18789 } });
+
+      const symlinkStat = await fs.lstat(symlinkPath);
+      expect(symlinkStat.isSymbolicLink()).toBe(true);
+      expect(await fs.readlink(symlinkPath)).toBe(targetPath);
+      expect(JSON.parse(await fs.readFile(targetPath, "utf-8"))).toMatchObject({
+        gateway: { mode: "local", port: 18789 },
+      });
+    });
+  });
+
+  it("writes runtime-derived edits back to source SecretRef markers", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      try {
+        setRuntimeConfigSnapshot(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: "sk-runtime-resolved",
+                  models: [],
+                },
+              },
+            },
+          },
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+        );
+
+        await writeConfigFile({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-runtime-resolved",
+                models: [],
+              },
+            },
+          },
+        });
+
+        expect(JSON.parse(await fs.readFile(configPath, "utf-8"))).toEqual({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                models: [],
+              },
+            },
+          },
+          meta: {
+            lastTouchedAt: expect.any(String),
+            lastTouchedVersion: expect.any(String),
+          },
+        });
+      } finally {
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #69396.

`config.write` had two related problems around config persistence:

1. **Atomic rename replaces symlinked config with a regular file.** When `~/.openclaw/openclaw.json` is a symlink (e.g. to a git-tracked workspace file), every config write clobbers the symlink with a freshly renamed regular file.

2. **Resolved SecretRef values are serialized back to disk.** The writer emits resolved (materialized) secret values instead of the original SecretRef marker objects, contradicting the documented behavior:
   > Marker persistence is source-authoritative: OpenClaw writes markers from the active source config snapshot (pre-resolution), not from resolved runtime secret values.

## Root cause

The writer always created its temp file alongside `configPath` and renamed it back onto `configPath`. When that path was a symlink, the rename replaced the symlink inode instead of updating the symlink target.

The SecretRef side is protected by the runtime-source projection path, but this regression needed coverage at the writer boundary to make sure runtime-derived edits still round-trip back to the source marker objects.

## What changed

- Resolve the real config file path (`fs.promises.realpath`) before choosing the temp-file directory and rename/copy destination
- Keep backup maintenance and post-write stat collection aligned with that resolved write target
- Add a regression test that writes through a symlinked `openclaw.json` and verifies the symlink survives while the target file is updated
- Add a regression test that simulates a runtime snapshot with resolved credentials and verifies `writeConfigFile(...)` still persists the original SecretRef marker object, not plaintext

## Testing

- `npm run test -- src/config/io.write-config.test.ts` — 10 passed
- Based on original PR #69416 by @EronFan which was closed due to PR queue limit

## Related issues

- Fixes #69396
- Related to #67171 (same bug class for ${VAR} syntax)
- Related to #58087 (SecretRef headers regression)