### PR TITLE
chore: update DEFAULT_HEARTBEAT_EVERY to 15m

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -13,7 +13,7 @@ export type HeartbeatTask = {
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
 export const HEARTBEAT_PROMPT =
   "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
-export const DEFAULT_HEARTBEAT_EVERY = "30m";
+export const DEFAULT_HEARTBEAT_EVERY = "15m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 
 /**


### PR DESCRIPTION
Updates the default heartbeat frequency for OpenClaw from 30m (and 1h in some configs) to 15m.