### PR TITLE
fix: quiet noninteractive doctor checks

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -87,6 +87,21 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("returns whether read-only config repairs are pending", async () => {
+    const clean = await runDoctorConfigWithInput({
+      config: {},
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+    expect((clean as { pendingChanges?: boolean }).pendingChanges).toBe(false);
+
+    const dirty = await runDoctorConfigWithInput({
+      config: { unknownTopLevelKey: true },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+    expect((dirty as { pendingChanges?: boolean }).pendingChanges).toBe(true);
+    expect((dirty as { shouldWriteConfig?: boolean }).shouldWriteConfig).toBe(false);
+  });
+
   it("does not warn on mutable account allowlists when dangerous name matching is inherited", async () => {
     const doctorWarnings = await collectDoctorWarnings({
       channels: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -150,6 +150,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   return {
     cfg,
     path: snapshot.path ?? CONFIG_PATH,
+    pendingChanges,
     shouldWriteConfig: finalized.shouldWriteConfig,
     sourceConfigValid: snapshot.valid,
   };

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { checkGatewayHealth } from "./doctor-gateway-health.js";
+
+const mocks = vi.hoisted(() => ({
+  buildGatewayConnectionDetails: vi.fn(() => ({ message: "gateway connection details" })),
+  callGateway: vi.fn(),
+  formatHealthCheckFailure: vi.fn(() => "formatted health failure"),
+  healthCommand: vi.fn(),
+  note: vi.fn(),
+}));
+
+vi.mock("../gateway/call.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/call.js")>();
+  return {
+    ...actual,
+    buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
+    callGateway: mocks.callGateway,
+  };
+});
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+vi.mock("./health-format.js", () => ({
+  formatHealthCheckFailure: mocks.formatHealthCheckFailure,
+}));
+
+vi.mock("./health.js", () => ({
+  healthCommand: mocks.healthCommand,
+}));
+
+describe("checkGatewayHealth", () => {
+  const cfg: OpenClawConfig = { gateway: { mode: "local" } };
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildGatewayConnectionDetails.mockReturnValue({
+      message: "gateway connection details",
+    });
+    mocks.callGateway.mockResolvedValue({});
+    mocks.healthCommand.mockResolvedValue(undefined);
+  });
+
+  it("uses a direct health probe and skips channel status in non-interactive fast path", async () => {
+    const result = await checkGatewayHealth({
+      runtime,
+      cfg,
+      timeoutMs: 1234,
+      nonInteractive: true,
+    });
+
+    expect(result).toEqual({ healthOk: true });
+    expect(mocks.healthCommand).not.toHaveBeenCalled();
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "health",
+      timeoutMs: 1234,
+      config: cfg,
+    });
+    expect(mocks.callGateway).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "channels.status" }),
+    );
+  });
+
+  it("keeps channel status probing in deep non-interactive mode", async () => {
+    await checkGatewayHealth({
+      runtime,
+      cfg,
+      timeoutMs: 1234,
+      nonInteractive: true,
+      deep: true,
+    });
+
+    expect(mocks.healthCommand).not.toHaveBeenCalled();
+    expect(mocks.callGateway.mock.calls.map(([arg]) => arg.method)).toEqual([
+      "health",
+      "channels.status",
+    ]);
+  });
+});

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -17,13 +17,23 @@ export async function checkGatewayHealth(params: {
   runtime: RuntimeEnv;
   cfg: OpenClawConfig;
   timeoutMs?: number;
+  nonInteractive?: boolean;
+  deep?: boolean;
 }) {
   const gatewayDetails = buildGatewayConnectionDetails({ config: params.cfg });
   const timeoutMs =
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 10_000;
   let healthOk = false;
   try {
-    await healthCommand({ json: false, timeoutMs, config: params.cfg }, params.runtime);
+    if (params.nonInteractive === true) {
+      await callGateway({
+        method: "health",
+        timeoutMs,
+        config: params.cfg,
+      });
+    } else {
+      await healthCommand({ json: false, timeoutMs, config: params.cfg }, params.runtime);
+    }
     healthOk = true;
   } catch (err) {
     const message = String(err);
@@ -35,7 +45,7 @@ export async function checkGatewayHealth(params: {
     }
   }
 
-  if (healthOk) {
+  if (healthOk && (params.nonInteractive !== true || params.deep === true)) {
     try {
       const status = await callGateway({
         method: "channels.status",

--- a/src/commands/doctor.fast-path.e2e.test.ts
+++ b/src/commands/doctor.fast-path.e2e.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  createDoctorRuntime,
+  detectLegacyStateMigrations,
+  ensureAuthProfileStore,
+  findExtraGatewayServices,
+  mockDoctorConfigSnapshot,
+} from "./doctor.e2e-harness.js";
+import "./doctor.fast-path-mocks.js";
+
+let doctorCommand: typeof import("./doctor.js").doctorCommand;
+let checkGatewayHealth: typeof import("./doctor-gateway-health.js").checkGatewayHealth;
+let probeGatewayMemoryStatus: typeof import("./doctor-gateway-health.js").probeGatewayMemoryStatus;
+let maybeRepairGatewayDaemon: typeof import("./doctor-gateway-daemon-flow.js").maybeRepairGatewayDaemon;
+let noteChromeMcpBrowserReadiness: typeof import("./doctor-browser.js").noteChromeMcpBrowserReadiness;
+let noteMemorySearchHealth: typeof import("./doctor-memory-search.js").noteMemorySearchHealth;
+let noteStateIntegrity: typeof import("./doctor-state-integrity.js").noteStateIntegrity;
+let noteWorkspaceStatus: typeof import("./doctor-workspace-status.js").noteWorkspaceStatus;
+
+describe("doctor command fast path", () => {
+  beforeAll(async () => {
+    ({ doctorCommand } = await import("./doctor.js"));
+    ({ checkGatewayHealth, probeGatewayMemoryStatus } = await import("./doctor-gateway-health.js"));
+    ({ maybeRepairGatewayDaemon } = await import("./doctor-gateway-daemon-flow.js"));
+    ({ noteChromeMcpBrowserReadiness } = await import("./doctor-browser.js"));
+    ({ noteMemorySearchHealth } = await import("./doctor-memory-search.js"));
+    ({ noteStateIntegrity } = await import("./doctor-state-integrity.js"));
+    ({ noteWorkspaceStatus } = await import("./doctor-workspace-status.js"));
+  });
+
+  it("skips expensive checks in non-interactive default mode", async () => {
+    mockDoctorConfigSnapshot();
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(ensureAuthProfileStore).not.toHaveBeenCalled();
+    expect(detectLegacyStateMigrations).not.toHaveBeenCalled();
+    expect(noteStateIntegrity).not.toHaveBeenCalled();
+    expect(findExtraGatewayServices).not.toHaveBeenCalled();
+    expect(noteChromeMcpBrowserReadiness).not.toHaveBeenCalled();
+    expect(noteWorkspaceStatus).not.toHaveBeenCalled();
+    expect(checkGatewayHealth).not.toHaveBeenCalled();
+    expect(probeGatewayMemoryStatus).not.toHaveBeenCalled();
+    expect(noteMemorySearchHealth).not.toHaveBeenCalled();
+    expect(maybeRepairGatewayDaemon).not.toHaveBeenCalled();
+  });
+
+  it("does not print the generic doctor --fix hint for a clean read-only config", async () => {
+    mockDoctorConfigSnapshot();
+    const runtime = createDoctorRuntime();
+
+    await doctorCommand(runtime, {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const logOutput = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(logOutput).not.toContain("openclaw doctor --fix");
+  });
+});

--- a/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
+++ b/src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts
@@ -9,6 +9,16 @@ import {
   serviceRestart,
   writeConfigFile,
 } from "./doctor.e2e-harness.js";
+import "./doctor.fast-path-mocks.js";
+
+vi.mock("./doctor-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./doctor-auth.js")>();
+  return {
+    ...actual,
+    maybeRemoveDeprecatedCliAuthProfiles: vi.fn(async (cfg: unknown) => cfg),
+    noteAuthProfileHealth: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 let doctorCommand: typeof import("./doctor.js").doctorCommand;
 let healthCommand: typeof import("./health.js").healthCommand;
@@ -32,7 +42,7 @@ describe("doctor command", () => {
     expect(confirm).not.toHaveBeenCalled();
   }, 30_000);
 
-  it("runs legacy state migrations in non-interactive mode without prompting", async () => {
+  it("skips legacy state migrations in non-interactive fast path", async () => {
     const { doctorCommand, runtime, runLegacyStateMigrations } =
       await arrangeLegacyStateMigrationTest();
 
@@ -41,7 +51,7 @@ describe("doctor command", () => {
       { nonInteractive: true },
     );
 
-    expect(runLegacyStateMigrations).toHaveBeenCalledTimes(1);
+    expect(runLegacyStateMigrations).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();
   }, 30_000);
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -47,7 +47,11 @@ import {
   noteMacLaunchctlGatewayEnvOverrides,
   noteStartupOptimizationHints,
 } from "./doctor-platform-notes.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import {
+  createDoctorPrompter,
+  type DoctorOptions,
+  type DoctorPrompter,
+} from "./doctor-prompter.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
 import { noteSessionLockHealth } from "./doctor-session-locks.js";
@@ -71,11 +75,19 @@ function resolveMode(cfg: OpenClawConfig): "local" | "remote" {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
+function shouldRunDetailedDoctorChecks(
+  options: DoctorOptions,
+  prompter: Pick<DoctorPrompter, "shouldRepair">,
+): boolean {
+  return prompter.shouldRepair || options.deep === true || options.nonInteractive !== true;
+}
+
 export async function doctorCommand(
   runtime: RuntimeEnv = defaultRuntime,
   options: DoctorOptions = {},
 ) {
   const prompter = createDoctorPrompter({ runtime, options });
+  const runDetailedChecks = shouldRunDetailedDoctorChecks(options, prompter);
   printWizardHeader(runtime);
   intro("OpenClaw doctor");
 
@@ -132,13 +144,15 @@ export async function doctorCommand(
     );
   }
 
-  cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
-  cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
-  await noteAuthProfileHealth({
-    cfg,
-    prompter,
-    allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
-  });
+  if (runDetailedChecks) {
+    cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
+    cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
+    await noteAuthProfileHealth({
+      cfg,
+      prompter,
+      allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
+    });
+  }
   const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
   if (gatewayDetails.remoteFallbackNote) {
     note(gatewayDetails.remoteFallbackNote, "Gateway");
@@ -196,44 +210,50 @@ export async function doctorCommand(
     }
   }
 
-  const legacyState = await detectLegacyStateMigrations({ cfg });
-  if (legacyState.preview.length > 0) {
-    note(legacyState.preview.join("\n"), "Legacy state detected");
-    const migrate =
-      options.nonInteractive === true
-        ? true
-        : await prompter.confirm({
-            message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
-            initialValue: true,
-          });
-    if (migrate) {
-      const migrated = await runLegacyStateMigrations({
-        detected: legacyState,
-      });
-      if (migrated.changes.length > 0) {
-        note(migrated.changes.join("\n"), "Doctor changes");
-      }
-      if (migrated.warnings.length > 0) {
-        note(migrated.warnings.join("\n"), "Doctor warnings");
+  if (runDetailedChecks) {
+    const legacyState = await detectLegacyStateMigrations({ cfg });
+    if (legacyState.preview.length > 0) {
+      note(legacyState.preview.join("\n"), "Legacy state detected");
+      const migrate =
+        options.nonInteractive === true
+          ? true
+          : await prompter.confirm({
+              message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
+              initialValue: true,
+            });
+      if (migrate) {
+        const migrated = await runLegacyStateMigrations({
+          detected: legacyState,
+        });
+        if (migrated.changes.length > 0) {
+          note(migrated.changes.join("\n"), "Doctor changes");
+        }
+        if (migrated.warnings.length > 0) {
+          note(migrated.warnings.join("\n"), "Doctor warnings");
+        }
       }
     }
   }
 
-  await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
-  await noteSessionLockHealth({ shouldRepair: prompter.shouldRepair });
-  await maybeRepairLegacyCronStore({
-    cfg,
-    options,
-    prompter,
-  });
+  if (runDetailedChecks) {
+    await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
+    await noteSessionLockHealth({ shouldRepair: prompter.shouldRepair });
+    await maybeRepairLegacyCronStore({
+      cfg,
+      options,
+      prompter,
+    });
+  }
 
   cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);
   noteSandboxScopeWarnings(cfg);
 
-  await maybeScanExtraGatewayServices(options, runtime, prompter);
-  await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
-  await noteMacLaunchAgentOverrides();
-  await noteMacLaunchctlGatewayEnvOverrides(cfg);
+  if (runDetailedChecks) {
+    await maybeScanExtraGatewayServices(options, runtime, prompter);
+    await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
+    await noteMacLaunchAgentOverrides();
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
+  }
 
   if (prompter.shouldRepair) {
     await runStartupMatrixMigration({
@@ -249,7 +269,9 @@ export async function doctorCommand(
   }
 
   await noteSecurityWarnings(cfg);
-  await noteChromeMcpBrowserReadiness(cfg);
+  if (runDetailedChecks) {
+    await noteChromeMcpBrowserReadiness(cfg);
+  }
   await noteOpenAIOAuthTlsPrerequisites({
     cfg,
     deep: options.deep === true,
@@ -319,34 +341,41 @@ export async function doctorCommand(
     }
   }
 
-  noteWorkspaceStatus(cfg);
-  await noteBootstrapFileSize(cfg);
+  if (runDetailedChecks) {
+    noteWorkspaceStatus(cfg);
+    await noteBootstrapFileSize(cfg);
+  }
 
   // Check and fix shell completion
   await doctorShellCompletion(runtime, prompter, {
     nonInteractive: options.nonInteractive,
   });
 
-  const { healthOk } = await checkGatewayHealth({
-    runtime,
-    cfg,
-    timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
-  });
-  const gatewayMemoryProbe = healthOk
-    ? await probeGatewayMemoryStatus({
-        cfg,
-        timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
-      })
-    : { checked: false, ready: false };
-  await noteMemorySearchHealth(cfg, { gatewayMemoryProbe });
-  await maybeRepairGatewayDaemon({
-    cfg,
-    runtime,
-    prompter,
-    options,
-    gatewayDetailsMessage: gatewayDetails.message,
-    healthOk,
-  });
+  let healthOk = false;
+  if (runDetailedChecks) {
+    ({ healthOk } = await checkGatewayHealth({
+      runtime,
+      cfg,
+      timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
+      nonInteractive: options.nonInteractive,
+      deep: options.deep,
+    }));
+    const gatewayMemoryProbe = healthOk
+      ? await probeGatewayMemoryStatus({
+          cfg,
+          timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
+        })
+      : { checked: false, ready: false };
+    await noteMemorySearchHealth(cfg, { gatewayMemoryProbe });
+    await maybeRepairGatewayDaemon({
+      cfg,
+      runtime,
+      prompter,
+      options,
+      gatewayDetailsMessage: gatewayDetails.message,
+      healthOk,
+    });
+  }
 
   const shouldWriteConfig =
     configResult.shouldWriteConfig || JSON.stringify(cfg) !== JSON.stringify(cfgForPersistence);
@@ -358,7 +387,7 @@ export async function doctorCommand(
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
-  } else if (!prompter.shouldRepair) {
+  } else if (!prompter.shouldRepair && configResult.pendingChanges) {
     runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -21,7 +21,7 @@ describe("doctor command", () => {
     terminalNoteMock.mockClear();
   });
 
-  it("warns when the state directory is missing", async () => {
+  it("skips the missing state directory check in non-interactive fast path", async () => {
     mockDoctorConfigSnapshot();
 
     const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-missing-state-"));
@@ -29,6 +29,24 @@ describe("doctor command", () => {
     process.env.OPENCLAW_STATE_DIR = missingDir;
     await doctorCommand(createDoctorRuntime(), {
       nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const stateNote = terminalNoteMock.mock.calls.find(([message]) =>
+      String(message).includes("state directory missing"),
+    );
+    expect(stateNote).toBeUndefined();
+  });
+
+  it("warns when the state directory is missing in deep non-interactive mode", async () => {
+    mockDoctorConfigSnapshot();
+
+    const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-missing-state-"));
+    fs.rmSync(missingDir, { recursive: true, force: true });
+    process.env.OPENCLAW_STATE_DIR = missingDir;
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      deep: true,
       workspaceSuggestions: false,
     });
 

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findExtraGatewayServices } from "./inspect.js";
 
@@ -81,6 +84,90 @@ describe("findExtraGatewayServices (win32)", () => {
         scope: "system",
         marker: "moltbot",
         legacy: true,
+      },
+    ]);
+  });
+});
+
+describe("findExtraGatewayServices (darwin)", () => {
+  const originalPlatform = process.platform;
+  let tempHome: string;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-launchd-"));
+    fs.mkdirSync(path.join(tempHome, "Library", "LaunchAgents"), { recursive: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  function writePlist(fileName: string, label: string, body: string) {
+    const plistPath = path.join(tempHome, "Library", "LaunchAgents", fileName);
+    fs.writeFileSync(
+      plistPath,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        "<plist>",
+        "<dict>",
+        "<key>Label</key>",
+        `<string>${label}</string>`,
+        body,
+        "</dict>",
+        "</plist>",
+      ].join("\n"),
+    );
+    return plistPath;
+  }
+
+  it("ignores OpenClaw support launch agents while keeping unrelated openclaw services visible", async () => {
+    writePlist(
+      "ai.openclaw.node.plist",
+      "ai.openclaw.node",
+      [
+        "<key>EnvironmentVariables</key>",
+        "<dict>",
+        "<key>OPENCLAW_SERVICE_MARKER</key>",
+        "<string>openclaw</string>",
+        "<key>OPENCLAW_SERVICE_KIND</key>",
+        "<string>node</string>",
+        "</dict>",
+      ].join("\n"),
+    );
+    writePlist(
+      "com.nats.server.plist",
+      "com.nats.server",
+      "<string>/Users/example/.openclaw/data/nats/server.conf</string>",
+    );
+    writePlist(
+      "com.signal-cli.daemon.plist",
+      "com.signal-cli.daemon",
+      "<string>/Users/example/.openclaw/logs/signal-cli/default.log</string>",
+    );
+    const unrelatedPath = writePlist(
+      "ai.openclaw.worker.plist",
+      "ai.openclaw.worker",
+      "<string>openclaw helper worker</string>",
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.worker",
+        detail: `plist: ${unrelatedPath}`,
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
       },
     ]);
   });

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  resolveNodeLaunchAgentLabel,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -87,6 +88,23 @@ function isOpenClawGatewayLaunchdService(label: string, contents: string): boole
     return false;
   }
   return label.startsWith("ai.openclaw.");
+}
+
+function isOpenClawSupportLaunchdService(label: string, contents: string): boolean {
+  const lowerContents = contents.toLowerCase();
+  if (label === resolveNodeLaunchAgentLabel()) {
+    return lowerContents.includes("openclaw_service_kind") && lowerContents.includes("node");
+  }
+  if (label === "com.nats.server") {
+    return (
+      lowerContents.includes("/.openclaw/data/nats") ||
+      lowerContents.includes("/.openclaw/logs/nats")
+    );
+  }
+  if (label === "com.signal-cli.daemon") {
+    return lowerContents.includes("/.openclaw/logs/signal-cli");
+  }
+  return false;
 }
 
 function isOpenClawGatewaySystemdService(name: string, contents: string): boolean {
@@ -207,6 +225,9 @@ async function scanLaunchdDir(params: {
       continue;
     }
     if (isIgnoredLaunchdLabel(label)) {
+      continue;
+    }
+    if (marker === "openclaw" && isOpenClawSupportLaunchdService(label, contents)) {
       continue;
     }
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {


### PR DESCRIPTION
## Summary
- skip expensive doctor probes in the default non-interactive path while preserving deep and repair flows
- use a lightweight direct gateway health probe for non-interactive gateway checks and skip channel status unless deep
- filter known OpenClaw support LaunchAgents from extra gateway-like service warnings
- only print the generic doctor --fix hint when config repairs are pending

## Verification
- pnpm exec oxfmt --check src/daemon/inspect.ts src/daemon/inspect.test.ts src/commands/doctor.ts src/commands/doctor-gateway-health.ts src/commands/doctor-gateway-health.test.ts src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.test.ts src/commands/doctor.fast-path.e2e.test.ts src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
- pnpm tsgo
- pnpm exec vitest run --config vitest.unit.config.ts src/daemon/inspect.test.ts
- pnpm exec vitest run src/commands/doctor-gateway-health.test.ts src/commands/doctor-config-flow.test.ts
- pnpm exec vitest run --config vitest.e2e.config.ts src/commands/doctor.fast-path.e2e.test.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts --testTimeout=30000
- git diff --check
- OPENCLAW_NO_RESPAWN=1 openclaw doctor --non-interactive --no-workspace-suggestions
- pnpm build
- pnpm pack --pack-destination /tmp/openclaw-pack-check