### PR TITLE
docs: add missing href attributes to 12 broken Card elements

### DIFF
--- a/docs/concepts/features.md
+++ b/docs/concepts/features.md
@@ -10,22 +10,22 @@ title: "Features"
 ## Highlights
 
 <Columns>
-  <Card title="Channels" icon="message-square">
+  <Card title="Channels" icon="message-square" href="/channels">
     Discord, iMessage, Signal, Slack, Telegram, WhatsApp, WebChat, and more with a single Gateway.
   </Card>
-  <Card title="Plugins" icon="plug">
+  <Card title="Plugins" icon="plug" href="/tools/plugin">
     Bundled plugins add Matrix, Nextcloud Talk, Nostr, Twitch, Zalo, and more without separate installs in normal current releases.
   </Card>
-  <Card title="Routing" icon="route">
+  <Card title="Routing" icon="route" href="/concepts/multi-agent">
     Multi-agent routing with isolated sessions.
   </Card>
-  <Card title="Media" icon="image">
+  <Card title="Media" icon="image" href="/nodes/media-understanding">
     Images, audio, video, documents, and image/video generation.
   </Card>
-  <Card title="Apps and UI" icon="monitor">
+  <Card title="Apps and UI" icon="monitor" href="/web/control-ui">
     Web Control UI and macOS companion app.
   </Card>
-  <Card title="Mobile nodes" icon="smartphone">
+  <Card title="Mobile nodes" icon="smartphone" href="/nodes">
     iOS and Android nodes with pairing, voice/chat, and rich device commands.
   </Card>
 </Columns>

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,22 +73,22 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 ## Key capabilities
 
 <Columns>
-  <Card title="Multi-channel gateway" icon="network">
+  <Card title="Multi-channel gateway" icon="network" href="/channels">
     Discord, iMessage, Signal, Slack, Telegram, WhatsApp, WebChat, and more with a single Gateway process.
   </Card>
-  <Card title="Plugin channels" icon="plug">
+  <Card title="Plugin channels" icon="plug" href="/tools/plugin">
     Bundled plugins add Matrix, Nostr, Twitch, Zalo, and more in normal current releases.
   </Card>
-  <Card title="Multi-agent routing" icon="route">
+  <Card title="Multi-agent routing" icon="route" href="/concepts/multi-agent">
     Isolated sessions per agent, workspace, or sender.
   </Card>
-  <Card title="Media support" icon="image">
+  <Card title="Media support" icon="image" href="/nodes/media-understanding">
     Send and receive images, audio, and documents.
   </Card>
-  <Card title="Web Control UI" icon="monitor">
+  <Card title="Web Control UI" icon="monitor" href="/web/control-ui">
     Browser dashboard for chat, config, sessions, and nodes.
   </Card>
-  <Card title="Mobile nodes" icon="smartphone">
+  <Card title="Mobile nodes" icon="smartphone" href="/nodes">
     Pair iOS and Android nodes for Canvas, camera, and voice-enabled workflows.
   </Card>
 </Columns>


### PR DESCRIPTION
## What

  Adds missing `href` attributes to 12 `<Card>` elements in the docs homepage and features overview, so that each card
  navigates to the relevant page instead of rendering as a dead link.

  ## Where

  - `docs/index.md` — "Key capabilities" section (6 cards)
  - `docs/concepts/features.md` — "Highlights" section (6 cards)

  ## Why

  Cards are intended as navigation entry points, but these 12 instances were missing `href` entirely, so users could not
  click through to the feature pages they describe. This is a direct follow-up to #43925, which fixed the same pattern in
  other files.

  Each new `href` points to a verified existing page:

  | Card | href |
  |---|---|
  | Channels / Multi-channel gateway | `/channels` |
  | Plugins / Plugin channels | `/tools/plugin` |
  | Routing / Multi-agent routing | `/concepts/multi-agent` |
  | Media / Media support | `/nodes/media-understanding` |
  | Apps and UI / Web Control UI | `/web/control-ui` |
  | Mobile nodes | `/nodes` |

  ## Testing

  - Verified each target path resolves to an existing file under `docs/`.
  - No content changes, only `href` attribute added; prose and icons are unchanged.

  ## Checklist

  - [x] PR is focused on one thing
  - [x] American English used
  - [x] No CODEOWNERS-protected files touched
  - [x] Follow-up to an existing merged PR pattern (#43925)