### PR TITLE
fix(cron): Fix delivery mode 'none' with channel 'last' causing Message failed error

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -56,7 +56,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   );
   if (hasDelivery) {
     const resolvedMode = mode ?? "announce";
-    const channel = resolvedMode === "announce" ? (deliveryChannel ?? "last") : deliveryChannel;
+    const channel = resolvedMode === "announce" ? (deliveryChannel ?? "last") : undefined;
     return {
       mode: resolvedMode,
       channel: resolvedMode === "webhook" ? undefined : channel,


### PR DESCRIPTION
## Summary

Fixes the bug where cron jobs with  fail with 'Message failed' error.

## Problem

When  is set to 'none' but  is set to 'last', the delivery system still attempts to deliver messages, causing a failure.

## Root Cause

In  function, when  is 'none', the  was still being set to  (which could be 'last') instead of .

## Fix

Changed the channel assignment from:


To:


This ensures that when delivery mode is 'none', no channel is requested, preventing delivery attempts.

## Test

The fix has been tested and resolves the issue described in #7.

## Type

- Bug fix