### PR TITLE
fix(agents): drop bare NO_REPLY while subagents are pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI sessions: persist CLI session clearing through the atomic session-store merge path, so expired Claude/Codex CLI bindings are actually removed before retrying without the stale session id. (#70298) Thanks @HFConsultant.
 - ACP/sessions_spawn: honor explicit `model` overrides for ACP child sessions instead of silently falling back to the target agent default model. (#70210) Thanks @felix-miao.
+- Agents/subagents: drop bare `NO_REPLY` from the parent turn when the session still has pending spawned children, so direct-conversation surfaces such as Telegram DMs no longer rewrite the sentinel into visible fallback chatter while waiting for the child completion event. (#69942) Thanks @neeravmakwana.
 - CLI/Claude: hash only static extra system prompt parts when deciding whether to reuse a CLI session, so per-message inbound metadata no longer resets Claude CLI conversations on every turn. (#70122) Thanks @zijunl.
 - Hooks/Slack: standardize shared message hook routing fields (`threadId` / `replyToId`) and stop Slack outbound delivery from re-running `message_sending` inside the channel adapter, so plugins like thread-ownership make one outbound routing decision per reply. Thanks @vincentkoc.
 - Auto-reply/media: share one run-scoped reply media context between streamed block delivery and final payload filtering, so a local `MEDIA:` attachment is staged once and duplicate media sends are suppressed reliably. (#68111) Thanks @ayeshakhalid192007-dev.

--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -167,6 +167,10 @@ Defaults live under `agents.defaults.silentReply` and
 `agents.defaults.silentReplyRewrite`; `surfaces.<id>.silentReply` and
 `surfaces.<id>.silentReplyRewrite` can override them per surface.
 
+When the parent session has one or more pending spawned subagent runs, bare
+silent replies are dropped on all surfaces instead of being rewritten, so the
+parent stays quiet until the child completion event delivers the real reply.
+
 ## Related
 
 - [Streaming](/concepts/streaming) — real-time message delivery

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import { registerPendingSpawnedChildrenQuery } from "../infra/outbound/pending-spawn-query.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { importRuntimeModule } from "../shared/runtime-import.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
@@ -924,3 +925,15 @@ export function getLatestSubagentRunByChildSessionKey(
 export function initSubagentRegistry() {
   restoreSubagentRunsOnce();
 }
+
+// Let the shared outbound plan treat bare silent replies as dropped (instead
+// of rewriting them to visible fallback text) when the parent session has at
+// least one pending spawned child whose completion will deliver the real
+// reply. Runtime-enforced, so it does not rely on agent prompt compliance.
+registerPendingSpawnedChildrenQuery((sessionKey) => {
+  const key = sessionKey?.trim();
+  if (!key) {
+    return false;
+  }
+  return countActiveRunsForSession(key) > 0;
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -929,11 +929,16 @@ export function initSubagentRegistry() {
 // Let the shared outbound plan treat bare silent replies as dropped (instead
 // of rewriting them to visible fallback text) when the parent session has at
 // least one pending spawned child whose completion will deliver the real
-// reply. Runtime-enforced, so it does not rely on agent prompt compliance.
+// reply. Uses the pending-descendant count so runs that have ended but whose
+// announce/cleanup is still in flight continue to suppress rewriting; without
+// this the window between `completeSubagentRun` setting `endedAt` and
+// `startSubagentAnnounceCleanupFlow` finishing could briefly re-enable
+// fallback chatter. Runtime-enforced, so it does not rely on agent prompt
+// compliance.
 registerPendingSpawnedChildrenQuery((sessionKey) => {
   const key = sessionKey?.trim();
   if (!key) {
     return false;
   }
-  return countActiveRunsForSession(key) > 0;
+  return countPendingDescendantRuns(key) > 0;
 });

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -301,16 +301,16 @@ describe("normalizeReplyPayloadsForDelivery", () => {
 
     it("drops bare silent replies via the registered runtime query", () => {
       const sessionKey = "agent:main:telegram:direct:456";
-      registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
+      const previousQuery = registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
       try {
         expect(planSilent(sessionKey)).toEqual([]);
       } finally {
-        registerPendingSpawnedChildrenQuery(undefined);
+        registerPendingSpawnedChildrenQuery(previousQuery);
       }
     });
 
     it("falls back to the rewrite path when the query throws", () => {
-      registerPendingSpawnedChildrenQuery(() => {
+      const previousQuery = registerPendingSpawnedChildrenQuery(() => {
         throw new Error("registry unavailable");
       });
       try {
@@ -319,7 +319,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         expect(delivery[0]?.text).toBeTruthy();
         expect(delivery[0]?.text).not.toMatch(/NO_REPLY/i);
       } finally {
-        registerPendingSpawnedChildrenQuery(undefined);
+        registerPendingSpawnedChildrenQuery(previousQuery);
       }
     });
   });

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -276,7 +276,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
-  it("drops bare silent replies when the session has pending spawned children", () => {
+  describe("pending spawned subagent children", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -285,43 +285,43 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         },
       },
     };
-
-    expect(
+    const planSilent = (sessionKey: string, hasPendingSpawnedChildren?: boolean) =>
       projectOutboundPayloadPlanForDelivery(
         createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
           cfg,
-          sessionKey: "agent:main:telegram:direct:123",
+          sessionKey,
           surface: "telegram",
-          hasPendingSpawnedChildren: true,
+          hasPendingSpawnedChildren,
         }),
-      ),
-    ).toEqual([]);
-  });
+      );
 
-  it("drops bare silent replies via registered pending-spawn runtime query", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: { direct: "disallow", group: "allow", internal: "allow" },
-          silentReplyRewrite: { direct: true },
-        },
-      },
-    };
-    const sessionKey = "agent:main:telegram:direct:456";
-    registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
-    try {
-      expect(
-        projectOutboundPayloadPlanForDelivery(
-          createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-            cfg,
-            sessionKey,
-            surface: "telegram",
-          }),
-        ),
-      ).toEqual([]);
-    } finally {
-      registerPendingSpawnedChildrenQuery(undefined);
-    }
+    it("drops bare silent replies when the context flag is set", () => {
+      expect(planSilent("agent:main:telegram:direct:123", true)).toEqual([]);
+    });
+
+    it("drops bare silent replies via the registered runtime query", () => {
+      const sessionKey = "agent:main:telegram:direct:456";
+      registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
+      try {
+        expect(planSilent(sessionKey)).toEqual([]);
+      } finally {
+        registerPendingSpawnedChildrenQuery(undefined);
+      }
+    });
+
+    it("falls back to the rewrite path when the query throws", () => {
+      registerPendingSpawnedChildrenQuery(() => {
+        throw new Error("registry unavailable");
+      });
+      try {
+        const delivery = planSilent("agent:main:telegram:direct:789");
+        expect(delivery).toHaveLength(1);
+        expect(delivery[0]?.text).toBeTruthy();
+        expect(delivery[0]?.text).not.toMatch(/NO_REPLY/i);
+      } finally {
+        registerPendingSpawnedChildrenQuery(undefined);
+      }
+    });
   });
 
   it("keeps bare NO_REPLY visible when silence is disallowed but rewrite is off", () => {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -14,6 +14,7 @@ import {
   projectOutboundPayloadPlanForMirror,
   projectOutboundPayloadPlanForOutbound,
 } from "./payloads.js";
+import { registerPendingSpawnedChildrenQuery } from "./pending-spawn-query.js";
 
 function resolveMirrorProjection(payloads: readonly ReplyPayload[]) {
   const normalized = normalizeReplyPayloadsForDelivery(payloads);
@@ -273,6 +274,54 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         text: "visible reply",
       }),
     ]);
+  });
+
+  it("drops bare silent replies when the session has pending spawned children", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          silentReply: { direct: "disallow", group: "allow", internal: "allow" },
+          silentReplyRewrite: { direct: true },
+        },
+      },
+    };
+
+    expect(
+      projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+          cfg,
+          sessionKey: "agent:main:telegram:direct:123",
+          surface: "telegram",
+          hasPendingSpawnedChildren: true,
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("drops bare silent replies via registered pending-spawn runtime query", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          silentReply: { direct: "disallow", group: "allow", internal: "allow" },
+          silentReplyRewrite: { direct: true },
+        },
+      },
+    };
+    const sessionKey = "agent:main:telegram:direct:456";
+    registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
+    try {
+      expect(
+        projectOutboundPayloadPlanForDelivery(
+          createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+            cfg,
+            sessionKey,
+            surface: "telegram",
+          }),
+        ),
+      ).toEqual([]);
+    } finally {
+      registerPendingSpawnedChildrenQuery(undefined);
+    }
   });
 
   it("keeps bare NO_REPLY visible when silence is disallowed but rewrite is off", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -21,6 +21,7 @@ import {
   resolveSilentReplyRewriteText,
   type SilentReplyConversationType,
 } from "../../shared/silent-reply-policy.js";
+import { resolvePendingSpawnedChildren } from "./pending-spawn-query.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
@@ -56,6 +57,14 @@ type OutboundPayloadPlanContext = {
   sessionKey?: string;
   surface?: string;
   conversationType?: SilentReplyConversationType;
+  /**
+   * When true, bare silent payloads are dropped instead of being rewritten to
+   * visible fallback text. Set by callers that know the parent session has at
+   * least one pending spawned child whose completion will deliver the real
+   * reply. If omitted, the outbound plan consults the registered runtime query
+   * (see `pending-spawn-query.ts`).
+   */
+  hasPendingSpawnedChildren?: boolean;
 };
 
 export type OutboundPayloadMirror = {
@@ -178,6 +187,8 @@ export function createOutboundPayloadPlan(
     surface: context.surface,
     conversationType: context.conversationType,
   });
+  const hasPendingSpawnedChildren =
+    context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);
   const prepared: PreparedOutboundPayloadPlanEntry[] = [];
   for (const payload of payloads) {
     const entry = createOutboundPayloadPlanEntry(payload);
@@ -208,7 +219,11 @@ export function createOutboundPayloadPlan(
       });
       continue;
     }
-    if (hasVisibleNonSilentContent || resolvedSilentReplySettings.policy === "allow") {
+    if (
+      hasVisibleNonSilentContent ||
+      resolvedSilentReplySettings.policy === "allow" ||
+      hasPendingSpawnedChildren
+    ) {
       continue;
     }
     if (!resolvedSilentReplySettings.rewrite) {

--- a/src/infra/outbound/pending-spawn-query.ts
+++ b/src/infra/outbound/pending-spawn-query.ts
@@ -16,8 +16,10 @@ let pendingSpawnedChildrenQuery: PendingSpawnedChildrenQuery | undefined;
 
 export function registerPendingSpawnedChildrenQuery(
   query: PendingSpawnedChildrenQuery | undefined,
-): void {
+): PendingSpawnedChildrenQuery | undefined {
+  const previous = pendingSpawnedChildrenQuery;
   pendingSpawnedChildrenQuery = query;
+  return previous;
 }
 
 function summarizeError(err: unknown): { name: string; message: string } {

--- a/src/infra/outbound/pending-spawn-query.ts
+++ b/src/infra/outbound/pending-spawn-query.ts
@@ -1,5 +1,16 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+/**
+ * Synchronous predicate: does `sessionKey` have pending spawned subagent runs?
+ * Runs on the outbound plan hot path, so implementations must be cheap/bounded
+ * (default in `subagent-registry.ts` is an in-memory map lookup). Internal to
+ * core; not re-exported through `openclaw/plugin-sdk`.
+ */
 export type PendingSpawnedChildrenQuery = (sessionKey?: string) => boolean;
 
+const log = createSubsystemLogger("outbound/pending-spawn");
+const THROW_LOG_INTERVAL_MS = 60_000;
+let lastThrowLogAt = 0;
 let pendingSpawnedChildrenQuery: PendingSpawnedChildrenQuery | undefined;
 
 export function registerPendingSpawnedChildrenQuery(
@@ -14,7 +25,12 @@ export function resolvePendingSpawnedChildren(sessionKey: string | undefined): b
   }
   try {
     return pendingSpawnedChildrenQuery(sessionKey);
-  } catch {
+  } catch (err) {
+    const now = Date.now();
+    if (now - lastThrowLogAt >= THROW_LOG_INTERVAL_MS) {
+      lastThrowLogAt = now;
+      log.warn("pending-spawn query threw; defaulting to false", { err, sessionKey });
+    }
     return false;
   }
 }

--- a/src/infra/outbound/pending-spawn-query.ts
+++ b/src/infra/outbound/pending-spawn-query.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 
 /**
@@ -19,6 +20,21 @@ export function registerPendingSpawnedChildrenQuery(
   pendingSpawnedChildrenQuery = query;
 }
 
+function summarizeError(err: unknown): { name: string; message: string } {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message };
+  }
+  return { name: "Unknown", message: typeof err === "string" ? err : "non-error throw" };
+}
+
+function hashSessionKey(key: string | undefined): string | undefined {
+  const trimmed = key?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return createHash("sha256").update(trimmed).digest("hex").slice(0, 12);
+}
+
 export function resolvePendingSpawnedChildren(sessionKey: string | undefined): boolean {
   if (!pendingSpawnedChildrenQuery) {
     return false;
@@ -29,7 +45,10 @@ export function resolvePendingSpawnedChildren(sessionKey: string | undefined): b
     const now = Date.now();
     if (now - lastThrowLogAt >= THROW_LOG_INTERVAL_MS) {
       lastThrowLogAt = now;
-      log.warn("pending-spawn query threw; defaulting to false", { err, sessionKey });
+      log.warn("pending-spawn query threw; defaulting to false", {
+        err: summarizeError(err),
+        sessionKeyHash: hashSessionKey(sessionKey),
+      });
     }
     return false;
   }

--- a/src/infra/outbound/pending-spawn-query.ts
+++ b/src/infra/outbound/pending-spawn-query.ts
@@ -1,0 +1,20 @@
+export type PendingSpawnedChildrenQuery = (sessionKey?: string) => boolean;
+
+let pendingSpawnedChildrenQuery: PendingSpawnedChildrenQuery | undefined;
+
+export function registerPendingSpawnedChildrenQuery(
+  query: PendingSpawnedChildrenQuery | undefined,
+): void {
+  pendingSpawnedChildrenQuery = query;
+}
+
+export function resolvePendingSpawnedChildren(sessionKey: string | undefined): boolean {
+  if (!pendingSpawnedChildrenQuery) {
+    return false;
+  }
+  try {
+    return pendingSpawnedChildrenQuery(sessionKey);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #69922.

## Root cause

When a parent agent spawns a subagent via `sessions_spawn`, the accepted-spawn
system note (`src/agents/subagent-spawn-accepted-note.ts`) instructs the parent
to reply with the silent sentinel `NO_REPLY` and wait for the child's
completion event to carry the actual reply. In direct conversations (e.g.
Telegram DMs) the outbound plan in `src/infra/outbound/payloads.ts` was
unaware of the pending-child state. Because the default silent-reply policy
for direct surfaces is `disallow` + `rewrite`, bare `NO_REPLY` was getting
rewritten into a visible fallback (`resolveSilentReplyRewriteText`), producing
user-visible chatter like `Nothing additional from me.` in between the spawn
and the child completion.

## Fix

- New helper module `src/infra/outbound/pending-spawn-query.ts` exposes a
  module-local `PendingSpawnedChildrenQuery` that callers can register and the
  outbound plan can consult. It stays a pure module boundary so
  `src/infra/outbound/**` keeps its existing architectural position and the
  public plugin SDK is untouched.
- `createOutboundPayloadPlan` accepts an optional
  `hasPendingSpawnedChildren` context hint; when omitted it defers to the
  registered runtime query. When true, bare silent payloads are dropped
  instead of being rewritten to the fallback text.
- `src/agents/subagent-registry.ts` registers a query backed by the existing
  `countActiveRunsForSession(...)`, so the outbound plan sees real pending
  subagent runs for the parent session key.

## Why this is safe

- The existing silent-reply policy, `SILENT_REPLY_REWRITE_TEXTS`,
  `resolveSilentReplySettings`, and conversation-type classification are all
  unchanged. Groups/internal/allow surfaces keep their current behavior.
- Non-silent payloads are unaffected: the new branch only applies when the
  payload would already have been classified as a bare silent reply (i.e.,
  there is no visible non-silent content and the silent token is present).
- The behavior is runtime-enforced via the subagent registry rather than
  relying on prompt-text compliance from the model.
- Default `hasPendingSpawnedChildren` is `false`/`undefined`, so callers that
  don't opt in (including test helpers that construct contexts today) keep
  their current semantics.
- No config defaults, schema, help text, or generated artifacts change; no
  plugin SDK surface changes; no new error codes or gateway protocol changes.

## Security / runtime controls that are unchanged

- `resolveSilentReplySettings` and the per-surface/per-conversation-type
  silent reply policy in `src/shared/silent-reply-policy.ts`.
- `projectOutboundPayloadPlanForDelivery` audit logging and the non-silent
  path through `createOutboundPayloadPlan`.
- The subagent-registry lifecycle (restore, retention, cleanup, retry grace).
- Inbound filtering, internal-context wrapping, and
  `SUBAGENT_SPAWN_ACCEPTED_NOTE` remain in place. The new suppression is a
  safety net that doesn't depend on the note being obeyed.

## Tests run

- `pnpm lint:core` — 0 warnings, 0 errors.
- `pnpm tsgo` — core prod typecheck clean.
- `pnpm check:import-cycles` — 0 runtime cycles.
- `pnpm test src/infra/outbound/payloads.test.ts` — 30/30 pass, including two
  new cases that exercise both the explicit `hasPendingSpawnedChildren: true`
  context path and the registered runtime query path.
- `pnpm test src/infra/outbound/` — 35 files, 451 tests, all pass.
- `pnpm test src/agents/subagent-registry-cleanup.test.ts src/agents/subagent-registry-completion.test.ts src/agents/subagent-registry-helpers.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry-queries.test.ts`
  — all selected registry unit suites pass.
- `pnpm test src/shared/silent-reply-policy.test.ts` — 8/8 pass.

The only failures observed locally (`subagent-announce.format.e2e.test.ts` and
`subagent-registry.lifecycle-retry-grace.e2e.test.ts`) reproduce on `origin/main`
without this change and are unrelated to the outbound-plan path touched here.

## AI-assisted PR checklist

- [x] Marked as AI-assisted here.
- [x] Degree of testing: fully tested at the changed seam (unit tests for
      outbound plan, targeted registry suites, typecheck, lint, import cycles).
- [x] Author understands the code path (silent-reply policy + subagent
      registry wiring).

Made with [Cursor](https://cursor.com)