### PR TITLE
Fix doctor bundled runtime dependency ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel. (#69869) thanks @gumadeiras.
 - Plugins/discovery: reject package plugin source entries that escape the package directory before explicit runtime entries or inferred built JavaScript peers can be used. (#69868) thanks @gumadeiras.
+- Doctor/plugins: keep configured channel doctor checks on read-only/setup adapters before bundled runtime-dep repair runs, so fresh packaged installs can repair missing bundled channel dependencies instead of importing the full channel runtime first.
 
 ## 2026.4.21
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -389,6 +389,9 @@ are missing, doctor reports the packages and installs them in
 use `openclaw plugins install` / `openclaw plugins update`; doctor does not
 install dependencies for arbitrary plugin paths.
 
+Config doctor checks use setup/read-only channel adapters where available so
+full bundled channel runtimes are not loaded before this dependency check runs.
+
 ### 8) Gateway service migrations and cleanup hints
 
 Doctor detects legacy gateway services (launchd/systemd/schtasks) and

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -88,6 +88,41 @@ describe("channel doctor compatibility mutations", () => {
     expect(mocks.listBundledChannelSetupPlugins).not.toHaveBeenCalled();
   });
 
+  it("falls back when configured read-only channel plugin has no doctor adapter", () => {
+    const normalizeCompatibilityConfig = vi.fn(({ cfg }: { cfg: unknown }) => ({
+      config: cfg,
+      changes: ["discord"],
+    }));
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+        },
+      ],
+    });
+    mocks.getBundledChannelSetupPlugin.mockImplementation((id: string) =>
+      id === "discord"
+        ? {
+            id: "discord",
+            doctor: { normalizeCompatibilityConfig },
+          }
+        : undefined,
+    );
+
+    const result = collectChannelDoctorCompatibilityMutations({
+      channels: {
+        discord: {
+          enabled: true,
+        },
+      },
+    } as never);
+
+    expect(result).toHaveLength(1);
+    expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("discord");
+    expect(mocks.getBundledChannelSetupPlugin).toHaveBeenCalledWith("discord");
+  });
+
   it("keeps configured channel doctor lookup non-fatal when setup loading fails", () => {
     mocks.resolveReadOnlyChannelPluginsForConfig.mockImplementation(() => {
       throw new Error("missing runtime dep");

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -2,36 +2,46 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { collectChannelDoctorCompatibilityMutations } from "./channel-doctor.js";
 
 const mocks = vi.hoisted(() => ({
-  getChannelPlugin: vi.fn(),
-  getBundledChannelPlugin: vi.fn(),
+  getLoadedChannelPlugin: vi.fn(),
+  getBundledChannelSetupPlugin: vi.fn(),
   listChannelPlugins: vi.fn(),
-  listBundledChannelPlugins: vi.fn(),
+  listBundledChannelSetupPlugins: vi.fn(),
+  resolveReadOnlyChannelPluginsForConfig: vi.fn(),
 }));
 
 vi.mock("../../../channels/plugins/registry.js", () => ({
-  getChannelPlugin: (...args: Parameters<typeof mocks.getChannelPlugin>) =>
-    mocks.getChannelPlugin(...args),
+  getLoadedChannelPlugin: (...args: Parameters<typeof mocks.getLoadedChannelPlugin>) =>
+    mocks.getLoadedChannelPlugin(...args),
   listChannelPlugins: (...args: Parameters<typeof mocks.listChannelPlugins>) =>
     mocks.listChannelPlugins(...args),
 }));
 
 vi.mock("../../../channels/plugins/bundled.js", () => ({
-  getBundledChannelPlugin: (...args: Parameters<typeof mocks.getBundledChannelPlugin>) =>
-    mocks.getBundledChannelPlugin(...args),
-  listBundledChannelPlugins: (...args: Parameters<typeof mocks.listBundledChannelPlugins>) =>
-    mocks.listBundledChannelPlugins(...args),
+  getBundledChannelSetupPlugin: (...args: Parameters<typeof mocks.getBundledChannelSetupPlugin>) =>
+    mocks.getBundledChannelSetupPlugin(...args),
+  listBundledChannelSetupPlugins: (
+    ...args: Parameters<typeof mocks.listBundledChannelSetupPlugins>
+  ) => mocks.listBundledChannelSetupPlugins(...args),
+}));
+
+vi.mock("../../../channels/plugins/read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: (
+    ...args: Parameters<typeof mocks.resolveReadOnlyChannelPluginsForConfig>
+  ) => mocks.resolveReadOnlyChannelPluginsForConfig(...args),
 }));
 
 describe("channel doctor compatibility mutations", () => {
   beforeEach(() => {
-    mocks.getChannelPlugin.mockReset();
-    mocks.getBundledChannelPlugin.mockReset();
+    mocks.getLoadedChannelPlugin.mockReset();
+    mocks.getBundledChannelSetupPlugin.mockReset();
     mocks.listChannelPlugins.mockReset();
-    mocks.listBundledChannelPlugins.mockReset();
-    mocks.getChannelPlugin.mockReturnValue(undefined);
-    mocks.getBundledChannelPlugin.mockReturnValue(undefined);
+    mocks.listBundledChannelSetupPlugins.mockReset();
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReset();
+    mocks.getLoadedChannelPlugin.mockReturnValue(undefined);
+    mocks.getBundledChannelSetupPlugin.mockReturnValue(undefined);
     mocks.listChannelPlugins.mockReturnValue([]);
-    mocks.listBundledChannelPlugins.mockReturnValue([]);
+    mocks.listBundledChannelSetupPlugins.mockReturnValue([]);
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({ plugins: [] });
   });
 
   it("skips plugin discovery when no channels are configured", () => {
@@ -39,22 +49,23 @@ describe("channel doctor compatibility mutations", () => {
 
     expect(result).toEqual([]);
     expect(mocks.listChannelPlugins).not.toHaveBeenCalled();
-    expect(mocks.listBundledChannelPlugins).not.toHaveBeenCalled();
+    expect(mocks.listBundledChannelSetupPlugins).not.toHaveBeenCalled();
+    expect(mocks.resolveReadOnlyChannelPluginsForConfig).not.toHaveBeenCalled();
   });
 
-  it("only evaluates configured channel ids", () => {
+  it("uses read-only doctor adapters for configured channel ids", () => {
     const normalizeCompatibilityConfig = vi.fn(({ cfg }: { cfg: unknown }) => ({
       config: cfg,
       changes: ["matrix"],
     }));
-    mocks.getBundledChannelPlugin.mockImplementation((id: string) =>
-      id === "matrix"
-        ? {
-            id: "matrix",
-            doctor: { normalizeCompatibilityConfig },
-          }
-        : undefined,
-    );
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
+      plugins: [
+        {
+          id: "matrix",
+          doctor: { normalizeCompatibilityConfig },
+        },
+      ],
+    });
 
     const cfg = {
       channels: {
@@ -68,9 +79,36 @@ describe("channel doctor compatibility mutations", () => {
 
     expect(result).toHaveLength(1);
     expect(normalizeCompatibilityConfig).toHaveBeenCalledTimes(1);
-    expect(mocks.getChannelPlugin).toHaveBeenCalledWith("matrix");
-    expect(mocks.getBundledChannelPlugin).toHaveBeenCalledWith("matrix");
-    expect(mocks.getBundledChannelPlugin).not.toHaveBeenCalledWith("discord");
-    expect(mocks.listBundledChannelPlugins).not.toHaveBeenCalled();
+    expect(mocks.resolveReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(cfg, {
+      includePersistedAuthState: false,
+    });
+    expect(mocks.getLoadedChannelPlugin).not.toHaveBeenCalledWith("matrix");
+    expect(mocks.getBundledChannelSetupPlugin).not.toHaveBeenCalledWith("matrix");
+    expect(mocks.getBundledChannelSetupPlugin).not.toHaveBeenCalledWith("discord");
+    expect(mocks.listBundledChannelSetupPlugins).not.toHaveBeenCalled();
+  });
+
+  it("keeps configured channel doctor lookup non-fatal when setup loading fails", () => {
+    mocks.resolveReadOnlyChannelPluginsForConfig.mockImplementation(() => {
+      throw new Error("missing runtime dep");
+    });
+    mocks.getBundledChannelSetupPlugin.mockImplementation((id: string) => {
+      if (id === "discord") {
+        throw new Error("missing runtime dep");
+      }
+      return undefined;
+    });
+
+    const result = collectChannelDoctorCompatibilityMutations({
+      channels: {
+        discord: {
+          enabled: true,
+        },
+      },
+    } as never);
+
+    expect(result).toEqual([]);
+    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("discord");
+    expect(mocks.getBundledChannelSetupPlugin).toHaveBeenCalledWith("discord");
   });
 });

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -82,12 +82,14 @@ function listChannelDoctorEntries(
     selectedIds && cfg
       ? safeListReadOnlyChannelPlugins(cfg).filter((plugin) => selectedIds.has(plugin.id))
       : [];
-  const readOnlyPluginIds = new Set(readOnlyPlugins.map((plugin) => plugin.id));
+  const readOnlyDoctorPluginIds = new Set(
+    readOnlyPlugins.filter((plugin) => plugin.doctor).map((plugin) => plugin.id),
+  );
   const plugins = selectedIds
     ? [
         ...readOnlyPlugins,
         ...[...selectedIds].flatMap((id) => {
-          if (readOnlyPluginIds.has(id)) {
+          if (readOnlyDoctorPluginIds.has(id)) {
             return [];
           }
           const loadedPlugin = safeGetLoadedChannelPlugin(id);

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -1,8 +1,9 @@
 import {
-  getBundledChannelPlugin,
-  listBundledChannelPlugins,
+  getBundledChannelSetupPlugin,
+  listBundledChannelSetupPlugins,
 } from "../../../channels/plugins/bundled.js";
-import { getChannelPlugin, listChannelPlugins } from "../../../channels/plugins/registry.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "../../../channels/plugins/read-only.js";
+import { getLoadedChannelPlugin, listChannelPlugins } from "../../../channels/plugins/registry.js";
 import type {
   ChannelDoctorAdapter,
   ChannelDoctorConfigMutation,
@@ -37,32 +38,67 @@ function safeListActiveChannelPlugins() {
   }
 }
 
-function safeListBundledChannelPlugins() {
+function safeListBundledChannelSetupPlugins() {
   try {
-    return listBundledChannelPlugins();
+    return listBundledChannelSetupPlugins();
   } catch {
     return [];
   }
 }
 
-function listChannelDoctorEntries(channelIds?: readonly string[]): ChannelDoctorEntry[] {
+function safeGetLoadedChannelPlugin(id: string) {
+  try {
+    return getLoadedChannelPlugin(id);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeGetBundledChannelSetupPlugin(id: string) {
+  try {
+    return getBundledChannelSetupPlugin(id);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeListReadOnlyChannelPlugins(cfg: OpenClawConfig) {
+  try {
+    return resolveReadOnlyChannelPluginsForConfig(cfg, {
+      includePersistedAuthState: false,
+    }).plugins;
+  } catch {
+    return [];
+  }
+}
+
+function listChannelDoctorEntries(
+  channelIds?: readonly string[],
+  cfg?: OpenClawConfig,
+): ChannelDoctorEntry[] {
   const byId = new Map<string, ChannelDoctorEntry>();
   const selectedIds = channelIds ? new Set(channelIds) : null;
+  const readOnlyPlugins =
+    selectedIds && cfg
+      ? safeListReadOnlyChannelPlugins(cfg).filter((plugin) => selectedIds.has(plugin.id))
+      : [];
+  const readOnlyPluginIds = new Set(readOnlyPlugins.map((plugin) => plugin.id));
   const plugins = selectedIds
-    ? [...selectedIds].flatMap((id) => {
-        let activeOrBundledPlugin;
-        try {
-          activeOrBundledPlugin = getChannelPlugin(id);
-        } catch {
-          activeOrBundledPlugin = undefined;
-        }
-        if (activeOrBundledPlugin?.doctor) {
-          return [activeOrBundledPlugin];
-        }
-        const bundledPlugin = getBundledChannelPlugin(id);
-        return bundledPlugin ? [bundledPlugin] : [];
-      })
-    : [...safeListActiveChannelPlugins(), ...safeListBundledChannelPlugins()];
+    ? [
+        ...readOnlyPlugins,
+        ...[...selectedIds].flatMap((id) => {
+          if (readOnlyPluginIds.has(id)) {
+            return [];
+          }
+          const loadedPlugin = safeGetLoadedChannelPlugin(id);
+          if (loadedPlugin?.doctor) {
+            return [loadedPlugin];
+          }
+          const bundledSetupPlugin = safeGetBundledChannelSetupPlugin(id);
+          return bundledSetupPlugin ? [bundledSetupPlugin] : [];
+        }),
+      ]
+    : [...safeListActiveChannelPlugins(), ...safeListBundledChannelSetupPlugins()];
   for (const plugin of plugins) {
     if (!plugin.doctor) {
       continue;
@@ -82,7 +118,10 @@ export async function runChannelDoctorConfigSequences(params: {
 }): Promise<ChannelDoctorSequenceResult> {
   const changeNotes: string[] = [];
   const warningNotes: string[] = [];
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(params.cfg))) {
+  for (const entry of listChannelDoctorEntries(
+    collectConfiguredChannelIds(params.cfg),
+    params.cfg,
+  )) {
     const result = await entry.doctor.runConfigSequence?.(params);
     if (!result) {
       continue;
@@ -102,7 +141,7 @@ export function collectChannelDoctorCompatibilityMutations(
   }
   const mutations: ChannelDoctorConfigMutation[] = [];
   let nextCfg = cfg;
-  for (const entry of listChannelDoctorEntries(channelIds)) {
+  for (const entry of listChannelDoctorEntries(channelIds, cfg)) {
     const mutation = entry.doctor.normalizeCompatibilityConfig?.({ cfg: nextCfg });
     if (!mutation || mutation.changes.length === 0) {
       continue;
@@ -118,7 +157,7 @@ export async function collectChannelDoctorStaleConfigMutations(
 ): Promise<ChannelDoctorConfigMutation[]> {
   const mutations: ChannelDoctorConfigMutation[] = [];
   let nextCfg = cfg;
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(cfg))) {
+  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(cfg), cfg)) {
     const mutation = await entry.doctor.cleanStaleConfig?.({ cfg: nextCfg });
     if (!mutation || mutation.changes.length === 0) {
       continue;
@@ -134,7 +173,10 @@ export async function collectChannelDoctorPreviewWarnings(params: {
   doctorFixCommand: string;
 }): Promise<string[]> {
   const warnings: string[] = [];
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(params.cfg))) {
+  for (const entry of listChannelDoctorEntries(
+    collectConfiguredChannelIds(params.cfg),
+    params.cfg,
+  )) {
     const lines = await entry.doctor.collectPreviewWarnings?.(params);
     if (lines?.length) {
       warnings.push(...lines);
@@ -147,7 +189,10 @@ export async function collectChannelDoctorMutableAllowlistWarnings(params: {
   cfg: OpenClawConfig;
 }): Promise<string[]> {
   const warnings: string[] = [];
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(params.cfg))) {
+  for (const entry of listChannelDoctorEntries(
+    collectConfiguredChannelIds(params.cfg),
+    params.cfg,
+  )) {
     const lines = await entry.doctor.collectMutableAllowlistWarnings?.(params);
     if (lines?.length) {
       warnings.push(...lines);
@@ -162,7 +207,10 @@ export async function collectChannelDoctorRepairMutations(params: {
 }): Promise<ChannelDoctorConfigMutation[]> {
   const mutations: ChannelDoctorConfigMutation[] = [];
   let nextCfg = params.cfg;
-  for (const entry of listChannelDoctorEntries(collectConfiguredChannelIds(params.cfg))) {
+  for (const entry of listChannelDoctorEntries(
+    collectConfiguredChannelIds(params.cfg),
+    params.cfg,
+  )) {
     const mutation = await entry.doctor.repairConfig?.({
       cfg: nextCfg,
       doctorFixCommand: params.doctorFixCommand,


### PR DESCRIPTION
## Summary
- keep configured channel doctor checks on read-only/setup channel adapters instead of full bundled channel runtimes
- make setup/read-only doctor adapter lookup failures non-fatal so bundled runtime-dep repair can still run
- document the doctor ordering invariant and add a changelog entry

## Tests
- `pnpm test src/commands/doctor/shared/channel-doctor.test.ts`
- `pnpm format:check src/commands/doctor/shared/channel-doctor.ts src/commands/doctor/shared/channel-doctor.test.ts docs/gateway/doctor.md`
- `pnpm check:changed`
- `scripts/committer 'fix doctor channel runtime dep ordering' ...` reran staged `pnpm check:changed --staged`
