### PR TITLE
fix(anthropic-transport): skip output_config.effort for github-copilot opus-4.7 (closes #69928)

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -40,6 +40,7 @@ function makeAnthropicTransportModel(
   params: {
     id?: string;
     name?: string;
+    provider?: AnthropicMessagesModel["provider"];
     reasoning?: boolean;
     maxTokens?: number;
     headers?: Record<string, string>;
@@ -51,7 +52,7 @@ function makeAnthropicTransportModel(
       id: params.id ?? "claude-sonnet-4-6",
       name: params.name ?? "Claude Sonnet 4.6",
       api: "anthropic-messages",
-      provider: "anthropic",
+      provider: params.provider ?? "anthropic",
       baseUrl: "https://api.anthropic.com",
       reasoning: params.reasoning ?? true,
       input: ["text"],
@@ -411,6 +412,104 @@ describe("anthropic transport stream", () => {
     expect(latestAnthropicRequest().payload).toMatchObject({
       thinking: { type: "adaptive" },
       output_config: { effort: "xhigh" },
+    });
+  });
+
+  it("skips output_config.effort for github-copilot claude-opus-4.7 with effort=high (regression #69928)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      provider: "github-copilot",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "copilot-token",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload).toMatchObject({ thinking: { type: "adaptive" } });
+    expect(payload.output_config).toBeUndefined();
+  });
+
+  it("skips output_config.effort for github-copilot claude-opus-4.7 with effort=xhigh (regression #69928)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      provider: "github-copilot",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "copilot-token",
+        reasoning: "xhigh",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload).toMatchObject({ thinking: { type: "adaptive" } });
+    expect(payload.output_config).toBeUndefined();
+  });
+
+  it("preserves output_config.effort for anthropic-direct claude-opus-4.7 (regression #69928)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      provider: "anthropic",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "high" },
+    });
+  });
+
+  it("preserves output_config.effort for github-copilot claude-opus-4.6 (regression #69928 scope)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-6",
+      name: "Claude Opus 4.6",
+      provider: "github-copilot",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "copilot-token",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "high" },
     });
   });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -658,7 +658,16 @@ function buildAnthropicParams(
       if (supportsAdaptiveThinking(model.id)) {
         params.thinking = { type: "adaptive" };
         if (options.effort) {
-          params.output_config = { effort: options.effort };
+          // The GitHub Copilot proxy for claude-opus-4.7 only accepts
+          // output_config.effort="medium" and 400s on low/high/xhigh, which
+          // cascades to auth-profile cooldown and fallback collapse. Skip the
+          // emission for the Copilot surface; Anthropic-direct opus-4.7 still
+          // receives the full effort range. See issue #69928.
+          const isCopilotOpus47 =
+            model.provider === "github-copilot" && isClaudeOpus47Model(model.id);
+          if (!isCopilotOpus47) {
+            params.output_config = { effort: options.effort };
+          }
         }
       } else {
         params.thinking = {


### PR DESCRIPTION
## Summary

- **Problem:** `github-copilot/claude-opus-4.7` sessions with `thinkingDefault` other than `medium` 400 on every request (`output_config.effort "high" is not supported by model claude-opus-4.7; supported values: [medium]`), classified as `format`, which cooldowns both Copilot auth profiles and collapses the fallback chain — session unusable until manual `/think medium` or model switch.
- **Why it matters:** Users with default thinking set to `high` / `xhigh` see opus-4.7 sessions silently 400-loop into fallback collapse across both Copilot auth profiles.
- **What changed:** Provider-gate the `output_config.effort` emission in `buildAnthropicParams`: when `model.provider === "github-copilot"` AND `isClaudeOpus47Model(model.id)`, skip the emission. Anthropic-direct opus-4.7 keeps the full effort range; opus-4.6 (both providers) is untouched.
- **What did NOT change (scope boundary):** No changes to `supportsAdaptiveThinking`, `isClaudeOpus47Model`, or any upstream model metadata. The lookup-table refactor (reporter's Option 2) is intentionally out of scope — this PR implements reporter's Option 1(a) minimum viable fix.

Credit to @elliott-dandelion-cult for a fully root-caused report with the exact fix location. cc @steipete (author of regression commit `c73a6d2f68`).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #69928
- Regression from `c73a6d2f68` ("feat: support xhigh for Claude Opus 4.7", v2026.4.20)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** commit `c73a6d2f68` added `isClaudeOpus47Model` to `supportsAdaptiveThinking()` in `src/agents/anthropic-transport-stream.ts`. The adaptive branch in `buildAnthropicParams` then unconditionally set `params.output_config = { effort: options.effort }` regardless of provider. Anthropic-direct opus-4.7 accepts the full effort range; the Copilot proxy for opus-4.7 only accepts `medium`.
- **Missing detection / guardrail:** no regression test in `anthropic-transport-stream.test.ts` asserted provider-specific emission of `output_config` for opus-4.7. The feature commit exercised the Anthropic-direct path only.
- **Contributing context:** the Copilot proxy surfaces 4xx errors as `format` classification, which triggers auth-profile cooldown — so the blast radius is "opus-4.7 unusable across all Copilot profiles", not just "one request fails".

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`.
- Scenario the test should lock in: `output_config` is omitted for `github-copilot/claude-opus-4.7` regardless of effort, preserved for `anthropic/claude-opus-4-7` at all efforts, and preserved for `github-copilot/claude-opus-4-6` (scope guard).
- Why this is the smallest reliable guardrail: the emission site is a single conditional in `buildAnthropicParams`; four matrix cases (two providers × in-scope / out-of-scope model) cover the full decision table.
- Existing test that already covers this (if any): none — feature commit only tested Anthropic-direct path.
- If no new test is added, why not: N/A (4 new cases added).

## User-visible / Behavior Changes

- `github-copilot/claude-opus-4.7` sessions with `thinkingDefault=high|xhigh` no longer 400-loop; requests succeed with adaptive thinking but without `output_config.effort`.
- Anthropic-direct opus-4.7 behavior is unchanged (`output_config.effort` still emitted).
- No config changes.

## Diagram (if applicable)

```text
Before (regression from c73a6d2f68):
  buildAnthropicParams: supportsAdaptiveThinking(opus-4.7) -> true
    -> params.thinking = { type: "adaptive" }
    -> params.output_config = { effort: "high" }   // Copilot rejects

After:
  buildAnthropicParams: supportsAdaptiveThinking(opus-4.7) -> true
    -> params.thinking = { type: "adaptive" }
    -> if (provider === "github-copilot" && isClaudeOpus47Model) skip output_config
    -> else params.output_config = { effort: options.effort }
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same outbound request, one fewer field on Copilot opus-4.7)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.5 (arm64)
- Runtime/container: Node v25.9.0, OpenClaw main
- Model/provider: `github-copilot/claude-opus-4.7`
- Integration/channel: any
- Relevant config: `thinkingDefault: "high"` (or `xhigh`)

### Steps

1. Set `thinkingDefault: "high"` in agents defaults.
2. Send any request to `github-copilot/claude-opus-4.7`.
3. Observe the Copilot proxy 400.

### Expected

- Request succeeds; adaptive thinking honored without `output_config.effort`.

### Actual (before fix)

- `400: output_config.effort "high" is not supported by model claude-opus-4.7; supported values: [medium]` — classified `format` → auth-profile cooldown → fallback collapse.

### Actual (after fix)

- Request succeeds; payload has `thinking.type = "adaptive"`, `output_config` omitted for Copilot opus-4.7.

## Evidence

- [x] Failing test/log before + passing after

**Scoped run:**

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/anthropic-transport-stream.test.ts
→ Test Files: 1 passed (1)
→ Tests: 12 passed (12)
```

Pre-commit hook ran the full `agents` suite: **378 files, 3973 tests passed, 4 skipped**.

**New regression cases:**

- **A:** `github-copilot/claude-opus-4-7` + `reasoning: "high"` → payload has `thinking.type = "adaptive"`, `output_config` is `undefined`.
- **B:** `github-copilot/claude-opus-4-7` + `reasoning: "xhigh"` → same (no xhigh leaks to Copilot).
- **C:** `anthropic/claude-opus-4-7` + `reasoning: "high"` → `output_config.effort = "high"` preserved.
- **D:** `github-copilot/claude-opus-4-6` + `reasoning: "high"` → `output_config.effort = "high"` preserved (scope guard).

## Human Verification (required)

- **Verified scenarios:** ran the full 12-test `anthropic-transport-stream.test.ts` suite locally; all pass. Walked through `buildAnthropicParams` to confirm the new conditional runs inside the existing adaptive branch and doesn't alter the non-adaptive paths.
- **Edge cases checked:** opus-4.6 on Copilot (preserved); opus-4.7 on Anthropic-direct (preserved); xhigh specifically (the originally surfaced effort).
- **What I did NOT verify:** live request to Copilot proxy with the fix applied — the provider-gate decision is a pure-function transformation covered by unit tests, and the outbound transport didn't change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- Anthropic-direct opus-4.7 behavior is identical to pre-PR. Copilot opus-4.7 goes from "broken on high/xhigh" to "works on all efforts but silently capped to medium-equivalent adaptive behavior on Copilot surface".

## Risks and Mitigations

- **Risk:** if the Copilot proxy later adds support for `output_config.effort` values beyond `medium`, this provider-gate would silently suppress them.
  - **Mitigation:** centralised conditional with a descriptive inline comment tying the behavior to issue #69928 — maintainers will see it when revisiting. The lookup-table refactor flagged in the issue as Option 2 would be the structural follow-up.
- **Risk:** the check relies on `model.provider === "github-copilot"` string match.
  - **Mitigation:** matches the established convention used elsewhere in the transport layer.
