### PR TITLE
fix(cli): forward lazy subcommand --help to the real command

### DIFF
--- a/src/cli/program/register-lazy-command.ts
+++ b/src/cli/program/register-lazy-command.ts
@@ -20,6 +20,9 @@ export function registerLazyCommand({
   const placeholder = program.command(name).description(description);
   placeholder.allowUnknownOption(true);
   placeholder.allowExcessArguments(true);
+  // Let lazy-loaded subcommands receive --help instead of printing the
+  // placeholder's empty help output before the real command is registered.
+  placeholder.helpOption(false);
   placeholder.action(async (...actionArgs) => {
     for (const commandName of new Set(removeNames ?? [name])) {
       removeCommandByName(program, commandName);

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -158,4 +158,34 @@ describe("registerSubCliCommands", () => {
     expect(registerAcpCli).toHaveBeenCalledTimes(1);
     expect(acpAction).toHaveBeenCalledTimes(1);
   });
+
+  it("passes --help through to the real subcommand, not the placeholder", async () => {
+    const program = createRegisteredProgram(
+      ["node", "openclaw", "nodes", "list", "--help"],
+      "openclaw",
+    );
+    program.exitOverride();
+
+    let helpOutput = "";
+    program.configureOutput({
+      writeOut: (str) => {
+        helpOutput += str;
+      },
+      writeErr: (str) => {
+        helpOutput += str;
+      },
+    });
+
+    await program
+      .parseAsync(["node", "openclaw", "nodes", "list", "--help"])
+      .catch((err: Error & { code?: string }) => {
+        if (err.code !== "commander.helpDisplayed") {
+          throw err;
+        }
+      });
+
+    expect(nodesAction).not.toHaveBeenCalled();
+    expect(helpOutput).toMatch(/nodes list/i);
+    expect(helpOutput).not.toMatch(/^Usage: openclaw nodes \[options\]/m);
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-4 bullets:

- Problem: `openclaw <lazy-subcommand> ... --help` could print the placeholder command help instead of the real subcommand help after lazy registration.
- Why it matters: users asking for help on commands like `openclaw nodes list --help` saw incomplete guidance at the exact point they needed command-specific usage.
- What changed: disable the placeholder command's built-in help option so `--help` is forwarded into the lazy reparse path, and add a regression test for `nodes list --help`.
- What did NOT change (scope boundary): no workflow, release, labeler, or other CI/CD changes from #59489 are included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59449
- Related #59489
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the lazy placeholder command kept Commander's default `-h/--help` handling enabled, so Commander printed placeholder help during option parsing before the placeholder action could register and reparse the real subcommand tree.
- Missing detection / guardrail: there was no regression test covering `--help` on a lazily registered nested subcommand.
- Contributing context (if known): the lazy-command path already forwarded unknown args correctly for normal execution, so the bug only showed up for Commander-handled help flags.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/program/register.subclis.test.ts`
- Scenario the test should lock in: `openclaw nodes list --help` should render `nodes list` help, not the placeholder `nodes` help.
- Why this is the smallest reliable guardrail: the regression happens entirely inside the lazy CLI registration/reparse seam, so a focused unit-level CLI program test exercises the exact failing path without involving unrelated runtime setup.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Lazy subcommands such as `openclaw nodes list --help` now show the real subcommand help text instead of placeholder help output.

## Diagram (if applicable)

```text
Before:
[user runs `openclaw nodes list --help`] -> [placeholder command parses `--help`] -> [placeholder help shown]

After:
[user runs `openclaw nodes list --help`] -> [placeholder treats `--help` as passthrough] -> [real subcommand registers] -> [real `nodes list` help shown]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local shell
- Model/provider: N/A
- Integration/channel (if any): CLI
- Relevant config (redacted): `OPENCLAW_LOCAL_CHECK=0` for local changed-scope tooling in a git worktree

### Steps

1. Run `openclaw nodes list --help` on `main` before this change.
2. Observe that Commander prints placeholder `nodes` help before the lazy action can register the real subcommand.
3. Apply this patch and rerun the same command.

### Expected

- `nodes list` help is shown.

### Actual

- Before this patch, placeholder `nodes` help was shown instead.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing after patch:
- `corepack pnpm test src/cli/program/register.subclis.test.ts`
- `corepack pnpm check:changed`

## Human Verification (required)

- Verified scenarios: added and ran the focused regression test for lazy `--help` passthrough; ran `check:changed` for the touched scope.
- Edge cases checked: the test also asserts the placeholder action does not execute and that output does not match `Usage: openclaw nodes [options]`.
- What you did **not** verify: full Node 22 local verification; this workspace only had Node 20 available locally, so final runtime coverage should come from CI.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: help passthrough could affect placeholder-level help handling for lazy commands.
  - Mitigation: top-level `openclaw --help` is unchanged, and the new regression test locks in the intended nested-subcommand behavior.

Supersedes the code path from #59489 with the same CLI fix on a clean branch based on current `main`.
