### PR TITLE
fix(agents): preserve CLI session across heartbeat runs and gateway restarts

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -107,7 +107,13 @@ export async function prepareCliRunContext(
     authCredential = authStore.profiles[effectiveAuthProfileId];
   }
   const extraSystemPrompt = params.extraSystemPrompt?.trim() ?? "";
-  const extraSystemPromptHash = hashCliSessionText(extraSystemPrompt);
+  // Heartbeat runs use a different provider in their inbound meta prompt, which would
+  // produce a different extraSystemPromptHash than user-chat runs. Preserve the stored
+  // hash during heartbeat runs so the CLI session is not invalidated and the user-chat
+  // hash is not overwritten.
+  const extraSystemPromptHash = params.isHeartbeat
+    ? (params.cliSessionBinding?.extraSystemPromptHash ?? hashCliSessionText(extraSystemPrompt))
+    : hashCliSessionText(extraSystemPrompt);
   const modelId = (params.model ?? "default").trim() || "default";
   const normalizedModel = normalizeCliModel(modelId, backendResolved.config);
   const modelDisplay = `${params.provider}/${modelId}`;

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -107,12 +107,14 @@ export async function prepareCliRunContext(
     authCredential = authStore.profiles[effectiveAuthProfileId];
   }
   const extraSystemPrompt = params.extraSystemPrompt?.trim() ?? "";
-  // Heartbeat runs use a different provider in their inbound meta prompt, which would
-  // produce a different extraSystemPromptHash than user-chat runs. Preserve the stored
-  // hash during heartbeat runs so the CLI session is not invalidated and the user-chat
-  // hash is not overwritten.
+  // Heartbeat runs inject a different provider value into the inbound meta system prompt,
+  // producing a different extraSystemPromptHash than user-chat runs. To prevent session
+  // invalidation, heartbeat runs reuse the stored binding hash (if one exists) rather than
+  // computing a new one. If no stored hash exists, they produce undefined — resolveCliSessionReuse
+  // treats a missing stored hash as compatible with any incoming hash, so the session is never
+  // invalidated solely because a heartbeat ran first.
   const extraSystemPromptHash = params.isHeartbeat
-    ? (params.cliSessionBinding?.extraSystemPromptHash ?? hashCliSessionText(extraSystemPrompt))
+    ? params.cliSessionBinding?.extraSystemPromptHash
     : hashCliSessionText(extraSystemPrompt);
   const modelId = (params.model ?? "default").trim() || "default";
   const normalizedModel = normalizeCliModel(modelId, backendResolved.config);

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -38,6 +38,7 @@ export type RunCliAgentParams = {
   senderIsOwner?: boolean;
   abortSignal?: AbortSignal;
   replyOperation?: ReplyOperation;
+  isHeartbeat?: boolean;
 };
 
 export type CliPreparedBackend = {

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -50,7 +50,7 @@ describe("cli-session helpers", () => {
     });
   });
 
-  it("invalidates legacy bindings when auth, prompt, or MCP state changes", () => {
+  it("invalidates legacy bindings when auth or MCP state changes", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
@@ -68,15 +68,28 @@ describe("cli-session helpers", () => {
     expect(
       resolveCliSessionReuse({
         binding,
-        extraSystemPromptHash: "prompt-hash",
-      }),
-    ).toEqual({ invalidatedReason: "system-prompt" });
-    expect(
-      resolveCliSessionReuse({
-        binding,
         mcpConfigHash: "mcp-hash",
       }),
     ).toEqual({ invalidatedReason: "mcp" });
+  });
+
+  it("reuses legacy bindings (no stored hash) regardless of current hash", () => {
+    // Legacy bindings and heartbeat-first sessions have no extraSystemPromptHash stored.
+    // Introducing hash tracking should not invalidate these sessions.
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      cliSessionIds: { "claude-cli": "legacy-session" },
+      claudeCliSessionId: "legacy-session",
+    };
+    const binding = getCliSessionBinding(entry, "claude-cli");
+
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        extraSystemPromptHash: "prompt-hash",
+      }),
+    ).toEqual({ sessionId: "legacy-session" });
   });
 
   it("invalidates reuse when stored auth profile or prompt shape changes", () => {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -148,7 +148,13 @@ export function resolveCliSessionReuse(params: {
     return { invalidatedReason: "auth-epoch" };
   }
   const storedExtraSystemPromptHash = normalizeOptionalString(binding?.extraSystemPromptHash);
-  if (storedExtraSystemPromptHash !== currentExtraSystemPromptHash) {
+  // Only invalidate when a stored hash is present and mismatches. A missing stored hash
+  // (e.g. from a heartbeat-first session) is treated as compatible with any incoming hash
+  // so the session is not spuriously reset.
+  if (
+    storedExtraSystemPromptHash !== undefined &&
+    storedExtraSystemPromptHash !== currentExtraSystemPromptHash
+  ) {
     return { invalidatedReason: "system-prompt" };
   }
   const storedMcpResumeHash = normalizeOptionalString(binding?.mcpResumeHash);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -919,6 +919,7 @@ export async function runAgentTurnWithFallback(params: {
                   senderIsOwner: params.followupRun.run.senderIsOwner,
                   abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
                   replyOperation: params.replyOperation,
+                  isHeartbeat: params.opts?.isHeartbeat === true,
                 });
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,


### PR DESCRIPTION
## Summary

- Heartbeat runs inject `\"provider\": \"heartbeat\"` into the inbound meta system prompt, producing a different `extraSystemPromptHash` than user-chat runs (`\"provider\": \"webchat\"`). After every heartbeat, the stored hash differed from the next user turn's hash → `resolveCliSessionReuse` returned `invalidatedReason: \"system-prompt\"` → new empty CLI session → `chat.history` returned `[]` → webUI reverted to the landing/welcome screen.
- Additionally, heartbeat-first sessions (heartbeat fires before any user message) would write a heartbeat hash, guaranteeing a reset on the first user turn.
- Gateway restarts assign a new random port to the MCP loopback server, previously causing `invalidatedReason: \"mcp\"` on the next run. This was already fixed upstream via `mcpResumeHash` (port-normalized); this PR rebases cleanly on top of that.

## Fix

**Part 1: extraSystemPromptHash** (`prepare.ts`, `types.ts`, `agent-runner-execution.ts`, `cli-session.ts`):
- Added `isHeartbeat?: boolean` to `RunCliAgentParams` and propagated from `agent-runner-execution.ts`.
- Heartbeat runs use the stored binding hash rather than computing a new one; if no stored hash exists they produce `undefined` (no hash written to binding).
- `resolveCliSessionReuse` now skips the hash check when the stored hash is `undefined` — legacy bindings and heartbeat-first sessions are treated as compatible with any incoming hash.

**Part 2: mcpResumeHash** (already in upstream, rebased here):
- `bundle-mcp.ts` computes a separate `mcpResumeHash` by normalizing the loopback port to a placeholder before hashing.
- `resolveCliSessionReuse` prefers `mcpResumeHash` for the MCP invalidation check when available, falling back to `mcpConfigHash` for older bindings.

Together these ensure the CLI session is preserved across heartbeat runs (in all orderings) and gateway restarts.

## Test plan

- [ ] All `cli-session` and `auto-reply` tests pass (verified locally: 1129 tests passing)
- [ ] `bundle-mcp` tests cover resume hash stability across port changes (upstream)
- [ ] Updated test: legacy/no-stored-hash binding now reuses the session rather than invalidating on hash introduction
- [ ] Manually: send messages to a Claude CLI agent with heartbeat enabled — webUI should retain conversation history after Otto responds and across gateway restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)