### PR TITLE
feat(whatsapp): suppress root groups inheritance in multi-account (#69874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/startup: prefer native Jiti loading for built bundled plugin dist modules on supported runtimes, cutting measured bundled plugin load time by 82-90% while keeping source TypeScript on the transform path. (#69925) Thanks @aauren.
 - Providers/Tencent: add the bundled Tencent Cloud provider plugin with TokenHub and Token Plan onboarding, docs, `hy3-preview` model catalog entries, and tiered Hy3 pricing metadata. (#68460) Thanks @JuniperSling.
 - TUI: add local embedded mode for running terminal chats without a Gateway while keeping plugin approval gates enforced. (#66767) Thanks @fuller-stack-dev.
+- WhatsApp/accounts: suppress root `channels.whatsapp.groups` inheritance across accounts when more than one account is configured, matching the existing Telegram behavior so per-chat `systemPrompt` overrides no longer fan out to every account implicitly. Single-account setups and explicit account-level `groups` maps are unchanged. **Breaking:** multi-account users relying on implicit root-level inheritance must move `groups` into each account config explicitly (or into `accounts.default` to share across named accounts). (#69874)
 
 ### Fixes
 

--- a/extensions/whatsapp/src/account-config.ts
+++ b/extensions/whatsapp/src/account-config.ts
@@ -38,6 +38,7 @@ function _resolveWhatsAppAccountConfig(
 function resolveMergedNamedWhatsAppAccountConfig(params: {
   cfg: OpenClawConfig;
   accountId: string;
+  omitKeys: string[];
 }): WhatsAppAccountConfig {
   const rootCfg = params.cfg.channels?.whatsapp;
   const accountConfig = _resolveWhatsAppAccountConfig(params.cfg, params.accountId);
@@ -45,7 +46,7 @@ function resolveMergedNamedWhatsAppAccountConfig(params: {
     ...mergeAccountConfig<WhatsAppAccountConfig>({
       channelConfig: rootCfg as WhatsAppAccountConfig | undefined,
       accountConfig: undefined,
-      omitKeys: ["defaultAccount"],
+      omitKeys: params.omitKeys,
     }),
     ...resolveWhatsAppDefaultAccountSharedConfig(params.cfg),
     ...accountConfig,
@@ -58,16 +59,24 @@ export function resolveMergedWhatsAppAccountConfig(params: {
 }): WhatsAppAccountConfig & { accountId: string } {
   const rootCfg = params.cfg.channels?.whatsapp;
   const accountId = params.accountId?.trim() || rootCfg?.defaultAccount || DEFAULT_ACCOUNT_ID;
+  // Multi-account bots must not inherit channel-level `groups` unless explicitly set,
+  // so root `channels.whatsapp.groups` does not fan out across accounts. Mirrors the
+  // Telegram guard in extensions/telegram/src/account-config.ts:mergeTelegramAccountConfig.
+  // Shared defaults under `channels.whatsapp.accounts.default.groups` still flow to named
+  // accounts because that is an explicit opt-in, not implicit root inheritance.
+  const configuredAccountIds = Object.keys(rootCfg?.accounts ?? {});
+  const isMultiAccount = configuredAccountIds.length > 1;
+  const omitKeys = isMultiAccount ? ["defaultAccount", "groups"] : ["defaultAccount"];
   const base = resolveMergedAccountConfig<WhatsAppAccountConfig>({
     channelConfig: rootCfg as WhatsAppAccountConfig | undefined,
     accounts: rootCfg?.accounts as Record<string, Partial<WhatsAppAccountConfig>> | undefined,
     accountId,
-    omitKeys: ["defaultAccount"],
+    omitKeys,
   });
   const merged =
     accountId === DEFAULT_ACCOUNT_ID
       ? base
-      : resolveMergedNamedWhatsAppAccountConfig({ cfg: params.cfg, accountId });
+      : resolveMergedNamedWhatsAppAccountConfig({ cfg: params.cfg, accountId, omitKeys });
   return {
     accountId,
     ...merged,

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -249,4 +249,32 @@ describe("resolveWhatsAppAuthDir", () => {
       "*": { systemPrompt: "You are WorkBot." },
     });
   });
+
+  it("multi-account: accounts.default.groups flow to named accounts as the opt-in migration path", () => {
+    // Pins the contract advertised in the #69874 PR body: with root `channels.whatsapp.groups`
+    // suppressed in multi-account mode, users can share `groups` across accounts by setting
+    // them under `accounts.default` instead. If `resolveWhatsAppDefaultAccountSharedConfig`
+    // ever stops spreading `groups`, this regression surfaces here.
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                groups: {
+                  "*": { systemPrompt: "You are Aria." },
+                },
+              },
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.groups).toEqual({
+      "*": { systemPrompt: "You are Aria." },
+    });
+  });
 });

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -179,4 +179,74 @@ describe("resolveWhatsAppAuthDir", () => {
 
     expect(resolved.selfChatMode).toBeUndefined();
   });
+
+  it("single-account: inherits root channels.whatsapp.groups when the account has none", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "You are Aria." },
+            },
+            accounts: {
+              default: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "default",
+    });
+
+    expect(resolved.groups).toEqual({
+      "*": { systemPrompt: "You are Aria." },
+    });
+  });
+
+  it("multi-account: suppresses root channels.whatsapp.groups when the account has none", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "You are Aria." },
+            },
+            accounts: {
+              default: {},
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.groups).toBeUndefined();
+  });
+
+  it("multi-account: account-level groups replace root groups", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "You are Aria." },
+            },
+            accounts: {
+              default: {},
+              work: {
+                groups: {
+                  "*": { systemPrompt: "You are WorkBot." },
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.groups).toEqual({
+      "*": { systemPrompt: "You are WorkBot." },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #69874. Normalizes multi-account `groups` inheritance on the WhatsApp channel so root-level `channels.whatsapp.groups` is not silently fan-inherited to every account when more than one account is configured. This matches the existing Telegram guard in `extensions/telegram/src/account-config.ts` (`mergeTelegramAccountConfig`) and carves out the follow-up that @Bluetegu flagged in #59553 and maintainers deferred so that PR could land cleanly.

This matters because #59553 added per-group `systemPrompt`. Before that, silent root-level fan-out of `groups` was mostly benign (`requireMention`, tool policies). Now a root `channels.whatsapp.groups["*"].systemPrompt: "You are Aria."` gets injected into every account's group sessions with no opt-out short of defining an empty `groups` map per account.

## Before / after

| Scenario | Telegram `groups` | WhatsApp today | WhatsApp after this PR |
|---|---|---|---|
| Single-account, no account-level `groups` | inherits root | inherits root | inherits root (unchanged) |
| Single-account, has account-level `groups` | account replaces root | account replaces root | account replaces root (unchanged) |
| Multi-account, no account-level `groups` | **`undefined` — root suppressed** | inherits root (discrepancy) | **`undefined` — root suppressed** |
| Multi-account, has account-level `groups` | account replaces root | account replaces root | account replaces root (unchanged) |

## Why accept the break

- Telegram parity: the same channel contract should behave the same way for multi-account setups; discrepancies here are a trap for users managing both bots.
- #59553 made the existing silent fan-out dangerous via `groups["*"].systemPrompt`; a root-level persona bleeds into every account's group sessions by default.
- #59553's author (@Bluetegu) explicitly flagged this design question and asked for a maintainer decision; the decision was deferred so #59553 could ship without breaking any current users. This PR is that follow-up.

## Migration

Multi-account users who previously relied on implicit root-level `groups` inheritance must move the map into each account block explicitly. Two supported patterns:

- Duplicate under each account: `channels.whatsapp.accounts.<id>.groups = { ... }`.
- Share via `accounts.default`: `channels.whatsapp.accounts.default.groups = { ... }` — this still flows to named accounts because the `accounts.default` shared-defaults path is an explicit opt-in, distinct from implicit root inheritance.

Single-account users see no behavior change.

## Open questions for maintainers

Two follow-ups the issue flagged; this PR stays minimal and matches Telegram exactly, so both are left open for maintainer decision:

1. **Extend the guard to `direct`?** Telegram only guards `groups`, so this PR only guards `groups`. `channels.whatsapp.direct` has the same per-chat `systemPrompt` shape (added by #59553) and the same silent fan-out risk in multi-account configs. Matching Telegram's current behavior means leaving it alone here; the question is whether Telegram should gain a `direct` equivalent, or whether WhatsApp should extend the guard unilaterally.
2. **Other per-account-shaped maps?** In `extensions/whatsapp/src/account-config.ts` / `src/config/types.whatsapp.ts`, the top-level fields that are `Record<chatId, ...>` shaped and have the same latent-inheritance concern are: `groups` (guarded here), `direct`, and `dms`. Nested under `groups[*]` there is also `toolsBySender`, which rides along with `groups` so it is covered transitively. None of the non-`groups` fields are touched by this PR.

## Tests

Added three cases to `extensions/whatsapp/src/accounts.test.ts` that lock in the matrix:

- Single-account, no account-level groups → inherits root (preservation).
- Multi-account, no account-level groups → `groups` is `undefined` on the resolved account (new behavior; was broken before).
- Multi-account, account defines groups → account replaces root (preservation).

The existing `accounts.default` shared-defaults tests still pass, confirming that explicit shared-defaults under `accounts.default` still flow to named accounts.

Closes #69874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
