### PR TITLE
fix: parse Ollama tool_call arguments

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -105,6 +105,47 @@ describe("buildAssistantMessage", () => {
       arguments: { command: "ls", path: "/tmp" },
     });
   });
+
+  it("preserves unsafe integers when parsing string tool call arguments", () => {
+    const response = makeOllamaResponse({
+      tool_calls: [
+        {
+          function: {
+            name: "send",
+            arguments: '{"target":9223372036854775807,"nested":{"thread":1234567890123456789}}',
+          },
+        },
+      ],
+    });
+    const msg = buildAssistantMessage(response, MODEL_INFO);
+    expect(msg.content[0]).toMatchObject({
+      type: "toolCall",
+      name: "send",
+      arguments: {
+        target: "9223372036854775807",
+        nested: { thread: "1234567890123456789" },
+      },
+    });
+  });
+
+  it("falls back to an empty object for malformed string tool arguments", () => {
+    const response = makeOllamaResponse({
+      tool_calls: [
+        {
+          function: {
+            name: "exec",
+            arguments: '{"command":"ls"',
+          },
+        },
+      ],
+    });
+    const msg = buildAssistantMessage(response, MODEL_INFO);
+    expect(msg.content[0]).toMatchObject({
+      type: "toolCall",
+      name: "exec",
+      arguments: {},
+    });
+  });
 });
 
 describe("createOllamaStreamFn thinking events", () => {

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -14,7 +14,7 @@ function makeOllamaResponse(params: {
   content?: string;
   thinking?: string;
   reasoning?: string;
-  tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> } }>;
+  tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> | string } }>;
 }) {
   return {
     model: "qwen3.5",
@@ -84,6 +84,26 @@ describe("buildAssistantMessage", () => {
     const msg = buildAssistantMessage(response, MODEL_INFO);
     expect(msg.content).toHaveLength(1);
     expect(msg.content[0]).toEqual({ type: "text", text: "Just text" });
+  });
+
+  it("parses tool call arguments when Ollama returns a JSON string", () => {
+    const response = makeOllamaResponse({
+      tool_calls: [
+        {
+          function: {
+            name: "exec",
+            arguments: '{"command":"ls","path":"/tmp"}',
+          },
+        },
+      ],
+    });
+    const msg = buildAssistantMessage(response, MODEL_INFO);
+    expect(msg.content).toHaveLength(1);
+    expect(msg.content[0]).toMatchObject({
+      type: "toolCall",
+      name: "exec",
+      arguments: { command: "ls", path: "/tmp" },
+    });
   });
 });
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -336,8 +336,21 @@ interface OllamaTool {
 interface OllamaToolCall {
   function: {
     name: string;
-    arguments: Record<string, unknown>;
+    arguments: Record<string, unknown> | string;
   };
+}
+
+function parseOllamaToolCallArguments(
+  argumentsValue: Record<string, unknown> | string,
+): Record<string, unknown> {
+  if (typeof argumentsValue !== "string") {
+    return argumentsValue;
+  }
+  const parsed = JSON.parse(argumentsValue) as unknown;
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  throw new Error("Ollama tool call arguments must deserialize to an object");
 }
 
 interface OllamaChatResponse {
@@ -540,7 +553,7 @@ export function buildAssistantMessage(
         type: "toolCall",
         id: `ollama_call_${randomUUID()}`,
         name: toolCall.function.name,
-        arguments: toolCall.function.arguments,
+        arguments: parseOllamaToolCallArguments(toolCall.function.arguments),
       });
     }
   }

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -346,11 +346,7 @@ function parseOllamaToolCallArguments(
   if (typeof argumentsValue !== "string") {
     return argumentsValue;
   }
-  const parsed = JSON.parse(argumentsValue) as unknown;
-  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-    return parsed as Record<string, unknown>;
-  }
-  throw new Error("Ollama tool call arguments must deserialize to an object");
+  return parseJsonObjectPreservingUnsafeIntegers(argumentsValue) ?? {};
 }
 
 interface OllamaChatResponse {


### PR DESCRIPTION
## Summary
- parse Ollama tool call arguments when the provider returns them as a JSON string
- preserve the existing pass-through behavior when arguments are already objects
- add a regression test covering stringified tool call arguments

## Testing
- pnpm vitest run extensions/ollama/src/stream.test.ts