### PR TITLE
fix: use static provider catalogs in models list --all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - memory-core/dreaming: surface a `Dreaming status: blocked` line in `openclaw memory status` when dreaming is enabled but the heartbeat that drives the managed cron is not firing for the default agent, and add a Troubleshooting section to the dreaming docs covering the two common causes (per-agent `heartbeat` blocks excluding `main`, and `heartbeat.every` set to `0`/empty/invalid), so the silent failure described in #69843 becomes legible on the status surface.
 - Cron/run-log: report generic `message` tool sends under the resolved delivery channel when they match the cron target, while preserving account-specific mismatch checks for delivery traces. (#69940) Thanks @davehappyminion.
 - Doctor/channels: merge configured-channel doctor hooks across read-only, loaded, setup, and runtime plugin discovery so partial adapters no longer hide runtime-only compatibility repair or allowlist warnings, preserve disabled-channel opt-outs, and ignore malformed hook values before they can mask valid fallbacks. (#69919) Thanks @gumadeiras.
+- Models/CLI: show bundled provider-owned static catalog rows in `models list --all` before auth is configured, including Kimi K2.6 rows for Moonshot, OpenRouter, and Vercel AI Gateway, while keeping local-only and workspace plugin catalog paths isolated. (#69909) Thanks @shakkernerd.
 
 ## 2026.4.21
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8ac8add8354dc1af76b9aa6f15f7fdcc5265b0bdaf72ea7fc1d3d11bc9f74b8c  plugin-sdk-api-baseline.json
-83310e1d3ea75e9216300ed36e61fdfcfdb6bba7d5c0df62cbfe03ec93565b73  plugin-sdk-api-baseline.jsonl
+cf3b7869a6870b51bfab5543a27f5f55a2754c59c268906d33b4da91352ab9bb  plugin-sdk-api-baseline.json
+6938561c972c419925ac17eb10d5d857502d339603de2cf4ece127827676da5f  plugin-sdk-api-baseline.jsonl

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1532,6 +1532,9 @@ Options:
 - `--json`
 - `--plain`
 
+`--all` includes bundled provider-owned static catalog rows before auth is
+configured. Rows remain unavailable until matching provider credentials exist.
+
 ### `models status`
 
 Options:

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -43,6 +43,9 @@ Probe rows can come from auth profiles, env credentials, or `models.json`.
 Notes:
 
 - `models set <model-or-alias>` accepts `provider/model` or an alias.
+- `models list --all` includes bundled provider-owned static catalog rows even
+  when you have not authenticated with that provider yet. Those rows still show
+  as unavailable until matching auth is configured.
 - Model refs are parsed by splitting on the **first** `/`. If the model ID includes `/` (OpenRouter-style), include the provider prefix (example: `openrouter/moonshotai/kimi-k2`).
 - If you omit the provider, OpenClaw resolves the input as an alias first, then
   as a unique configured-provider match for that exact model id, and only then

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -390,7 +390,8 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 
 - Provider: `vercel-ai-gateway`
 - Auth: `AI_GATEWAY_API_KEY`
-- Example model: `vercel-ai-gateway/anthropic/claude-opus-4.6`
+- Example models: `vercel-ai-gateway/anthropic/claude-opus-4.6`,
+  `vercel-ai-gateway/moonshotai/kimi-k2.6`
 - CLI: `openclaw onboard --auth-choice ai-gateway-api-key`
 
 ### Kilo Gateway
@@ -411,7 +412,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 ### Other bundled provider plugins
 
 - OpenRouter: `openrouter` (`OPENROUTER_API_KEY`)
-- Example model: `openrouter/auto`
+- Example models: `openrouter/auto`, `openrouter/moonshotai/kimi-k2.6`
 - OpenClaw applies OpenRouter's documented app-attribution headers only when
   the request actually targets `openrouter.ai`
 - OpenRouter-specific Anthropic `cache_control` markers are likewise gated to

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -167,6 +167,10 @@ Shows configured models by default. Useful flags:
 - `--plain`: one model per line
 - `--json`: machine‑readable output
 
+`--all` includes bundled provider-owned static catalog rows before auth is
+configured, so discovery-only views can show models that are unavailable until
+you add matching provider credentials.
+
 ### `models status`
 
 Shows the resolved primary model, fallbacks, image model, and an auth overview

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -243,7 +243,8 @@ API key auth, and dynamic model resolution.
     provider auth. It may perform provider-specific discovery. Use
     `buildStaticProvider` only for bundled/offline rows that are safe to show in
     display-only surfaces such as `models list --all` before auth is configured;
-    it must not require credentials or make network requests.
+    it must not require credentials or make network requests. Static catalog
+    hooks run with an empty config, empty env, and no agent/workspace paths.
 
     If your auth flow also needs to patch `models.providers.*`, aliases, and
     the agent default model during onboarding, use the preset helpers from

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -229,10 +229,21 @@ API key auth, and dynamic model resolution.
             baseUrl: "https://api.acme-ai.com/v1",
             models: [{ id: "acme-large", name: "Acme Large" }],
           }),
+          buildStaticProvider: () => ({
+            api: "openai-completions",
+            baseUrl: "https://api.acme-ai.com/v1",
+            models: [{ id: "acme-large", name: "Acme Large" }],
+          }),
         },
       },
     });
     ```
+
+    `buildProvider` is the live catalog path used when OpenClaw can resolve real
+    provider auth. It may perform provider-specific discovery. Use
+    `buildStaticProvider` only for bundled/offline rows that are safe to show in
+    display-only surfaces such as `models list --all` before auth is configured;
+    it must not require credentials or make network requests.
 
     If your auth flow also needs to patch `models.providers.*`, aliases, and
     the agent default model during onboarding, use the preset helpers from

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -241,10 +241,11 @@ API key auth, and dynamic model resolution.
 
     `buildProvider` is the live catalog path used when OpenClaw can resolve real
     provider auth. It may perform provider-specific discovery. Use
-    `buildStaticProvider` only for bundled/offline rows that are safe to show in
-    display-only surfaces such as `models list --all` before auth is configured;
-    it must not require credentials or make network requests. Static catalog
-    hooks run with an empty config, empty env, and no agent/workspace paths.
+    `buildStaticProvider` only for offline rows that are safe to show before auth
+    is configured; it must not require credentials or make network requests.
+    OpenClaw's `models list --all` display currently executes static catalogs
+    only for bundled provider plugins, with an empty config, empty env, and no
+    agent/workspace paths.
 
     If your auth flow also needs to patch `models.providers.*`, aliases, and
     the agent default model during onboarding, use the preset helpers from

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -52,6 +52,15 @@ Model refs follow the pattern `openrouter/<provider>/<model>`. For the full list
 available providers and models, see [/concepts/model-providers](/concepts/model-providers).
 </Note>
 
+Bundled fallback examples:
+
+| Model ref                            | Notes                         |
+| ------------------------------------ | ----------------------------- |
+| `openrouter/auto`                    | OpenRouter automatic routing  |
+| `openrouter/moonshotai/kimi-k2.6`    | Kimi K2.6 via MoonshotAI      |
+| `openrouter/openrouter/healer-alpha` | OpenRouter Healer Alpha route |
+| `openrouter/openrouter/hunter-alpha` | OpenRouter Hunter Alpha route |
+
 ## Authentication and headers
 
 OpenRouter uses a Bearer token with your API key under the hood.

--- a/docs/providers/vercel-ai-gateway.md
+++ b/docs/providers/vercel-ai-gateway.md
@@ -21,7 +21,8 @@ access hundreds of models through a single endpoint.
 <Tip>
 OpenClaw auto-discovers the Gateway `/v1/models` catalog, so
 `/models vercel-ai-gateway` includes current model refs such as
-`vercel-ai-gateway/openai/gpt-5.4`.
+`vercel-ai-gateway/openai/gpt-5.4` and
+`vercel-ai-gateway/moonshotai/kimi-k2.6`.
 </Tip>
 
 ## Getting started
@@ -102,7 +103,8 @@ configuration. OpenClaw resolves the canonical form automatically.
     Vercel AI Gateway routes requests to the upstream provider based on the model
     ref prefix. For example, `vercel-ai-gateway/anthropic/claude-opus-4.6` routes
     through Anthropic, while `vercel-ai-gateway/openai/gpt-5.4` routes through
-    OpenAI. Your single `AI_GATEWAY_API_KEY` handles authentication for all
+    OpenAI and `vercel-ai-gateway/moonshotai/kimi-k2.6` routes through
+    MoonshotAI. Your single `AI_GATEWAY_API_KEY` handles authentication for all
     upstream providers.
   </Accordion>
 </AccordionGroup>

--- a/extensions/chutes/index.ts
+++ b/extensions/chutes/index.ts
@@ -13,7 +13,7 @@ import {
   applyChutesApiKeyConfig,
   applyChutesProviderConfig,
 } from "./onboard.js";
-import { buildChutesProvider } from "./provider-catalog.js";
+import { buildChutesProvider, buildStaticChutesProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "chutes";
 
@@ -179,6 +179,12 @@ export default definePluginEntry({
             },
           };
         },
+      },
+      staticCatalog: {
+        order: "profile",
+        run: async () => ({
+          provider: buildStaticChutesProvider(),
+        }),
       },
     });
   },

--- a/extensions/chutes/provider-catalog.ts
+++ b/extensions/chutes/provider-catalog.ts
@@ -6,6 +6,14 @@ import {
   discoverChutesModels,
 } from "./models.js";
 
+export function buildStaticChutesProvider(): ModelProviderConfig {
+  return {
+    baseUrl: CHUTES_BASE_URL,
+    api: "openai-completions",
+    models: CHUTES_MODEL_CATALOG.map(buildChutesModelDefinition),
+  };
+}
+
 /**
  * Build the Chutes provider with dynamic model discovery.
  * Falls back to the static catalog on failure.

--- a/extensions/kilocode/index.ts
+++ b/extensions/kilocode/index.ts
@@ -3,7 +3,7 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { PASSTHROUGH_GEMINI_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
 import { KILOCODE_THINKING_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
 import { applyKilocodeConfig, KILOCODE_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildKilocodeProviderWithDiscovery } from "./provider-catalog.js";
+import { buildKilocodeProvider, buildKilocodeProviderWithDiscovery } from "./provider-catalog.js";
 
 const PROVIDER_ID = "kilocode";
 
@@ -29,6 +29,7 @@ export default defineSingleProviderPluginEntry({
     ],
     catalog: {
       buildProvider: buildKilocodeProviderWithDiscovery,
+      buildStaticProvider: buildKilocodeProvider,
     },
     augmentModelCatalog: ({ config }) =>
       readConfiguredProviderCatalogEntries({

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -52,6 +52,7 @@ export default defineSingleProviderPluginEntry({
     ],
     catalog: {
       buildProvider: buildMoonshotProvider,
+      buildStaticProvider: buildMoonshotProvider,
       allowExplicitBaseUrl: true,
     },
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import { expectPassthroughReplayPolicy } from "../../test/helpers/provider-replay-policy.ts";
 import openrouterPlugin from "./index.js";
+import { buildOpenrouterProvider } from "./provider-catalog.js";
 
 describe("openrouter provider hooks", () => {
+  it("includes Kimi K2.6 in the bundled catalog", () => {
+    expect(buildOpenrouterProvider().models?.map((model) => model.id)).toContain(
+      "moonshotai/kimi-k2.6",
+    );
+  });
+
   it("owns passthrough-gemini replay policy for Gemini-backed models", async () => {
     await expectPassthroughReplayPolicy({
       plugin: openrouterPlugin,

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -110,6 +110,12 @@ export default definePluginEntry({
           };
         },
       },
+      staticCatalog: {
+        order: "simple",
+        run: async () => ({
+          provider: buildOpenrouterProvider(),
+        }),
+      },
       resolveDynamicModel: (ctx) => buildDynamicOpenRouterModel(ctx),
       prepareDynamicModel: async (ctx) => {
         await loadOpenRouterModelCapabilities(ctx.modelId);

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -11,6 +11,12 @@ const OPENROUTER_DEFAULT_COST = {
   cacheRead: 0,
   cacheWrite: 0,
 };
+const OPENROUTER_KIMI_K2_6_COST = {
+  input: 0.8,
+  output: 3.5,
+  cacheRead: 0.2,
+  cacheWrite: 0,
+};
 
 function normalizeBaseUrl(baseUrl: string | undefined): string {
   return (baseUrl ?? "").trim().replace(/\/+$/, "");
@@ -58,6 +64,15 @@ export function buildOpenrouterProvider(): ModelProviderConfig {
         cost: OPENROUTER_DEFAULT_COST,
         contextWindow: 262144,
         maxTokens: 65536,
+      },
+      {
+        id: "moonshotai/kimi-k2.6",
+        name: "MoonshotAI: Kimi K2.6",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: OPENROUTER_KIMI_K2_6_COST,
+        contextWindow: 262144,
+        maxTokens: 262144,
       },
     ],
   };

--- a/extensions/vercel-ai-gateway/index.ts
+++ b/extensions/vercel-ai-gateway/index.ts
@@ -1,6 +1,9 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyVercelAiGatewayConfig, VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildVercelAiGatewayProvider } from "./provider-catalog.js";
+import {
+  buildStaticVercelAiGatewayProvider,
+  buildVercelAiGatewayProvider,
+} from "./provider-catalog.js";
 
 const PROVIDER_ID = "vercel-ai-gateway";
 
@@ -30,6 +33,7 @@ export default defineSingleProviderPluginEntry({
     ],
     catalog: {
       buildProvider: buildVercelAiGatewayProvider,
+      buildStaticProvider: buildStaticVercelAiGatewayProvider,
     },
   },
 });

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -1,5 +1,6 @@
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
 export const VERCEL_AI_GATEWAY_PROVIDER_ID = "vercel-ai-gateway";
 export const VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh";
@@ -191,18 +192,24 @@ export async function discoverVercelAiGatewayModels(): Promise<ModelDefinitionCo
   }
 
   try {
-    const response = await fetch(`${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`, {
-      signal: AbortSignal.timeout(5000),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+      timeoutMs: 5000,
+      auditContext: "vercel-ai-gateway.models",
     });
-    if (!response.ok) {
-      log.warn(`Failed to discover Vercel AI Gateway models: HTTP ${response.status}`);
-      return getStaticVercelAiGatewayModelCatalog();
+    try {
+      if (!response.ok) {
+        log.warn(`Failed to discover Vercel AI Gateway models: HTTP ${response.status}`);
+        return getStaticVercelAiGatewayModelCatalog();
+      }
+      const data = (await response.json()) as VercelGatewayModelsResponse;
+      const discovered = (data.data ?? [])
+        .map(buildDiscoveredModelDefinition)
+        .filter((entry): entry is ModelDefinitionConfig => entry !== null);
+      return discovered.length > 0 ? discovered : getStaticVercelAiGatewayModelCatalog();
+    } finally {
+      await release();
     }
-    const data = (await response.json()) as VercelGatewayModelsResponse;
-    const discovered = (data.data ?? [])
-      .map(buildDiscoveredModelDefinition)
-      .filter((entry): entry is ModelDefinitionConfig => entry !== null);
-    return discovered.length > 0 ? discovered : getStaticVercelAiGatewayModelCatalog();
   } catch (error) {
     log.warn(`Failed to discover Vercel AI Gateway models: ${String(error)}`);
     return getStaticVercelAiGatewayModelCatalog();

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -86,8 +86,8 @@ const STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG: readonly StaticVercelGatewayModel[
     name: "Kimi K2.6",
     reasoning: true,
     input: ["text", "image"],
-    contextWindow: 262_000,
-    maxTokens: 262_000,
+    contextWindow: 262_144,
+    maxTokens: 262_144,
     cost: {
       input: 0.95,
       output: 4,

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -81,6 +81,19 @@ const STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG: readonly StaticVercelGatewayModel[
       cacheRead: 0,
     },
   },
+  {
+    id: "moonshotai/kimi-k2.6",
+    name: "Kimi K2.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 262_000,
+    maxTokens: 262_000,
+    cost: {
+      input: 0.95,
+      output: 4,
+      cacheRead: 0.16,
+    },
+  },
 ] as const;
 
 function toPerMillionCost(value: number | string | undefined): number {

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { getStaticVercelAiGatewayModelCatalog, VERCEL_AI_GATEWAY_BASE_URL } from "./api.js";
-import { buildVercelAiGatewayProvider } from "./provider-catalog.js";
+import {
+  buildStaticVercelAiGatewayProvider,
+  buildVercelAiGatewayProvider,
+} from "./provider-catalog.js";
 
 describe("vercel ai gateway provider catalog", () => {
   it("builds the bundled Vercel AI Gateway defaults", async () => {
@@ -9,13 +12,29 @@ describe("vercel ai gateway provider catalog", () => {
     expect(provider.baseUrl).toBe(VERCEL_AI_GATEWAY_BASE_URL);
     expect(provider.api).toBe("anthropic-messages");
     expect(provider.models?.map((model) => model.id)).toEqual(
-      expect.arrayContaining(["anthropic/claude-opus-4.6", "openai/gpt-5.4", "openai/gpt-5.4-pro"]),
+      expect.arrayContaining([
+        "anthropic/claude-opus-4.6",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-pro",
+        "moonshotai/kimi-k2.6",
+      ]),
     );
   });
 
   it("exposes the static fallback model catalog", () => {
     expect(getStaticVercelAiGatewayModelCatalog().map((model) => model.id)).toEqual(
-      expect.arrayContaining(["anthropic/claude-opus-4.6", "openai/gpt-5.4", "openai/gpt-5.4-pro"]),
+      expect.arrayContaining([
+        "anthropic/claude-opus-4.6",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-pro",
+        "moonshotai/kimi-k2.6",
+      ]),
+    );
+  });
+
+  it("builds an offline static provider catalog", () => {
+    expect(buildStaticVercelAiGatewayProvider().models?.map((model) => model.id)).toEqual(
+      expect.arrayContaining(["moonshotai/kimi-k2.6"]),
     );
   });
 });

--- a/extensions/vercel-ai-gateway/provider-catalog.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.ts
@@ -1,5 +1,17 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { discoverVercelAiGatewayModels, VERCEL_AI_GATEWAY_BASE_URL } from "./models.js";
+import {
+  discoverVercelAiGatewayModels,
+  getStaticVercelAiGatewayModelCatalog,
+  VERCEL_AI_GATEWAY_BASE_URL,
+} from "./models.js";
+
+export function buildStaticVercelAiGatewayProvider(): ModelProviderConfig {
+  return {
+    baseUrl: VERCEL_AI_GATEWAY_BASE_URL,
+    api: "anthropic-messages",
+    models: getStaticVercelAiGatewayModelCatalog(),
+  };
+}
 
 export async function buildVercelAiGatewayProvider(): Promise<ModelProviderConfig> {
   return {

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -369,6 +369,16 @@ describe("models list/status", () => {
     ]);
   });
 
+  it("models list all local skips unauthenticated provider catalog rows", async () => {
+    setDefaultZaiRegistry({ available: false });
+    loadProviderCatalogModelsForList.mockResolvedValueOnce([MOONSHOT_MODEL]);
+    const runtime = makeRuntime();
+
+    await modelsListCommand({ all: true, local: true, json: true }, runtime);
+
+    expect(loadProviderCatalogModelsForList).not.toHaveBeenCalled();
+  });
+
   it("models list does not treat availability-unavailable code as discovery fallback", async () => {
     configureGoogleAntigravityModel("claude-opus-4-6-thinking");
     modelRegistryState.getAllError = Object.assign(new Error("model discovery failed"), {

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -17,6 +17,9 @@ const listProfilesForProvider = vi.fn().mockReturnValue([]);
 const resolveEnvApiKey = vi.fn().mockReturnValue(undefined);
 const resolveAwsSdkEnvVarName = vi.fn().mockReturnValue(undefined);
 const hasUsableCustomProviderApiKey = vi.fn().mockReturnValue(false);
+const loadProviderCatalogModelsForList = vi.fn<() => Promise<Array<Record<string, unknown>>>>(
+  async () => [],
+);
 const shouldSuppressBuiltInModel = vi.fn().mockReturnValue(false);
 const modelRegistryState = {
   models: [] as Array<Record<string, unknown>>,
@@ -72,6 +75,7 @@ vi.mock("./models/list.runtime.js", () => {
     resolveAwsSdkEnvVarName,
     hasUsableCustomProviderApiKey,
     loadModelCatalog: vi.fn(async () => []),
+    loadProviderCatalogModelsForList,
     discoverAuthStorage: () => ({}) as unknown,
     discoverModels: () => new MockModelRegistry() as unknown,
     resolveModelWithRegistry: ({
@@ -132,6 +136,8 @@ beforeEach(() => {
   getRuntimeConfig.mockReturnValue({});
   listProfilesForProvider.mockReturnValue([]);
   ensureOpenClawModelsJson.mockClear();
+  loadProviderCatalogModelsForList.mockReset();
+  loadProviderCatalogModelsForList.mockResolvedValue([]);
   shouldSuppressBuiltInModel.mockReset();
   shouldSuppressBuiltInModel.mockReturnValue(false);
   readConfigFileSnapshotForWrite.mockClear();
@@ -178,6 +184,14 @@ describe("models list/status", () => {
     input: ["text"],
     baseUrl: "https://chatgpt.com/backend-api",
     contextWindow: 128000,
+  };
+  const MOONSHOT_MODEL = {
+    provider: "moonshot",
+    id: "kimi-k2.6",
+    name: "Kimi K2.6",
+    input: ["text", "image"],
+    baseUrl: "https://api.moonshot.ai/v1",
+    contextWindow: 262144,
   };
   const AZURE_OPENAI_SPARK_MODEL = {
     provider: "azure-openai-responses",
@@ -335,6 +349,24 @@ describe("models list/status", () => {
 
     const payload = parseJsonLog(runtime);
     expect(payload.models[0]?.available).toBe(false);
+  });
+
+  it("models list all includes unauthenticated provider catalog rows", async () => {
+    setDefaultZaiRegistry({ available: false });
+    loadProviderCatalogModelsForList.mockResolvedValueOnce([MOONSHOT_MODEL]);
+    const runtime = makeRuntime();
+
+    await modelsListCommand({ all: true, provider: "moonshot", json: true }, runtime);
+
+    const payload = parseJsonLog(runtime);
+    expect(payload.models).toEqual([
+      expect.objectContaining({
+        key: "moonshot/kimi-k2.6",
+        name: "Kimi K2.6",
+        available: false,
+        missing: false,
+      }),
+    ]);
   });
 
   it("models list does not treat availability-unavailable code as discovery fallback", async () => {

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -58,8 +58,10 @@ const mocks = vi.hoisted(() => {
     loadModelsConfigWithSource: vi.fn(),
     ensureOpenClawModelsJson: vi.fn(),
     ensureAuthProfileStore: vi.fn(),
+    resolveOpenClawAgentDir: vi.fn(),
     loadModelRegistry: vi.fn(),
     loadModelCatalog: vi.fn(),
+    loadProviderCatalogModelsForList: vi.fn(),
     resolveConfiguredEntries: vi.fn(),
     printModelTable: vi.fn(),
     listProfilesForProvider: vi.fn(),
@@ -75,6 +77,7 @@ function resetMocks() {
   });
   mocks.ensureOpenClawModelsJson.mockResolvedValue({ wrote: false });
   mocks.ensureAuthProfileStore.mockReturnValue({ version: 1, profiles: {}, order: {} });
+  mocks.resolveOpenClawAgentDir.mockReturnValue("/tmp/openclaw-agent");
   mocks.loadModelRegistry.mockResolvedValue({
     models: [],
     availableKeys: new Set(),
@@ -83,6 +86,7 @@ function resetMocks() {
     },
   });
   mocks.loadModelCatalog.mockResolvedValue([]);
+  mocks.loadProviderCatalogModelsForList.mockResolvedValue([]);
   mocks.resolveConfiguredEntries.mockReturnValue({
     entries: [
       {
@@ -138,8 +142,10 @@ function installModelsListCommandForwardCompatMocks() {
   vi.doMock("./list.runtime.js", () => ({
     ensureOpenClawModelsJson: mocks.ensureOpenClawModelsJson,
     ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+    resolveOpenClawAgentDir: mocks.resolveOpenClawAgentDir,
     listProfilesForProvider: mocks.listProfilesForProvider,
     loadModelCatalog: mocks.loadModelCatalog,
+    loadProviderCatalogModelsForList: mocks.loadProviderCatalogModelsForList,
     resolveModelWithRegistry: mocks.resolveModelWithRegistry,
     resolveEnvApiKey: vi.fn().mockReturnValue(undefined),
     resolveAwsSdkEnvVarName: vi.fn().mockReturnValue(undefined),
@@ -160,6 +166,7 @@ async function buildAllOpenAiCodexRows(opts: { supplementCatalog?: boolean } = {
   const rows: unknown[] = [];
   const context = {
     cfg: mocks.resolvedConfig,
+    agentDir: "/tmp/openclaw-agent",
     authStore: mocks.ensureAuthProfileStore(),
     availableKeys: loaded.availableKeys,
     configuredByKey: new Map(),

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -26,12 +26,14 @@ export async function modelsListCommand(
   runtime: RuntimeEnv,
 ) {
   ensureFlagCompatibility(opts);
-  const { ensureAuthProfileStore, ensureOpenClawModelsJson } = await import("./list.runtime.js");
+  const { ensureAuthProfileStore, ensureOpenClawModelsJson, resolveOpenClawAgentDir } =
+    await import("./list.runtime.js");
   const { sourceConfig, resolvedConfig: cfg } = await loadModelsConfigWithSource({
     commandName: "models list",
     runtime,
   });
   const authStore = ensureAuthProfileStore();
+  const agentDir = resolveOpenClawAgentDir();
   const providerFilter = (() => {
     const raw = opts.provider?.trim();
     if (!raw) {
@@ -70,6 +72,7 @@ export async function modelsListCommand(
   const rows: ModelRow[] = [];
   const rowContext = {
     cfg,
+    agentDir,
     authStore,
     availableKeys,
     configuredByKey,

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ProviderPlugin } from "../../plugins/types.js";
 import {
   loadProviderCatalogModelsForList,
   resolveProviderCatalogPluginIdsForFilter,
@@ -24,7 +23,6 @@ const baseParams = {
 
 describe("loadProviderCatalogModelsForList", () => {
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -53,48 +51,6 @@ describe("loadProviderCatalogModelsForList", () => {
     );
   });
 
-  it("skips static catalogs that exceed the display budget", async () => {
-    vi.useFakeTimers();
-    const hungProvider = {
-      id: "hung",
-      label: "Hung",
-      auth: [],
-      staticCatalog: {
-        run: async () => new Promise<never>(() => {}),
-      },
-    } satisfies ProviderPlugin;
-    const healthyProvider = {
-      id: "healthy",
-      label: "Healthy",
-      auth: [],
-      staticCatalog: {
-        run: async () => ({
-          provider: {
-            baseUrl: "https://healthy.example/v1",
-            models: [{ id: "healthy-model", name: "Healthy Model" }],
-          },
-        }),
-      },
-    } satisfies ProviderPlugin;
-    const discovery = await import("../../plugins/provider-discovery.js");
-    vi.spyOn(discovery, "resolvePluginDiscoveryProviders").mockResolvedValue([
-      hungProvider,
-      healthyProvider,
-    ]);
-
-    const rowsPromise = loadProviderCatalogModelsForList({
-      ...baseParams,
-    });
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    await expect(rowsPromise).resolves.toEqual([
-      expect.objectContaining({
-        provider: "healthy",
-        id: "healthy-model",
-      }),
-    ]);
-  });
-
   it("recognizes bundled provider hook aliases before the unknown-provider short-circuit", async () => {
     await expect(
       resolveProviderCatalogPluginIdsForFilter({
@@ -105,47 +61,46 @@ describe("loadProviderCatalogModelsForList", () => {
     ).resolves.toEqual(["openai"]);
   });
 
-  it("recognizes trusted workspace provider aliases before the unknown-provider short-circuit", async () => {
-    const manifestRegistry = await import("../../plugins/manifest-registry.js");
+  it("does not execute workspace provider static catalogs", async () => {
     const providers = await import("../../plugins/providers.js");
     const discovery = await import("../../plugins/provider-discovery.js");
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-demo",
-          origin: "workspace",
-          providers: ["workspace-demo"],
-          cliBackends: [],
-        },
-      ],
-      diagnostics: [],
-    } as never);
-    vi.spyOn(providers, "resolveDiscoveredProviderPluginIds").mockReturnValue(["workspace-demo"]);
+    const workspaceStaticCatalog = vi.fn(async () => ({
+      provider: { baseUrl: "https://workspace.example/v1", models: [] },
+    }));
+    vi.spyOn(providers, "resolveBundledProviderCompatPluginIds").mockReturnValue(["bundled-demo"]);
     vi.spyOn(discovery, "resolvePluginDiscoveryProviders").mockResolvedValue([
+      {
+        id: "bundled-demo",
+        pluginId: "bundled-demo",
+        label: "Bundled Demo",
+        auth: [],
+        staticCatalog: {
+          run: async () => null,
+        },
+      },
       {
         id: "workspace-demo",
         pluginId: "workspace-demo",
         label: "Workspace Demo",
-        aliases: ["workspace-demo-alias"],
         auth: [],
         staticCatalog: {
-          run: async () => ({
-            provider: {
-              baseUrl: "https://workspace.example/v1",
-              models: [],
-            },
-          }),
+          run: workspaceStaticCatalog,
         },
       },
     ]);
 
-    await expect(
-      resolveProviderCatalogPluginIdsForFilter({
-        cfg: baseParams.cfg,
-        env: baseParams.env,
-        providerFilter: "workspace-demo-alias",
+    const rows = await loadProviderCatalogModelsForList({
+      ...baseParams,
+    });
+
+    expect(discovery.resolvePluginDiscoveryProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["bundled-demo"],
+        includeUntrustedWorkspacePlugins: false,
       }),
-    ).resolves.toEqual(["workspace-demo"]);
+    );
+    expect(workspaceStaticCatalog).not.toHaveBeenCalled();
+    expect(rows).toEqual([]);
   });
 
   it("keeps unknown provider filters eligible for early empty results", async () => {

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderPlugin } from "../../plugins/types.js";
 import {
   loadProviderCatalogModelsForList,
   resolveProviderCatalogPluginIdsForFilter,
@@ -23,6 +24,7 @@ const baseParams = {
 
 describe("loadProviderCatalogModelsForList", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -51,6 +53,48 @@ describe("loadProviderCatalogModelsForList", () => {
     );
   });
 
+  it("skips static catalogs that exceed the display budget", async () => {
+    vi.useFakeTimers();
+    const hungProvider = {
+      id: "hung",
+      label: "Hung",
+      auth: [],
+      staticCatalog: {
+        run: async () => new Promise<never>(() => {}),
+      },
+    } satisfies ProviderPlugin;
+    const healthyProvider = {
+      id: "healthy",
+      label: "Healthy",
+      auth: [],
+      staticCatalog: {
+        run: async () => ({
+          provider: {
+            baseUrl: "https://healthy.example/v1",
+            models: [{ id: "healthy-model", name: "Healthy Model" }],
+          },
+        }),
+      },
+    } satisfies ProviderPlugin;
+    const discovery = await import("../../plugins/provider-discovery.js");
+    vi.spyOn(discovery, "resolvePluginDiscoveryProviders").mockResolvedValue([
+      hungProvider,
+      healthyProvider,
+    ]);
+
+    const rowsPromise = loadProviderCatalogModelsForList({
+      ...baseParams,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(rowsPromise).resolves.toEqual([
+      expect.objectContaining({
+        provider: "healthy",
+        id: "healthy-model",
+      }),
+    ]);
+  });
+
   it("recognizes bundled provider hook aliases before the unknown-provider short-circuit", async () => {
     await expect(
       resolveProviderCatalogPluginIdsForFilter({
@@ -59,6 +103,49 @@ describe("loadProviderCatalogModelsForList", () => {
         providerFilter: "azure-openai-responses",
       }),
     ).resolves.toEqual(["openai"]);
+  });
+
+  it("recognizes trusted workspace provider aliases before the unknown-provider short-circuit", async () => {
+    const manifestRegistry = await import("../../plugins/manifest-registry.js");
+    const providers = await import("../../plugins/providers.js");
+    const discovery = await import("../../plugins/provider-discovery.js");
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-demo",
+          origin: "workspace",
+          providers: ["workspace-demo"],
+          cliBackends: [],
+        },
+      ],
+      diagnostics: [],
+    } as never);
+    vi.spyOn(providers, "resolveDiscoveredProviderPluginIds").mockReturnValue(["workspace-demo"]);
+    vi.spyOn(discovery, "resolvePluginDiscoveryProviders").mockResolvedValue([
+      {
+        id: "workspace-demo",
+        pluginId: "workspace-demo",
+        label: "Workspace Demo",
+        aliases: ["workspace-demo-alias"],
+        auth: [],
+        staticCatalog: {
+          run: async () => ({
+            provider: {
+              baseUrl: "https://workspace.example/v1",
+              models: [],
+            },
+          }),
+        },
+      },
+    ]);
+
+    await expect(
+      resolveProviderCatalogPluginIdsForFilter({
+        cfg: baseParams.cfg,
+        env: baseParams.env,
+        providerFilter: "workspace-demo-alias",
+      }),
+    ).resolves.toEqual(["workspace-demo"]);
   });
 
   it("keeps unknown provider filters eligible for early empty results", async () => {

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadProviderCatalogModelsForList } from "./list.provider-catalog.js";
+
+const baseParams = {
+  cfg: {
+    plugins: {
+      entries: {
+        chutes: { enabled: true },
+        moonshot: { enabled: true },
+      },
+    },
+  },
+  agentDir: "/tmp/openclaw-provider-catalog-test",
+  env: {
+    ...process.env,
+    CHUTES_API_KEY: "",
+    MOONSHOT_API_KEY: "",
+  },
+};
+
+describe("loadProviderCatalogModelsForList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not use live provider discovery for display-only rows", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("blocked fetch"));
+
+    await loadProviderCatalogModelsForList({
+      ...baseParams,
+      providerFilter: "chutes",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("includes unauthenticated Moonshot static catalog rows", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("blocked fetch"));
+
+    const rows = await loadProviderCatalogModelsForList({
+      ...baseParams,
+      providerFilter: "moonshot",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(rows.map((row) => `${row.provider}/${row.id}`)).toEqual(
+      expect.arrayContaining(["moonshot/kimi-k2.6"]),
+    );
+  });
+});

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadProviderCatalogModelsForList } from "./list.provider-catalog.js";
+import {
+  loadProviderCatalogModelsForList,
+  resolveProviderCatalogPluginIdsForFilter,
+} from "./list.provider-catalog.js";
 
 const baseParams = {
   cfg: {
@@ -46,5 +49,25 @@ describe("loadProviderCatalogModelsForList", () => {
     expect(rows.map((row) => `${row.provider}/${row.id}`)).toEqual(
       expect.arrayContaining(["moonshot/kimi-k2.6"]),
     );
+  });
+
+  it("recognizes bundled provider hook aliases before the unknown-provider short-circuit", async () => {
+    await expect(
+      resolveProviderCatalogPluginIdsForFilter({
+        cfg: baseParams.cfg,
+        env: baseParams.env,
+        providerFilter: "azure-openai-responses",
+      }),
+    ).resolves.toEqual(["openai"]);
+  });
+
+  it("keeps unknown provider filters eligible for early empty results", async () => {
+    await expect(
+      resolveProviderCatalogPluginIdsForFilter({
+        cfg: baseParams.cfg,
+        env: baseParams.env,
+        providerFilter: "unknown-provider-for-catalog-test",
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -6,11 +6,10 @@ import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
   resolvePluginDiscoveryProviders,
-  runProviderCatalog,
+  runProviderStaticCatalog,
 } from "../../plugins/provider-discovery.js";
 import { resolveOwningPluginIdsForProvider } from "../../plugins/providers.js";
 
-const CATALOG_DISPLAY_API_KEY = "__openclaw_catalog_display__";
 const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
 
@@ -65,21 +64,13 @@ export async function loadProviderCatalogModelsForList(params: {
       if (!providerFilter && SELF_HOSTED_DISCOVERY_PROVIDER_IDS.has(provider.id)) {
         continue;
       }
-      let result: Awaited<ReturnType<typeof runProviderCatalog>> | null;
+      let result: Awaited<ReturnType<typeof runProviderStaticCatalog>> | null;
       try {
-        result = await runProviderCatalog({
+        result = await runProviderStaticCatalog({
           provider,
           config: params.cfg,
           agentDir: params.agentDir,
           env,
-          resolveProviderApiKey: () => ({
-            apiKey: CATALOG_DISPLAY_API_KEY,
-          }),
-          resolveProviderAuth: () => ({
-            apiKey: CATALOG_DISPLAY_API_KEY,
-            mode: "api_key",
-            source: "env",
-          }),
         });
       } catch {
         result = null;

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -50,10 +50,14 @@ export async function loadProviderCatalogModelsForList(params: {
         env,
       })
     : undefined;
+  if (providerFilter && !onlyPluginIds) {
+    return [];
+  }
   const providers = await resolvePluginDiscoveryProviders({
     config: params.cfg,
     env,
     ...(onlyPluginIds ? { onlyPluginIds } : {}),
+    includeUntrustedWorkspacePlugins: false,
   });
   const byOrder = groupPluginDiscoveryProvidersByOrder(providers);
   const rows: Model<Api>[] = [];

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -2,6 +2,8 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
@@ -12,6 +14,7 @@ import { resolveOwningPluginIdsForProvider } from "../../plugins/providers.js";
 
 const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
+const log = createSubsystemLogger("models/list-provider-catalog");
 
 function modelFromProviderCatalog(params: {
   provider: string;
@@ -76,7 +79,8 @@ export async function loadProviderCatalogModelsForList(params: {
           agentDir: params.agentDir,
           env,
         });
-      } catch {
+      } catch (error) {
+        log.warn(`provider static catalog failed for ${provider.id}: ${formatErrorMessage(error)}`);
         result = null;
       }
       const normalized = normalizePluginDiscoveryResult({ provider, result });

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -16,6 +16,28 @@ const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
 const log = createSubsystemLogger("models/list-provider-catalog");
 
+export async function resolveProviderCatalogPluginIdsForFilter(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  providerFilter: string;
+}): Promise<string[] | undefined> {
+  const providerFilter = normalizeProviderId(params.providerFilter);
+  if (!providerFilter) {
+    return undefined;
+  }
+  const manifestPluginIds = resolveOwningPluginIdsForProvider({
+    provider: providerFilter,
+    config: params.cfg,
+    env: params.env,
+  });
+  if (manifestPluginIds) {
+    return manifestPluginIds;
+  }
+  const { resolveProviderContractPluginIdsForProviderAlias } =
+    await import("../../plugins/contracts/registry.js");
+  return resolveProviderContractPluginIdsForProviderAlias(providerFilter);
+}
+
 function modelFromProviderCatalog(params: {
   provider: string;
   providerConfig: ModelProviderConfig;
@@ -47,10 +69,10 @@ export async function loadProviderCatalogModelsForList(params: {
   const env = params.env ?? process.env;
   const providerFilter = params.providerFilter ? normalizeProviderId(params.providerFilter) : "";
   const onlyPluginIds = providerFilter
-    ? resolveOwningPluginIdsForProvider({
-        provider: providerFilter,
-        config: params.cfg,
+    ? await resolveProviderCatalogPluginIdsForFilter({
+        cfg: params.cfg,
         env,
+        providerFilter,
       })
     : undefined;
   if (providerFilter && !onlyPluginIds) {

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -104,6 +104,7 @@ export async function loadProviderCatalogModelsForList(params: {
       env,
       onlyPluginIds: scopedPluginIds,
       includeUntrustedWorkspacePlugins: false,
+      requireCompleteDiscoveryEntryCoverage: true,
     })
   ).filter(
     (provider) =>

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -1,0 +1,121 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { normalizeProviderId } from "../../agents/provider-id.js";
+import type { ModelProviderConfig } from "../../config/types.models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  groupPluginDiscoveryProvidersByOrder,
+  normalizePluginDiscoveryResult,
+  resolvePluginDiscoveryProviders,
+  runProviderCatalog,
+} from "../../plugins/provider-discovery.js";
+import { resolveOwningPluginIdsForProvider } from "../../plugins/providers.js";
+
+const CATALOG_DISPLAY_API_KEY = "__openclaw_catalog_display__";
+const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
+const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
+
+function modelFromProviderCatalog(params: {
+  provider: string;
+  providerConfig: ModelProviderConfig;
+  model: ModelProviderConfig["models"][number];
+}): Model<Api> {
+  return {
+    id: params.model.id,
+    name: params.model.name || params.model.id,
+    provider: params.provider,
+    api: params.model.api ?? params.providerConfig.api ?? "openai-responses",
+    baseUrl: params.providerConfig.baseUrl,
+    reasoning: params.model.reasoning,
+    input: params.model.input ?? ["text"],
+    cost: params.model.cost,
+    contextWindow: params.model.contextWindow,
+    contextTokens: params.model.contextTokens,
+    maxTokens: params.model.maxTokens,
+    headers: params.model.headers,
+    compat: params.model.compat,
+  } as Model<Api>;
+}
+
+export async function loadProviderCatalogModelsForList(params: {
+  cfg: OpenClawConfig;
+  agentDir: string;
+  env?: NodeJS.ProcessEnv;
+  providerFilter?: string;
+}): Promise<Model<Api>[]> {
+  const env = params.env ?? process.env;
+  const providerFilter = params.providerFilter ? normalizeProviderId(params.providerFilter) : "";
+  const onlyPluginIds = providerFilter
+    ? resolveOwningPluginIdsForProvider({
+        provider: providerFilter,
+        config: params.cfg,
+        env,
+      })
+    : undefined;
+  const providers = await resolvePluginDiscoveryProviders({
+    config: params.cfg,
+    env,
+    ...(onlyPluginIds ? { onlyPluginIds } : {}),
+  });
+  const byOrder = groupPluginDiscoveryProvidersByOrder(providers);
+  const rows: Model<Api>[] = [];
+  const seen = new Set<string>();
+
+  for (const order of DISCOVERY_ORDERS) {
+    for (const provider of byOrder[order] ?? []) {
+      if (!providerFilter && SELF_HOSTED_DISCOVERY_PROVIDER_IDS.has(provider.id)) {
+        continue;
+      }
+      let result: Awaited<ReturnType<typeof runProviderCatalog>> | null;
+      try {
+        result = await runProviderCatalog({
+          provider,
+          config: params.cfg,
+          agentDir: params.agentDir,
+          env,
+          resolveProviderApiKey: () => ({
+            apiKey: CATALOG_DISPLAY_API_KEY,
+          }),
+          resolveProviderAuth: () => ({
+            apiKey: CATALOG_DISPLAY_API_KEY,
+            mode: "api_key",
+            source: "env",
+          }),
+        });
+      } catch {
+        result = null;
+      }
+      const normalized = normalizePluginDiscoveryResult({ provider, result });
+      for (const [providerIdRaw, providerConfig] of Object.entries(normalized)) {
+        const providerId = normalizeProviderId(providerIdRaw);
+        if (providerFilter && providerId !== providerFilter) {
+          continue;
+        }
+        if (!providerId || !Array.isArray(providerConfig.models)) {
+          continue;
+        }
+        for (const model of providerConfig.models) {
+          const key = `${providerId}/${model.id}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          rows.push(
+            modelFromProviderCatalog({
+              provider: providerId,
+              providerConfig,
+              model,
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  return rows.toSorted((left, right) => {
+    const provider = left.provider.localeCompare(right.provider);
+    if (provider !== 0) {
+      return provider;
+    }
+    return left.id.localeCompare(right.id);
+  });
+}

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -4,7 +4,6 @@ import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
@@ -12,62 +11,13 @@ import {
   runProviderStaticCatalog,
 } from "../../plugins/provider-discovery.js";
 import {
-  resolveDiscoveredProviderPluginIds,
+  resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProvider,
 } from "../../plugins/providers.js";
-import type { ProviderPlugin } from "../../plugins/types.js";
 
 const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
-const STATIC_CATALOG_TIMEOUT_MS = 2_000;
 const log = createSubsystemLogger("models/list-provider-catalog");
-
-function providerMatchesFilterAlias(provider: ProviderPlugin, providerFilter: string): boolean {
-  return [provider.id, ...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
-    (providerId) => normalizeProviderId(providerId) === providerFilter,
-  );
-}
-
-async function resolveWorkspacePluginIdsForProviderAlias(params: {
-  cfg: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  providerFilter: string;
-}): Promise<string[] | undefined> {
-  const discoverablePluginIds = new Set(
-    resolveDiscoveredProviderPluginIds({
-      config: params.cfg,
-      env: params.env,
-      includeUntrustedWorkspacePlugins: false,
-    }),
-  );
-  const workspacePluginIds = loadPluginManifestRegistry({
-    config: params.cfg,
-    env: params.env,
-  })
-    .plugins.filter(
-      (plugin) => plugin.origin === "workspace" && discoverablePluginIds.has(plugin.id),
-    )
-    .map((plugin) => plugin.id);
-  if (workspacePluginIds.length === 0) {
-    return undefined;
-  }
-
-  const providers = await resolvePluginDiscoveryProviders({
-    config: params.cfg,
-    env: params.env,
-    onlyPluginIds: workspacePluginIds,
-    includeUntrustedWorkspacePlugins: false,
-  });
-  const pluginIds = [
-    ...new Set(
-      providers
-        .filter((provider) => providerMatchesFilterAlias(provider, params.providerFilter))
-        .map((provider) => provider.pluginId)
-        .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
-    ),
-  ].toSorted((left, right) => left.localeCompare(right));
-  return pluginIds.length > 0 ? pluginIds : undefined;
-}
 
 export async function resolveProviderCatalogPluginIdsForFilter(params: {
   cfg: OpenClawConfig;
@@ -92,11 +42,7 @@ export async function resolveProviderCatalogPluginIdsForFilter(params: {
   if (bundledAliasPluginIds) {
     return bundledAliasPluginIds;
   }
-  return await resolveWorkspacePluginIdsForProviderAlias({
-    cfg: params.cfg,
-    env: params.env,
-    providerFilter,
-  });
+  return undefined;
 }
 
 function modelFromProviderCatalog(params: {
@@ -121,29 +67,6 @@ function modelFromProviderCatalog(params: {
   } as Model<Api>;
 }
 
-async function withStaticCatalogTimeout<T>(
-  providerId: string,
-  run: () => T | Promise<T>,
-): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(
-        new Error(
-          `provider static catalog timed out for ${providerId} after ${STATIC_CATALOG_TIMEOUT_MS}ms`,
-        ),
-      );
-    }, STATIC_CATALOG_TIMEOUT_MS);
-  });
-  try {
-    return await Promise.race([Promise.resolve().then(run), timeout]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 export async function loadProviderCatalogModelsForList(params: {
   cfg: OpenClawConfig;
   agentDir: string;
@@ -162,12 +85,30 @@ export async function loadProviderCatalogModelsForList(params: {
   if (providerFilter && !onlyPluginIds) {
     return [];
   }
-  const providers = await resolvePluginDiscoveryProviders({
+
+  const bundledPluginIds = resolveBundledProviderCompatPluginIds({
     config: params.cfg,
     env,
-    ...(onlyPluginIds ? { onlyPluginIds } : {}),
-    includeUntrustedWorkspacePlugins: false,
   });
+  const bundledPluginIdSet = new Set(bundledPluginIds);
+  const scopedPluginIds = onlyPluginIds
+    ? onlyPluginIds.filter((pluginId) => bundledPluginIdSet.has(pluginId))
+    : bundledPluginIds;
+  if (scopedPluginIds.length === 0) {
+    return [];
+  }
+
+  const providers = (
+    await resolvePluginDiscoveryProviders({
+      config: params.cfg,
+      env,
+      onlyPluginIds: scopedPluginIds,
+      includeUntrustedWorkspacePlugins: false,
+    })
+  ).filter(
+    (provider) =>
+      typeof provider.pluginId === "string" && bundledPluginIdSet.has(provider.pluginId),
+  );
   const byOrder = groupPluginDiscoveryProvidersByOrder(providers);
   const rows: Model<Api>[] = [];
   const seen = new Set<string>();
@@ -179,14 +120,12 @@ export async function loadProviderCatalogModelsForList(params: {
       }
       let result: Awaited<ReturnType<typeof runProviderStaticCatalog>> | null;
       try {
-        result = await withStaticCatalogTimeout(provider.id, () =>
-          runProviderStaticCatalog({
-            provider,
-            config: params.cfg,
-            agentDir: params.agentDir,
-            env,
-          }),
-        );
+        result = await runProviderStaticCatalog({
+          provider,
+          config: params.cfg,
+          agentDir: params.agentDir,
+          env,
+        });
       } catch (error) {
         log.warn(`provider static catalog failed for ${provider.id}: ${formatErrorMessage(error)}`);
         result = null;

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -4,17 +4,70 @@ import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
   resolvePluginDiscoveryProviders,
   runProviderStaticCatalog,
 } from "../../plugins/provider-discovery.js";
-import { resolveOwningPluginIdsForProvider } from "../../plugins/providers.js";
+import {
+  resolveDiscoveredProviderPluginIds,
+  resolveOwningPluginIdsForProvider,
+} from "../../plugins/providers.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
 
 const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
+const STATIC_CATALOG_TIMEOUT_MS = 2_000;
 const log = createSubsystemLogger("models/list-provider-catalog");
+
+function providerMatchesFilterAlias(provider: ProviderPlugin, providerFilter: string): boolean {
+  return [provider.id, ...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
+    (providerId) => normalizeProviderId(providerId) === providerFilter,
+  );
+}
+
+async function resolveWorkspacePluginIdsForProviderAlias(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  providerFilter: string;
+}): Promise<string[] | undefined> {
+  const discoverablePluginIds = new Set(
+    resolveDiscoveredProviderPluginIds({
+      config: params.cfg,
+      env: params.env,
+      includeUntrustedWorkspacePlugins: false,
+    }),
+  );
+  const workspacePluginIds = loadPluginManifestRegistry({
+    config: params.cfg,
+    env: params.env,
+  })
+    .plugins.filter(
+      (plugin) => plugin.origin === "workspace" && discoverablePluginIds.has(plugin.id),
+    )
+    .map((plugin) => plugin.id);
+  if (workspacePluginIds.length === 0) {
+    return undefined;
+  }
+
+  const providers = await resolvePluginDiscoveryProviders({
+    config: params.cfg,
+    env: params.env,
+    onlyPluginIds: workspacePluginIds,
+    includeUntrustedWorkspacePlugins: false,
+  });
+  const pluginIds = [
+    ...new Set(
+      providers
+        .filter((provider) => providerMatchesFilterAlias(provider, params.providerFilter))
+        .map((provider) => provider.pluginId)
+        .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+  return pluginIds.length > 0 ? pluginIds : undefined;
+}
 
 export async function resolveProviderCatalogPluginIdsForFilter(params: {
   cfg: OpenClawConfig;
@@ -35,7 +88,15 @@ export async function resolveProviderCatalogPluginIdsForFilter(params: {
   }
   const { resolveProviderContractPluginIdsForProviderAlias } =
     await import("../../plugins/contracts/registry.js");
-  return resolveProviderContractPluginIdsForProviderAlias(providerFilter);
+  const bundledAliasPluginIds = resolveProviderContractPluginIdsForProviderAlias(providerFilter);
+  if (bundledAliasPluginIds) {
+    return bundledAliasPluginIds;
+  }
+  return await resolveWorkspacePluginIdsForProviderAlias({
+    cfg: params.cfg,
+    env: params.env,
+    providerFilter,
+  });
 }
 
 function modelFromProviderCatalog(params: {
@@ -58,6 +119,29 @@ function modelFromProviderCatalog(params: {
     headers: params.model.headers,
     compat: params.model.compat,
   } as Model<Api>;
+}
+
+async function withStaticCatalogTimeout<T>(
+  providerId: string,
+  run: () => T | Promise<T>,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(
+          `provider static catalog timed out for ${providerId} after ${STATIC_CATALOG_TIMEOUT_MS}ms`,
+        ),
+      );
+    }, STATIC_CATALOG_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(run), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export async function loadProviderCatalogModelsForList(params: {
@@ -95,12 +179,14 @@ export async function loadProviderCatalogModelsForList(params: {
       }
       let result: Awaited<ReturnType<typeof runProviderStaticCatalog>> | null;
       try {
-        result = await runProviderStaticCatalog({
-          provider,
-          config: params.cfg,
-          agentDir: params.agentDir,
-          env,
-        });
+        result = await withStaticCatalogTimeout(provider.id, () =>
+          runProviderStaticCatalog({
+            provider,
+            config: params.cfg,
+            agentDir: params.agentDir,
+            env,
+          }),
+        );
       } catch (error) {
         log.warn(`provider static catalog failed for ${provider.id}: ${formatErrorMessage(error)}`);
         result = null;

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -160,6 +160,10 @@ export async function appendCatalogSupplementRows(params: {
     params.seenKeys.add(key);
   }
 
+  if (params.context.filter.local) {
+    return;
+  }
+
   for (const model of await loadProviderCatalogModelsForList({
     cfg: params.context.cfg,
     agentDir: params.context.agentDir,

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -5,7 +5,11 @@ import { shouldSuppressBuiltInModel } from "../../agents/model-suppression.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadModelRegistry, toModelRow } from "./list.registry.js";
-import { loadModelCatalog, resolveModelWithRegistry } from "./list.runtime.js";
+import {
+  loadModelCatalog,
+  loadProviderCatalogModelsForList,
+  resolveModelWithRegistry,
+} from "./list.runtime.js";
 import type { ConfiguredEntry, ModelRow } from "./list.types.js";
 import { isLocalBaseUrl, modelKey } from "./shared.js";
 
@@ -18,6 +22,7 @@ type RowFilter = {
 
 type RowBuilderContext = {
   cfg: OpenClawConfig;
+  agentDir: string;
   authStore: AuthProfileStore;
   availableKeys?: Set<string>;
   configuredByKey: ConfiguredByKey;
@@ -142,6 +147,39 @@ export async function appendCatalogSupplementRows(params: {
         config: params.context.cfg,
       })
     ) {
+      continue;
+    }
+    params.rows.push(
+      buildRow({
+        model,
+        key,
+        context: params.context,
+        allowProviderAvailabilityFallback: !params.context.discoveredKeys.has(key),
+      }),
+    );
+    params.seenKeys.add(key);
+  }
+
+  for (const model of await loadProviderCatalogModelsForList({
+    cfg: params.context.cfg,
+    agentDir: params.context.agentDir,
+    providerFilter: params.context.filter.provider,
+  })) {
+    if (!matchesRowFilter(params.context.filter, model)) {
+      continue;
+    }
+    if (
+      shouldSuppressBuiltInModel({
+        provider: model.provider,
+        id: model.id,
+        baseUrl: model.baseUrl,
+        config: params.context.cfg,
+      })
+    ) {
+      continue;
+    }
+    const key = modelKey(model.provider, model.id);
+    if (params.seenKeys.has(key)) {
       continue;
     }
     params.rows.push(

--- a/src/commands/models/list.runtime.ts
+++ b/src/commands/models/list.runtime.ts
@@ -10,3 +10,4 @@ export {
 export { loadModelCatalog } from "../../agents/model-catalog.js";
 export { resolveModelWithRegistry } from "../../agents/pi-embedded-runner/model.js";
 export { discoverAuthStorage, discoverModels } from "../../agents/pi-model-discovery.js";
+export { loadProviderCatalogModelsForList } from "./list.provider-catalog.js";

--- a/src/commands/models/list.table.ts
+++ b/src/commands/models/list.table.ts
@@ -1,4 +1,5 @@
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { sanitizeTerminalText } from "../../terminal/safe-text.js";
 import { colorize, theme } from "../../terminal/theme.js";
 import { formatTag, isRich, pad, truncate } from "./list.format.js";
 import type { ModelRow } from "./list.types.js";
@@ -25,7 +26,7 @@ export function printModelTable(
 
   if (opts.plain) {
     for (const row of rows) {
-      runtime.log(row.key);
+      runtime.log(sanitizeTerminalText(row.key));
     }
     return;
   }
@@ -42,18 +43,19 @@ export function printModelTable(
   runtime.log(rich ? theme.heading(header) : header);
 
   for (const row of rows) {
-    const keyLabel = pad(truncate(row.key, MODEL_PAD), MODEL_PAD);
-    const inputLabel = pad(row.input || "-", INPUT_PAD);
+    const keyLabel = pad(truncate(sanitizeTerminalText(row.key), MODEL_PAD), MODEL_PAD);
+    const inputLabel = pad(sanitizeTerminalText(row.input) || "-", INPUT_PAD);
     const ctxLabel = pad(formatTokenK(row.contextWindow), CTX_PAD);
     const localText = row.local === null ? "-" : row.local ? "yes" : "no";
     const localLabel = pad(localText, LOCAL_PAD);
     const authText = row.available === null ? "-" : row.available ? "yes" : "no";
     const authLabel = pad(authText, AUTH_PAD);
+    const tags = row.tags.map(sanitizeTerminalText);
     const tagsLabel =
-      row.tags.length > 0
+      tags.length > 0
         ? rich
-          ? row.tags.map((tag) => formatTag(tag, rich)).join(",")
-          : row.tags.join(",")
+          ? tags.map((tag) => formatTag(tag, rich)).join(",")
+          : tags.join(",")
         : "";
 
     const coloredInput = colorize(

--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -42,7 +42,8 @@ async function captureProviderEntry(params: {
   const captured = capturePluginRegistration(params.entry);
   const provider = captured.providers[0];
   const catalog = await provider?.catalog?.run(createCatalogContext(params.config));
-  return { captured, provider, catalog };
+  const staticCatalog = await provider?.staticCatalog?.run(createCatalogContext(params.config));
+  return { captured, provider, catalog, staticCatalog };
 }
 
 describe("defineSingleProviderPluginEntry", () => {
@@ -72,11 +73,16 @@ describe("defineSingleProviderPluginEntry", () => {
             baseUrl: "https://api.demo.test/v1",
             models: [createModel("default", "Default")],
           }),
+          buildStaticProvider: () => ({
+            api: "openai-completions",
+            baseUrl: "https://api.demo.test/v1",
+            models: [createModel("default", "Default")],
+          }),
         },
       },
     });
 
-    const { captured, provider, catalog } = await captureProviderEntry({ entry });
+    const { captured, provider, catalog, staticCatalog } = await captureProviderEntry({ entry });
     expect(captured.providers).toHaveLength(1);
     expect(provider).toMatchObject({
       id: "demo",
@@ -103,6 +109,13 @@ describe("defineSingleProviderPluginEntry", () => {
       provider: {
         api: "openai-completions",
         apiKey: "test-key",
+        baseUrl: "https://api.demo.test/v1",
+        models: [createModel("default", "Default")],
+      },
+    });
+    expect(staticCatalog).toEqual({
+      provider: {
+        api: "openai-completions",
         baseUrl: "https://api.demo.test/v1",
         models: [createModel("default", "Default")],
       },

--- a/src/plugin-sdk/provider-entry.ts
+++ b/src/plugin-sdk/provider-entry.ts
@@ -27,14 +27,18 @@ export type SingleProviderPluginApiKeyAuthOptions = Omit<
 export type SingleProviderPluginCatalogOptions =
   | {
       buildProvider: Parameters<typeof buildSingleProviderApiKeyCatalog>[0]["buildProvider"];
+      buildStaticProvider?: Parameters<typeof buildSingleProviderApiKeyCatalog>[0]["buildProvider"];
       allowExplicitBaseUrl?: boolean;
       run?: never;
       order?: never;
+      staticRun?: never;
     }
   | {
       run: ProviderPluginCatalog["run"];
+      staticRun?: ProviderPluginCatalog["run"];
       order?: ProviderPluginCatalog["order"];
       buildProvider?: never;
+      buildStaticProvider?: never;
       allowExplicitBaseUrl?: never;
     };
 
@@ -54,7 +58,7 @@ export type SingleProviderPluginOptions = {
     catalog: SingleProviderPluginCatalogOptions;
   } & Omit<
     ProviderPlugin,
-    "id" | "label" | "docsPath" | "aliases" | "envVars" | "auth" | "catalog"
+    "id" | "label" | "docsPath" | "aliases" | "envVars" | "auth" | "catalog" | "staticCatalog"
   >;
   register?: (api: OpenClawPluginApi) => void;
 };
@@ -146,6 +150,22 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
               }),
           };
         }
+        const staticCatalog: ProviderPluginCatalog | undefined =
+          "run" in provider.catalog
+            ? provider.catalog.staticRun
+              ? {
+                  order: provider.catalog.order ?? "simple",
+                  run: provider.catalog.staticRun,
+                }
+              : undefined
+            : provider.catalog.buildStaticProvider
+              ? {
+                  order: "simple",
+                  run: async () => ({
+                    provider: await provider.catalog.buildStaticProvider!(),
+                  }),
+                }
+              : undefined;
         api.registerProvider({
           id: providerId,
           label: provider.label,
@@ -154,10 +174,20 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
           ...(envVars ? { envVars } : {}),
           auth,
           catalog,
+          ...(staticCatalog ? { staticCatalog } : {}),
           ...Object.fromEntries(
             Object.entries(provider).filter(
               ([key]) =>
-                !["id", "label", "docsPath", "aliases", "envVars", "auth", "catalog"].includes(key),
+                ![
+                  "id",
+                  "label",
+                  "docsPath",
+                  "aliases",
+                  "envVars",
+                  "auth",
+                  "catalog",
+                  "staticCatalog",
+                ].includes(key),
             ),
           ),
         });

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "../../agents/provider-id.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { loadBundledCapabilityRuntimeRegistry } from "../bundled-capability-runtime.js";
 import {
@@ -720,6 +721,30 @@ export function resolveProviderContractPluginIdsForProvider(
   providerId: string,
 ): string[] | undefined {
   const pluginIds = resolveBundledProviderContractPluginIdsByProviderId().get(providerId) ?? [];
+  return pluginIds.length > 0 ? pluginIds : undefined;
+}
+
+export function resolveProviderContractPluginIdsForProviderAlias(
+  providerId: string,
+): string[] | undefined {
+  const normalizedProvider = normalizeProviderId(providerId);
+  if (!normalizedProvider) {
+    return undefined;
+  }
+  const pluginIds = uniqueStrings(
+    loadProviderContractEntriesForPluginIds(resolveBundledProviderContractPluginIds())
+      .filter((entry) => {
+        const providerIds = [
+          entry.provider.id,
+          ...(entry.provider.aliases ?? []),
+          ...(entry.provider.hookAliases ?? []),
+        ];
+        return providerIds.some(
+          (candidate) => normalizeProviderId(candidate) === normalizedProvider,
+        );
+      })
+      .map((entry) => entry.pluginId),
+  ).toSorted((left, right) => left.localeCompare(right));
   return pluginIds.length > 0 ? pluginIds : undefined;
 }
 

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -43,6 +43,7 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
   includeUntrustedWorkspacePlugins?: boolean;
+  requireCompleteDiscoveryEntryCoverage?: boolean;
 }): ProviderPlugin[] {
   const pluginIds = resolveDiscoveredProviderPluginIds(params);
   const pluginIdSet = new Set(pluginIds);
@@ -52,7 +53,7 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   if (records.length === 0) {
     return [];
   }
-  if (records.length < pluginIdSet.size) {
+  if (params.requireCompleteDiscoveryEntryCoverage && records.length < pluginIdSet.size) {
     return [];
   }
   const loadSource = createPluginSourceLoader();
@@ -80,6 +81,7 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
   includeUntrustedWorkspacePlugins?: boolean;
+  requireCompleteDiscoveryEntryCoverage?: boolean;
 }): ProviderPlugin[] {
   const entryProviders = resolveProviderDiscoveryEntryPlugins(params);
   if (entryProviders.length > 0) {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -42,6 +42,7 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
+  includeUntrustedWorkspacePlugins?: boolean;
 }): ProviderPlugin[] {
   const pluginIds = resolveDiscoveredProviderPluginIds(params);
   const pluginIdSet = new Set(pluginIds);
@@ -75,6 +76,7 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
+  includeUntrustedWorkspacePlugins?: boolean;
 }): ProviderPlugin[] {
   const entryProviders = resolveProviderDiscoveryEntryPlugins(params);
   if (entryProviders.length > 0) {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -52,6 +52,9 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   if (records.length === 0) {
     return [];
   }
+  if (records.length < pluginIdSet.size) {
+    return [];
+  }
   const loadSource = createPluginSourceLoader();
   const providers: ProviderPlugin[] = [];
   for (const manifest of records) {

--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -4,6 +4,7 @@ import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
   runProviderCatalog,
+  runProviderStaticCatalog,
 } from "./provider-discovery.js";
 import type { ProviderCatalogResult, ProviderDiscoveryOrder, ProviderPlugin } from "./types.js";
 
@@ -84,13 +85,20 @@ function expectNormalizedDiscoveryResult(params: {
   result: Parameters<typeof normalizePluginDiscoveryResult>[0]["result"];
   expected: Record<string, unknown>;
 }) {
-  expect(
-    normalizePluginDiscoveryResult({
-      provider: params.provider,
-      result: params.result,
-    }),
-  ).toEqual(params.expected);
+  const normalized = normalizePluginDiscoveryResult({
+    provider: params.provider,
+    result: params.result,
+  });
+  expect(Object.getPrototypeOf(normalized)).toBe(null);
+  expect(Object.fromEntries(Object.entries(normalized))).toEqual(params.expected);
 }
+
+type NormalizePluginDiscoveryResultCase = {
+  name: string;
+  provider: ProviderPlugin;
+  result: Parameters<typeof normalizePluginDiscoveryResult>[0]["result"];
+  expected: Record<string, unknown>;
+};
 
 async function expectProviderCatalogResult(params: {
   provider: ProviderPlugin;
@@ -140,7 +148,7 @@ describe("groupPluginDiscoveryProvidersByOrder", () => {
 });
 
 describe("normalizePluginDiscoveryResult", () => {
-  it.each([
+  const cases: NormalizePluginDiscoveryResultCase[] = [
     {
       name: "maps a single provider result to the plugin id",
       provider: makeProvider({ id: "Ollama" }),
@@ -205,8 +213,98 @@ describe("normalizePluginDiscoveryResult", () => {
         },
       },
     },
-  ] as const)("$name", ({ provider, result, expected }) => {
+    {
+      name: "drops dangerous normalized provider keys",
+      provider: makeProvider({ id: "__proto__", aliases: ["constructor"], hookAliases: ["safe"] }),
+      result: {
+        provider: makeModelProviderConfig({
+          baseUrl: "http://safe.example/v1",
+        }),
+      },
+      expected: {
+        safe: {
+          baseUrl: "http://safe.example/v1",
+          models: [],
+        },
+      },
+    },
+    {
+      name: "drops dangerous multi-provider discovery keys",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: {
+          ["__proto__"]: makeModelProviderConfig({ baseUrl: "http://polluted.example/v1" }),
+          constructor: makeModelProviderConfig({ baseUrl: "http://constructor.example/v1" }),
+          prototype: makeModelProviderConfig({ baseUrl: "http://prototype.example/v1" }),
+          safe: makeModelProviderConfig({ baseUrl: "http://safe.example/v1" }),
+        },
+      },
+      expected: {
+        safe: {
+          baseUrl: "http://safe.example/v1",
+          models: [],
+        },
+      },
+    },
+  ];
+
+  it.each(cases)("$name", ({ provider, result, expected }) => {
     expectNormalizedDiscoveryResult({ provider, result, expected });
+  });
+});
+
+describe("runProviderStaticCatalog", () => {
+  it("runs static catalogs with a sterile context", async () => {
+    const seenContexts: unknown[] = [];
+    const provider: ProviderPlugin = {
+      id: "demo",
+      label: "Demo",
+      auth: [],
+      staticCatalog: {
+        run: async (ctx) => {
+          seenContexts.push(ctx);
+          return {
+            provider: makeModelProviderConfig({ baseUrl: "https://static.example/v1" }),
+          };
+        },
+      },
+    };
+
+    await expect(
+      runProviderStaticCatalog({
+        provider,
+        config: {
+          models: {
+            providers: {
+              demo: {
+                baseUrl: "https://configured.example/v1",
+                models: [],
+                apiKey: "secret-value",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/agent",
+        workspaceDir: "/tmp/workspace",
+        env: {
+          SECRET_TOKEN: "secret-value",
+        },
+      }),
+    ).resolves.toEqual({
+      provider: {
+        baseUrl: "https://static.example/v1",
+        models: [],
+      },
+    });
+
+    expect(seenContexts).toEqual([
+      expect.objectContaining({
+        config: {},
+        env: {},
+      }),
+    ]);
+    expect(seenContexts[0]).not.toHaveProperty("agentDir");
+    expect(seenContexts[0]).not.toHaveProperty("workspaceDir");
   });
 });
 

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -24,6 +24,7 @@ export async function resolvePluginDiscoveryProviders(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
+  includeUntrustedWorkspacePlugins?: boolean;
 }): Promise<ProviderPlugin[]> {
   return (await loadProviderRuntime())
     .resolvePluginDiscoveryProvidersRuntime(params)

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -15,6 +15,10 @@ function resolveProviderCatalogHook(provider: ProviderPlugin) {
   return provider.catalog ?? provider.discovery;
 }
 
+function resolveProviderCatalogOrderHook(provider: ProviderPlugin) {
+  return resolveProviderCatalogHook(provider) ?? provider.staticCatalog;
+}
+
 export async function resolvePluginDiscoveryProviders(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -23,7 +27,7 @@ export async function resolvePluginDiscoveryProviders(params: {
 }): Promise<ProviderPlugin[]> {
   return (await loadProviderRuntime())
     .resolvePluginDiscoveryProvidersRuntime(params)
-    .filter((provider) => resolveProviderCatalogHook(provider));
+    .filter((provider) => resolveProviderCatalogOrderHook(provider));
 }
 
 export function groupPluginDiscoveryProvidersByOrder(
@@ -37,7 +41,7 @@ export function groupPluginDiscoveryProvidersByOrder(
   } as Record<ProviderDiscoveryOrder, ProviderPlugin[]>;
 
   for (const provider of providers) {
-    const order = resolveProviderCatalogHook(provider)?.order ?? "late";
+    const order = resolveProviderCatalogOrderHook(provider)?.order ?? "late";
     grouped[order].push(provider);
   }
 
@@ -116,5 +120,28 @@ export function runProviderCatalog(params: {
     env: params.env,
     resolveProviderApiKey: params.resolveProviderApiKey,
     resolveProviderAuth: params.resolveProviderAuth,
+  });
+}
+
+export function runProviderStaticCatalog(params: {
+  provider: ProviderPlugin;
+  config: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}) {
+  return params.provider.staticCatalog?.run({
+    config: params.config,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    resolveProviderApiKey: () => ({
+      apiKey: undefined,
+    }),
+    resolveProviderAuth: () => ({
+      apiKey: undefined,
+      mode: "none",
+      source: "none",
+    }),
   });
 }

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -34,6 +34,7 @@ export async function resolvePluginDiscoveryProviders(params: {
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
   includeUntrustedWorkspacePlugins?: boolean;
+  requireCompleteDiscoveryEntryCoverage?: boolean;
 }): Promise<ProviderPlugin[]> {
   return (await loadProviderRuntime())
     .resolvePluginDiscoveryProvidersRuntime(params)

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderDiscoveryOrder, ProviderPlugin } from "./types.js";
 
 const DISCOVERY_ORDER: readonly ProviderDiscoveryOrder[] = ["simple", "profile", "paired", "late"];
+const DANGEROUS_PROVIDER_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 let providerRuntimePromise: Promise<typeof import("./provider-discovery.runtime.js")> | undefined;
 
 function loadProviderRuntime() {
@@ -17,6 +18,14 @@ function resolveProviderCatalogHook(provider: ProviderPlugin) {
 
 function resolveProviderCatalogOrderHook(provider: ProviderPlugin) {
   return resolveProviderCatalogHook(provider) ?? provider.staticCatalog;
+}
+
+function createProviderConfigRecord(): Record<string, ModelProviderConfig> {
+  return Object.create(null) as Record<string, ModelProviderConfig>;
+}
+
+function isSafeProviderConfigKey(value: string): boolean {
+  return value !== "" && !DANGEROUS_PROVIDER_KEYS.has(value);
 }
 
 export async function resolvePluginDiscoveryProviders(params: {
@@ -67,14 +76,14 @@ export function normalizePluginDiscoveryResult(params: {
   }
 
   if ("provider" in result) {
-    const normalized: Record<string, ModelProviderConfig> = {};
+    const normalized = createProviderConfigRecord();
     for (const providerId of [
       params.provider.id,
       ...(params.provider.aliases ?? []),
       ...(params.provider.hookAliases ?? []),
     ]) {
       const normalizedKey = normalizeProviderId(providerId);
-      if (!normalizedKey) {
+      if (!isSafeProviderConfigKey(normalizedKey)) {
         continue;
       }
       normalized[normalizedKey] = result.provider;
@@ -82,10 +91,10 @@ export function normalizePluginDiscoveryResult(params: {
     return normalized;
   }
 
-  const normalized: Record<string, ModelProviderConfig> = {};
+  const normalized = createProviderConfigRecord();
   for (const [key, value] of Object.entries(result.providers)) {
     const normalizedKey = normalizeProviderId(key);
-    if (!normalizedKey || !value) {
+    if (!isSafeProviderConfigKey(normalizedKey) || !value) {
       continue;
     }
     normalized[normalizedKey] = value;
@@ -132,10 +141,8 @@ export function runProviderStaticCatalog(params: {
   env: NodeJS.ProcessEnv;
 }) {
   return params.provider.staticCatalog?.run({
-    config: params.config,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
+    config: {},
+    env: {},
     resolveProviderApiKey: () => ({
       apiKey: undefined,
     }),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1084,6 +1084,14 @@ export type ProviderPlugin = {
    */
   catalog?: ProviderPluginCatalog;
   /**
+   * Offline provider catalog for display-only surfaces.
+   *
+   * Unlike `catalog`, this hook must not perform network I/O or require real
+   * credentials. Use it for bundled/static rows that can be shown before auth is
+   * configured.
+   */
+  staticCatalog?: ProviderPluginCatalog;
+  /**
    * Legacy alias for catalog.
    * Kept for compatibility with existing provider plugins.
    */


### PR DESCRIPTION
## Summary

`models list --all` now includes bundled provider-owned static catalog rows even before provider auth is configured. This keeps provider discovery consistent across setup and listing flows: if OpenClaw has a safe offline catalog for a provider, the full catalog view can show those models and mark them unavailable until credentials are added.

This PR uses an explicit provider `staticCatalog` contract for that display-only path instead of running normal live provider catalog hooks with synthetic auth. That lets `models list --all` show known bundled rows without triggering provider network discovery or auth-required catalog code.

This also adds confirmed Kimi K2.6 catalog rows for aggregator providers:

- `openrouter/moonshotai/kimi-k2.6`
- `vercel-ai-gateway/moonshotai/kimi-k2.6`

## Static catalog safety

- Adds `ProviderPlugin.staticCatalog` and `defineSingleProviderPluginEntry` support via `buildStaticProvider` / `staticRun`.
- `models list --all` provider supplements call only `runProviderStaticCatalog`, not the live `catalog` / `discovery` hook.
- Static catalog execution gets a sterile context with no credentials, config, agent directory, workspace directory, or environment values.
- Unknown `--provider` filters return before provider discovery.
- Local-only listing skips provider static catalog supplements.
- Display-only provider discovery is scoped to bundled provider plugins and passes `includeUntrustedWorkspacePlugins: false`.
- Provider hook aliases, such as `azure-openai-responses`, resolve before the unknown-provider short-circuit.
- Mixed provider-discovery scopes fall back to full provider loading when some bundled providers do not define a discovery entry, so unfiltered `models list --all` includes static rows from Moonshot, OpenRouter, Chutes, and other non-entry providers.
- Human `models list` output sanitizes provider/model/tag text before terminal rendering; JSON output keeps raw values.
- Vercel AI Gateway Kimi K2.6 context/max tokens now match the exact Moonshot/OpenRouter `262_144` value.

## Before

`openclaw models list --all --provider moonshot` could return no rows even though Moonshot appeared in provider configuration.
<img width="784" height="120" alt="image" src="https://github.com/user-attachments/assets/5ec298cb-f534-41ad-814f-d6745c7ebb41" />

## After

`openclaw models list --all --provider moonshot` shows the bundled Moonshot Kimi catalog, including `moonshot/kimi-k2.6`, with auth shown as unavailable when no Moonshot credentials are configured.
<img width="1130" height="195" alt="image" src="https://github.com/user-attachments/assets/315aced1-62da-4c63-9551-814c806300b5" />

## Verification

- `pnpm format -- src/commands/models/list.table.ts src/plugins/provider-discovery.runtime.ts`
- `pnpm format:check -- src/commands/models/list.table.ts src/plugins/provider-discovery.runtime.ts`
- `pnpm openclaw models list --all --local --plain` returns `No models found.`
- `pnpm openclaw models list --all --provider unknown-provider-for-catalog-test --plain` returns `No models found.`
- `pnpm openclaw models list --all --provider azure-openai-responses --plain` returns alias-owned OpenAI rows.
- `pnpm openclaw models list --all --plain | rg '^(moonshot/kimi-k2\.6|openrouter/moonshotai/kimi-k2\.6|vercel-ai-gateway/moonshotai/kimi-k2\.6)$'`
- `pnpm check:changed`
