### PR TITLE
fix: archive completed run-mode subagents

### DIFF
--- a/src/agents/subagent-announce-output.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce-output.capture-completion-reply.test.ts
@@ -1,0 +1,123 @@
+import crypto from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn(async (_request: unknown) => ({ messages: [] as Array<unknown> }));
+const loadConfigMock = vi.fn(() => ({ session: { mainKey: "main", scope: "per-sender" } }));
+const loadSessionStoreMock = vi.fn((_storePath: string) => ({}));
+const resolveAgentIdFromSessionKeyMock = vi.fn((sessionKey: string) => {
+  return sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main";
+});
+const resolveStorePathMock = vi.fn((_store: unknown, _options: unknown) => "/tmp/sessions.json");
+const readLatestAssistantReplyMock = vi.fn(async (_params?: unknown) => undefined);
+
+vi.mock("./subagent-announce.runtime.js", () => ({
+  callGateway: (request: unknown) => callGatewayMock(request),
+  loadConfig: () => loadConfigMock(),
+  loadSessionStore: (storePath: string) => loadSessionStoreMock(storePath),
+  resolveAgentIdFromSessionKey: (sessionKey: string) =>
+    resolveAgentIdFromSessionKeyMock(sessionKey),
+  resolveStorePath: (store: unknown, options: unknown) => resolveStorePathMock(store, options),
+}));
+
+vi.mock("./tools/agent-step.js", () => ({
+  readLatestAssistantReply: (params?: unknown) => readLatestAssistantReplyMock(params),
+}));
+
+import {
+  __testing as subagentAnnounceOutputTesting,
+  captureSubagentCompletionReply,
+} from "./subagent-announce-output.js";
+
+describe("captureSubagentCompletionReply live-first ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subagentAnnounceOutputTesting.setDepsForTest();
+    callGatewayMock.mockImplementation(async (_request: unknown) => ({
+      messages: [] as Array<unknown>,
+    }));
+    loadConfigMock.mockImplementation(() => ({
+      session: { mainKey: "main", scope: "per-sender" },
+    }));
+    loadSessionStoreMock.mockImplementation(() => ({}));
+    resolveAgentIdFromSessionKeyMock.mockImplementation((sessionKey: string) => {
+      return sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main";
+    });
+    resolveStorePathMock.mockImplementation(() => "/tmp/sessions.json");
+    readLatestAssistantReplyMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    subagentAnnounceOutputTesting.setDepsForTest();
+  });
+
+  it.each([
+    {
+      name: "an older transcript reply",
+      staleTranscriptText: "old completion from previous run",
+      currentLiveText: "fresh completion from current run",
+    },
+    {
+      name: "an older ANNOUNCE_SKIP marker",
+      staleTranscriptText: "ANNOUNCE_SKIP",
+      currentLiveText: "fresh completion from current run",
+    },
+  ])("prefers live history over %s when reusing a child session key", async (scenario) => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "subagent-capture-"));
+    const sessionId = crypto.randomUUID();
+    const sessionKey = "agent:main:subagent:reused";
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    try {
+      resolveStorePathMock.mockImplementation(() => storePath);
+      loadSessionStoreMock.mockImplementation(() => ({
+        [sessionKey]: {
+          sessionId,
+          sessionFile,
+        },
+      }));
+      await writeFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id: "assistant-old",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: scenario.staleTranscriptText }],
+          },
+        })}\n`,
+        "utf8",
+      );
+      callGatewayMock.mockImplementation(async (request: unknown) => {
+        const typed = request as { method?: string };
+        if (typed.method === "chat.history") {
+          return {
+            messages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: scenario.currentLiveText }],
+              },
+            ] as Array<unknown>,
+          };
+        }
+        return { messages: [] as Array<unknown> };
+      });
+
+      const reply = await captureSubagentCompletionReply(sessionKey, {
+        waitForReply: true,
+      });
+
+      expect(reply).toBe(scenario.currentLiveText);
+      expect(callGatewayMock).toHaveBeenCalledWith({
+        method: "chat.history",
+        params: { sessionKey, limit: 100 },
+      });
+      expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -64,6 +64,10 @@ export type SubagentRunOutcome = {
   elapsedMs?: number;
 };
 
+function isFailedOutcome(outcome?: SubagentRunOutcome): boolean {
+  return outcome?.status === "error";
+}
+
 function readFiniteNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -254,6 +258,9 @@ function selectSubagentOutputText(
   snapshot: SubagentOutputSnapshot,
   outcome?: SubagentRunOutcome,
 ): string | undefined {
+  if (isFailedOutcome(outcome)) {
+    return undefined;
+  }
   if (snapshot.latestSilentText) {
     return snapshot.latestSilentText;
   }
@@ -301,6 +308,9 @@ export async function readSubagentOutput(
   sessionKey: string,
   outcome?: SubagentRunOutcome,
 ): Promise<string | undefined> {
+  if (isFailedOutcome(outcome)) {
+    return undefined;
+  }
   const history = await subagentAnnounceOutputDeps.callGateway({
     method: "chat.history",
     params: { sessionKey, limit: 100 },
@@ -381,14 +391,18 @@ export function applySubagentWaitOutcome(params: {
 
 export async function captureSubagentCompletionReply(
   sessionKey: string,
-  options?: { waitForReply?: boolean },
+  options?: { waitForReply?: boolean; outcome?: SubagentRunOutcome },
 ): Promise<string | undefined> {
+  if (isFailedOutcome(options?.outcome)) {
+    return undefined;
+  }
   return await captureSubagentCompletionReplyUsing({
     sessionKey,
     waitForReply: options?.waitForReply,
     maxWaitMs: isFastTestMode() ? 50 : 1_500,
     retryIntervalMs: isFastTestMode() ? FAST_TEST_RETRY_INTERVAL_MS : 100,
-    readSubagentOutput: async (nextSessionKey) => await readSubagentOutput(nextSessionKey),
+    readSubagentOutput: async (nextSessionKey) =>
+      await readSubagentOutput(nextSessionKey, options?.outcome),
   });
 }
 

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -1,4 +1,5 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { readSessionMessages } from "../gateway/session-utils.fs.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   captureSubagentCompletionReplyUsing,
@@ -273,6 +274,36 @@ function selectSubagentOutputText(
   return snapshot.latestRawText;
 }
 
+function readTranscriptMessagesForSession(sessionKey: string): Array<unknown> {
+  try {
+    const cfg = subagentAnnounceOutputDeps.loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const entry = loadSessionStore(storePath)[sessionKey] as
+      | { sessionId?: unknown; sessionFile?: unknown }
+      | undefined;
+    const sessionId = typeof entry?.sessionId === "string" ? entry.sessionId.trim() : "";
+    if (!sessionId) {
+      return [];
+    }
+    const sessionFile = typeof entry?.sessionFile === "string" ? entry.sessionFile : undefined;
+    return readSessionMessages(sessionId, storePath, sessionFile);
+  } catch {
+    return [];
+  }
+}
+
+export function readPersistedSubagentOutput(
+  sessionKey: string,
+  outcome?: SubagentRunOutcome,
+): string | undefined {
+  const transcriptSelected = selectSubagentOutputText(
+    summarizeSubagentOutputHistory(readTranscriptMessagesForSession(sessionKey)),
+    outcome,
+  );
+  return transcriptSelected?.trim() ? transcriptSelected : undefined;
+}
+
 export async function readSubagentOutput(
   sessionKey: string,
   outcome?: SubagentRunOutcome,
@@ -293,7 +324,10 @@ export async function readSubagentOutput(
     sessionKey,
     limit: 100,
   });
-  return latestAssistant?.trim() ? latestAssistant : undefined;
+  if (latestAssistant?.trim()) {
+    return latestAssistant;
+  }
+  return readPersistedSubagentOutput(sessionKey, outcome);
 }
 
 export async function readLatestSubagentOutputWithRetry(params: {
@@ -361,6 +395,10 @@ export async function captureSubagentCompletionReply(
 ): Promise<string | undefined> {
   if (isFailedOutcome(options?.outcome)) {
     return undefined;
+  }
+  const persisted = readPersistedSubagentOutput(sessionKey, options?.outcome);
+  if (persisted?.trim()) {
+    return persisted;
   }
   return await captureSubagentCompletionReplyUsing({
     sessionKey,

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -64,10 +64,6 @@ export type SubagentRunOutcome = {
   elapsedMs?: number;
 };
 
-function isFailedOutcome(outcome?: SubagentRunOutcome): boolean {
-  return outcome?.status === "error";
-}
-
 function readFiniteNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -258,9 +254,6 @@ function selectSubagentOutputText(
   snapshot: SubagentOutputSnapshot,
   outcome?: SubagentRunOutcome,
 ): string | undefined {
-  if (isFailedOutcome(outcome)) {
-    return undefined;
-  }
   if (snapshot.latestSilentText) {
     return snapshot.latestSilentText;
   }
@@ -308,9 +301,6 @@ export async function readSubagentOutput(
   sessionKey: string,
   outcome?: SubagentRunOutcome,
 ): Promise<string | undefined> {
-  if (isFailedOutcome(outcome)) {
-    return undefined;
-  }
   const history = await subagentAnnounceOutputDeps.callGateway({
     method: "chat.history",
     params: { sessionKey, limit: 100 },
@@ -391,22 +381,14 @@ export function applySubagentWaitOutcome(params: {
 
 export async function captureSubagentCompletionReply(
   sessionKey: string,
-  options?: { waitForReply?: boolean; outcome?: SubagentRunOutcome },
+  options?: { waitForReply?: boolean },
 ): Promise<string | undefined> {
-  if (isFailedOutcome(options?.outcome)) {
-    return undefined;
-  }
-  const persisted = readPersistedSubagentOutput(sessionKey, options?.outcome);
-  if (persisted?.trim()) {
-    return persisted;
-  }
   return await captureSubagentCompletionReplyUsing({
     sessionKey,
     waitForReply: options?.waitForReply,
     maxWaitMs: isFastTestMode() ? 50 : 1_500,
     retryIntervalMs: isFastTestMode() ? FAST_TEST_RETRY_INTERVAL_MS : 100,
-    readSubagentOutput: async (nextSessionKey) =>
-      await readSubagentOutput(nextSessionKey, options?.outcome),
+    readSubagentOutput: async (nextSessionKey) => await readSubagentOutput(nextSessionKey),
   });
 }
 

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
 
@@ -280,6 +283,252 @@ describe("subagent announce seam flow", () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it("uses a persisted ANNOUNCE_SKIP reply even when embedded run activity looks stale", async () => {
+    isEmbeddedPiRunActiveMock.mockReturnValue(true);
+    waitForEmbeddedPiRunEndMock.mockResolvedValue(false);
+    callGatewayMock.mockImplementation(async (req: unknown) => {
+      const typed = req as AgentCallRequest;
+      if (typed.method === "agent") {
+        return await agentSpy(typed);
+      }
+      if (typed.method === "agent.wait") {
+        return { status: "ok", startedAt: 10, endedAt: 20 };
+      }
+      if (typed.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+            },
+          ] as Array<unknown>,
+        };
+      }
+      if (typed.method === "sessions.patch") {
+        return {};
+      }
+      if (typed.method === "sessions.delete") {
+        sessionsDeleteSpy(typed);
+        return {};
+      }
+      return {};
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-stale-active-skip",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(waitForEmbeddedPiRunEndMock).toHaveBeenCalledWith("agent:main:subagent:test", 10);
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps stale embedded settle waits during post-completion cleanup retries", async () => {
+    isEmbeddedPiRunActiveMock.mockReturnValue(true);
+    waitForEmbeddedPiRunEndMock.mockResolvedValue(false);
+    loadSessionStoreMock.mockImplementation(() => ({
+      "agent:main:subagent:test": {
+        sessionId: "child-session-active",
+      },
+    }));
+    callGatewayMock.mockImplementation(async (req: unknown) => {
+      const typed = req as AgentCallRequest;
+      if (typed.method === "agent") {
+        return await agentSpy(typed);
+      }
+      if (typed.method === "agent.wait") {
+        return { status: "ok", startedAt: 10, endedAt: 20 };
+      }
+      if (typed.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+            },
+          ] as Array<unknown>,
+        };
+      }
+      if (typed.method === "sessions.patch") {
+        return {};
+      }
+      if (typed.method === "sessions.delete") {
+        sessionsDeleteSpy(typed);
+        return {};
+      }
+      return {};
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-stale-active-skip-capped-timeout",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 10_000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(waitForEmbeddedPiRunEndMock).toHaveBeenCalledWith("child-session-active", 1500);
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the transcript file when gateway chat history has not caught up", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "subagent-announce-"));
+    const sessionId = "123e4567-e89b-12d3-a456-426614174000";
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+    try {
+      resolveStorePathMock.mockImplementation(() => storePath);
+      await writeFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+          },
+        })}\n`,
+        "utf8",
+      );
+      isEmbeddedPiRunActiveMock.mockReturnValue(true);
+      waitForEmbeddedPiRunEndMock.mockResolvedValue(false);
+      readLatestAssistantReplyMock.mockResolvedValue("");
+      loadSessionStoreMock.mockImplementation(() => ({
+        "agent:main:subagent:test": {
+          sessionId,
+          sessionFile,
+        },
+      }));
+      callGatewayMock.mockImplementation(async (req: unknown) => {
+        const typed = req as AgentCallRequest;
+        if (typed.method === "agent") {
+          return await agentSpy(typed);
+        }
+        if (typed.method === "agent.wait") {
+          return { status: "ok", startedAt: 10, endedAt: 20 };
+        }
+        if (typed.method === "chat.history") {
+          return { messages: [] as Array<unknown> };
+        }
+        if (typed.method === "sessions.patch") {
+          return {};
+        }
+        if (typed.method === "sessions.delete") {
+          sessionsDeleteSpy(typed);
+          return {};
+        }
+        return {};
+      });
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-transcript-fallback",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "do thing",
+        timeoutMs: 10_000,
+        cleanup: "keep",
+        waitForCompletion: false,
+        startedAt: 10,
+        endedAt: 20,
+        outcome: { status: "ok" },
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(agentSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses persisted transcript output before gateway history during stale cleanup", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "subagent-announce-"));
+    const sessionId = "223e4567-e89b-12d3-a456-426614174000";
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+    try {
+      resolveStorePathMock.mockImplementation(() => storePath);
+      await writeFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
+          },
+        })}\n`,
+        "utf8",
+      );
+      isEmbeddedPiRunActiveMock.mockReturnValue(true);
+      waitForEmbeddedPiRunEndMock.mockResolvedValue(false);
+      readLatestAssistantReplyMock.mockResolvedValue("");
+      loadSessionStoreMock.mockImplementation(() => ({
+        "agent:main:subagent:test": {
+          sessionId,
+          sessionFile,
+        },
+      }));
+      callGatewayMock.mockImplementation(async (req: unknown) => {
+        const typed = req as AgentCallRequest;
+        if (typed.method === "agent") {
+          return await agentSpy(typed);
+        }
+        if (typed.method === "agent.wait") {
+          return { status: "ok", startedAt: 10, endedAt: 20 };
+        }
+        if (typed.method === "chat.history") {
+          throw new Error("chat history should not be needed");
+        }
+        if (typed.method === "sessions.patch") {
+          return {};
+        }
+        if (typed.method === "sessions.delete") {
+          sessionsDeleteSpy(typed);
+          return {};
+        }
+        return {};
+      });
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-transcript-first-fallback",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "do thing",
+        timeoutMs: 10_000,
+        cleanup: "keep",
+        waitForCompletion: false,
+        startedAt: 10,
+        endedAt: 20,
+        outcome: { status: "ok" },
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(agentSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -31,6 +31,7 @@ import {
   dedupeLatestChildCompletionRows,
   filterCurrentDirectChildCompletionRows,
   readLatestSubagentOutputWithRetry,
+  readPersistedSubagentOutput,
   readSubagentOutput,
   type SubagentRunOutcome,
   waitForSubagentRunOutcome,
@@ -94,6 +95,9 @@ function buildAnnounceSteerMessage(events: AgentInternalEvent[]): string {
     "A background task finished. Process the completion update now."
   );
 }
+
+const MAX_EMBEDDED_RUN_SETTLE_TIMEOUT_MS = 120_000;
+const MAX_POST_COMPLETION_EMBEDDED_RUN_SETTLE_TIMEOUT_MS = 1_500;
 
 function hasUsableSessionEntry(entry: unknown): boolean {
   if (!entry || typeof entry !== "object") {
@@ -258,14 +262,26 @@ export async function runSubagentAnnounceFlow(params: {
         ? entry.sessionId.trim()
         : undefined;
     })();
-    const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
+    const settleTimeoutMs = Math.min(
+      Math.max(params.timeoutMs, 1),
+      params.waitForCompletion === false
+        ? MAX_POST_COMPLETION_EMBEDDED_RUN_SETTLE_TIMEOUT_MS
+        : MAX_EMBEDDED_RUN_SETTLE_TIMEOUT_MS,
+    );
     let reply = params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
     if (childSessionId && isEmbeddedPiRunActive(childSessionId)) {
       const settled = await waitForEmbeddedPiRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedPiRunActive(childSessionId)) {
-        shouldDeleteChildSession = false;
-        return false;
+        if (params.waitForCompletion === false && !reply?.trim()) {
+          reply =
+            readPersistedSubagentOutput(params.childSessionKey, outcome) ??
+            (await readSubagentOutput(params.childSessionKey, outcome));
+        }
+        if (!reply?.trim()) {
+          shouldDeleteChildSession = false;
+          return false;
+        }
       }
     }
 

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -72,6 +72,7 @@ vi.mock("./subagent-registry-helpers.js", () => ({
   persistSubagentSessionTiming: helperMocks.persistSubagentSessionTiming,
   resolveAnnounceRetryDelayMs: (retryCount: number) =>
     Math.min(1_000 * 2 ** Math.max(0, retryCount - 1), 8_000),
+  resolveArchiveAfterMs: () => 60_000,
   safeRemoveAttachmentsDir: helperMocks.safeRemoveAttachmentsDir,
 }));
 

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -28,6 +28,7 @@ import {
   MIN_ANNOUNCE_RETRY_DELAY_MS,
   persistSubagentSessionTiming,
   resolveAnnounceRetryDelayMs,
+  resolveArchiveAfterMs,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -401,6 +402,17 @@ export function createSubagentRegistryLifecycleController(params: {
       workspaceDir: cleanupParams.entry.workspaceDir,
     });
     cleanupParams.entry.cleanupCompletedAt = cleanupParams.completedAt;
+    if (
+      cleanupParams.entry.spawnMode !== "session" &&
+      typeof cleanupParams.entry.archiveAtMs !== "number"
+    ) {
+      const archiveAfterMs = resolveArchiveAfterMs();
+      cleanupParams.entry.archiveAtMs = archiveAfterMs
+        ? cleanupParams.completedAt + archiveAfterMs
+        : undefined;
+    } else if (cleanupParams.entry.spawnMode === "session") {
+      cleanupParams.entry.archiveAtMs = undefined;
+    }
     params.persist();
     retryDeferredCompletedAnnounces(cleanupParams.runId);
   };

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -236,11 +236,7 @@ export function createSubagentRunManager(params: {
     const archiveAfterMs = resolveArchiveAfterMs(cfg);
     const spawnMode = source.spawnMode === "session" ? "session" : "run";
     const archiveAtMs =
-      spawnMode === "session" || source.cleanup === "keep"
-        ? undefined
-        : archiveAfterMs
-          ? now + archiveAfterMs
-          : undefined;
+      spawnMode === "session" ? undefined : archiveAfterMs ? now + archiveAfterMs : undefined;
     const runTimeoutSeconds = replaceParams.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = params.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
     const preserveFrozenResultFallback = replaceParams.preserveFrozenResultFallback === true;
@@ -302,11 +298,7 @@ export function createSubagentRunManager(params: {
     const archiveAfterMs = resolveArchiveAfterMs(cfg);
     const spawnMode = registerParams.spawnMode === "session" ? "session" : "run";
     const archiveAtMs =
-      spawnMode === "session" || registerParams.cleanup === "keep"
-        ? undefined
-        : archiveAfterMs
-          ? now + archiveAfterMs
-          : undefined;
+      spawnMode === "session" ? undefined : archiveAfterMs ? now + archiveAfterMs : undefined;
     const runTimeoutSeconds = registerParams.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = params.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
     const requesterOrigin = normalizeDeliveryContext(registerParams.requesterOrigin);

--- a/src/agents/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagent-registry.archive.e2e.test.ts
@@ -5,6 +5,19 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { callGateway } from "../gateway/call.js";
 
 const noop = () => {};
+let lifecycleHandler:
+  | ((evt: {
+      stream?: string;
+      runId: string;
+      data?: {
+        phase?: string;
+        startedAt?: number;
+        endedAt?: number;
+        aborted?: boolean;
+        error?: string;
+      };
+    }) => void)
+  | undefined;
 let currentConfig = {
   agents: { defaults: { subagents: { archiveAfterMinutes: 60 } } },
 };
@@ -26,7 +39,10 @@ vi.mock("../gateway/call.js", () => ({
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
-  onAgentEvent: vi.fn((_handler: unknown) => noop),
+  onAgentEvent: vi.fn((handler: typeof lifecycleHandler) => {
+    lifecycleHandler = handler;
+    return noop;
+  }),
 }));
 
 vi.mock("../config/config.js", async () => {
@@ -43,6 +59,10 @@ vi.mock("./subagent-announce.js", () => ({
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
+  getGlobalPluginRegistry: vi.fn(() => null),
+  hasGlobalHooks: vi.fn(() => false),
+  initializeGlobalHookRunner: vi.fn(),
+  resetGlobalHookRunner: vi.fn(),
 }));
 
 vi.mock("./subagent-registry.store.js", () => ({
@@ -60,6 +80,7 @@ describe("subagent registry archive behavior", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    lifecycleHandler = undefined;
     currentConfig = {
       agents: { defaults: { subagents: { archiveAfterMinutes: 60 } } },
     };
@@ -83,7 +104,11 @@ describe("subagent registry archive behavior", () => {
     vi.useRealTimers();
   });
 
-  it("does not set archiveAtMs for keep-mode run subagents", () => {
+  it("does not sweep keep-mode run subagents before cleanup completes, even after the archive window elapses", async () => {
+    currentConfig = {
+      agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
+    };
+
     mod.registerSubagentRun({
       runId: "run-keep-1",
       childSessionKey: "agent:main:subagent:keep-1",
@@ -96,7 +121,48 @@ describe("subagent registry archive behavior", () => {
     const run = mod.listSubagentRunsForRequester("agent:main:main")[0];
     expect(run?.runId).toBe("run-keep-1");
     expect(run?.spawnMode).toBe("run");
-    expect(run?.archiveAtMs).toBeUndefined();
+    expect(run?.archiveAtMs).toBe(Date.now() + 60_000);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mod.listSubagentRunsForRequester("agent:main:main")).toHaveLength(1);
+  });
+
+  it("sets archiveAtMs after keep-mode cleanup completes and sweeps after the archive window elapses", async () => {
+    currentConfig = {
+      agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
+    };
+
+    mod.registerSubagentRun({
+      runId: "run-keep-complete",
+      childSessionKey: "agent:main:subagent:keep-complete",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "persistent-run",
+      cleanup: "keep",
+    });
+
+    const initialRun = mod.listSubagentRunsForRequester("agent:main:main")[0];
+    expect(initialRun?.archiveAtMs).toBe(Date.now() + 60_000);
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-keep-complete",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+    await vi.waitFor(() => {
+      const run = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+      expect(run?.archiveAtMs).toBe(initialRun?.archiveAtMs);
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mod.listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
   });
 
   it("sets archiveAtMs and sweeps delete-mode run subagents", async () => {
@@ -252,7 +318,11 @@ describe("subagent registry archive behavior", () => {
     expect(run?.archiveAtMs).toBeUndefined();
   });
 
-  it("keeps archiveAtMs unset when replacing a keep-mode run after steer restart", () => {
+  it("recomputes archiveAtMs when replacing a keep-mode run after steer restart", async () => {
+    currentConfig = {
+      agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
+    };
+
     mod.registerSubagentRun({
       runId: "run-old",
       childSessionKey: "agent:main:subagent:run-1",
@@ -261,6 +331,8 @@ describe("subagent registry archive behavior", () => {
       task: "persistent-run",
       cleanup: "keep",
     });
+
+    await vi.advanceTimersByTimeAsync(5_000);
 
     const replaced = mod.replaceSubagentRunAfterSteer({
       previousRunId: "run-old",
@@ -272,7 +344,7 @@ describe("subagent registry archive behavior", () => {
       .listSubagentRunsForRequester("agent:main:main")
       .find((entry) => entry.runId === "run-new");
     expect(run?.spawnMode).toBe("run");
-    expect(run?.archiveAtMs).toBeUndefined();
+    expect(run?.archiveAtMs).toBe(Date.now() + 60_000);
   });
 
   it("recomputes archiveAtMs when replacing a delete-mode run after steer restart", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -601,6 +601,9 @@ async function sweepSubagentRuns() {
       if (entry.archiveAtMs > now) {
         continue;
       }
+      if (entry.cleanup === "keep" && typeof entry.cleanupCompletedAt !== "number") {
+        continue;
+      }
       clearPendingLifecycleError(runId);
       try {
         await subagentRegistryDeps.callGateway({


### PR DESCRIPTION
## Problem

Completed `sessions_spawn(mode="run")` subagents were not being reaped reliably after they finished. That left completed child sessions and transcripts in the live session store, which contributes directly to the session accumulation and RSS growth reported in #69632 / #69628.

There were two gaps in the cleanup path:

- run-mode subagents with `cleanup: "keep"` did not consistently carry archive timing, so they could miss the normal archive sweep path
- post-completion announce cleanup could fail when embedded-run state or `chat.history` lagged behind persisted transcript state, leaving `cleanupCompletedAt` unset and blocking keep-mode sweep

## What this changes

- assign archive timing to all run-mode subagents, including `cleanup: "keep"`
- only sweep keep-mode runs after cleanup bookkeeping has actually completed
- during stale post-completion cleanup, cap embedded-run settle waits and recover output from the persisted transcript when live gateway history has not caught up yet
- add regression coverage for archive bookkeeping and transcript-based cleanup recovery

## Why this fixes the reported issue

This makes completed run-mode subagents actually transition out of the live session store within the configured archive window instead of accumulating indefinitely.

In other words: this PR fixes a subagent reaping gap. It does **not** redesign session storage or lazy loading in this PR; it makes sure finished run-mode child sessions get archived once delivery/cleanup is done.

## Testing

- `pnpm check:changed --staged`
- `pnpm repro:subagent run 69632`
- `pnpm test src/agents/subagent-announce.test.ts`
- `pnpm test src/agents/subagent-registry.archive.e2e.test.ts`
- `pnpm test src/agents/subagent-registry-lifecycle.test.ts`

Fixes #69632
Fixes #69628
