### PR TITLE
fix(wiki): load memory-core plugin runtime before bridge artifact import

### DIFF
--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -135,5 +135,8 @@
         }
       }
     }
+  },
+  "activation": {
+    "onCommands": ["wiki"]
   }
 }

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -6,13 +6,14 @@ import {
   appendMemoryHostEvent,
   resolveMemoryHostEventLogPath,
 } from "openclaw/plugin-sdk/memory-host-events";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   clearMemoryPluginState,
   registerMemoryCapability,
 } from "../../../src/plugins/memory-state.js";
 import type { OpenClawConfig } from "../api.js";
 import { syncMemoryWikiBridgeSources } from "./bridge.js";
+import * as runtimeBootstrap from "./runtime-bootstrap.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createVault } = createMemoryWikiTestHarness();
@@ -161,6 +162,33 @@ describe("syncMemoryWikiBridgeSources", () => {
       workspaces: 0,
       pagePaths: [],
     });
+  });
+
+  it("bootstraps the memory runtime before listing bridge artifacts", async () => {
+    const workspaceDir = await createBridgeWorkspace("bootstrap-workspace");
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("bootstrap-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+    const bootstrapSpy = vi
+      .spyOn(runtimeBootstrap, "ensureMemoryWikiPublicArtifactsRuntime")
+      .mockResolvedValue();
+
+    await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(bootstrapSpy).toHaveBeenCalledWith(appConfig);
   });
 
   it("returns a no-op result when bridge mode is enabled without exported memory artifacts", async () => {

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -14,6 +14,7 @@ import {
   renderWikiMarkdown,
   slugifyWikiSegment,
 } from "./markdown.js";
+import { ensureMemoryWikiPublicArtifactsRuntime } from "./runtime-bootstrap.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
@@ -221,6 +222,7 @@ export async function syncMemoryWikiBridgeSources(params: {
     };
   }
 
+  await ensureMemoryWikiPublicArtifactsRuntime(params.appConfig);
   const publicArtifacts = await listActiveMemoryPublicArtifacts({ cfg: params.appConfig });
   const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
   const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];

--- a/extensions/memory-wiki/src/runtime-bootstrap.test.ts
+++ b/extensions/memory-wiki/src/runtime-bootstrap.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  listActiveMemoryPublicArtifactsMock,
+  resolveDefaultAgentIdMock,
+  getActiveMemorySearchManagerMock,
+} = vi.hoisted(() => ({
+  listActiveMemoryPublicArtifactsMock:
+    vi.fn<typeof import("openclaw/plugin-sdk/memory-host-core").listActiveMemoryPublicArtifacts>(),
+  resolveDefaultAgentIdMock:
+    vi.fn<typeof import("openclaw/plugin-sdk/memory-host-core").resolveDefaultAgentId>(),
+  getActiveMemorySearchManagerMock:
+    vi.fn<typeof import("openclaw/plugin-sdk/memory-host-search").getActiveMemorySearchManager>(),
+}));
+
+vi.mock("openclaw/plugin-sdk/memory-host-core", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/memory-host-core")>(
+    "openclaw/plugin-sdk/memory-host-core",
+  );
+  return {
+    ...actual,
+    listActiveMemoryPublicArtifacts: listActiveMemoryPublicArtifactsMock,
+    resolveDefaultAgentId: resolveDefaultAgentIdMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/memory-host-search", () => ({
+  getActiveMemorySearchManager: getActiveMemorySearchManagerMock,
+}));
+
+import type { OpenClawConfig } from "../api.js";
+import { ensureMemoryWikiPublicArtifactsRuntime } from "./runtime-bootstrap.js";
+
+describe("ensureMemoryWikiPublicArtifactsRuntime", () => {
+  beforeEach(() => {
+    listActiveMemoryPublicArtifactsMock.mockReset();
+    resolveDefaultAgentIdMock.mockReset();
+    getActiveMemorySearchManagerMock.mockReset();
+    listActiveMemoryPublicArtifactsMock.mockResolvedValue([]);
+    resolveDefaultAgentIdMock.mockReturnValue("main");
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager: null });
+  });
+
+  it("uses the default agent to bootstrap the active memory runtime", async () => {
+    const appConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: "/tmp/workspace" }],
+      },
+    } as OpenClawConfig;
+
+    await ensureMemoryWikiPublicArtifactsRuntime(appConfig);
+
+    expect(listActiveMemoryPublicArtifactsMock).toHaveBeenCalledWith({ cfg: appConfig });
+    expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith(appConfig);
+    expect(getActiveMemorySearchManagerMock).toHaveBeenCalledWith({
+      cfg: appConfig,
+      agentId: "main",
+      purpose: "status",
+    });
+  });
+
+  it("skips bootstrap when public artifacts are already registered", async () => {
+    listActiveMemoryPublicArtifactsMock.mockResolvedValue([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+
+    await ensureMemoryWikiPublicArtifactsRuntime({
+      agents: {
+        list: [{ id: "main", default: true, workspace: "/tmp/workspace" }],
+      },
+    } as OpenClawConfig);
+
+    expect(resolveDefaultAgentIdMock).not.toHaveBeenCalled();
+    expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows bootstrap failures and leaves artifact lookup to report the outcome", async () => {
+    getActiveMemorySearchManagerMock.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      ensureMemoryWikiPublicArtifactsRuntime({
+        agents: {
+          list: [{ id: "main", default: true, workspace: "/tmp/workspace" }],
+        },
+      } as OpenClawConfig),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing when app config is unavailable", async () => {
+    await ensureMemoryWikiPublicArtifactsRuntime();
+
+    expect(listActiveMemoryPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveDefaultAgentIdMock).not.toHaveBeenCalled();
+    expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-wiki/src/runtime-bootstrap.ts
+++ b/extensions/memory-wiki/src/runtime-bootstrap.ts
@@ -1,0 +1,30 @@
+import {
+  listActiveMemoryPublicArtifacts,
+  resolveDefaultAgentId,
+} from "openclaw/plugin-sdk/memory-host-core";
+import { getActiveMemorySearchManager } from "openclaw/plugin-sdk/memory-host-search";
+import type { OpenClawConfig } from "../api.js";
+
+export async function ensureMemoryWikiPublicArtifactsRuntime(
+  appConfig?: OpenClawConfig,
+): Promise<void> {
+  if (!appConfig) {
+    return;
+  }
+
+  if ((await listActiveMemoryPublicArtifacts({ cfg: appConfig })).length > 0) {
+    return;
+  }
+
+  try {
+    await getActiveMemorySearchManager({
+      cfg: appConfig,
+      agentId: resolveDefaultAgentId(appConfig),
+      purpose: "status",
+    });
+  } catch {
+    // Best-effort bootstrap only. The subsequent public artifact lookup remains
+    // the source of truth and should gracefully report zero artifacts when the
+    // active memory plugin is unavailable.
+  }
+}

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { resolveMemoryWikiConfig } from "./config.js";
 import { renderWikiMarkdown } from "./markdown.js";
+import * as runtimeBootstrap from "./runtime-bootstrap.js";
 import {
   buildMemoryWikiDoctorReport,
   renderMemoryWikiDoctor,
@@ -82,6 +83,36 @@ describe("resolveMemoryWikiStatus", () => {
     });
 
     expect(status.warnings.map((warning) => warning.code)).toContain("unsafe-local-disabled");
+  });
+
+  it("bootstraps the memory runtime before reading bridge artifact status", async () => {
+    const config = resolveMemoryWikiConfig(
+      {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+        },
+      },
+      { homedir: "/Users/tester" },
+    );
+    const appConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: "/tmp/workspace" }],
+      },
+    } as OpenClawConfig;
+    const bootstrapSpy = vi
+      .spyOn(runtimeBootstrap, "ensureMemoryWikiPublicArtifactsRuntime")
+      .mockResolvedValue();
+
+    await resolveMemoryWikiStatus(config, {
+      appConfig,
+      listPublicArtifacts: async () => [],
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(bootstrapSpy).toHaveBeenCalledWith(appConfig);
   });
 
   it("warns when bridge mode has no exported memory artifacts", async () => {

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../api.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { inferWikiPageKind, toWikiPageSummary, type WikiPageKind } from "./markdown.js";
 import { probeObsidianCli } from "./obsidian.js";
+import { ensureMemoryWikiPublicArtifactsRuntime } from "./runtime-bootstrap.js";
 
 export type MemoryWikiStatusWarning = {
   code:
@@ -217,14 +218,15 @@ export async function resolveMemoryWikiStatus(
 ): Promise<MemoryWikiStatus> {
   const exists = deps?.pathExists ?? pathExists;
   const vaultExists = await exists(config.vault.path);
-  const bridgePublicArtifactCount =
-    deps?.appConfig && config.vaultMode === "bridge" && config.bridge.enabled
-      ? (
-          await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
-            cfg: deps.appConfig,
-          })
-        ).length
-      : null;
+  let bridgePublicArtifactCount: number | null = null;
+  if (deps?.appConfig && config.vaultMode === "bridge" && config.bridge.enabled) {
+    await ensureMemoryWikiPublicArtifactsRuntime(deps.appConfig);
+    bridgePublicArtifactCount = (
+      await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
+        cfg: deps.appConfig,
+      })
+    ).length;
+  }
   const obsidianProbe = await probeObsidianCli({ resolveCommand: deps?.resolveCommand });
   const counts = vaultExists
     ? await collectVaultCounts(config.vault.path)


### PR DESCRIPTION
Fixes #65722

## Problem
`openclaw wiki bridge import` always returns 0 artifacts because the CLI does not initialize the memory-core plugin runtime before querying for public memory artifacts. Despite valid workspace memory files being present, the bridge import path sees zero artifacts.

## Root Cause
The wiki CLI path asks for public artifacts without first loading the active memory plugin into the in-process memory-state singleton. The bundled memory-core plugin registers `publicArtifacts.listArtifacts(...)` but the wiki CLI doesn't trigger that registration.

## Fix
Before the wiki CLI queries public artifacts, it now explicitly loads the active/default memory plugin into the in-process memory-state singleton.

## Testing
- Verified that `openclaw wiki status` now reports the correct artifact count
- Verified that `openclaw wiki bridge import` now imports artifacts correctly
- Tested with bridge mode enabled and memory files present

[AI-assisted] — Lightly tested locally.