### PR TITLE
feat(googlemeet): add OAuth and media preflight groundwork

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,11 @@
       - any-glob-to-any-file:
           - "extensions/googlechat/**"
           - "docs/channels/googlechat.md"
+"extensions: googlemeet":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/googlemeet/**"
+          - "docs/plugins/googlemeet.md"
 "channel: imessage":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/Google Meet: add an experimental bundled `googlemeet` plugin with OAuth login, meeting-space resolution, and media-ingest preflight commands so Meet Media API groundwork can land before the browser-hosted audio capture layer.
 - Pi/models: update the bundled pi packages to `0.68.1` and let the OpenCode Go catalog come from pi instead of plugin-maintained model aliases, adding the refreshed `opencode-go/kimi-k2.6`, Qwen, GLM, MiMo, and MiniMax entries.
 - CLI/doctor plugins: lazy-load doctor plugin paths and prefer installed plugin `dist/*` runtime entries over source-adjacent JavaScript fallbacks, reducing the measured `doctor --non-interactive` runtime by about 74% while keeping cold doctor startup on built plugin artifacts. (#69840) Thanks @gumadeiras.
 - WhatsApp/groups+direct: forward per-group and per-direct `systemPrompt` config into inbound context `GroupSystemPrompt` so configured per-chat behavioral instructions are injected on every turn. Supports `"*"` wildcard fallback and account-scoped overrides under `channels.whatsapp.accounts.<id>.{groups,direct}`; account maps fully replace root maps (no deep merge), matching the existing `requireMention` pattern. Closes #7011. (#59553) Thanks @Bluetegu.

--- a/docs/plugins/googlemeet.md
+++ b/docs/plugins/googlemeet.md
@@ -1,0 +1,133 @@
+---
+summary: "Google Meet plugin: experimental OAuth + meeting preflight groundwork for future Meet Media API audio ingest"
+read_when:
+  - You want to prepare OpenClaw for Google Meet Media API audio ingest
+  - You are configuring or developing the googlemeet plugin
+title: "Google Meet Plugin"
+---
+
+# Google Meet (plugin)
+
+Experimental groundwork for Google Meet Media API audio ingest.
+
+Current scope:
+
+- OAuth login helper for a Google user account
+- access-token refresh from a stored refresh token
+- meeting-space resolution from a Meet URL, meeting code, or `spaces/{id}`
+- preflight checks for future media-ingest sessions
+
+Current non-scope:
+
+- live audio capture
+- in-call Meet chat capture
+- automatic headless browser media bridge
+
+That split is deliberate. Google’s Meet Media API currently exposes a browser or
+native-client media surface, so this first plugin release lands the control
+plane first instead of pretending the audio path is finished.
+
+## Prerequisites
+
+- A Google Cloud OAuth client that can mint **user** tokens.
+- Redirect URI: `http://localhost:8085/oauth2callback`
+- Google Meet Media API preview enrollment for:
+  - your Google Cloud project
+  - the OAuth principal you sign in as
+  - the meeting participants you want to test with
+
+The plugin currently expects these OAuth scopes:
+
+- `https://www.googleapis.com/auth/meetings.space.readonly`
+- `https://www.googleapis.com/auth/meetings.conference.media.readonly`
+
+## Config
+
+Configure under `plugins.entries.googlemeet.config`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      googlemeet: {
+        enabled: true,
+        config: {
+          defaults: {
+            meeting: "https://meet.google.com/abc-defg-hij",
+          },
+          preview: {
+            enrollmentAcknowledged: true,
+          },
+          oauth: {
+            clientId: "1234567890-abc.apps.googleusercontent.com",
+            clientSecret: "GOCSPX-...",
+            refreshToken: "1//0g...",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Environment fallbacks are also supported:
+
+- `GOOGLE_MEET_CLIENT_ID`
+- `GOOGLE_MEET_CLIENT_SECRET`
+- `GOOGLE_MEET_REFRESH_TOKEN`
+- `GOOGLE_MEET_ACCESS_TOKEN`
+- `GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT`
+- `GOOGLE_MEET_DEFAULT_MEETING`
+- `GOOGLE_MEET_PREVIEW_ACK`
+
+`OPENCLAW_GOOGLE_MEET_*` variants are accepted too.
+
+## OAuth login
+
+If you do not have a refresh token yet:
+
+```bash
+openclaw googlemeet auth login --client-id "$GOOGLE_MEET_CLIENT_ID" --client-secret "$GOOGLE_MEET_CLIENT_SECRET"
+```
+
+The command prints a JSON payload you can paste into
+`plugins.entries.googlemeet.config`.
+
+For remote shells or locked-down hosts, use manual mode:
+
+```bash
+openclaw googlemeet auth login --manual --client-id "$GOOGLE_MEET_CLIENT_ID"
+```
+
+## Resolve a meeting
+
+Resolve a Meet URL or meeting code to its canonical space:
+
+```bash
+openclaw googlemeet resolve-space --meeting https://meet.google.com/pdq-bixx-kjf
+```
+
+The command accepts:
+
+- full Meet URLs
+- meeting codes like `pdq-bixx-kjf`
+- canonical names like `spaces/jQCFfuBOdN5z`
+
+## Preflight
+
+Run a control-plane preflight before building or testing media capture:
+
+```bash
+openclaw googlemeet preflight --meeting https://meet.google.com/pdq-bixx-kjf
+```
+
+This checks:
+
+- OAuth token resolution
+- `spaces.get` access to the target meeting
+- canonical meeting-space resolution
+- whether you acknowledged the preview-only requirement in config
+
+It does **not** guarantee live media ingest will succeed. The remaining data
+plane still depends on Google’s Developer Preview gating and a future browser
+capture layer.

--- a/extensions/googlemeet/api.ts
+++ b/extensions/googlemeet/api.ts
@@ -1,0 +1,15 @@
+export {
+  buildPluginConfigSchema,
+  definePluginEntry,
+  type OpenClawConfig,
+  type OpenClawPluginApi,
+  type OpenClawPluginConfigSchema,
+} from "openclaw/plugin-sdk/plugin-entry";
+export { mapPluginConfigIssues } from "openclaw/plugin-sdk/extension-shared";
+export { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
+export {
+  generateOAuthState,
+  parseOAuthCallbackInput,
+  waitForLocalOAuthCallback,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+export { z } from "openclaw/plugin-sdk/zod";

--- a/extensions/googlemeet/index.test.ts
+++ b/extensions/googlemeet/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+import plugin from "./index.js";
+
+describe("googlemeet plugin", () => {
+  it("registers the googlemeet cli surface", () => {
+    const registerCli = vi.fn();
+    const api = createTestPluginApi({
+      id: "googlemeet",
+      name: "Google Meet",
+      source: "test",
+      config: {},
+      runtime: {} as never,
+      registerCli,
+    });
+
+    plugin.register(api);
+
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    expect(registerCli.mock.calls[0]?.[1]).toMatchObject({
+      descriptors: [
+        expect.objectContaining({
+          name: "googlemeet",
+          hasSubcommands: true,
+        }),
+      ],
+    });
+  });
+});

--- a/extensions/googlemeet/index.ts
+++ b/extensions/googlemeet/index.ts
@@ -1,0 +1,30 @@
+import { definePluginEntry } from "./api.js";
+import { registerGoogleMeetCli } from "./src/cli.js";
+import { googleMeetPluginConfigSchema, resolveGoogleMeetPluginConfig } from "./src/config.js";
+
+export default definePluginEntry({
+  id: "googlemeet",
+  name: "Google Meet",
+  description: "Experimental Google Meet media-ingest groundwork.",
+  configSchema: googleMeetPluginConfigSchema,
+  register(api) {
+    const pluginConfig = resolveGoogleMeetPluginConfig(api.pluginConfig);
+    api.registerCli(
+      ({ program }) => {
+        registerGoogleMeetCli({
+          program,
+          pluginConfig,
+        });
+      },
+      {
+        descriptors: [
+          {
+            name: "googlemeet",
+            description: "Google Meet OAuth and media preflight helpers",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+  },
+});

--- a/extensions/googlemeet/openclaw.plugin.json
+++ b/extensions/googlemeet/openclaw.plugin.json
@@ -1,0 +1,85 @@
+{
+  "id": "googlemeet",
+  "name": "Google Meet",
+  "description": "Experimental Google Meet media-ingest groundwork for OAuth login and meeting preflight.",
+  "uiHints": {
+    "defaults.meeting": {
+      "label": "Default Meeting",
+      "help": "Meet URL, meeting code, or spaces/{id} used when CLI commands omit a meeting."
+    },
+    "preview.enrollmentAcknowledged": {
+      "label": "Preview Acknowledged",
+      "help": "Confirms you understand the Google Meet Media API is still Developer Preview."
+    },
+    "oauth.clientId": {
+      "label": "OAuth Client ID"
+    },
+    "oauth.clientSecret": {
+      "label": "OAuth Client Secret",
+      "sensitive": true
+    },
+    "oauth.refreshToken": {
+      "label": "OAuth Refresh Token",
+      "sensitive": true
+    },
+    "oauth.accessToken": {
+      "label": "Cached Access Token",
+      "advanced": true,
+      "sensitive": true
+    },
+    "oauth.expiresAt": {
+      "label": "Cached Access Token Expiry",
+      "advanced": true,
+      "help": "Unix epoch milliseconds used only for the cached access-token fast path."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "defaults": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "meeting": {
+            "type": "string"
+          }
+        }
+      },
+      "preview": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enrollmentAcknowledged": {
+            "type": "boolean"
+          }
+        }
+      },
+      "oauth": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  },
+  "commandAliases": [{ "name": "googlemeet" }]
+}

--- a/extensions/googlemeet/package.json
+++ b/extensions/googlemeet/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@openclaw/googlemeet",
+  "version": "2026.4.20",
+  "private": true,
+  "description": "OpenClaw Google Meet plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.20"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "minHostVersion": ">=2026.4.20"
+    }
+  }
+}

--- a/extensions/googlemeet/src/cli.ts
+++ b/extensions/googlemeet/src/cli.ts
@@ -1,0 +1,248 @@
+import { createInterface } from "node:readline/promises";
+import type { Command } from "commander";
+import type { ResolvedGoogleMeetPluginConfig } from "./config.js";
+import { fetchGoogleMeetSpace, buildGoogleMeetPreflightReport } from "./meet.js";
+import {
+  buildGoogleMeetAuthUrl,
+  createGoogleMeetOAuthState,
+  createGoogleMeetPkce,
+  exchangeGoogleMeetAuthCode,
+  resolveGoogleMeetAccessToken,
+  waitForGoogleMeetAuthCode,
+} from "./oauth.js";
+
+type GoogleMeetCliRegistrationParams = {
+  program: Command;
+  pluginConfig: ResolvedGoogleMeetPluginConfig;
+};
+
+type OAuthLoginOptions = {
+  clientId?: string;
+  clientSecret?: string;
+  manual?: boolean;
+  json?: boolean;
+  timeoutSec?: string;
+};
+
+type ResolveSpaceOptions = {
+  meeting?: string;
+  accessToken?: string;
+  refreshToken?: string;
+  clientId?: string;
+  clientSecret?: string;
+  expiresAt?: string;
+  json?: boolean;
+};
+
+type PreflightOptions = ResolveSpaceOptions;
+
+function writeLine(message: string): void {
+  process.stdout.write(message.endsWith("\n") ? message : `${message}\n`);
+}
+
+function writeJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function promptInput(message: string): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    return await rl.question(message);
+  } finally {
+    rl.close();
+  }
+}
+
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Expected a numeric value, received ${value}`);
+  }
+  return parsed;
+}
+
+function resolveTokenOptions(
+  pluginConfig: ResolvedGoogleMeetPluginConfig,
+  options: ResolveSpaceOptions,
+): {
+  meeting: string;
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  accessToken?: string;
+  expiresAt?: number;
+} {
+  const meeting = options.meeting?.trim() || pluginConfig.defaults.meeting;
+  if (!meeting) {
+    throw new Error("Meeting input is required. Pass --meeting or configure defaults.meeting.");
+  }
+  return {
+    meeting,
+    clientId: options.clientId?.trim() || pluginConfig.oauth.clientId,
+    clientSecret: options.clientSecret?.trim() || pluginConfig.oauth.clientSecret,
+    refreshToken: options.refreshToken?.trim() || pluginConfig.oauth.refreshToken,
+    accessToken: options.accessToken?.trim() || pluginConfig.oauth.accessToken,
+    expiresAt: parseOptionalNumber(options.expiresAt) ?? pluginConfig.oauth.expiresAt,
+  };
+}
+
+export function registerGoogleMeetCli(params: GoogleMeetCliRegistrationParams): void {
+  const root = params.program
+    .command("googlemeet")
+    .description("Google Meet OAuth and media preflight helpers")
+    .addHelpText(
+      "after",
+      () =>
+        "\nDocs: https://docs.openclaw.ai/plugins/googlemeet\n\nThis plugin currently ships OAuth + preflight groundwork. Live media capture is a follow-up.\n",
+    );
+
+  const auth = root.command("auth").description("Google Meet OAuth helpers");
+
+  auth
+    .command("login")
+    .description("Run a PKCE OAuth flow and print refresh-token JSON to store in plugin config")
+    .option("--client-id <id>", "OAuth client id override")
+    .option("--client-secret <secret>", "OAuth client secret override")
+    .option("--manual", "Use copy/paste callback flow instead of localhost callback")
+    .option("--json", "Print the token payload as JSON", false)
+    .option("--timeout-sec <n>", "Local callback timeout in seconds", "300")
+    .action(async (options: OAuthLoginOptions) => {
+      const clientId = options.clientId?.trim() || params.pluginConfig.oauth.clientId;
+      const clientSecret = options.clientSecret?.trim() || params.pluginConfig.oauth.clientSecret;
+      if (!clientId) {
+        throw new Error(
+          "Missing Google Meet OAuth client id. Configure oauth.clientId or pass --client-id.",
+        );
+      }
+      const { verifier, challenge } = createGoogleMeetPkce();
+      const state = createGoogleMeetOAuthState();
+      const authUrl = buildGoogleMeetAuthUrl({
+        clientId,
+        challenge,
+        state,
+      });
+      const code = await waitForGoogleMeetAuthCode({
+        state,
+        manual: Boolean(options.manual),
+        timeoutMs: (parseOptionalNumber(options.timeoutSec) ?? 300) * 1000,
+        authUrl,
+        promptInput,
+        writeLine,
+      });
+      const tokens = await exchangeGoogleMeetAuthCode({
+        clientId,
+        clientSecret,
+        code,
+        verifier,
+      });
+      const payload = {
+        oauth: {
+          clientId,
+          ...(clientSecret ? { clientSecret } : {}),
+          refreshToken: tokens.refreshToken,
+          accessToken: tokens.accessToken,
+          expiresAt: tokens.expiresAt,
+        },
+        scope: tokens.scope,
+        tokenType: tokens.tokenType,
+      };
+      if (!tokens.refreshToken) {
+        throw new Error(
+          "Google OAuth did not return a refresh token. Re-run the flow with consent and offline access.",
+        );
+      }
+      if (options.json) {
+        writeJson(payload);
+        return;
+      }
+      writeLine("Paste this into plugins.entries.googlemeet.config:");
+      writeJson(payload);
+    });
+
+  root
+    .command("resolve-space")
+    .description("Resolve a Meet URL, meeting code, or spaces/{id} to its canonical space")
+    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
+    .option("--access-token <token>", "Access token override")
+    .option("--refresh-token <token>", "Refresh token override")
+    .option("--client-id <id>", "OAuth client id override")
+    .option("--client-secret <secret>", "OAuth client secret override")
+    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+    .option("--json", "Print JSON output", false)
+    .action(async (options: ResolveSpaceOptions) => {
+      const resolved = resolveTokenOptions(params.pluginConfig, options);
+      const token = await resolveGoogleMeetAccessToken(resolved);
+      const space = await fetchGoogleMeetSpace({
+        accessToken: token.accessToken,
+        meeting: resolved.meeting,
+      });
+      if (options.json) {
+        writeJson(space);
+        return;
+      }
+      writeLine(`input: ${resolved.meeting}`);
+      writeLine(`space: ${space.name}`);
+      if (space.meetingCode) {
+        writeLine(`meeting code: ${space.meetingCode}`);
+      }
+      if (space.meetingUri) {
+        writeLine(`meeting uri: ${space.meetingUri}`);
+      }
+      writeLine(`active conference: ${space.activeConference ? "yes" : "no"}`);
+      writeLine(`token source: ${token.refreshed ? "refresh-token" : "cached-access-token"}`);
+    });
+
+  root
+    .command("preflight")
+    .description("Validate OAuth + meeting resolution prerequisites for future media ingest")
+    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
+    .option("--access-token <token>", "Access token override")
+    .option("--refresh-token <token>", "Refresh token override")
+    .option("--client-id <id>", "OAuth client id override")
+    .option("--client-secret <secret>", "OAuth client secret override")
+    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+    .option("--json", "Print JSON output", false)
+    .action(async (options: PreflightOptions) => {
+      const resolved = resolveTokenOptions(params.pluginConfig, options);
+      const token = await resolveGoogleMeetAccessToken(resolved);
+      const space = await fetchGoogleMeetSpace({
+        accessToken: token.accessToken,
+        meeting: resolved.meeting,
+      });
+      const report = buildGoogleMeetPreflightReport({
+        input: resolved.meeting,
+        space,
+        previewAcknowledged: params.pluginConfig.preview.enrollmentAcknowledged,
+        tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+      });
+      if (options.json) {
+        writeJson(report);
+        return;
+      }
+      writeLine(`input: ${report.input}`);
+      writeLine(`resolved space: ${report.resolvedSpaceName}`);
+      if (report.meetingCode) {
+        writeLine(`meeting code: ${report.meetingCode}`);
+      }
+      if (report.meetingUri) {
+        writeLine(`meeting uri: ${report.meetingUri}`);
+      }
+      writeLine(`active conference: ${report.hasActiveConference ? "yes" : "no"}`);
+      writeLine(`preview acknowledged: ${report.previewAcknowledged ? "yes" : "no"}`);
+      writeLine(`token source: ${report.tokenSource}`);
+      if (report.blockers.length === 0) {
+        writeLine("blockers: none");
+        return;
+      }
+      writeLine("blockers:");
+      for (const blocker of report.blockers) {
+        writeLine(`- ${blocker}`);
+      }
+    });
+}

--- a/extensions/googlemeet/src/config.test.ts
+++ b/extensions/googlemeet/src/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { resolveGoogleMeetPluginConfig } from "./config.js";
+
+describe("resolveGoogleMeetPluginConfig", () => {
+  it("uses env fallbacks for OAuth and default meeting values", () => {
+    const config = resolveGoogleMeetPluginConfig(
+      {},
+      {
+        env: {
+          GOOGLE_MEET_CLIENT_ID: "client-id",
+          GOOGLE_MEET_CLIENT_SECRET: "client-secret",
+          GOOGLE_MEET_REFRESH_TOKEN: "refresh-token",
+          GOOGLE_MEET_ACCESS_TOKEN: "access-token",
+          GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT: "123456",
+          GOOGLE_MEET_DEFAULT_MEETING: "https://meet.google.com/abc-defg-hij",
+          GOOGLE_MEET_PREVIEW_ACK: "true",
+        },
+      },
+    );
+
+    expect(config).toMatchObject({
+      enabled: true,
+      defaults: {
+        meeting: "https://meet.google.com/abc-defg-hij",
+      },
+      preview: {
+        enrollmentAcknowledged: true,
+      },
+      oauth: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+        accessToken: "access-token",
+        expiresAt: 123456,
+      },
+    });
+  });
+
+  it("prefers explicit config over env values", () => {
+    const config = resolveGoogleMeetPluginConfig(
+      {
+        defaults: {
+          meeting: "spaces/jQCFfuBOdN5z",
+        },
+        preview: {
+          enrollmentAcknowledged: false,
+        },
+        oauth: {
+          clientId: "config-client",
+          refreshToken: "config-refresh",
+        },
+      },
+      {
+        env: {
+          GOOGLE_MEET_CLIENT_ID: "env-client",
+          GOOGLE_MEET_REFRESH_TOKEN: "env-refresh",
+          GOOGLE_MEET_PREVIEW_ACK: "true",
+        },
+      },
+    );
+
+    expect(config.defaults.meeting).toBe("spaces/jQCFfuBOdN5z");
+    expect(config.preview.enrollmentAcknowledged).toBe(false);
+    expect(config.oauth.clientId).toBe("config-client");
+    expect(config.oauth.refreshToken).toBe("config-refresh");
+  });
+});

--- a/extensions/googlemeet/src/config.ts
+++ b/extensions/googlemeet/src/config.ts
@@ -1,0 +1,184 @@
+import {
+  buildPluginConfigSchema,
+  mapPluginConfigIssues,
+  type OpenClawPluginConfigSchema,
+  z,
+} from "../api.js";
+
+const GOOGLE_MEET_CLIENT_ID_KEYS = ["OPENCLAW_GOOGLE_MEET_CLIENT_ID", "GOOGLE_MEET_CLIENT_ID"];
+const GOOGLE_MEET_CLIENT_SECRET_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_CLIENT_SECRET",
+  "GOOGLE_MEET_CLIENT_SECRET",
+] as const;
+const GOOGLE_MEET_REFRESH_TOKEN_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_REFRESH_TOKEN",
+  "GOOGLE_MEET_REFRESH_TOKEN",
+] as const;
+const GOOGLE_MEET_ACCESS_TOKEN_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_ACCESS_TOKEN",
+  "GOOGLE_MEET_ACCESS_TOKEN",
+] as const;
+const GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT",
+  "GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT",
+] as const;
+const GOOGLE_MEET_DEFAULT_MEETING_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_DEFAULT_MEETING",
+  "GOOGLE_MEET_DEFAULT_MEETING",
+] as const;
+const GOOGLE_MEET_PREVIEW_ACK_KEYS = [
+  "OPENCLAW_GOOGLE_MEET_PREVIEW_ACK",
+  "GOOGLE_MEET_PREVIEW_ACK",
+] as const;
+
+export type GoogleMeetPluginConfig = {
+  enabled?: boolean;
+  defaults?: {
+    meeting?: string;
+  };
+  preview?: {
+    enrollmentAcknowledged?: boolean;
+  };
+  oauth?: {
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+    accessToken?: string;
+    expiresAt?: number;
+  };
+};
+
+export type ResolvedGoogleMeetPluginConfig = {
+  enabled: boolean;
+  defaults: {
+    meeting?: string;
+  };
+  preview: {
+    enrollmentAcknowledged: boolean;
+  };
+  oauth: {
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+    accessToken?: string;
+    expiresAt?: number;
+  };
+};
+
+const GoogleMeetPluginConfigSource = z.strictObject({
+  enabled: z.boolean().optional(),
+  defaults: z
+    .strictObject({
+      meeting: z.string().optional(),
+    })
+    .optional(),
+  preview: z
+    .strictObject({
+      enrollmentAcknowledged: z.boolean().optional(),
+    })
+    .optional(),
+  oauth: z
+    .strictObject({
+      clientId: z.string().optional(),
+      clientSecret: z.string().optional(),
+      refreshToken: z.string().optional(),
+      accessToken: z.string().optional(),
+      expiresAt: z.number().finite().optional(),
+    })
+    .optional(),
+});
+
+function readEnvString(env: NodeJS.ProcessEnv, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readEnvBoolean(env: NodeJS.ProcessEnv, keys: readonly string[]): boolean | undefined {
+  const value = readEnvString(env, keys)?.toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+  if (["1", "true", "yes", "on"].includes(value)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(value)) {
+    return false;
+  }
+  return undefined;
+}
+
+function readEnvNumber(env: NodeJS.ProcessEnv, keys: readonly string[]): number | undefined {
+  const value = readEnvString(env, keys);
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export const googleMeetPluginConfigSchema: OpenClawPluginConfigSchema = buildPluginConfigSchema(
+  GoogleMeetPluginConfigSource,
+  {
+    safeParse(value: unknown) {
+      const result = GoogleMeetPluginConfigSource.safeParse(value ?? {});
+      if (result.success) {
+        return { success: true, data: resolveGoogleMeetPluginConfig(result.data) };
+      }
+      return {
+        success: false,
+        error: {
+          issues: mapPluginConfigIssues(result.error.issues),
+        },
+      };
+    },
+  },
+);
+
+export function resolveGoogleMeetPluginConfig(
+  value: unknown,
+  options?: { env?: NodeJS.ProcessEnv },
+): ResolvedGoogleMeetPluginConfig {
+  const env = options?.env ?? process.env;
+  const parsed = GoogleMeetPluginConfigSource.safeParse(value ?? {});
+  const raw = parsed.success ? parsed.data : {};
+  return {
+    enabled: raw.enabled ?? true,
+    defaults: {
+      meeting:
+        normalizeOptionalString(raw.defaults?.meeting) ??
+        readEnvString(env, GOOGLE_MEET_DEFAULT_MEETING_KEYS),
+    },
+    preview: {
+      enrollmentAcknowledged:
+        raw.preview?.enrollmentAcknowledged ??
+        readEnvBoolean(env, GOOGLE_MEET_PREVIEW_ACK_KEYS) ??
+        false,
+    },
+    oauth: {
+      clientId:
+        normalizeOptionalString(raw.oauth?.clientId) ??
+        readEnvString(env, GOOGLE_MEET_CLIENT_ID_KEYS),
+      clientSecret:
+        normalizeOptionalString(raw.oauth?.clientSecret) ??
+        readEnvString(env, GOOGLE_MEET_CLIENT_SECRET_KEYS),
+      refreshToken:
+        normalizeOptionalString(raw.oauth?.refreshToken) ??
+        readEnvString(env, GOOGLE_MEET_REFRESH_TOKEN_KEYS),
+      accessToken:
+        normalizeOptionalString(raw.oauth?.accessToken) ??
+        readEnvString(env, GOOGLE_MEET_ACCESS_TOKEN_KEYS),
+      expiresAt:
+        raw.oauth?.expiresAt ?? readEnvNumber(env, GOOGLE_MEET_ACCESS_TOKEN_EXPIRES_AT_KEYS),
+    },
+  };
+}

--- a/extensions/googlemeet/src/meet.test.ts
+++ b/extensions/googlemeet/src/meet.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildGoogleMeetPreflightReport, normalizeGoogleMeetSpaceName } from "./meet.js";
+
+describe("normalizeGoogleMeetSpaceName", () => {
+  it("accepts canonical spaces ids, meeting codes, and meet urls", () => {
+    expect(normalizeGoogleMeetSpaceName("spaces/jQCFfuBOdN5z")).toBe("spaces/jQCFfuBOdN5z");
+    expect(normalizeGoogleMeetSpaceName("abc-defg-hij")).toBe("spaces/abc-defg-hij");
+    expect(normalizeGoogleMeetSpaceName("https://meet.google.com/pdq-bixx-kjf")).toBe(
+      "spaces/pdq-bixx-kjf",
+    );
+  });
+
+  it("rejects non-Meet urls", () => {
+    expect(() => normalizeGoogleMeetSpaceName("https://example.com/not-meet")).toThrow(
+      /Expected a meet\.google\.com URL/,
+    );
+  });
+});
+
+describe("buildGoogleMeetPreflightReport", () => {
+  it("surfaces preview acknowledgment blockers", () => {
+    const report = buildGoogleMeetPreflightReport({
+      input: "https://meet.google.com/pdq-bixx-kjf",
+      space: {
+        name: "spaces/jQCFfuBOdN5z",
+        meetingCode: "pdq-bixx-kjf",
+      },
+      previewAcknowledged: false,
+      tokenSource: "refresh-token",
+    });
+
+    expect(report.blockers).toHaveLength(1);
+    expect(report.hasActiveConference).toBe(false);
+  });
+});

--- a/extensions/googlemeet/src/meet.ts
+++ b/extensions/googlemeet/src/meet.ts
@@ -1,0 +1,96 @@
+const GOOGLE_MEET_API_BASE_URL = "https://meet.googleapis.com/v2";
+const GOOGLE_MEET_URL_HOST = "meet.google.com";
+
+export type GoogleMeetSpace = {
+  name: string;
+  meetingCode?: string;
+  meetingUri?: string;
+  activeConference?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+};
+
+export type GoogleMeetPreflightReport = {
+  input: string;
+  resolvedSpaceName: string;
+  meetingCode?: string;
+  meetingUri?: string;
+  hasActiveConference: boolean;
+  previewAcknowledged: boolean;
+  tokenSource: "cached-access-token" | "refresh-token";
+  blockers: string[];
+};
+
+export function normalizeGoogleMeetSpaceName(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Meeting input is required");
+  }
+  if (trimmed.startsWith("spaces/")) {
+    const suffix = trimmed.slice("spaces/".length).trim();
+    if (!suffix) {
+      throw new Error("spaces/ input must include a meeting code or space id");
+    }
+    return `spaces/${suffix}`;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    const url = new URL(trimmed);
+    if (url.hostname !== GOOGLE_MEET_URL_HOST) {
+      throw new Error(`Expected a ${GOOGLE_MEET_URL_HOST} URL, received ${url.hostname}`);
+    }
+    const firstSegment = url.pathname
+      .split("/")
+      .map((segment) => segment.trim())
+      .find(Boolean);
+    if (!firstSegment) {
+      throw new Error("Google Meet URL did not include a meeting code");
+    }
+    return `spaces/${firstSegment}`;
+  }
+  return `spaces/${trimmed}`;
+}
+
+export async function fetchGoogleMeetSpace(params: {
+  accessToken: string;
+  meeting: string;
+}): Promise<GoogleMeetSpace> {
+  const name = normalizeGoogleMeetSpaceName(params.meeting);
+  const response = await fetch(`${GOOGLE_MEET_API_BASE_URL}/${encodeURIComponent(name)}`, {
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Google Meet spaces.get failed (${response.status}): ${detail}`);
+  }
+  const payload = (await response.json()) as GoogleMeetSpace;
+  if (!payload.name?.trim()) {
+    throw new Error("Google Meet spaces.get response was missing name");
+  }
+  return payload;
+}
+
+export function buildGoogleMeetPreflightReport(params: {
+  input: string;
+  space: GoogleMeetSpace;
+  previewAcknowledged: boolean;
+  tokenSource: "cached-access-token" | "refresh-token";
+}): GoogleMeetPreflightReport {
+  const blockers: string[] = [];
+  if (!params.previewAcknowledged) {
+    blockers.push(
+      "Set preview.enrollmentAcknowledged=true after confirming your Cloud project, OAuth principal, and meeting participants are enrolled in the Google Workspace Developer Preview Program.",
+    );
+  }
+  return {
+    input: params.input,
+    resolvedSpaceName: params.space.name,
+    meetingCode: params.space.meetingCode,
+    meetingUri: params.space.meetingUri,
+    hasActiveConference: Boolean(params.space.activeConference),
+    previewAcknowledged: params.previewAcknowledged,
+    tokenSource: params.tokenSource,
+    blockers,
+  };
+}

--- a/extensions/googlemeet/src/oauth.test.ts
+++ b/extensions/googlemeet/src/oauth.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GOOGLE_MEET_SCOPES,
+  buildGoogleMeetAuthUrl,
+  refreshGoogleMeetAccessToken,
+  resolveGoogleMeetAccessToken,
+  shouldUseCachedGoogleMeetAccessToken,
+} from "./oauth.js";
+
+describe("buildGoogleMeetAuthUrl", () => {
+  it("includes the required Meet Media scopes and PKCE fields", () => {
+    const url = new URL(
+      buildGoogleMeetAuthUrl({
+        clientId: "client-id",
+        challenge: "challenge",
+        state: "state",
+      }),
+    );
+
+    expect(url.searchParams.get("client_id")).toBe("client-id");
+    expect(url.searchParams.get("code_challenge")).toBe("challenge");
+    expect(url.searchParams.get("state")).toBe("state");
+    expect(url.searchParams.get("scope")).toBe(GOOGLE_MEET_SCOPES.join(" "));
+  });
+});
+
+describe("refreshGoogleMeetAccessToken", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts a refresh-token grant and parses the response", async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = init?.body instanceof URLSearchParams ? init.body : new URLSearchParams();
+      expect(body.get("grant_type")).toBe("refresh_token");
+      expect(body.get("client_id")).toBe("client-id");
+      expect(body.get("refresh_token")).toBe("refresh-token");
+      return new Response(
+        JSON.stringify({
+          access_token: "next-access-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokens = await refreshGoogleMeetAccessToken({
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+    });
+
+    expect(tokens.accessToken).toBe("next-access-token");
+    expect(tokens.tokenType).toBe("Bearer");
+  });
+
+  it("prefers a fresh cached access token before refresh", async () => {
+    const resolved = await resolveGoogleMeetAccessToken({
+      accessToken: "cached-token",
+      expiresAt: Date.now() + 120_000,
+    });
+
+    expect(resolved).toEqual({
+      accessToken: "cached-token",
+      expiresAt: expect.any(Number),
+      refreshed: false,
+    });
+    expect(
+      shouldUseCachedGoogleMeetAccessToken({
+        accessToken: "cached-token",
+        expiresAt: Date.now() + 120_000,
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/googlemeet/src/oauth.ts
+++ b/extensions/googlemeet/src/oauth.ts
@@ -1,0 +1,216 @@
+import {
+  generateHexPkceVerifierChallenge,
+  generateOAuthState,
+  parseOAuthCallbackInput,
+  waitForLocalOAuthCallback,
+} from "../api.js";
+
+export const GOOGLE_MEET_REDIRECT_URI = "http://localhost:8085/oauth2callback";
+export const GOOGLE_MEET_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+export const GOOGLE_MEET_TOKEN_URL = "https://oauth2.googleapis.com/token";
+export const GOOGLE_MEET_SCOPES = [
+  "https://www.googleapis.com/auth/meetings.space.readonly",
+  "https://www.googleapis.com/auth/meetings.conference.media.readonly",
+] as const;
+
+export type GoogleMeetOAuthTokens = {
+  accessToken: string;
+  expiresAt: number;
+  refreshToken?: string;
+  scope?: string;
+  tokenType?: string;
+};
+
+export function buildGoogleMeetAuthUrl(params: {
+  clientId: string;
+  challenge: string;
+  state: string;
+  redirectUri?: string;
+  scopes?: readonly string[];
+}): string {
+  const search = new URLSearchParams({
+    client_id: params.clientId,
+    response_type: "code",
+    redirect_uri: params.redirectUri ?? GOOGLE_MEET_REDIRECT_URI,
+    scope: (params.scopes ?? GOOGLE_MEET_SCOPES).join(" "),
+    code_challenge: params.challenge,
+    code_challenge_method: "S256",
+    access_type: "offline",
+    prompt: "consent",
+    state: params.state,
+  });
+  return `${GOOGLE_MEET_AUTH_URL}?${search.toString()}`;
+}
+
+function buildGoogleMeetTokenRequestBody(
+  values: Record<string, string | undefined>,
+): URLSearchParams {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value?.trim()) {
+      body.set(key, value);
+    }
+  }
+  return body;
+}
+
+async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleMeetOAuthTokens> {
+  const response = await fetch(GOOGLE_MEET_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+      Accept: "application/json",
+    },
+    body,
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Google OAuth token request failed (${response.status}): ${detail}`);
+  }
+  const payload = (await response.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    scope?: string;
+    token_type?: string;
+  };
+  const accessToken = payload.access_token?.trim();
+  if (!accessToken) {
+    throw new Error("Google OAuth token response was missing access_token");
+  }
+  const expiresInSeconds =
+    typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in)
+      ? payload.expires_in
+      : 3600;
+  return {
+    accessToken,
+    expiresAt: Date.now() + expiresInSeconds * 1000,
+    refreshToken: payload.refresh_token?.trim() || undefined,
+    scope: payload.scope?.trim() || undefined,
+    tokenType: payload.token_type?.trim() || undefined,
+  };
+}
+
+export async function exchangeGoogleMeetAuthCode(params: {
+  clientId: string;
+  clientSecret?: string;
+  code: string;
+  verifier: string;
+  redirectUri?: string;
+}): Promise<GoogleMeetOAuthTokens> {
+  return await executeGoogleTokenRequest(
+    buildGoogleMeetTokenRequestBody({
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+      code: params.code,
+      grant_type: "authorization_code",
+      redirect_uri: params.redirectUri ?? GOOGLE_MEET_REDIRECT_URI,
+      code_verifier: params.verifier,
+    }),
+  );
+}
+
+export async function refreshGoogleMeetAccessToken(params: {
+  clientId: string;
+  clientSecret?: string;
+  refreshToken: string;
+}): Promise<GoogleMeetOAuthTokens> {
+  return await executeGoogleTokenRequest(
+    buildGoogleMeetTokenRequestBody({
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: params.refreshToken,
+    }),
+  );
+}
+
+export function shouldUseCachedGoogleMeetAccessToken(params: {
+  accessToken?: string;
+  expiresAt?: number;
+  now?: number;
+  safetyWindowMs?: number;
+}): boolean {
+  const now = params.now ?? Date.now();
+  const safetyWindowMs = params.safetyWindowMs ?? 60_000;
+  return Boolean(
+    params.accessToken?.trim() &&
+    typeof params.expiresAt === "number" &&
+    Number.isFinite(params.expiresAt) &&
+    params.expiresAt > now + safetyWindowMs,
+  );
+}
+
+export async function resolveGoogleMeetAccessToken(params: {
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  accessToken?: string;
+  expiresAt?: number;
+}): Promise<{ accessToken: string; expiresAt?: number; refreshed: boolean }> {
+  if (shouldUseCachedGoogleMeetAccessToken(params)) {
+    return {
+      accessToken: params.accessToken!.trim(),
+      expiresAt: params.expiresAt,
+      refreshed: false,
+    };
+  }
+  if (!params.clientId?.trim() || !params.refreshToken?.trim()) {
+    throw new Error(
+      "Missing Google Meet OAuth credentials. Configure oauth.clientId and oauth.refreshToken, or pass --client-id and --refresh-token.",
+    );
+  }
+  const refreshed = await refreshGoogleMeetAccessToken({
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+    refreshToken: params.refreshToken,
+  });
+  return {
+    accessToken: refreshed.accessToken,
+    expiresAt: refreshed.expiresAt,
+    refreshed: true,
+  };
+}
+
+export function createGoogleMeetPkce() {
+  const { verifier, challenge } = generateHexPkceVerifierChallenge();
+  return { verifier, challenge };
+}
+
+export function createGoogleMeetOAuthState(): string {
+  return generateOAuthState();
+}
+
+export async function waitForGoogleMeetAuthCode(params: {
+  state: string;
+  manual: boolean;
+  timeoutMs: number;
+  authUrl: string;
+  promptInput: (message: string) => Promise<string>;
+  writeLine: (message: string) => void;
+}): Promise<string> {
+  params.writeLine(`Open this URL in your browser:\n\n${params.authUrl}\n`);
+  if (params.manual) {
+    const input = await params.promptInput("Paste the full redirect URL here: ");
+    const parsed = parseOAuthCallbackInput(input, {
+      missingState: "Missing 'state' parameter. Paste the full redirect URL.",
+      invalidInput: "Paste the full redirect URL, not just the code.",
+    });
+    if ("error" in parsed) {
+      throw new Error(parsed.error);
+    }
+    if (parsed.state !== params.state) {
+      throw new Error("OAuth state mismatch - please try again");
+    }
+    return parsed.code;
+  }
+  const callback = await waitForLocalOAuthCallback({
+    expectedState: params.state,
+    timeoutMs: params.timeoutMs,
+    port: 8085,
+    callbackPath: "/oauth2callback",
+    redirectUri: GOOGLE_MEET_REDIRECT_URI,
+    successTitle: "Google Meet OAuth complete",
+  });
+  return callback.code;
+}

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -27,6 +27,7 @@ const packageManifestContractTests: PackageManifestContractParams[] = [
     pluginLocalRuntimeDeps: ["gaxios", "google-auth-library"],
     minHostVersionBaseline: "2026.3.22",
   },
+  { pluginId: "googlemeet", minHostVersionBaseline: "2026.3.22" },
   { pluginId: "irc", minHostVersionBaseline: "2026.3.22" },
   { pluginId: "line", minHostVersionBaseline: "2026.3.22" },
   {


### PR DESCRIPTION
## Summary

- Problem: OpenClaw has Google Chat support but no bundled path for Google Meet Media API onboarding, OAuth, or meeting-space preflight.
- Why it matters: we can't responsibly build Meet audio ingest until the control plane exists for user OAuth, canonical meeting-space resolution, and preview gating checks.
- What changed: adds an experimental bundled `googlemeet` plugin with PKCE OAuth login, access-token refresh, `spaces.get` resolution/preflight CLI commands, docs, manifest coverage, and labeler support.
- What did NOT change (scope boundary): this PR does not ship live audio capture, browser-hosted media transport, or in-call Meet chat reading.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/googlemeet/*.test.ts`, `src/plugins/contracts/package-manifest.contract.test.ts`
- Scenario the test should lock in: OAuth URL/token refresh behavior, Meet URL -> `spaces/*` resolution, preflight blocker reporting, and package-manifest coverage for the new bundled plugin.
- Why this is the smallest reliable guardrail: the shipped behavior in this PR is control-plane logic plus plugin registration, not live media transport.
- Existing test that already covers this (if any): `src/plugins/contracts/package-manifest.contract.test.ts`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Adds `openclaw googlemeet auth login`
- Adds `openclaw googlemeet resolve-space`
- Adds `openclaw googlemeet preflight`
- Adds `plugins.entries.googlemeet.config` docs and manifest metadata

## Diagram (if applicable)

```text
Before:
[user wants Meet audio ingest] -> [no Meet plugin] -> [manual OAuth / meeting lookup / preview debugging]

After:
[user runs googlemeet auth login] -> [stores OAuth refresh token]
[user runs googlemeet preflight] -> [canonical meeting space + blocker report]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Adds Google user OAuth token handling and Meet REST API reads behind an explicit experimental plugin surface.
  - Scopes are limited to `meetings.space.readonly` and `meetings.conference.media.readonly`.
  - No live media capture ships in this PR, so the data plane stays out of scope.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): bundled `googlemeet` plugin
- Relevant config (redacted): `plugins.entries.googlemeet.config.oauth.{clientId,clientSecret,refreshToken}`

### Steps

1. Run `pnpm test:serial extensions/googlemeet/index.test.ts extensions/googlemeet/src/config.test.ts extensions/googlemeet/src/meet.test.ts extensions/googlemeet/src/oauth.test.ts src/plugins/contracts/package-manifest.contract.test.ts`
2. Run `pnpm exec oxfmt --check .github/labeler.yml CHANGELOG.md src/plugins/contracts/package-manifest.contract.test.ts docs/plugins/googlemeet.md extensions/googlemeet`
3. Optionally run `openclaw googlemeet auth login` and `openclaw googlemeet preflight --meeting <meet-url>` with real Google OAuth credentials.

### Expected

- Plugin CLI registers
- OAuth helpers produce refresh-token payloads
- Meet URLs resolve to canonical `spaces/*`
- Manifest contract covers the new bundled plugin

### Actual

- Matches expected locally for the shipped control-plane slice

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - local plugin/config/oauth/meeting tests pass
  - package-manifest contract passes with the new plugin
  - targeted `oxfmt` check passes on touched files
- Edge cases checked:
  - non-Meet URLs rejected
  - env/config precedence for OAuth values
  - cached access-token fast path vs refresh-token fallback
- What you did **not** verify:
  - live Meet Media API audio capture
  - preview-enrollment success with a real enrolled Google project/user/meeting

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: reviewers could mistake this for finished Meet media ingest.
  - Mitigation: docs, changelog, CLI help, and PR scope all explicitly say this is OAuth + preflight groundwork only.
- Risk: local `pnpm check:changed` is blocked in this sparse worktree by unrelated core-test missing-module imports under `ui/` and `packages/plugin-package-contract/`.
  - Mitigation: included targeted tests and contract coverage for the actual changed surface.

## Transparency

- [x] AI-assisted
- Testing: fully tested for the shipped control-plane slice
