### PR TITLE
Fix configure startup lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Cron/run-log: report generic `message` tool sends under the resolved delivery channel when they match the cron target, while preserving account-specific mismatch checks for delivery traces. (#69940) Thanks @davehappyminion.
 - Doctor/channels: merge configured-channel doctor hooks across read-only, loaded, setup, and runtime plugin discovery so partial adapters no longer hide runtime-only compatibility repair or allowlist warnings, preserve disabled-channel opt-outs, and ignore malformed hook values before they can mask valid fallbacks. (#69919) Thanks @gumadeiras.
 - Models/CLI: show bundled provider-owned static catalog rows in `models list --all` before auth is configured, including Kimi K2.6 rows for Moonshot, OpenRouter, and Vercel AI Gateway, while keeping local-only and workspace plugin catalog paths isolated. (#69909) Thanks @shakkernerd.
+- Configure: skip generic CLI startup bootstrap for `openclaw configure` and bound hint-only gateway probes so the onboarding TUI reaches its first prompt faster when the Gateway is unavailable. (#69984) Thanks @obviyus.
 
 ## 2026.4.21
 

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -37,7 +37,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["channels"], policy: { loadPlugins: "always" } },
   { commandPath: ["directory"], policy: { loadPlugins: "always" } },
   { commandPath: ["agents"], policy: { loadPlugins: "always" } },
-  { commandPath: ["configure"], policy: { loadPlugins: "always" } },
+  { commandPath: ["configure"], policy: { bypassConfigGuard: true, loadPlugins: "never" } },
   {
     commandPath: ["status"],
     policy: {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -44,6 +44,13 @@ describe("command-path-policy", () => {
   });
 
   it("resolves mixed startup-only rules", () => {
+    expect(resolveCliCommandPathPolicy(["configure"])).toEqual({
+      bypassConfigGuard: true,
+      routeConfigGuard: "never",
+      loadPlugins: "never",
+      hideBanner: false,
+      ensureCliPath: true,
+    });
     expect(resolveCliCommandPathPolicy(["config", "validate"])).toEqual({
       bypassConfigGuard: true,
       routeConfigGuard: "never",

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -266,6 +266,16 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
+  it("lets configure own config validation and plugin loading", async () => {
+    await runPreAction({
+      parseArgv: ["configure"],
+      processArgv: ["node", "openclaw", "configure"],
+    });
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
   it("only allows invalid config for explicit Matrix reinstall requests", async () => {
     await runPreAction({
       parseArgv: ["plugins", "install", "@openclaw/matrix"],

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -242,6 +242,38 @@ describe("runConfigureWizard", () => {
     );
   });
 
+  it("keeps startup gateway hint probes bounded", async () => {
+    setupBaseWizardState({
+      gateway: {
+        mode: "local",
+        remote: {
+          url: "wss://gateway.example.test",
+          token: "token",
+        },
+      },
+    });
+    queueWizardPrompts({
+      select: ["local", "__continue"],
+      confirm: [],
+    });
+
+    await runConfigureWizard({ command: "configure" }, createRuntime());
+
+    expect(mocks.probeGatewayReachable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 300,
+      }),
+    );
+    expect(mocks.probeGatewayReachable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://gateway.example.test",
+        token: "token",
+        timeoutMs: 300,
+      }),
+    );
+  });
+
   it("exits with code 1 when configure wizard is cancelled", async () => {
     const runtime = createRuntime();
     setupBaseWizardState();

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -52,6 +52,8 @@ import { setupSkills } from "./onboard-skills.js";
 type ConfigureSectionChoice = WizardSection | "__continue";
 type SetupPluginConfigModule = typeof import("../wizard/setup.plugin-config.js");
 
+const GATEWAY_HINT_PROBE_TIMEOUT_MS = 300;
+
 let setupPluginConfigModulePromise: Promise<SetupPluginConfigModule> | undefined;
 
 function loadSetupPluginConfigModule(): Promise<SetupPluginConfigModule> {
@@ -386,33 +388,42 @@ export async function runConfigureWizard(
     }
 
     const localUrl = "ws://127.0.0.1:18789";
-    const baseLocalProbeToken = await resolveGatewaySecretInputForWizard({
-      cfg: baseConfig,
-      value: baseConfig.gateway?.auth?.token,
-      path: "gateway.auth.token",
-    });
-    const baseLocalProbePassword = await resolveGatewaySecretInputForWizard({
-      cfg: baseConfig,
-      value: baseConfig.gateway?.auth?.password,
-      path: "gateway.auth.password",
-    });
-    const localProbe = await probeGatewayReachable({
-      url: localUrl,
-      token: process.env.OPENCLAW_GATEWAY_TOKEN ?? baseLocalProbeToken,
-      password: process.env.OPENCLAW_GATEWAY_PASSWORD ?? baseLocalProbePassword,
-    });
     const remoteUrl = normalizeOptionalString(baseConfig.gateway?.remote?.url) ?? "";
-    const baseRemoteProbeToken = await resolveGatewaySecretInputForWizard({
-      cfg: baseConfig,
-      value: baseConfig.gateway?.remote?.token,
-      path: "gateway.remote.token",
-    });
-    const remoteProbe = remoteUrl
-      ? await probeGatewayReachable({
-          url: remoteUrl,
-          token: baseRemoteProbeToken,
-        })
-      : null;
+    const localProbePromise = (async () => {
+      const [baseLocalProbeToken, baseLocalProbePassword] = await Promise.all([
+        resolveGatewaySecretInputForWizard({
+          cfg: baseConfig,
+          value: baseConfig.gateway?.auth?.token,
+          path: "gateway.auth.token",
+        }),
+        resolveGatewaySecretInputForWizard({
+          cfg: baseConfig,
+          value: baseConfig.gateway?.auth?.password,
+          path: "gateway.auth.password",
+        }),
+      ]);
+      return probeGatewayReachable({
+        url: localUrl,
+        token: process.env.OPENCLAW_GATEWAY_TOKEN ?? baseLocalProbeToken,
+        password: process.env.OPENCLAW_GATEWAY_PASSWORD ?? baseLocalProbePassword,
+        timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
+      });
+    })();
+    const remoteProbePromise = remoteUrl
+      ? (async () => {
+          const baseRemoteProbeToken = await resolveGatewaySecretInputForWizard({
+            cfg: baseConfig,
+            value: baseConfig.gateway?.remote?.token,
+            path: "gateway.remote.token",
+          });
+          return probeGatewayReachable({
+            url: remoteUrl,
+            token: baseRemoteProbeToken,
+            timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
+          });
+        })()
+      : Promise.resolve(null);
+    const [localProbe, remoteProbe] = await Promise.all([localProbePromise, remoteProbePromise]);
 
     const mode = guardCancel(
       await select({


### PR DESCRIPTION
## Summary
- skip generic CLI config/plugin bootstrap for `openclaw configure`
- bound startup gateway hint probes and run local/remote checks in parallel

## Verification
- `pnpm check:changed`