### PR TITLE
fix(release-check): assert bundled plugin runtime deps after packed postinstall

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -222,6 +222,26 @@ function runPackedBundledPluginPostinstall(packageRoot: string): void {
   });
 }
 
+export function collectInstalledBundledPluginRuntimeDepErrors(packageRoot: string): string[] {
+  return collectBuiltBundledPluginStagedRuntimeDependencyErrors({
+    bundledPluginsDir: join(packageRoot, "dist", "extensions"),
+  });
+}
+
+function assertInstalledBundledPluginRuntimeDepsResolved(packageRoot: string): void {
+  const errors = collectInstalledBundledPluginRuntimeDepErrors(packageRoot);
+  if (errors.length === 0) {
+    return;
+  }
+  console.error("release-check: packed install is missing bundled plugin runtime dependencies:");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  throw new Error(
+    "release-check: bundled plugin runtime dependencies were not installed after packed postinstall.",
+  );
+}
+
 function runPackedBundledChannelEntrySmoke(): void {
   const tmpRoot = mkdtempSync(join(tmpdir(), "openclaw-release-pack-smoke-"));
   try {
@@ -235,6 +255,7 @@ function runPackedBundledChannelEntrySmoke(): void {
 
     const packageRoot = join(resolveGlobalRoot(prefixDir, tmpRoot), "openclaw");
     runPackedBundledPluginPostinstall(packageRoot);
+    assertInstalledBundledPluginRuntimeDepsResolved(packageRoot);
     execFileSync(
       process.execPath,
       [

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --import tsx
 
 import { execFileSync, execSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -27,6 +27,7 @@ import {
   runInstalledWorkspaceBootstrapSmoke,
   WORKSPACE_TEMPLATE_PACK_PATHS,
 } from "./lib/workspace-bootstrap-smoke.mjs";
+import { discoverBundledPluginRuntimeDeps } from "./postinstall-bundled-plugins.mjs";
 import { listStaticExtensionAssetOutputs } from "./runtime-postbuild.mjs";
 import { sparkleBuildFloorsFromShortVersion, type SparkleBuildFloors } from "./sparkle-build.ts";
 
@@ -223,9 +224,18 @@ function runPackedBundledPluginPostinstall(packageRoot: string): void {
 }
 
 export function collectInstalledBundledPluginRuntimeDepErrors(packageRoot: string): string[] {
-  return collectBuiltBundledPluginStagedRuntimeDependencyErrors({
-    bundledPluginsDir: join(packageRoot, "dist", "extensions"),
-  });
+  const extensionsDir = join(packageRoot, "dist", "extensions");
+  if (!existsSync(extensionsDir)) {
+    return [];
+  }
+  const runtimeDeps = discoverBundledPluginRuntimeDeps({ extensionsDir });
+  return runtimeDeps
+    .filter((dep) => !existsSync(join(packageRoot, dep.sentinelPath)))
+    .map((dep) => {
+      const owners = dep.pluginIds.length > 0 ? dep.pluginIds.join(", ") : "unknown";
+      return `bundled plugin runtime dependency '${dep.name}@${dep.version}' (owners: ${owners}) is missing at ${dep.sentinelPath}.`;
+    })
+    .toSorted((left, right) => left.localeCompare(right));
 }
 
 function assertInstalledBundledPluginRuntimeDepsResolved(packageRoot: string): void {

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -487,19 +487,18 @@ describe("collectInstalledBundledPluginRuntimeDepErrors", () => {
     packageRoot: string,
     pluginId: string,
     packageJson: Record<string, unknown>,
-  ): string {
+  ): void {
     const pluginRoot = join(packageRoot, "dist", "extensions", pluginId);
     mkdirSync(pluginRoot, { recursive: true });
     writeFileSync(join(pluginRoot, "package.json"), JSON.stringify(packageJson, null, 2));
-    return pluginRoot;
   }
 
-  function stagePluginRuntimeDependency(
-    pluginRoot: string,
+  function installRuntimeDependencyAtPackageRoot(
+    packageRoot: string,
     dependencyName: string,
     version: string,
   ): void {
-    const dependencyRoot = join(pluginRoot, "node_modules", ...dependencyName.split("/"));
+    const dependencyRoot = join(packageRoot, "node_modules", ...dependencyName.split("/"));
     mkdirSync(dependencyRoot, { recursive: true });
     writeFileSync(
       join(dependencyRoot, "package.json"),
@@ -507,15 +506,15 @@ describe("collectInstalledBundledPluginRuntimeDepErrors", () => {
     );
   }
 
-  it("returns no errors when declared runtime deps are staged under the installed plugin", () => {
+  it("returns no errors when declared deps are installed at the openclaw package root", () => {
     const packageRoot = createPackageRoot();
     try {
-      const pluginRoot = writeBundledPluginPackageJson(packageRoot, "whatsapp", {
+      writeBundledPluginPackageJson(packageRoot, "whatsapp", {
         name: "@openclaw/whatsapp",
         dependencies: { "@whiskeysockets/baileys": "7.0.0-rc.9" },
         openclaw: { bundle: { stageRuntimeDependencies: true } },
       });
-      stagePluginRuntimeDependency(pluginRoot, "@whiskeysockets/baileys", "7.0.0-rc.9");
+      installRuntimeDependencyAtPackageRoot(packageRoot, "@whiskeysockets/baileys", "7.0.0-rc.9");
 
       expect(collectInstalledBundledPluginRuntimeDepErrors(packageRoot)).toEqual([]);
     } finally {
@@ -523,7 +522,7 @@ describe("collectInstalledBundledPluginRuntimeDepErrors", () => {
     }
   });
 
-  it("surfaces an error naming the plugin and missing dependency", () => {
+  it("surfaces an error naming the owning plugin and missing dependency", () => {
     const packageRoot = createPackageRoot();
     try {
       writeBundledPluginPackageJson(packageRoot, "whatsapp", {
@@ -533,7 +532,7 @@ describe("collectInstalledBundledPluginRuntimeDepErrors", () => {
       });
 
       expect(collectInstalledBundledPluginRuntimeDepErrors(packageRoot)).toEqual([
-        "built bundled plugin 'whatsapp' is missing staged runtime dependency '@whiskeysockets/baileys: 7.0.0-rc.9' under dist/extensions/whatsapp/node_modules.",
+        "bundled plugin runtime dependency '@whiskeysockets/baileys@7.0.0-rc.9' (owners: whatsapp) is missing at node_modules/@whiskeysockets/baileys/package.json.",
       ]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -10,6 +10,7 @@ import {
   collectBundledExtensionManifestErrors,
   collectBundledPluginRootRuntimeMirrorErrors,
   collectForbiddenPackContentPaths,
+  collectInstalledBundledPluginRuntimeDepErrors,
   collectRootDistBundledRuntimeMirrors,
   collectForbiddenPackPaths,
   collectMissingPackPaths,
@@ -472,5 +473,70 @@ describe("createPackedBundledPluginPostinstallEnv", () => {
       OPENCLAW_DISABLE_BUNDLED_ENTRY_SOURCE_FALLBACK: "1",
       OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "1",
     });
+  });
+});
+
+describe("collectInstalledBundledPluginRuntimeDepErrors", () => {
+  function createPackageRoot(): string {
+    const packageRoot = mkdtempSync(join(tmpdir(), "release-check-installed-bundled-"));
+    mkdirSync(join(packageRoot, "dist", "extensions"), { recursive: true });
+    return packageRoot;
+  }
+
+  function writeBundledPluginPackageJson(
+    packageRoot: string,
+    pluginId: string,
+    packageJson: Record<string, unknown>,
+  ): string {
+    const pluginRoot = join(packageRoot, "dist", "extensions", pluginId);
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(join(pluginRoot, "package.json"), JSON.stringify(packageJson, null, 2));
+    return pluginRoot;
+  }
+
+  function stagePluginRuntimeDependency(
+    pluginRoot: string,
+    dependencyName: string,
+    version: string,
+  ): void {
+    const dependencyRoot = join(pluginRoot, "node_modules", ...dependencyName.split("/"));
+    mkdirSync(dependencyRoot, { recursive: true });
+    writeFileSync(
+      join(dependencyRoot, "package.json"),
+      JSON.stringify({ name: dependencyName, version }, null, 2),
+    );
+  }
+
+  it("returns no errors when declared runtime deps are staged under the installed plugin", () => {
+    const packageRoot = createPackageRoot();
+    try {
+      const pluginRoot = writeBundledPluginPackageJson(packageRoot, "whatsapp", {
+        name: "@openclaw/whatsapp",
+        dependencies: { "@whiskeysockets/baileys": "7.0.0-rc.9" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      });
+      stagePluginRuntimeDependency(pluginRoot, "@whiskeysockets/baileys", "7.0.0-rc.9");
+
+      expect(collectInstalledBundledPluginRuntimeDepErrors(packageRoot)).toEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces an error naming the plugin and missing dependency", () => {
+    const packageRoot = createPackageRoot();
+    try {
+      writeBundledPluginPackageJson(packageRoot, "whatsapp", {
+        name: "@openclaw/whatsapp",
+        dependencies: { "@whiskeysockets/baileys": "7.0.0-rc.9" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      });
+
+      expect(collectInstalledBundledPluginRuntimeDepErrors(packageRoot)).toEqual([
+        "built bundled plugin 'whatsapp' is missing staged runtime dependency '@whiskeysockets/baileys: 7.0.0-rc.9' under dist/extensions/whatsapp/node_modules.",
+      ]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- release-check already validates that bundled plugin runtime deps are staged in the **source** `dist/extensions/<id>/node_modules/` via `checkBundledExtensionMetadata`, but `runPackedBundledChannelEntrySmoke` never re-validates after `runPackedBundledPluginPostinstall` against the **installed** tarball.
- That gap is how `2026.4.21` published to npm with `dist/extensions/whatsapp/node_modules/@whiskeysockets/baileys` missing: the source staging passed during build, `npm pack` strips every `node_modules/` path, and the packed postinstall silently failed to reinstall baileys. Release-check never noticed because it did not re-check the installed layout.
- This PR re-uses the existing `collectBuiltBundledPluginStagedRuntimeDependencyErrors` helper, aimed at the installed `packageRoot`, right after the packed postinstall runs, and fails release-check if any declared runtime dep is missing from the plugin-local `node_modules`.

## Change Type

- [x] Bug fix (regression guard)
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] CI/CD / infra (release-check)

## Linked Issue/PR

- Follow-up to #69842 (closed prematurely relative to npm release: `v2026.4.21` was tagged ~11 minutes before the doctor-side repair commit landed, so npm still shipped the broken state)
- Related: #68778 (deeper fragility around RC dep + postinstall hotfix; not addressed here)

## Root Cause / Why release-check missed it

- `checkBundledExtensionMetadata` runs `collectBuiltBundledPluginStagedRuntimeDependencyErrors` against the repo's own `dist/extensions/`. At that point the staged `node_modules` are present, so the check passes.
- `collectForbiddenPackPaths` then strips all `node_modules/` entries from `npm pack` output (correct, so tarballs stay small and deterministic).
- `runPackedBundledChannelEntrySmoke` installs the tarball and invokes `runPackedBundledPluginPostinstall` to reinstall the plugin runtime deps into the installed layout. If that postinstall silently under-installs a bundled plugin's declared deps (as happened for WhatsApp + baileys in `v2026.4.21`), nothing downstream notices: the compiled channel entry smoke loads entry files but does not force-import the lazy runtime dep, and the completion smoke does not touch it either.
- Net result: release-check ships a "green" tarball whose installed layout is broken for users.

## What this PR changes

- `scripts/release-check.ts`:
  - New exported helper `collectInstalledBundledPluginRuntimeDepErrors(packageRoot)` that adapts the existing `collectBuiltBundledPluginStagedRuntimeDependencyErrors` to the installed `packageRoot/dist/extensions/` layout.
  - New internal `assertInstalledBundledPluginRuntimeDepsResolved(packageRoot)` that surfaces each missing dep with its owning plugin id and throws so release-check fails visibly.
  - Wired into `runPackedBundledChannelEntrySmoke` immediately after `runPackedBundledPluginPostinstall(packageRoot)`.
- `test/release-check.test.ts`:
  - Unit coverage for the new helper: passes when declared deps are staged under the installed plugin, and surfaces a precise error naming plugin id + missing dep when they are not.

No runtime behavior changes in any plugin, no changes to postinstall logic, no changes to tarball contents.

## Regression Test Plan

- Coverage level:
  - [x] Unit test (new)
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient (for the underlying helper)
- Target tests: `test/release-check.test.ts` ("collectInstalledBundledPluginRuntimeDepErrors") + existing `test/scripts/bundled-plugin-staged-runtime-deps.test.ts` (already covers the collector).
- Scenario the test locks in:
  - A simulated installed `packageRoot` with a bundled plugin that declares `@whiskeysockets/baileys` but has no staged `node_modules/@whiskeysockets/baileys/package.json` under the plugin dir produces an error naming plugin `whatsapp` and dependency `@whiskeysockets/baileys`.
  - The same simulated installed layout with the dep staged returns no errors.
- Why this is the smallest reliable guardrail: the release-check wiring is a thin shim over a helper that is already covered in isolation; the new test asserts only that the shim assembles the `packageRoot -> dist/extensions` path correctly and threads errors through. The full packed install + postinstall flow is exercised by `runPackedBundledChannelEntrySmoke` in CI and does not need a parallel unit harness.

## Verification

```
pnpm check:changed
  [check:changed] lanes=tooling
  [check:changed] scripts/release-check.ts: tooling surface
  [check:changed] test/release-check.test.ts: root test/support surface
  [check:changed] conflict markers ... OK
  [check:changed] lint scripts ... Found 0 warnings and 0 errors.
  [check:changed] tests changed ... Test Files 1 passed (1) / Tests 28 passed (28)
```

## User-visible / behavior changes

- Release-check now fails when the packed + installed + postinstalled layout is missing any declared runtime dep of a bundled plugin that opted into `stageRuntimeDependencies`.
- No change for users running `openclaw` normally. Only affects the release lane.

## Out of scope

- The deeper WhatsApp fragility (RC baileys version, postinstall-only hotfix, doctor self-heal coverage). Tracked in #68778.
- Supply-chain lockfile coverage for bundled plugins. Tracked in #58291.
- The actual doctor-side repair that shipped to main as `f9b20c7d17` after `v2026.4.21` was tagged. That change is expected to ship in the next release; this PR is an independent regression guard that would have caught the `v2026.4.21` publish itself.