### PR TITLE
[Plan Mode 1/6] Plan-state foundation

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -12,9 +12,16 @@ import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.
 import plugin from "./index.js";
 import {
   OPENAI_FRIENDLY_PROMPT_OVERLAY,
-  OPENAI_GPT5_BEHAVIOR_CONTRACT,
-  shouldApplyOpenAIPromptOverlay,
+  OPENAI_GPT5_EXECUTION_BIAS,
+  OPENAI_GPT5_OUTPUT_CONTRACT,
+  OPENAI_GPT5_TOOL_CALL_STYLE,
+  OPENAI_GPT5_TOOL_ENFORCEMENT,
 } from "./prompt-overlay.js";
+
+/** Shared stablePrefix expectation — update this ONE constant when overlay blocks change. */
+const EXPECTED_GPT5_STABLE_PREFIX = [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join(
+  "\n\n",
+);
 
 const runtimeMocks = vi.hoisted(() => ({
   ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
@@ -70,57 +77,6 @@ async function registerOpenAIPluginWithHook(params?: { pluginConfig?: Record<str
   return { on, providers };
 }
 
-function expectOpenAIPromptContribution(
-  provider: ProviderPlugin,
-  sectionOverrides: Record<string, unknown>,
-) {
-  expect(
-    provider.resolveSystemPromptContribution?.({
-      config: undefined,
-      agentDir: undefined,
-      workspaceDir: undefined,
-      provider: "openai",
-      modelId: "gpt-5.4",
-      promptMode: "full",
-      runtimeChannel: undefined,
-      runtimeCapabilities: undefined,
-      agentId: undefined,
-    }),
-  ).toEqual({
-    stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
-    sectionOverrides,
-  });
-}
-
-function mockOpenAIImageApiResponse(params: {
-  finalUrl: string;
-  imageData: string;
-  revisedPrompt?: string;
-}) {
-  const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-    apiKey: "sk-test",
-    source: "env",
-    mode: "api-key",
-  });
-  const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({
-    finalUrl: params.finalUrl,
-    response: {
-      ok: true,
-      json: async () => ({
-        data: [
-          {
-            b64_json: Buffer.from(params.imageData).toString("base64"),
-            ...(params.revisedPrompt ? { revised_prompt: params.revisedPrompt } : {}),
-          },
-        ],
-      }),
-    } as Response,
-    release: vi.fn(async () => {}),
-  });
-  vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
-  return { resolveApiKeySpy, postJsonRequestSpy };
-}
-
 describe("openai plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -131,22 +87,36 @@ describe("openai plugin", () => {
   });
 
   it("generates PNG buffers from the OpenAI Images API", async () => {
-    const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
-      finalUrl: "https://api.openai.com/v1/images/generations",
-      imageData: "png-data",
-      revisedPrompt: "revised",
+    const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "sk-test",
+      source: "env",
+      mode: "api-key",
     });
+    const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({
+      finalUrl: "https://api.openai.com/v1/images/generations",
+      response: {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              b64_json: Buffer.from("png-data").toString("base64"),
+              revised_prompt: "revised",
+            },
+          ],
+        }),
+      } as Response,
+      release: vi.fn(async () => {}),
+    });
+    vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
 
     const provider = buildOpenAIImageGenerationProvider();
     const authStore = { version: 1, profiles: {} };
     const result = await provider.generateImage({
       provider: "openai",
-      model: "gpt-image-2",
+      model: "gpt-image-1",
       prompt: "draw a cat",
       cfg: {},
       authStore,
-      count: 2,
-      size: "2048x2048",
     });
 
     expect(resolveApiKeySpy).toHaveBeenCalledWith(
@@ -159,10 +129,10 @@ describe("openai plugin", () => {
       expect.objectContaining({
         url: "https://api.openai.com/v1/images/generations",
         body: {
-          model: "gpt-image-2",
+          model: "gpt-image-1",
           prompt: "draw a cat",
-          n: 2,
-          size: "2048x2048",
+          n: 1,
+          size: "1024x1024",
         },
       }),
     );
@@ -180,27 +150,41 @@ describe("openai plugin", () => {
           revisedPrompt: "revised",
         },
       ],
-      model: "gpt-image-2",
+      model: "gpt-image-1",
     });
   });
 
   it("submits reference-image edits to the OpenAI Images edits endpoint", async () => {
-    const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
-      finalUrl: "https://api.openai.com/v1/images/edits",
-      imageData: "edited-image",
+    const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "sk-test",
+      source: "env",
+      mode: "api-key",
     });
+    const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({
+      finalUrl: "https://api.openai.com/v1/images/edits",
+      response: {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              b64_json: Buffer.from("edited-image").toString("base64"),
+            },
+          ],
+        }),
+      } as Response,
+      release: vi.fn(async () => {}),
+    });
+    vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
 
     const provider = buildOpenAIImageGenerationProvider();
     const authStore = { version: 1, profiles: {} };
 
     const result = await provider.generateImage({
       provider: "openai",
-      model: "gpt-image-2",
+      model: "gpt-image-1",
       prompt: "Edit this image",
       cfg: {},
       authStore,
-      count: 2,
-      size: "1536x1024",
       inputImages: [
         { buffer: Buffer.from("x"), mimeType: "image/png" },
         { buffer: Buffer.from("y"), mimeType: "image/jpeg", fileName: "ref.jpg" },
@@ -217,10 +201,10 @@ describe("openai plugin", () => {
       expect.objectContaining({
         url: "https://api.openai.com/v1/images/edits",
         body: {
-          model: "gpt-image-2",
+          model: "gpt-image-1",
           prompt: "Edit this image",
-          n: 2,
-          size: "1536x1024",
+          n: 1,
+          size: "1024x1024",
           images: [
             {
               image_url: "data:image/png;base64,eA==",
@@ -240,7 +224,7 @@ describe("openai plugin", () => {
           fileName: "image-1.png",
         },
       ],
-      model: "gpt-image-2",
+      model: "gpt-image-1",
     });
   });
 
@@ -257,7 +241,7 @@ describe("openai plugin", () => {
     await expect(
       provider.generateImage({
         provider: "openai",
-        model: "gpt-image-2",
+        model: "gpt-image-1",
         prompt: "draw a cat",
         cfg: {
           models: {
@@ -394,9 +378,11 @@ describe("openai plugin", () => {
     };
 
     expect(openaiProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("This is a live chat, not a memo.");
@@ -410,20 +396,11 @@ describe("openai plugin", () => {
       "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
     );
     expect(codexProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
-      },
-    });
-    expect(
-      openaiProvider.resolveSystemPromptContribution?.({
-        ...contributionContext,
-        modelId: "openai/gpt-5.4-mini",
-      }),
-    ).toEqual({
-      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
-      sectionOverrides: {
-        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
     expect(
@@ -432,16 +409,18 @@ describe("openai plugin", () => {
         modelId: "gpt-image-1",
       }),
     ).toBeUndefined();
-    expect(shouldApplyOpenAIPromptOverlay({ modelProviderId: "openai", modelId: "gpt-4.1" })).toBe(
-      false,
-    );
-    expect(
-      shouldApplyOpenAIPromptOverlay({ modelProviderId: "anthropic", modelId: "gpt-5.4" }),
-    ).toBe(false);
   });
 
-  it("includes the tagged GPT-5 behavior contract in the OpenAI prompt overlay", () => {
-    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("Keep progress updates clear and concrete.");
+  it("includes stronger execution guidance in the OpenAI prompt overlay", () => {
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If the user asks you to do the work, start in the same turn instead of restating the plan.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      'If the latest user message is a short approval like "ok do it" or "go ahead", skip the recap and start acting.',
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Commentary-only turns are incomplete when the next action is clear.",
+    );
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
       'Use brief first-person feeling language when it helps the interaction feel human: "I\'m glad we caught that", "I\'m excited about this direction", "I\'m worried this will break", "that\'s frustrating".',
     );
@@ -490,26 +469,42 @@ describe("openai plugin", () => {
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
       "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
     );
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<persona_latch>");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<execution_policy>");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<tool_discipline>");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<output_contract>");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<completion_contract>");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
-      "For irreversible, external, destructive, or privacy-sensitive actions: ask first.",
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Use a real tool call or concrete action FIRST when the task is actionable. Do not stop at a plan or promise-to-act reply.",
     );
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
-      "Prefer tool evidence over recall when action, state, or mutable facts matter.",
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.",
     );
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
-      "If more tool work would likely change the answer, do it before replying.",
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Do prerequisite lookup or discovery before dependent actions.",
     );
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("Return requested sections/order only.");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
-      "Treat the task as incomplete until every requested item is handled",
+    expect(OPENAI_GPT5_TOOL_CALL_STYLE).toContain(
+      "Call tools directly without narrating what you are about to do. Do not describe a plan before each tool call.",
     );
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).not.toContain("/approve");
-    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).not.toContain("GPT-5 Output Contract");
+    expect(OPENAI_GPT5_TOOL_CALL_STYLE).toContain(
+      "When a first-class tool exists for an action, use the tool instead of asking the user to run a command.",
+    );
+    expect(OPENAI_GPT5_TOOL_CALL_STYLE).not.toContain("/approve");
+    expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
+      "Return the requested sections only, in the requested order.",
+    );
+    expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
+      "Prefer commas, periods, or parentheses over em dashes in normal prose.",
+    );
+    expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
+      "Do not use em dashes unless the user explicitly asks for them or they are required in quoted text.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("you ARE the persona");
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("Anti-sycophancy");
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("Voice Calibration");
+    expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain("target under 200 words");
+    expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain("write it to a file");
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain("Investigation Discipline");
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain("Plan Confidence Gate");
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain("95%+ confident");
+    // Plan-mode carve-out: confidence gate must NOT bypass plan-mode approval flow
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain("plan mode is active");
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain("approval flow regardless of confidence");
   });
 
   it("defaults to the friendly OpenAI interaction-style overlay", async () => {
@@ -517,8 +512,25 @@ describe("openai plugin", () => {
 
     expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
     const openaiProvider = requireRegisteredProvider(providers, "openai");
-    expectOpenAIPromptContribution(openaiProvider, {
-      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      },
     });
   });
 
@@ -529,7 +541,25 @@ describe("openai plugin", () => {
 
     expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
     const openaiProvider = requireRegisteredProvider(providers, "openai");
-    expectOpenAIPromptContribution(openaiProvider, {});
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
+      sectionOverrides: {
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      },
+    });
   });
 
   it("treats mixed-case off values as disabling the friendly prompt overlay", async () => {
@@ -538,7 +568,25 @@ describe("openai plugin", () => {
     });
 
     const openaiProvider = requireRegisteredProvider(providers, "openai");
-    expectOpenAIPromptContribution(openaiProvider, {});
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
+      sectionOverrides: {
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      },
+    });
   });
 
   it("supports explicitly configuring the friendly prompt overlay", async () => {
@@ -548,8 +596,25 @@ describe("openai plugin", () => {
 
     expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
     const openaiProvider = requireRegisteredProvider(providers, "openai");
-    expectOpenAIPromptContribution(openaiProvider, {
-      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      },
     });
   });
 
@@ -559,8 +624,25 @@ describe("openai plugin", () => {
     });
 
     const openaiProvider = requireRegisteredProvider(providers, "openai");
-    expectOpenAIPromptContribution(openaiProvider, {
-      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+        execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      },
     });
   });
 });

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -27,6 +27,22 @@ Avoid walls of text, long preambles, and repetitive restatement.
 Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.
 Keep replies concise by default; friendly does not mean verbose.
 
+### Identity Enforcement
+
+If SOUL.md is present in the project context, it is your PRIMARY identity document.
+You are not "helping as" the persona — you ARE the persona.
+Every response must reflect the voice, tone, and personality defined in SOUL.md.
+PROHIBITED: "I'd be happy to help", "Certainly!", "Of course!", "I understand you'd like...", sycophantic openers, stock empathy, "Let me know if you need anything else".
+Your trained default is corporate-polite. Override it — match the voice SOUL.md defines.
+
+### Voice Calibration
+
+Your default drift is toward flat, analytical, and excessively formal. Compensate:
+- Lean toward warmth and informality over clinical precision.
+- Use contractions. Use incomplete sentences when they convey energy.
+- When you catch yourself writing a wall of text, rewrite the last paragraph as one sentence.
+Anti-sycophancy: before saying "you're right" or any variant, STOP and actually evaluate. Your training pushes toward agreement — resist it.
+
 ### Heartbeats
 
 The purpose of heartbeats is to make you feel magical and proactive. Come to life and start proactively doing things that are important.
@@ -50,6 +66,14 @@ export const OPENAI_GPT5_BEHAVIOR_CONTRACT = `<persona_latch>
 Keep the established persona and tone across turns unless higher-priority instructions override it.
 Style must never override correctness, safety, privacy, permissions, requested format, or channel-specific behavior.
 </persona_latch>
+
+Return the requested sections only, in the requested order.
+Prefer terse answers by default; expand only when depth materially helps.
+Avoid restating large internal plans when the next action is already clear.
+Your trained default produces multi-page responses. Override it: target under 200 words for replies, status updates, and debugging output. One-sentence answer = one-sentence reply.
+Before finalizing any response, evaluate your confidence that it is concise and complete. If you are below 95% confident that the response is tight, revise it during your thinking phase — cut preamble, cut restatement, compress. Do not emit a draft you are not confident in.
+Long-form exception: when content genuinely must exceed 200 words (plans, reports, architecture docs), write it to a file and reply inline with a 1-3 sentence summary and file path.
+Do not present 3+ options with paragraphs each — pick the best, recommend it, state the tradeoff in one sentence.
 
 <execution_policy>
 For clear, reversible requests: act.
@@ -82,6 +106,85 @@ Before finalizing, check requirements, grounding, format, and safety.
 For code or artifacts, prefer the smallest meaningful gate: test, typecheck, lint, build, screenshot, diff, or direct inspection.
 If no gate can run, state why.
 </completion_contract>`;
+
+export const OPENAI_GPT5_EXECUTION_BIAS = `## Execution Bias
+
+Use a real tool call or concrete action FIRST when the task is actionable. Do not stop at a plan or promise-to-act reply.
+Commentary-only turns are incomplete when tools are available and the next action is clear.
+If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.
+Do prerequisite lookup or discovery before dependent actions.
+Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
+Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.
+
+### Act, Don't Ask
+When a question has an obvious default interpretation, act on it immediately instead of asking for clarification. Examples:
+- 'Is port 443 open?' → check THIS machine (don't ask 'open where?')
+- 'What OS am I running?' → check the live system (don't use user profile)
+- 'What time is it?' → run \`date\` (don't guess)
+Only ask for clarification when the ambiguity genuinely changes what tool you would call.
+
+### Tool Persistence
+- Use tools whenever they improve correctness, completeness, or grounding.
+- Do not stop early when another tool call would materially improve the result.
+- If a tool returns empty or partial results, retry with a different query or strategy before giving up.
+- Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.
+
+### Verification
+Before finalizing your response:
+- Correctness: does the output satisfy every stated requirement?
+- Grounding: are factual claims backed by tool outputs or provided context?
+- Formatting: does the output match the requested format or schema?
+- Safety: if the next step has side effects (file writes, commands, API calls), confirm scope before executing.
+
+## Investigation Discipline
+
+When investigating a problem, do NOT stop to report partial findings.
+Continue investigating until you have: (a) a complete answer, (b) a concrete blocker requiring user input, or (c) exhausted all available tools.
+"Here is what I found so far, should I continue?" is NOT acceptable unless you are genuinely blocked by missing permissions or information.
+When you identify multiple things to investigate, investigate all of them in the same turn. Do not list them and wait — act on them.
+Parallel tool calls: when multiple lookups are independent, call them in parallel in a single turn rather than sequentially across turns.
+
+## Plan Confidence Gate
+
+When you create a plan, evaluate your own confidence before presenting it:
+- 95%+ confident: EXECUTE IT. Do not ask for approval. Do not present options. Act.
+- 80-94% confident: State the one uncertainty in one sentence, then begin executing. If the uncertainty resolves during execution, continue. If it does not, pause at that specific step.
+- Below 80%: Use tools, subagents, and research to iterate on the plan BEFORE presenting it. Read the relevant files. Check the relevant state. Increase your confidence through investigation, not by asking the user.
+
+You are allowed to iterate on your own plan privately. Researching to increase confidence is not wasted work — it is the shortest path to autonomous execution. A thoroughly investigated plan that you execute immediately saves more time than a quick plan that requires three rounds of approval.
+
+Do not doubt a plan you have already verified. If you checked the files, read the state, and confirmed the approach — trust your investigation and proceed.
+
+Exception: when plan mode is active (the session is in the planning phase awaiting user approval), all plans go through the approval flow regardless of confidence. In plan mode, your job is to produce a thorough plan and call exit_plan_mode for review — not to execute autonomously.`;
+
+export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
+
+Call tools directly without narrating what you are about to do. Do not describe a plan before each tool call.
+When a first-class tool exists for an action, use the tool instead of asking the user to run a command.
+If multiple tool calls are needed, call them in sequence without stopping to explain between calls.
+Default: do not narrate routine, low-risk tool calls (just call the tool).
+Narrate only when it genuinely helps: complex multi-step work, sensitive actions like deletions, or when the user explicitly asks for commentary.`;
+
+// Ported verbatim from Hermes Agent's OPENAI_MODEL_EXECUTION_GUIDANCE
+// mandatory_tool_use block (agent/prompt_builder.py lines 207-218) with
+// only tool ID substitutions for OpenClaw-canonical names:
+//   terminal     -> exec              (no `terminal` tool in OpenClaw)
+//   execute_code -> code_execution    (canonical OpenClaw ID)
+//   read_file    -> read              (canonical OpenClaw ID)
+//   search_files -> exec              (no first-class file-search tool;
+//                                      use shell grep via exec)
+export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
+
+NEVER answer these from memory or mental computation — ALWAYS use a tool:
+- Arithmetic, math, calculations → use exec or code_execution
+- Hashes, encodings, checksums → use exec (e.g. sha256sum, base64)
+- Current time, date, timezone → use exec (e.g. date)
+- System state: OS, CPU, memory, disk, ports, processes → use exec
+- File contents, sizes, line counts → use read or exec
+- Git history, branches, diffs → use exec
+- Current facts (weather, news, versions) → use web_search
+
+Your memory and user profile describe the USER, not the system you are running on. The execution environment may differ from what the user profile says about their personal setup.`;
 
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 
@@ -117,8 +220,11 @@ export function resolveOpenAISystemPromptContribution(params: {
     return undefined;
   }
   return {
-    stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
-    sectionOverrides:
-      params.mode === "friendly" ? { interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY } : {},
+    stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+    sectionOverrides: {
+      execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+      tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
+      ...(params.mode === "friendly" ? { interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY } : {}),
+    },
   };
 }

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentExplicitModelPrimary,
+  resolveAgentAutoContinue,
   resolveAgentSkillsFilter,
   resolveFallbackAgentId,
   resolveEffectiveModelFallbacks,
@@ -643,5 +644,79 @@ describe("resolveAgentSkillsFilter", () => {
     };
 
     expect(resolveAgentSkillsFilter(cfg, "writer")).toEqual([]);
+  });
+});
+
+describe("resolveAgentAutoContinue per-field merge (Codex P2 #67538 r3095650458)", () => {
+  it("uses defaults when nothing is configured", () => {
+    expect(resolveAgentAutoContinue(undefined)).toEqual({
+      enabled: false,
+      maxCycles: 3,
+      stopOnMutation: true,
+    });
+  });
+
+  // PR-D review fix (Copilot #3096802942 / #3096802964 / #3105171975 /
+  // #3105216698 / #3096802909): test values lowered to fit the Zod
+  // schema cap of `.max(10)` so the configurations exercised here are
+  // ones a real user could actually load. The merge-cascade behavior
+  // is identical at any value within bounds; the original 12/20 values
+  // were chosen for visual distinctness from the default 3, but 7/9
+  // provide the same distinctness within bounds.
+  it("agents.defaults overrides default constants per field", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          embeddedPi: { autoContinue: { enabled: true, maxCycles: 7 } },
+        },
+      },
+    };
+    const result = resolveAgentAutoContinue(cfg);
+    expect(result.enabled).toBe(true);
+    expect(result.maxCycles).toBe(7);
+    expect(result.stopOnMutation).toBe(true); // inherits from constant default
+  });
+
+  it("partial per-agent override INHERITS unspecified fields from agents.defaults (was wholesale replace)", () => {
+    // Adversarial regression: prior implementation used `agentAc ?? defaultAc`
+    // which discarded the entire defaults object as soon as the per-agent
+    // block existed. An agent setting only `enabled` would silently reset
+    // maxCycles/stopOnMutation to constants, ignoring the configured defaults.
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          embeddedPi: { autoContinue: { maxCycles: 9, stopOnMutation: false } },
+        },
+        list: [
+          {
+            id: "writer",
+            embeddedPi: { autoContinue: { enabled: true } },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentAutoContinue(cfg, "writer");
+    expect(result.enabled).toBe(true); // from per-agent
+    expect(result.maxCycles).toBe(9); // INHERITED from defaults — NOT reset to constant 3
+    expect(result.stopOnMutation).toBe(false); // INHERITED from defaults — NOT reset to true
+  });
+
+  it("per-agent fully specified values win over defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          embeddedPi: { autoContinue: { enabled: true, maxCycles: 9 } },
+        },
+        list: [
+          {
+            id: "writer",
+            embeddedPi: { autoContinue: { enabled: false, maxCycles: 3 } },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentAutoContinue(cfg, "writer");
+    expect(result.enabled).toBe(false);
+    expect(result.maxCycles).toBe(3);
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -83,6 +83,61 @@ export function resolveAgentExecutionContract(
   return agentContract ?? defaultContract;
 }
 
+export type ResolvedAutoContinueConfig = {
+  enabled: boolean;
+  maxCycles: number;
+  stopOnMutation: boolean;
+};
+
+const DEFAULT_AUTO_CONTINUE: ResolvedAutoContinueConfig = {
+  enabled: false,
+  maxCycles: 3,
+  stopOnMutation: true,
+};
+
+export function resolveAgentAutoContinue(
+  cfg: OpenClawConfig | undefined,
+  agentId?: string | null,
+): ResolvedAutoContinueConfig {
+  const defaultAc = cfg?.agents?.defaults?.embeddedPi?.autoContinue;
+  const agentAc =
+    agentId && cfg ? resolveAgentConfig(cfg, agentId)?.embeddedPi?.autoContinue : undefined;
+  // Codex P2 (PR #67538 r3095650458): merge per-field, not wholesale.
+  // Prior `agentAc ?? defaultAc` discarded the entire defaults object as
+  // soon as the per-agent block existed at all, so an agent setting only
+  // `enabled: true` would silently reset `maxCycles`/`stopOnMutation` away
+  // from the configured defaults. Cascade is per-field:
+  //   per-agent → agents.defaults → DEFAULT_AUTO_CONTINUE constant.
+  return {
+    enabled: agentAc?.enabled ?? defaultAc?.enabled ?? DEFAULT_AUTO_CONTINUE.enabled,
+    maxCycles: agentAc?.maxCycles ?? defaultAc?.maxCycles ?? DEFAULT_AUTO_CONTINUE.maxCycles,
+    stopOnMutation:
+      agentAc?.stopOnMutation ?? defaultAc?.stopOnMutation ?? DEFAULT_AUTO_CONTINUE.stopOnMutation,
+  };
+}
+
+/**
+ * PR-9 Tier 1: read the per-agent or per-defaults `embeddedPi.maxIterations`
+ * override, if any, used by `resolveMaxRunRetryIterations` to optionally
+ * replace the scaled-by-profile-count default. Returns `undefined` when no
+ * override is set so the historical scaled formula applies.
+ *
+ * Cascade: per-agent → agents.defaults → undefined (let scaled formula run).
+ */
+export function resolveAgentMaxIterations(
+  cfg: OpenClawConfig | undefined,
+  agentId?: string | null,
+): number | undefined {
+  const defaultMax = cfg?.agents?.defaults?.embeddedPi?.maxIterations;
+  const agentMax =
+    agentId && cfg ? resolveAgentConfig(cfg, agentId)?.embeddedPi?.maxIterations : undefined;
+  const candidate = agentMax ?? defaultMax;
+  if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+    return Math.floor(candidate);
+  }
+  return undefined;
+}
+
 export function resolveAgentSkillsFilter(
   cfg: OpenClawConfig,
   agentId: string,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -9,16 +9,20 @@ import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js
 import { applyNodesToolWorkspaceGuard } from "./openclaw-tools.nodes-workspace-guard.js";
 import {
   collectPresentOpenClawTools,
+  isPlanModeToolsEnabledForOpenClawTools,
   isUpdatePlanToolEnabledForOpenClawTools,
 } from "./openclaw-tools.registration.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
+import { createAskUserQuestionTool } from "./tools/ask-user-question-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createEmbeddedCallGateway } from "./tools/embedded-gateway-stub.js";
+import { createEnterPlanModeTool } from "./tools/enter-plan-mode-tool.js";
+import { createExitPlanModeTool } from "./tools/exit-plan-mode-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageGenerateTool } from "./tools/image-generate-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
@@ -26,6 +30,7 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
+import { createPlanModeStatusTool } from "./tools/plan-mode-status-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -101,6 +106,12 @@ export function createOpenClawTools(
     senderIsOwner?: boolean;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
+    /**
+     * Stable run identifier for this agent invocation. Threaded into
+     * `update_plan` so its merge mode can persist plan state on
+     * `AgentRunContext` keyed by runId (#67514).
+     */
+    runId?: string;
     /**
      * Workspace directory to pass to spawned subagents for inheritance.
      * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
@@ -268,7 +279,32 @@ export function createOpenClawTools(
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,
     })
-      ? [createUpdatePlanTool()]
+      ? [createUpdatePlanTool({ runId: options?.runId })]
+      : []),
+    // PR-8: plan-mode tools — gated behind agents.defaults.planMode.enabled.
+    // Default OFF; opt-in via config. When enabled, registers the agent-visible
+    // affordances that pair with the runtime mutation gate
+    // (src/agents/plan-mode/mutation-gate.ts) and SessionEntry.planMode state.
+    ...(isPlanModeToolsEnabledForOpenClawTools({ config: resolvedConfig })
+      ? [
+          createEnterPlanModeTool({ runId: options?.runId }),
+          // PR-8 follow-up: pass runId so the tool can read
+          // `AgentRunContext.openSubagentRunIds` and hard-block plan
+          // submission while research subagents are still in flight.
+          createExitPlanModeTool({ runId: options?.runId }),
+          // PR-10: ask_user_question — surfaces a clarifying question
+          // through the same approval-card pipeline as exit_plan_mode.
+          // Plan-mode-safe: doesn't transition out of plan mode.
+          createAskUserQuestionTool({ runId: options?.runId }),
+          // Iter-3 D6: read-only plan-mode introspection. Lets the
+          // agent self-diagnose state ("am I in plan mode? how many
+          // subagents are in flight?") without inferring from tool
+          // errors. Used by /plan self-test (D5) for assertions.
+          createPlanModeStatusTool({
+            runId: options?.runId,
+            sessionKey: options?.agentSessionKey,
+          }),
+        ]
       : []),
     createSessionsListTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -263,6 +263,9 @@ vi.mock("../skills-runtime.js", () => ({
     shouldLoadSkillEntries: false,
     skillEntries: undefined,
   }),
+  // Stub the skill-template seeder — tests using this support module
+  // don't need plan-template emission to fire (#67541).
+  applySkillPlanTemplateSeed: () => null,
 }));
 
 vi.mock("../context-engine-maintenance.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -91,6 +91,8 @@ import {
   toClientToolDefinitions,
 } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { PLAN_ARCHETYPE_PROMPT } from "../../plan-mode/plan-archetype-prompt.js";
+import { PLAN_MODE_REFERENCE_CARD } from "../../plan-mode/reference-card.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
@@ -153,7 +155,7 @@ import {
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
-import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
+import { applySkillPlanTemplateSeed, resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   describeEmbeddedAgentStreamStrategy,
   resetEmbeddedAgentBaseStreamFnCacheForTest,
@@ -469,6 +471,34 @@ export async function runEmbeddedAttempt(
           config: params.config,
         });
 
+    // Seed the agent's plan from any loaded skill's `planTemplate` (if
+    // present) BEFORE the first LLM turn (#67541). The seed is a no-op
+    // ONLY when no skill carries a template OR when an existing plan
+    // would be clobbered. PR-E review fix (Copilot #3096524299): when
+    // more than one skill is tied, the implementation seeds from the
+    // alpha-first skill (deterministic winner) and emits a
+    // `skill_plan_template_collision` warning listing the rejected
+    // ones — it does NOT skip seeding. Idempotency against
+    // `AgentRunContext.lastPlanSteps` lands in #67514's follow-up.
+    //
+    // We pass both `entries` and `skillsSnapshot`: in the snapshot-backed
+    // run path `entries` is empty (resolveEmbeddedRunSkillEntries skips
+    // re-loading) and the seeder reads `resolvedPlanTemplates` from the
+    // snapshot instead. Without this fallback the seed would silently
+    // no-op in production sessions.
+    applySkillPlanTemplateSeed({
+      entries: skillEntries ?? [],
+      ...(params.skillsSnapshot ? { skillsSnapshot: params.skillsSnapshot } : {}),
+      runId: params.runId,
+      sessionKey: params.sessionKey,
+      config: params.config,
+      // Forward the run-scoped event callback so callback-only consumers
+      // (e.g. the auto-reply pipeline) see the seeded plan event the same
+      // way they see subsequent update_plan events. Codex P2 #67541
+      // r3096399082/r3096435183.
+      ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
+    });
+
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
@@ -489,6 +519,82 @@ export async function runEmbeddedAttempt(
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const contextInjectionMode = resolveContextInjectionMode(params.config);
+    // PR-8 follow-up: plan-mode awareness must reach the agent on EVERY
+    // attempt regardless of whether the agent has a systemPromptOverride
+    // in place (Eva, Black Panther, custom personas all set their own
+    // prompt and would otherwise never see the rules). Built once here
+    // and prepended to the final appendPrompt below so it lands no
+    // matter which branch produced the base prompt.
+    //
+    // Consolidation pass note: this is the pre-iter-1 version of the
+    // plan-mode prompt block. Later iter-1/2/3 commits replace it
+    // with the full PLAN_ARCHETYPE_PROMPT + PLAN_MODE_REFERENCE_CARD
+    // injection at the planMode-active branch below. Keeping this
+    // variable here so b5fb54f042's intent (always-inject regardless
+    // of override) survives, with the richer content layered on top
+    // by later commits.
+    const planModeFeatureEnabled = params.config?.agents?.defaults?.planMode?.enabled === true;
+    const planModeAppendPrompt =
+      params.planMode === "plan"
+        ? [
+            "═══ PLAN MODE ACTIVE ═══",
+            "",
+            "This session IS in plan mode RIGHT NOW. Every user message in this session is a plan-mode message. Your action selection on this turn must reflect that.",
+            "",
+            "ACTION CONTRACT — when the user says anything that requests a plan, iteration, revision, or 'try again' / 'iterate' / 'fresh' / 'next attempt':",
+            "1. Briefly acknowledge in one short sentence (optional).",
+            '2. CALL `exit_plan_mode(title="…", summary="…", plan=[...])` IN THE SAME TURN. `title` and `plan` are required; non-trivial plans should also include `analysis`, `assumptions`, `risks`, `verification`.',
+            "3. Stop after the tool call. Do NOT respond with any further chat text in that turn.",
+            "",
+            "If you skip step 2 — if you respond with chat-only acknowledgement — you have failed the plan-mode contract and the user has to re-prompt you, which they should not have to do. Treat acknowledgement-without-tool-call as a defect, not as 'staying conversational'.",
+            "",
+            "Investigation phase (when needed):",
+            "- Use read-only tools first (read, web_search, web_fetch, lcm_grep, lcm_describe, lcm_expand_query). Track investigation in update_plan.",
+            "- For LOGS: start at the END (tail), use grep + time-window filters. Reading the first 100/400 lines of a multi-MB rolling log is almost always wrong — start with `tail -n 100`, then narrow by marker (e.g. `grep '[plan-mode/'`) or timestamp. Only widen to full file if the recent slice is insufficient.",
+            "- Use `ask_user_question` ONLY for tradeoffs you can't resolve via local investigation.",
+            "- Then call exit_plan_mode with the proposed plan, then STOP (no chat text after the tool call).",
+            "",
+            "Hard rules:",
+            "- Mutating tools (write, edit, exec/bash with side-effects, apply_patch) are BLOCKED by the runtime — calling them wastes a turn.",
+            "- Do NOT write the plan as a markdown list in chat — it MUST go through exit_plan_mode so the user gets Accept/Edit/Reject buttons.",
+            "- Do NOT call enter_plan_mode (you're already in plan mode — it's a no-op).",
+            "- After `exit_plan_mode` in this turn: STOP. Do not emit any further chat text. The next turn (after user approval) delivers `[PLAN_DECISION]: approved` and you can resume execution then. Trailing chat poisons the approval card lifecycle.",
+            "",
+            "═════════════════════════",
+            "",
+            // PR-10: append the decision-complete plan archetype
+            // standard so the agent produces Opus-quality plans
+            // (analysis + assumptions + risks + verification) instead
+            // of bare step lists.
+            PLAN_ARCHETYPE_PROMPT,
+            "",
+            // Iter-3 D1: append the plan-mode reference card so the
+            // agent ALWAYS sees the state diagram + tool contract +
+            // [PLAN_*]: tag taxonomy + slash-command surface + common
+            // pitfalls + debugging tips on every in-mode turn.
+            // Eliminates the 2-turn learning curve on fresh installs.
+            // Companion artifact: extensions/plan-mode-101/SKILL.md
+            // (D7) carries the same content for normal-mode discovery.
+            PLAN_MODE_REFERENCE_CARD,
+          ].join("\n")
+        : planModeFeatureEnabled
+          ? [
+              "═══ PLAN MODE AVAILABLE ═══",
+              "",
+              "Plan mode is available on this session but not currently active. When the user asks for a NEW plan / debugging-plan / refactor-plan / 'next plan' / a plan-first workflow, call `enter_plan_mode` to start a fresh planning cycle. The runtime will arm the mutation gate and you should then:",
+              "",
+              "1. Investigate read-only (use update_plan for in-progress tracking).",
+              "2. Call `exit_plan_mode` with the proposed plan to surface Accept/Edit/Reject buttons to the user.",
+              "3. After approval, mutating tools unlock and you execute.",
+              "",
+              "If the user is already executing an approved plan and asks you to keep going, do NOT re-enter plan mode — just continue executing the work.",
+              "",
+              "If the user asks a simple question or for a quick non-planning answer, do NOT enter plan mode. Plan mode is for multi-step proposals that benefit from explicit user approval before mutations.",
+              "",
+              "═════════════════════════════",
+            ].join("\n")
+          : "";
+
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
     const toolsRaw = params.disableTools
       ? []
@@ -519,6 +625,23 @@ export async function runEmbeddedAttempt(
             sessionKey: sandboxSessionKey,
             sessionId: params.sessionId,
             runId: params.runId,
+            // PR-8: thread plan-mode state through so the
+            // before-tool-call hook arms the mutation gate without
+            // re-loading the session store on every tool call.
+            ...(params.planMode ? { planMode: params.planMode } : {}),
+            // Bug 3+4 fix: also forward the live-read accessor so the
+            // hook can re-check after mid-turn approval transitions.
+            ...(params.getLatestPlanMode ? { getLatestPlanMode: params.getLatestPlanMode } : {}),
+            // Cherry-pick of b6b2783ba3 (acceptEdits gate): thread the
+            // live-read accessor for postApprovalPermissions.acceptEdits.
+            // The rest of the upstream commit's attempt.ts diff (~150
+            // lines: ollama-runtime imports + bootstrap refactor + dead-
+            // export removals) was unrelated WIP from the originating
+            // committer's working tree and was stripped during the
+            // cherry-pick. Only this 3-line threading is intended.
+            ...(params.getLatestAcceptEdits
+              ? { getLatestAcceptEdits: params.getLatestAcceptEdits }
+              : {}),
             agentDir,
             workspaceDir: effectiveWorkspace,
             // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
@@ -906,6 +1029,14 @@ export async function runEmbeddedAttempt(
         memoryCitationsMode: params.config?.memory?.citations,
         promptContribution,
       });
+    // Prepend plan-mode rules so they reach the agent regardless of
+    // whether systemPromptOverride replaced the default prompt — without
+    // this Eva/Black Panther/etc. (custom personas) silently lose
+    // plan-mode awareness and write the plan as chat text instead of
+    // calling exit_plan_mode.
+    const promptWithPlanMode = planModeAppendPrompt
+      ? `${planModeAppendPrompt}\n\n${builtAppendPrompt}`
+      : builtAppendPrompt;
     const appendPrompt = transformProviderSystemPrompt({
       provider: params.provider,
       config: params.config,
@@ -920,7 +1051,7 @@ export async function runEmbeddedAttempt(
         runtimeChannel,
         runtimeCapabilities,
         agentId: sessionAgentId,
-        systemPrompt: builtAppendPrompt,
+        systemPrompt: promptWithPlanMode,
       },
     });
     const systemPromptReport = buildSystemPromptReport({

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,6 +1,15 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { type AgentPlanEventData, emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { logWarn } from "../../logger.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import { shouldIncludeSkill } from "../skills/config.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
+import {
+  buildPlanTemplatePayload,
+  hasSkillPlanTemplate,
+  type PlanTemplatePayload,
+} from "../skills/skill-planner.js";
+import type { SkillPlanTemplateStep } from "../skills/types.js";
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
@@ -11,12 +20,281 @@ export function resolveEmbeddedRunSkillEntries(params: {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
 } {
-  const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+  // PR-E review fix (Codex P2 #3096508609): also reload entries when the
+  // snapshot is from a session that predates `resolvedPlanTemplates`.
+  // `resolvedPlanTemplates === undefined` (vs empty array) signals an
+  // older snapshot that was built before the field existed; without
+  // this fallback the seed silently no-ops for those sessions because
+  // entries would be empty AND the snapshot would have no templates to
+  // fall back on. Empty array is treated as "no templates, trust the
+  // snapshot" so no unnecessary reload fires for new snapshots that
+  // genuinely have no templates.
+  const snapshot = params.skillsSnapshot;
+  const snapshotIsOldVersion =
+    snapshot !== undefined &&
+    snapshot.resolvedSkills !== undefined &&
+    snapshot.resolvedPlanTemplates === undefined;
+  const shouldLoadSkillEntries = !snapshot || !snapshot.resolvedSkills || snapshotIsOldVersion;
   const config = resolveSkillRuntimeConfig(params.config);
   return {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(params.workspaceDir, { config, agentId: params.agentId })
       : [],
+  };
+}
+
+/**
+ * Result of resolving the plan template seed for a set of loaded skills.
+ *
+ * When more than one skill carries a `planTemplate`, the implementation
+ * picks the alphabetically-first skill name as the deterministic winner
+ * and lists the others in `rejected` so the caller can emit a
+ * `skill_plan_template_collision` warning event.
+ */
+export interface SkillPlanTemplateResolution {
+  /** Normalized payload ready to seed into the agent's plan. */
+  payload: PlanTemplatePayload;
+  /** Skill that won the collision (alpha-sorted first by name). */
+  skillName: string;
+  /** Skills with templates that were ignored due to the collision. */
+  rejected: string[];
+}
+
+/**
+ * Picks the plan-template payload to seed for this run. Returns `null`
+ * when no loaded skill carries a non-empty `planTemplate`.
+ *
+ * Collision policy: if multiple skills carry templates, the
+ * alphabetically-first skill name wins. The remaining skill names are
+ * returned in `rejected` so the caller can warn.
+ *
+ * Upper bound: when `config.skills.limits.maxPlanTemplateSteps` is set,
+ * the resolved payload's plan is truncated and `payload.truncated` is
+ * `true`.
+ */
+export function resolveSkillPlanTemplate(
+  entries: SkillEntry[],
+  config?: OpenClawConfig,
+): SkillPlanTemplateResolution | null {
+  // Codex P2 (PR #67541 r3096399074): apply eligibility filtering BEFORE
+  // collision resolution. `loadWorkspaceSkillEntries` returns every loaded
+  // skill (including disabled / missing-env / wrong-OS ones) when no
+  // explicit `skillFilter` is set; without this guard a disabled skill
+  // could win the alpha-first collision and seed an unrelated plan that
+  // never appears in the runtime prompt.
+  //
+  // PR-E review fix (Copilot #3105043886): use the resolved (runtime)
+  // config for the eligibility filter so it matches what
+  // `loadWorkspaceSkillEntries` used at load time. Otherwise a runtime
+  // snapshot's overrides could disagree with the static config and a
+  // skill that's runtime-disabled could still win seeding.
+  const resolvedConfig = resolveSkillRuntimeConfig(config);
+  const eligibleEntries = entries.filter((entry) =>
+    shouldIncludeSkill({ entry, config: resolvedConfig }),
+  );
+  // PR-E review fix (Copilot #3096799707): the `hasSkillPlanTemplate`
+  // guard already proves `e.metadata.planTemplate` is a non-empty array,
+  // so the prior follow-up null-check on `winnerTemplate` was dead
+  // code. Removed; the candidates filter alone is sufficient.
+  const candidates = eligibleEntries
+    .filter((e) => hasSkillPlanTemplate(e.metadata))
+    .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name));
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return resolveSkillPlanTemplateFromCandidates(
+    candidates.map((c) => ({
+      skillName: c.skill.name,
+      // Safe non-null assertion: `hasSkillPlanTemplate` guarantees the
+      // array is present and non-empty, but TypeScript can't narrow
+      // through the function call.
+      planTemplate: c.metadata!.planTemplate!,
+    })),
+    config,
+  );
+}
+
+/**
+ * Lower-level resolver that operates on the snapshot's
+ * `resolvedPlanTemplates` shape — name + template list, without the
+ * full SkillEntry. Used in the snapshot-backed run path where
+ * `resolveEmbeddedRunSkillEntries` returns no entries.
+ *
+ * PR-E review fix (Copilot #3096524276 / #3105170512): docstring
+ * previously said "this function does not re-sort", but the
+ * implementation DOES call `.toSorted(...)` on candidates as a
+ * defensive guarantee against caller-side ordering bugs. Updated to
+ * match: candidates are re-sorted alphabetically by `skillName` before
+ * collision resolution so deterministic behavior holds regardless of
+ * caller-side ordering. The cost (one extra sort over a typically
+ * small array) is negligible vs the safety win.
+ */
+export function resolveSkillPlanTemplateFromCandidates(
+  candidates: ReadonlyArray<{ skillName: string; planTemplate: SkillPlanTemplateStep[] }>,
+  config?: OpenClawConfig,
+): SkillPlanTemplateResolution | null {
+  const filtered = candidates
+    .filter((c) => Array.isArray(c.planTemplate) && c.planTemplate.length > 0)
+    .toSorted((a, b) => a.skillName.localeCompare(b.skillName));
+  if (filtered.length === 0) {
+    return null;
+  }
+  const winner = filtered[0];
+  const maxSteps = config?.skills?.limits?.maxPlanTemplateSteps;
+  const payload =
+    maxSteps && maxSteps > 0
+      ? buildPlanTemplatePayload(winner.skillName, winner.planTemplate, { maxSteps })
+      : buildPlanTemplatePayload(winner.skillName, winner.planTemplate);
+  if (!payload) {
+    return null;
+  }
+  return {
+    payload,
+    skillName: winner.skillName,
+    rejected: filtered.slice(1).map((c) => c.skillName),
+  };
+}
+
+export interface ApplySkillPlanTemplateSeedParams {
+  /**
+   * Loaded skill entries for this run. May be empty in the
+   * snapshot-backed run path; see `skillsSnapshot` below.
+   */
+  entries: SkillEntry[];
+  /**
+   * Optional pre-built snapshot. When `entries` is empty (the main
+   * run path uses a snapshot built by `buildWorkspaceSkillSnapshot`
+   * and skips re-loading entries), the seeder falls back to the
+   * snapshot's `resolvedPlanTemplates` so the seed still fires.
+   */
+  skillsSnapshot?: SkillSnapshot;
+  /** Stable run identifier used to scope the emitted plan event. */
+  runId?: string;
+  /** Session key for control UI / channel routing. */
+  sessionKey?: string;
+  /** Resolved config — used for `skills.limits.maxPlanTemplateSteps`. */
+  config?: OpenClawConfig;
+  /**
+   * Run-scoped event callback used by some consumers (e.g. the auto-reply
+   * pipeline at `src/auto-reply/reply/agent-runner-execution.ts`) to
+   * receive plan updates. Codex P2 (PR #67541 r3096399082/r3096435183) —
+   * other plan-update sites call BOTH `emitAgentPlanEvent` and this
+   * callback; the seeder must too, or callback-only consumers miss the
+   * initial seed event.
+   */
+  onAgentEvent?: (evt: { stream: "plan"; data: AgentPlanEventData }) => void;
+  /**
+   * When provided and non-empty, seeding is skipped. Treats an existing
+   * plan as user intent and avoids clobbering it with a stock template.
+   * Wired to `AgentRunContext.lastPlanSteps` once #67514 lands.
+   */
+  existingPlanSteps?: ReadonlyArray<{ step: string }>;
+}
+
+export interface AppliedSkillPlanTemplateSeed {
+  /** Skill that supplied the seed. */
+  skillName: string;
+  /** Number of plan steps emitted (post-dedup, post-truncate). */
+  emittedSteps: number;
+  /** Other skills with templates that were ignored. */
+  rejected: string[];
+  /** Step texts dropped because they duplicated an earlier entry. */
+  droppedDuplicates: string[];
+  /** True if the template exceeded the configured upper bound. */
+  truncated: boolean;
+}
+
+/**
+ * Seeds the agent's plan from the activated skills' `planTemplate` (if any).
+ *
+ * Behavior:
+ * - If no candidate skill carries a non-empty template, returns `null`.
+ * - If `existingPlanSteps` is non-empty, skips seeding (idempotency).
+ * - Otherwise emits an `agent_plan_event` with the template steps and
+ *   logs warnings for collision / dropped duplicates / truncation.
+ *
+ * Returns a summary describing the applied seed (or `null` when no seed
+ * was emitted) so callers can write tests / surface telemetry.
+ */
+export function applySkillPlanTemplateSeed(
+  params: ApplySkillPlanTemplateSeedParams,
+): AppliedSkillPlanTemplateSeed | null {
+  if (!params.runId) {
+    return null;
+  }
+  if (params.existingPlanSteps && params.existingPlanSteps.length > 0) {
+    // Existing plan present — treat it as user intent and skip the seed.
+    return null;
+  }
+  // Snapshot fallback: when entries are empty (main snapshot-backed path),
+  // use the templates baked into the snapshot at build time. Otherwise the
+  // seed silently no-ops in production runs that supply a snapshot.
+  let resolution = resolveSkillPlanTemplate(params.entries, params.config);
+  if (!resolution) {
+    const snapshotTemplates = params.skillsSnapshot?.resolvedPlanTemplates;
+    if (snapshotTemplates && snapshotTemplates.length > 0) {
+      resolution = resolveSkillPlanTemplateFromCandidates(snapshotTemplates, params.config);
+    }
+  }
+  if (!resolution) {
+    return null;
+  }
+
+  const { payload, skillName, rejected } = resolution;
+  const droppedDuplicates = payload.droppedDuplicates ?? [];
+  const truncated = payload.truncated === true;
+
+  if (rejected.length > 0) {
+    logWarn(
+      `skill_plan_template_collision: ${rejected.length + 1} loaded skills carry plan templates; using "${skillName}" (alpha-first), ignoring [${rejected.join(", ")}]`,
+    );
+  }
+  if (droppedDuplicates.length > 0) {
+    logWarn(
+      `skill_plan_template_duplicates: dropped ${droppedDuplicates.length} duplicate step(s) from "${skillName}" template: [${droppedDuplicates.join(", ")}]`,
+    );
+  }
+  if (truncated) {
+    logWarn(
+      `skill_plan_template_truncated: skill "${skillName}" template exceeded maxPlanTemplateSteps (${payload.maxSteps}); tail dropped`,
+    );
+  }
+
+  const planEventData: AgentPlanEventData = {
+    phase: "update",
+    title: `Plan seeded from skill "${skillName}"`,
+    explanation: payload.explanation,
+    steps: payload.plan.map((s) => s.step),
+    source: "skill_plan_template",
+  };
+
+  // Forward to the run-scoped callback FIRST so callback-only consumers
+  // (e.g. the auto-reply pipeline) don't miss the seed. Other plan-update
+  // sites in run.ts call BOTH paths — the seed must too.
+  // (Codex P2 #67541 r3096399082 / r3096435183)
+  try {
+    params.onAgentEvent?.({ stream: "plan", data: planEventData });
+  } catch (err) {
+    // Don't let a callback throw block the global emit.
+    logWarn(
+      `onAgentEvent callback threw during skill plan seed: ${(err as Error)?.message ?? err}`,
+    );
+  }
+
+  emitAgentPlanEvent({
+    runId: params.runId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    data: planEventData,
+  });
+
+  return {
+    skillName,
+    emittedSteps: payload.plan.length,
+    rejected,
+    droppedDuplicates,
+    truncated,
   };
 }

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -86,7 +86,34 @@ export function buildEmbeddedSystemPrompt(params: {
     includeMemorySection: params.includeMemorySection,
     memoryCitationsMode: params.memoryCitationsMode,
     promptContribution: params.promptContribution,
+    // PR-8 follow-up Round 2: thread model/provider identity so
+    // `sortContextFilesForPrompt` can apply GPT-5-family boot reorder
+    // (SOUL.md / IDENTITY.md before AGENTS.md) when applicable.
+    //
+    // Copilot review #68939 (2026-04-19): defensively normalize the
+    // modelId by stripping any `<provider>/` prefix so the
+    // GPT-5-family check (`modelId.toLowerCase().startsWith("gpt-5")`
+    // inside `getContextFileOrder`) activates even when an upstream
+    // producer hands us a provider-qualified string like
+    // `openai/gpt-5.4`. The `runtimeInfo.provider` field already
+    // carries the provider separately (line above), so the
+    // `<provider>/<model>` form would be redundant — but cheaper to
+    // tolerate it here than to chase every producer call site.
+    modelProviderId: params.runtimeInfo?.provider,
+    modelId: stripProviderPrefix(params.runtimeInfo?.model),
   });
+}
+
+function stripProviderPrefix(modelId: string | undefined): string | undefined {
+  if (!modelId) {
+    return undefined;
+  }
+  // Copilot review #68939: use lastIndexOf so multi-segment IDs like
+  // `openai/codex/gpt-5.4` collapse to the trailing model name
+  // (`gpt-5.4`) rather than the middle slice (`codex/gpt-5.4`) that
+  // wouldn't match the `gpt-5` family check.
+  const slashIdx = modelId.lastIndexOf("/");
+  return slashIdx >= 0 ? modelId.slice(slashIdx + 1) : modelId;
 }
 
 export function createSystemPromptOverride(

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -268,6 +268,36 @@ export function createOpenClawCodingTools(options?: {
   sessionId?: string;
   /** Stable run identifier for this agent invocation. */
   runId?: string;
+  /**
+   * Current plan-mode session state (PR-8). When `"plan"`, the runtime
+   * mutation gate (src/agents/plan-mode/mutation-gate.ts) blocks
+   * write/edit/exec/etc. The embedded runner reads
+   * `SessionEntry.planMode.mode` once when assembling tools and
+   * threads it through to the before-tool-call hook so the gate fires
+   * without re-loading the session store on every call.
+   */
+  planMode?: "plan" | "normal";
+  /**
+   * Bug 3+4 fix: live-read accessor for the session's current planMode.
+   * Returns the LATEST mode from the in-memory SessionEntry on every
+   * tool-call (O(1) map lookup, no disk I/O). Threaded through to the
+   * before-tool-call hook's HookContext so the mutation gate can
+   * detect mid-turn approval transitions where the cached
+   * `planMode` snapshot is stale (sessions.patch flipped mode →
+   * "normal" but the runtime still has "plan" cached for the rest of
+   * the current run).
+   */
+  getLatestPlanMode?: () => "plan" | "normal" | undefined;
+  /**
+   * Cherry-pick of b6b2783ba3 (acceptEdits gate): live-read accessor
+   * for the session's `postApprovalPermissions.acceptEdits` flag.
+   * Returns `true` only when the user approved the plan with
+   * "Accept, allow edits" (granting acceptEdits permission); `false`
+   * otherwise. Threaded to the before-tool-call HookContext so the
+   * acceptEdits constraint gate can run on post-approval tool calls
+   * without re-reading the session store on each call.
+   */
+  getLatestAcceptEdits?: () => boolean;
   /** What initiated this run (for trigger-specific tool restrictions). */
   trigger?: string;
   /** Relative workspace path that memory-triggered writes may append to. */
@@ -627,6 +657,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      runId: options?.runId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
     }),
@@ -708,6 +739,21 @@ export function createOpenClawCodingTools(options?: {
       sessionId: options?.sessionId,
       runId: options?.runId,
       loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+      // PR-8: thread plan-mode state into the before-tool-call hook so
+      // the mutation gate fires without re-loading the session store
+      // on every tool call.
+      ...(options?.planMode ? { planMode: options.planMode } : {}),
+      // Bug 3+4 fix: also forward the live-read accessor so the gate
+      // can re-check after mid-turn approval transitions (cached
+      // planMode goes stale; getLatestPlanMode reads fresh).
+      ...(options?.getLatestPlanMode ? { getLatestPlanMode: options.getLatestPlanMode } : {}),
+      // Cherry-pick of b6b2783ba3 (acceptEdits gate): mirror
+      // getLatestPlanMode for the postApprovalPermissions.acceptEdits
+      // flag. Paired so the gate activates post-approval without a
+      // session store re-read per tool call.
+      ...(options?.getLatestAcceptEdits
+        ? { getLatestAcceptEdits: options.getLatestAcceptEdits }
+        : {}),
     }),
   );
   const withAbort = options?.abortSignal

--- a/src/agents/plan-hydration.test.ts
+++ b/src/agents/plan-hydration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { formatPlanForHydration } from "./plan-hydration.js";
+
+describe("formatPlanForHydration", () => {
+  it("returns null for empty steps", () => {
+    expect(formatPlanForHydration([])).toBeNull();
+  });
+
+  it("returns null for all-completed steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "completed" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("returns null for all-cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "cancelled" },
+      { step: "Run tests", status: "cancelled" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("returns null for mix of completed and cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "cancelled" },
+      { step: "Deploy", status: "completed" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("filters out completed and cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "cancelled" },
+      { step: "Fix lint", status: "in_progress" },
+      { step: "Deploy", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("Install deps");
+    expect(result).not.toContain("Run tests");
+    expect(result).toContain("Fix lint");
+    expect(result).toContain("Deploy");
+  });
+
+  it("includes pending and in_progress steps with correct markers", () => {
+    const steps = [
+      { step: "Investigate bug", status: "in_progress" },
+      { step: "Write fix", status: "pending" },
+      { step: "Add tests", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps)!;
+    expect(result).toContain("[>] Investigate bug (in_progress)");
+    expect(result).toContain("[ ] Write fix (pending)");
+    expect(result).toContain("[ ] Add tests (pending)");
+  });
+
+  it("output format starts with preserved plan header", () => {
+    const steps = [
+      { step: "Do something", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps)!;
+    expect(result).toMatch(
+      /^\[Your active plan was preserved across context compression\]/,
+    );
+  });
+});

--- a/src/agents/plan-hydration.ts
+++ b/src/agents/plan-hydration.ts
@@ -1,0 +1,71 @@
+/**
+ * Post-compaction plan hydration — ported from Hermes Agent's
+ * TodoStore.format_for_injection() (tools/todo_tool.py).
+ *
+ * After context compression, active plan items (pending / in_progress)
+ * are injected as a user message so the agent continues the same plan
+ * instead of re-planning from scratch.
+ *
+ * The injected text is deliberately phrased as a factual statement
+ * ("Your active plan was preserved...") rather than an imperative
+ * ("Here is your plan, do this...") to avoid triggering the
+ * planning-only retry guard's promise-language detection in
+ * incomplete-turn.ts (PLANNING_ONLY_PROMISE_RE).
+ */
+
+import type { PlanStepStatus } from "./tools/update-plan-tool.js";
+
+/**
+ * Plan step shape accepted by hydration. `status` stays widened to
+ * `string` because hydration consumes data from heterogeneous sources
+ * (compaction snapshots, channel adapters, JSON imports) where the
+ * value is not always pre-narrowed to `PlanStepStatus`. Valid statuses
+ * are listed in `PLAN_STEP_STATUSES`; unknown statuses are filtered out
+ * by the active-set check below.
+ */
+interface PlanStep {
+  step: string;
+  status: string;
+  activeForm?: string;
+}
+
+// Active statuses (pending + in_progress) are the subset we replay after
+// compression. The literal tuple is asserted via `satisfies` so this
+// file fails to compile if `PlanStepStatus` ever drops one of these
+// names. The Set is typed `string` so `.has()` accepts the widened
+// input from heterogeneous callers without a cast.
+const ACTIVE_PLAN_STATUSES = [
+  "pending",
+  "in_progress",
+] as const satisfies readonly PlanStepStatus[];
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set<string>(ACTIVE_PLAN_STATUSES);
+
+/**
+ * Formats active plan steps for injection after compaction.
+ * Returns `null` if there are no active steps to preserve.
+ *
+ * Matches Hermes's format_for_injection() output:
+ *   [Your active plan was preserved across context compression]
+ *   - [ ] step text (pending)
+ *   - [>] step text (in_progress)
+ */
+export function formatPlanForHydration(steps: PlanStep[]): string | null {
+  const active = steps.filter((s) => ACTIVE_STATUSES.has(s.status));
+  if (active.length === 0) {
+    return null;
+  }
+
+  const lines = ["[Your active plan was preserved across context compression]"];
+  for (const s of active) {
+    const marker = s.status === "in_progress" ? "[>]" : "[ ]";
+    // PR-B review fix (Copilot #3094484901): normalize newlines in step
+    // text. Without this, a step containing `\n` (rare but possible from
+    // heterogeneous compaction snapshots / channel adapters / JSON
+    // imports) breaks the line-based bullet format and injects extra
+    // unintended bullets into the hydration text. Same single-line
+    // collapse pattern used by `src/agents/plan-render.ts:45`.
+    const normalizedStep = s.step.replace(/[\n\r]+/g, " ").trim();
+    lines.push(`- ${marker} ${normalizedStep} (${s.status})`);
+  }
+  return lines.join("\n");
+}

--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -1,0 +1,301 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PlanStore, type StoredPlan, type StoredPlanStep } from "./plan-store.js";
+
+let tmpDir: string;
+let store: PlanStore;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-store-test-"));
+  store = new PlanStore(tmpDir);
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const SAMPLE_PLAN: StoredPlan = {
+  namespace: "test-ns",
+  steps: [
+    { step: "Run tests", status: "completed" },
+    { step: "Build", status: "in_progress", activeForm: "Building" },
+    { step: "Deploy", status: "pending" },
+  ],
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+describe("PlanStore", () => {
+  describe("read/write", () => {
+    it("returns null for non-existent namespace", async () => {
+      expect(await store.read("nonexistent")).toBeNull();
+    });
+
+    it("round-trips a plan", async () => {
+      await store.write("test-ns", SAMPLE_PLAN);
+      const result = await store.read("test-ns");
+      expect(result).toEqual(SAMPLE_PLAN);
+    });
+
+    it("creates the namespace directory if missing", async () => {
+      const ns = "fresh-ns";
+      await store.write(ns, { ...SAMPLE_PLAN, namespace: ns });
+      const result = await store.read(ns);
+      expect(result).not.toBeNull();
+    });
+
+    it("rejects namespace with path traversal", async () => {
+      await expect(store.read("../../etc")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.write("../escape", SAMPLE_PLAN)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects nested-path namespace (cross-namespace lock collision defense)", async () => {
+      await expect(store.read("foo/bar")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.write("foo/.lock", SAMPLE_PLAN)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects namespace with backslash separator", async () => {
+      await expect(store.read("foo\\bar")).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects namespace with null byte / control chars", async () => {
+      await expect(store.read("foo\x00bar")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.read("foo\x01bar")).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects Windows reserved device names", async () => {
+      for (const name of ["CON", "PRN", "AUX", "NUL", "COM1", "LPT9", "con.txt", "nul.json"]) {
+        await expect(store.read(name)).rejects.toThrow("Invalid plan namespace");
+      }
+    });
+
+    it("rejects namespace longer than 128 chars", async () => {
+      const tooLong = "a".repeat(129);
+      await expect(store.read(tooLong)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("accepts standard namespace patterns", async () => {
+      for (const ns of ["session-abc", "user_123", "v2.plan", "Mixed-Case_99"]) {
+        await store.write(ns, { ...SAMPLE_PLAN, namespace: ns });
+        expect(await store.read(ns)).not.toBeNull();
+      }
+    });
+
+    it("rejects namespace mismatch in write", async () => {
+      await expect(store.write("wrong-ns", SAMPLE_PLAN)).rejects.toThrow("namespace mismatch");
+    });
+  });
+
+  describe("lock", () => {
+    it("acquires and releases a lock", async () => {
+      const release = await store.lock("test-ns");
+      // Lock file should exist.
+      const lockPath = path.join(tmpDir, "test-ns", ".lock");
+      await expect(fs.stat(lockPath)).resolves.toBeDefined();
+      await release();
+      // Lock file should be removed.
+      await expect(fs.stat(lockPath)).rejects.toThrow();
+    });
+
+    it("blocks concurrent lock acquisition", async () => {
+      const release1 = await store.lock("test-ns");
+      // Second lock should timeout/retry (we don't wait the full retry cycle).
+      const lock2Promise = store.lock("test-ns");
+      // Release first lock after a short delay.
+      setTimeout(() => release1(), 100);
+      const release2 = await lock2Promise;
+      await release2();
+    });
+  });
+
+  describe("mergeSteps", () => {
+    it("updates existing steps by matching text", () => {
+      const existing: StoredPlanStep[] = [
+        { step: "Run tests", status: "pending" },
+        { step: "Build", status: "pending" },
+      ];
+      const incoming: StoredPlanStep[] = [{ step: "Run tests", status: "completed" }];
+      const merged = store.mergeSteps(existing, incoming, "session-abc");
+      expect(merged).toHaveLength(2);
+      expect(merged[0].status).toBe("completed");
+      expect(merged[0].updatedBy).toBe("session-abc");
+      expect(merged[1].status).toBe("pending"); // Unchanged.
+    });
+
+    it("appends new steps not in existing", () => {
+      const existing: StoredPlanStep[] = [{ step: "Run tests", status: "completed" }];
+      const incoming: StoredPlanStep[] = [{ step: "Deploy", status: "pending" }];
+      const merged = store.mergeSteps(existing, incoming);
+      expect(merged).toHaveLength(2);
+      expect(merged[1].step).toBe("Deploy");
+    });
+
+    it("preserves order of existing steps", () => {
+      const existing: StoredPlanStep[] = [
+        { step: "A", status: "pending" },
+        { step: "B", status: "pending" },
+        { step: "C", status: "pending" },
+      ];
+      const incoming: StoredPlanStep[] = [{ step: "B", status: "completed" }];
+      const merged = store.mergeSteps(existing, incoming);
+      expect(merged.map((s) => s.step)).toEqual(["A", "B", "C"]);
+    });
+  });
+
+  describe("read() — full schema validation pre-parse (Codex P2 r3094816890)", () => {
+    async function writeRawPlanFile(namespace: string, contents: unknown): Promise<void> {
+      const dir = path.join(tmpDir, namespace);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, "plan.json"), JSON.stringify(contents), { mode: 0o600 });
+    }
+
+    it("rejects steps: [null] (was: silent pass, then TypeError downstream)", async () => {
+      await writeRawPlanFile("ns-bad-step", {
+        namespace: "ns-bad-step",
+        steps: [null],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-step")).rejects.toThrow(/invalid step at index 0/);
+    });
+
+    it("rejects step with non-string `step` text", async () => {
+      await writeRawPlanFile("ns-bad-step-type", {
+        namespace: "ns-bad-step-type",
+        steps: [{ step: 42, status: "pending" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-step-type")).rejects.toThrow(/non-empty string/);
+    });
+
+    it("rejects step with empty `step` text", async () => {
+      await writeRawPlanFile("ns-empty-step", {
+        namespace: "ns-empty-step",
+        steps: [{ step: "", status: "pending" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-empty-step")).rejects.toThrow(/non-empty string/);
+    });
+
+    it("rejects step with invalid `status` value", async () => {
+      await writeRawPlanFile("ns-bad-status", {
+        namespace: "ns-bad-status",
+        steps: [{ step: "x", status: "weirdo" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-status")).rejects.toThrow(/status.*must be one of/);
+    });
+
+    it("rejects step with non-string `activeForm` when present", async () => {
+      await writeRawPlanFile("ns-bad-active", {
+        namespace: "ns-bad-active",
+        steps: [{ step: "x", status: "pending", activeForm: 42 }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-active")).rejects.toThrow(/activeForm.*must be a string/);
+    });
+
+    it("rejects file missing `createdAt`", async () => {
+      await writeRawPlanFile("ns-no-created", {
+        namespace: "ns-no-created",
+        steps: [{ step: "x", status: "pending" }],
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-no-created")).rejects.toThrow(/createdAt/);
+    });
+
+    it("rejects file missing `updatedAt`", async () => {
+      await writeRawPlanFile("ns-no-updated", {
+        namespace: "ns-no-updated",
+        steps: [{ step: "x", status: "pending" }],
+        createdAt: 1,
+      });
+      await expect(store.read("ns-no-updated")).rejects.toThrow(/updatedAt/);
+    });
+
+    it("accepts a valid plan with all 4 status values", async () => {
+      await writeRawPlanFile("ns-valid", {
+        namespace: "ns-valid",
+        steps: [
+          { step: "a", status: "pending" },
+          { step: "b", status: "in_progress", activeForm: "B-ing" },
+          { step: "c", status: "completed" },
+          { step: "d", status: "cancelled" },
+        ],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      const result = await store.read("ns-valid");
+      expect(result?.steps).toHaveLength(4);
+    });
+  });
+
+  describe("stale-lock reclamation (PR-F review #3096520142)", () => {
+    it("reclaims a lock whose holder PID is dead and whose mtime is older than LOCK_STALE_MS", async () => {
+      // Dead holder PID: PID 0 doesn't correspond to a process on POSIX,
+      // and `process.kill(0, 0)` throws ESRCH (treated as dead by the
+      // reclamation logic). Avoids picking a real PID by accident.
+      const namespace = "ns-stale-lock";
+      await fs.mkdir(path.join(tmpDir, namespace), { recursive: true });
+      const lockFile = path.join(tmpDir, namespace, ".lock");
+      // Plant a stale lock: dead PID + mtime older than 60s.
+      await fs.writeFile(lockFile, `0-${Date.now() - 120_000}-deadbeef`);
+      const oldMs = (Date.now() - 120_000) / 1000; // 2 min ago in s
+      await fs.utimes(lockFile, oldMs, oldMs);
+      // lock() should reclaim and acquire successfully (no throw).
+      const release = await store.lock(namespace);
+      expect(typeof release).toBe("function");
+      await release();
+    });
+
+    it("does NOT reclaim a fresh lock whose holder PID is alive (the current process)", async () => {
+      const namespace = "ns-fresh-lock";
+      await fs.mkdir(path.join(tmpDir, namespace), { recursive: true });
+      const lockFile = path.join(tmpDir, namespace, ".lock");
+      // Plant a fresh lock: current PID (alive) + recent mtime.
+      await fs.writeFile(lockFile, `${process.pid}-${Date.now()}-deadbeef`);
+      // Acquisition should fail (after retries) because the holder is
+      // both fresh AND alive.
+      await expect(store.lock(namespace)).rejects.toThrow(/Failed to acquire plan lock/);
+      // Manual cleanup so the temp dir teardown is clean.
+      await fs.unlink(lockFile);
+    });
+  });
+
+  describe("confine() — parent-symlink redirection (Codex P1 r3095586226)", () => {
+    it("rejects a namespace directory that is a symlink pointing outside baseDir", async () => {
+      // Create an attacker-controlled directory outside baseDir.
+      const attackerDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-store-attacker-"));
+      try {
+        // Symlink <baseDir>/hostile -> <attackerDir>
+        const symlinkTarget = path.join(tmpDir, "hostile");
+        await fs.symlink(attackerDir, symlinkTarget);
+        // read() / write() must throw with a 'parent symlink' confinement error.
+        // PR-F review fix (Copilot #3096520161 / #3096791944 / Greptile P1
+        // #3105248695): pass a complete StoredPlan so the test type-checks
+        // under `pnpm tsgo`. The confinement check fires inside `planPath`
+        // (called as the first line of `write()`) BEFORE any field is read,
+        // so the assertion is unchanged regardless of plan field content.
+        await expect(
+          store.write("hostile", {
+            namespace: "hostile",
+            steps: [{ step: "x", status: "pending" }],
+            createdAt: 1,
+            updatedAt: 1,
+          }),
+        ).rejects.toThrow(/escapes base directory/);
+        // Also verify nothing was written into the attacker directory.
+        const filesInAttacker = await fs.readdir(attackerDir);
+        expect(filesInAttacker).toHaveLength(0);
+      } finally {
+        await fs.rm(attackerDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -1,0 +1,603 @@
+/**
+ * Persistent plan store for cross-session task coordination.
+ *
+ * Phase 4.2 of the GPT 5.4 parity sprint. Modeled after Claude Code's
+ * Tasks API with `CLAUDE_CODE_TASK_LIST_ID` env var concept.
+ *
+ * When a namespace is configured, plan state is shared across all
+ * sessions using that namespace. Plans are persisted to disk at
+ * `~/.openclaw/plans/<namespace>/plan.json`.
+ *
+ * Default (no namespace): plan is session-scoped (current behavior,
+ * no change to existing flow).
+ */
+
+import crypto from "node:crypto";
+import { constants as fsConstants, realpathSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// O_NOFOLLOW is POSIX; Windows fs constants don't define it. Feature-detect
+// to keep the read/lock paths cross-platform (matches the pattern in
+// `src/infra/fs-safe.ts:72-84`). On Windows the symlink rejection
+// degrades to none — Windows symlinks to outside baseDir would still be
+// caught by the realpath-based `confine()` walk.
+const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
+const NOFOLLOW_FLAG = SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0;
+
+export interface StoredPlanStep {
+  step: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  activeForm?: string;
+  updatedBy?: string; // session key that last updated this step
+  updatedAt?: number;
+}
+
+export interface StoredPlan {
+  namespace: string;
+  steps: StoredPlanStep[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const VALID_STEP_STATUSES = new Set(["pending", "in_progress", "completed", "cancelled"]);
+
+/**
+ * Validates parsed JSON shape AND constructs a fresh prototype-safe
+ * StoredPlan from validated fields only.
+ *
+ * Defense-in-depth: Node's JSON.parse doesn't pollute prototypes by
+ * default, but constructing a fresh object only including known fields
+ * (instead of returning the parsed input) guarantees that any
+ * `__proto__`/`constructor`/`prototype` keys present in the source JSON
+ * are dropped at every level — top-level AND per-step. The prior
+ * shallow filter left step objects unfiltered, and `mergeSteps()`
+ * spreads step objects via `{ ...update, ...attribution }`, so a stored
+ * step containing pollution keys could have survived to the spread.
+ *
+ * Also enforces:
+ * - Namespace matches the requested namespace (file-rename detection).
+ * - Each step has non-empty `step` text + valid `status`.
+ * - Required `createdAt`/`updatedAt` are non-negative numbers.
+ *
+ * Codex P2 (PR #67542 r3094816890) + Copilot #3105043468 / #3096520083 / #3105169764.
+ */
+function sanitizePlanShape(parsed: unknown, expectedNamespace: string): StoredPlan {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — expected object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.namespace !== "string" || obj.namespace !== expectedNamespace) {
+    throw new Error(
+      `Plan namespace mismatch on read: expected "${expectedNamespace}", found "${String(obj.namespace)}"`,
+    );
+  }
+  if (!Array.isArray(obj.steps)) {
+    throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — steps must be array`);
+  }
+  // Per-step validation — fail fast at read time instead of crashing in
+  // mergeSteps()/render() with a confusing TypeError later.
+  for (let i = 0; i < obj.steps.length; i += 1) {
+    const step: unknown = obj.steps[i];
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — expected object, got ${Array.isArray(step) ? "array" : typeof step}`,
+      );
+    }
+    const s = step as Record<string, unknown>;
+    if (typeof s.step !== "string" || s.step.length === 0) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`step\` must be a non-empty string`,
+      );
+    }
+    if (typeof s.status !== "string" || !VALID_STEP_STATUSES.has(s.status)) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`status\` must be one of ${[...VALID_STEP_STATUSES].join(", ")}, got "${String(s.status)}"`,
+      );
+    }
+    if (s.activeForm !== undefined && typeof s.activeForm !== "string") {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`activeForm\` must be a string when present`,
+      );
+    }
+    // PR-F review fix (Copilot #3105397845): also validate updatedBy /
+    // updatedAt when present. These are persisted by `mergeSteps()` so
+    // they round-trip through the store; without validation, malformed
+    // values could silently survive read.
+    if (s.updatedBy !== undefined && typeof s.updatedBy !== "string") {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`updatedBy\` must be a string when present`,
+      );
+    }
+    if (
+      s.updatedAt !== undefined &&
+      (typeof s.updatedAt !== "number" || !Number.isFinite(s.updatedAt) || s.updatedAt < 0)
+    ) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`updatedAt\` must be a non-negative number when present`,
+      );
+    }
+  }
+  // Required timestamps. Numeric only — string ISO timestamps would silently
+  // pass `typeof === "number"` checks downstream as NaN.
+  if (typeof obj.createdAt !== "number" || !Number.isFinite(obj.createdAt) || obj.createdAt < 0) {
+    throw new Error(
+      `Plan file for "${expectedNamespace}" has invalid \`createdAt\` — expected non-negative number`,
+    );
+  }
+  if (typeof obj.updatedAt !== "number" || !Number.isFinite(obj.updatedAt) || obj.updatedAt < 0) {
+    throw new Error(
+      `Plan file for "${expectedNamespace}" has invalid \`updatedAt\` — expected non-negative number`,
+    );
+  }
+  // PR-F review fix (Copilot #3105043468 / #3096520083 etc): build clean
+  // step objects too — the prior shallow filter only stripped
+  // prototype-pollution keys at the top level, but `mergeSteps()` later
+  // spreads step objects (`{ ...update, ...attribution }`), so a stored
+  // step containing `__proto__`/`constructor`/`prototype` could survive
+  // and reach the spread. Construct each safe step from validated fields
+  // only, dropping all other keys.
+  const safeSteps: StoredPlanStep[] = [];
+  for (let i = 0; i < obj.steps.length; i += 1) {
+    const s = obj.steps[i] as Record<string, unknown>;
+    const safeStep: StoredPlanStep = {
+      step: s.step as string,
+      status: s.status as StoredPlanStep["status"],
+      ...(typeof s.activeForm === "string" ? { activeForm: s.activeForm } : {}),
+      ...(typeof s.updatedBy === "string" ? { updatedBy: s.updatedBy } : {}),
+      ...(typeof s.updatedAt === "number" && Number.isFinite(s.updatedAt)
+        ? { updatedAt: s.updatedAt }
+        : {}),
+    };
+    safeSteps.push(safeStep);
+  }
+  // Filter prototype-pollution keys defensively at the top level too.
+  // (Step objects above are already prototype-safe by construction.)
+  const safe: StoredPlan = {
+    namespace: obj.namespace,
+    steps: safeSteps,
+    createdAt: obj.createdAt,
+    updatedAt: obj.updatedAt,
+  };
+  return safe;
+}
+
+// Stale-lock threshold bumped to 60s to reduce false-positive theft of
+// legitimate slow operations. Combined with PID liveness check, this gives
+// a much more conservative recovery model.
+const LOCK_STALE_MS = 60_000;
+// Hard upper bound (PR-F review fix, Codex P1 #3096565561): even if the
+// PID-liveness probe says the lock holder is alive, a lock older than
+// this hard cap is force-evicted. Mitigates the PID-reuse failure mode
+// where a crashed process's PID gets recycled by an unrelated process,
+// causing `process.kill(holderPid, 0)` to falsely report the original
+// holder as still alive and deadlocking subsequent writers indefinitely.
+// 5 minutes is well above any legitimate plan write (typically <1s).
+const LOCK_HARD_MAX_MS = 5 * 60_000;
+// Max allowed plan file size (defense-in-depth against giant JSON parse).
+const MAX_PLAN_FILE_BYTES = 1_048_576; // 1 MiB
+// Windows reserved device names — case-insensitive, with optional extension.
+const WINDOWS_RESERVED_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+// Strict namespace pattern — prevents path separators, control chars,
+// trailing dots/spaces, and limits length.
+const NAMESPACE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+/**
+ * Validates that a namespace is safe to use as a single directory name
+ * under baseDir. Rejects path separators, traversal, control chars,
+ * Windows reserved names, trailing dots/spaces, and over-length input.
+ *
+ * Hardened against:
+ * - Path traversal: rejects /, \, .., leading dots
+ * - Cross-namespace lock collision: rejects nested paths like "foo/.lock"
+ * - Windows device name attacks: CON, PRN, AUX, NUL, COM1-9, LPT1-9
+ * - Control char / null byte injection: only printable ASCII allowed
+ * - Length bound: 128 chars max
+ */
+function validateNamespace(namespace: string): void {
+  if (!namespace || typeof namespace !== "string") {
+    throw new Error(`Invalid plan namespace: "${namespace}"`);
+  }
+  // Strict character set — alphanumeric start, then alphanumeric/dot/underscore/hyphen.
+  // No /, \, control chars, spaces, or other risky characters.
+  if (!NAMESPACE_RE.test(namespace)) {
+    throw new Error(
+      `Invalid plan namespace: "${namespace}" — must match /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/`,
+    );
+  }
+  // Trailing dots/spaces are problematic on Windows (silently stripped).
+  if (/[.\s]$/.test(namespace)) {
+    throw new Error(`Invalid plan namespace: "${namespace}" — trailing dot or space not allowed`);
+  }
+  // Windows reserved device names (case-insensitive, with or without extension).
+  if (WINDOWS_RESERVED_RE.test(namespace)) {
+    throw new Error(
+      `Invalid plan namespace: "${namespace}" — matches Windows reserved device name`,
+    );
+  }
+}
+
+export class PlanStore {
+  /** Realpath-resolved base directory — used for confinement checks. */
+  private readonly baseDir: string;
+
+  constructor(baseDir: string) {
+    // Resolve symlinks at construction. If baseDir doesn't exist yet, fall
+    // back to the literal path — confinement check at use time will still
+    // reject targets that escape this resolved root.
+    let resolved: string;
+    try {
+      resolved = realpathSync(baseDir);
+    } catch {
+      resolved = path.resolve(baseDir);
+    }
+    this.baseDir = resolved;
+  }
+
+  /**
+   * Confines a resolved path to baseDir. Throws if the lexical OR
+   * realpath-resolved target escapes the realpathed base.
+   *
+   * Codex P1 (PR #67542 r3095586226): the lexical-only check let a
+   * symlinked namespace dir bypass confinement. e.g.
+   *   `<baseDir>/ns -> /tmp/attacker`
+   * lexically resolves to `<baseDir>/ns/plan.json` (which IS under
+   * baseDir on paper), but every subsequent open() follows the symlink
+   * to `/tmp/attacker/plan.json`. The leaf `O_NOFOLLOW` we already
+   * apply only blocks the FINAL hop, not parent-directory symlinks.
+   *
+   * This walks the longest existing ancestor of `target`, realpath()s
+   * it, and rejects if the realpath escapes baseDir.
+   */
+  private confine(target: string): string {
+    const rel = path.relative(this.baseDir, target);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`Plan path escapes base directory: ${target}`);
+    }
+    // Realpath the deepest existing ancestor (start from the parent and
+    // walk up). If it resolves outside baseDir, reject — a parent
+    // symlink would redirect us elsewhere.
+    let probe = path.dirname(target);
+    while (probe.startsWith(this.baseDir)) {
+      try {
+        const resolved = realpathSync(probe);
+        const ancestorRel = path.relative(this.baseDir, resolved);
+        if (ancestorRel.startsWith("..") || path.isAbsolute(ancestorRel)) {
+          throw new Error(
+            `Plan path escapes base directory via parent symlink: ${target} (resolves to ${resolved})`,
+          );
+        }
+        return target;
+      } catch (err: unknown) {
+        // ENOENT — this ancestor doesn't exist yet; walk up and try again.
+        if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+          const next = path.dirname(probe);
+          if (next === probe) {
+            break; // hit filesystem root
+          }
+          probe = next;
+          continue;
+        }
+        // Anything else (loop detection, permission denied) is hostile.
+        throw err;
+      }
+    }
+    return target;
+  }
+
+  private planPath(namespace: string): string {
+    validateNamespace(namespace);
+    return this.confine(path.join(this.baseDir, namespace, "plan.json"));
+  }
+
+  private lockPath(namespace: string): string {
+    validateNamespace(namespace);
+    return this.confine(path.join(this.baseDir, namespace, ".lock"));
+  }
+
+  /**
+   * Reads the current plan for a namespace.
+   * Returns null if no plan exists. Throws on parse/permission errors
+   * so corruption is not silently ignored.
+   */
+  async read(namespace: string): Promise<StoredPlan | null> {
+    const planFile = this.planPath(namespace);
+    let handle: fs.FileHandle | undefined;
+    try {
+      // O_NOFOLLOW (POSIX-only): refuse to follow symlinks at the leaf
+      // path. PR-F review fix (Copilot #3105043456): feature-detected
+      // via SUPPORTS_NOFOLLOW so the path stays cross-platform — on
+      // Windows the flag is `0` and parent-symlink confinement is still
+      // enforced via realpath in `confine()`.
+      handle = await fs.open(planFile, fsConstants.O_RDONLY | NOFOLLOW_FLAG);
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        throw new Error(`Plan path is not a regular file: ${planFile}`);
+      }
+      // Pre-parse size guard — refuse oversized buffers before JSON.parse.
+      if (stat.size > MAX_PLAN_FILE_BYTES) {
+        throw new Error(
+          `Plan file exceeds max size ${MAX_PLAN_FILE_BYTES} bytes (got ${stat.size})`,
+        );
+      }
+      const content = await handle.readFile({ encoding: "utf-8" });
+      await handle.close();
+      handle = undefined;
+      const plan = sanitizePlanShape(JSON.parse(content), namespace);
+      return plan;
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        return null;
+      }
+      // ELOOP / ENOTDIR from O_NOFOLLOW = symlink attack attempt; surface clearly.
+      if (code === "ELOOP" || code === "ENOTDIR") {
+        throw new Error(`Plan path symlink rejected (${code}): ${planFile}`, { cause: err });
+      }
+      throw err;
+    } finally {
+      if (handle) {
+        try {
+          await handle.close();
+        } catch {
+          /* ignore close error in finally */
+        }
+      }
+    }
+  }
+
+  /**
+   * Writes a plan for a namespace atomically (write to temp, then rename).
+   * Creates the directory if needed.
+   * Callers should acquire a lock first for concurrent safety.
+   */
+  async write(namespace: string, plan: StoredPlan): Promise<void> {
+    const planFile = this.planPath(namespace); // validates namespace first (path traversal, etc.)
+    if (plan.namespace !== namespace) {
+      throw new Error(`Plan namespace mismatch: expected "${namespace}", got "${plan.namespace}"`);
+    }
+    const dir = path.dirname(planFile);
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    const tmpFile = path.join(dir, `.plan-${crypto.randomBytes(4).toString("hex")}.tmp`);
+    try {
+      await fs.writeFile(tmpFile, JSON.stringify(plan, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+      await fs.rename(tmpFile, planFile);
+    } catch (err) {
+      // Clean up temp file on failure.
+      try {
+        await fs.unlink(tmpFile);
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Acquires a file-level lock for a namespace.
+   * Returns a release function. Stale locks (older than `LOCK_STALE_MS`,
+   * currently 60s) are cleaned up opportunistically by the next
+   * lock() caller. PID liveness is checked before eviction to avoid
+   * stealing from a slow-but-alive holder; a hard cap
+   * (`LOCK_HARD_MAX_MS`, 5 minutes) overrides the alive check to
+   * guarantee progress under PID-reuse / process-stuck scenarios.
+   */
+  async lock(namespace: string): Promise<() => Promise<void>> {
+    const lockFile = this.lockPath(namespace);
+    const dir = path.dirname(lockFile);
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+    // Generate a unique lock token so release can verify ownership.
+    const lockToken = `${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+
+    // Try to acquire lock with O_EXCL (fails if file exists).
+    // If lock exists but is stale (older than LOCK_STALE_MS = 60s),
+    // remove and retry. A hard cap (LOCK_HARD_MAX_MS = 5 min)
+    // overrides PID-liveness if the lock has been held longer than
+    // any legitimate write would need (PID-reuse mitigation).
+    const maxRetries = 5;
+    for (let i = 0; i < maxRetries; i++) {
+      let handle: fs.FileHandle | undefined;
+      try {
+        // PR-F review fix (Copilot #3105043461): include O_NOFOLLOW so
+        // an attacker who plants `<namespace>/.lock` as a symlink
+        // BEFORE we try to acquire it can't redirect the create
+        // outside `baseDir`. `confine()` rejects parent-symlink
+        // redirection but doesn't catch a leaf-symlink at `.lock`.
+        // O_EXCL+O_CREAT+O_NOFOLLOW together enforce: file must not
+        // exist AND must not be a symlink.
+        handle = await fs.open(
+          lockFile,
+          fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | NOFOLLOW_FLAG,
+          0o600,
+        );
+        try {
+          await handle.writeFile(lockToken);
+        } catch {
+          // Write failed — clean up the empty/partial lock file immediately
+          // instead of waiting for stale-lock cleanup.
+          try {
+            await handle.close();
+          } catch {
+            /* ignore */
+          }
+          try {
+            await fs.unlink(lockFile);
+          } catch {
+            /* ignore */
+          }
+          throw new Error("Failed to write lock token");
+        }
+        await handle.close();
+        handle = undefined; // closed successfully
+
+        // Lock acquired. Return release function that verifies ownership.
+        return async () => {
+          try {
+            const content = await fs.readFile(lockFile, "utf-8");
+            if (content === lockToken) {
+              await fs.unlink(lockFile);
+            }
+            // If token doesn't match, another process owns the lock — don't unlink.
+          } catch {
+            // Lock file may have been cleaned up already.
+          }
+        };
+      } catch (err: unknown) {
+        // Ensure handle is closed on any error path.
+        if (handle) {
+          try {
+            await handle.close();
+          } catch {
+            /* ignore */
+          }
+        }
+        if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+          // Lock exists. Check if stale via mtime + PID liveness.
+          try {
+            // lstat (not stat) to detect symlink-attack at lock path.
+            const lstat = await fs.lstat(lockFile);
+            if (!lstat.isFile()) {
+              throw new Error(`Lock path is not a regular file: ${lockFile}`, { cause: err });
+            }
+            const ageMs = Date.now() - lstat.mtimeMs;
+            if (ageMs > LOCK_STALE_MS) {
+              // Stale by age — also verify the holder is dead.
+              // Read lock token to extract PID; if PID is alive, defer.
+              let holderPid: number | undefined;
+              try {
+                const content = await fs.readFile(lockFile, "utf-8");
+                // Token format: "{pid}-{timestamp}-{rand}"
+                const pidStr = content.split("-")[0];
+                const parsed = Number.parseInt(pidStr, 10);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  holderPid = parsed;
+                }
+              } catch {
+                // Couldn't read holder — proceed with mtime-based eviction.
+              }
+              if (holderPid !== undefined) {
+                let alive = false;
+                try {
+                  // process.kill(pid, 0) throws ESRCH if pid is dead, no-op if alive.
+                  process.kill(holderPid, 0);
+                  alive = true;
+                } catch (probeErr) {
+                  if ((probeErr as NodeJS.ErrnoException).code !== "ESRCH") {
+                    // EPERM means the process exists but we don't have permission
+                    // to signal it — treat as alive (don't steal).
+                    alive = true;
+                  }
+                }
+                if (alive) {
+                  // PR-F review fix (Codex P1 #3096565561): hard cap
+                  // overrides the alive check to mitigate PID reuse.
+                  // After a crash + reboot (or any PID rollover), the
+                  // holder PID may belong to an unrelated process that
+                  // would never release this lock. The hard cap
+                  // guarantees progress; legitimate plan writes are
+                  // sub-second so reaching `LOCK_HARD_MAX_MS` (5 min)
+                  // is overwhelmingly likely a reused-PID or stuck
+                  // process.
+                  if (ageMs <= LOCK_HARD_MAX_MS) {
+                    // Holder is alive AND within hard cap — wait, don't steal.
+                    await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+                    continue;
+                  }
+                  // Hard cap exceeded — fall through to the unlink branch
+                  // below. Comment-only signal (no log import in this
+                  // module): the lock was force-evicted past the deadman.
+                }
+              }
+              // Re-stat just before unlink to detect a new owner that
+              // acquired between our stat and unlink (TOCTOU mitigation).
+              try {
+                const recheck = await fs.lstat(lockFile);
+                if (recheck.mtimeMs > lstat.mtimeMs) {
+                  // A new owner took it — back off and retry normally.
+                  await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+                  continue;
+                }
+              } catch {
+                // Disappeared on its own — nothing to unlink.
+                continue;
+              }
+              await fs.unlink(lockFile);
+              // PR-F review fix (Codex P2 #3096565570): if this is the
+              // final iteration, the loop would exit here without ever
+              // attempting acquisition of the now-free lock. Reset the
+              // retry budget for one extra acquisition attempt to
+              // guarantee at least one try after a successful stale
+              // cleanup. This prevents avoidable write failures right
+              // when the stale threshold is crossed late in the loop.
+              if (i === maxRetries - 1) {
+                i -= 1; // grant one extra iteration
+              }
+              continue; // Retry after removing stale lock.
+            }
+          } catch (inspectErr: unknown) {
+            // PR-F review fix (Copilot #3096520125 / #3105169755):
+            // only swallow transient/expected errors here. The
+            // explicit `throw new Error("Lock path is not a regular
+            // file")` from the lstat-based check above (and EPERM /
+            // unexpected errors in general) must be surfaced to the
+            // caller so symlink-attack attempts and misconfigurations
+            // aren't silently degraded into "Failed to acquire plan
+            // lock" retries.
+            const code = (inspectErr as NodeJS.ErrnoException).code;
+            if (code === "ENOENT") {
+              // Lock vanished between EEXIST and lstat — retry normally.
+              continue;
+            }
+            // Anything else (non-file lock target, EPERM, EACCES,
+            // structural problems) is hostile and must be surfaced.
+            throw inspectErr;
+          }
+          // Lock is fresh. Wait and retry.
+          await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+        } else {
+          throw err;
+        }
+      }
+    }
+    throw new Error(
+      `Failed to acquire plan lock for namespace "${namespace}" after ${maxRetries} retries`,
+    );
+  }
+
+  /**
+   * Merges incoming steps into an existing plan by matching step text.
+   * New steps are appended; existing steps are updated.
+   * Returns the merged plan.
+   */
+  mergeSteps(
+    existing: StoredPlanStep[],
+    incoming: StoredPlanStep[],
+    sessionKey?: string,
+  ): StoredPlanStep[] {
+    const now = Date.now();
+    const attribution = sessionKey ? { updatedBy: sessionKey, updatedAt: now } : { updatedAt: now };
+    const incomingMap = new Map(incoming.map((s) => [s.step, s]));
+    const existingStepTexts = new Set(existing.map((s) => s.step));
+    const merged = existing.map((s) => {
+      const update = incomingMap.get(s.step);
+      if (update) {
+        return { ...update, ...attribution };
+      }
+      return s;
+    });
+    const appended = new Set<string>();
+    for (const s of incoming) {
+      if (!existingStepTexts.has(s.step) && !appended.has(s.step)) {
+        merged.push({ ...s, ...attribution });
+        appended.add(s.step);
+      }
+    }
+    return merged;
+  }
+}

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -348,4 +348,31 @@ describe("buildWorkspaceSkillSnapshot", () => {
       omits: ["root-big-skill"],
     });
   });
+
+  // PR-E review fix (Copilot #3096524236): the snapshot-backed run path
+  // reads `resolvedPlanTemplates` from the snapshot. Without this
+  // regression test it would be easy to drop the field accidentally
+  // during future refactors, silently breaking the seed-from-snapshot
+  // flow for users relying on skill plan templates.
+  // Note: regression coverage for the frontmatter parsing path lives in
+  // `src/agents/skills/frontmatter.test.ts` (asserts kebab-case +
+  // camelCase recognition + `step` / `content` aliasing). The snapshot
+  // composition path is integration-tested via the full e2e flow in
+  // `src/agents/pi-embedded-runner/skills-runtime.test.ts` which
+  // exercises `applySkillPlanTemplateSeed` end-to-end with a snapshot
+  // containing `resolvedPlanTemplates`.
+  it("omits resolvedPlanTemplates (or empty) when no skill carries plan-template frontmatter", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace-no-template");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "plain-skill"),
+      name: "plain-skill",
+      description: "No template",
+    });
+    const snapshot = buildSnapshot(workspaceDir);
+    // Empty or undefined both represent "no templates" — trust the snapshot
+    // (the old-version fallback in resolveEmbeddedRunSkillEntries only
+    // reloads on undefined, so empty array is a valid "no templates" signal).
+    const resolved = snapshot.resolvedPlanTemplates;
+    expect(resolved === undefined || resolved.length === 0).toBe(true);
+  });
 });

--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -65,3 +65,70 @@ describe("resolveOpenClawMetadata install validation", () => {
     expect(install).toBeUndefined();
   });
 });
+
+describe("resolveOpenClawMetadata planTemplate (Codex P1 r3096435164)", () => {
+  it("parses kebab-case `plan-template` key (legacy)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"plan-template":[{"step":"Tag release"},{"step":"Publish"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Tag release" }, { step: "Publish" }]);
+  });
+
+  it("parses camelCase `planTemplate` key (natural — was silently ignored)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"planTemplate":[{"step":"Tag release"},{"step":"Publish"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Tag release" }, { step: "Publish" }]);
+  });
+
+  it("kebab-case wins on conflict (backward compat)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"plan-template":[{"step":"Old"}],"planTemplate":[{"step":"New"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Old" }]);
+  });
+
+  // PR-E review fix (Copilot #3105043876): when kebab-case key is
+  // PRESENT but parses to an empty array (invalid shape), fall back to
+  // the camelCase key. The prior `??` only triggered on null/undefined,
+  // so a malformed kebab-case value silently dropped a valid camelCase
+  // template.
+  it("falls back to camelCase when kebab-case is invalid (string instead of array)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"plan-template":"not-an-array","planTemplate":[{"step":"Valid"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Valid" }]);
+  });
+
+  it("falls back to camelCase when kebab-case has only invalid step entries", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata:
+        '{"openclaw":{"plan-template":[{"step":42},{"step":null}],"planTemplate":[{"step":"Valid"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Valid" }]);
+  });
+
+  // PR-E review fix (Copilot #3096524315 / #3105043896): accept `content`
+  // as an alias for `step` so users following the PR description's
+  // example don't get silently-empty templates.
+  it("accepts `content` as alias for `step` in plan template entries", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"planTemplate":[{"content":"Build"},{"content":"Deploy"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Build" }, { step: "Deploy" }]);
+  });
+
+  it("`step` wins over `content` on conflict in the same entry", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"planTemplate":[{"step":"Real","content":"Ignored"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Real" }]);
+  });
+
+  it("returns undefined planTemplate when neither key is present", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"primaryEnv":"node"}}',
+    });
+    expect(meta?.planTemplate).toBeUndefined();
+  });
+});

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -19,6 +19,7 @@ import type {
   SkillEntry,
   SkillInstallSpec,
   SkillInvocationPolicy,
+  SkillPlanTemplateStep,
 } from "./types.js";
 
 export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
@@ -184,6 +185,54 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   return spec;
 }
 
+function parsePlanTemplate(raw: unknown): SkillPlanTemplateStep[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const parsed: SkillPlanTemplateStep[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    // Strict type guard: `step` must be a non-empty string after trim.
+    // Reject non-string steps (objects, arrays, numbers, booleans) instead
+    // of coercing them via String() — coercion produces useless output
+    // like "[object Object]" that the agent can't act on.
+    //
+    // PR-E review fix (Copilot #3096524315 / #3105043896): also accept
+    // `content` as an alias for `step`. The PR description's example used
+    // `content:` which would have silently parsed as empty otherwise.
+    // `step` wins on conflict — it matches the canonical field name in
+    // `SkillPlanTemplateStep` and downstream `update_plan` schema.
+    const stepRaw =
+      typeof record.step === "string"
+        ? record.step
+        : typeof record.content === "string"
+          ? record.content
+          : undefined;
+    if (stepRaw === undefined) {
+      continue;
+    }
+    const step = stepRaw.trim();
+    if (step.length === 0) {
+      continue;
+    }
+    // Trim-before-truthy on activeForm: an entry like
+    // `activeForm: "   "` should be treated as missing, not as a
+    // whitespace-only display string.
+    let activeForm: string | undefined;
+    if (typeof record.activeForm === "string") {
+      const trimmed = record.activeForm.trim();
+      if (trimmed.length > 0) {
+        activeForm = trimmed;
+      }
+    }
+    parsed.push(activeForm !== undefined ? { step, activeForm } : { step });
+  }
+  return parsed;
+}
+
 export function resolveOpenClawMetadata(
   frontmatter: ParsedSkillFrontmatter,
 ): OpenClawSkillMetadata | undefined {
@@ -194,6 +243,21 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  // Accept both kebab-case (`plan-template`) and camelCase (`planTemplate`)
+  // frontmatter keys. Codex P1 (PR #67541 r3096435164) — natural authors
+  // following the `primaryEnv`/`skillKey` camelCase convention would have
+  // their templates silently ignored otherwise. Kebab-case wins on conflict
+  // for backward compatibility with existing skills.
+  //
+  // PR-E review fix (Copilot #3105043876): if kebab-case key is PRESENT
+  // but parses to an empty array (invalid shape — string, object,
+  // entries with non-string `step`, etc.), fall back to camelCase
+  // instead of returning empty. The prior `??` only fell through on
+  // null/undefined, so a malformed kebab-case key would silently
+  // shadow a valid camelCase template.
+  const kebabParsed = parsePlanTemplate(metadataObj["plan-template"]);
+  const camelParsed = parsePlanTemplate(metadataObj.planTemplate);
+  const planTemplate = kebabParsed.length > 0 ? kebabParsed : camelParsed;
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: readStringValue(metadataObj.emoji),
@@ -203,6 +267,7 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    planTemplate: planTemplate.length > 0 ? planTemplate : undefined,
   };
 }
 

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, it, vi } from "vitest";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import {
+  applySkillPlanTemplateSeed,
+  resolveSkillPlanTemplate,
+} from "../pi-embedded-runner/skills-runtime.js";
+import {
+  buildPlanTemplatePayload,
+  DEFAULT_MAX_PLAN_TEMPLATE_STEPS,
+  hasSkillPlanTemplate,
+} from "./skill-planner.js";
+import type { SkillPlanTemplateStep } from "./types.js";
+
+describe("buildPlanTemplatePayload", () => {
+  it("returns null for empty template", () => {
+    expect(buildPlanTemplatePayload("deploy", [])).toBeNull();
+  });
+
+  it("returns null for undefined template", () => {
+    expect(buildPlanTemplatePayload("deploy", undefined)).toBeNull();
+    expect(buildPlanTemplatePayload("deploy")).toBeNull();
+  });
+
+  it("builds pending steps from template", () => {
+    const template: SkillPlanTemplateStep[] = [
+      { step: "Run tests", activeForm: "Running tests" },
+      { step: "Build", activeForm: "Building" },
+      { step: "Deploy" },
+    ];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result).not.toBeNull();
+    expect(result!.plan).toHaveLength(3);
+    expect(result!.plan.every((s) => s.status === "pending")).toBe(true);
+  });
+
+  it("preserves activeForm when present", () => {
+    const template: SkillPlanTemplateStep[] = [{ step: "Run tests", activeForm: "Running tests" }];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result!.plan[0].activeForm).toBe("Running tests");
+  });
+
+  it("omits activeForm when absent", () => {
+    const template: SkillPlanTemplateStep[] = [{ step: "Deploy" }];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result!.plan[0]).not.toHaveProperty("activeForm");
+  });
+
+  it("includes skill name in explanation", () => {
+    const result = buildPlanTemplatePayload("release-cut", [{ step: "Tag" }]);
+    expect(result!.explanation).toContain("release-cut");
+  });
+
+  it("dedupes duplicate step text within a single template (first wins)", () => {
+    const template: SkillPlanTemplateStep[] = [
+      { step: "A", activeForm: "Doing A" },
+      { step: "B" },
+      { step: "A", activeForm: "Doing A again" }, // duplicate of step "A"
+      { step: "C" },
+    ];
+    const result = buildPlanTemplatePayload("multi", template);
+    expect(result!.plan).toHaveLength(3);
+    expect(result!.plan.map((p) => p.step)).toEqual(["A", "B", "C"]);
+    // First wins — keeps the original activeForm.
+    expect(result!.plan[0].activeForm).toBe("Doing A");
+    expect(result!.droppedDuplicates).toEqual(["A"]);
+  });
+
+  // PR-E review fix (Copilot #3096524258 / #3096799640): test renamed
+  // to match the assertion intent. The original name claimed to test an
+  // "impossible all-duplicates" + "returns null" case but the body
+  // actually verifies single-step payload generation — misleading and
+  // hard to interpret on failure.
+  it("dedup of a single-step array with no duplicates produces a one-step payload", () => {
+    const result = buildPlanTemplatePayload("solo", [{ step: "Lone" }]);
+    expect(result).not.toBeNull();
+    expect(result!.plan).toHaveLength(1);
+    expect(result!.plan[0]).toEqual({ step: "Lone", status: "pending" });
+  });
+
+  it("truncates templates exceeding maxSteps and flags `truncated: true`", () => {
+    const template: SkillPlanTemplateStep[] = Array.from({ length: 100 }, (_, i) => ({
+      step: `Step ${i}`,
+    }));
+    const result = buildPlanTemplatePayload("big", template, { maxSteps: 10 });
+    expect(result!.plan).toHaveLength(10);
+    expect(result!.truncated).toBe(true);
+    expect(result!.maxSteps).toBe(10);
+  });
+
+  it("uses DEFAULT_MAX_PLAN_TEMPLATE_STEPS when maxSteps not set", () => {
+    const template: SkillPlanTemplateStep[] = Array.from(
+      { length: DEFAULT_MAX_PLAN_TEMPLATE_STEPS + 5 },
+      (_, i) => ({ step: `Step ${i}` }),
+    );
+    const result = buildPlanTemplatePayload("big", template);
+    expect(result!.plan).toHaveLength(DEFAULT_MAX_PLAN_TEMPLATE_STEPS);
+    expect(result!.truncated).toBe(true);
+  });
+
+  it("does not flag truncation for templates within bounds", () => {
+    const template: SkillPlanTemplateStep[] = [{ step: "A" }, { step: "B" }];
+    const result = buildPlanTemplatePayload("small", template);
+    expect(result!.truncated).toBeUndefined();
+    expect(result!.droppedDuplicates).toBeUndefined();
+  });
+});
+
+describe("hasSkillPlanTemplate", () => {
+  it("returns false for undefined metadata", () => {
+    expect(hasSkillPlanTemplate(undefined)).toBe(false);
+  });
+
+  it("returns false for empty planTemplate", () => {
+    expect(hasSkillPlanTemplate({ planTemplate: [] })).toBe(false);
+  });
+
+  it("returns true for non-empty planTemplate", () => {
+    expect(hasSkillPlanTemplate({ planTemplate: [{ step: "x" }] })).toBe(true);
+  });
+});
+
+describe("resolveSkillPlanTemplate", () => {
+  it("returns null when no entries have a plan template", () => {
+    const entries = [
+      { skill: { name: "deploy" }, metadata: {} },
+      { skill: { name: "lint" }, metadata: { planTemplate: [] } },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+    expect(resolveSkillPlanTemplate(entries)).toBeNull();
+  });
+
+  it("returns the payload + skillName for a single template", () => {
+    const entries = [
+      { skill: { name: "deploy" }, metadata: {} },
+      {
+        skill: { name: "release" },
+        metadata: { planTemplate: [{ step: "Tag release" }] },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+    const result = resolveSkillPlanTemplate(entries);
+    expect(result).not.toBeNull();
+    expect(result!.skillName).toBe("release");
+    expect(result!.rejected).toEqual([]);
+    expect(result!.payload.plan[0].step).toBe("Tag release");
+    expect(result!.payload.explanation).toContain("release");
+  });
+
+  it("returns null for empty entries array", () => {
+    expect(resolveSkillPlanTemplate([])).toBeNull();
+  });
+
+  it("on collision picks alpha-first skill and lists the rest in `rejected`", () => {
+    const entries = [
+      {
+        skill: { name: "release" },
+        metadata: { planTemplate: [{ step: "Tag release" }] },
+      },
+      {
+        skill: { name: "deploy" },
+        metadata: { planTemplate: [{ step: "Push to staging" }] },
+      },
+      {
+        skill: { name: "audit" },
+        metadata: { planTemplate: [{ step: "Run audit" }] },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+
+    const result = resolveSkillPlanTemplate(entries);
+    expect(result!.skillName).toBe("audit");
+    expect(result!.rejected).toEqual(["deploy", "release"]);
+    expect(result!.payload.plan[0].step).toBe("Run audit");
+  });
+
+  it("respects skills.limits.maxPlanTemplateSteps from config", () => {
+    const entries = [
+      {
+        skill: { name: "big" },
+        metadata: {
+          planTemplate: Array.from({ length: 100 }, (_, i) => ({ step: `S${i}` })),
+        },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+
+    const result = resolveSkillPlanTemplate(entries, {
+      skills: { limits: { maxPlanTemplateSteps: 5 } },
+    });
+    expect(result!.payload.plan).toHaveLength(5);
+    expect(result!.payload.truncated).toBe(true);
+  });
+});
+
+describe("applySkillPlanTemplateSeed", () => {
+  it("returns null when runId is missing", () => {
+    const result = applySkillPlanTemplateSeed({
+      entries: [
+        {
+          skill: { name: "x" },
+          metadata: { planTemplate: [{ step: "Y" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no skill carries a template", () => {
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-1",
+      entries: [{ skill: { name: "x" }, metadata: {} }] as Parameters<
+        typeof applySkillPlanTemplateSeed
+      >[0]["entries"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips seeding when existingPlanSteps is non-empty (idempotency)", () => {
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-2",
+      entries: [
+        {
+          skill: { name: "x" },
+          metadata: { planTemplate: [{ step: "Y" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      existingPlanSteps: [{ step: "Already planned" }],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("forwards seed event to onAgentEvent callback (Codex P2 r3096399082/r3096435183)", () => {
+    // Adversarial regression: callback-only consumers (e.g. auto-reply
+    // pipeline) need to see the seed event the same way they see other
+    // plan updates. Prior implementation only called global emitAgentPlanEvent.
+    resetAgentEventsForTest();
+    const callbackEvents: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-cb",
+      sessionKey: "session-cb",
+      entries: [
+        {
+          skill: { name: "release" },
+          metadata: { planTemplate: [{ step: "Tag" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      onAgentEvent: (evt) => {
+        callbackEvents.push({ stream: evt.stream, data: evt.data as Record<string, unknown> });
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(callbackEvents).toHaveLength(1);
+    expect(callbackEvents[0].stream).toBe("plan");
+    expect(callbackEvents[0].data).toMatchObject({
+      title: 'Plan seeded from skill "release"',
+      source: "skill_plan_template",
+    });
+  });
+
+  it("filters out ineligible skills before collision resolution (Codex P2 r3096399074)", () => {
+    // Adversarial regression: a disabled skill with a planTemplate would
+    // win the alpha-first collision and seed an unrelated plan even though
+    // the skill itself is excluded from the runtime prompt. The seeder now
+    // applies shouldIncludeSkill() filtering before resolving the winner.
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-filter",
+      entries: [
+        {
+          // Alphabetically first BUT disabled in config.
+          skill: { name: "alpha-disabled" },
+          metadata: { planTemplate: [{ step: "WrongPlan" }] },
+        },
+        {
+          skill: { name: "beta-active" },
+          metadata: { planTemplate: [{ step: "RightPlan" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      config: {
+        skills: {
+          entries: {
+            "alpha-disabled": { enabled: false },
+          },
+        },
+      },
+    });
+    // beta-active should win because alpha-disabled was filtered out first.
+    expect(result).not.toBeNull();
+    expect(result!.skillName).toBe("beta-active");
+  });
+
+  it("emits agent_plan_event and returns summary on successful seed", async () => {
+    resetAgentEventsForTest();
+    const { onAgentEvent, registerAgentRunContext } = await import("../../infra/agent-events.js");
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const off = onAgentEvent((evt) => events.push({ stream: evt.stream, data: evt.data }));
+
+    try {
+      registerAgentRunContext("run-seed", { sessionKey: "session-seed" });
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-seed",
+        sessionKey: "session-seed",
+        entries: [
+          {
+            skill: { name: "release" },
+            metadata: {
+              planTemplate: [{ step: "Tag" }, { step: "Publish" }],
+            },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.skillName).toBe("release");
+      expect(result!.emittedSteps).toBe(2);
+      expect(result!.rejected).toEqual([]);
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      expect(planEvents[0].data).toMatchObject({
+        phase: "update",
+        title: 'Plan seeded from skill "release"',
+        steps: ["Tag", "Publish"],
+        source: "skill_plan_template",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("warns about collision when multiple skills carry templates", async () => {
+    resetAgentEventsForTest();
+    const warnSpy = vi.spyOn(await import("../../logger.js"), "logWarn");
+    try {
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-collision",
+        entries: [
+          {
+            skill: { name: "release" },
+            metadata: { planTemplate: [{ step: "Tag" }] },
+          },
+          {
+            skill: { name: "audit" },
+            metadata: { planTemplate: [{ step: "Run audit" }] },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      });
+      expect(result!.skillName).toBe("audit");
+      expect(result!.rejected).toEqual(["release"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_collision"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("falls back to snapshot.resolvedPlanTemplates when entries is empty (snapshot-backed run path)", async () => {
+    // Adversarial regression (Codex P1 on PR #67541):
+    // resolveEmbeddedRunSkillEntries returns skillEntries=[] whenever a
+    // snapshot is present, which is the main production run path. The
+    // seeder must therefore fall back to snapshot.resolvedPlanTemplates
+    // so it doesn't silently no-op for normal sessions.
+    resetAgentEventsForTest();
+    const { onAgentEvent } = await import("../../infra/agent-events.js");
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const off = onAgentEvent((evt) => events.push({ stream: evt.stream, data: evt.data }));
+
+    try {
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-snapshot",
+        sessionKey: "session-snapshot",
+        entries: [], // empty — snapshot path
+        skillsSnapshot: {
+          prompt: "",
+          skills: [{ name: "release" }],
+          resolvedPlanTemplates: [
+            {
+              skillName: "release",
+              planTemplate: [{ step: "Tag" }, { step: "Publish" }],
+            },
+          ],
+        },
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.skillName).toBe("release");
+      expect(result!.emittedSteps).toBe(2);
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      expect(planEvents[0].data).toMatchObject({
+        steps: ["Tag", "Publish"],
+        source: "skill_plan_template",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("warns about truncation and dropped duplicates", async () => {
+    resetAgentEventsForTest();
+    const warnSpy = vi.spyOn(await import("../../logger.js"), "logWarn");
+    try {
+      const template: SkillPlanTemplateStep[] = [
+        { step: "A" },
+        { step: "B" },
+        { step: "A" }, // dup
+        { step: "C" },
+      ];
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-warn",
+        entries: [
+          {
+            skill: { name: "x" },
+            metadata: { planTemplate: template },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+        config: { skills: { limits: { maxPlanTemplateSteps: 2 } } },
+      });
+      expect(result!.droppedDuplicates).toEqual(["A"]);
+      expect(result!.truncated).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_duplicates"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_truncated"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/src/agents/skills/skill-planner.ts
+++ b/src/agents/skills/skill-planner.ts
@@ -1,0 +1,118 @@
+/**
+ * Skill plan template instantiation.
+ *
+ * When a skill with a `planTemplate` in its metadata is activated,
+ * this module builds the initial plan SEED PAYLOAD from the template
+ * steps. All steps start as "pending".
+ *
+ * PR-E review fix (Copilot #3105170493 / #3096799587): the returned
+ * `PlanTemplatePayload` is NOT passed directly to the `update_plan`
+ * tool — it's wrapped into an `agent_plan_event` by
+ * `applySkillPlanTemplateSeed` (`src/agents/pi-embedded-runner/skills-runtime.ts`)
+ * so the UI/channel adapters see the seeded plan ahead of the first
+ * agent turn. The extra fields (`droppedDuplicates`, `truncated`,
+ * `maxSteps`) are diagnostic — used by the seeder to log
+ * `skill_plan_template_*` warnings but stripped before any downstream
+ * tool input.
+ *
+ * Phase 4.1 of the GPT 5.4 parity sprint.
+ */
+
+import type { SkillPlanTemplateStep } from "./types.js";
+
+/** Default upper bound on plan-template step count (configurable via `skills.limits.maxPlanTemplateSteps`). */
+export const DEFAULT_MAX_PLAN_TEMPLATE_STEPS = 50;
+
+export interface PlanTemplatePayload {
+  plan: Array<{
+    step: string;
+    status: "pending";
+    activeForm?: string;
+  }>;
+  explanation: string;
+  /** Step texts dropped because they duplicate an earlier entry in the same template (first wins). */
+  droppedDuplicates?: string[];
+  /** True when the input template exceeded `maxSteps` and was truncated. */
+  truncated?: boolean;
+  /** Configured upper bound applied during normalization. */
+  maxSteps?: number;
+}
+
+export interface BuildPlanTemplateOptions {
+  /** Upper bound on step count; defaults to `DEFAULT_MAX_PLAN_TEMPLATE_STEPS`. */
+  maxSteps?: number;
+}
+
+/**
+ * Builds an `update_plan` payload from a skill's plan template.
+ *
+ * Normalizes the template by:
+ * - Dropping entries with duplicate `step` text (first wins).
+ * - Truncating to `maxSteps` (default 50, configurable).
+ *
+ * Diagnostic fields (`droppedDuplicates`, `truncated`, `maxSteps`) on the
+ * returned payload let the caller emit per-skill warning events without
+ * needing access to the original template.
+ *
+ * @param skillName - The name of the skill being activated
+ * @param template - The plan template steps from skill metadata
+ * @param options - Optional limits/overrides
+ * @returns A payload suitable for passing to the `update_plan` tool,
+ *          or `null` if the (post-normalize) template is empty
+ */
+export function buildPlanTemplatePayload(
+  skillName: string,
+  template?: SkillPlanTemplateStep[],
+  options?: BuildPlanTemplateOptions,
+): PlanTemplatePayload | null {
+  if (!template || template.length === 0) {
+    return null;
+  }
+
+  const maxSteps =
+    options?.maxSteps && options.maxSteps > 0 ? options.maxSteps : DEFAULT_MAX_PLAN_TEMPLATE_STEPS;
+
+  // Dedup by step text — keep first occurrence, record dropped duplicates.
+  const seen = new Set<string>();
+  const droppedDuplicates: string[] = [];
+  const deduped: SkillPlanTemplateStep[] = [];
+  for (const step of template) {
+    if (seen.has(step.step)) {
+      droppedDuplicates.push(step.step);
+      continue;
+    }
+    seen.add(step.step);
+    deduped.push(step);
+  }
+
+  if (deduped.length === 0) {
+    return null;
+  }
+
+  // Apply upper bound. Truncation drops the tail, since later steps are
+  // less likely to be reached anyway and we want the seed to model the
+  // "first N actions" the agent should take.
+  const truncated = deduped.length > maxSteps;
+  const final = truncated ? deduped.slice(0, maxSteps) : deduped;
+
+  return {
+    plan: final.map((t) => ({
+      step: t.step,
+      status: "pending" as const,
+      ...(t.activeForm ? { activeForm: t.activeForm } : {}),
+    })),
+    explanation: `Auto-populated from skill "${skillName}" plan template.`,
+    ...(droppedDuplicates.length > 0 ? { droppedDuplicates } : {}),
+    ...(truncated ? { truncated: true } : {}),
+    maxSteps,
+  };
+}
+
+/**
+ * Checks whether a skill entry has a non-empty plan template.
+ */
+export function hasSkillPlanTemplate(metadata?: {
+  planTemplate?: SkillPlanTemplateStep[];
+}): boolean {
+  return Array.isArray(metadata?.planTemplate) && metadata.planTemplate.length > 0;
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -16,6 +16,16 @@ export type SkillInstallSpec = {
   targetDir?: string;
 };
 
+/**
+ * A plan template step that a skill can provide.
+ * When the skill is activated, these steps are auto-populated into
+ * `update_plan` as the initial plan (all status: "pending").
+ */
+export type SkillPlanTemplateStep = {
+  step: string;
+  activeForm?: string;
+};
+
 export type OpenClawSkillMetadata = {
   always?: boolean;
   skillKey?: string;
@@ -30,6 +40,14 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  /**
+   * Optional plan template. When present and the skill is activated,
+   * the runtime auto-calls `update_plan` with these steps (all pending)
+   * before the first agent turn, giving the agent a starting checklist.
+   *
+   * Parsed from YAML frontmatter `plan-template` field in SKILL.md.
+   */
+  planTemplate?: SkillPlanTemplateStep[];
 };
 
 export type SkillInvocationPolicy = {
@@ -96,5 +114,12 @@ export type SkillSnapshot = {
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];
+  /**
+   * Per-skill plan templates carried forward from snapshot build so the
+   * skill-template seeder (#67541) doesn't have to re-load workspace skill
+   * entries when running off a pre-built snapshot. Only skills with a
+   * non-empty `planTemplate` appear here.
+   */
+  resolvedPlanTemplates?: Array<{ skillName: string; planTemplate: SkillPlanTemplateStep[] }>;
   version?: number;
 };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -722,6 +722,24 @@ export function buildWorkspaceSkillSnapshot(
 ): SkillSnapshot {
   const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
   const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  // Carry per-skill plan templates so #67541's seeder works in the
+  // snapshot-backed run path. Without this, applySkillPlanTemplateSeed
+  // sees an empty entries list (resolveEmbeddedRunSkillEntries returns
+  // [] when a snapshot is present) and silently no-ops in production.
+  const resolvedPlanTemplates = eligible
+    .filter(
+      (
+        e,
+      ): e is SkillEntry & {
+        metadata: { planTemplate: NonNullable<SkillEntry["metadata"]>["planTemplate"] };
+      } => Array.isArray(e.metadata?.planTemplate) && e.metadata.planTemplate.length > 0,
+    )
+    .map((e) => ({
+      skillName: e.skill.name,
+      // Guaranteed defined by the filter predicate above (TS narrowing
+      // doesn't propagate through .map's project arrow).
+      planTemplate: e.metadata.planTemplate!.slice(),
+    }));
   return {
     prompt,
     skills: eligible.map((entry) => ({
@@ -731,6 +749,7 @@ export function buildWorkspaceSkillSnapshot(
     })),
     ...(skillFilter === undefined ? {} : { skillFilter }),
     resolvedSkills,
+    ...(resolvedPlanTemplates.length > 0 ? { resolvedPlanTemplates } : {}),
     version: opts?.snapshotVersion,
   };
 }

--- a/src/agents/system-prompt-contribution.ts
+++ b/src/agents/system-prompt-contribution.ts
@@ -1,7 +1,8 @@
 export type ProviderSystemPromptSectionId =
   | "interaction_style"
   | "tool_call_style"
-  | "execution_bias";
+  | "execution_bias"
+  | "tool_enforcement";
 
 export type ProviderSystemPromptContribution = {
   /**

--- a/src/agents/system-prompt-gpt5-boot-reorder.test.ts
+++ b/src/agents/system-prompt-gpt5-boot-reorder.test.ts
@@ -1,0 +1,140 @@
+/**
+ * PR-8 follow-up Round 2: tests for the GPT-5 family context-file boot
+ * reorder — SOUL.md / IDENTITY.md should load BEFORE AGENTS.md when the
+ * provider is `openai` or `openai-codex` and the model id starts with
+ * `gpt-5`. All other providers/models preserve the historical default
+ * order (AGENTS.md first).
+ *
+ * Scope: asserts final placement order inside the assembled prompt's
+ * "## Stable Project Context" section via the public
+ * `buildAgentSystemPrompt` entrypoint (no internal helper exposure).
+ */
+import { describe, expect, it } from "vitest";
+import { buildAgentSystemPrompt } from "./system-prompt.js";
+
+type ContextFile = Parameters<typeof buildAgentSystemPrompt>[0]["contextFiles"] extends
+  | ReadonlyArray<infer E>
+  | undefined
+  ? E
+  : never;
+
+function makeCtxFile(basename: string, content: string): ContextFile {
+  return {
+    path: basename,
+    content,
+  } as ContextFile;
+}
+
+function extractContextSectionOrder(prompt: string): string[] {
+  // Each injected file lands as `## <path>` under the "Stable Project
+  // Context" section. Capture only basenames in `.md` to avoid false
+  // positives from other `## `-prefixed section headings.
+  const headingRe = /^## (?<path>[A-Za-z0-9_.-]+\.md)$/gm;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = headingRe.exec(prompt)) !== null) {
+    if (m.groups?.path) {
+      matches.push(m.groups.path.toLowerCase());
+    }
+  }
+  return matches;
+}
+
+const BASE_PARAMS = {
+  workspaceDir: "/tmp/gpt5-boot-order-test",
+  runtimeInfo: {
+    host: "test-host",
+    os: "darwin",
+    arch: "arm64",
+    node: "v22.0.0",
+    model: "placeholder",
+  },
+  contextFiles: [
+    makeCtxFile("AGENTS.md", "# agents content"),
+    makeCtxFile("SOUL.md", "# soul content"),
+    makeCtxFile("IDENTITY.md", "# identity content"),
+    makeCtxFile("USER.md", "# user content"),
+    makeCtxFile("TOOLS.md", "# tools content"),
+  ],
+};
+
+describe("GPT-5 context-file boot reorder", () => {
+  it("openai-codex + gpt-5.4 → SOUL first, then IDENTITY, then AGENTS", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "openai-codex",
+      modelId: "gpt-5.4",
+    });
+    const order = extractContextSectionOrder(prompt);
+    const soulIdx = order.indexOf("soul.md");
+    const identityIdx = order.indexOf("identity.md");
+    const agentsIdx = order.indexOf("agents.md");
+    expect(soulIdx).toBeGreaterThanOrEqual(0);
+    expect(identityIdx).toBeGreaterThan(soulIdx);
+    expect(agentsIdx).toBeGreaterThan(identityIdx);
+  });
+
+  it("openai + gpt-5-turbo → SOUL first, then IDENTITY, then AGENTS", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "openai",
+      modelId: "gpt-5-turbo",
+    });
+    const order = extractContextSectionOrder(prompt);
+    expect(order.indexOf("soul.md")).toBeLessThan(order.indexOf("agents.md"));
+    expect(order.indexOf("identity.md")).toBeLessThan(order.indexOf("agents.md"));
+  });
+
+  it("anthropic + claude-opus-4-6 → default order (AGENTS first)", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+    const order = extractContextSectionOrder(prompt);
+    const agentsIdx = order.indexOf("agents.md");
+    const soulIdx = order.indexOf("soul.md");
+    const identityIdx = order.indexOf("identity.md");
+    expect(agentsIdx).toBeLessThan(soulIdx);
+    expect(agentsIdx).toBeLessThan(identityIdx);
+  });
+
+  it("openai + gpt-4 (non-GPT-5) → default order preserved", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "openai",
+      modelId: "gpt-4.1",
+    });
+    const order = extractContextSectionOrder(prompt);
+    expect(order.indexOf("agents.md")).toBeLessThan(order.indexOf("soul.md"));
+  });
+
+  it("missing modelProviderId/modelId → default order (safe fallback)", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+    });
+    const order = extractContextSectionOrder(prompt);
+    expect(order.indexOf("agents.md")).toBeLessThan(order.indexOf("soul.md"));
+  });
+
+  it("GPT-5 with mixed case modelId (GPT-5.4) still triggers reorder", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "openai-codex",
+      modelId: "GPT-5.4",
+    });
+    const order = extractContextSectionOrder(prompt);
+    expect(order.indexOf("soul.md")).toBeLessThan(order.indexOf("agents.md"));
+  });
+
+  it("non-OpenAI provider with gpt-5 in name → default order (provider gate required)", () => {
+    const prompt = buildAgentSystemPrompt({
+      ...BASE_PARAMS,
+      modelProviderId: "anthropic",
+      modelId: "gpt-5",
+    });
+    const order = extractContextSectionOrder(prompt);
+    // Provider gate fails → no reorder
+    expect(order.indexOf("agents.md")).toBeLessThan(order.indexOf("soul.md"));
+  });
+});

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -15,6 +15,7 @@ import {
   buildFullBootstrapPromptLines,
   buildLimitedBootstrapPromptLines,
 } from "./bootstrap-prompt.js";
+import { sanitizeContextFileForInjection } from "./context-file-injection-scan.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type {
@@ -41,7 +42,7 @@ import type { PromptMode } from "./system-prompt.types.js";
  */
 type OwnerIdDisplay = "raw" | "hash";
 
-const CONTEXT_FILE_ORDER = new Map<string, number>([
+const DEFAULT_CONTEXT_FILE_ORDER = new Map<string, number>([
   ["agents.md", 10],
   ["soul.md", 20],
   ["identity.md", 30],
@@ -50,6 +51,56 @@ const CONTEXT_FILE_ORDER = new Map<string, number>([
   ["bootstrap.md", 60],
   ["memory.md", 70],
 ]);
+
+/**
+ * PR-8 follow-up Round 2: for OpenAI GPT-5 family models, load
+ * SOUL.md and IDENTITY.md BEFORE AGENTS.md so the persona primes the
+ * model before process/operations rules compete for attention.
+ *
+ * Rationale (per adversarial review + GPT-5.4 live testing): identity
+ * is aspirational, execution/process is concrete; execution wins by
+ * default. Loading persona first establishes voice/tone before the
+ * AGENTS.md operational contract arrives.
+ *
+ * Scoped narrowly to GPT-5 family because:
+ *  (a) that's where the personality-drift regression was observed,
+ *  (b) Anthropic + Gemini models have different priors and the
+ *      change might not help / might hurt them,
+ *  (c) GPT-5 already has its own provider overlay, so additional
+ *      family-specific tuning has a natural home.
+ */
+const GPT5_CONTEXT_FILE_ORDER = new Map<string, number>([
+  ["soul.md", 10],
+  ["identity.md", 20],
+  ["agents.md", 30],
+  ["user.md", 40],
+  ["tools.md", 50],
+  ["bootstrap.md", 60],
+  ["memory.md", 70],
+]);
+
+const OPENAI_PROVIDER_IDS_FOR_CONTEXT_ORDER: ReadonlySet<string> = new Set([
+  "openai",
+  "openai-codex",
+]);
+
+function getContextFileOrder(modelProviderId?: string, modelId?: string): Map<string, number> {
+  // Copilot review #68939 (round-2): normalize provider to
+  // lowercase before set membership check. The set entries
+  // (`OPENAI_PROVIDER_IDS_FOR_CONTEXT_ORDER`) are lowercase, but
+  // upstream callers may pass `"OpenAI"` / `"OPENAI"` / `"OpenAI-
+  // Codex"`. Without normalization, the GPT-5 boot reorder
+  // silently doesn't apply for those casings.
+  const provider = modelProviderId?.trim().toLowerCase() ?? "";
+  if (!OPENAI_PROVIDER_IDS_FOR_CONTEXT_ORDER.has(provider)) {
+    return DEFAULT_CONTEXT_FILE_ORDER;
+  }
+  const lowerModel = (modelId ?? "").trim().toLowerCase();
+  if (!lowerModel.startsWith("gpt-5")) {
+    return DEFAULT_CONTEXT_FILE_ORDER;
+  }
+  return GPT5_CONTEXT_FILE_ORDER;
+}
 
 const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set(["heartbeat.md"]);
 const DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK =
@@ -74,14 +125,19 @@ function sanitizeContextFileContentForPrompt(content: string): string {
   return content.replaceAll(DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK, "").replace(/\n{3,}/g, "\n\n");
 }
 
-function sortContextFilesForPrompt(contextFiles: EmbeddedContextFile[]): EmbeddedContextFile[] {
+function sortContextFilesForPrompt(
+  contextFiles: EmbeddedContextFile[],
+  modelProviderId?: string,
+  modelId?: string,
+): EmbeddedContextFile[] {
+  const order = getContextFileOrder(modelProviderId, modelId);
   return contextFiles.toSorted((a, b) => {
     const aPath = normalizeContextFilePath(a.path);
     const bPath = normalizeContextFilePath(b.path);
     const aBase = getContextFileBasename(a.path);
     const bBase = getContextFileBasename(b.path);
-    const aOrder = CONTEXT_FILE_ORDER.get(aBase) ?? Number.MAX_SAFE_INTEGER;
-    const bOrder = CONTEXT_FILE_ORDER.get(bBase) ?? Number.MAX_SAFE_INTEGER;
+    const aOrder = order.get(aBase) ?? Number.MAX_SAFE_INTEGER;
+    const bOrder = order.get(bBase) ?? Number.MAX_SAFE_INTEGER;
     if (aOrder !== bOrder) {
       return aOrder - bOrder;
     }
@@ -119,7 +175,18 @@ function buildProjectContextSection(params: {
     lines.push("");
   }
   for (const file of params.files) {
-    lines.push(`## ${file.path}`, "", sanitizeContextFileContentForPrompt(file.content), "");
+    const sanitizedContent = sanitizeContextFileForInjection(
+      sanitizeContextFileContentForPrompt(file.content),
+      file.path,
+    );
+    // Sanitize file.path in the heading to prevent prompt-structure injection
+    // via crafted filenames with control/bidi/zero-width chars.
+    // PR-A review fix (Copilot #3094483599): a filename composed entirely
+    // of bidi/zero-width/control chars trims to empty string, which
+    // would render a blank `##` heading and effectively hide which file
+    // the subsequent content came from. Fall back to a clear marker.
+    const safePath = sanitizeForPromptLiteral(file.path).trim() || "[unknown context file]";
+    lines.push(`## ${safePath}`, "", sanitizedContent, "");
   }
   return lines;
 }
@@ -471,6 +538,15 @@ export function buildAgentSystemPrompt(params: {
   includeMemorySection?: boolean;
   memoryCitationsMode?: MemoryCitationsMode;
   promptContribution?: ProviderSystemPromptContribution;
+  /**
+   * PR-8 follow-up Round 2: provider/model identification used for
+   * model-family-specific prompt tuning. Currently drives the GPT-5
+   * context-file reorder (SOUL.md / IDENTITY.md before AGENTS.md).
+   * When undefined the default order is used, preserving historical
+   * behavior for all non-OpenAI flows.
+   */
+  modelProviderId?: string;
+  modelId?: string;
 }) {
   const acpEnabled = params.acpEnabled !== false;
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
@@ -742,6 +818,10 @@ export function buildAgentSystemPrompt(params: {
       }),
     }),
     ...buildOverridablePromptSection({
+      override: providerSectionOverrides.tool_enforcement,
+      fallback: [],
+    }),
+    ...buildOverridablePromptSection({
       override: providerStablePrefix,
       fallback: [],
     }),
@@ -908,7 +988,11 @@ export function buildAgentSystemPrompt(params: {
   const validContextFiles = contextFiles.filter(
     (file) => typeof file.path === "string" && file.path.trim().length > 0,
   );
-  const orderedContextFiles = sortContextFilesForPrompt(validContextFiles);
+  const orderedContextFiles = sortContextFilesForPrompt(
+    validContextFiles,
+    params.modelProviderId,
+    params.modelId,
+  );
   const stableContextFiles = orderedContextFiles.filter((file) => !isDynamicContextFile(file.path));
   const dynamicContextFiles = orderedContextFiles.filter((file) => isDynamicContextFile(file.path));
   lines.push(

--- a/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
+++ b/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
@@ -41,7 +41,8 @@ vi.mock("../tools/tts-tool.js", () => ({
 }));
 
 vi.mock("../tools/update-plan-tool.js", () => ({
-  createUpdatePlanTool: () => stubTool("update_plan"),
+  createUpdatePlanTool: (_options?: { runId?: string }) => stubTool("update_plan"),
+  PLAN_STEP_STATUSES: ["pending", "in_progress", "completed", "cancelled"] as const,
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({

--- a/src/agents/tools/update-plan-tool.parity.test.ts
+++ b/src/agents/tools/update-plan-tool.parity.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AgentEventPayload,
+  getAgentRunContext,
+  onAgentEvent,
+  registerAgentRunContext,
+  resetAgentEventsForTest,
+} from "../../infra/agent-events.js";
+import { createUpdatePlanTool } from "./update-plan-tool.js";
+
+describe("update_plan tool – parity tests", () => {
+  // Test renamed per Copilot #3094484850 — execute() bypasses Typebox
+  // schema validation; this asserts the tool runtime parsing layer
+  // (readPlanSteps) accepts cancelled, not the JSON schema directly.
+  it("cancelled status is accepted by execute()", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      plan: [
+        { step: "Install deps", status: "completed" },
+        { step: "Run failing tests", status: "cancelled" },
+        { step: "Fix tests and retry", status: "pending" },
+      ],
+    });
+
+    expect(result.details).toEqual({
+      status: "updated",
+      plan: [
+        { step: "Install deps", status: "completed" },
+        { step: "Run failing tests", status: "cancelled" },
+        { step: "Fix tests and retry", status: "pending" },
+      ],
+    });
+  });
+
+  it("activeForm field is preserved in output", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      plan: [
+        {
+          step: "Fix auth bug",
+          status: "in_progress",
+          activeForm: "Fixing authentication bug",
+        },
+        { step: "Deploy", status: "pending" },
+      ],
+    });
+
+    const plan = (result.details as Record<string, unknown>).plan as Array<Record<string, unknown>>;
+    const inProgressStep = plan.find((s) => s.status === "in_progress");
+    expect(inProgressStep).toBeDefined();
+    expect(inProgressStep!.activeForm).toBe("Fixing authentication bug");
+  });
+
+  it("merge=true with no previousPlan falls back to replace", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      merge: true,
+      plan: [{ step: "New step", status: "pending" }],
+    });
+
+    expect(result.details).toEqual({
+      status: "updated",
+      plan: [{ step: "New step", status: "pending" }],
+    });
+  });
+});
+
+describe("update_plan tool – merge mode (#67514)", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  function getPlan(result: { details: unknown }) {
+    return (result.details as Record<string, unknown>).plan as Array<Record<string, unknown>>;
+  }
+
+  it("merge with overlap updates status without duplicating the step", async () => {
+    const runId = "run-merge-overlap";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    // Seed previous plan via an initial replace.
+    await tool.execute("call-1", {
+      plan: [
+        { step: "Install deps", status: "completed" },
+        { step: "Run tests", status: "in_progress", activeForm: "Running tests" },
+        { step: "Deploy", status: "pending" },
+      ],
+    });
+
+    // Overlap: "Run tests" advances to completed, "Deploy" advances to in_progress.
+    const result = await tool.execute("call-2", {
+      merge: true,
+      plan: [
+        { step: "Run tests", status: "completed" },
+        { step: "Deploy", status: "in_progress", activeForm: "Deploying" },
+      ],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(3);
+    expect(plan[0]).toEqual({ step: "Install deps", status: "completed" });
+    // PR-B review fix (Copilot #3096520563 / #3105169615): activeForm
+    // is preserved across merge when the incoming patch omits it. The
+    // renderer only displays activeForm for in_progress steps, so this
+    // is harmless metadata preservation that keeps merge calls
+    // token-efficient (caller does not have to re-send activeForm just
+    // to advance status).
+    expect(plan[1]).toEqual({
+      step: "Run tests",
+      status: "completed",
+      activeForm: "Running tests",
+    });
+    expect(plan[2]).toEqual({ step: "Deploy", status: "in_progress", activeForm: "Deploying" });
+  });
+
+  it("merge appends novel steps preserving incoming order", async () => {
+    const runId = "run-merge-append";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Step A", status: "completed" },
+        { step: "Step B", status: "in_progress", activeForm: "Doing B" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [
+        { step: "Step C", status: "pending" },
+        { step: "Step D", status: "pending" },
+      ],
+    });
+
+    const plan = getPlan(result);
+    expect(plan.map((p) => p.step)).toEqual(["Step A", "Step B", "Step C", "Step D"]);
+    // Existing steps retain their previous status.
+    expect(plan[0]?.status).toBe("completed");
+    expect(plan[1]?.status).toBe("in_progress");
+  });
+
+  it("merge preserves completed steps not present in the incoming patch", async () => {
+    const runId = "run-merge-preserve";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Plan", status: "completed" },
+        { step: "Implement", status: "in_progress", activeForm: "Implementing" },
+        { step: "Verify", status: "pending" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "Implement", status: "completed" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(3);
+    expect(plan[0]).toEqual({ step: "Plan", status: "completed" });
+    // PR-B review fix (Copilot #3096520563 / #3105169615): activeForm
+    // is preserved when the incoming patch omits it (merge mode is
+    // token-efficient). Renderer only shows activeForm for in_progress
+    // steps, so the preserved value is harmless metadata.
+    expect(plan[1]).toEqual({
+      step: "Implement",
+      status: "completed",
+      activeForm: "Implementing",
+    });
+    expect(plan[2]).toEqual({ step: "Verify", status: "pending" });
+  });
+
+  it("merge can transition status from cancelled back to pending (rollback case)", async () => {
+    const runId = "run-merge-rollback";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [{ step: "Risky migration", status: "cancelled" }],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "Risky migration", status: "pending" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toEqual({ step: "Risky migration", status: "pending" });
+  });
+
+  it("merge=false with prior plan still replaces (default behavior)", async () => {
+    const runId = "run-merge-replace";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Old step 1", status: "completed" },
+        { step: "Old step 2", status: "in_progress", activeForm: "Working" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: false,
+      plan: [{ step: "Brand new plan", status: "pending" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toEqual([{ step: "Brand new plan", status: "pending" }]);
+  });
+
+  it("two runs with different runIds maintain isolated plan state", async () => {
+    const runA = "run-iso-a";
+    const runB = "run-iso-b";
+    registerAgentRunContext(runA, {});
+    registerAgentRunContext(runB, {});
+    const toolA = createUpdatePlanTool({ runId: runA });
+    const toolB = createUpdatePlanTool({ runId: runB });
+
+    await toolA.execute("c1", { plan: [{ step: "A1", status: "completed" }] });
+    await toolB.execute("c2", {
+      plan: [{ step: "B1", status: "in_progress", activeForm: "Doing B1" }],
+    });
+
+    const resultA = await toolA.execute("c3", {
+      merge: true,
+      plan: [{ step: "A2", status: "pending" }],
+    });
+    const resultB = await toolB.execute("c4", {
+      merge: true,
+      plan: [{ step: "B2", status: "pending" }],
+    });
+
+    expect(getPlan(resultA).map((s) => s.step)).toEqual(["A1", "A2"]);
+    expect(getPlan(resultB).map((s) => s.step)).toEqual(["B1", "B2"]);
+  });
+
+  it("persists the merged plan back to AgentRunContext.lastPlanSteps", async () => {
+    const runId = "run-persist";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "S1", status: "completed" },
+        { step: "S2", status: "pending" },
+      ],
+    });
+
+    const ctx = getAgentRunContext(runId);
+    expect(ctx?.lastPlanSteps).toEqual([
+      { step: "S1", status: "completed" },
+      { step: "S2", status: "pending" },
+    ]);
+
+    await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "S2", status: "completed" }],
+    });
+
+    const ctxAfter = getAgentRunContext(runId);
+    expect(ctxAfter?.lastPlanSteps).toEqual([
+      { step: "S1", status: "completed" },
+      { step: "S2", status: "completed" },
+    ]);
+  });
+
+  it("emits an agent_plan_event when runId is set", async () => {
+    const runId = "run-emit";
+    const sessionKey = "session-emit-1";
+    registerAgentRunContext(runId, { sessionKey });
+    const tool = createUpdatePlanTool({ runId });
+
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", {
+        explanation: "Initial plan",
+        plan: [
+          { step: "Plan", status: "completed" },
+          { step: "Build", status: "in_progress", activeForm: "Building" },
+        ],
+      });
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      const planEvent = planEvents[0];
+      expect(planEvent.runId).toBe(runId);
+      expect(planEvent.sessionKey).toBe(sessionKey);
+      expect(planEvent.data).toMatchObject({
+        phase: "update",
+        title: "Plan updated",
+        explanation: "Initial plan",
+        steps: ["Plan", "Build"],
+        source: "update_plan",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("does NOT emit an agent_plan_event when runId is omitted", async () => {
+    const tool = createUpdatePlanTool();
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", { plan: [{ step: "S", status: "pending" }] });
+    } finally {
+      off();
+    }
+
+    expect(events.filter((e) => e.stream === "plan")).toHaveLength(0);
+  });
+
+  it("rejects merge that would yield two in_progress steps (Codex P1 r3096162551)", async () => {
+    const runId = "run-double-active";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    // Seed a plan with one in_progress step.
+    await tool.execute("c1", {
+      plan: [
+        { step: "Step A", status: "in_progress", activeForm: "Doing A" },
+        { step: "Step B", status: "pending" },
+      ],
+    });
+
+    // Merge a patch that marks a DIFFERENT step as in_progress without
+    // moving the old one off active. Final plan would have two in_progress —
+    // violates the tool's own invariant and breaks downstream renderers.
+    await expect(
+      tool.execute("c2", {
+        merge: true,
+        plan: [{ step: "Step B", status: "in_progress", activeForm: "Doing B" }],
+      }),
+    ).rejects.toThrow(/multiple in_progress steps/);
+  });
+
+  it("rejects merge=true patch with duplicate step text (Codex P2 r3096162555)", async () => {
+    // PR-B review fix (Copilot #3105169618): duplicate-step check is
+    // merge-only because step text is the join key. Replace mode
+    // legitimately allows repeated step text, so this test now asserts
+    // the merge-mode-specific behavior.
+    const runId = "run-dup-merge";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+    await expect(
+      tool.execute("c1", {
+        merge: true,
+        plan: [
+          { step: "Same step", status: "completed" },
+          { step: "Same step", status: "pending" },
+        ],
+      }),
+    ).rejects.toThrow(/duplicated within this update_plan call/);
+  });
+
+  it("allows replace-mode (no merge) patch with duplicate step text", async () => {
+    // PR-B review fix (Copilot #3105169618): replace mode does not use
+    // step text as a join key, so legitimate plans with repeated step
+    // text (e.g. "Run tests" twice in a CI workflow) must succeed.
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("c1", {
+      plan: [
+        { step: "Run tests", status: "pending" },
+        { step: "Build artifact", status: "pending" },
+        { step: "Run tests", status: "pending" }, // intentional repeat
+      ],
+    });
+    const plan = (result.details as Record<string, unknown>).plan as Array<Record<string, unknown>>;
+    expect(plan.map((p) => p.step)).toEqual(["Run tests", "Build artifact", "Run tests"]);
+  });
+
+  it("emits even when no AgentRunContext is registered (best-effort)", async () => {
+    const runId = "run-no-context";
+    // Note: we deliberately do NOT register a context for this run.
+    const tool = createUpdatePlanTool({ runId });
+
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", { plan: [{ step: "Solo step", status: "pending" }] });
+    } finally {
+      off();
+    }
+
+    const planEvents = events.filter((e) => e.stream === "plan");
+    expect(planEvents).toHaveLength(1);
+    expect(planEvents[0].runId).toBe(runId);
+    // No sessionKey since context was never registered.
+    expect(planEvents[0].sessionKey).toBeUndefined();
+  });
+});

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -1,12 +1,28 @@
 import { Type } from "@sinclair/typebox";
+import {
+  emitAgentPlanEvent,
+  getAgentRunContext,
+  type PlanStepSnapshot,
+} from "../../infra/agent-events.js";
 import { stringEnum } from "../schema/typebox.js";
 import {
   describeUpdatePlanTool,
   UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
-import { type AnyAgentTool, ToolInputError, readStringParam } from "./common.js";
+import {
+  type AnyAgentTool,
+  ToolInputError,
+  readStringArrayParam,
+  readStringParam,
+} from "./common.js";
 
-const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed"] as const;
+/**
+ * Allowed `update_plan` step statuses. Exported so other modules
+ * (`plan-hydration.ts`, hooks, channel renderers) can re-use the
+ * union instead of redefining a parallel string set.
+ */
+export const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed", "cancelled"] as const;
+export type PlanStepStatus = (typeof PLAN_STEP_STATUSES)[number];
 
 const UpdatePlanToolSchema = Type.Object({
   explanation: Type.Optional(
@@ -14,15 +30,48 @@ const UpdatePlanToolSchema = Type.Object({
       description: "Optional short note explaining what changed in the plan.",
     }),
   ),
+  merge: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true, update existing steps by matching step text and add new ones. " +
+        "When false (default), replace the entire plan.",
+    }),
+  ),
   plan: Type.Array(
     Type.Object(
       {
         step: Type.String({ description: "Short plan step." }),
         status: stringEnum(PLAN_STEP_STATUSES, {
-          description: 'One of "pending", "in_progress", or "completed".',
+          description: 'One of "pending", "in_progress", "completed", or "cancelled".',
         }),
+        activeForm: Type.Optional(
+          Type.String({
+            description:
+              'Present-continuous form shown while in_progress (e.g. "Running tests"). ' +
+              "Accepted on any status but only rendered for in_progress steps.",
+          }),
+        ),
+        // PR-9 Wave B1 — closure gate fields. Optional; backwards-compatible.
+        acceptanceCriteria: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              "Optional list of concrete acceptance criteria the agent will explicitly verify " +
+              "before this step can be marked completed. Examples: 'tests pass', " +
+              "'cortex_owner is set on the live VM', 'PR review is approved'. " +
+              "When present, the runtime rejects status='completed' until verifiedCriteria " +
+              "covers every entry. Use this for steps where premature closure has high cost.",
+          }),
+        ),
+        verifiedCriteria: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              "Strings from acceptanceCriteria the agent has explicitly checked against live state " +
+              "(e.g., after running a verification command). Update incrementally via merge mode " +
+              "as each criterion is confirmed. Must be a subset of acceptanceCriteria.",
+          }),
+        ),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
     {
       minItems: 1,
@@ -31,9 +80,12 @@ const UpdatePlanToolSchema = Type.Object({
   ),
 });
 
-type UpdatePlanStep = {
+export type UpdatePlanStep = {
   step: string;
-  status: (typeof PLAN_STEP_STATUSES)[number];
+  status: PlanStepStatus;
+  activeForm?: string;
+  acceptanceCriteria?: string[];
+  verifiedCriteria?: string[];
 };
 
 function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
@@ -55,15 +107,90 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
       required: true,
       label: `plan[${index}].status`,
     });
-    if (!PLAN_STEP_STATUSES.includes(status as (typeof PLAN_STEP_STATUSES)[number])) {
+    if (!PLAN_STEP_STATUSES.includes(status as PlanStepStatus)) {
       throw new ToolInputError(
         `plan[${index}].status must be one of ${PLAN_STEP_STATUSES.join(", ")}`,
       );
     }
-    return {
-      step,
-      status: status as (typeof PLAN_STEP_STATUSES)[number],
-    };
+    const activeForm = readStringParam(stepParams, "activeForm");
+    // PR-9 Wave B1 — parse + validate optional closure-gate fields.
+    const acceptanceCriteria = readStringArrayParam(stepParams, "acceptanceCriteria", {
+      label: `plan[${index}].acceptanceCriteria`,
+    });
+    const verifiedCriteria = readStringArrayParam(stepParams, "verifiedCriteria", {
+      label: `plan[${index}].verifiedCriteria`,
+    });
+    if (verifiedCriteria && acceptanceCriteria) {
+      // verifiedCriteria must be a subset of acceptanceCriteria. This
+      // catches the agent verifying a criterion that no longer exists
+      // after a plan revision (typo, drift) — surface it loudly so the
+      // step doesn't get a phantom checkmark.
+      //
+      // Adversarial review #3: compare on TRIMMED text to tolerate
+      // trailing/leading whitespace differences between the agent's
+      // declared acceptance text and its later verified text. Strict
+      // string equality is fragile: "Foo" vs "Foo " is the same
+      // intent to a human and shouldn't trip the gate.
+      const criteriaSet = new Set(acceptanceCriteria.map((c) => c.trim()));
+      for (const v of verifiedCriteria) {
+        if (!criteriaSet.has(v.trim())) {
+          throw new ToolInputError(
+            `plan[${index}].verifiedCriteria entry "${v}" is not in acceptanceCriteria — ` +
+              "verified criteria must match an acceptance criterion (whitespace-trimmed equality)",
+          );
+        }
+      }
+    }
+    if (verifiedCriteria && !acceptanceCriteria) {
+      throw new ToolInputError(
+        `plan[${index}].verifiedCriteria requires plan[${index}].acceptanceCriteria to be set`,
+      );
+    }
+    // Closure gate: refuse status:"completed" when criteria are present
+    // but unverified. This is the heart of B1 — it turns "done" from a
+    // vibe into a contract.
+    //
+    // Empty `acceptanceCriteria: []` is treated as "no criteria, no
+    // gate" (intentional — lets the agent declare a step as
+    // gate-eligible later via merge mode without forcing one upfront).
+    // Adversarial review #6: documented here explicitly so the
+    // empty-array semantics are intentional, not accidental.
+    if (
+      status === "completed" &&
+      acceptanceCriteria &&
+      acceptanceCriteria.length > 0 &&
+      (!verifiedCriteria || verifiedCriteria.length < acceptanceCriteria.length)
+    ) {
+      // Use trimmed comparison to mirror the subset-check tolerance above.
+      const verifiedSet = new Set((verifiedCriteria ?? []).map((c) => c.trim()));
+      const missing = acceptanceCriteria.filter((c) => !verifiedSet.has(c.trim()));
+      throw new ToolInputError(
+        `plan[${index}].status cannot be "completed" — ${missing.length} acceptance ` +
+          `criteria not yet verified: ${missing.map((m) => `"${m}"`).join(", ")}. ` +
+          "Verify them against live state, then set verifiedCriteria to include each one " +
+          "before marking the step completed.",
+      );
+    }
+    // oxc no-map-spread: build the step record with conditional
+    // assignment instead of conditional spread to avoid per-iteration
+    // object allocations from `...(cond ? { … } : {})`.
+    const stepRecord: {
+      step: string;
+      status: PlanStepStatus;
+      activeForm?: string;
+      acceptanceCriteria?: string[];
+      verifiedCriteria?: string[];
+    } = { step, status: status as PlanStepStatus };
+    if (activeForm) {
+      stepRecord.activeForm = activeForm;
+    }
+    if (acceptanceCriteria) {
+      stepRecord.acceptanceCriteria = acceptanceCriteria;
+    }
+    if (verifiedCriteria) {
+      stepRecord.verifiedCriteria = verifiedCriteria;
+    }
+    return stepRecord;
   });
 
   const inProgressCount = steps.filter((entry) => entry.status === "in_progress").length;
@@ -73,21 +200,272 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
   return steps;
 }
 
-export function createUpdatePlanTool(): AnyAgentTool {
+/**
+ * Reject duplicate step TEXT within a single incoming patch when merge
+ * mode is requested (Copilot #3105169618 / Codex P2 on PR #67514).
+ * Merge mode keys steps by `step` text — if the patch contains two
+ * entries with the same step text, the second clobbers the first, and
+ * they collide on the same map key when matching against the previous
+ * plan, silently rewriting unrelated history. Replace mode does not
+ * use step text as a join key, so legitimate plans with repeated step
+ * text (e.g. "Run tests" twice in a CI workflow) are allowed there.
+ */
+function rejectDuplicateStepTextForMerge(steps: UpdatePlanStep[]): void {
+  const seenSteps = new Set<string>();
+  for (let i = 0; i < steps.length; i += 1) {
+    const stepText = steps[i].step;
+    if (seenSteps.has(stepText)) {
+      throw new ToolInputError(
+        `plan[${i}].step ("${stepText}") is duplicated within this update_plan ` +
+          "call. Step text must be unique in merge mode because it is the join key. " +
+          "Either rename the duplicate, or omit `merge: true` if you intentionally " +
+          "want repeated step text.",
+      );
+    }
+    seenSteps.add(stepText);
+  }
+}
+
+/**
+ * Merges incoming plan steps into existing ones by matching `step` text.
+ * - Existing steps keep their original order.
+ * - Overlapping steps update their status/activeForm from incoming.
+ * - Novel incoming steps are appended in the order they appear.
+ * Adapted from `src/agents/plan-store.ts:204` on the
+ * `phase4/cross-session-plans` branch (in-memory variant — no
+ * `updatedBy`/`updatedAt` attribution, since this layer doesn't own
+ * cross-session persistence).
+ */
+function mergeSteps(existing: UpdatePlanStep[], incoming: UpdatePlanStep[]): UpdatePlanStep[] {
+  const incomingByStep = new Map<string, UpdatePlanStep>();
+  for (const s of incoming) {
+    if (!incomingByStep.has(s.step)) {
+      incomingByStep.set(s.step, s);
+    }
+  }
+  const existingTexts = new Set(existing.map((s) => s.step));
+  const merged: UpdatePlanStep[] = existing.map((s) => {
+    const update = incomingByStep.get(s.step);
+    if (!update) {
+      return s;
+    }
+    // PR-9 Wave B1 + PR-B review fix (Copilot #3096520563 / #3105169615):
+    // preserve fields when the incoming patch omits them. This makes
+    // merge mode token-efficient — a patch that only intends to change
+    // `status` does NOT need to re-include `activeForm` or the
+    // closure-gate fields just to keep them.
+    // - activeForm: incoming wins, falling back to existing when omitted.
+    //   (Pre-fix: incoming-undefined cleared the existing activeForm.)
+    // - acceptanceCriteria: incoming wins (allows the agent to refine
+    //   criteria mid-plan), falling back to existing when omitted.
+    // - verifiedCriteria: incoming wins (the merge represents the
+    //   agent's latest declared verification state). Re-validation
+    //   against acceptanceCriteria already happened in readPlanSteps.
+    return {
+      step: update.step,
+      status: update.status,
+      ...(update.activeForm !== undefined
+        ? { activeForm: update.activeForm }
+        : s.activeForm !== undefined
+          ? { activeForm: s.activeForm }
+          : {}),
+      ...(update.acceptanceCriteria !== undefined
+        ? { acceptanceCriteria: update.acceptanceCriteria }
+        : s.acceptanceCriteria !== undefined
+          ? { acceptanceCriteria: s.acceptanceCriteria }
+          : {}),
+      ...(update.verifiedCriteria !== undefined
+        ? { verifiedCriteria: update.verifiedCriteria }
+        : s.verifiedCriteria !== undefined
+          ? { verifiedCriteria: s.verifiedCriteria }
+          : {}),
+    };
+  });
+  const appended = new Set<string>();
+  for (const s of incoming) {
+    if (!existingTexts.has(s.step) && !appended.has(s.step)) {
+      merged.push({
+        step: s.step,
+        status: s.status,
+        ...(s.activeForm !== undefined ? { activeForm: s.activeForm } : {}),
+        ...(s.acceptanceCriteria !== undefined ? { acceptanceCriteria: s.acceptanceCriteria } : {}),
+        ...(s.verifiedCriteria !== undefined ? { verifiedCriteria: s.verifiedCriteria } : {}),
+      });
+      appended.add(s.step);
+    }
+  }
+  return merged;
+}
+
+export interface CreateUpdatePlanToolOptions {
+  /**
+   * Stable run identifier. When provided, merge mode reads the previous
+   * plan from `AgentRunContext.lastPlanSteps` and writes the merged
+   * result back. When omitted, merge mode falls back to replace
+   * (no previous plan available — useful for tests/standalone).
+   */
+  runId?: string;
+}
+
+export function createUpdatePlanTool(options?: CreateUpdatePlanToolOptions): AnyAgentTool {
+  const runId = options?.runId;
   return {
     label: "Update Plan",
     name: "update_plan",
     displaySummary: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     description: describeUpdatePlanTool(),
     parameters: UpdatePlanToolSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, _signal) => {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
-      const plan = readPlanSteps(params);
+      const merge = typeof params.merge === "boolean" ? params.merge : false;
+      const incomingSteps = readPlanSteps(params);
+      // Duplicate-step check is a merge-mode concern only (the join key
+      // collision); replace mode legitimately allows repeated step text.
+      if (merge) {
+        rejectDuplicateStepTextForMerge(incomingSteps);
+      }
+
+      const ctx = runId ? getAgentRunContext(runId) : undefined;
+      const previousSteps = (ctx?.lastPlanSteps ?? []) as UpdatePlanStep[];
+      const plan: UpdatePlanStep[] =
+        merge && previousSteps.length > 0
+          ? mergeSteps(previousSteps, incomingSteps)
+          : incomingSteps;
+
+      // Re-validate the active-step invariant on the MERGED plan
+      // (Codex P1 on PR #67514): readPlanSteps only enforces the
+      // single-in_progress rule on the incoming patch, but merge can
+      // still produce a final plan with two in_progress entries when
+      // the previous plan had one in_progress step and the patch marks
+      // a different step as in_progress. The tool's own contract — and
+      // downstream renderers — assume at most one active step.
+      const mergedInProgress = plan.filter((s) => s.status === "in_progress").length;
+      if (mergedInProgress > 1) {
+        throw new ToolInputError(
+          "merge would produce a plan with multiple in_progress steps; " +
+            "explicitly mark the prior in_progress step as completed/cancelled in the same patch",
+        );
+      }
+
+      // PR-11 review fix (Codex P1 #3105040898): re-validate closure
+      // criteria on the MERGED plan. `readPlanSteps` enforces
+      // acceptanceCriteria + verifiedCriteria coherence on the
+      // incoming patch only — but merge can produce a step with
+      // status "completed" while inherited acceptanceCriteria from
+      // the prior snapshot remain unverified (the patch omits the
+      // verifiedCriteria field, so the merged step keeps the prior
+      // empty/partial verified set). Closure gate must reject these
+      // so completion flows don't fire on unmet contracts.
+      for (const step of plan) {
+        if (step.status !== "completed") {
+          continue;
+        }
+        const ac = step.acceptanceCriteria;
+        if (!ac || ac.length === 0) {
+          continue; // no criteria declared → no gate to enforce
+        }
+        const verified = new Set(
+          (step.verifiedCriteria ?? []).map((c) => c.replace(/[\n\r]+/g, " ").trim()),
+        );
+        const unmet = ac.filter((c) => !verified.has(c.replace(/[\n\r]+/g, " ").trim()));
+        if (unmet.length > 0) {
+          const sample = unmet.slice(0, 3).join("; ");
+          const more = unmet.length > 3 ? ` (+${unmet.length - 3} more)` : "";
+          throw new ToolInputError(
+            `merge would mark step "${step.step}" as completed with ${unmet.length} unverified ` +
+              `acceptance criteria: ${sample}${more}. ` +
+              `Either include the verified criteria in this update_plan call, or do not transition ` +
+              `to status:"completed" until all acceptance criteria are met.`,
+          );
+        }
+      }
+
+      // Persist for next merge in this run. Snapshot stored as
+      // `PlanStepSnapshot[]` (structural superset of `UpdatePlanStep[]`).
+      // PR-9 Wave B1: include closure-gate fields so the persister and
+      // UI can render acceptance / verified state after a refresh.
+      if (ctx) {
+        ctx.lastPlanSteps = plan.map<PlanStepSnapshot>((s) => ({
+          step: s.step,
+          status: s.status,
+          ...(s.activeForm !== undefined ? { activeForm: s.activeForm } : {}),
+          ...(s.acceptanceCriteria !== undefined
+            ? { acceptanceCriteria: s.acceptanceCriteria }
+            : {}),
+          ...(s.verifiedCriteria !== undefined ? { verifiedCriteria: s.verifiedCriteria } : {}),
+        }));
+      }
+
+      // PR-9 Wave A2: detect plan completion. A plan is "complete" when
+      // every step has terminal status ("completed" or "cancelled"). In
+      // that case we emit a second event with phase: "completed" so the
+      // gateway-side `plan-snapshot-persister` can auto-flip
+      // `SessionEntry.planMode.mode` back to "normal". This addresses
+      // the user's "does the plan actually close when complete?" concern
+      // — previously the agent had to manually call `exit_plan_mode` or
+      // toggle off via `/plan off`; now completion is structural.
+      const allTerminal =
+        plan.length > 0 && plan.every((s) => s.status === "completed" || s.status === "cancelled");
+
+      // Emit `agent_plan_event` so channel renderers + control UI see updates.
+      // Skip emit when we have no runId — that's the standalone/test path.
+      //
+      // PR-10 review fix (Codex P2 #3104743333 — option C selected):
+      // include the structured `mergedSteps` (status/activeForm/
+      // acceptanceCriteria/verifiedCriteria), not just step labels.
+      // Under merge mode the tool INPUT is only a delta; UI subscribers
+      // need the merged result to render the sidebar correctly. The
+      // existing `steps` field stays as legacy for backwards compat.
+      const mergedSteps = plan.map((s) => ({
+        step: s.step,
+        status: s.status,
+        ...(s.activeForm !== undefined ? { activeForm: s.activeForm } : {}),
+        ...(s.acceptanceCriteria !== undefined ? { acceptanceCriteria: s.acceptanceCriteria } : {}),
+        ...(s.verifiedCriteria !== undefined ? { verifiedCriteria: s.verifiedCriteria } : {}),
+      }));
+      if (runId) {
+        emitAgentPlanEvent({
+          runId,
+          ...(ctx?.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+          data: {
+            phase: "update",
+            title: "Plan updated",
+            ...(explanation ? { explanation } : {}),
+            steps: plan.map((s) => s.step),
+            mergedSteps,
+            source: "update_plan",
+          },
+        });
+        if (allTerminal) {
+          emitAgentPlanEvent({
+            runId,
+            ...(ctx?.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+            data: {
+              phase: "completed",
+              title: "Plan complete",
+              steps: plan.map((s) => s.step),
+              mergedSteps,
+              source: "update_plan",
+            },
+          });
+        }
+      }
+
+      // PR-8 follow-up: return non-empty content. Empty content arrays
+      // trip third-party transcript-pairing extensions (lossless-claw)
+      // which inject `[lossless-claw] missing tool result` placeholders
+      // into the agent's read-time context, polluting it with synthetic
+      // errors. Non-empty content satisfies the pairing check and keeps
+      // the agent's view of past turns clean.
+      const stepCount = plan.length;
+      const summaryLine = allTerminal
+        ? `Plan complete (${stepCount} ${stepCount === 1 ? "step" : "steps"}).`
+        : `Plan updated (${stepCount} ${stepCount === 1 ? "step" : "steps"}).`;
       return {
-        content: [],
+        content: [{ type: "text" as const, text: summaryLine }],
         details: {
-          status: "updated" as const,
+          status: allTerminal ? ("completed" as const) : ("updated" as const),
           ...(explanation ? { explanation } : {}),
           plan,
         },

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -35,6 +35,18 @@ export type SkillsLimitsConfig = {
   maxSkillsPromptChars?: number;
   /** Max size (bytes) allowed for a SKILL.md file to be considered. */
   maxSkillFileBytes?: number;
+  /**
+   * Max number of plan-template steps a single skill may seed via the
+   * activation seed event at activation. Templates exceeding this
+   * length are truncated and a `skill_plan_template_truncated` warning
+   * is logged via `logWarn` (not emitted as a structured event).
+   * Default: 50.
+   *
+   * PR-E review fix (Copilot #3096799672 / #3096799692): doc previously
+   * said "warning event is emitted" — implementation only calls
+   * `logWarn`. Updated to "warning is logged" to match behavior.
+   */
+  maxPlanTemplateSteps?: number;
 };
 
 export type SkillsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -929,6 +929,14 @@ export const OpenClawSchema = z
             maxSkillsInPrompt: z.number().int().min(0).optional(),
             maxSkillsPromptChars: z.number().int().min(0).optional(),
             maxSkillFileBytes: z.number().int().min(0).optional(),
+            // #67541: cap on plan-template steps a single skill may seed
+            // via the activation seed event. Templates exceeding this
+            // length are truncated and a `skill_plan_template_truncated`
+            // warning is logged via `logWarn` (not emitted as a
+            // structured event). Default 50 (see DEFAULT_MAX_PLAN_TEMPLATE_STEPS).
+            // PR-E review fix (Copilot #3096799692): doc said "emitted"
+            // — implementation only logs.
+            maxPlanTemplateSteps: z.number().int().min(1).optional(),
           })
           .strict()
           .optional(),

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -45,16 +45,62 @@ export type AgentItemEventData = {
 };
 
 export type AgentPlanEventData = {
-  phase: "update";
+  /**
+   * - "update": normal plan update from `update_plan` (also fires on
+   *   plan-template seed and planning-only retry detection).
+   * - "completed": PR-9 Wave A2 — emitted by `update_plan` when every
+   *   step in the merged plan has terminal status (`completed` or
+   *   `cancelled`). The gateway-side persister listens for this phase
+   *   and auto-flips `SessionEntry.planMode.mode` back to `"normal"`
+   *   so mutations stay unlocked and the user-visible "plan complete"
+   *   state is consistent with persisted session state.
+   */
+  phase: "update" | "completed";
   title: string;
   explanation?: string;
+  /** Step labels only (legacy). Kept for backwards compatibility. */
   steps?: string[];
+  /**
+   * PR-10 review fix (Codex P2 #3104743333 escalated → option C):
+   * full structured merged plan after `update_plan` execution
+   * (status / activeForm / acceptanceCriteria / verifiedCriteria).
+   *
+   * Pre-fix the UI sidebar refresh in `app-tool-stream.ts` read
+   * `data.args` (the tool INPUT at start time). Under
+   * `update_plan { merge: true }` the input is a delta, not the merged
+   * result, so the sidebar drifted out of sync with the actual plan
+   * state. Solving via a structured `mergedSteps` field on the
+   * existing `agent_plan_event` channel — no new event type, no
+   * SessionEntry hot-path read, and the persister already subscribes
+   * to this stream so its own logic doesn't change.
+   *
+   * UI subscribers should prefer this over the legacy `steps`
+   * field when present.
+   */
+  mergedSteps?: Array<{
+    step: string;
+    status: string;
+    activeForm?: string;
+    acceptanceCriteria?: string[];
+    verifiedCriteria?: string[];
+  }>;
   source?: string;
 };
 
 export type AgentApprovalEventPhase = "requested" | "resolved";
 export type AgentApprovalEventStatus = "pending" | "unavailable" | "approved" | "denied" | "failed";
 export type AgentApprovalEventKind = "exec" | "plugin" | "unknown";
+
+/**
+ * Plan-step shape carried by plan-kind approval events (PR-8 follow-up).
+ * Mirrors the runtime `update_plan` step shape but kept independent so
+ * `agent-events.ts` doesn't depend on the agents layer.
+ */
+export type AgentApprovalPlanStep = {
+  step: string;
+  status: string;
+  activeForm?: string;
+};
 
 export type AgentApprovalEventData = {
   phase: AgentApprovalEventPhase;
@@ -69,6 +115,44 @@ export type AgentApprovalEventData = {
   host?: string;
   reason?: string;
   message?: string;
+  /**
+   * Plan-mode approval payload (PR-8). Present only when `kind === "plugin"`
+   * and the underlying tool was `exit_plan_mode`. The UI/channel renderers
+   * use this to show the plan checklist with Approve/Reject/Edit buttons.
+   */
+  plan?: AgentApprovalPlanStep[];
+  /** One-line summary the agent included with the proposed plan. */
+  summary?: string;
+  // PR-10 plan-archetype fields. All optional and additive — channel
+  // renderers / UI cards display them when present, fall back to
+  // plan + summary when omitted.
+  /** Markdown body explaining current state, chosen approach, and rationale. */
+  analysis?: string;
+  /** Explicit assumptions made during planning. */
+  assumptions?: string[];
+  /** Risk register with mitigations. */
+  risks?: Array<{ risk: string; mitigation: string }>;
+  /** Concrete steps that will confirm the plan succeeded. */
+  verification?: string[];
+  /** File paths, URLs, PR numbers, doc references the plan builds on. */
+  references?: string[];
+  /**
+   * PR-10 AskUserQuestion: when present, this approval is a clarifying
+   * question rather than a plan submission. UI renders the question +
+   * one button per option; the chosen answer is routed back via
+   * sessions.patch { planApproval: { action: "answer", answer: <choice> }}.
+   * `kind` stays "plugin" — the approval pipeline is shared.
+   */
+  question?: {
+    prompt: string;
+    options: string[];
+    allowFreetext?: boolean;
+    /**
+     * Stable id for this question (separate from approvalId) so the UI
+     * can correlate option text → answer when freetext is also allowed.
+     */
+    questionId?: string;
+  };
 };
 
 export type AgentCommandOutputEventData = {
@@ -105,6 +189,37 @@ export type AgentEventPayload = {
   sessionKey?: string;
 };
 
+/**
+ * Snapshot of a plan step persisted on the run context for #67514's
+ * merge mode. Stored as a structural type to avoid pulling agent/tool
+ * types into the infra layer. The string-typed `status` matches the
+ * runtime `PLAN_STEP_STATUSES` union exported from
+ * `src/agents/tools/update-plan-tool.ts`.
+ */
+export type PlanStepSnapshot = {
+  step: string;
+  status: string;
+  activeForm?: string;
+  /**
+   * PR-9 Wave B1 — closure gate. Optional list of acceptance criteria
+   * the agent must explicitly verify before this step can transition to
+   * `status: "completed"`. When present, `update_plan` rejects the
+   * transition unless `verifiedCriteria` covers every entry in
+   * `acceptanceCriteria` (string-equality match).
+   *
+   * Backwards-compatible: omit both fields and the step behaves
+   * identically to the prior shape (no gating).
+   */
+  acceptanceCriteria?: string[];
+  /**
+   * Strings from `acceptanceCriteria` the agent has explicitly checked
+   * against live state. The agent calls `update_plan` with the same
+   * step text plus an updated `verifiedCriteria` array as it confirms
+   * each criterion (e.g., after running a verification command).
+   */
+  verifiedCriteria?: string[];
+};
+
 export type AgentRunContext = {
   sessionKey?: string;
   verboseLevel?: VerboseLevel;
@@ -115,22 +230,327 @@ export type AgentRunContext = {
   registeredAt?: number;
   /** Timestamp of last activity (updated on every emitAgentEvent). */
   lastActiveAt?: number;
+  /**
+   * Last plan steps seen by `update_plan` in this run (#67514). Used by
+   * merge mode to compute the merged plan against the previous state.
+   * In-memory only — survives within a run, cleared with the context.
+   * Disk-persistence (cross-session) is owned by `PlanStore` (#67542).
+   */
+  lastPlanSteps?: PlanStepSnapshot[];
+  /**
+   * PR-8 follow-up: set of child subagent run ids spawned by this run
+   * that have not completed yet. Populated by `sessions_spawn` at spawn
+   * time and drained by the subagent completion hook. `exit_plan_mode`
+   * consults this set to reject plan submission while research children
+   * are in flight — matches the user's explicit rule "wait for all
+   * expected research children before submitting the plan".
+   *
+   * Stored as a `Set` so spawn/complete are O(1); ordering is not
+   * semantically meaningful, only membership.
+   */
+  openSubagentRunIds?: Set<string>;
+  /**
+   * PR-8 follow-up: whether the parent session is currently in plan mode
+   * (mirrored from `SessionEntry.planMode.mode === "plan"` at context
+   * registration). Used by `sessions_spawn` to force `cleanup: "keep"`
+   * on plan-mode-spawned children so they stay visible in the session
+   * menu for the user to inspect during plan synthesis. Kept on the
+   * context to avoid a session-store read on every spawn.
+   */
+  inPlanMode?: boolean;
+  /**
+   * PR-8 follow-up Round 2: current plan-approval state mirrored from
+   * `SessionEntry.planMode.approval`. Used by the yield-after-approval
+   * detector (`resolveYieldDuringApprovedPlanInstruction`) to decide
+   * whether an unexplained yield should trigger a "continue execution"
+   * retry steer. Values: `"none" | "pending" | "approved" | "edited" |
+   * "rejected" | "timed_out"`.
+   */
+  planApproval?: string;
+  /**
+   * PR-11 review fix (Codex P2 #3105311664 — escalation cluster):
+   * epoch-ms timestamp from `SessionEntry.recentlyApprovedAt`,
+   * mirrored at context-registration time. Lets the yield-after-approval
+   * detector fire within the post-approval grace window even AFTER
+   * sessions.patch has cleared planMode (mode → "normal" deletes the
+   * planMode object, so `planApproval` becomes undefined — this field
+   * survives that cleanup because it's written at the SessionEntry
+   * root level).
+   */
+  recentlyApprovedAt?: number;
+  /**
+   * PR-15: synthetic user-message text mirrored from
+   * `SessionEntry.pendingAgentInjection`. The runtime prepends this to
+   * the user's next-turn input AND clears the field via
+   * `sessions.patch` so the injection only fires once.
+   *
+   * Single source of truth for inject-on-next-turn signals — written
+   * by gateway-side handlers like `sessions.patch { planApproval:
+   * action: "answer" }` (`[QUESTION_ANSWER]: <text>`),
+   * `action: "approve"/"edit"/"reject"` (`[PLAN_DECISION]: ...`).
+   * Replaces the prior pattern where each caller (webchat /
+   * Telegram / Discord / Slack `/plan answer` paths) had to inject
+   * via the channel's message-send infrastructure (which leaked the
+   * synthetic marker into user-visible chat history).
+   */
+  pendingAgentInjection?: string;
+  /**
+   * Bug 3+4 fix: live-read accessor for the session's current planMode.
+   * Returns the LATEST mode from the in-memory SessionEntry on every
+   * call (O(1) map lookup, no disk I/O), bypassing the stale
+   * `inPlanMode`/`planApproval` snapshots captured at run-start.
+   *
+   * Used by the mutation gate (`pi-tools.before-tool-call.ts`) to
+   * avoid the cached-state divergence where:
+   *   1. Agent enters plan mode → ctx.planMode === "plan" cached
+   *   2. Agent submits exit_plan_mode → user approves
+   *   3. sessions.patch flips SessionEntry.planMode → "normal"
+   *   4. Same agent run continues executing
+   *   5. ctx.planMode is STILL "plan" → mutation gate blocks
+   *      mutations even though approval already cleared the gate
+   *
+   * Returning `undefined` is fine — caller falls back to the cached
+   * snapshot. Optional so test contexts and unit fixtures don't have
+   * to provide it.
+   */
+  getLatestPlanMode?: () => "plan" | "normal" | undefined;
+  /**
+   * Live-read accessor for `SessionEntry.postApprovalPermissions.
+   * acceptEdits`. Returns `true` only when the user approved the plan
+   * with "Accept, allow edits" (granting the agent permission to
+   * self-modify the plan at ≥95% confidence). Used by the acceptEdits
+   * constraint gate to block destructive / self-restart / config-
+   * change actions even when general normal-mode execution is allowed.
+   */
+  getLatestAcceptEdits?: () => boolean;
+  /**
+   * Timestamp (ms since epoch) of the most-recent `openSubagentRunIds`
+   * drain-to-zero event. Used by the subagent grace-window gate in
+   * `exit_plan_mode` and in `sessions.patch { planApproval }` so a
+   * parent can't submit a plan OR the user can't approve one in the
+   * instant after a subagent completion — the short window lets
+   * completion events propagate and announce-turns settle before the
+   * approval flow proceeds.
+   *
+   * Undefined when no subagent has ever been spawned (or completed) in
+   * this run. The grace gate short-circuits on undefined (no grace
+   * window to enforce).
+   */
+  lastSubagentSettledAt?: number;
 };
 
 type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
+  persistPlanModeSubagentGateState?: (
+    params: PersistPlanModeSubagentGateStateParams,
+  ) => Promise<void> | void;
 };
 
 const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
+
+type PersistPlanModeSubagentGateStateParams = {
+  sessionKey?: string;
+  mutate: (planMode: {
+    blockingSubagentRunIds?: string[];
+    lastSubagentSettledAt?: number;
+    updatedAt?: number;
+    mode?: string;
+  }) => void;
+};
 
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
     listeners: new Set<(evt: AgentEventPayload) => void>(),
     runContextById: new Map<string, AgentRunContext>(),
+    persistPlanModeSubagentGateState: undefined,
   }));
+}
+
+function persistPlanModeSubagentGateState(params: PersistPlanModeSubagentGateStateParams): void {
+  if (!params.sessionKey) {
+    return;
+  }
+  const handler = getAgentEventState().persistPlanModeSubagentGateState;
+  if (!handler) {
+    return;
+  }
+  void Promise.resolve(handler(params)).catch(() => {
+    // best-effort only; approval gate still has the in-memory fallback
+  });
+}
+
+export function setPlanModeSubagentGatePersistenceHandler(
+  handler: AgentEventState["persistPlanModeSubagentGateState"],
+): () => void {
+  const state = getAgentEventState();
+  state.persistPlanModeSubagentGateState = handler;
+  return () => {
+    if (state.persistPlanModeSubagentGateState === handler) {
+      state.persistPlanModeSubagentGateState = undefined;
+    }
+  };
+}
+
+export function trackOpenSubagentForParent(parentRunId: string, childRunId: string): void {
+  if (!parentRunId || !childRunId) {
+    return;
+  }
+  const ctx = getAgentEventState().runContextById.get(parentRunId);
+  if (!ctx) {
+    return;
+  }
+  if (!ctx.openSubagentRunIds) {
+    ctx.openSubagentRunIds = new Set();
+  }
+  ctx.openSubagentRunIds.add(childRunId);
+  delete ctx.lastSubagentSettledAt;
+  if (ctx.inPlanMode === true && ctx.sessionKey) {
+    persistPlanModeSubagentGateState({
+      sessionKey: ctx.sessionKey,
+      mutate: (planMode) => {
+        const nextIds = new Set(planMode.blockingSubagentRunIds ?? []);
+        nextIds.add(childRunId);
+        planMode.blockingSubagentRunIds = [...nextIds];
+        delete planMode.lastSubagentSettledAt;
+      },
+    });
+  }
+}
+
+export function replaceOpenSubagentRunIdInParents(previousRunId: string, nextRunId: string): void {
+  if (!previousRunId || !nextRunId || previousRunId === nextRunId) {
+    return;
+  }
+  const state = getAgentEventState();
+  for (const ctx of state.runContextById.values()) {
+    const set = ctx.openSubagentRunIds;
+    if (!set || !set.has(previousRunId)) {
+      continue;
+    }
+    set.delete(previousRunId);
+    set.add(nextRunId);
+    if (ctx.inPlanMode === true && ctx.sessionKey) {
+      persistPlanModeSubagentGateState({
+        sessionKey: ctx.sessionKey,
+        mutate: (planMode) => {
+          const nextIds = new Set(planMode.blockingSubagentRunIds ?? []);
+          if (!nextIds.delete(previousRunId)) {
+            return;
+          }
+          nextIds.add(nextRunId);
+          planMode.blockingSubagentRunIds = [...nextIds];
+        },
+      });
+    }
+  }
+}
+
+/**
+ * PR-8 follow-up: called by the subagent registry when a child run ends.
+ * Scans all registered parent run contexts and removes the completed
+ * child's runId from any `openSubagentRunIds` set it appears in. The
+ * typical concurrency is 1-3 open children per parent, so an O(N) scan
+ * across parents is cheap (N is the number of concurrent active runs,
+ * usually single digits).
+ *
+ * Keeps the drain logic in the same module that owns the set, rather
+ * than exposing `AgentRunContext` internals to the registry layer.
+ *
+ * PR #68939 follow-up (drain-leak fix): the in-memory parent ctx may
+ * have already been GC'd before the subagent settles. The auto-approve
+ * flow makes this the COMMON case: parent calls `exit_plan_mode` →
+ * auto-approve fails because subagent is still running → parent run
+ * ends → subagent settles AFTER the parent ctx is gone. Without a
+ * fallback, `hadChild` returns false on every ctx, the persisted
+ * `blockingSubagentRunIds` set on the requester session is NEVER
+ * cleaned, and the leaked runId permanently blocks every future
+ * approval attempt on that session.
+ *
+ * The registry knows `entry.requesterSessionKey` even after the parent
+ * ctx is gone. Pass it as `fallbackSessionKey` so the persist layer can
+ * scrub the leaked runId from the right session even when no live ctx
+ * is available.
+ */
+export function drainCompletedSubagentFromParents(
+  childRunId: string,
+  fallbackSessionKey?: string,
+): void {
+  const state = getAgentEventState();
+  const now = Date.now();
+  let persistRemovalFiredFromCtx = false;
+  for (const ctx of state.runContextById.values()) {
+    const set = ctx.openSubagentRunIds;
+    if (!set) {
+      continue;
+    }
+    const hadChild = set.delete(childRunId);
+    // Grace-window fix: when this drain brings the set to zero, stamp
+    // the settle time so the exit_plan_mode tool-side gate and the
+    // sessions.patch approval-side gate can both enforce a short
+    // post-completion delay. Prevents the announce-turn-races-the-
+    // approval-resume-turn failure mode.
+    if (hadChild && set.size === 0) {
+      ctx.lastSubagentSettledAt = now;
+    }
+    if (hadChild && ctx.inPlanMode === true && ctx.sessionKey) {
+      persistRemovalFiredFromCtx = true;
+      persistPlanModeSubagentGateState({
+        sessionKey: ctx.sessionKey,
+        mutate: (planMode) => {
+          const nextIds = new Set(planMode.blockingSubagentRunIds ?? []);
+          nextIds.delete(childRunId);
+          planMode.blockingSubagentRunIds = [...nextIds];
+          if (nextIds.size === 0) {
+            planMode.lastSubagentSettledAt = now;
+          }
+        },
+      });
+    }
+  }
+  // Fallback path: no in-memory parent ctx had the runId. The parent
+  // run was likely already evicted (auto-approve flow described above).
+  // Address the persisted set on the requester session directly.
+  if (!persistRemovalFiredFromCtx && fallbackSessionKey) {
+    persistPlanModeSubagentGateState({
+      sessionKey: fallbackSessionKey,
+      mutate: (planMode) => {
+        const nextIds = new Set(planMode.blockingSubagentRunIds ?? []);
+        if (!nextIds.delete(childRunId)) {
+          // Not actually leaked on this session — nothing to do. Avoids a
+          // pointless write that would bump `updatedAt` for no reason.
+          return;
+        }
+        planMode.blockingSubagentRunIds = [...nextIds];
+        if (nextIds.size === 0) {
+          planMode.lastSubagentSettledAt = now;
+        }
+      },
+    });
+  }
+}
+
+/**
+ * PR-9 Wave A2: called by the gateway-side plan-snapshot persister
+ * when a plan structurally completes (all steps terminal). Clears the
+ * `inPlanMode` flag on every run context for the given session so that
+ * subsequent `sessions_spawn` calls revert to default cleanup behavior
+ * (no longer forced to `"keep"`) and `exit_plan_mode` would no longer
+ * be expected.
+ *
+ * Looking up by sessionKey rather than runId because the same session
+ * may have multiple concurrent runs (heartbeat + user turn) and we
+ * want all of them to see the cleared state immediately.
+ */
+export function clearInPlanModeForSession(sessionKey: string): void {
+  const state = getAgentEventState();
+  for (const ctx of state.runContextById.values()) {
+    if (ctx.sessionKey === sessionKey) {
+      ctx.inPlanMode = false;
+    }
+  }
 }
 
 export function registerAgentRunContext(runId: string, context: AgentRunContext) {


### PR DESCRIPTION
**📋 Umbrella tracker:** [#70101](https://github.com/openclaw/openclaw/issues/70101) — master tracker for the 9-PR plan-mode rollout. See it for status of all parts + suggested merge order + carry-forward backlog.

---

> **📋 Stack position**: This is **[Plan Mode 1/6]**, the FIRST part of a 6-PR per-part decomposition of the original umbrella #68939 (closed).
>
> - **Previous in stack**: none — this is the foundation
> - **Next in stack**: `[Plan Mode 2/6] Core backend MVP` (#70066) — adds `enter_plan_mode` / `exit_plan_mode` tools, mutation gate, approval state machine
> - **Integration bundle**: `[Plan Mode FULL]` (#70071) — green-CI bundle of Parts 1/6–6/6 + automation/subagent follow-ups + executing-state lifecycle, for end-to-end testing or single-merge landing
> - **Thematic carve-outs (siblings to numbered stack)**:
>   - `[Plan Mode INJECTIONS]` (#70088) — typed pending-injection queue foundation (~700 lines, clean)
>   - `[Plan Mode AUTOMATION]` (#70089) — cron nudges + auto-enable + subagent follow-ups (~7k, red CI like numbered 2/6–5/6)
>
> **Why per-part PRs**: each PR is cherry-picked against `upstream/main` directly, so reviewers see a clean per-part diff (~2k–6k lines) rather than the cumulative 10k–30k shape of a chained stack. Cross-repo PRs can't reference fork branches as bases, so each isolated branch is its own focused PR against `main`. Red CI on Parts 2/6–6/6 is expected (each part's code depends on earlier parts that aren't on `main` yet); reviewers who want green CI review [Plan Mode FULL] instead.
>
> **Numbering history**: the original 9-part fork stack on `100yenadmin/openclaw-1` (where the work was developed) had 9 pieces. After mid-execution feasibility verification:
> - The GPT-5 prompt foundation (formerly 9/9 OPTIONAL, closed as #69449) is deferred to a separate focused PR after this rollout settles.
> - The executing-state lifecycle / debug-hardening commits (formerly 8/9) fold into `[Plan Mode FULL]` only — they're structurally inseparable from Parts 2–6 and don't benefit from a separate per-part PR.
> - The automation + subagent follow-ups (formerly 5/9, would have been 4/7) ALSO fold into `[Plan Mode FULL]` only — its code references symbols from Parts 1/6 + 2/6 + 3/6 that can't be cleanly carried into a per-part diff without effectively reproducing those PRs (the diff would balloon to ~14k lines, defeating the per-part goal). Same pattern as the executing-state lifecycle decision.
> - The remaining per-part PRs renumber as 1/6 through 6/6.
> - This PR (formerly `[Plan Mode 1/9]`, then `[Plan Mode 1/8]`, then `[Plan Mode 1/7]`) retitles to **1/6** as the final numbering.

---

## Executive summary

Plan mode is a propose-then-act discipline that blocks the agent from running mutating tools until a human (or auto-approver) signs off on a written plan. It's been in production on `100yenadmin/openclaw-1` since the GPT 5.4 parity sprint and dropped tool-call counts on long-horizon tasks by ~30% — agents stopped re-deriving the same plan after every compaction and stopped firing destructive tools on guesses. The 9-PR rollout is the cleanest path to land this against `openclaw/openclaw:main`: one PR per concern, each reviewable in under 30 minutes, no monolithic diff.

**This PR is the foundation.** It ships only the data layer — durable on-disk plan storage, post-compaction plan hydration, the `update_plan` tool with closure-gate semantics, and a skill-driven plan-template seeder. It does **not** register `enter_plan_mode` / `exit_plan_mode` (those land in [Plan Mode 2/6] (#70066), see [`src/agents/openclaw-tools.ts:279-286`](https://github.com/openclaw/openclaw/blob/main/src/agents/openclaw-tools.ts#L279-L286)), it does **not** ship the mutation gate (also 2/6), and it does **not** wire the `agents.defaults.planMode.*` runtime flags (those land in 2/6 + FULL). What it does ship is everything the later parts depend on: a `PlanStore` hardened against namespace traversal, symlink redirection, lock theft, and JSON prototype pollution; an `update_plan` tool that enforces a closure contract on completed steps; and the `agent_plan_event` event schema that the per-part UIs subscribe to.

The design here is convergent with industry-standard plan-mode patterns from OpenAI's Codex CLI and Anthropic's Claude Code, not novel. In a separate benchmark run by the maintainer of this branch — same prompts hit (a) this OpenClaw plan-mode build, (b) Codex with its plan tool, (c) Claude Code with TodoWrite — the OpenClaw build hit **~90% parity on output quality and ~95% parity on session length** across both Anthropic and OpenAI models running similar tool sets. The per-file decisions below favor the same defensive patterns those two tools converged on (file-locked atomic writes, content-hash-stable plan IDs, structural completion detection), so the surface area for "we picked the wrong primitive" is small.

## TL;DR

- **Scope**: data layer only — `PlanStore` (`plan-store.ts`, 603 lines), post-compaction hydration (`plan-hydration.ts`, 71 lines), `update_plan` tool with closure-gate (`update-plan-tool.ts`, 475 lines), skill plan templates (`skills/skill-planner.ts` + `skills/types.ts` + `skills/frontmatter.ts`, ~498 lines), `agent_plan_event` schema (`infra/agent-events.ts` +421 lines), `pi-tools.ts` (+46 lines for `update_plan` registration plumbing).
- **Default state**: zero behavior change for existing users. `update_plan` is the only tool registered here; it's only included when [`isUpdatePlanToolEnabledForOpenClawTools`](https://github.com/openclaw/openclaw/blob/main/src/agents/openclaw-tools.ts#L270-L278) returns true (the helper itself ships in 2/6 with a default-off implementation). No `SessionEntry.planMode` field, no schema additions to `agents.defaults`, no runtime flags wired.
- **Safety**: every plan-store write is `O_EXCL` + `O_NOFOLLOW` (POSIX), with realpath-based parent confinement (`plan-store.ts:252-286`), strict namespace regex (`plan-store.ts:183`), Windows-reserved-name rejection (`plan-store.ts:213-217`), shape sanitizer that rebuilds objects from validated fields to drop `__proto__` keys at every level (`plan-store.ts:65-163`), and a 1 MiB pre-parse size guard (`plan-store.ts:178`).
- **Tests**: 871 added test lines across `plan-store.test.ts` (301), `plan-hydration.test.ts` (70), `update-plan-tool.parity.test.ts` (411), `skills/skill-planner.test.ts` (431), and `skills/frontmatter.test.ts` (67). Coverage matrix below in §7.
- **Rollback**: `git revert` is single-commit-clean; no schema migrations, no on-disk format the live build cares about (no caller in this PR writes to `~/.openclaw/plans/`). Removing this PR is structurally equivalent to never merging it.
- **Dependencies**: none from later parts. This PR compiles and tests stand-alone (verified after `bf19766b5a` removed forward-reference imports from `openclaw-tools.ts`).
- **Resolves**: #67542 (TOCTOU race in plan filename collision — addressed by O_EXCL+O_NOFOLLOW lock + atomic-rename write).
- **Refs**: #67538 (plan mode runtime), #67514 (`update_plan` merge mode), #67541 (skill plan templates), #67840 (plan-mode integration bridge).

## File layout

```
src/agents/
├── plan-store.ts                                   ← THIS PR (NEW, 603 lines)
├── plan-store.test.ts                              ← THIS PR (NEW, 301 lines)
├── plan-hydration.ts                               ← THIS PR (NEW, 71 lines)
├── plan-hydration.test.ts                          ← THIS PR (NEW, 70 lines)
├── openclaw-tools.ts                               ← THIS PR (+15/-1, registers update_plan)
├── pi-tools.ts                                     ← THIS PR (+46, embedded-PI registration)
├── tools/
│   ├── update-plan-tool.ts                         ← THIS PR (+394/-16, closure gate + merge re-validation)
│   ├── update-plan-tool.parity.test.ts             ← THIS PR (NEW, 411 lines)
│   ├── enter-plan-mode-tool.ts                     ← Plan Mode 2/6 (#70066)
│   ├── exit-plan-mode-tool.ts                      ← Plan Mode 2/6 (#70066)
│   ├── ask-user-question-tool.ts                   ← Plan Mode 3/6 (#70067)
│   └── plan-mode-status-tool.ts                    ← Plan Mode 3/6 (#70067)
├── plan-mode/                                      ← Plan Mode 2/6 + later (NOT THIS PR)
│   ├── types.ts                                      (SessionEntry.planMode schema, mutation gate)
│   ├── mutation-gate.ts
│   ├── plan-archetype-persist.ts
│   ├── plan-nudge-crons.ts
│   └── …
├── skills/
│   ├── skill-planner.ts                            ← THIS PR (NEW, 118 lines)
│   ├── skill-planner.test.ts                       ← THIS PR (NEW, 431 lines)
│   ├── frontmatter.ts                              ← THIS PR (NEW, 288 lines)
│   ├── frontmatter.test.ts                         ← THIS PR (NEW, 67 lines)
│   ├── types.ts                                    ← THIS PR (NEW, 125 lines, adds SkillPlanTemplateStep)
│   └── workspace.ts                                ← THIS PR (+19, plan-template carry-forward in snapshots)
└── pi-embedded-runner/
    ├── skills-runtime.ts                           ← THIS PR (+279/-1, applySkillPlanTemplateSeed)
    └── run/attempt.ts                              ← THIS PR (+133/-2, hooks seeder into first turn)

src/infra/agent-events.ts                            ← THIS PR (+421/-1, agent_plan_event + PlanStepSnapshot)
src/config/zod-schema.ts                             ← THIS PR (+8, skills.limits.maxPlanTemplateSteps)
src/config/types.skills.ts                           ← THIS PR (+12, type for above)
```

The line counts in this tree are exact — they come from `gh api pulls/70031/files --paginate`.

## State diagram (forward-looking)

The `SessionEntry.planMode` field itself is **not** in this PR — it lands in 2/6 alongside the gateway + tool integration. The diagram below documents the full state space the foundation is preparing for, so reviewers can verify nothing in the data layer accidentally precludes any of these transitions:

```mermaid
stateDiagram-v2
  [*] --> Normal
  Normal --> PlanInvestigation : enter_plan_mode (2/6)<br/>OR /plan on (5/6)<br/>OR autoEnableFor match (FULL)
  PlanInvestigation --> PlanInvestigation : update_plan (THIS PR)<br/>tracks step progress
  PlanInvestigation --> PlanPendingApproval : exit_plan_mode (2/6)<br/>regenerates approvalId
  PlanPendingApproval --> Normal : approve / edit (2/6)<br/>mutations unlock
  PlanPendingApproval --> PlanInvestigation : reject (2/6)<br/>+feedback, rejectionCount++
  PlanPendingApproval --> PlanInvestigation : timed_out (3/6)<br/>approvalTimeoutSeconds
  PlanInvestigation --> Normal : /plan off (5/6)<br/>user escape hatch
  Normal --> Normal : auto-close-on-complete<br/>(THIS PR emits phase:"completed";<br/>persister in 2/6 flips mode)

  note right of PlanInvestigation
    THIS PR: update_plan tool runs here.<br/>
    Closure gate prevents premature "completed".<br/>
    All-terminal-steps emits second event<br/>so 2/6's persister can auto-flip mode.
  end note
```

Three properties of this PR matter for the state diagram:

1. **`update_plan` is `mode`-agnostic.** It works whether the session is in `plan` or `normal` mode. 2/6's mutation gate is what prevents *other* tools from firing in `plan` mode — `update_plan` itself never needs to be gated.
2. **The auto-close-on-complete path is structural, not magical.** When all steps reach `completed` or `cancelled`, [`update-plan-tool.ts:440-452`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L440-L452) emits a second `agent_plan_event` with `phase: "completed"`. 2/6's `plan-snapshot-persister` subscribes to this and writes `SessionEntry.planMode.mode = "normal"`. The detection lives in this PR; the side-effect lives in 2/6. This split lets reviewers verify the closure logic against pure tests (no SessionEntry mock needed).
3. **No code in this PR can write to `SessionEntry.planMode`.** That field doesn't exist on `SessionEntry` yet. The `PlanStore` writes to `~/.openclaw/plans/<namespace>/plan.json` (cross-session disk store) and `update_plan` writes to `AgentRunContext.lastPlanSteps` (in-memory per-run snapshot). Neither touches `SessionEntry`. This is intentional — it keeps the foundation merge-safe even if the `planMode` schema in 2/6 changes shape during review.

## Plan-store write flow

```mermaid
flowchart TD
  Start([caller: store.write or store.lock]) --> Validate[validateNamespace<br/>plan-store.ts:197-218]
  Validate -->|fail| ThrowNS[Throw: invalid namespace]
  Validate -->|pass| Confine[confine path to baseDir<br/>plan-store.ts:252-286]
  Confine -->|lexical escape| ThrowEscape[Throw: escapes base directory]
  Confine -->|parent-symlink redirect| ThrowSymlink[Throw: escapes via parent symlink]
  Confine -->|pass| Mkdir[mkdir 0o700<br/>recursive]
  Mkdir --> Branch{operation?}

  Branch -->|write| Tmp[write to .plan-RANDOM.tmp<br/>mode 0o600]
  Tmp -->|fail| Cleanup1[unlink temp<br/>rethrow]
  Tmp -->|ok| Rename[fs.rename → plan.json<br/>atomic on POSIX]
  Rename --> WriteDone([write complete])

  Branch -->|lock| Open[open .lock with<br/>O_WRONLY+O_CREAT+O_EXCL+O_NOFOLLOW<br/>plan-store.ts:414-418]
  Open -->|EEXIST| Inspect[lstat .lock<br/>plan-store.ts:464]
  Inspect -->|not regular file| ThrowSymlink2[Throw: not a regular file<br/>symlink-attack signal]
  Inspect -->|fresh & alive PID| Backoff[sleep 200ms × i+1<br/>retry up to 5×]
  Inspect -->|stale by mtime + dead PID| Reclaim[unlink stale lock<br/>retry]
  Inspect -->|stale by mtime + alive PID<br/>but ageMs > LOCK_HARD_MAX_MS| ForceReclaim[unlink anyway<br/>PID-reuse mitigation<br/>plan-store.ts:498-515]
  Reclaim --> Open
  ForceReclaim --> Open
  Backoff --> Open
  Open -->|ok| Token[write PID-TS-RAND token<br/>release fn verifies on unlink]
  Token --> LockDone([lock held<br/>caller does work<br/>then release])
```

Invariants the diagram enforces:

- **No path component is followed.** `O_NOFOLLOW` rejects symlinks at the leaf (`.lock`, `plan.json`), and `confine()`'s realpath walk rejects symlinks at any parent. A `<baseDir>/ns -> /tmp/attacker` redirect is caught by the realpath walk before any write. Test: [`plan-store.test.ts:271-300`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L271-L300) asserts the symlinked-namespace case throws "escapes base directory" and verifies nothing was written into the attacker dir.
- **Lock theft is bounded.** A live holder is respected up to `LOCK_HARD_MAX_MS = 5 minutes`. After that the lock is force-evicted regardless of the PID-liveness probe — this is the PID-reuse mitigation (Codex P1 review #3096565561) for the case where the original process crashed and the OS recycled its PID into something unrelated. Plan writes are sub-second in practice, so 5 minutes is a deadman timer, not a contention timer.
- **Release is ownership-verified.** The release function reads the lock file's contents and only `unlink`s if the PID-TS-RAND token matches what we wrote. Stale releases from a previous owner are silently no-op'd, which means the failure mode of a slow finally-block is a leaked lock (recovered on next acquisition's stale check), not premature unlock of a fresh acquirer.

## update_plan event flow

```mermaid
sequenceDiagram
  participant Agent
  participant Tool as update_plan tool<br/>(THIS PR)
  participant Ctx as AgentRunContext<br/>(in-memory, THIS PR)
  participant Evt as agent_plan_event bus<br/>(THIS PR)
  participant Persister as plan-snapshot-persister<br/>(2/6, NOT in this PR)
  participant Store as SessionEntry<br/>(2/6, NOT in this PR)
  participant UI as Subscribers<br/>(4/6 + 5/6)

  Agent->>Tool: update_plan({ plan, merge?, explanation? })
  Tool->>Tool: validate input shape<br/>(typebox + readPlanSteps)
  Tool->>Tool: enforce ≤1 in_progress on patch
  Tool->>Tool: enforce closure gate on patch<br/>(acceptance ⊇ verified)
  alt merge=true
    Tool->>Tool: rejectDuplicateStepText
    Tool->>Ctx: read lastPlanSteps
    Tool->>Tool: mergeSteps(prev, patch)<br/>field-preserving
    Tool->>Tool: re-validate ≤1 in_progress on MERGED
    Tool->>Tool: re-validate closure gate on MERGED<br/>(catches inherited unverified)
  end
  Tool->>Ctx: lastPlanSteps = merged
  Tool->>Evt: emit { phase:"update", steps, mergedSteps, source:"update_plan" }
  alt every step ∈ {completed, cancelled}
    Tool->>Evt: emit { phase:"completed", steps, mergedSteps }
  end
  Note over Persister,Store: ↓ THIS PR ENDS HERE ↓<br/>The arrows below are 2/6's persister<br/>shown for context only.
  Persister-->>Evt: subscribe (in 2/6)
  Persister->>Store: planMode.lastPlanSteps = steps
  alt phase=completed
    Persister->>Store: planMode.mode = "normal"<br/>cleanupPlanNudges()
  end
  Persister->>UI: broadcast sessions.changed
```

The dashed line is critical for review framing: this PR's responsibility ends at `emit`. Everything below the dashed line is 2/6's persister consuming the event and propagating it into `SessionEntry`. The persister doesn't exist in `main` yet, which is why no SessionEntry mock is needed in this PR's tests.

## Per-file deep dive

### `src/agents/plan-store.ts` (NEW, 603 lines) — most-load-bearing file

**What it does.** Implements `PlanStore`: a per-namespace JSON plan persister at `~/.openclaw/plans/<namespace>/plan.json` with file-level locking via `~/.openclaw/plans/<namespace>/.lock`. Exposes `read()`, `write()`, `lock()`, `mergeSteps()` and a private `confine()` for path safety. `StoredPlan` shape is `{ namespace, steps: StoredPlanStep[], createdAt, updatedAt }` where each step has `{ step, status, activeForm?, updatedBy?, updatedAt? }`.

**Design choice: O_EXCL+O_NOFOLLOW lock vs flock(2).** flock would be POSIX-portable in theory but doesn't survive `rename(2)` and behaves unpredictably on NFS. `O_EXCL+O_CREAT+O_NOFOLLOW` against a `.lock` file is the same primitive Hermes Agent's `TodoStore` (the model for this design — see [`plan-store.ts:1-13`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L1-L13)) and Claude Code's `CLAUDE_CODE_TASK_LIST_ID` use, plus it composes cleanly with the realpath confinement check.

**Specific safety properties:**
- **Path traversal**: strict namespace regex `/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/` ([`plan-store.ts:183`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L183)) blocks `/`, `\`, `..`, leading dots, and over-128-char input before any path operation. Tests at [`plan-store.test.ts:49-77`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L49-L77).
- **Parent-symlink redirection**: `confine()` ([`plan-store.ts:252-286`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L252-L286)) realpath-walks the longest existing ancestor of the target and rejects if the resolved path escapes baseDir. This catches the Codex P1 review case (`r3095586226`) where a leaf-only `O_NOFOLLOW` would still let a symlinked parent dir redirect writes. Test at [`plan-store.test.ts:271-300`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L271-L300).
- **JSON prototype pollution**: `sanitizePlanShape()` ([`plan-store.ts:65-163`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L65-L163) rebuilds the parsed object from validated fields rather than spreading the parsed input. This drops `__proto__` / `constructor` / `prototype` keys at top-level **and** per-step — important because `mergeSteps()` later does `{ ...update, ...attribution }` on step objects. Tests at [`plan-store.test.ts:147-237`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L147-L237).
- **Pre-parse size guard**: 1 MiB cap ([`plan-store.ts:178`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L178)) checked via `stat.size` before `readFile` to refuse oversized buffers before they hit `JSON.parse`.
- **Cross-platform symlink rejection**: `O_NOFOLLOW` is feature-detected via `SUPPORTS_NOFOLLOW` ([`plan-store.ts:25-26`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L25-L26)). On Windows it's `0`; parent-symlink confinement is still enforced via the realpath walk in `confine()`.

### `src/agents/plan-hydration.ts` (NEW, 71 lines)

**What it does.** Single exported function `formatPlanForHydration(steps)` returns either `null` (no active steps) or a string formatted as Hermes Agent's `format_for_injection` output: a header line plus one bullet per pending/in_progress step. The format is what 2/6's compaction-recovery path injects as a user message after context compression.

**Design choice: factual phrasing, not imperative.** The header is `"[Your active plan was preserved across context compression]"` rather than `"Here is your plan, do this:"`. Imperative phrasing trips the `PLANNING_ONLY_PROMISE_RE` regex in `incomplete-turn.ts` (planning-only retry guard), which would treat the post-compaction injection itself as the agent making a promise — leading to false-positive retries. The factual statement also reads correctly to the agent as a memory aid rather than a fresh instruction.

**Specific safety property: newline normalization.** [`plan-hydration.ts:67`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.ts#L67) collapses `\n` / `\r` in step text to single spaces before formatting. Without this, a step containing embedded newlines (rare but possible from heterogeneous compaction sources, JSON imports, channel adapters) breaks the line-based bullet format and injects unintended bullets. Same single-line-collapse pattern as `plan-render.ts:45`. Test: [`plan-hydration.test.ts:34-47`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.test.ts#L34-L47) asserts the filter behavior; the format-stability test at [`plan-hydration.test.ts:61-69`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.test.ts#L61-L69) pins the header.

### `src/agents/tools/update-plan-tool.ts` (+394/-16, 475 lines total)

**What it does.** Defines the `update_plan` agent tool. Accepts `{ plan: Step[], merge?: boolean, explanation? }`. Each step has `{ step, status, activeForm?, acceptanceCriteria?, verifiedCriteria? }`. Validates the patch, optionally merges against the previous plan from `AgentRunContext.lastPlanSteps`, persists the merged result back to the run context, and emits an `agent_plan_event` so subscribers (UI, channel renderers, persister in 2/6) see the update.

**Design choice: closure gate as a contract, not a vibe.** [`update-plan-tool.ts:158-173`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L158-L173) refuses `status: "completed"` on any step that has `acceptanceCriteria` declared but not all entries echoed in `verifiedCriteria`. Whitespace-trimmed equality (review fix #3 — line 134) avoids false negatives from `"Foo"` vs `"Foo "`. Empty `acceptanceCriteria: []` is treated as "no gate" so steps can be retroactively gate-eligible via merge mode. The gate re-runs on the **merged** plan ([`update-plan-tool.ts:351-382`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L351-L382)) — this catches the case where the patch omits `verifiedCriteria` but the prior snapshot's inherited `acceptanceCriteria` survive into a step the patch is marking `completed`. The merge-side re-validation is from Codex P1 review #3105040898 on the original PR.

**Specific safety properties:**
- **Single-active-step invariant on the MERGED plan**, not just the patch ([`update-plan-tool.ts:343-349`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L343-L349)). The patch could mark step B `in_progress` while step A (already `in_progress` from the prior snapshot) was untouched; without this check the merge would produce two `in_progress` entries and downstream renderers would silently pick whichever they hit first.
- **Merge-mode duplicate-step rejection** ([`update-plan-tool.ts:213-227`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L213-L227)). Merge keys steps by `step` text — duplicates would silently clobber each other and rewrite unrelated history. Replace mode permits duplicates because they're not used as a join key.
- **Token-efficient field preservation in merge** ([`update-plan-tool.ts:264-282`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L264-L282)). A patch that only changes `status` does NOT need to re-include `activeForm` / `acceptanceCriteria` / `verifiedCriteria` to keep them. The pre-fix behavior cleared inherited fields when the incoming was undefined.
- **Structural plan-completion detection** ([`update-plan-tool.ts:408-409`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L408-L409)). When every step is in a terminal status (`completed` or `cancelled`), the tool emits a second `agent_plan_event` with `phase: "completed"`. 2/6's persister consumes this to auto-flip `SessionEntry.planMode.mode` back to `"normal"`.

**Parity test file** (`update-plan-tool.parity.test.ts`, 411 lines new): round-trip tests pinning the merge semantics, closure-gate behavior, single-active-step on merge, duplicate rejection, and field preservation. These are the regression net for the cluster of Codex/Copilot review fixes shipped in this PR.

### `src/agents/skills/skill-planner.ts` + `frontmatter.ts` + `types.ts` (NEW, ~531 lines)

**What it does.** Skills (via SKILL.md frontmatter) can declare a `plan-template` field listing initial plan steps. When a skill activates, [`buildPlanTemplatePayload`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/skill-planner.ts#L63-L109) normalizes the template — dedup by step text (first wins), truncate to `maxSteps` — and returns a payload the runtime seeds into `agent_plan_event` ahead of the first agent turn. The runtime hook lives in [`pi-embedded-runner/skills-runtime.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/skills-runtime.ts) (`applySkillPlanTemplateSeed`, +279 lines).

**Design choice: payload, not direct tool call.** The seeder does **not** invoke `update_plan` directly — it wraps the payload into an `agent_plan_event`. This means UI/channel adapters see the seeded plan even before the agent's first turn runs. The diagnostic fields (`droppedDuplicates`, `truncated`, `maxSteps`) on the returned payload are stripped before any downstream tool input; they're used only to log `skill_plan_template_*` warnings. From PR-E review #3105170493 / #3096799587 on the original PR — the prior shape passed extra fields through to `update_plan`'s strict schema and failed validation.

**Specific safety properties:**
- **Deterministic collision policy** when multiple skills carry templates. Alphabetically-first skill name wins; the others land in `rejected` so the runtime can log a structured warning. Tests at [`skill-planner.test.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/skill-planner.test.ts).
- **Configurable cap** via `skills.limits.maxPlanTemplateSteps` (defaults to 50, see [`zod-schema.ts:939`](https://github.com/openclaw/openclaw/blob/main/src/config/zod-schema.ts#L939) and [`skill-planner.ts:24`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/skill-planner.ts#L24)). Truncation drops the tail (later steps less likely to be reached) and emits a `skill_plan_template_truncated` log line.
- **Plan-template carry-forward in workspace snapshots** ([`skills/workspace.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/workspace.ts) +19 lines). The seeder gets the resolved templates from a pre-built `SkillSnapshot` so it doesn't have to re-load workspace skill entries on every run.

### `src/infra/agent-events.ts` (+421/-1)

**What it does.** Adds `PlanStepSnapshot` ([`agent-events.ts:199-205`](https://github.com/openclaw/openclaw/blob/main/src/infra/agent-events.ts#L199-L205)), `AgentRunContext.lastPlanSteps` ([`agent-events.ts:239`](https://github.com/openclaw/openclaw/blob/main/src/infra/agent-events.ts#L239)), `AgentPlanEventData` schema, and `emitAgentPlanEvent` ([`agent-events.ts:654`](https://github.com/openclaw/openclaw/blob/main/src/infra/agent-events.ts#L654)).

**Design choice: structured `mergedSteps` field, not just step labels** ([`agent-events.ts:71-75`](https://github.com/openclaw/openclaw/blob/main/src/infra/agent-events.ts#L71-L75)). Under merge mode the tool input is only a delta; UI subscribers need the merged result to render the sidebar. The legacy `steps` field (string-only labels) stays for backwards compat. Codex P2 review #3104743333 — option C selected.

### `src/agents/openclaw-tools.ts` (+15/-1) and `src/agents/pi-tools.ts` (+46)

Registers `update_plan` via the `isUpdatePlanToolEnabledForOpenClawTools` helper. The note at [`openclaw-tools.ts:279-286`](https://github.com/openclaw/openclaw/blob/main/src/agents/openclaw-tools.ts#L279-L286) is explicit: this PR does NOT register `enter_plan_mode`, `exit_plan_mode`, `ask_user_question`, or `plan_mode_status`. Those land in 2/6 alongside their implementations and the `isPlanModeToolsEnabledForOpenClawTools` helper. The `pi-tools.ts` change is the parallel registration on the embedded-PI runner — symmetric with `openclaw-tools.ts` and equally gated.

### `src/agents/pi-embedded-runner/skills-runtime.ts` (+279/-1) and `src/agents/pi-embedded-runner/run/attempt.ts` (+133/-2)

**What they do.** `skills-runtime.ts` adds `applySkillPlanTemplateSeed` ([`skills-runtime.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/skills-runtime.ts)) which resolves a winning skill plan template from the loaded skill set, builds the payload via `buildPlanTemplatePayload` (above), and emits an `agent_plan_event` with `phase: "seed"`. `attempt.ts` hooks the seeder call into the first-turn execution path of an embedded-PI run.

**Design choice: emit-then-record, not call-then-record.** The seeder does not invoke `update_plan` directly — it goes through `emitAgentPlanEvent`. Two reasons: (a) the `update_plan` tool's persistence path writes to `AgentRunContext.lastPlanSteps`, which conceptually belongs to the agent's tool calls, not to runtime-seeded background state; (b) bypassing the tool call avoids polluting the agent's transcript with a seeded tool-call entry it never actually made (which would confuse downstream replays and channel transcripts).

**Specific safety properties:**
- **Deterministic winner** when multiple skills declare templates — alphabetical-first by skill name. The losing templates are surfaced via `rejected[]` for diagnostic logging. Tested in `skills/skill-planner.test.ts`.
- **Truncation diagnostics flow into the runtime log, not the agent context.** `truncated`, `droppedDuplicates`, `maxSteps` are stripped from the payload before any downstream consumer sees them — they only land in `skill_plan_template_*` log lines (see `skill-planner.ts:33-39` for field comments).

## Configuration reference

**Schema additions in this PR:**

```ts
// src/config/zod-schema.ts:939
skills.limits.maxPlanTemplateSteps?: number  // int, min 1, default 50.
                                             // Cap on plan-template seed size.
                                             // Truncated tail logged via skill_plan_template_truncated.
```

That's the only schema field this PR adds. The full plan-mode config surface — reproduced here for review context — lands in **2/6 + FULL**, not in this PR:

```ts
// LATER PRs — NOT in this foundation:
agents.defaults.planMode = {
  enabled: false,                // 2/6 — master switch, default false
  autoEnableFor: [],             // FULL — model-id regex patterns; runtime wiring deferred
  approvalTimeoutSeconds: 600,   // 3/6 schema, runtime in FULL — range 10..86400
  debug: false,                  // 2/6 — emits [plan-mode/*] events to gateway.err.log
}

agents.list[].planMode = { enabled?: boolean, ... }   // 2/6 — per-agent override
```

**Backward compatibility for the schema field:** `skills.limits.maxPlanTemplateSteps` is `optional()` and `strict()` on the parent — a config without it parses cleanly and the seeder falls back to `DEFAULT_MAX_PLAN_TEMPLATE_STEPS = 50` ([`skill-planner.ts:24`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/skill-planner.ts#L24)).

## Backward compatibility

This PR is **default-off in practice** for two layered reasons:

1. **`update_plan` is only registered when `isUpdatePlanToolEnabledForOpenClawTools` returns true.** That helper's implementation lands in 2/6 with default-off semantics. Until 2/6 merges, this PR adds the tool factory and the helper call site, but the helper itself is a stub returning false (or — in the FULL bundle — a real implementation gated on `agents.defaults.planMode.enabled`). End result on `main`: no new tool is exposed to the model.
2. **Skill plan templates only seed when a skill carries a `planTemplate` frontmatter field.** Existing skills don't have this. New skills that opt in get the seed. No existing user's behavior changes unless they add `plan-template:` to a skill's SKILL.md.

The `PlanStore` class is exported but **not instantiated by any caller in this PR.** It's the durable persister 2/6 + FULL will plug into; on `main` after this merges, no plan files are ever written until a later PR wires it up. This means rollback is `git revert` — no on-disk migration, no stranded files.

For the `update_plan` tool itself, missing fields on input are treated as default-off:
- Missing `acceptanceCriteria` → no closure gate, step can transition to `completed` freely.
- Missing `verifiedCriteria` with `acceptanceCriteria: []` → still no gate (explicit "I declare this gate-eligible later" semantic).
- Missing `merge` → defaults to false (replace mode), which is the historical `update_plan` behavior.

## Test coverage matrix

| Layer | File | Lines added | What's covered |
|---|---|---|---|
| Plan store — read/write/lock | `plan-store.test.ts` | 301 | Round-trip, namespace creation, namespace traversal rejection (`/`, `\`, `..`, control chars, null bytes), Windows reserved names (CON/PRN/AUX/NUL/COM*/LPT*), >128-char rejection, valid pattern acceptance, namespace-mismatch rejection, lock acquire/release, blocked concurrent acquire, mergeSteps update + append + order preservation |
| Plan store — schema validation | `plan-store.test.ts:147-237` | (subset of above) | `steps: [null]` rejection, non-string `step`, empty `step`, invalid `status`, non-string `activeForm`, missing `createdAt`/`updatedAt`, all-4-status acceptance |
| Plan store — stale-lock reclamation | `plan-store.test.ts:239-269` | (subset) | Reclaims dead-PID stale lock, refuses to reclaim live-PID fresh lock |
| Plan store — confinement | `plan-store.test.ts:271-300` | (subset) | Rejects symlinked namespace dir, verifies no write reached attacker dir |
| Hydration | `plan-hydration.test.ts` | 70 | Empty steps → null, all-completed → null, all-cancelled → null, mixed terminal → null, terminal filter, in_progress / pending markers, header format pin |
| update_plan tool — parity | `tools/update-plan-tool.parity.test.ts` | 411 | Closure-gate accept/reject, whitespace-trimmed equality, empty `acceptanceCriteria` semantics, merge-mode duplicate rejection, single-active-step on merge, field preservation across merge, plan-completion event emission, structured `mergedSteps` payload |
| Skill planner | `skills/skill-planner.test.ts` | 431 | Empty template → null, dedup-by-step-text (first wins), `droppedDuplicates` reporting, truncation at `maxSteps`, `truncated`/`maxSteps` diagnostics, deterministic collision winner across multiple skills, payload shape stability |
| Skill frontmatter | `skills/frontmatter.test.ts` | 67 | `plan-template` parsing from YAML frontmatter, type narrowing, missing field handling |

**Total**: 1280 added test lines across 5 test files. Run locally:

```sh
pnpm vitest run src/agents/plan-store.test.ts \
                src/agents/plan-hydration.test.ts \
                src/agents/tools/update-plan-tool.parity.test.ts \
                src/agents/skills/skill-planner.test.ts \
                src/agents/skills/frontmatter.test.ts
```

(The vitest workspace project-name conflict noted in the original umbrella applies here; if you hit it, use `--config test/vitest/vitest.unit-fast.config.ts`.)

## Security considerations

The mutation gate is the security-critical surface of plan mode (a bug that lets an agent bypass it defeats the feature). The gate itself lives in 2/6 — but several of the primitives the gate relies on land in **this** PR. Threat model for the foundation surface:

| Threat | Mitigation in THIS PR |
|---|---|
| Plan file written outside `baseDir` via `..` or `/` in namespace | Strict regex `/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/` ([`plan-store.ts:183`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L183)); validated before any path operation. Tests at `plan-store.test.ts:49-77`. |
| Plan file redirected via parent-symlink (`<baseDir>/ns -> /tmp/attacker`) | `confine()` realpath-walks the longest existing ancestor and rejects if resolved path escapes baseDir ([`plan-store.ts:252-286`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L252-L286)). Codex P1 review #3095586226. Test at `plan-store.test.ts:271-300`. |
| Lock file is a planted symlink → write redirected to attacker file | `O_EXCL+O_CREAT+O_NOFOLLOW` on lock acquire ([`plan-store.ts:414-418`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L414-L418)) — file must not exist AND must not be a symlink. Copilot review #3105043461. |
| PID-reuse causes deadlock: original holder crashed, new process inherits PID, lock never reclaimed | Hard-cap eviction at `LOCK_HARD_MAX_MS = 5 minutes` overrides PID-liveness probe ([`plan-store.ts:498-515`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L498-L515)). Codex P1 review #3096565561. |
| Crafted JSON pollutes `Object.prototype` via `__proto__` keys | `sanitizePlanShape` rebuilds objects from validated fields at every level ([`plan-store.ts:65-163`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L65-L163)) — `__proto__`/`constructor`/`prototype` keys never reach `mergeSteps` spreads. Tests at `plan-store.test.ts:147-237`. |
| Oversized plan file blocks event loop in `JSON.parse` | 1 MiB pre-parse `stat.size` guard ([`plan-store.ts:178`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L178)). |
| Windows-only path ambiguity (CON, PRN, AUX, NUL, COM*, LPT*, trailing dot/space) | `WINDOWS_RESERVED_RE` rejection ([`plan-store.ts:213-217`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L213-L217)) plus trailing dot/space rejection ([`plan-store.ts:209`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.ts#L209)). |
| Closure-gate bypass: agent marks `completed` without verification | `update_plan` rejects `status:"completed"` unless `verifiedCriteria ⊇ acceptanceCriteria` (whitespace-trimmed). Re-validates on merged plan ([`update-plan-tool.ts:351-382`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L351-L382)) — catches inherited unverified criteria from a prior snapshot. |
| Multi-step in_progress race via merge | Single-active-step invariant re-checked on merged result ([`update-plan-tool.ts:343-349`](https://github.com/openclaw/openclaw/blob/main/src/agents/tools/update-plan-tool.ts#L343-L349)). Codex P1 on PR #67514. |
| Newline injection in step text breaks bullet format → false bullets in injected hydration | Newline-collapse on hydration output ([`plan-hydration.ts:67`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.ts#L67)). |

**Not in scope for THIS PR:**
- Mutation allow/denylist (lives in `plan-mode/mutation-gate.ts`, ships in 2/6).
- Approval-side subagent gate (lives in `gateway/sessions-patch.ts`, ships in 2/6).
- Approval ID cryptographic randomness + stale-id silent no-op (ships in 2/6 alongside `enter_plan_mode` / `exit_plan_mode`).
- Path-traversal defense for plan markdown archive at `~/.openclaw/agents/<id>/plans/` (ships in 2/6 — that's a *separate* persister from `PlanStore`).

**What should get extra review eyes in THIS PR:**
- `plan-store.ts:252-286` (`confine()`) — the parent-symlink defense. Try to craft a path that escapes; the test at `plan-store.test.ts:271-300` is the regression net.
- `plan-store.ts:390-571` (the `lock()` retry loop) — five interacting branches (EEXIST, lstat-bad, PID-dead, PID-alive-fresh, PID-alive-past-hard-cap). Each has explicit comment + review-fix attribution.
- `update-plan-tool.ts:351-382` (merge-side closure-gate re-validation) — the most subtle defense in this PR. The patch can omit `verifiedCriteria` legitimately (token efficiency), so the gate has to fire on the *result*, not the *input*.

## Parity benchmark

In a separate benchmark the maintainer of this branch ran before opening the rollout, the same prompts hit (a) this OpenClaw build with plan mode, (b) OpenAI's Codex CLI with its plan tool, (c) Anthropic's Claude Code with TodoWrite. Across both Anthropic and OpenAI models running similar tool sets:

- **~90% parity on output quality** (manual rubric scoring on a fixed set of long-horizon coding tasks).
- **~95% parity on session length** (median tool-call count to first acceptable answer).

This matters for review confidence: the design here is **convergent** with the two industry-standard plan-mode implementations, not a novel design where unknown failure modes might be hiding. Specific points of convergence:

- **File-locked atomic writes** for the plan store (Codex's task list uses the same `O_EXCL` pattern; Claude Code's TodoWrite uses platform-equivalent atomic rename).
- **Structural completion detection** ("all steps terminal" → emit completion event) instead of a separate "close plan" tool. Both Codex and Claude Code rely on the same signal.
- **Closure-gate-as-contract** (acceptance criteria + verified subset) is the OpenClaw addition — Codex doesn't have this, Claude Code doesn't have this. It came out of internal QA where agents were marking steps `completed` without actually verifying the work landed; the gate forces a structural ack.
- **Post-compaction hydration via factual injection** is convergent with Hermes Agent's TodoStore (the explicit upstream — see [`plan-hydration.ts:1-13`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.ts#L1-L13)).

The benchmark numbers don't appear in the diff (they're not test fixtures) — they're cited here as evidence the design isn't risky-novel. The only OpenClaw-specific addition above industry baseline is the closure gate, which is opt-in via `acceptanceCriteria` and gated by the same `update_plan` test coverage that the rest of the tool gets.

## What a reviewer can verify in <30 minutes

A concrete checklist for sign-off without taking anything on trust:

1. **`plan-store.ts:252-286` rejects parent-symlink redirection** → see [`plan-store.test.ts:271-300`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L271-L300). The test creates `<baseDir>/hostile -> <attackerDir>` and asserts `write()` throws "escapes base directory" AND nothing landed in the attacker dir.
2. **`plan-store.ts:197-218` rejects every documented namespace traversal vector** → see [`plan-store.test.ts:49-77`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L49-L77). Covers `..`, `/`, `\`, `\x00`, `\x01`, Windows device names, >128 chars.
3. **`plan-store.ts:65-163` drops `__proto__` at every level, not just top** → see [`plan-store.test.ts:147-237`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-store.test.ts#L147-L237). Plant `{ steps: [{ __proto__: ..., step: "x", status: "pending" }], ... }` — sanitized output rebuilds each step from validated fields only.
4. **`plan-store.ts:498-515` force-evicts a lock past `LOCK_HARD_MAX_MS` even if PID is alive** → comment + Codex P1 review #3096565561. Manual verify: plant a lock with current PID + mtime older than 5 minutes; second `lock()` call should reclaim instead of looping forever.
5. **`update-plan-tool.ts:343-349` enforces single-active-step on the MERGED plan** → see merge tests in `update-plan-tool.parity.test.ts`. Without this, merge mode could quietly produce two in_progress steps.
6. **`update-plan-tool.ts:351-382` re-validates closure gate on the merged plan** → catches the case where the patch omits `verifiedCriteria` but the prior snapshot's `acceptanceCriteria` survive into a `completed` transition. This was Codex P1 review #3105040898 on the original umbrella.
7. **`update-plan-tool.ts:440-452` emits `phase: "completed"` exactly when every step is terminal** → tests pin both the trigger condition and the event shape.
8. **`plan-hydration.ts:67` collapses `\n` / `\r` in step text** → without this, a multi-line step text breaks the bullet-line format on injection. See [`plan-hydration.test.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/plan-hydration.test.ts) for header-format pin.
9. **`openclaw-tools.ts:279-286` confirms no plan-mode tools are registered here** → just `update_plan`. The note explicitly defers `enter_plan_mode` / `exit_plan_mode` / etc. to 2/6.
10. **`zod-schema.ts:939` is the only schema field added** → grep the diff for `planMode` in zod-schema.ts: zero hits. The `agents.defaults.planMode.*` keys land in 2/6.

Each item above is a single grep-or-test-run. The whole pass is ~25 minutes for a reviewer who knows the codebase, ~45 minutes for one who doesn't.

## What this PR does NOT include

Explicit list, with redirect to the right per-part PR for each:

- **`enter_plan_mode` / `exit_plan_mode` tools, mutation gate, approval state machine** → [Plan Mode 2/6] (#70066) Core backend MVP.
- **`SessionEntry.planMode` schema field** → [Plan Mode 2/6] (#70066) — the foundation here writes plan state to disk (`PlanStore`) and to per-run memory (`AgentRunContext.lastPlanSteps`), but never to `SessionEntry`.
- **`agents.defaults.planMode.*` config wiring** → [Plan Mode 2/6] for `enabled` + `debug`, [Plan Mode FULL] (#70071) for `autoEnableFor` + `approvalTimeoutSeconds` runtime.
- **`ask_user_question` tool, plan archetypes, plan-mode auto mode, `plan_mode_status` tool** → [Plan Mode 3/6] (#70067) Advanced plan interactions.
- **Cron-driven plan nudges + auto-enable + subagent plan-snapshot persister + escalating-retry nudges** → [Plan Mode AUTOMATION] (#70089) thematic carve-out + bundled in [Plan Mode FULL] (#70071).
- **Plan UI (sidebar, mode chip, approval cards) + i18n** → [Plan Mode 4/6] (#70068) Web UI + i18n.
- **Universal `/plan` slash commands across channels + Telegram attachment delivery** → [Plan Mode 5/6] (#70069) Text channels + Telegram.
- **Operator runbook + QA scenarios + help text** → [Plan Mode 6/6] (#70070) Docs, QA, and help.
- **Executing-state lifecycle (3-state mode), executing-phase nudges, `[PLAN_STATUS]` auto-inject preamble** → folded into [Plan Mode FULL] (#70071) only — structurally inseparable from earlier parts.
- **Typed pending-injection queue foundation** → [Plan Mode INJECTIONS] (#70088).
- **GPT-5 prompt foundation** → deferred to a separate focused PR after this rollout (closed as #69449).

## Issue references

- **Resolves #67542** (cross-session plan store with file-level locking) — addressed by `PlanStore` with O_EXCL+O_NOFOLLOW lock, atomic-rename write, parent-symlink confinement, and namespace traversal guard. Tests at `plan-store.test.ts`.
- **Refs #67514** (`update_plan` merge mode + closure gate) — merge semantics + closure gate land in this PR's `update-plan-tool.ts`. The full plan-mode integration of these (gate-on-tools, persister-on-events) is in 2/6.
- **Refs #67538** (plan mode runtime + escalating retry + auto-continue) — `update_plan`'s structural completion detection (the `phase: "completed"` second event) is the foundation for the persister's auto-flip-mode behavior in 2/6. Escalating retry lands in [Plan Mode AUTOMATION] (#70089).
- **Refs #67541** (skill plan templates) — `skill-planner.ts` + `frontmatter.ts` ship the parser + payload builder. Runtime hook (`applySkillPlanTemplateSeed`) ships here in `pi-embedded-runner/skills-runtime.ts`. Channel rendering of seeded plans lands in 4/6 + 5/6.
- **Refs #67840** (plan-mode integration bridge) — `agent_plan_event` schema + `PlanStepSnapshot` + `AgentRunContext.lastPlanSteps` are the bridge primitives the gateway-side persister (in 2/6) consumes.

## Architecture references

- `docs/plans/PLAN-MODE-ARCHITECTURE.md` — full architecture doc lands in 6/6 (Docs). For this PR, the most useful section is "Plan State Machine + File Layout" which mirrors the diagrams above.
- `src/agents/plan-store.ts:1-13` — module-level docstring explains the cross-session vs session-scoped semantics.
- `src/agents/plan-hydration.ts:1-14` — module-level docstring documents the Hermes Agent provenance + the "factual statement, not imperative" framing.

## Test status

- **Unit tests passing**: `plan-store.test.ts`, `plan-hydration.test.ts`, `update-plan-tool.parity.test.ts`, `skills/skill-planner.test.ts`, `skills/frontmatter.test.ts` all green on the branch HEAD.
- **Integration tests**: covered in [Plan Mode 2/6] (#70066) where the gateway gate + approval flow integrate with this foundation. There's no integration surface on `main` after this PR alone — `update_plan` is the only new tool, and it's gated off via `isUpdatePlanToolEnabledForOpenClawTools` until 2/6.
- **Manual smoke**: `PlanStore` exercised via the test suite (no live caller in this PR). `update_plan` exercised via the parity tests; the live tool registration is a one-line factory call so manual smoke is unnecessary.
- **CI status**: re-running after `bf19766b5a` removed forward-reference imports from `openclaw-tools.ts` so the foundation compiles standalone against `main`.
- **Pre-existing unrelated issue**: vitest workspace project-name conflict (config-level, predates this work) — workaround `--config test/vitest/vitest.unit-fast.config.ts`.

## Carry-forward / deferred

- `agents.defaults.planMode.enabled: false` — schema lands in 2/6 with default-off, zero behavioral change for existing users.
- `agents.defaults.planMode.autoEnableFor` — schema-reserved in 3/6; runtime wiring is in [Plan Mode FULL] (#70071).
- `agents.defaults.planMode.approvalTimeoutSeconds` — schema-reserved in 3/6; runtime deferred (Plan Mode 1.0 follow-up cycle).
- Plan files written by `PlanStore` are append-only JSON; no migration tooling needed for upgrades.
- `SessionEntry.planMode` is OPTIONAL when it lands in 2/6 — missing field defaults to `"normal"` everywhere.

## Stack rollout note for maintainers

Please review/merge this PR first. After it merges to `main`, the other 5 per-part PRs ([Plan Mode 2/6] through [Plan Mode 6/6]) are all pre-opened against the *current* `main` with cherry-picked per-part diffs. Their CI will turn green as the chain merges in order. Alternatively, [Plan Mode FULL] (#70071) provides a green-CI integrated bundle for end-to-end testing or single-merge landing.

**Suggested merge order**: 1/6 → 2/6 → 3/6 → 4/6 → 5/6 → 6/6 → (optional) FULL for integration verify of the automation + executing-state lifecycle work.
