### PR TITLE
fix(discord): guard partial channel access in /new slash command thread path

### DIFF
--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1072,7 +1072,9 @@ async function dispatchDiscordCommandInteraction(params: {
       interaction.channel?.type === ChannelType.AnnouncementThread;
     const messageThreadId = !isDirectMessage && isThreadChannel ? channelId : undefined;
     const threadParentId =
-      !isDirectMessage && isThreadChannel ? (interaction.channel.parentId ?? undefined) : undefined;
+      !isDirectMessage && isThreadChannel && interaction.channel && "parentId" in interaction.channel
+        ? (interaction.channel.parentId ?? undefined)
+        : undefined;
     const { effectiveRoute } = await getNativeRouteState();
     const pluginReply = await executePluginCommandImpl({
       command: pluginMatch.command,


### PR DESCRIPTION
Fixes #69861.

## Problem

When `/new` (or any plugin-dispatched slash command) is invoked inside a Discord thread, `interaction.channel` can be a partial Channel object. Accessing `.parentId` on it triggers Carbon's `BaseChannel.rawData` getter and throws:

```
Error: Cannot access rawData on partial Channel. Use fetch() to populate data.
    at GuildThreadChannel.get rawData [as rawData] (@buape/carbon/src/abstracts/BaseChannel.ts:65:10)
    at GuildThreadChannel.get parentId [as parentId] (@buape/carbon/src/abstracts/BaseGuildChannel.ts:44:13)
    at dispatchDiscordCommandInteraction (extensions/discord/provider-CraktAkD.js:2451:47)
```

## Root cause

PR #68953 (landed in 2026.4.20) introduced the `"parentId" in channel` guard pattern at two call sites in `extensions/discord/src/monitor/native-command.ts` (lines 469 and 862), but missed the plugin-command dispatch path at line 1074 — which is exactly the path `/new` goes through.

## Fix

Apply the same guard at the third site. Drop-in consistent with the pattern established by #68953, plus a nullish check on `interaction.channel` itself (the enclosing `isThreadChannel` computation already uses `interaction.channel?.type`, so `interaction.channel` can be nullish here).

```ts
const threadParentId =
  !isDirectMessage && isThreadChannel && interaction.channel && "parentId" in interaction.channel
    ? (interaction.channel.parentId ?? undefined)
    : undefined;
```

## Verification

- Mirrors the exact guard shape at lines 469 and 862 of the same file.
- Triage swarm on the issue ([comment](https://github.com/openclaw/openclaw/issues/69861#issuecomment-4292481616)) independently confirmed this is the offending line and the correct fix direction.
- No behavior change for non-thread or fully-populated channel paths: `"parentId" in` is always true on fully-populated thread channels, so `threadParentId` still resolves to the parent id as before.