### PR TITLE
fix(gateway): redact secrets in skills.update response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory-core: respect configured memory-search embedding concurrency during non-batch indexing so local Ollama embedding backends can serialize indexing instead of flooding the server. Fixes #66822. (#66931) Thanks @oliviareid-svg and @LyraInTheFlesh.
 - Docker/update smoke: keep the package-derived update-channel fixture on package-shipped files and make its UI build stub create the asset the updater verifies. Thanks @vincentkoc.
 - Gateway/models: repair legacy `models.providers.*.api = "openai"` config values to `openai-completions`, and skip providers with future stale API enum values during startup instead of bricking the gateway. Fixes #72477. (#72542) Thanks @JooyoungChoi14 and @obviyus.
+- Gateway/skills: redact `apiKey` and secret-named `env` values from the `skills.update` RPC response to prevent leaking credentials into WebSocket traffic, client logs, or session transcripts. Config is still written to disk in full; only the response payload is redacted. (#69998) Thanks @Ziy1-Tan.
 
 ## 2026.4.26
 

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -14,6 +14,7 @@ import { buildWorkspaceSkillStatus } from "../../agents/skills-status.js";
 import { loadWorkspaceSkillEntries, type SkillEntry } from "../../agents/skills.js";
 import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
+import { redactConfigObject } from "../../config/redact-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { fetchClawHubSkillDetail } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -341,6 +342,10 @@ export const skillsHandlers: GatewayRequestHandlers = {
       skills,
     };
     await writeConfigFile(nextConfig);
-    respond(true, { ok: true, skillKey: p.skillKey, config: current }, undefined);
+    respond(
+      true,
+      { ok: true, skillKey: p.skillKey, config: redactConfigObject(current) },
+      undefined,
+    );
   },
 };

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -14,7 +14,7 @@ import { buildWorkspaceSkillStatus } from "../../agents/skills-status.js";
 import { loadWorkspaceSkillEntries, type SkillEntry } from "../../agents/skills.js";
 import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
-import { redactConfigObject } from "../../config/redact-snapshot.js";
+import { redactConfigObject, REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { fetchClawHubSkillDetail } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -313,7 +313,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
     }
     if (typeof p.apiKey === "string") {
       const trimmed = normalizeSecretInput(p.apiKey);
-      if (trimmed) {
+      if (trimmed === REDACTED_SENTINEL) {
+        // Keep the stored secret when a client round-trips a redacted response value.
+      } else if (trimmed) {
         current.apiKey = trimmed;
       } else {
         delete current.apiKey;
@@ -327,6 +329,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
           continue;
         }
         const trimmedVal = value.trim();
+        if (trimmedVal === REDACTED_SENTINEL) {
+          continue;
+        }
         if (!trimmedVal) {
           delete nextEnv[trimmedKey];
         } else {

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -90,9 +90,9 @@ describe("skills.update", () => {
 
     // Response must not expose plaintext secrets
     const config = (responseResult as { config: Record<string, unknown> }).config;
-    expect(config.apiKey).not.toBe("secret-api-key-123");
+    expect(config.apiKey).toBe("__OPENCLAW_REDACTED__");
     const env = config.env as Record<string, string>;
-    expect(env.GEMINI_API_KEY).not.toBe("secret-env-key-456");
+    expect(env.GEMINI_API_KEY).toBe("__OPENCLAW_REDACTED__");
     // Non-secret env values should still be present
     expect(env.BRAVE_REGION).toBe("us");
   });

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -50,4 +50,50 @@ describe("skills.update", () => {
       },
     });
   });
+
+  it("redacts apiKey and secret env values from the response but writes full values to config", async () => {
+    writtenConfig = null;
+
+    let responseResult: unknown = null;
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "demo-skill",
+        apiKey: "secret-api-key-123",
+        env: {
+          GEMINI_API_KEY: "secret-env-key-456",
+          BRAVE_REGION: "us",
+        },
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond: (_success, result, _err) => {
+        responseResult = result;
+      },
+    });
+
+    // Full values must be persisted to config
+    expect(writtenConfig).toMatchObject({
+      skills: {
+        entries: {
+          "demo-skill": {
+            apiKey: "secret-api-key-123",
+            env: {
+              GEMINI_API_KEY: "secret-env-key-456",
+              BRAVE_REGION: "us",
+            },
+          },
+        },
+      },
+    });
+
+    // Response must not expose plaintext secrets
+    const config = (responseResult as { config: Record<string, unknown> }).config;
+    expect(config.apiKey).not.toBe("secret-api-key-123");
+    const env = config.env as Record<string, string>;
+    expect(env.GEMINI_API_KEY).not.toBe("secret-env-key-456");
+    // Non-secret env values should still be present
+    expect(env.BRAVE_REGION).toBe("us");
+  });
 });

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 
 let writtenConfig: unknown = null;
+let loadedConfig: unknown = {
+  skills: {
+    entries: {},
+  },
+};
 
 vi.mock("../../config/config.js", () => {
   return {
-    loadConfig: () => ({
-      skills: {
-        entries: {},
-      },
-    }),
+    loadConfig: () => loadedConfig,
     writeConfigFile: async (cfg: unknown) => {
       writtenConfig = cfg;
     },
@@ -20,6 +22,11 @@ const { skillsHandlers } = await import("./skills.js");
 describe("skills.update", () => {
   it("strips embedded CR/LF from apiKey", async () => {
     writtenConfig = null;
+    loadedConfig = {
+      skills: {
+        entries: {},
+      },
+    };
 
     let ok: boolean | null = null;
     let error: unknown = null;
@@ -53,6 +60,11 @@ describe("skills.update", () => {
 
   it("redacts apiKey and secret env values from the response but writes full values to config", async () => {
     writtenConfig = null;
+    loadedConfig = {
+      skills: {
+        entries: {},
+      },
+    };
 
     let responseResult: unknown = null;
     await skillsHandlers["skills.update"]({
@@ -90,10 +102,57 @@ describe("skills.update", () => {
 
     // Response must not expose plaintext secrets
     const config = (responseResult as { config: Record<string, unknown> }).config;
-    expect(config.apiKey).toBe("__OPENCLAW_REDACTED__");
+    expect(config.apiKey).toBe(REDACTED_SENTINEL);
     const env = config.env as Record<string, string>;
-    expect(env.GEMINI_API_KEY).toBe("__OPENCLAW_REDACTED__");
+    expect(env.GEMINI_API_KEY).toBe(REDACTED_SENTINEL);
     // Non-secret env values should still be present
     expect(env.BRAVE_REGION).toBe("us");
+  });
+
+  it("keeps existing secrets when clients submit redacted sentinel values", async () => {
+    writtenConfig = null;
+    loadedConfig = {
+      skills: {
+        entries: {
+          "demo-skill": {
+            apiKey: "secret-api-key-123",
+            env: {
+              GEMINI_API_KEY: "secret-env-key-456",
+              BRAVE_REGION: "us",
+            },
+          },
+        },
+      },
+    };
+
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "demo-skill",
+        apiKey: REDACTED_SENTINEL,
+        env: {
+          GEMINI_API_KEY: REDACTED_SENTINEL,
+          BRAVE_REGION: "eu",
+        },
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond: () => {},
+    });
+
+    expect(writtenConfig).toMatchObject({
+      skills: {
+        entries: {
+          "demo-skill": {
+            apiKey: "secret-api-key-123",
+            env: {
+              GEMINI_API_KEY: "secret-env-key-456",
+              BRAVE_REGION: "eu",
+            },
+          },
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

`skills.update` was returning the full updated `SkillConfig` entry — including plaintext `apiKey` and `env` values — in the RPC response. This could leak credentials into:
- Control UI WebSocket traffic
- Client logs
- Session transcripts

## Fix

Pass the response config through the existing `redactConfigObject()` utility before returning it. This reuses the same redaction infrastructure used by `config.get`, which already handles all sensitive paths via `isSensitiveConfigPath()` (`apiKey`, `token`, `password`, `secret`, etc.).

Config is still written to disk in full — only the RPC response payload is redacted.

**Diff surface:** +2 lines in production code (1 import, 1 call site).

## Testing

- Existing test: `strips embedded CR/LF from apiKey` — still passes, config written correctly
- New test: `redacts apiKey and secret env values from the response but writes full values to config`
  - Verifies `apiKey` is redacted in response
  - Verifies secret-named `env` key (`GEMINI_API_KEY`) is redacted in response  
  - Verifies non-secret `env` key (`BRAVE_REGION`) is still returned
  - Verifies full values are still persisted to config file

## AI Transparency

- 🤖 AI-assisted
- Testing depth: fully tested (2 targeted unit tests)
- All generated code reviewed and understood

Fixes #66769