### PR TITLE
fix(memory-core): suppress startup "cron service unavailable" warning (closes #69939)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory-core/dreaming: suppress the startup-only managed dreaming cron unavailable warning when the cron service is still attaching, while preserving the runtime warning if cron genuinely remains unavailable. Fixes #69939. (#69941) Thanks @Sanjays2402.
 - Mattermost: suppress reasoning-only payloads even when they arrive as blockquoted `> Reasoning:` text, preventing `/reasoning on` from leaking thinking into channel posts. (#69927) Thanks @lawrence3699.
 - Discord: read `channel.parentId` through a safe accessor in the slash-command, reaction, and model-picker paths so partial `GuildThreadChannel` prototype getters no longer throw `Cannot access rawData on partial Channel` when commands like `/new` run from inside a thread. Fixes #69861. (#69908) Thanks @neeravmakwana.
 - Browser/Chrome MCP: reset cached existing-session control sessions when a `navigate_page` call times out, so one stuck navigation no longer poisons the browser profile until a gateway restart. (#69733) Thanks @ayeshakhalid192007-dev.

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -42,6 +42,7 @@ type DreamingPluginApiTestDouble = {
 
 function createLogger() {
   return {
+    debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -1236,6 +1237,111 @@ describe("gateway startup reconciliation", () => {
         handled: true,
         reason: "memory-core: short-term dreaming disabled",
       });
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("does not emit the cron-unavailable warning on gateway:startup when deps.cron is missing (regression #69939)", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const api: DreamingPluginApiTestDouble = {
+      config: { plugins: { entries: {} } },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      registerHook: (event: string, handler: Parameters<typeof registerInternalHook>[1]) => {
+        registerInternalHook(event, handler);
+      },
+      on: vi.fn(),
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      // Simulate the startup race: gateway:startup fires before deps.cron is attached.
+      await triggerInternalHook(
+        createInternalHookEvent("gateway", "startup", "gateway:startup", {
+          cfg: {
+            hooks: { internal: { enabled: true } },
+            plugins: {
+              entries: {
+                "memory-core": {
+                  config: {
+                    dreaming: {
+                      enabled: true,
+                      frequency: "15 4 * * *",
+                      timezone: "UTC",
+                    },
+                  },
+                },
+              },
+            },
+          } as OpenClawConfig,
+          deps: {},
+        }),
+      );
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("cron service unavailable"),
+      );
+      // The startup-path log should be demoted to debug instead.
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("cron service not yet available at gateway:startup"),
+      );
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("still warns on runtime reconciliation when cron remains unavailable (preserves #69939 genuine-failure signal)", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      registerHook: (event: string, handler: Parameters<typeof registerInternalHook>[1]) => {
+        registerInternalHook(event, handler);
+      },
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      // Startup without cron — must stay silent on warn.
+      await triggerInternalHook(
+        createInternalHookEvent("gateway", "startup", "gateway:startup", {
+          cfg: api.config,
+          deps: {},
+        }),
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      // Now a runtime heartbeat reconciliation happens and cron is still missing
+      // (e.g. the cron service genuinely failed to initialize). The warning must fire.
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      await beforeAgentReply(
+        { cleanedBody: "" },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
     } finally {
       clearInternalHooks();
     }

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -718,10 +718,21 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     const cron = resolveCronServiceFromStartupSource(startupCronSource);
     const configKey = runtimeConfigKey(config);
     if (!cron && config.enabled && !unavailableCronWarningEmitted) {
-      api.logger.warn(
-        "memory-core: managed dreaming cron could not be reconciled (cron service unavailable).",
-      );
-      unavailableCronWarningEmitted = true;
+      // The gateway emits `gateway:startup` via a deferred setTimeout, and
+      // `deps.cron` may not be attached to the event context yet when memory-core's
+      // startup hook fires (see issue #69939). Avoid logging a confusing warning on
+      // the startup path — the runtime reconciliation path (heartbeat-driven) will
+      // still warn if the cron service remains unavailable after boot.
+      if (params.reason === "startup") {
+        api.logger.debug?.(
+          "memory-core: cron service not yet available at gateway:startup; deferring to runtime reconciliation.",
+        );
+      } else {
+        api.logger.warn(
+          "memory-core: managed dreaming cron could not be reconciled (cron service unavailable).",
+        );
+        unavailableCronWarningEmitted = true;
+      }
     }
     if (cron) {
       unavailableCronWarningEmitted = false;


### PR DESCRIPTION
Closes #69939.

## Bug

On every gateway startup, `memory-core` logs:

```
memory-core: managed dreaming cron could not be reconciled (cron service unavailable).
```

The warning fires once (guarded by `unavailableCronWarningEmitted`), but recurs on every cold/warm restart. The managed dreaming cron job itself runs correctly — this is purely a log-noise regression, not a functional failure.

## Root cause

In `src/plugins/core/server.impl` the `gateway:startup` event is emitted via a deferred `setTimeout` (~250ms). `deps.cron` is not yet attached to the event context when memory-core's startup hook runs, so `resolveCronServiceFromStartupSource(startupCronSource)` → `source.context.cron ?? source.deps?.cron` returns `null` on the first invocation. `reconcileManagedDreamingCron()` then emits the warning on the startup path, even though the cron service comes up seconds later and the runtime heartbeat reconciliation path successfully attaches the job.

Reporter's diagnosis and reproduction steps are in the issue (thanks @mlaihk).

## Fix — Option A (minimally invasive)

In `reconcileManagedDreamingCron()`, only emit the `warn` when the function is called from the **runtime** reconciliation path (`before_agent_reply` heartbeat). On the **startup** path with `cron == null`, demote the message to `logger.debug` and leave the `unavailableCronWarningEmitted` flag unset so that if cron genuinely fails to initialize, the next runtime reconciliation still warns.

This preserves the existing "cron service is actually missing" signal — we only silence the known startup race.

### Before

```ts
const cron = resolveCronServiceFromStartupSource(startupCronSource);
if (!cron && config.enabled && !unavailableCronWarningEmitted) {
  api.logger.warn(
    "memory-core: managed dreaming cron could not be reconciled (cron service unavailable).",
  );
  unavailableCronWarningEmitted = true;
}
```

### After

```ts
const cron = resolveCronServiceFromStartupSource(startupCronSource);
if (!cron && config.enabled && !unavailableCronWarningEmitted) {
  // The gateway emits `gateway:startup` via a deferred setTimeout, and
  // `deps.cron` may not be attached yet when memory-core's startup hook fires
  // (see issue #69939). Avoid logging a confusing warning on the startup path —
  // the runtime reconciliation path (heartbeat-driven) will still warn if the
  // cron service remains unavailable after boot.
  if (params.reason === "startup") {
    api.logger.debug?.(
      "memory-core: cron service not yet available at gateway:startup; deferring to runtime reconciliation.",
    );
  } else {
    api.logger.warn(
      "memory-core: managed dreaming cron could not be reconciled (cron service unavailable).",
    );
    unavailableCronWarningEmitted = true;
  }
}
```

Considered but rejected:

- **Option B (track `cronServiceSeen`):** more state for the same observable behavior.
- **Option C (reorder startup so `deps.cron` is attached before emitting `gateway:startup`):** correct fix long-term, but touches `server.impl` and the core startup sequencer — out of scope for a log-noise patch. Worth tracking separately.

## Tests

Added to `extensions/memory-core/src/dreaming.test.ts`:

1. `does not emit the cron-unavailable warning on gateway:startup when deps.cron is missing (regression #69939)` — reproduces the issue: fires `gateway:startup` with `deps: {}`, asserts `logger.warn` is never called with `"cron service unavailable"`, and asserts the debug message is logged instead.
2. `still warns on runtime reconciliation when cron remains unavailable (preserves #69939 genuine-failure signal)` — fires startup with no cron (silent), then a `heartbeat` `before_agent_reply` with no cron, and asserts the warning **does** fire — ensuring the genuine reconciliation-failure signal is preserved.

Also added `debug: vi.fn()` to the existing `createLogger()` test helper to observe the downgraded log.

### Test run

Full memory-core suite (`test/vitest/vitest.extension-memory.config.ts`):

```
Test Files  47 passed (47)
     Tests  496 passed | 3 skipped (499)
```

## Scope

- 2 files changed, 121 insertions, 4 deletions.
- No changes to `server.impl`, the 250ms startup setTimeout, or the cron service itself.
- No changes to dist/.
