### PR TITLE
feat(tencent): remove Token Plan provider and auth

### DIFF
--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -1,64 +1,40 @@
 ---
-title: "Tencent Cloud (TokenHub + Token Plan)"
-summary: "Tencent Cloud TokenHub and Token Plan setup (separate keys)"
+title: "Tencent Cloud (TokenHub)"
+summary: "Tencent Cloud TokenHub setup"
 read_when:
   - You want to use Tencent Hy models with OpenClaw
-  - You need the TokenHub API key or Token Plan (LKEAP) setup
+  - You need the TokenHub API key setup
 ---
 
-# Tencent Cloud (TokenHub + Token Plan)
+# Tencent Cloud (TokenHub)
 
-The Tencent Cloud provider gives access to Tencent Hy models via two endpoints
-with separate API keys:
+The Tencent Cloud provider gives access to Tencent Hy models via the TokenHub
+endpoint (`tencent-tokenhub`).
 
-- **TokenHub** (`tencent-tokenhub`) — call Hy via Tencent TokenHub Gateway
-- **Token Plan** (`tencent-token-plan`) — call Hy via the LKEAP
-  Token Plan endpoint
-
-Both providers use OpenAI-compatible APIs.
+The provider uses an OpenAI-compatible API.
 
 ## Quick start
-
-TokenHub:
 
 ```bash
 openclaw onboard --auth-choice tokenhub-api-key
 ```
 
-Token Plan:
-
-```bash
-openclaw onboard --auth-choice tencent-token-plan-api-key
-```
-
 ## Non-interactive example
 
 ```bash
-# TokenHub
 openclaw onboard --non-interactive \
   --mode local \
   --auth-choice tokenhub-api-key \
   --tokenhub-api-key "$TOKENHUB_API_KEY" \
   --skip-health \
   --accept-risk
-
-# Token Plan
-openclaw onboard --non-interactive \
-  --mode local \
-  --auth-choice tencent-token-plan-api-key \
-  --tencent-token-plan-api-key "$LKEAP_API_KEY" \
-  --skip-health \
-  --accept-risk
 ```
 
 ## Providers and endpoints
 
-| Provider             | Endpoint                              | Use case                |
-| -------------------- | ------------------------------------- | ----------------------- |
-| `tencent-tokenhub`   | `tokenhub.tencentmaas.com/v1`         | Hy via Tencent TokenHub |
-| `tencent-token-plan` | `api.lkeap.cloud.tencent.com/plan/v3` | Hy via LKEAP Token Plan |
-
-Each provider uses its own API key. Setup registers only the selected provider.
+| Provider           | Endpoint                      | Use case                |
+| ------------------ | ----------------------------- | ----------------------- |
+| `tencent-tokenhub` | `tokenhub.tencentmaas.com/v1` | Hy via Tencent TokenHub |
 
 ## Available models
 
@@ -66,25 +42,19 @@ Each provider uses its own API key. Setup registers only the selected provider.
 
 - **hy3-preview** — Hy3 preview (256K context, reasoning, default)
 
-### tencent-token-plan
-
-- **hy3-preview** — Hy3 preview (256K context, reasoning, default)
-
 ## Notes
 
-- TokenHub model refs use `tencent-tokenhub/<modelId>`. Token Plan model refs
-  use `tencent-token-plan/<modelId>`.
+- TokenHub model refs use `tencent-tokenhub/<modelId>`.
 - Override pricing and context metadata in `models.providers` if needed.
 
 ## Environment note
 
 If the Gateway runs as a daemon (launchd/systemd), make sure `TOKENHUB_API_KEY`
-or `LKEAP_API_KEY` is available to that process (for example, in
-`~/.openclaw/.env` or via `env.shellEnv`).
+is available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
 
 ## Related documentation
 
 - [OpenClaw Configuration](/configuration)
 - [Model Providers](/concepts/model-providers)
 - [Tencent TokenHub](https://cloud.tencent.com/document/product/1823/130050)
-- [Tencent Token Plan API](https://cloud.tencent.com/document/product/1823/130060)

--- a/extensions/tencent/api.ts
+++ b/extensions/tencent/api.ts
@@ -1,11 +1,7 @@
 export {
   buildTokenHubModelDefinition,
-  buildTokenPlanModelDefinition,
   TOKENHUB_BASE_URL,
   TOKENHUB_MODEL_CATALOG,
   TOKENHUB_PROVIDER_ID,
-  TOKEN_PLAN_BASE_URL,
-  TOKEN_PLAN_MODEL_CATALOG,
-  TOKEN_PLAN_PROVIDER_ID,
 } from "./models.js";
-export { buildTokenHubProvider, buildTokenPlanProvider } from "./provider-catalog.js";
+export { buildTokenHubProvider } from "./provider-catalog.js";

--- a/extensions/tencent/index.ts
+++ b/extensions/tencent/index.ts
@@ -1,19 +1,9 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { buildSingleProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
-import {
-  TOKENHUB_MODEL_CATALOG,
-  TOKENHUB_PROVIDER_ID,
-  TOKEN_PLAN_MODEL_CATALOG,
-  TOKEN_PLAN_PROVIDER_ID,
-} from "./models.js";
-import {
-  applyTokenHubConfig,
-  TOKENHUB_DEFAULT_MODEL_REF,
-  applyTokenPlanConfig,
-  TOKEN_PLAN_DEFAULT_MODEL_REF,
-} from "./onboard.js";
-import { buildTokenHubProvider, buildTokenPlanProvider } from "./provider-catalog.js";
+import { TOKENHUB_MODEL_CATALOG, TOKENHUB_PROVIDER_ID } from "./models.js";
+import { applyTokenHubConfig, TOKENHUB_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildTokenHubProvider } from "./provider-catalog.js";
 
 function buildStaticCatalogEntries(providerId: string, catalog: typeof TOKENHUB_MODEL_CATALOG) {
   return catalog.map((entry) => ({
@@ -29,9 +19,8 @@ function buildStaticCatalogEntries(providerId: string, catalog: typeof TOKENHUB_
 export default definePluginEntry({
   id: "tencent",
   name: "Tencent Cloud Provider",
-  description: "Bundled Tencent Cloud provider plugins (TokenHub + Token Plan)",
+  description: "Bundled Tencent Cloud provider plugin (TokenHub)",
   register(api) {
-    // ---------- TokenHub provider ----------
     api.registerProvider({
       id: TOKENHUB_PROVIDER_ID,
       label: "Tencent TokenHub",
@@ -55,7 +44,7 @@ export default definePluginEntry({
             choiceLabel: "Tencent TokenHub",
             groupId: "tencent",
             groupLabel: "Tencent Cloud",
-            groupHint: "TokenHub + Token Plan",
+            groupHint: "Tencent TokenHub",
           },
         }),
       ],
@@ -70,47 +59,6 @@ export default definePluginEntry({
       },
       augmentModelCatalog: () =>
         buildStaticCatalogEntries(TOKENHUB_PROVIDER_ID, TOKENHUB_MODEL_CATALOG),
-    });
-
-    // ---------- Token Plan provider ----------
-    api.registerProvider({
-      id: TOKEN_PLAN_PROVIDER_ID,
-      label: "Tencent Token Plan",
-      docsPath: "/providers/tencent",
-      envVars: ["LKEAP_API_KEY"],
-      auth: [
-        createProviderApiKeyAuthMethod({
-          providerId: TOKEN_PLAN_PROVIDER_ID,
-          methodId: "api-key",
-          label: "Tencent Token Plan",
-          hint: "Hy via Token Plan",
-          optionKey: "tencentTokenPlanApiKey",
-          flagName: "--tencent-token-plan-api-key",
-          envVar: "LKEAP_API_KEY",
-          promptMessage: "Enter Tencent Token Plan API key",
-          defaultModel: TOKEN_PLAN_DEFAULT_MODEL_REF,
-          expectedProviders: [TOKEN_PLAN_PROVIDER_ID],
-          applyConfig: (cfg) => applyTokenPlanConfig(cfg),
-          wizard: {
-            choiceId: "tencent-token-plan-api-key",
-            choiceLabel: "Tencent Token Plan",
-            groupId: "tencent",
-            groupLabel: "Tencent Cloud",
-            groupHint: "TokenHub + Token Plan",
-          },
-        }),
-      ],
-      catalog: {
-        order: "simple",
-        run: (ctx) =>
-          buildSingleProviderApiKeyCatalog({
-            ctx,
-            providerId: TOKEN_PLAN_PROVIDER_ID,
-            buildProvider: buildTokenPlanProvider,
-          }),
-      },
-      augmentModelCatalog: () =>
-        buildStaticCatalogEntries(TOKEN_PLAN_PROVIDER_ID, TOKEN_PLAN_MODEL_CATALOG),
     });
   },
 });

--- a/extensions/tencent/models.ts
+++ b/extensions/tencent/models.ts
@@ -61,33 +61,3 @@ export function buildTokenHubModelDefinition(
     api: "openai-completions",
   };
 }
-
-// ---------- Token Plan provider ----------
-
-export const TOKEN_PLAN_BASE_URL = "https://api.lkeap.cloud.tencent.com/plan/v3";
-export const TOKEN_PLAN_PROVIDER_ID = "tencent-token-plan";
-
-export const TOKEN_PLAN_MODEL_CATALOG: ModelDefinitionConfig[] = [
-  {
-    id: "hy3-preview",
-    name: "Hy3 preview (Token Plan)",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: 256_000,
-    maxTokens: 64_000,
-    cost: HY3_PREVIEW_COST,
-    compat: {
-      supportsUsageInStreaming: true,
-      supportsReasoningEffort: true,
-    },
-  },
-];
-
-export function buildTokenPlanModelDefinition(
-  model: (typeof TOKEN_PLAN_MODEL_CATALOG)[number],
-): ModelDefinitionConfig {
-  return {
-    ...model,
-    api: "openai-completions",
-  };
-}

--- a/extensions/tencent/onboard.ts
+++ b/extensions/tencent/onboard.ts
@@ -5,13 +5,9 @@ import {
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
   buildTokenHubModelDefinition,
-  buildTokenPlanModelDefinition,
   TOKENHUB_BASE_URL,
   TOKENHUB_MODEL_CATALOG,
   TOKENHUB_PROVIDER_ID,
-  TOKEN_PLAN_BASE_URL,
-  TOKEN_PLAN_MODEL_CATALOG,
-  TOKEN_PLAN_PROVIDER_ID,
 } from "./api.js";
 
 // ---------- TokenHub ----------
@@ -22,8 +18,6 @@ function applyTokenHubProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[TOKENHUB_DEFAULT_MODEL_REF] = {
     ...models[TOKENHUB_DEFAULT_MODEL_REF],
-    // Provider-specific alias to keep alias resolution deterministic when
-    // both Tencent providers are enabled (see buildModelAliasIndex).
     alias: models[TOKENHUB_DEFAULT_MODEL_REF]?.alias ?? "Hy3 preview (TokenHub)",
   };
 
@@ -40,34 +34,5 @@ export function applyTokenHubConfig(cfg: OpenClawConfig): OpenClawConfig {
   return applyAgentDefaultModelPrimary(
     applyTokenHubProviderConfig(cfg),
     TOKENHUB_DEFAULT_MODEL_REF,
-  );
-}
-
-// ---------- Token Plan ----------
-
-export const TOKEN_PLAN_DEFAULT_MODEL_REF = `${TOKEN_PLAN_PROVIDER_ID}/hy3-preview`;
-
-function applyTokenPlanProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
-  const models = { ...cfg.agents?.defaults?.models };
-  models[TOKEN_PLAN_DEFAULT_MODEL_REF] = {
-    ...models[TOKEN_PLAN_DEFAULT_MODEL_REF],
-    // Provider-specific alias to keep alias resolution deterministic when
-    // both Tencent providers are enabled (see buildModelAliasIndex).
-    alias: models[TOKEN_PLAN_DEFAULT_MODEL_REF]?.alias ?? "Hy3 preview (Token Plan)",
-  };
-
-  return applyProviderConfigWithModelCatalog(cfg, {
-    agentModels: models,
-    providerId: TOKEN_PLAN_PROVIDER_ID,
-    api: "openai-completions",
-    baseUrl: TOKEN_PLAN_BASE_URL,
-    catalogModels: TOKEN_PLAN_MODEL_CATALOG.map(buildTokenPlanModelDefinition),
-  });
-}
-
-export function applyTokenPlanConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(
-    applyTokenPlanProviderConfig(cfg),
-    TOKEN_PLAN_DEFAULT_MODEL_REF,
   );
 }

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -1,10 +1,9 @@
 {
   "id": "tencent",
   "enabledByDefault": true,
-  "providers": ["tencent-tokenhub", "tencent-token-plan"],
+  "providers": ["tencent-tokenhub"],
   "providerAuthEnvVars": {
-    "tencent-tokenhub": ["TOKENHUB_API_KEY"],
-    "tencent-token-plan": ["LKEAP_API_KEY"]
+    "tencent-tokenhub": ["TOKENHUB_API_KEY"]
   },
   "providerAuthChoices": [
     {
@@ -14,24 +13,11 @@
       "choiceLabel": "Tencent TokenHub",
       "groupId": "tencent",
       "groupLabel": "Tencent Cloud",
-      "groupHint": "TokenHub + Token Plan",
+      "groupHint": "Tencent TokenHub",
       "optionKey": "tokenhubApiKey",
       "cliFlag": "--tokenhub-api-key",
       "cliOption": "--tokenhub-api-key <key>",
       "cliDescription": "Tencent TokenHub API key"
-    },
-    {
-      "provider": "tencent-token-plan",
-      "method": "api-key",
-      "choiceId": "tencent-token-plan-api-key",
-      "choiceLabel": "Tencent Token Plan",
-      "groupId": "tencent",
-      "groupLabel": "Tencent Cloud",
-      "groupHint": "TokenHub + Token Plan",
-      "optionKey": "tencentTokenPlanApiKey",
-      "cliFlag": "--tencent-token-plan-api-key",
-      "cliOption": "--tencent-token-plan-api-key <key>",
-      "cliDescription": "Tencent Token Plan API key"
     }
   ],
   "configSchema": {

--- a/extensions/tencent/provider-catalog.ts
+++ b/extensions/tencent/provider-catalog.ts
@@ -1,11 +1,8 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   buildTokenHubModelDefinition,
-  buildTokenPlanModelDefinition,
   TOKENHUB_BASE_URL,
   TOKENHUB_MODEL_CATALOG,
-  TOKEN_PLAN_BASE_URL,
-  TOKEN_PLAN_MODEL_CATALOG,
 } from "./models.js";
 
 export function buildTokenHubProvider(): ModelProviderConfig {
@@ -13,13 +10,5 @@ export function buildTokenHubProvider(): ModelProviderConfig {
     baseUrl: TOKENHUB_BASE_URL,
     api: "openai-completions",
     models: TOKENHUB_MODEL_CATALOG.map(buildTokenHubModelDefinition),
-  };
-}
-
-export function buildTokenPlanProvider(): ModelProviderConfig {
-  return {
-    baseUrl: TOKEN_PLAN_BASE_URL,
-    api: "openai-completions",
-    models: TOKEN_PLAN_MODEL_CATALOG.map(buildTokenPlanModelDefinition),
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** The Tencent Token Plan (LKEAP) endpoint and auth method are being decommissioned.
- **Why it matters:** Keeping a removed endpoint in the plugin causes misleading onboarding options and dead auth paths for users.
- **What changed:** Removed `tencent-token-plan` provider registration, model catalog, auth choice, env var (`LKEAP_API_KEY`), onboard config helpers, and all related docs references from the `tencent` plugin.
- **What did NOT change:** `tencent-tokenhub` provider, its model catalog, pricing config, onboarding flow, and all other plugin behavior are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — this is a planned endpoint removal, not a bug fix.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): Tencent Token Plan (LKEAP) endpoint is being shut down.

## Regression Test Plan (if applicable)

N/A — removal of a dead code path; no runtime behavior to regress.

- Coverage level that should have caught this: N/A
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: The removed code path had no distinct logic worth testing; TokenHub coverage is unchanged.

## User-visible / Behavior Changes

- `openclaw onboard` no longer presents the Token Plan (`tencent-token-plan-api-key`) auth choice.
- `LKEAP_API_KEY` env var is no longer read or documented.
- `tencent-token-plan/*` model refs no longer resolve.
- `docs/providers/tencent.md` updated to reflect TokenHub-only setup.

## Diagram (if applicable)

```text
Before:
[openclaw onboard] -> [choose: TokenHub | Token Plan]

After:
[openclaw onboard] -> [TokenHub only]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — `LKEAP_API_KEY` env var removed from plugin manifest and auth surface (reduces attack surface).
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Removing an API key path only reduces surface; no new risk introduced.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: tencent-tokenhub
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm tsgo:prod` — zero errors in tencent extension.
2. Run `openclaw onboard` — only TokenHub choice appears under Tencent Cloud.
3. Confirm `tencent-token-plan` is absent from provider list.

### Expected

- Only `tencent-tokenhub` provider and auth choice visible.

### Actual

- Matches expected after this change.

## Evidence

- [x] Screenshot/recording

  <img width="714" height="334" alt="企业微信截图_99a4c866-dd5a-423a-9134-90c5bdf1fdd0" src="https://github.com/user-attachments/assets/8ea3a2b9-1c79-4505-9583-5ae651b1f4ad" />

## Human Verification (required)

- Verified scenarios: TypeScript compilation clean; `openclaw.plugin.json` manifest contains only TokenHub entries; `onboard.ts`, `index.ts`, `api.ts`, `provider-catalog.ts`, `models.ts` all free of Token Plan references; docs updated.
- Edge cases checked: No other extension imports Token Plan symbols; `api.ts` barrel is the only public surface and is cleaned.
- What you did **not** verify: Live API call against TokenHub endpoint post-removal (TokenHub itself is unchanged).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? No — `tencent-token-plan` provider and `LKEAP_API_KEY` are removed.
- Config/env changes? Yes — `LKEAP_API_KEY` no longer used; users should remove it from their env.
- Migration needed? Yes
- If yes, exact upgrade steps:
  1. Remove `LKEAP_API_KEY` from your environment / `~/.openclaw/.env`.
  2. If your config references `tencent-token-plan/*` model refs, switch to `tencent-tokenhub/hy3-preview`.
  3. Re-run `openclaw onboard --auth-choice tokenhub-api-key` if not already on TokenHub.

## Risks and Mitigations

- Risk: Users with existing Token Plan credentials lose access without warning.
  - Mitigation: Endpoint is being decommissioned upstream; affected users must migrate regardless. Docs updated with clear TokenHub-only instructions.
