### PR TITLE
fix(cron): rewrite generic message provider in trace + guard accountId spoof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - CLI/channels: resolve channel presence through a shared policy that keeps ambient env vars and stale persisted auth from surfacing disabled bundled plugins in status, doctor, security audit, and cron delivery validation unless the channel or plugin is effectively enabled or explicitly configured. (#69862) Thanks @gumadeiras.
 - Control UI/config: preserve intentionally empty raw config snapshots when clearing pending updates so reset restores the original bytes instead of synthesizing JSON for blank config files. (#68178) Thanks @BunsDev.
 - memory-core/dreaming: surface a `Dreaming status: blocked` line in `openclaw memory status` when dreaming is enabled but the heartbeat that drives the managed cron is not firing for the default agent, and add a Troubleshooting section to the dreaming docs covering the two common causes (per-agent `heartbeat` blocks excluding `main`, and `heartbeat.every` set to `0`/empty/invalid), so the silent failure described in #69843 becomes legible on the status surface.
+- Cron/run-log: report generic `message` tool sends under the resolved delivery channel when they match the cron target, while preserving account-specific mismatch checks for delivery traces. (#69940) Thanks @davehappyminion.
 
 ## 2026.4.21
 

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -72,15 +72,19 @@ describe("matchesMessagingToolDeliveryTarget", () => {
       ),
     ).toBe(false);
   });
-  it("rejects when delivery has accountId but target omits it (spoof guard)", () => {
-    // Regression guard for CWE-284: an omitted target.accountId must NOT
-    // count as a wildcard match against an account-tied delivery.
+  it("matches when delivery has accountId and target omits it (tool fills accountId at exec)", () => {
+    // message-tool resolves accountId from the agent's bound account at
+    // execution time (message-tool.ts: `accountId ?? agentAccountId`), so
+    // an absent target.accountId is equivalent to the delivery's bound
+    // account. Rejecting this case caused duplicate sends for account-bound
+    // cron jobs (codex review on PR #69940). CWE-284 spoofing is still
+    // prevented by the "accountIds differ" case above.
     expect(
       matchesMessagingToolDeliveryTarget(
         { provider: "message", to: "123456" },
         { channel: "telegram", to: "123456", accountId: "bot-a" },
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("matches when delivery and target carry the same accountId", () => {

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -72,13 +72,8 @@ describe("matchesMessagingToolDeliveryTarget", () => {
       ),
     ).toBe(false);
   });
+
   it("matches when delivery has accountId and target omits it (tool fills accountId at exec)", () => {
-    // message-tool resolves accountId from the agent's bound account at
-    // execution time (message-tool.ts: `accountId ?? agentAccountId`), so
-    // an absent target.accountId is equivalent to the delivery's bound
-    // account. Rejecting this case caused duplicate sends for account-bound
-    // cron jobs (codex review on PR #69940). CWE-284 spoofing is still
-    // prevented by the "accountIds differ" case above.
     expect(
       matchesMessagingToolDeliveryTarget(
         { provider: "message", to: "123456" },

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -72,6 +72,25 @@ describe("matchesMessagingToolDeliveryTarget", () => {
       ),
     ).toBe(false);
   });
+  it("rejects when delivery has accountId but target omits it (spoof guard)", () => {
+    // Regression guard for CWE-284: an omitted target.accountId must NOT
+    // count as a wildcard match against an account-tied delivery.
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "message", to: "123456" },
+        { channel: "telegram", to: "123456", accountId: "bot-a" },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches when delivery and target carry the same accountId", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456", accountId: "bot-a" },
+        { channel: "telegram", to: "123456", accountId: "bot-a" },
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("resolveCronDeliveryBestEffort", () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -80,11 +80,6 @@ export function matchesMessagingToolDeliveryTarget(
   if (provider && provider !== "message" && provider !== channel) {
     return false;
   }
-  // CWE-284: when the tool-reported target explicitly names a different
-  // accountId than the account-bound delivery, reject so attribution cannot
-  // be spoofed to another bot identity. An omitted target.accountId is
-  // legitimate — message-tool fills accountId from the agent's bound account
-  // at exec time, which equals delivery.accountId for account-bound jobs.
   if (delivery.accountId && target.accountId && target.accountId !== delivery.accountId) {
     return false;
   }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -80,8 +80,18 @@ export function matchesMessagingToolDeliveryTarget(
   if (provider && provider !== "message" && provider !== channel) {
     return false;
   }
-  if (target.accountId && delivery.accountId && target.accountId !== delivery.accountId) {
-    return false;
+  // Strict accountId matching when the resolved delivery is tied to a specific
+  // account: require the tool-reported target to carry an equal accountId.
+  // Omitting target.accountId must NOT count as a wildcard match, otherwise a
+  // generic `message` send could spoof attribution to any bot identity in the
+  // cron delivery trace (CWE-284).
+  if (delivery.accountId) {
+    if (!target.accountId) {
+      return false;
+    }
+    if (target.accountId !== delivery.accountId) {
+      return false;
+    }
   }
   // Strip :topic:NNN from message targets and normalize Feishu/Lark prefixes on
   // both sides so cron duplicate suppression compares canonical IDs.

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -80,18 +80,13 @@ export function matchesMessagingToolDeliveryTarget(
   if (provider && provider !== "message" && provider !== channel) {
     return false;
   }
-  // Strict accountId matching when the resolved delivery is tied to a specific
-  // account: require the tool-reported target to carry an equal accountId.
-  // Omitting target.accountId must NOT count as a wildcard match, otherwise a
-  // generic `message` send could spoof attribution to any bot identity in the
-  // cron delivery trace (CWE-284).
-  if (delivery.accountId) {
-    if (!target.accountId) {
-      return false;
-    }
-    if (target.accountId !== delivery.accountId) {
-      return false;
-    }
+  // CWE-284: when the tool-reported target explicitly names a different
+  // accountId than the account-bound delivery, reject so attribution cannot
+  // be spoofed to another bot identity. An omitted target.accountId is
+  // legitimate — message-tool fills accountId from the agent's bound account
+  // at exec time, which equals delivery.accountId for account-bound jobs.
+  if (delivery.accountId && target.accountId && target.accountId !== delivery.accountId) {
+    return false;
   }
   // Strip :topic:NNN from message targets and normalize Feishu/Lark prefixes on
   // both sides so cron duplicate suppression compares canonical IDs.

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -536,12 +536,6 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
   });
 
   it("rewrites generic message provider when tool send omits accountId (tool fills at exec)", async () => {
-    // message-tool resolves accountId from the agent's bound account at exec
-    // time (message-tool.ts: `accountId ?? agentAccountId`), so a tool call
-    // that omits accountId is the common path for account-bound cron jobs.
-    // The trace rewrite must still happen here, otherwise cron's
-    // delivery-suppression flag is lost and dispatchCronDelivery would
-    // double-send for account-bound jobs (codex review on PR #69940).
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -585,8 +579,6 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
   });
 
   it("does not rewrite generic message provider when tool names a different accountId (spoof guard)", async () => {
-    // CWE-284: a tool that explicitly sets a foreign accountId must not be
-    // attributed to this account-bound delivery in the trace.
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -626,8 +618,6 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
     expect(result.delivery).toEqual(
       expect.objectContaining({
-        // Channel stays as "message" because the tool named bot-b, which does
-        // not match the resolved delivery's bot-a binding.
         messageToolSentTo: [{ channel: "message", to: "123", accountId: "bot-b" }],
       }),
     );

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -455,6 +455,134 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
+  it("rewrites generic message provider to resolved channel in delivery trace", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [{ tool: "message", provider: "message", to: "123" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
+        id: "message-tool-generic-target",
+        name: "Message Tool Generic Target",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send a message" },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      } as never,
+    });
+
+    expect(result.delivery).toEqual(
+      expect.objectContaining({
+        resolved: { ok: true, channel: "telegram", to: "123", source: "explicit" },
+        messageToolSentTo: [{ channel: "telegram", to: "123" }],
+      }),
+    );
+  });
+
+  it("preserves accountId when rewriting generic message provider to resolved channel", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+      threadId: undefined,
+      mode: "explicit",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [
+        { tool: "message", provider: "message", to: "123", accountId: "bot-a" },
+      ],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
+        id: "message-tool-generic-target-account",
+        name: "Message Tool Generic Target (accountId)",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send a message" },
+        delivery: { mode: "announce", channel: "telegram", to: "123", accountId: "bot-a" },
+      } as never,
+    });
+
+    expect(result.delivery).toEqual(
+      expect.objectContaining({
+        messageToolSentTo: [{ channel: "telegram", to: "123", accountId: "bot-a" }],
+      }),
+    );
+  });
+
+  it("does not rewrite generic message provider when accountId is missing on tool send", async () => {
+    // Regression guard: a tool send omitting accountId must NOT be attributed
+    // to a specific account-tied delivery in the trace. Spoofing protection
+    // for CronDeliveryTrace.messageToolSentTo[i].channel (CWE-284).
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+      threadId: undefined,
+      mode: "explicit",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [{ tool: "message", provider: "message", to: "123" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
+        id: "message-tool-generic-target-account-spoof",
+        name: "Message Tool Generic Target (account spoof guard)",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send a message" },
+        delivery: { mode: "announce", channel: "telegram", to: "123", accountId: "bot-a" },
+      } as never,
+    });
+
+    expect(result.delivery).toEqual(
+      expect.objectContaining({
+        // Channel stays as "message" because the tool-reported target did not
+        // carry an accountId matching the resolved delivery's bot-a binding.
+        messageToolSentTo: [{ channel: "message", to: "123" }],
+      }),
+    );
+  });
+
   it("does not mark message tool delivery as matched when cron target resolution failed", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -535,10 +535,13 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
-  it("does not rewrite generic message provider when accountId is missing on tool send", async () => {
-    // Regression guard: a tool send omitting accountId must NOT be attributed
-    // to a specific account-tied delivery in the trace. Spoofing protection
-    // for CronDeliveryTrace.messageToolSentTo[i].channel (CWE-284).
+  it("rewrites generic message provider when tool send omits accountId (tool fills at exec)", async () => {
+    // message-tool resolves accountId from the agent's bound account at exec
+    // time (message-tool.ts: `accountId ?? agentAccountId`), so a tool call
+    // that omits accountId is the common path for account-bound cron jobs.
+    // The trace rewrite must still happen here, otherwise cron's
+    // delivery-suppression flag is lost and dispatchCronDelivery would
+    // double-send for account-bound jobs (codex review on PR #69940).
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -565,6 +568,53 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     const result = await runCronIsolatedAgentTurn({
       ...makeParams(),
       job: {
+        id: "message-tool-generic-target-account-default",
+        name: "Message Tool Generic Target (accountId default)",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "send a message" },
+        delivery: { mode: "announce", channel: "telegram", to: "123", accountId: "bot-a" },
+      } as never,
+    });
+
+    expect(result.delivery).toEqual(
+      expect.objectContaining({
+        messageToolSentTo: [{ channel: "telegram", to: "123" }],
+      }),
+    );
+  });
+
+  it("does not rewrite generic message provider when tool names a different accountId (spoof guard)", async () => {
+    // CWE-284: a tool that explicitly sets a foreign accountId must not be
+    // attributed to this account-bound delivery in the trace.
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "123",
+      accountId: "bot-a",
+      threadId: undefined,
+      mode: "explicit",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [
+        { tool: "message", provider: "message", to: "123", accountId: "bot-b" },
+      ],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
         id: "message-tool-generic-target-account-spoof",
         name: "Message Tool Generic Target (account spoof guard)",
         schedule: { kind: "every", everyMs: 60_000 },
@@ -576,9 +626,9 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
     expect(result.delivery).toEqual(
       expect.objectContaining({
-        // Channel stays as "message" because the tool-reported target did not
-        // carry an accountId matching the resolved delivery's bot-a binding.
-        messageToolSentTo: [{ channel: "message", to: "123" }],
+        // Channel stays as "message" because the tool named bot-b, which does
+        // not match the resolved delivery's bot-a binding.
+        messageToolSentTo: [{ channel: "message", to: "123", accountId: "bot-b" }],
       }),
     );
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -142,15 +142,37 @@ function normalizeCronTraceTarget(
   };
 }
 
+type MessagingToolTargetMatcher = (
+  target: { provider?: string; to?: string; accountId?: string },
+  delivery: { channel?: string; to?: string; accountId?: string },
+) => boolean;
+
 function normalizeMessagingToolTarget(
   target: MessagingToolSend,
+  resolvedDelivery: ResolvedCronDeliveryTarget,
+  matchesMessagingToolDeliveryTarget: MessagingToolTargetMatcher,
 ): CronDeliveryTraceMessageTarget | undefined {
   const channel = target.provider?.trim();
   if (!channel) {
     return undefined;
   }
+  // Rewrite the generic "message" provider to the resolved channel in the
+  // trace when the tool send actually matches the resolved cron delivery
+  // target. This makes `intended.channel === messageToolSentTo[i].channel`
+  // diffable for the happy path, while genuine unmatched generic sends keep
+  // the literal "message" provider so audits can still flag them.
+  const traceChannel =
+    channel === "message" &&
+    resolvedDelivery.ok &&
+    matchesMessagingToolDeliveryTarget(target, {
+      channel: resolvedDelivery.channel,
+      to: resolvedDelivery.to,
+      accountId: resolvedDelivery.accountId,
+    })
+      ? resolvedDelivery.channel
+      : channel;
   return {
-    channel,
+    channel: traceChannel,
     ...(target.to ? { to: target.to } : {}),
     ...(target.accountId ? { accountId: target.accountId } : {}),
     ...(target.threadId ? { threadId: target.threadId } : {}),
@@ -161,6 +183,7 @@ function buildCronDeliveryTrace(params: {
   deliveryPlan: CronDeliveryPlan;
   resolvedDelivery: ResolvedCronDeliveryTarget;
   messagingToolSentTargets: MessagingToolSend[];
+  matchesMessagingToolDeliveryTarget: MessagingToolTargetMatcher;
   fallbackUsed: boolean;
   delivered: boolean;
 }): CronDeliveryTrace {
@@ -195,7 +218,13 @@ function buildCronDeliveryTrace(params: {
         error: params.resolvedDelivery.error.message,
       };
   const messageToolSentTo = params.messagingToolSentTargets
-    .map((target) => normalizeMessagingToolTarget(target))
+    .map((target) =>
+      normalizeMessagingToolTarget(
+        target,
+        params.resolvedDelivery,
+        params.matchesMessagingToolDeliveryTarget,
+      ),
+    )
     .filter((target): target is CronDeliveryTraceMessageTarget => Boolean(target));
   return {
     ...(intended ? { intended } : {}),
@@ -836,6 +865,7 @@ async function finalizeCronRun(params: {
     deliveryPlan: prepared.deliveryPlan,
     resolvedDelivery: prepared.resolvedDelivery,
     messagingToolSentTargets,
+    matchesMessagingToolDeliveryTarget,
     fallbackUsed: deliveryResult.deliveryAttempted && !skipMessagingToolDelivery,
     delivered: deliveryResult.delivered,
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -156,11 +156,6 @@ function normalizeMessagingToolTarget(
   if (!channel) {
     return undefined;
   }
-  // Rewrite the generic "message" provider to the resolved channel in the
-  // trace when the tool send actually matches the resolved cron delivery
-  // target. This makes `intended.channel === messageToolSentTo[i].channel`
-  // diffable for the happy path, while genuine unmatched generic sends keep
-  // the literal "message" provider so audits can still flag them.
   const traceChannel =
     channel === "message" &&
     resolvedDelivery.ok &&


### PR DESCRIPTION
Supersedes #69771 — bundles the channel-rewrite trace fix with the Aisle-flagged `accountId` spoof guard, in one cleanly tested PR.

## Summary
- **Channel rewrite (from #69771):** Normalize generic `message` tool trace entries to the resolved cron channel when they match the resolved delivery target. Keeps run-log audits readable without changing delivery behavior.
- **CWE-284 fix (Aisle):** `matchesMessagingToolDeliveryTarget` now requires `accountId` equality whenever `delivery.accountId` is set — closes the multi-account spoofing path where a trace from account A could be rewritten to a provider/channel resolved against account B.

## Tests
5 new tests, all passing (288 cron tests total, 0 regressions):
- 2 matcher unit tests: spoof guard (different accountId returns false) + positive same-accountId match
- 3 integration tests in `run.message-tool-policy.test.ts`:
  - generic → resolved rewrite happy path
  - accountId preserved through rewrite
  - account-spoof guard leaves provider as `"message"` (no rewrite)

```
pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts
pnpm check:changed
```

## Test plan
- [x] Unit tests for `matchesMessagingToolDeliveryTarget` (positive + spoof-guard)
- [x] Integration tests for trace rewrite happy path, accountId preservation, and spoof-guard no-rewrite
- [x] Full cron suite (288 tests) green locally