### PR TITLE
feat(skills): add mrscraper-cli workspace skill

### DIFF
--- a/skills/mrscraper-cli/SKILL.md
+++ b/skills/mrscraper-cli/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: mrscraper-cli
+description: Official MrScraper CLI for terminal scraping, AI extraction jobs, and polling results outside OpenClaw's built-in tools.
+homepage: https://www.npmjs.com/package/@mrscraper/cli
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🕷️",
+        "requires": { "bins": ["mrscraper"] },
+        "install":
+          [
+            {
+              "id": "node",
+              "kind": "node",
+              "package": "@mrscraper/cli",
+              "bins": ["mrscraper"],
+              "label": "Install @mrscraper/cli (global npm)",
+            },
+          ],
+      },
+  }
+---
+
+# MrScraper CLI
+
+Use the `mrscraper` command for scripted or agent-driven flows that mirror the
+[MrScraper](https://app.mrscraper.com) dashboard from the terminal. OpenClaw's
+bundled **MrScraper plugin** exposes related capabilities as agent tools; this
+skill covers the standalone CLI when you want the same platform from your shell.
+
+## Install
+
+```bash
+npm install -g @mrscraper/cli
+```
+
+Or run without a global install: `npx --yes @mrscraper/cli --help`
+
+## Auth
+
+- Interactive: `mrscraper login`
+- Non-interactive: `mrscraper login --api-key "$MRSCRAPER_API_KEY"`
+- Environment: `MRSCRAPER_API_KEY` or `MRSCRAPER_API_TOKEN` (see upstream docs)
+
+## Common commands
+
+- `mrscraper scrape "<url>"` — HTML render, or add `--prompt` / `--agent` for AI mode
+- `mrscraper results` / `mrscraper result --id <uuid>` — inspect job output
+- `mrscraper --help` — full reference
+
+Package and changelog: https://www.npmjs.com/package/@mrscraper/cli


### PR DESCRIPTION


**Problem:** [MrScraper](https://mrscraper.com/) helps people pull fresh, structured, LLM-friendly data from the web—including sites that are hard or impossible to fetch with a plain HTTP client (bot protection, rendering, extraction jobs). OpenClaw agents should be able to use that capability from the shell via the official `mrscraper` CLI when users prefer scripted flows or want parity with the dashboard outside built-in tools.

**Why it matters:** The CLI gives a direct path to scrape, AI extraction, and job polling (`mrscraper scrape`, results commands, auth via `mrscraper login` / API keys) so users can get analysis-ready data and plug it into downstream steps without re-documenting upstream behavior inside OpenClaw.

**What changed:** Added a bundled workspace skill at `skills/mrscraper-cli/SKILL.md`: frontmatter (`name`, `description`, `homepage`, OpenClaw `metadata` with `requires.bins: ["mrscraper"]` and a Node/npm install hint for `@mrscraper/cli`), plus concise body copy for install (`npm` / `npx`), auth (`mrscraper login`, env vars), and common commands so agents can discover and use the CLI when it is installed.

**What did NOT change (scope boundary):** No changes to `extensions/mrscraper/`, no `web_fetch` provider registration, no new or modified agent tools, no `openclaw.plugin.json`, no Vitest or labeler updates, and no CHANGELOG or `docs/` page—this PR is skill-only for the standalone CLI; the optional MrScraper OpenClaw plugin remains separate from this change.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none — remove line or add issue #)
- Related # (none — remove line or add issue #)
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `N/A` (new skill content, not a bug fix)
- Missing detection / guardrail: `N/A`
- Contributing context (if known): `N/A`

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: `N/A` — no runtime or contract change in OpenClaw; behavior is “skill appears in inventory when bundled” plus optional manual CLI check.
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient (no executable paths added in this repo)
- Target test or file: `N/A`
- Scenario the test should lock in: `N/A`
- Why this is the smallest reliable guardrail: `N/A`
- Existing test that already covers this (if any): `N/A`
- If no new test is added, why not: Markdown-only skill; no new modules or gateway logic to exercise.

## User-visible / Behavior Changes

- Bundled **MrScraper CLI** skill (`mrscraper-cli`) is available for discovery like other workspace skills when this tree is used.
- Skill status may show **missing `mrscraper` binary** until `@mrscraper/cli` is installed (expected from `requires.bins`).
- No change to OpenClaw defaults, config schema, or built-in tools.

## Diagram (if applicable)

`N/A`

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (skill text references upstream env vars; no new OpenClaw token plumbing.)
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (no new registered OpenClaw tools; agents may run user-installed `mrscraper` when following the skill—same class as any CLI skill.)
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: *(e.g. macOS 15 — your machine)*
- Runtime/container: *(local dev / n/a)*
- Model/provider: `N/A` for skill file review
- Integration/channel (if any): `N/A`
- Relevant config (redacted): `N/A`

### Steps

1. Confirm `skills/mrscraper-cli/SKILL.md` exists and frontmatter parses (name, `openclaw.metadata.requires.bins`, install block).
2. Optional: `npm install -g @mrscraper/cli` then `mrscraper --help` (or `npx --yes @mrscraper/cli --help`).
3. Optional: run your usual OpenClaw **skills status / inventory** path and confirm `mrscraper-cli` lists as expected and eligibility reflects whether `mrscraper` is on `PATH`.

### Expected

- Skill documents install, auth, and common commands; `mrscraper` works per upstream when installed.

### Actual

- *(what you saw — e.g. “skill listed; missing bin before install, eligible after”)*
-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant) — `N/A`

*(For a docs-only PR, linking the single added file in the “Files changed” tab is usually enough; add a one-line skills screenshot if your process requires it.)*

## Human Verification (required)

- **Verified scenarios:** Read `SKILL.md` for accuracy vs [@mrscraper/cli](https://www.npmjs.com/package/@mrscraper/cli) / `mrscraper --help`; confirmed scope is CLI-only (no plugin files touched).
- **Edge cases checked:** Skill notes `npx` path; env var names match skill body.
- **What you did not verify:** Full OpenClaw gateway run with a live agent session *(or say you did, if you did)*.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (no new OpenClaw config keys; MrScraper auth remains per CLI/upstream.)
- Migration needed? **No**
- If yes, exact upgrade steps: `N/A`

## Risks and Mitigations

- **Risk:** Overlap in intent with the **MrScraper extension** / other MrScraper docs could confuse users about “plugin vs CLI.”  
  - **Mitigation:** Skill body already states the plugin vs CLI split; PR description repeats scope boundary.

*(If not a concern for your team, replace with: `None`.)*
