### PR TITLE
fix(telegram): mark polling transport dirty on 409 conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/polling: rebuild the polling HTTP transport after `getUpdates` 409 conflicts, so retries use a fresh TCP connection instead of looping on a Telegram-terminated keep-alive socket. (#69873) Thanks @hclsys.
 - Slack/files: resolve `downloadFile` bot tokens from the runtime config when callers provide `cfg` without an explicit token or prebuilt client, preserving cfg-only file downloads outside the action runtime path. (#70160) Thanks @martingarramon.
 - Slack/HTTP: dispatch registered Request URL webhooks through the same handler registry used by Slack monitor setup, so HTTP-mode Slack events no longer 404 after successful route registration. (#70275) Thanks @FroeMic.
 - CLI sessions: persist CLI session clearing through the atomic session-store merge path, so expired Claude/Codex CLI bindings are actually removed before retrying without the stale session id. (#70298) Thanks @HFConsultant.

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -844,6 +844,8 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(2);
     expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport1);
     expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport2);
+    expect(telegramTransport1.close).toHaveBeenCalledTimes(1);
+    expect(telegramTransport2.close).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to configured webhookSecret when not passed explicitly", async () => {

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -787,16 +787,25 @@ describe("monitorTelegramProvider (grammY)", () => {
     await expectOffsetConfirmationSkipped(Number.MAX_SAFE_INTEGER);
   });
 
-  it("resets webhookCleared latch on 409 conflict so deleteWebhook re-runs", async () => {
+  it("resets webhookCleared latch on 409 conflict so deleteWebhook re-runs, and rebuilds transport for a fresh TCP socket (#69787)", async () => {
     const abort = new AbortController();
     api.deleteWebhook.mockReset();
     api.deleteWebhook.mockResolvedValue(true);
-    const telegramTransport = {
+    const telegramTransport1 = {
       fetch: globalThis.fetch,
       sourceFetch: globalThis.fetch,
       close: vi.fn(async () => undefined),
     };
-    resolveTelegramTransportSpy.mockReturnValueOnce(telegramTransport);
+    const telegramTransport2 = {
+      fetch: globalThis.fetch,
+      sourceFetch: globalThis.fetch,
+      close: vi.fn(async () => undefined),
+    };
+    // First call is the initial cycle; second call is the post-409 rebuild
+    // that forces a fresh TCP connection (see #69787 polling-session fix).
+    resolveTelegramTransportSpy
+      .mockReturnValueOnce(telegramTransport1)
+      .mockReturnValueOnce(telegramTransport2);
 
     const conflictError = Object.assign(
       new Error("Conflict: terminated by other getUpdates request"),
@@ -829,9 +838,12 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(api.deleteWebhook).toHaveBeenCalledTimes(2);
     expect(pollingCycle).toBe(2);
     expect(runSpy).toHaveBeenCalledTimes(2);
-    expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(1);
-    expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport);
-    expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport);
+    // Transport is rebuilt on 409 conflict — the second cycle gets a fresh
+    // transport so Telegram sees a new TCP socket instead of reusing the
+    // keep-alive connection it already terminated.
+    expect(resolveTelegramTransportSpy).toHaveBeenCalledTimes(2);
+    expect(createTelegramBotCalls[0]?.telegramTransport).toBe(telegramTransport1);
+    expect(createTelegramBotCalls[1]?.telegramTransport).toBe(telegramTransport2);
   });
 
   it("falls back to configured webhookSecret when not passed explicitly", async () => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -914,7 +914,12 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("reuses the transport after a getUpdates conflict", async () => {
+  it("rebuilds the transport after a getUpdates conflict to force a fresh TCP socket", async () => {
+    // Regression for #69787: Telegram-side session termination returns 409
+    // and the previous behavior retried on the same HTTP keep-alive socket,
+    // which Telegram repeatedly terminated as the "old" session — producing
+    // a sustained low-rate 409 loop. The polling session must now mark the
+    // transport dirty on 409 so the next cycle uses a fresh connection.
     const abort = new AbortController();
     const conflictError = Object.assign(
       new Error("Conflict: terminated by other getUpdates request"),
@@ -924,7 +929,10 @@ describe("TelegramPollingSession", () => {
       },
     );
     const transport1 = makeTelegramTransport();
-    const createTelegramTransport = vi.fn(() => makeTelegramTransport());
+    const transport2 = makeTelegramTransport();
+    const createTelegramTransport = vi
+      .fn<() => ReturnType<typeof makeTelegramTransport>>()
+      .mockReturnValueOnce(transport2);
     createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
     isRecoverableTelegramNetworkErrorMock.mockReturnValue(false);
     mockRestartAfterPollingError(conflictError, abort);
@@ -937,8 +945,11 @@ describe("TelegramPollingSession", () => {
 
     await session.runUntilAbort();
 
-    expectTelegramBotTransportSequence(transport1, transport1);
-    expect(createTelegramTransport).not.toHaveBeenCalled();
+    expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+    // The stale transport is closed by the dirty-rebuild; the new transport
+    // is closed when dispose() fires on session exit.
+    expect(transport1.close).toHaveBeenCalled();
+    expect(transport2.close).toHaveBeenCalled();
   });
 
   it("closes the transport once when runUntilAbort exits normally", async () => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -946,10 +946,11 @@ describe("TelegramPollingSession", () => {
     await session.runUntilAbort();
 
     expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+    expectTelegramBotTransportSequence(transport1, transport2);
     // The stale transport is closed by the dirty-rebuild; the new transport
     // is closed when dispose() fires on session exit.
-    expect(transport1.close).toHaveBeenCalled();
-    expect(transport2.close).toHaveBeenCalled();
+    expect(transport1.close).toHaveBeenCalledTimes(1);
+    expect(transport2.close).toHaveBeenCalledTimes(1);
   });
 
   it("closes the transport once when runUntilAbort exits normally", async () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -368,7 +368,12 @@ export class TelegramPollingSession {
         this.#webhookCleared = false;
       }
       const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
-      if (isRecoverable) {
+      // Mark transport dirty on 409 conflict as well as recoverable network
+      // errors. Without this, Telegram-side session termination returns 409
+      // and the retry reuses the same HTTP keep-alive TCP socket, which
+      // Telegram treats as the "old" session and keeps terminating — producing
+      // a tight 409 retry loop at low but non-zero rate. (#69787)
+      if (isRecoverable || isConflict) {
         this.#transportState.markDirty();
       }
       if (!isConflict && !isRecoverable) {


### PR DESCRIPTION
## Summary

Fixes #69787. When Telegram returns HTTP 409 Conflict on `getUpdates` (e.g. `terminated by other getUpdates request`), the polling runtime retried on the same HTTP keep-alive TCP socket because `markDirty()` was only called in the `isRecoverable` branch.

Telegram treats that connection as the *old* session and keeps terminating it — producing a sustained low-rate 409 retry loop (reporter: a few per minute after eliminating duplicate pollers).

## Fix

Broaden the dirty-mark condition in `extensions/telegram/src/polling-session.ts` so `isConflict` also triggers `markDirty()`. This forces the next cycle to build a fresh transport (fresh TCP connection) instead of reusing the keep-alive socket that Telegram already considers closed on its side.

```ts
// Mark transport dirty on 409 conflict as well as recoverable network
// errors. (#69787)
if (isRecoverable || isConflict) {
  this.#transportState.markDirty();
}
```

## Test

The existing test `reuses the transport after a getUpdates conflict` locked in the buggy behavior — it asserted `createTelegramTransport` was never called. That test has been updated (renamed to `rebuilds the transport after a getUpdates conflict to force a fresh TCP socket`) and flipped to assert the correct behavior: one fresh transport is built, the stale one is closed.

oxlint passes on both changed files. Local vitest run blocked by a pre-existing vitest config naming conflict unrelated to this change (`vitest.contracts-channel-surface.config.ts`).

## Scope

1 production file, 1 test file. Behavior change limited to 409 conflict path.

Closes #69787.