### PR TITLE
fix(agents): strip thinking blocks with invalid signatures before API replay

### DIFF
--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -40,7 +40,7 @@ import {
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
-import { dropThinkingBlocks } from "./thinking.js";
+import { dropThinkingBlocks, stripInvalidThinkingSignatures } from "./thinking.js";
 
 const INTER_SESSION_PREFIX_BASE = "[Inter-session message]";
 const MODEL_SNAPSHOT_CUSTOM_TYPE = "model-snapshot";
@@ -476,9 +476,17 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(sanitizedImages)
+  // Strip thinking blocks with empty/invalid signatures before replay.
+  // Bedrock can return thinking blocks with empty thinkingSignature; these
+  // cause "Invalid signature in thinking block" API errors on subsequent turns.
+  // This runs before dropThinkingBlocks so it also catches cases where
+  // preserveSignatures is true (Anthropic/Bedrock providers). See #45010.
+  const validatedSignatures = policy.preserveSignatures
+    ? stripInvalidThinkingSignatures(sanitizedImages)
     : sanitizedImages;
+  const droppedThinking = policy.dropThinkingBlocks
+    ? dropThinkingBlocks(validatedSignatures)
+    : validatedSignatures;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
     allowProviderOwnedThinkingReplay,

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -6,7 +6,9 @@ import {
   assessLastAssistantMessage,
   dropThinkingBlocks,
   isAssistantMessageWithContent,
+  isInvalidThinkingSignatureError,
   sanitizeThinkingForRecovery,
+  stripInvalidThinkingSignatures,
   wrapAnthropicStreamWithRecovery,
 } from "./thinking.js";
 
@@ -102,6 +104,143 @@ describe("dropThinkingBlocks", () => {
       { type: "thinking", thinking: "latest", thinkingSignature: "sig_latest" },
       { type: "text", text: "latest text" },
     ]);
+  });
+});
+
+describe("stripInvalidThinkingSignatures", () => {
+  it("returns the original reference when no thinking blocks are present", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "world" }] }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("returns the original reference when all thinking blocks have valid signatures", () => {
+    const validSig = "a".repeat(356); // Real signatures are 356-2344+ chars
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning", thinkingSignature: validSig },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("strips thinking blocks with empty thinkingSignature", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning", thinkingSignature: "" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("strips thinking blocks with missing thinkingSignature", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("keeps thinking blocks with non-empty signatures regardless of length", () => {
+    // Non-empty signatures are kept — the API is the source of truth for validity.
+    // stripInvalidThinkingSignatures only catches empty/missing/non-string signatures.
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning", thinkingSignature: "short" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("preserves assistant turn when all thinking blocks are invalid", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "reasoning", thinkingSignature: "" }],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("keeps valid thinking blocks while stripping invalid ones in same message", () => {
+    const validSig = "b".repeat(356); // Real signatures are 356-2344+ chars
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "valid reasoning", thinkingSignature: validSig },
+          { type: "thinking", thinking: "bad reasoning", thinkingSignature: "" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toHaveLength(2);
+    expect((assistant.content[0] as { type: string }).type).toBe("thinking");
+    expect((assistant.content[1] as { type: string }).type).toBe("text");
+  });
+
+  it("does not touch non-assistant messages", () => {
+    const messages: AgentMessage[] = [castAgentMessage({ role: "user", content: "hello" })];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+});
+
+describe("isInvalidThinkingSignatureError", () => {
+  it("matches the Anthropic invalid signature error message", () => {
+    expect(isInvalidThinkingSignatureError("Invalid signature in thinking block")).toBe(true);
+    expect(
+      isInvalidThinkingSignatureError(
+        'Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Invalid signature in thinking block"}}',
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isInvalidThinkingSignatureError("context overflow")).toBe(false);
+    expect(isInvalidThinkingSignatureError("Invalid signature")).toBe(false);
+    expect(isInvalidThinkingSignatureError("")).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -272,6 +272,83 @@ describe("stripInvalidThinkingSignatures", () => {
     const result = stripInvalidThinkingSignatures(messages);
     expect(result).toBe(messages);
   });
+
+  it("keeps thinking blocks signed only via snake_case thought_signature", () => {
+    // sanitizeSessionMessagesImages preserves Anthropic's snake_case
+    // thought_signature field when preserveSignatures: true. Those blocks
+    // must NOT be treated as missing a signature.
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning", thought_signature: "AQID" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("keeps redacted_thinking blocks signed only via thought_signature", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", thought_signature: "AQID" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("strips thinking blocks where all signature fields are empty", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: "",
+            thought_signature: "",
+          },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("keeps thinking blocks when at least one signature field is valid", () => {
+    // Belt-and-braces: even if thinkingSignature is empty, a valid
+    // thought_signature is enough to keep the block.
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: "",
+            thought_signature: "AQID",
+          },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
 });
 
 describe("isInvalidThinkingSignatureError", () => {

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -225,6 +225,53 @@ describe("stripInvalidThinkingSignatures", () => {
     const result = stripInvalidThinkingSignatures(messages);
     expect(result).toBe(messages);
   });
+
+  it("strips redacted_thinking blocks with empty signature", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", signature: "" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("strips redacted_thinking blocks with missing signature", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "redacted_thinking" }, { type: "text", text: "answer" }],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("keeps redacted_thinking blocks with non-empty signatures", () => {
+    const validSig = "c".repeat(356);
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", signature: validSig },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
 });
 
 describe("isInvalidThinkingSignatureError", () => {

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -56,6 +56,70 @@ function hasMeaningfulText(block: AssistantContentBlock): boolean {
 }
 
 /**
+ * Strip thinking blocks that have obviously invalid `thinkingSignature` from
+ * assistant messages. This prevents Anthropic API rejection errors like
+ * "Invalid signature in thinking block" caused by empty signatures that were
+ * persisted from Bedrock streaming responses.
+ *
+ * Only strips thinking blocks with missing, empty, or non-string signatures —
+ * the clearly broken cases. Does NOT attempt length-based heuristics to guess
+ * whether a signature is valid; the API itself is the authoritative validator.
+ *
+ * Unlike `dropThinkingBlocks` which removes ALL thinking blocks, this function
+ * preserves thinking blocks that have a non-empty string signature.
+ *
+ * Returns the original array reference when nothing was changed.
+ */
+export function stripInvalidThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (!isAssistantMessageWithContent(msg)) {
+      out.push(msg);
+      continue;
+    }
+    const nextContent: AssistantContentBlock[] = [];
+    let changed = false;
+    for (const block of msg.content) {
+      if (!block || typeof block !== "object") {
+        nextContent.push(block);
+        continue;
+      }
+      const rec = block as { type?: unknown; thinkingSignature?: unknown };
+      if (rec.type !== "thinking") {
+        nextContent.push(block);
+        continue;
+      }
+      const sig = rec.thinkingSignature;
+      if (typeof sig === "string" && sig.length > 0) {
+        nextContent.push(block);
+        continue;
+      }
+      touched = true;
+      changed = true;
+    }
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
+    const content =
+      nextContent.length > 0 ? nextContent : [{ type: "text", text: "" } as AssistantContentBlock];
+    out.push({ ...msg, content });
+  }
+  return touched ? out : messages;
+}
+
+/**
+ * Returns true if the given error message indicates an Anthropic
+ * "Invalid signature in thinking block" rejection. Useful for callers that
+ * want to apply `dropThinkingBlocks` and retry once when this specific error
+ * surfaces despite `stripInvalidThinkingSignatures` running on replay.
+ */
+export function isInvalidThinkingSignatureError(errorText: string): boolean {
+  return /invalid signature in thinking block/i.test(errorText);
+}
+
+/**
  * Strip `type: "thinking"` and `type: "redacted_thinking"` content blocks from
  * all assistant messages except the latest one.
  *

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -55,22 +55,49 @@ function hasMeaningfulText(block: AssistantContentBlock): boolean {
     : false;
 }
 
+function hasNonEmptyStringSignature(block: AssistantContentBlock): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const rec = block as {
+    signature?: unknown;
+    thinkingSignature?: unknown;
+    thought_signature?: unknown;
+  };
+  const candidates = [rec.signature, rec.thinkingSignature, rec.thought_signature];
+  for (const sig of candidates) {
+    if (typeof sig === "string" && sig.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Strip thinking blocks that have obviously invalid signatures from assistant
  * messages. This prevents Anthropic API rejection errors like "Invalid
  * signature in thinking block" caused by empty signatures that were persisted
  * from Bedrock streaming responses.
  *
- * Covers both block shapes:
- *   - `type: "thinking"` blocks carry the signature in `thinkingSignature`.
- *   - `type: "redacted_thinking"` blocks carry it in `signature`.
+ * Covers both block shapes (`type: "thinking"` and `type: "redacted_thinking"`)
+ * and matches the same set of signature field names that `isSignedThinkingBlock`
+ * recognises so that any block the rest of the runner treats as signed is also
+ * treated as signed here:
+ *   - `signature` (canonical for `redacted_thinking`)
+ *   - `thinkingSignature` (older camelCase form)
+ *   - `thought_signature` (snake_case form preserved by
+ *     `sanitizeSessionMessagesImages` when `preserveSignatures: true`)
  *
- * Only strips blocks with missing, empty, or non-string signatures — the
- * clearly broken cases. Does NOT attempt length-based heuristics to guess
- * whether a signature is valid; the API itself is the authoritative validator.
+ * A block is considered signed if ANY of those fields holds a non-empty string,
+ * mirroring the union semantics of `isSignedThinkingBlock`. A block is stripped
+ * only when ALL of its recognised signature fields are missing, empty, or
+ * non-string — the clearly broken case.
+ *
+ * Does NOT attempt length-based heuristics to guess whether a signature is
+ * valid; the API itself is the authoritative validator.
  *
  * Unlike `dropThinkingBlocks` which removes ALL thinking blocks, this function
- * preserves blocks that have a non-empty string signature.
+ * preserves blocks that have at least one non-empty string signature.
  *
  * Returns the original array reference when nothing was changed.
  */
@@ -85,25 +112,11 @@ export function stripInvalidThinkingSignatures(messages: AgentMessage[]): AgentM
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      if (!block || typeof block !== "object") {
+      if (!isThinkingBlock(block)) {
         nextContent.push(block);
         continue;
       }
-      const rec = block as {
-        type?: unknown;
-        thinkingSignature?: unknown;
-        signature?: unknown;
-      };
-      let sig: unknown;
-      if (rec.type === "thinking") {
-        sig = rec.thinkingSignature;
-      } else if (rec.type === "redacted_thinking") {
-        sig = rec.signature;
-      } else {
-        nextContent.push(block);
-        continue;
-      }
-      if (typeof sig === "string" && sig.length > 0) {
+      if (hasNonEmptyStringSignature(block)) {
         nextContent.push(block);
         continue;
       }

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -56,17 +56,21 @@ function hasMeaningfulText(block: AssistantContentBlock): boolean {
 }
 
 /**
- * Strip thinking blocks that have obviously invalid `thinkingSignature` from
- * assistant messages. This prevents Anthropic API rejection errors like
- * "Invalid signature in thinking block" caused by empty signatures that were
- * persisted from Bedrock streaming responses.
+ * Strip thinking blocks that have obviously invalid signatures from assistant
+ * messages. This prevents Anthropic API rejection errors like "Invalid
+ * signature in thinking block" caused by empty signatures that were persisted
+ * from Bedrock streaming responses.
  *
- * Only strips thinking blocks with missing, empty, or non-string signatures —
- * the clearly broken cases. Does NOT attempt length-based heuristics to guess
+ * Covers both block shapes:
+ *   - `type: "thinking"` blocks carry the signature in `thinkingSignature`.
+ *   - `type: "redacted_thinking"` blocks carry it in `signature`.
+ *
+ * Only strips blocks with missing, empty, or non-string signatures — the
+ * clearly broken cases. Does NOT attempt length-based heuristics to guess
  * whether a signature is valid; the API itself is the authoritative validator.
  *
  * Unlike `dropThinkingBlocks` which removes ALL thinking blocks, this function
- * preserves thinking blocks that have a non-empty string signature.
+ * preserves blocks that have a non-empty string signature.
  *
  * Returns the original array reference when nothing was changed.
  */
@@ -85,12 +89,20 @@ export function stripInvalidThinkingSignatures(messages: AgentMessage[]): AgentM
         nextContent.push(block);
         continue;
       }
-      const rec = block as { type?: unknown; thinkingSignature?: unknown };
-      if (rec.type !== "thinking") {
+      const rec = block as {
+        type?: unknown;
+        thinkingSignature?: unknown;
+        signature?: unknown;
+      };
+      let sig: unknown;
+      if (rec.type === "thinking") {
+        sig = rec.thinkingSignature;
+      } else if (rec.type === "redacted_thinking") {
+        sig = rec.signature;
+      } else {
         nextContent.push(block);
         continue;
       }
-      const sig = rec.thinkingSignature;
       if (typeof sig === "string" && sig.length > 0) {
         nextContent.push(block);
         continue;


### PR DESCRIPTION
Rebase of #45072 onto current `main`, scoped down to the prevention piece so it can land independently. Original work by @4ier (credited via `Co-authored-by` trailer).

## Summary

- Adds `stripInvalidThinkingSignatures()` to `src/agents/pi-embedded-runner/thinking.ts`. Strips assistant `thinking` blocks whose `thinkingSignature` is missing, empty, or non-string — the cases where Bedrock streaming has been observed to persist a corrupt block to the session JSONL transcript.
- Wires it into `sanitizeSessionHistory()` in `src/agents/pi-embedded-runner/replay-history.ts` (this is where #45072's `google.ts` change moved to in the file restructure that happened after that PR was opened). Runs whenever `policy.preserveSignatures` is true (Anthropic / Bedrock path), before the existing `dropThinkingBlocks` step.
- Adds `isInvalidThinkingSignatureError()` so a future PR can wrap the runner stream with a retry-on-API-rejection safety net using the existing `wrapAnthropicStreamWithRecovery` pattern.
- Tests in `thinking.test.ts` cover the empty / missing / mixed-validity / non-assistant cases plus the error-matcher.

## Why this fixes #45010

The reproducible failure on Bedrock + Claude Opus 4.6 + extended thinking is:

1. Bedrock's converse-stream provider returns a thinking block with `thinkingSignature: \"\"`.
2. The runner persists it verbatim to the session JSONL.
3. Every subsequent turn replays the corrupt block to the Anthropic API, which rejects with `Invalid signature in thinking block`.
4. The session is permanently poisoned — no path to recover except `/reset`.

Stripping at replay-sanitisation time prevents step 3 from ever sending the bad block to the API. Both newly-corrupted sessions and existing damaged ones recover automatically on the next turn.

## What this PR deliberately does NOT include from #45072

The original PR added a defense-in-depth retry by threading a new `forceDropThinkingBlocks` flag through `run.ts`, `run/attempt.ts`, and `run/types.ts`. Those files have changed substantially since #45072 was opened, and `wrapAnthropicStreamWithRecovery` (introduced after #45072) provides the same retry shape with less plumbing. Splitting prevention from retry keeps this PR small and avoids re-doing diverged plumbing — retry can ride on top of the wrapper in a follow-up that also covers `THINKING_BLOCK_ERROR_PATTERN`-style errors.

## Bot feedback from #45072

Both review comments (greptile + codex) on the original PR were about `MIN_VALID_SIGNATURE_LENGTH = 10` being too permissive. @4ier addressed them in c999982 by removing the length heuristic entirely and treating the API as the authoritative validator. Those resolutions are incorporated here — the implementation only checks for empty / missing / non-string signatures, never length thresholds, and the test for a \"valid\" signature uses `\"b\".repeat(356)` to match the documented real-signature lower bound.

## Local verification

- `pnpm exec tsgo --noEmit -p tsconfig.json` — clean
- `pnpm exec oxlint <touched files>` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check <touched files>` — formatted
- Vitest run was attempted locally on Windows but `test/setup-openclaw-runtime.ts:372` failed with `Vitest failed to find the runner` for all 381 tests in the agents project — looks like a local/Windows env issue unrelated to this change. Relying on CI (which was green for these files in #45072) to confirm.

## Test plan

- [ ] CI green on Linux + Windows + macOS shards
- [ ] Greptile / Codex review surface no new findings
- [ ] Maintainer to confirm the scope split (prevention here, retry follow-up) is the preferred shape

Closes #45010
Supersedes #45072


Made with [Cursor](https://cursor.com)

---

## AI-assisted PR disclosure

Per [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#aivibe-coded-prs-welcome-):

- [x] **AI-assisted**: Authored with assistance from an LLM coding agent (Cursor + Claude). The original PR #45072 was authored by @4ier (credited via `Co-authored-by` trailer); this PR is a manual rebase of that work onto current `main` with the scope reduction described above. All edits, the rebase strategy, and the bot-feedback responses were reviewed and approved by the human submitter.
- [x] **Degree of testing**: Lightly tested. `pnpm exec tsgo --noEmit -p tsconfig.json`, `pnpm exec oxlint`, and `pnpm exec oxfmt --check` are clean for the touched files. Local Vitest run was attempted but `test/setup-openclaw-runtime.ts:372` failed with `Vitest failed to find the runner` for all 381 agents-project tests on Windows — appears to be a local env issue unrelated to this change. Relying on CI (currently 92 SUCCESS / 8 SKIPPED / 0 FAILURE) for full test validation. Production workaround in our downstream deployment confirms the empty-signature symptom and that boundary-side stripping mitigates it; the upstream fix here is the canonical version.
- [x] **Codex review**: GitHub Codex review did not trigger automatically on this PR. Ran `codex review --base upstream/main` locally (codex-cli 0.122.0) and it caught a P1 regression in my own implementation — `stripInvalidThinkingSignatures` was missing the snake_case `thought_signature` field that `sanitizeSessionMessagesImages` preserves, which would have silently erased valid Claude-signed reasoning turns. Fixed in e07342328c with new tests; re-running codex on the fix confirms no remaining actionable findings. Greptile also reviewed (5/5 confidence, all findings addressed).
- [x] **I understand what the code does**: `stripInvalidThinkingSignatures` walks assistant messages in the replay history and removes `thinking` / `redacted_thinking` blocks whose signature field is missing, empty, or non-string. It runs in `sanitizeSessionHistory` only when `policy.preserveSignatures` is true (Anthropic / Bedrock providers), and runs *before* `dropThinkingBlocks` so the latest-assistant-message preservation in `dropThinkingBlocks` doesn't reintroduce corrupt blocks. Returns the original array reference when nothing changed (caller can use reference equality to skip work). The retry helper `isInvalidThinkingSignatureError` is additive and not yet wired — left for a follow-up that uses `wrapAnthropicStreamWithRecovery` to retry on API rejection.


