### PR TITLE
fix: skip clean run-node runtime restaging

### DIFF
--- a/scripts/run-node.d.mts
+++ b/scripts/run-node.d.mts
@@ -13,6 +13,15 @@ export function resolveBuildRequirement(deps: {
   configFiles: string[];
 }): { shouldBuild: boolean; reason: string };
 
+export function resolveRuntimePostBuildRequirement(deps: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  fs: unknown;
+  spawnSync: unknown;
+  buildStampPath: string;
+  runtimePostBuildStampPath: string;
+}): { shouldSync: boolean; reason: string };
+
 export function acquireRunNodeBuildLock(deps: {
   cwd: string;
   args: readonly string[];

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -17,9 +17,31 @@ const compilerArgs = [buildScript, "--no-clean"];
 const runNodeSourceRoots = ["src", BUNDLED_PLUGIN_ROOT_DIR];
 const runNodeConfigFiles = ["tsconfig.json", "package.json", "tsdown.config.ts"];
 export const runNodeWatchedPaths = [...runNodeSourceRoots, ...runNodeConfigFiles];
+const runtimePostBuildStampFile = ".runtime-postbuildstamp";
+const runtimePostBuildWatchedPaths = [
+  "scripts/copy-bundled-plugin-metadata.mjs",
+  "scripts/copy-plugin-sdk-root-alias.mjs",
+  "scripts/lib",
+  "scripts/npm-runner.mjs",
+  "scripts/runtime-postbuild-shared.mjs",
+  "scripts/runtime-postbuild.mjs",
+  "scripts/stage-bundled-plugin-runtime-deps.mjs",
+  "scripts/stage-bundled-plugin-runtime.mjs",
+  "scripts/windows-cmd-helpers.mjs",
+  "scripts/write-official-channel-catalog.mjs",
+  "src/plugin-sdk/root-alias.cjs",
+  BUNDLED_PLUGIN_ROOT_DIR,
+];
 const ignoredRunNodeRepoPaths = new Set([
   "src/canvas-host/a2ui/.bundle.hash",
   "src/canvas-host/a2ui/a2ui.bundle.js",
+]);
+const runtimePostBuildScriptPaths = new Set(
+  runtimePostBuildWatchedPaths.filter((entry) => entry.startsWith("scripts/")),
+);
+const runtimePostBuildStaticAssetPaths = new Set([
+  "extensions/acpx/src/runtime-internals/mcp-proxy.mjs",
+  "extensions/diffs/assets/viewer-runtime.js",
 ]);
 const extensionSourceFilePattern = /\.(?:[cm]?[jt]sx?)$/;
 const extensionRestartMetadataFiles = new Set(["openclaw.plugin.json", "package.json"]);
@@ -130,11 +152,11 @@ const findLatestMtime = (dirPath, shouldSkip, deps) => {
   return latest;
 };
 
-const readGitStatus = (deps) => {
+const readGitStatus = (deps, paths = runNodeWatchedPaths) => {
   try {
     const result = deps.spawnSync(
       "git",
-      ["status", "--porcelain", "--untracked-files=normal", "--", ...runNodeWatchedPaths],
+      ["status", "--porcelain", "--untracked-files=normal", "--", ...paths],
       {
         cwd: deps.cwd,
         encoding: "utf8",
@@ -165,6 +187,38 @@ const hasDirtySourceTree = (deps) => {
   return parseGitStatusPaths(output).some((repoPath) => isBuildRelevantRunNodePath(repoPath));
 };
 
+const isRuntimePostBuildRelevantPath = (repoPath) => {
+  const normalizedPath = normalizePath(repoPath).replace(/^\.\/+/, "");
+  if (normalizedPath === "src/plugin-sdk/root-alias.cjs") {
+    return true;
+  }
+  if (runtimePostBuildStaticAssetPaths.has(normalizedPath)) {
+    return true;
+  }
+  if (
+    normalizedPath.startsWith("scripts/") &&
+    (runtimePostBuildScriptPaths.has(normalizedPath) || normalizedPath.startsWith("scripts/lib/"))
+  ) {
+    return true;
+  }
+  if (!normalizedPath.startsWith(BUNDLED_PLUGIN_PATH_PREFIX)) {
+    return false;
+  }
+  const pluginRelativePath = normalizedPath.slice(BUNDLED_PLUGIN_PATH_PREFIX.length);
+  if (pluginRelativePath.startsWith("skills/")) {
+    return true;
+  }
+  return extensionRestartMetadataFiles.has(path.posix.basename(pluginRelativePath));
+};
+
+const hasDirtyRuntimePostBuildInputs = (deps) => {
+  const output = readGitStatus(deps, runtimePostBuildWatchedPaths);
+  if (output === null) {
+    return null;
+  }
+  return parseGitStatusPaths(output).some((repoPath) => isRuntimePostBuildRelevantPath(repoPath));
+};
+
 const readBuildStamp = (deps) => {
   const mtime = statMtime(deps.buildStampPath, deps.fs);
   if (mtime == null) {
@@ -172,6 +226,24 @@ const readBuildStamp = (deps) => {
   }
   try {
     const raw = deps.fs.readFileSync(deps.buildStampPath, "utf8").trim();
+    if (!raw.startsWith("{")) {
+      return { mtime, head: null };
+    }
+    const parsed = JSON.parse(raw);
+    const head = typeof parsed?.head === "string" && parsed.head.trim() ? parsed.head.trim() : null;
+    return { mtime, head };
+  } catch {
+    return { mtime, head: null };
+  }
+};
+
+const readRuntimePostBuildStamp = (deps) => {
+  const mtime = statMtime(deps.runtimePostBuildStampPath, deps.fs);
+  if (mtime == null) {
+    return { mtime: null, head: null };
+  }
+  try {
+    const raw = deps.fs.readFileSync(deps.runtimePostBuildStampPath, "utf8").trim();
     if (!raw.startsWith("{")) {
       return { mtime, head: null };
     }
@@ -196,6 +268,43 @@ const hasSourceMtimeChanged = (stampMtime, deps) => {
     }
   }
   return latestSourceMtime != null && latestSourceMtime > stampMtime;
+};
+
+const findLatestRuntimePostBuildInputMtime = (absolutePath, relativePath, deps) => {
+  const normalizedRelativePath = normalizePath(relativePath);
+  const statsMtime = statMtime(absolutePath, deps.fs);
+  if (statsMtime == null) {
+    return null;
+  }
+  let stat;
+  try {
+    stat = deps.fs.statSync(absolutePath);
+  } catch {
+    return null;
+  }
+  if (!stat.isDirectory()) {
+    return isRuntimePostBuildRelevantPath(normalizedRelativePath) ? statsMtime : null;
+  }
+  return findLatestMtime(
+    absolutePath,
+    (candidate) => {
+      const candidateRelativePath = path.relative(deps.cwd, candidate);
+      return !isRuntimePostBuildRelevantPath(candidateRelativePath);
+    },
+    deps,
+  );
+};
+
+const hasRuntimePostBuildInputMtimeChanged = (stampMtime, deps) => {
+  let latestInputMtime = null;
+  for (const relativePath of runtimePostBuildWatchedPaths) {
+    const absolutePath = path.join(deps.cwd, relativePath);
+    const inputMtime = findLatestRuntimePostBuildInputMtime(absolutePath, relativePath, deps);
+    if (inputMtime != null && (latestInputMtime == null || inputMtime > latestInputMtime)) {
+      latestInputMtime = inputMtime;
+    }
+  }
+  return latestInputMtime != null && latestInputMtime > stampMtime;
 };
 
 export const resolveBuildRequirement = (deps) => {
@@ -248,6 +357,48 @@ export const resolveBuildRequirement = (deps) => {
   return { shouldBuild: false, reason: "clean" };
 };
 
+export const resolveRuntimePostBuildRequirement = (deps) => {
+  if (deps.env.OPENCLAW_FORCE_RUNTIME_POSTBUILD === "1") {
+    return { shouldSync: true, reason: "force_runtime_postbuild" };
+  }
+
+  const stamp = readRuntimePostBuildStamp(deps);
+  if (stamp.mtime == null) {
+    return { shouldSync: true, reason: "missing_runtime_postbuild_stamp" };
+  }
+
+  const buildStamp = readBuildStamp(deps);
+  if (buildStamp.mtime == null) {
+    return { shouldSync: true, reason: "missing_build_stamp" };
+  }
+  if (buildStamp.mtime > stamp.mtime) {
+    return { shouldSync: true, reason: "build_stamp_newer" };
+  }
+
+  const currentHead = resolveGitHead(deps);
+  if (currentHead && !stamp.head) {
+    return { shouldSync: true, reason: "runtime_postbuild_stamp_missing_head" };
+  }
+  if (currentHead && stamp.head && currentHead !== stamp.head) {
+    return { shouldSync: true, reason: "git_head_changed" };
+  }
+  if (currentHead) {
+    const dirty = hasDirtyRuntimePostBuildInputs(deps);
+    if (dirty === true) {
+      return { shouldSync: true, reason: "dirty_runtime_postbuild_inputs" };
+    }
+    if (dirty === false) {
+      return { shouldSync: false, reason: "clean" };
+    }
+  }
+
+  if (hasRuntimePostBuildInputMtimeChanged(stamp.mtime, deps)) {
+    return { shouldSync: true, reason: "runtime_postbuild_input_mtime_newer" };
+  }
+
+  return { shouldSync: false, reason: "clean" };
+};
+
 const BUILD_REASON_LABELS = {
   force_build: "forced by OPENCLAW_FORCE_BUILD",
   missing_build_stamp: "build stamp missing",
@@ -261,7 +412,20 @@ const BUILD_REASON_LABELS = {
   clean: "clean",
 };
 
+const RUNTIME_POSTBUILD_REASON_LABELS = {
+  force_runtime_postbuild: "forced by OPENCLAW_FORCE_RUNTIME_POSTBUILD",
+  missing_runtime_postbuild_stamp: "runtime postbuild stamp missing",
+  missing_build_stamp: "build stamp missing",
+  build_stamp_newer: "build stamp newer than runtime postbuild stamp",
+  runtime_postbuild_stamp_missing_head: "runtime postbuild stamp missing git head",
+  git_head_changed: "git head changed",
+  dirty_runtime_postbuild_inputs: "dirty runtime postbuild inputs",
+  runtime_postbuild_input_mtime_newer: "runtime postbuild input mtime newer than stamp",
+  clean: "clean",
+};
+
 const formatBuildReason = (reason) => BUILD_REASON_LABELS[reason] ?? reason;
+const formatRuntimePostBuildReason = (reason) => RUNTIME_POSTBUILD_REASON_LABELS[reason] ?? reason;
 
 const SIGNAL_EXIT_CODES = {
   SIGINT: 130,
@@ -565,6 +729,38 @@ const syncRuntimeArtifacts = async (deps) => {
   return true;
 };
 
+const writeRuntimePostBuildStamp = (deps) => {
+  try {
+    deps.fs.mkdirSync(path.dirname(deps.runtimePostBuildStampPath), { recursive: true });
+    const head = resolveGitHead(deps);
+    deps.fs.writeFileSync(
+      deps.runtimePostBuildStampPath,
+      `${JSON.stringify(
+        {
+          syncedAt: Date.now(),
+          ...(head ? { head } : {}),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  } catch (error) {
+    logRunner(
+      `Failed to write runtime postbuild stamp: ${error?.message ?? "unknown error"}`,
+      deps,
+    );
+  }
+};
+
+const syncRuntimeArtifactsAndStamp = async (deps) => {
+  const synced = await syncRuntimeArtifacts(deps);
+  if (synced) {
+    writeRuntimePostBuildStamp(deps);
+  }
+  return synced;
+};
+
 const writeBuildStamp = (deps) => {
   try {
     writeDistBuildStamp({
@@ -598,6 +794,7 @@ export async function runNodeMain(params = {}) {
   deps.distRoot = path.join(deps.cwd, "dist");
   deps.distEntry = path.join(deps.distRoot, "/entry.js");
   deps.buildStampPath = path.join(deps.distRoot, ".buildstamp");
+  deps.runtimePostBuildStampPath = path.join(deps.distRoot, runtimePostBuildStampFile);
   deps.sourceRoots = runNodeSourceRoots.map((sourceRoot) => ({
     name: sourceRoot,
     path: path.join(deps.cwd, sourceRoot),
@@ -615,12 +812,22 @@ export async function runNodeMain(params = {}) {
     const buildRequirement = resolveBuildRequirement(deps);
     if (!buildRequirement.shouldBuild) {
       if (!shouldSkipCleanWatchRuntimeSync(deps)) {
-        const synced = await withRunNodeBuildLock(
-          deps,
-          async () => await syncRuntimeArtifacts(deps),
-        );
-        if (!synced) {
-          return await closeRunNodeOutputTee(deps, 1);
+        const runtimePostBuildRequirement = resolveRuntimePostBuildRequirement(deps);
+        if (runtimePostBuildRequirement.shouldSync) {
+          const synced = await withRunNodeBuildLock(deps, async () => {
+            const lockedRuntimePostBuildRequirement = resolveRuntimePostBuildRequirement(deps);
+            if (!lockedRuntimePostBuildRequirement.shouldSync) {
+              return true;
+            }
+            logRunner(
+              `Syncing runtime artifacts (${lockedRuntimePostBuildRequirement.reason} - ${formatRuntimePostBuildReason(lockedRuntimePostBuildRequirement.reason)}).`,
+              deps,
+            );
+            return await syncRuntimeArtifactsAndStamp(deps);
+          });
+          if (!synced) {
+            return await closeRunNodeOutputTee(deps, 1);
+          }
         }
       }
       exitCode = await runOpenClaw(deps);
@@ -630,7 +837,15 @@ export async function runNodeMain(params = {}) {
     const buildExitCode = await withRunNodeBuildLock(deps, async () => {
       const lockedBuildRequirement = resolveBuildRequirement(deps);
       if (!lockedBuildRequirement.shouldBuild) {
-        return (await syncRuntimeArtifacts(deps)) ? 0 : 1;
+        const runtimePostBuildRequirement = resolveRuntimePostBuildRequirement(deps);
+        if (!runtimePostBuildRequirement.shouldSync) {
+          return 0;
+        }
+        logRunner(
+          `Syncing runtime artifacts (${runtimePostBuildRequirement.reason} - ${formatRuntimePostBuildReason(runtimePostBuildRequirement.reason)}).`,
+          deps,
+        );
+        return (await syncRuntimeArtifactsAndStamp(deps)) ? 0 : 1;
       }
 
       logRunner(
@@ -658,6 +873,7 @@ export async function runNodeMain(params = {}) {
         return 1;
       }
       writeBuildStamp(deps);
+      writeRuntimePostBuildStamp(deps);
       return 0;
     });
     if (buildExitCode !== 0) {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   acquireRunNodeBuildLock,
   resolveBuildRequirement,
+  resolveRuntimePostBuildRequirement,
   runNodeMain,
 } from "../../scripts/run-node.mjs";
 import {
@@ -23,6 +24,7 @@ const GENERATED_A2UI_BUNDLE = "src/canvas-host/a2ui/a2ui.bundle.js";
 const GENERATED_A2UI_BUNDLE_HASH = "src/canvas-host/a2ui/.bundle.hash";
 const DIST_ENTRY = "dist/entry.js";
 const BUILD_STAMP = "dist/.buildstamp";
+const RUNTIME_POSTBUILD_STAMP = "dist/.runtime-postbuildstamp";
 const QA_LAB_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-lab.js";
 const QA_RUNTIME_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-runtime.js";
 const EXTENSION_SRC = bundledPluginFile("demo", "src/index.ts");
@@ -189,6 +191,7 @@ function createBuildRequirementDeps(
     distRoot: path.join(tmp, "dist"),
     distEntry: path.join(tmp, DIST_ENTRY),
     buildStampPath: path.join(tmp, BUILD_STAMP),
+    runtimePostBuildStampPath: path.join(tmp, RUNTIME_POSTBUILD_STAMP),
     sourceRoots: [path.join(tmp, "src"), path.join(tmp, bundledPluginRoot("demo"))].map(
       (sourceRoot) => ({
         name: path.relative(tmp, sourceRoot).replaceAll("\\", "/"),
@@ -623,6 +626,72 @@ describe("run-node script", () => {
     });
   });
 
+  it("skips runtime postbuild restaging when the runtime stamp is current", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+        buildPaths: [DIST_ENTRY, BUILD_STAMP, RUNTIME_POSTBUILD_STAMP],
+      });
+
+      const runRuntimePostBuild = vi.fn();
+      const { spawnCalls, spawn, spawnSync } = createSpawnRecorder({
+        gitHead: "abc123\n",
+        gitStatus: "",
+      });
+      const exitCode = await runStatusCommand({
+        tmp,
+        spawn,
+        spawnSync,
+        runRuntimePostBuild,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(spawnCalls).toEqual([statusCommandSpawn()]);
+      expect(runRuntimePostBuild).not.toHaveBeenCalled();
+    });
+  });
+
+  it("restages runtime artifacts when runtime metadata is dirty", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_MANIFEST,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+
+      const runRuntimePostBuild = vi.fn();
+      const { spawnCalls, spawn, spawnSync } = createSpawnRecorder({
+        gitHead: "abc123\n",
+        gitStatus: ` M ${EXTENSION_MANIFEST}\n`,
+      });
+      const exitCode = await runStatusCommand({
+        tmp,
+        spawn,
+        spawnSync,
+        runRuntimePostBuild,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(spawnCalls).toEqual([statusCommandSpawn()]);
+      expect(runRuntimePostBuild).toHaveBeenCalledOnce();
+    });
+  });
+
   it("serializes runtime postbuild restaging across concurrent clean launchers", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
@@ -669,7 +738,7 @@ describe("run-node script", () => {
         ]),
       ).resolves.toEqual([0, 0]);
 
-      expect(runRuntimePostBuild).toHaveBeenCalledTimes(2);
+      expect(runRuntimePostBuild).toHaveBeenCalledTimes(1);
       expect(maxActivePostbuilds).toBe(1);
       expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
     });
@@ -937,6 +1006,66 @@ describe("run-node script", () => {
       expect(requirement).toEqual({
         shouldBuild: false,
         reason: "clean",
+      });
+    });
+  });
+
+  it("reports clean runtime postbuild artifacts when the runtime stamp matches HEAD", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+        buildPaths: [DIST_ENTRY, BUILD_STAMP, RUNTIME_POSTBUILD_STAMP],
+      });
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: false,
+        reason: "clean",
+      });
+    });
+  });
+
+  it("reports dirty runtime postbuild inputs separately from rebuild inputs", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_MANIFEST,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+
+      const deps = createBuildRequirementDeps(tmp, {
+        gitHead: "abc123\n",
+        gitStatus: ` M ${EXTENSION_MANIFEST}\n`,
+      });
+
+      expect(resolveBuildRequirement(deps)).toEqual({
+        shouldBuild: false,
+        reason: "clean",
+      });
+      expect(resolveRuntimePostBuildRequirement(deps)).toEqual({
+        shouldSync: true,
+        reason: "dirty_runtime_postbuild_inputs",
       });
     });
   });


### PR DESCRIPTION
## Summary

- Problem: clean source-checkout CLI runs still repeated runtime postbuild staging, so even commands like `openclaw --help` paid unnecessary runtime artifact work after the TypeScript build was already current.
- Why it matters: the local CLI loop is slow enough that simple commands feel blocked by build/runtime setup instead of reaching command execution quickly.
- What changed: added a runtime-postbuild stamp and lock-aware freshness checks so clean `run-node` launches skip runtime restaging when the build stamp, runtime stamp, git HEAD, and runtime-postbuild inputs are current.
- What did NOT change (scope boundary): this does not change the TypeScript build command, does not make dirty source trees skip rebuilds, and does not solve first-run rebuild time after a new git HEAD.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `scripts/run-node.mjs` only stamped the TypeScript build output. On clean non-watch launches where the build was current, it still ran runtime postbuild staging unconditionally.
- Missing detection / guardrail: there was no separate freshness stamp for runtime-postbuild outputs or their input set.
- Contributing context (if known): runtime-postbuild copies plugin metadata, SDK aliases, channel catalogs, and bundled plugin runtime dependencies, so rerunning it on every clean launch is expensive.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/run-node.test.ts`
- Scenario the test should lock in: clean current build/runtime stamps skip runtime restaging; dirty runtime metadata still restages; concurrent clean launchers do not duplicate restaging.
- Why this is the smallest reliable guardrail: it exercises the `run-node` decision path directly without paying the full TypeScript build/runtime staging cost in every test.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Clean source-checkout CLI launches can skip runtime postbuild staging after the current HEAD has already built and staged runtime artifacts once. First runs after a new commit and dirty source trees still rebuild as before.

## Diagram (if applicable)

```text
Before:
clean run-node launch -> build stamp current -> runtime postbuild runs again -> command starts

After:
clean run-node launch -> build stamp current -> runtime stamp current -> command starts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start from a clean branch with stale or missing `dist/.runtime-postbuildstamp`.
2. Run `pnpm openclaw --help` once to build/stage artifacts.
3. Run `pnpm openclaw --help` again from the same clean HEAD.

### Expected

- First run may build/stage if stamps are stale.
- Second clean run starts without rebuilding or restaging runtime artifacts.

### Actual

- Before this PR, clean non-watch launches still reran runtime postbuild.
- After this PR, a second clean `pnpm openclaw --help` completed locally in about `506ms` without a build/restage log line.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Verification run locally in this workspace:

- `pnpm test src/infra/run-node.test.ts`
- `pnpm check:changed`
- `pnpm openclaw --help` first run after stale HEAD updated stamps
- `pnpm openclaw --help` second clean run completed in about `506ms`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: clean current runtime stamp skips restaging; stale git HEAD builds/stages once; uncommitted source changes still trigger rebuilds; help output still renders after build.
- Edge cases checked: concurrent clean launchers covered by `src/infra/run-node.test.ts`; dirty runtime metadata restage path covered by `src/infra/run-node.test.ts`.
- What you did **not** verify: Blacksmith Testbox was not run because the `blacksmith` CLI is not installed in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: runtime artifacts could be skipped when an input changes.
  - Mitigation: runtime-postbuild freshness checks include the runtime scripts, script helpers, plugin metadata, plugin skill content, static runtime assets, SDK alias, and recursive mtime fallback when git status is unavailable.
