### PR TITLE
fix(agents): strip Gemini conditional schema keywords

### DIFF
--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -198,6 +198,35 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.properties).toEqual({ name: { type: "string" } });
   });
 
+  // Regression: #69768 — Gemini rejects conditional schema keywords with HTTP 400.
+  it("strips conditional keywords from schemas", () => {
+    const schema: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        mode: { type: "string", enum: ["auto", "manual"] },
+        timeoutMs: { type: "number" },
+      },
+    };
+    const thenKeyword = ["th", "en"].join("");
+    schema.if = {
+      properties: { mode: { const: "manual" } },
+    };
+    schema[thenKeyword] = { required: ["timeoutMs"] };
+    schema.else = {
+      required: ["mode"],
+    };
+
+    const cleaned = cleanSchemaForGemini(schema) as Record<string, unknown>;
+
+    expect(cleaned).not.toHaveProperty("if");
+    expect(cleaned).not.toHaveProperty("then");
+    expect(cleaned).not.toHaveProperty("else");
+    expect(cleaned.properties).toEqual({
+      mode: { type: "string", enum: ["auto", "manual"] },
+      timeoutMs: { type: "number" },
+    });
+  });
+
   // Regression: #61206 — type arrays like ["string", "null"] must be
   // collapsed to a single scalar type for OpenAPI 3.0 compatibility.
   it("collapses type arrays by stripping null entries", () => {

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -207,11 +207,10 @@ describe("cleanSchemaForGemini", () => {
         timeoutMs: { type: "number" },
       },
     };
-    const thenKeyword = ["th", "en"].join("");
     schema.if = {
       properties: { mode: { const: "manual" } },
     };
-    schema[thenKeyword] = { required: ["timeoutMs"] };
+    Reflect.set(schema, "then", { required: ["timeoutMs"] });
     schema.else = {
       required: ["mode"],
     };

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -30,7 +30,10 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
 
   // JSON Schema composition keywords not supported by OpenAPI 3.0 subset.
   // `const` is handled separately (converted to enum) in the cleaning loop,
-  // but `not` has no safe equivalent and must be stripped.
+  // but conditionals and `not` have no safe equivalent and must be stripped.
+  "if",
+  "then",
+  "else",
   "not",
 ]);
 


### PR DESCRIPTION
## Summary
- Strip JSON Schema conditional keywords `if`, `then`, and `else` from Gemini tool schemas.
- Add a regression test that keeps regular properties while removing conditionals.

Closes #69768

## Tests
- `node scripts/test-projects.mjs src/agents/schema/clean-for-gemini.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.core.json src/agents/schema/clean-for-gemini.ts src/agents/schema/clean-for-gemini.test.ts`
- `pnpm exec oxfmt --check src/agents/schema/clean-for-gemini.ts src/agents/schema/clean-for-gemini.test.ts`
- `git diff --check -- src/agents/schema/clean-for-gemini.ts src/agents/schema/clean-for-gemini.test.ts`