### PR TITLE
fix(mattermost): suppress reasoning-only replies [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mattermost: suppress reasoning-only payloads even when they arrive as blockquoted `> Reasoning:` text, preventing `/reasoning on` from leaking thinking into channel posts. (#69927) Thanks @lawrence3699.
 - Browser/Chrome MCP: reset cached existing-session control sessions when a `navigate_page` call times out, so one stuck navigation no longer poisons the browser profile until a gateway restart. (#69733) Thanks @ayeshakhalid192007-dev.
 - Browser/Chrome MCP: propagate click timeouts and abort signals to existing-session actions so a stuck click fails fast and reconnects instead of poisoning the browser tool until gateway restart. (#63524) Thanks @dongseok0.
 - OpenCode Go: canonicalize stale bundled `opencode-go` base URLs from `/go` or `/go/v1` to `/zen/go` or `/zen/go/v1`, so older generated model metadata stops hitting the 404 HTML endpoint. (#69898)

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d7f6e6ecdfb78c73760689af5a684c20ec7ca28509d4f63bf0d990a2d739c6ce  plugin-sdk-api-baseline.json
-584681e4436a4e84c2ff20196ff194a63915caf4dda70de9c27f34ab0d7bde0b  plugin-sdk-api-baseline.jsonl
+8ac8add8354dc1af76b9aa6f15f7fdcc5265b0bdaf72ea7fc1d3d11bc9f74b8c  plugin-sdk-api-baseline.json
+83310e1d3ea75e9216300ed36e61fdfcfdb6bba7d5c0df62cbfe03ec93565b73  plugin-sdk-api-baseline.jsonl

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -257,7 +257,7 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     const deliverFinal = vi.fn(async () => {});
 
     await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "  \n Reasoning:\n_hidden_" } as never,
+      payload: { text: "  \n > Reasoning:\n> _hidden_" } as never,
       info: { kind: "final" },
       client: createMattermostClientMock(),
       draftStream,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -252,6 +252,29 @@ describe("shouldClearMattermostDraftPreview", () => {
 });
 
 describe("deliverMattermostReplyWithDraftPreview", () => {
+  it("suppresses reasoning-prefixed finals before preview finalization", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "  \n Reasoning:\n_hidden_" } as never,
+      info: { kind: "final" },
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverFinal,
+    });
+
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+  });
+
   it("deletes the preview after a successful normal final send", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -55,7 +55,10 @@ import {
   type MattermostWebSocketFactory,
 } from "./monitor-websocket.js";
 import { runWithReconnect } from "./reconnect.js";
-import { deliverMattermostReplyPayload } from "./reply-delivery.js";
+import {
+  deliverMattermostReplyPayload,
+  shouldSuppressMattermostReasoningReply,
+} from "./reply-delivery.js";
 import type {
   ChannelAccountSnapshot,
   ChatType,
@@ -289,7 +292,7 @@ type MattermostDraftPreviewDeliverParams = {
 export async function deliverMattermostReplyWithDraftPreview(
   params: MattermostDraftPreviewDeliverParams,
 ): Promise<void> {
-  if (params.payload.isReasoning) {
+  if (shouldSuppressMattermostReasoningReply(params.payload)) {
     return;
   }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1,5 +1,6 @@
 import { deliverFinalizableDraftPreview } from "openclaw/plugin-sdk/channel-lifecycle";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
+import { isReasoningReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -55,10 +56,7 @@ import {
   type MattermostWebSocketFactory,
 } from "./monitor-websocket.js";
 import { runWithReconnect } from "./reconnect.js";
-import {
-  deliverMattermostReplyPayload,
-  shouldSuppressMattermostReasoningReply,
-} from "./reply-delivery.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type {
   ChannelAccountSnapshot,
   ChatType,
@@ -292,7 +290,7 @@ type MattermostDraftPreviewDeliverParams = {
 export async function deliverMattermostReplyWithDraftPreview(
   params: MattermostDraftPreviewDeliverParams,
 ): Promise<void> {
-  if (shouldSuppressMattermostReasoningReply(params.payload)) {
+  if (isReasoningReplyPayload(params.payload)) {
     return;
   }
 

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -80,6 +80,27 @@ describe("deliverMattermostReplyPayload", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("suppresses reasoning payloads formatted as a Mattermost blockquote", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "> Reasoning:\n> _hidden_" },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not suppress messages that mention Reasoning: mid-text", async () => {
     const sendMessage = vi.fn(async () => undefined);
     const cfg = {} satisfies OpenClawConfig;

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -38,6 +38,78 @@ function createReplyDeliveryCore(): DeliverMattermostReplyPayloadParams["core"] 
 }
 
 describe("deliverMattermostReplyPayload", () => {
+  it("suppresses payloads flagged as reasoning", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "Reasoning:\n_hidden_", isReasoning: true },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("suppresses reasoning-prefixed payloads even without an explicit flag", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "  \n Reasoning:\n_hidden_" },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress messages that mention Reasoning: mid-text", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+
+    await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "Intro line\nReasoning: appears in content but is not a prefix" },
+      to: "channel:town-square",
+      accountId: "default",
+      agentId: "agent-1",
+      replyToId: "root-post",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "channel:town-square",
+      "Intro line\nReasoning: appears in content but is not a prefix",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+        replyToId: "root-post",
+      }),
+    );
+  });
+
   it("passes agent-scoped mediaLocalRoots when sending media paths", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mm-state-"));

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -1,8 +1,8 @@
 import {
   deliverTextOrMediaReply,
+  isReasoningReplyPayload,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
   getAgentScopedMediaLocalRoots,
   type OpenClawConfig,
@@ -24,19 +24,6 @@ type SendMattermostMessage = (
   },
 ) => Promise<unknown>;
 
-const REASONING_PREFIX = "reasoning:";
-
-export function shouldSuppressMattermostReasoningReply(payload: ReplyPayload): boolean {
-  if (payload.isReasoning === true) {
-    return true;
-  }
-  const text = payload.text;
-  if (typeof text !== "string") {
-    return false;
-  }
-  return normalizeLowercaseStringOrEmpty(text.trimStart()).startsWith(REASONING_PREFIX);
-}
-
 export async function deliverMattermostReplyPayload(params: {
   core: PluginRuntime;
   cfg: OpenClawConfig;
@@ -49,7 +36,7 @@ export async function deliverMattermostReplyPayload(params: {
   tableMode: MarkdownTableMode;
   sendMessage: SendMattermostMessage;
 }): Promise<void> {
-  if (shouldSuppressMattermostReasoningReply(params.payload)) {
+  if (isReasoningReplyPayload(params.payload)) {
     return;
   }
   const reply = resolveSendableOutboundReplyParts(params.payload, {

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -2,6 +2,7 @@ import {
   deliverTextOrMediaReply,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
   getAgentScopedMediaLocalRoots,
   type OpenClawConfig,
@@ -23,6 +24,19 @@ type SendMattermostMessage = (
   },
 ) => Promise<unknown>;
 
+const REASONING_PREFIX = "reasoning:";
+
+function shouldSuppressReasoningReply(payload: ReplyPayload): boolean {
+  if (payload.isReasoning === true) {
+    return true;
+  }
+  const text = payload.text;
+  if (typeof text !== "string") {
+    return false;
+  }
+  return normalizeLowercaseStringOrEmpty(text.trimStart()).startsWith(REASONING_PREFIX);
+}
+
 export async function deliverMattermostReplyPayload(params: {
   core: PluginRuntime;
   cfg: OpenClawConfig;
@@ -35,6 +49,9 @@ export async function deliverMattermostReplyPayload(params: {
   tableMode: MarkdownTableMode;
   sendMessage: SendMattermostMessage;
 }): Promise<void> {
+  if (shouldSuppressReasoningReply(params.payload)) {
+    return;
+  }
   const reply = resolveSendableOutboundReplyParts(params.payload, {
     text: params.core.channel.text.convertMarkdownTables(
       params.payload.text ?? "",

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -26,7 +26,7 @@ type SendMattermostMessage = (
 
 const REASONING_PREFIX = "reasoning:";
 
-function shouldSuppressReasoningReply(payload: ReplyPayload): boolean {
+export function shouldSuppressMattermostReasoningReply(payload: ReplyPayload): boolean {
   if (payload.isReasoning === true) {
     return true;
   }
@@ -49,7 +49,7 @@ export async function deliverMattermostReplyPayload(params: {
   tableMode: MarkdownTableMode;
   sendMessage: SendMattermostMessage;
 }): Promise<void> {
-  if (shouldSuppressReasoningReply(params.payload)) {
+  if (shouldSuppressMattermostReasoningReply(params.payload)) {
     return;
   }
   const reply = resolveSendableOutboundReplyParts(params.payload, {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -101,6 +101,10 @@ describe("deliverWebReply", () => {
     await expectReplySuppressed({ text: "   \n Reasoning:\n_hidden_" });
   });
 
+  it("suppresses payloads that start with a quoted reasoning prefix", async () => {
+    await expectReplySuppressed({ text: " > Reasoning:\n> _hidden_" });
+  });
+
   it("does not suppress messages that mention Reasoning: mid-text", async () => {
     const msg = makeMsg();
 

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -2,11 +2,11 @@ import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-chunking";
 import {
+  isReasoningReplyPayload,
   resolveOutboundMediaUrls,
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { loadWebMedia } from "../media.js";
 import { newConnectionId } from "../reconnect.js";
 import { formatError } from "../session.js";
@@ -15,19 +15,6 @@ import { markdownToWhatsApp } from "../text-runtime.js";
 import { whatsappOutboundLog } from "./loggers.js";
 import type { WebInboundMsg } from "./types.js";
 import { elide } from "./util.js";
-
-const REASONING_PREFIX = "reasoning:";
-
-function shouldSuppressReasoningReply(payload: ReplyPayload): boolean {
-  if (payload.isReasoning === true) {
-    return true;
-  }
-  const text = payload.text;
-  if (typeof text !== "string") {
-    return false;
-  }
-  return normalizeLowercaseStringOrEmpty(text.trimStart()).startsWith(REASONING_PREFIX);
-}
 
 export async function deliverWebReply(params: {
   replyResult: ReplyPayload;
@@ -46,7 +33,7 @@ export async function deliverWebReply(params: {
 }) {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
   const replyStarted = Date.now();
-  if (shouldSuppressReasoningReply(replyResult)) {
+  if (isReasoningReplyPayload(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
     return;
   }

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -6,6 +6,7 @@ import {
   hasOutboundMedia,
   hasOutboundReplyContent,
   hasOutboundText,
+  isReasoningReplyPayload,
   isNumericTargetId,
   resolveOutboundMediaUrls,
   resolveSendableOutboundReplyParts,
@@ -13,6 +14,22 @@ import {
   sendMediaWithLeadingCaption,
   sendPayloadWithChunkedTextAndMedia,
 } from "./reply-payload.js";
+
+describe("isReasoningReplyPayload", () => {
+  it.each([
+    { name: "flagged", payload: { text: "Visible", isReasoning: true }, expected: true },
+    { name: "prefix", payload: { text: "  \n Reasoning:\n_hidden_" }, expected: true },
+    { name: "blockquote", payload: { text: "> Reasoning:\n> _hidden_" }, expected: true },
+    {
+      name: "mid-message mention",
+      payload: { text: "Intro\nReasoning: visible discussion" },
+      expected: false,
+    },
+    { name: "missing text", payload: {}, expected: false },
+  ])("$name", ({ payload, expected }) => {
+    expect(isReasoningReplyPayload(payload)).toBe(expected);
+  });
+});
 
 describe("sendPayloadWithChunkedTextAndMedia", () => {
   it("returns empty result when payload has no text and no media", async () => {

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -1,5 +1,5 @@
 import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
-import { readStringValue } from "../shared/string-coerce.js";
+import { normalizeLowercaseStringOrEmpty, readStringValue } from "../shared/string-coerce.js";
 
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
@@ -10,6 +10,11 @@ export type OutboundReplyPayload = {
   mediaUrls?: string[];
   mediaUrl?: string;
   replyToId?: string;
+};
+
+export type ReasoningReplyPayload = {
+  text?: string;
+  isReasoning?: boolean;
 };
 
 export type SendableOutboundReplyParts = {
@@ -28,6 +33,33 @@ type SendPayloadAdapter = Pick<
   ChannelOutboundAdapter,
   "sendMedia" | "sendText" | "chunker" | "textChunkLimit"
 >;
+
+const REASONING_PREFIX = "reasoning:";
+
+function trimLeadingMarkdownQuoteMarkers(text: string): string {
+  let candidate = text.trimStart();
+  while (candidate.startsWith(">")) {
+    candidate = candidate.replace(/^(?:>[ \t]?)+/, "").trimStart();
+  }
+  return candidate;
+}
+
+export function isReasoningReplyPayload(payload: ReasoningReplyPayload): boolean {
+  if (payload.isReasoning === true) {
+    return true;
+  }
+  const text = payload.text;
+  if (typeof text !== "string") {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(text.trimStart());
+  if (normalized.startsWith(REASONING_PREFIX)) {
+    return true;
+  }
+  return normalizeLowercaseStringOrEmpty(trimLeadingMarkdownQuoteMarkers(text)).startsWith(
+    REASONING_PREFIX,
+  );
+}
 
 /** Extract the supported outbound reply fields from loose tool or agent payload objects. */
 export function normalizeOutboundReplyPayload(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost delivers reasoning-only payloads as visible replies, and the draft-preview finalizer can also surface `Reasoning:`-prefixed text.
- Why it matters: hidden reasoning leaks into user-facing channel posts when reasoning is enabled.
- What changed: suppress reasoning-only payloads in the Mattermost reply-delivery and draft-preview finalization paths, with regression tests for both seams.
- What did NOT change (scope boundary): no changes to reasoning generation, non-Mattermost channels, or reply chunking behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69830
- Related #24991
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Mattermost uses channel-specific delivery and draft-preview helpers that did not suppress reasoning-only payloads before send/edit, unlike the generic dispatch path fixed earlier.
- Missing detection / guardrail: Mattermost had no regression tests covering reasoning-only payload delivery or preview finalization.
- Contributing context (if known): #24991 fixed the generic path, but Mattermost kept its own delivery seams.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/mattermost/src/mattermost/reply-delivery.test.ts`
  - `extensions/mattermost/src/mattermost/monitor.test.ts`
- Scenario the test should lock in: reasoning-only payloads, including plain `Reasoning:`-prefixed text, are suppressed before Mattermost sends or preview finalization; ordinary text that merely mentions `Reasoning:` mid-message still delivers.
- Why this is the smallest reliable guardrail: the bug lives in Mattermost-specific delivery helpers, so unit tests hit the exact send/edit seams without requiring a live Mattermost instance.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Mattermost no longer posts reasoning-only replies or finalizes draft previews with hidden reasoning text.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[reasoning payload] -> [Mattermost reply delivery or preview finalizer] -> [user-visible reasoning post]

After:
[reasoning payload] -> [suppression check] -> [no user-visible post]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15.5
- Runtime/container: local source checkout via `corepack pnpm`
- Model/provider: N/A (unit repro)
- Integration/channel (if any): Mattermost
- Relevant config (redacted): N/A (unit fixtures)

### Steps

1. On clean `origin/main`, add focused Mattermost tests for a reasoning-only payload and a `Reasoning:`-prefixed payload.
2. Run `corepack pnpm test extensions/mattermost/src/mattermost/reply-delivery.test.ts`.
3. Observe both tests fail because `sendMessage` is called with the reasoning text.

### Expected

- Reasoning-only payloads are suppressed before Mattermost send/edit paths.

### Actual

- Reasoning-only payloads were delivered to `sendMessage`, and the preview finalizer also lacked the same prefix-based suppression.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Clean-main failing repro for `reply-delivery.test.ts`
  - Passing targeted tests for `reply-delivery.test.ts` and `monitor.test.ts`
  - Passing Mattermost extension lane after the fix
- Edge cases checked:
  - explicit `isReasoning` payloads
  - plain `Reasoning:` prefix without `isReasoning`
  - visible content that mentions `Reasoning:` mid-text
  - draft-preview finalization path
- What you did **not** verify:
  - live Mattermost instance delivery against a real server

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-suppressing legitimate Mattermost messages that start with `Reasoning:`.
  - Mitigation: added a regression test that content mentioning `Reasoning:` mid-message still delivers, and the suppression check is limited to reasoning-only prefix patterns already used on other channel surfaces.
