### PR TITLE
fix(memory/dreaming): surface blocked status when heartbeat is disabled for main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - CLI/doctor plugins: lazy-load doctor plugin paths and prefer installed plugin `dist/*` runtime entries over source-adjacent JavaScript fallbacks, reducing the measured `doctor --non-interactive` runtime by about 74% while keeping cold doctor startup on built plugin artifacts. (#69840) Thanks @gumadeiras.
 
+### Fixes
+
+- memory-core/dreaming: surface a `Dreaming status: blocked` line in `openclaw memory status` when dreaming is enabled but the heartbeat that drives the managed cron is not firing for the default agent, and add a Troubleshooting section to the dreaming docs covering the two common causes (per-agent `heartbeat` blocks excluding `main`, and `heartbeat.every` set to `0`/empty/invalid), so the silent failure described in #69843 becomes legible on the status surface.
+
 ## 2026.4.21
 
 ### Changes

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -229,8 +229,20 @@ When enabled, the Gateway **Dreams** tab shows:
 - a distinct grounded Scene lane for staged historical replay entries
 - an expandable Dream Diary reader backed by `doctor.memory.dreamDiary`
 
+## Troubleshooting
+
+### Dreaming never runs (status shows blocked)
+
+`openclaw memory status` shows `Dreaming status: blocked` when dreaming is enabled but the heartbeat that drives the cron is not firing for the default agent. Dreaming requires a heartbeat, so if the heartbeat is not scheduled for `main`, the managed cron never gets a chance to run.
+
+Two common causes:
+
+- Another agent declares an explicit `heartbeat:` block. When any entry in `agents.list` has its own `heartbeat` block, only those agents heartbeat — the defaults stop applying to everyone else, so `main` goes silent. Move the heartbeat settings to `agents.defaults.heartbeat`, or add an explicit `heartbeat` block on the `main` entry. See [Scope and precedence](/gateway/heartbeat#scope-and-precedence).
+- `heartbeat.every` is `0`, empty, or unparseable. The cron has no interval to schedule against, so the heartbeat is effectively disabled. Set `every` to a positive duration such as `30m`. See [Defaults](/gateway/heartbeat#defaults).
+
 ## Related
 
+- [Heartbeat](/gateway/heartbeat)
 - [Memory](/concepts/memory)
 - [Memory Search](/concepts/memory-search)
 - [memory CLI](/cli/memory)

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -233,11 +233,11 @@ When enabled, the Gateway **Dreams** tab shows:
 
 ### Dreaming never runs (status shows blocked)
 
-The managed dreaming cron targets `main` regardless of which agent is your configured default. If heartbeat is not firing for `main`, the cron enqueues a system event that nobody consumes and dreaming silently does not run. Both `openclaw memory status` and `/dreaming status` will report `blocked` in that case.
+The managed dreaming cron rides the default agent's heartbeat. If heartbeat is not firing for that agent, the cron enqueues a system event that nobody consumes and dreaming silently does not run. Both `openclaw memory status` and `/dreaming status` will report `blocked` in that case and name the agent whose heartbeat is the blocker.
 
 Two common causes:
 
-- Another agent declares an explicit `heartbeat:` block. When any entry in `agents.list` has its own `heartbeat` block, only those agents heartbeat — the defaults stop applying to everyone else, so `main` goes silent. Move the heartbeat settings to `agents.defaults.heartbeat`, or add an explicit `heartbeat` block on the `main` entry. See [Scope and precedence](/gateway/heartbeat#scope-and-precedence).
+- Another agent declares an explicit `heartbeat:` block. When any entry in `agents.list` has its own `heartbeat` block, only those agents heartbeat — the defaults stop applying to everyone else, so the default agent can go silent. Move the heartbeat settings to `agents.defaults.heartbeat`, or add an explicit `heartbeat` block on the default agent. See [Scope and precedence](/gateway/heartbeat#scope-and-precedence).
 - `heartbeat.every` is `0`, empty, or unparseable. The cron has no interval to schedule against, so the heartbeat is effectively disabled. Set `every` to a positive duration such as `30m`. See [Defaults](/gateway/heartbeat#defaults).
 
 ## Related

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -233,7 +233,7 @@ When enabled, the Gateway **Dreams** tab shows:
 
 ### Dreaming never runs (status shows blocked)
 
-`openclaw memory status` shows `Dreaming status: blocked` when dreaming is enabled but the heartbeat that drives the cron is not firing for the default agent. Dreaming requires a heartbeat, so if the heartbeat is not scheduled for `main`, the managed cron never gets a chance to run.
+The managed dreaming cron targets `main` regardless of which agent is your configured default. If heartbeat is not firing for `main`, the cron enqueues a system event that nobody consumes and dreaming silently does not run. Both `openclaw memory status` and `/dreaming status` will report `blocked` in that case.
 
 Two common causes:
 

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveHeartbeatSummaryForAgent } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
@@ -217,6 +218,22 @@ function formatDreamingSummary(cfg: OpenClawConfig): string {
   }
   const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
   return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"}`;
+}
+
+function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null {
+  const pluginConfig = resolveMemoryPluginConfig(cfg);
+  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
+  if (!dreaming.enabled) {
+    return null;
+  }
+
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, defaultAgentId);
+  if (heartbeat.enabled && heartbeat.everyMs != null) {
+    return null;
+  }
+
+  return `managed dreaming cron targets "${defaultAgentId}" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting`;
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {
@@ -858,6 +875,10 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       `${label("Workspace")} ${info(workspacePath)}`,
       `${label("Dreaming")} ${info(formatDreamingSummary(cfg))}`,
     ].filter(Boolean) as string[];
+    const dreamingBlockedReason = resolveDreamingBlockedReason(cfg);
+    if (dreamingBlockedReason) {
+      lines.push(`${label("Dreaming status")} ${warn(`blocked - ${dreamingBlockedReason}`)}`);
+    }
     if (embeddingProbe) {
       const state = embeddingProbe.ok ? "ready" : "unavailable";
       const stateColor = embeddingProbe.ok ? theme.success : theme.warn;

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,7 +2,6 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveHeartbeatSummaryForAgent } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
@@ -45,7 +44,10 @@ import {
   type RepairDreamingArtifactsResult,
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
-import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import {
+  resolveDreamingBlockedReason,
+  resolveShortTermPromotionDreamingConfig,
+} from "./dreaming.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import {
   applyShortTermPromotions,
@@ -218,22 +220,6 @@ function formatDreamingSummary(cfg: OpenClawConfig): string {
   }
   const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
   return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"}`;
-}
-
-function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null {
-  const pluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
-  if (!dreaming.enabled) {
-    return null;
-  }
-
-  const defaultAgentId = resolveDefaultAgentId(cfg);
-  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, defaultAgentId);
-  if (heartbeat.enabled && heartbeat.everyMs != null) {
-    return null;
-  }
-
-  return `managed dreaming cron targets "${defaultAgentId}" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting`;
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -472,7 +472,8 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
-  it("reports dreaming blocked for main even when a non-main agent is the default", async () => {
+  it("reports dreaming blocked for the configured default agent when it is not main", async () => {
+    resolveDefaultAgentId.mockReturnValue("ops");
     loadConfig.mockReturnValue({
       plugins: {
         entries: {
@@ -488,19 +489,10 @@ describe("memory cli", () => {
       agents: {
         defaults: {
           heartbeat: {
-            every: "30m",
+            every: "0m",
           },
         },
-        list: [
-          {
-            id: "ops",
-            default: true,
-            heartbeat: {
-              every: "30m",
-            },
-          },
-          { id: "main" },
-        ],
+        list: [{ id: "ops", default: true }],
       },
     });
     const close = vi.fn(async () => {});
@@ -515,7 +507,7 @@ describe("memory cli", () => {
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Dreaming status: blocked - dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+        'Dreaming status: blocked - dreaming is enabled but will not run because heartbeat is disabled for "ops". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
       ),
     );
     expect(close).toHaveBeenCalled();

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -426,7 +426,7 @@ describe("memory cli", () => {
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Dreaming status: blocked - managed dreaming cron targets "main" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+        'Dreaming status: blocked - dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
       ),
     );
     expect(close).toHaveBeenCalled();
@@ -466,7 +466,56 @@ describe("memory cli", () => {
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Dreaming status: blocked - managed dreaming cron targets "main" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+        'Dreaming status: blocked - dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+      ),
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("reports dreaming blocked for main even when a non-main agent is the default", async () => {
+    loadConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            default: true,
+            heartbeat: {
+              every: "30m",
+            },
+          },
+          { id: "main" },
+        ],
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus({ workspaceDir: "/tmp/openclaw" }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--agent", "ops"]);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Dreaming status: blocked - dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
       ),
     );
     expect(close).toHaveBeenCalled();

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -384,6 +384,94 @@ describe("memory cli", () => {
     });
   });
 
+  it("reports dreaming blocked when another explicit heartbeat agent excludes main", async () => {
+    loadConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+          },
+        },
+        list: [
+          { id: "main", default: true },
+          {
+            id: "ops",
+            heartbeat: {
+              every: "1h",
+            },
+          },
+        ],
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus({ workspaceDir: "/tmp/openclaw" }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--agent", "main"]);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Dreaming status: blocked - managed dreaming cron targets "main" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+      ),
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('reports dreaming blocked when main heartbeat interval is "0m"', async () => {
+    loadConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "0m",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus({ workspaceDir: "/tmp/openclaw" }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Dreaming status: blocked - managed dreaming cron targets "main" but heartbeat is not firing there. See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+      ),
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -197,4 +197,95 @@ describe("memory-core /dreaming command", () => {
     expect(result.text).toContain("Usage: /dreaming status");
     expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
   });
+
+  it("shows a blocked line directly after enabled when main heartbeat is disabled", async () => {
+    const { command } = createHarness({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "0m",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    const result = await command.handler(createCommandContext("status"));
+    const text = result.text ?? "";
+
+    expect(text).toContain(
+      '- blocked: dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+    );
+
+    const lines = text.split("\n");
+    const enabledIdx = lines.findIndex((line) => line.startsWith("- enabled:"));
+    const blockedIdx = lines.findIndex((line) => line.startsWith("- blocked:"));
+    expect(enabledIdx).toBeGreaterThan(-1);
+    expect(blockedIdx).toBe(enabledIdx + 1);
+  });
+
+  it("surfaces the blocked line on /dreaming on when main heartbeat is disabled", async () => {
+    const { command } = createHarness({
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "0m",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    const result = await command.handler(
+      createCommandContext("on", {
+        gatewayClientScopes: ["operator.admin"],
+      }),
+    );
+    const text = result.text ?? "";
+
+    expect(text).toContain("Dreaming enabled.");
+    expect(text).toContain(
+      '- blocked: dreaming is enabled but will not run because heartbeat is disabled for "main". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting',
+    );
+  });
+
+  it("omits the blocked line when dreaming is enabled and main heartbeat is healthy", async () => {
+    const { command } = createHarness({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "30m",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    const result = await command.handler(createCommandContext("status"));
+
+    expect(result.text).toContain("- enabled: on");
+    expect(result.text).not.toContain("- blocked:");
+  });
 });

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -2,7 +2,10 @@ import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memo
 import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { asRecord } from "./dreaming-shared.js";
-import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import {
+  resolveDreamingBlockedReason,
+  resolveShortTermPromotionDreamingConfig,
+} from "./dreaming.js";
 
 function resolveMemoryCorePluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
   const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
@@ -54,10 +57,12 @@ function formatStatus(cfg: OpenClawConfig): string {
   });
   const deep = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
   const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
+  const blockedReason = resolveDreamingBlockedReason(cfg);
 
   return [
     "Dreaming status:",
     `- enabled: ${formatEnabled(dreaming.enabled)}${timezone}`,
+    ...(blockedReason ? [`- blocked: ${blockedReason}`] : []),
     `- sweep cadence: ${dreaming.frequency}`,
     `- promotion policy: score>=${deep.minScore}, recalls>=${deep.minRecallCount}, uniqueQueries>=${deep.minUniqueQueries}`,
   ].join("\n");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,4 +1,7 @@
-import { peekSystemEventEntries } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  peekSystemEventEntries,
+  resolveHeartbeatSummaryForAgent,
+} from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
 import {
   DEFAULT_MEMORY_DREAMING_FREQUENCY as DEFAULT_MEMORY_DREAMING_CRON_EXPR,
@@ -11,6 +14,7 @@ import {
   resolveMemoryDeepDreamingConfig,
   resolveMemoryDreamingWorkspaces,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { DEFAULT_AGENT_ID } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { writeDeepDreamingReport } from "./dreaming-markdown.js";
 import { generateAndAppendDreamNarrative, type NarrativePhaseData } from "./dreaming-narrative.js";
@@ -48,7 +52,7 @@ type ManagedCronJobCreate = {
   description: string;
   enabled: boolean;
   schedule: CronSchedule;
-  sessionTarget: "main";
+  sessionTarget: typeof DEFAULT_AGENT_ID;
   wakeMode: "now";
   payload: CronPayload;
 };
@@ -58,7 +62,7 @@ type ManagedCronJobPatch = {
   description?: string;
   enabled?: boolean;
   schedule?: CronSchedule;
-  sessionTarget?: "main";
+  sessionTarget?: typeof DEFAULT_AGENT_ID;
   wakeMode?: "now";
   payload?: CronPayload;
 };
@@ -155,7 +159,7 @@ function buildManagedDreamingCronJob(
       expr: config.cron,
       ...(config.timezone ? { tz: config.timezone } : {}),
     },
-    sessionTarget: "main",
+    sessionTarget: DEFAULT_AGENT_ID,
     wakeMode: "now",
     payload: {
       kind: "systemEvent",
@@ -393,6 +397,21 @@ export function resolveShortTermPromotionDreamingConfig(params: {
     verboseLogging: resolved.verboseLogging,
     storage: resolved.storage,
   };
+}
+
+export function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null {
+  const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
+  if (!dreaming.enabled) {
+    return null;
+  }
+
+  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, DEFAULT_AGENT_ID);
+  if (heartbeat.enabled && heartbeat.everyMs != null) {
+    return null;
+  }
+
+  return `dreaming is enabled but will not run because heartbeat is disabled for "${DEFAULT_AGENT_ID}". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting`;
 }
 
 export async function reconcileShortTermDreamingCronJob(params: {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/config-runtime";
 import {
   peekSystemEventEntries,
   resolveHeartbeatSummaryForAgent,
@@ -14,7 +15,6 @@ import {
   resolveMemoryDeepDreamingConfig,
   resolveMemoryDreamingWorkspaces,
 } from "openclaw/plugin-sdk/memory-core-host-status";
-import { DEFAULT_AGENT_ID } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { writeDeepDreamingReport } from "./dreaming-markdown.js";
 import { generateAndAppendDreamNarrative, type NarrativePhaseData } from "./dreaming-narrative.js";
@@ -34,6 +34,7 @@ import {
 const MANAGED_DREAMING_CRON_NAME = "Memory Dreaming Promotion";
 const MANAGED_DREAMING_CRON_TAG = "[managed-by=memory-core.short-term-promotion]";
 const DREAMING_SYSTEM_EVENT_TEXT = "__openclaw_memory_core_short_term_promotion_dream__";
+const CRON_SESSION_TARGET_MAIN = "main" as const;
 const LEGACY_LIGHT_SLEEP_CRON_NAME = "Memory Light Dreaming";
 const LEGACY_LIGHT_SLEEP_CRON_TAG = "[managed-by=memory-core.dreaming.light]";
 const LEGACY_LIGHT_SLEEP_EVENT_TEXT = "__openclaw_memory_core_light_sleep__";
@@ -52,7 +53,7 @@ type ManagedCronJobCreate = {
   description: string;
   enabled: boolean;
   schedule: CronSchedule;
-  sessionTarget: typeof DEFAULT_AGENT_ID;
+  sessionTarget: typeof CRON_SESSION_TARGET_MAIN;
   wakeMode: "now";
   payload: CronPayload;
 };
@@ -62,7 +63,7 @@ type ManagedCronJobPatch = {
   description?: string;
   enabled?: boolean;
   schedule?: CronSchedule;
-  sessionTarget?: typeof DEFAULT_AGENT_ID;
+  sessionTarget?: typeof CRON_SESSION_TARGET_MAIN;
   wakeMode?: "now";
   payload?: CronPayload;
 };
@@ -159,7 +160,7 @@ function buildManagedDreamingCronJob(
       expr: config.cron,
       ...(config.timezone ? { tz: config.timezone } : {}),
     },
-    sessionTarget: DEFAULT_AGENT_ID,
+    sessionTarget: CRON_SESSION_TARGET_MAIN,
     wakeMode: "now",
     payload: {
       kind: "systemEvent",
@@ -406,12 +407,13 @@ export function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null
     return null;
   }
 
-  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, DEFAULT_AGENT_ID);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, defaultAgentId);
   if (heartbeat.enabled && heartbeat.everyMs != null) {
     return null;
   }
 
-  return `dreaming is enabled but will not run because heartbeat is disabled for "${DEFAULT_AGENT_ID}". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting`;
+  return `dreaming is enabled but will not run because heartbeat is disabled for "${defaultAgentId}". See https://docs.openclaw.ai/concepts/dreaming#troubleshooting`;
 }
 
 export async function reconcileShortTermDreamingCronJob(params: {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,7 +1,8 @@
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/config-runtime";
 import {
+  isHeartbeatEnabledForAgent,
   peekSystemEventEntries,
-  resolveHeartbeatSummaryForAgent,
+  resolveHeartbeatIntervalMs,
 } from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
 import {
@@ -408,8 +409,13 @@ export function resolveDreamingBlockedReason(cfg: OpenClawConfig): string | null
   }
 
   const defaultAgentId = resolveDefaultAgentId(cfg);
-  const heartbeat = resolveHeartbeatSummaryForAgent(cfg, defaultAgentId);
-  if (heartbeat.enabled && heartbeat.everyMs != null) {
+  // Mirror the managed dreaming wake path in server-cron: the job carries no
+  // agentId/sessionKey, so the wake uses defaults-only heartbeat. Not using
+  // resolveHeartbeatSummaryForAgent since it would apply the per-agent override
+  // and diverge from actual runtime behavior.
+  const enabledForDefault = isHeartbeatEnabledForAgent(cfg, defaultAgentId);
+  const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, cfg.agents?.defaults?.heartbeat);
+  if (enabledForDefault && intervalMs != null) {
     return null;
   }
 

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -87,6 +87,7 @@ export * from "../infra/file-lock.js";
 export * from "../infra/format-time/format-duration.ts";
 export * from "../infra/fs-safe.ts";
 export * from "../infra/heartbeat-events.ts";
+export * from "../infra/heartbeat-summary.ts";
 export * from "../infra/heartbeat-visibility.ts";
 export * from "../infra/home-dir.js";
 export * from "../infra/http-body.js";

--- a/src/plugin-sdk/routing.ts
+++ b/src/plugin-sdk/routing.ts
@@ -10,7 +10,6 @@ export {
 export {
   buildAgentMainSessionKey,
   DEFAULT_ACCOUNT_ID,
-  DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   buildGroupHistoryKey,
   isCronSessionKey,

--- a/src/plugin-sdk/routing.ts
+++ b/src/plugin-sdk/routing.ts
@@ -10,6 +10,7 @@ export {
 export {
   buildAgentMainSessionKey,
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   buildGroupHistoryKey,
   isCronSessionKey,


### PR DESCRIPTION
## Summary

Surface a `blocked` line in both `openclaw memory status` and `/dreaming status|on|off` when dreaming is enabled but heartbeat for `main` is not firing — currently fails silently.

- Both the CLI status and the `/dreaming` slash command now flag a blocked cron, instead of appearing healthy while silently not running.
- Added a Troubleshooting section in dreaming docsexplaining the blocked state and its common causes.
- Memory-core reuses existing heartbeat-state logic from core instead of re-implementing heartbeat rules in the extension.

Refs #69811, #46046.

## Scope note

Observability only, not execution semantics. The cron hardcodes `sessionTarget: "main"` regardless of the configured default agent — so if a user sets `default: true` on a non-main agent, dreaming still silently never runs. Fixing that is a behavior change to the cron target itself and belongs in a follow-up.

## Test plan

- [x] `pnpm test extensions/memory-core` (503 pass)
- [x] `pnpm tsgo:prod`, `pnpm lint:{core,extensions}`, `pnpm plugin-sdk:api:check`
- [x] Manual preview against a live config with `heartbeat.every: "0m"` — renders as expected