### PR TITLE
[AI-assisted] fix(github-copilot): omit Opus 4.7 effort override

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -413,4 +413,42 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("omits adaptive effort for github-copilot Claude Opus 4.7 transport runs", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-opus-4-7",
+        name: "Claude Opus 4.7",
+        api: "anthropic-messages",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com/anthropic",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies AnthropicMessagesModel,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think extra hard." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "github-copilot-token",
+        reasoning: "xhigh",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+    });
+    expect(latestAnthropicRequest().payload).not.toHaveProperty("output_config");
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -123,6 +123,13 @@ function supportsAdaptiveThinking(modelId: string): boolean {
   );
 }
 
+function shouldEmitAdaptiveThinkingEffort(model: AnthropicTransportModel): boolean {
+  return !(
+    normalizeLowercaseStringOrEmpty(model.provider) === "github-copilot" &&
+    isClaudeOpus47Model(model.id)
+  );
+}
+
 function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
   switch (level) {
     case "minimal":
@@ -657,7 +664,7 @@ function buildAnthropicParams(
     if (options?.thinkingEnabled) {
       if (supportsAdaptiveThinking(model.id)) {
         params.thinking = { type: "adaptive" };
-        if (options.effort) {
+        if (options.effort && shouldEmitAdaptiveThinkingEffort(model)) {
           params.output_config = { effort: options.effort };
         }
       } else {


### PR DESCRIPTION
## Summary

- Problem: `github-copilot/claude-opus-4.7` rejects non-`medium` adaptive thinking efforts, but the Anthropic transport was forwarding `output_config.effort` for that proxy path.
- Why it matters: `/think high` or `xhigh` turns on that model could fail with `invalid_reasoning_effort`, then burn through Copilot auth-profile cooldowns.
- What changed: keep adaptive thinking enabled for Copilot Opus 4.7, but stop emitting the explicit `output_config.effort` override for that one provider/model pair.
- What did NOT change (scope boundary): direct Anthropic Opus 4.7 behavior and the existing Claude 4.6/Anthropic adaptive effort mapping stay unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69928
- Related #69928
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Anthropic transport treated adaptive-thinking effort as model-only capability, so `github-copilot/claude-opus-4.7` inherited the same `output_config.effort` payload as direct Anthropic Opus 4.7.
- Missing detection / guardrail: there was no provider-specific regression test for the Copilot Opus 4.7 transport shape.
- Contributing context (if known): the Copilot proxy only accepts `medium` for this field, while direct Anthropic accepts the broader effort range.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`
- Scenario the test should lock in: `github-copilot/claude-opus-4.7` keeps adaptive thinking enabled without forwarding `output_config.effort`.
- Why this is the smallest reliable guardrail: the regression is in provider-specific request shaping, and the transport test already inspects the exact outbound payload.
- Existing test that already covers this (if any): the existing Anthropic transport tests already cover direct Anthropic adaptive-effort mapping for Claude 4.6 and Opus 4.7.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Copilot-backed Claude Opus 4.7 runs no longer send the incompatible adaptive-effort override, so `/think high` and `xhigh` stop tripping the proxy-only schema rejection described in #69928.

## Diagram (if applicable)

```text
Before:
[user selects github-copilot/claude-opus-4.7 + high/xhigh] -> [transport sends output_config.effort] -> [Copilot 400 invalid_reasoning_effort]

After:
[user selects github-copilot/claude-opus-4.7 + high/xhigh] -> [transport omits output_config.effort] -> [adaptive thinking request stays accepted]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.2 arm64
- Runtime/container: local source checkout on `origin/main`
- Model/provider: `github-copilot/claude-opus-4.7`
- Integration/channel (if any): GitHub Copilot Anthropic-messages proxy
- Relevant config (redacted): reasoning enabled with `high`/`xhigh`

### Steps

1. Run an Anthropic transport turn with `provider: "github-copilot"`, `model: "claude-opus-4-7"`, and reasoning enabled.
2. Inspect the outbound payload.
3. Confirm the Copilot path no longer includes `output_config.effort` while direct Anthropic coverage remains unchanged.

### Expected

- Copilot Opus 4.7 keeps `thinking: { type: "adaptive" }` without forwarding `output_config.effort`.

### Actual

- Before this change, the Copilot Opus 4.7 path still emitted `output_config.effort`, matching the failing issue report.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bad payload shape with a new focused transport test, then reran `corepack pnpm test src/agents/anthropic-transport-stream.test.ts` and `corepack pnpm build` after the fix.
- Edge cases checked: direct Anthropic Opus 4.7 and Claude 4.6 adaptive-effort tests still pass unchanged.
- What you did **not** verify: I did not run a live GitHub Copilot request against real proxy credentials in this checkout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another Copilot Claude model may eventually need its own effort gating.
  - Mitigation: keep the change scoped to the one provider/model pair with concrete failure evidence and add the regression test for that exact payload shape.

AI-assisted: yes.
