### PR TITLE
[Plan Mode 4/6] Web UI + i18n

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -369,6 +369,35 @@
         "plan.0.step"
       ]
     },
+    "enter_plan_mode": {
+      "emoji": "🧭",
+      "title": "Enter Plan Mode",
+      "detailKeys": [
+        "reason"
+      ]
+    },
+    "exit_plan_mode": {
+      "emoji": "✅",
+      "title": "Exit Plan Mode",
+      "detailKeys": [
+        "title",
+        "summary",
+        "plan.0.step"
+      ]
+    },
+    "plan_mode_status": {
+      "emoji": "🔍",
+      "title": "Plan Mode Status",
+      "detailKeys": []
+    },
+    "ask_user_question": {
+      "emoji": "❓",
+      "title": "Ask User",
+      "detailKeys": [
+        "question",
+        "options.0"
+      ]
+    },
     "gateway": {
       "emoji": "🔌",
       "title": "Gateway",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -661,6 +661,7 @@ export const de: TranslationMap = {
   chat: {
     disconnected: "Verbindung zum Gateway getrennt.",
     refreshTitle: "Chat-Daten aktualisieren",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Ausgabe des Assistenten ein-/ausblenden",
     toolCallsToggle: "Tool-Aufrufe und Tool-Ergebnisse umschalten",
     focusToggle: "Fokusmodus ein-/ausschalten (Seitenleiste + Kopfzeile ausblenden)",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -648,6 +648,7 @@ export const en: TranslationMap = {
   chat: {
     disconnected: "Disconnected from gateway.",
     refreshTitle: "Refresh chat data",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Toggle assistant thinking/working output",
     toolCallsToggle: "Toggle tool calls and tool results",
     focusToggle: "Toggle focus mode (hide sidebar + page header)",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -660,6 +660,7 @@ export const es: TranslationMap = {
   chat: {
     disconnected: "Desconectado de la puerta de enlace.",
     refreshTitle: "Actualizar datos del chat",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Alternar salida de pensamiento/trabajo del asistente",
     toolCallsToggle: "Alternar llamadas a herramientas y resultados de herramientas",
     focusToggle: "Alternar modo de enfoque (ocultar barra lateral + cabecera)",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -662,6 +662,7 @@ export const fr: TranslationMap = {
   chat: {
     disconnected: "Déconnecté du Gateway.",
     refreshTitle: "Actualiser les données du chat",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Afficher/masquer la sortie de réflexion/travail de l’assistant",
     toolCallsToggle: "Afficher/masquer les appels d’outil et les résultats d’outil",
     focusToggle: "Activer/désactiver le mode focus (masquer la barre latérale + l’en-tête de page)",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -655,6 +655,7 @@ export const id: TranslationMap = {
   chat: {
     disconnected: "Terputus dari gateway.",
     refreshTitle: "Refresh data chat",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Alihkan output berpikir/bekerja asisten",
     toolCallsToggle: "Alihkan panggilan alat dan hasil alat",
     focusToggle: "Alihkan mode fokus (sembunyikan bilah samping + header halaman)",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -658,6 +658,7 @@ export const ja_JP: TranslationMap = {
   chat: {
     disconnected: "Gateway から切断されました。",
     refreshTitle: "チャットデータを更新",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "アシスタントの思考 / 作業出力の表示を切り替え",
     toolCallsToggle: "ツール呼び出しとツール結果の表示を切り替え",
     focusToggle: "フォーカスモードを切り替え（サイドバー + ページヘッダーを非表示）",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -651,6 +651,7 @@ export const ko: TranslationMap = {
   chat: {
     disconnected: "Gateway와 연결이 끊어졌습니다.",
     refreshTitle: "채팅 데이터 새로고침",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "어시스턴트 생각/작업 출력 전환",
     toolCallsToggle: "도구 호출 및 도구 결과 전환",
     focusToggle: "집중 모드 전환(사이드바 + 페이지 헤더 숨기기)",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -660,6 +660,7 @@ export const pl: TranslationMap = {
   chat: {
     disconnected: "Rozłączono z Gateway.",
     refreshTitle: "Odśwież dane czatu",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Przełącz wyświetlanie myślenia/pracy asystenta",
     toolCallsToggle: "Przełącz wyświetlanie wywołań narzędzi i wyników narzędzi",
     focusToggle: "Przełącz tryb skupienia (ukryj pasek boczny i nagłówek strony)",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -657,6 +657,7 @@ export const pt_BR: TranslationMap = {
   chat: {
     disconnected: "Desconectado do gateway.",
     refreshTitle: "Atualizar dados do chat",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Alternar saída de pensamento/trabalho do assistente",
     toolCallsToggle: "Alternar chamadas de ferramenta e resultados de ferramenta",
     focusToggle: "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -660,6 +660,7 @@ export const tr: TranslationMap = {
   chat: {
     disconnected: "Gateway bağlantısı kesildi.",
     refreshTitle: "Sohbet verilerini yenile",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Asistanın düşünme/çalışma çıktısını aç/kapat",
     toolCallsToggle: "Araç çağrılarını ve araç sonuçlarını aç/kapat",
     focusToggle: "Odak modunu aç/kapat (kenar çubuğunu + sayfa başlığını gizle)",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -659,6 +659,7 @@ export const uk: TranslationMap = {
   chat: {
     disconnected: "Відключено від шлюзу.",
     refreshTitle: "Оновити дані чату",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "Перемкнути показ мислення/роботи асистента",
     toolCallsToggle: "Перемкнути виклики інструментів і результати інструментів",
     focusToggle: "Перемкнути режим фокусу (сховати бічну панель і заголовок сторінки)",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -642,6 +642,7 @@ export const zh_CN: TranslationMap = {
   chat: {
     disconnected: "已断开与网关的连接。",
     refreshTitle: "刷新聊天数据",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "切换助手思考/工作输出",
     toolCallsToggle: "切换工具调用和工具结果",
     focusToggle: "切换专注模式 (隐藏侧边栏 + 页面页眉)",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -643,6 +643,7 @@ export const zh_TW: TranslationMap = {
   chat: {
     disconnected: "已斷開與網關的連接。",
     refreshTitle: "刷新聊天數據",
+    planViewToggle: "Toggle plan view sidebar",
     thinkingToggle: "切換助手思考/工作輸出",
     toolCallsToggle: "切換工具呼叫與工具結果",
     focusToggle: "切換專注模式 (隱藏側邊欄 + 頁面頁眉)",

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -2,4 +2,5 @@
 @import "./chat/text.css";
 @import "./chat/grouped.css";
 @import "./chat/tool-cards.css";
+@import "./chat/plan-cards.css";
 @import "./chat/sidebar.css";

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1122,3 +1122,231 @@
 
 /* Mobile dropdown toggle — hidden on desktop */
 /* Mobile gear toggle + dropdown are hidden by default in layout.css */
+
+/* ── Mode switcher ── */
+
+.agent-chat__mode-switcher {
+  position: relative;
+}
+
+.agent-chat__mode-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--mono);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+
+.agent-chat__mode-chip:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.agent-chat__mode-chip-label {
+  white-space: nowrap;
+}
+
+.agent-chat__mode-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  min-width: 200px;
+  background: var(--card, #1a1a2e);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  padding: 4px;
+  z-index: 100;
+}
+
+.agent-chat__mode-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.agent-chat__mode-menu__item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.agent-chat__mode-menu__item--active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+
+.agent-chat__mode-menu__label {
+  flex: 1;
+}
+
+.agent-chat__mode-menu__shortcut {
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text-tertiary);
+  padding: 1px 4px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-hover);
+}
+
+/* PR-8 / #67721 inline plan approval card — sits ABOVE the chat input
+ * bar, mirrors Claude Code's "proposed a plan" affordance. Compact by
+ * default; the "Open plan" button pushes the full checklist into the
+ * right sidebar via the same path tool-output details use. */
+.plan-inline-card {
+  margin: 0 16px 8px 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-2));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plan-inline-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.plan-inline-card__title strong {
+  color: var(--text);
+}
+
+.plan-inline-card__summary {
+  color: var(--text-secondary);
+  margin-left: 6px;
+}
+
+.plan-inline-card__open {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+  text-decoration: underline;
+}
+
+.plan-inline-card__open:hover {
+  text-decoration: none;
+}
+
+.plan-inline-card__meta {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.plan-inline-card__error {
+  font-size: 12px;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.plan-inline-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/*
+ * PR-13 Bug 1: question-variant approval cards stack option buttons
+ * VERTICALLY instead of the standard plan-approval Approve/Edit/Revise
+ * triad. Long answer strings clip + overlap when laid out horizontally
+ * on narrow viewports — vertical alignment lets each option breathe
+ * and matches Codex's question pattern (numbered vertical list).
+ */
+.plan-inline-card__actions--question {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.plan-inline-card__actions--question .plan-inline-card__btn {
+  width: 100%;
+  text-align: left;
+  padding: 10px 14px;
+  white-space: normal; /* allow long option text to wrap instead of clipping */
+  line-height: 1.4;
+}
+
+.plan-inline-card__btn {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 100ms ease;
+}
+
+.plan-inline-card__btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.plan-inline-card__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.plan-inline-card__btn--primary {
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  border-color: var(--accent);
+}
+
+.plan-inline-card__btn--primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 90%, #000);
+}
+
+.plan-inline-card__btn--danger {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 30%, var(--border));
+}
+
+.plan-inline-card__btn--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+}
+
+.plan-inline-card__revise-input {
+  width: 100%;
+  min-height: 64px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
+}
+
+.plan-inline-card__revise-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
+}

--- a/ui/src/styles/chat/plan-cards.css
+++ b/ui/src/styles/chat/plan-cards.css
@@ -1,0 +1,134 @@
+/* Plan card styles — expandable plan display in the message thread.
+ * Mirrors tool-cards.css patterns with an accent left-border to distinguish. */
+
+.chat-plan-card {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent, #6366f1);
+  border-radius: var(--radius-md, 8px);
+  background: var(--card, #1a1a2e);
+  margin: 8px 0;
+  overflow: hidden;
+}
+
+.chat-plan-card summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 13px;
+  color: var(--text-secondary, #a0a0b0);
+  list-style: none;
+}
+
+.chat-plan-card summary::-webkit-details-marker {
+  display: none;
+}
+/* Firefox uses ::marker (not ::-webkit-details-marker). Without this,
+   Firefox renders the native disclosure triangle ALONGSIDE the custom
+   chevron we draw in the markup. */
+.chat-plan-card summary::marker {
+  content: "";
+}
+
+.chat-plan-card summary:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+}
+
+/* Copilot review #68939 (2026-04-19): a11y — `<summary>` is keyboard-
+ * focusable as the disclosure control, but the prior CSS only had a
+ * hover affordance, leaving keyboard navigation untracked. Add a
+ * `:focus-visible` outline using existing accent/border tokens so
+ * keyboard users can see the focused card. `:focus-visible` (vs
+ * `:focus`) avoids the outline showing on mouse click, matching the
+ * focus-ring conventions used elsewhere in the UI. */
+.chat-plan-card summary:focus-visible {
+  outline: 2px solid var(--accent, #6366f1);
+  outline-offset: -2px;
+  background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+}
+
+.chat-plan-card__icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--accent, #6366f1);
+}
+
+.chat-plan-card__title {
+  flex: 1;
+  font-weight: 500;
+  color: var(--text-primary, #e0e0e8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-card__meta {
+  font-size: 12px;
+  color: var(--text-tertiary, #666680);
+  white-space: nowrap;
+}
+
+.chat-plan-card__chevron {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.15s ease;
+  color: var(--text-tertiary, #666680);
+}
+
+.chat-plan-card[open] .chat-plan-card__chevron {
+  transform: rotate(90deg);
+}
+
+.chat-plan-card__body {
+  padding: 0 12px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.chat-plan-card__explanation {
+  color: var(--text-secondary, #a0a0b0);
+  margin-bottom: 8px;
+  font-style: italic;
+}
+
+.chat-plan-card__steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-plan-card__step {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 3px 0;
+  font-size: 13px;
+  color: var(--text-primary, #e0e0e8);
+}
+
+.chat-plan-card__step--completed {
+  color: var(--text-tertiary, #666680);
+  text-decoration: line-through;
+}
+
+.chat-plan-card__step--cancelled {
+  color: var(--text-tertiary, #666680);
+  text-decoration: line-through;
+}
+
+.chat-plan-card__step--in-progress {
+  font-weight: 500;
+}
+
+.chat-plan-card__step-marker {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: 14px;
+}

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,7 @@
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
+import { resumePendingPlanInteraction } from "./chat/plan-resume.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand, refreshSlashCommands } from "./chat/slash-commands.ts";
@@ -420,6 +421,16 @@ async function dispatchSlashCommand(
 
   if (result.action === "refresh") {
     await refreshChat(host);
+  }
+
+  if (result.action === "toggle-plan-view") {
+    host.onSlashAction?.("toggle-plan-view");
+  }
+
+  if (result.resumePlanInteraction && host.client) {
+    void resumePendingPlanInteraction(host.client, targetSessionKey).catch((err: unknown) => {
+      host.lastError = `Plan command succeeded but failed to resume the agent: ${String(err)}`;
+    });
   }
 
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -233,8 +233,26 @@ export function renderChatControls(state: AppViewState) {
       <circle cx="12" cy="12" r="3"></circle>
     </svg>
   `;
+  // PR-8 follow-up: track whether the right sidebar is currently
+  // showing the live plan markdown. Used to set aria-pressed on the
+  // plan-view toggle so the chip looks "on" while the sidebar is open.
+  const sidebarPlanOpen =
+    state.sidebarOpen &&
+    state.sidebarContent?.kind === "markdown" &&
+    state.latestPlanMarkdown != null &&
+    state.sidebarContent.content === state.latestPlanMarkdown;
   return html`
     <div class="chat-controls">
+      <button
+        class="btn btn--sm btn--icon ${sidebarPlanOpen ? "active" : ""}"
+        @click=${() => {
+          state.togglePlanViewSidebar();
+        }}
+        aria-pressed=${sidebarPlanOpen}
+        title=${t("chat.planViewToggle")}
+      >
+        ${icons.scrollText}
+      </button>
       <button
         class="btn btn--sm btn--icon"
         ?disabled=${state.chatLoading || !state.connected}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2211,6 +2211,7 @@ export function renderApp(state: AppViewState) {
               sending: state.chatSending,
               compactionStatus: state.compactionStatus,
               fallbackStatus: state.fallbackStatus,
+              subagentBlockingStatus: state.subagentBlockingStatus,
               assistantAvatarUrl: chatAvatarUrl,
               messages: state.chatMessages,
               sideResult: state.chatSideResult,
@@ -2300,6 +2301,173 @@ export function renderApp(state: AppViewState) {
               allowExternalEmbedUrls: state.allowExternalEmbedUrls,
               assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
               basePath: state.basePath ?? "",
+              onSetMode: (mode) => {
+                // PR-8 / #67721: translate the chip selection into the
+                // appropriate sessions.patch call. Plan mode is its own
+                // dimension and does NOT touch execSecurity/execAsk; the
+                // permission modes (Ask/Accept/Bypass) toggle execSecurity
+                // + execAsk while leaving plan-mode state untouched. If
+                // the user picks anything-but-plan while a plan-mode
+                // session is active, also clear plan mode so the chip
+                // labels match the actual runtime state.
+                //
+                // PR-10 auto-mode: when the user picks "Plan ⚡" we
+                // also fire a planApproval { action: "auto",
+                // autoEnabled: true } patch. Picking plain "Plan"
+                // clears the flag (autoEnabled: false). The two
+                // patches are independent so the auto toggle survives
+                // approval/cancel cycles cleanly.
+                if (!state.client || !state.connected) {
+                  return;
+                }
+                // PR-10 review M2: skip the patch entirely when the
+                // selection matches the currently-resolved chip state.
+                // Without this, clicking the active mode in the dropdown
+                // bumps `planMode.updatedAt` and re-fires both patches —
+                // visible to crons that watch `updatedAt` as activity
+                // and adds noise to the gateway log.
+                const activeSession = state.sessionsResult?.sessions?.find(
+                  (s: { key?: string }) => s.key === state.sessionKey,
+                );
+                const currentChipMode: string | null = (() => {
+                  // Inline minimal copy of resolveCurrentMode's plan-aware
+                  // logic; the imported helper isn't accessible from this
+                  // bundling layer without a cycle. Cheap structural check:
+                  if (activeSession?.planMode?.mode === "plan") {
+                    if (activeSession.planMode.autoApprove === true) {
+                      return "plan-auto";
+                    }
+                    return "plan";
+                  }
+                  return null; // permission-mode comparison handled by patch idempotency
+                })();
+                if (
+                  currentChipMode &&
+                  mode.id === currentChipMode &&
+                  // Plan ⚡ → Plan ⚡ and Plan → Plan are the only redundant
+                  // selections worth short-circuiting; permission-mode
+                  // chips are already idempotent server-side (same
+                  // execSecurity/execAsk = no state delta).
+                  (mode.id === "plan" || mode.id === "plan-auto")
+                ) {
+                  return;
+                }
+                const sessionKey = state.sessionKey;
+                const planAction: "plan" | "normal" | null =
+                  mode.planMode === "plan" ? "plan" : "normal";
+                const patch: Record<string, unknown> = { key: sessionKey };
+                if (mode.planMode === "plan") {
+                  patch.planMode = "plan";
+                } else {
+                  // Clear any active plan mode so the chip + backend agree.
+                  patch.planMode = "normal";
+                  // For the "Default" mode entry (execSecurity +
+                  // execAsk both undefined) send `null` to DELETE the
+                  // session override so the runtime falls back to
+                  // config defaults. Explicit null is the patch
+                  // contract's "clear" signal. Without this, Default
+                  // would no-op (the patch handler skips undefined
+                  // keys) and the chip would immediately flip back to
+                  // whatever the prior override was.
+                  patch.execSecurity = mode.execSecurity ?? null;
+                  patch.execAsk = mode.execAsk ?? null;
+                }
+                void state.client.request("sessions.patch", patch).then(
+                  () => {
+                    state.lastError = null;
+                  },
+                  (err: unknown) => {
+                    state.lastError =
+                      planAction === "plan"
+                        ? `Failed to enter plan mode: ${String(err)}`
+                        : `Failed to set mode: ${String(err)}`;
+                  },
+                );
+                // PR-10 auto-toggle: fire a follow-up patch only when
+                // we're switching INTO or OUT OF plan mode AND the
+                // selected mode disagrees with the current autoApprove
+                // state. We always send for plan-* selections so the
+                // backend is the source of truth (and so toggling
+                // between Plan and Plan ⚡ flips the flag without
+                // re-entering plan mode).
+                if (mode.planMode === "plan") {
+                  const autoEnabled = mode.planAutoApprove === true;
+                  const autoPatch: Record<string, unknown> = {
+                    key: sessionKey,
+                    planApproval: { action: "auto", autoEnabled },
+                  };
+                  void state.client.request("sessions.patch", autoPatch).then(
+                    () => {
+                      // No-op; lastError already cleared by the
+                      // primary patch above.
+                    },
+                    (err: unknown) => {
+                      state.lastError = `Failed to ${autoEnabled ? "enable" : "disable"} auto-approve: ${String(err)}`;
+                    },
+                  );
+                }
+              },
+              // PR-8 follow-up: inline plan approval card lives above
+              // the chat input. Replaces the modal overlay so the rest
+              // of the UI stays interactive while a plan is pending.
+              planApprovalRequest: state.planApprovalRequest,
+              planApprovalBusy: state.planApprovalBusy,
+              planApprovalError: state.planApprovalError,
+              planApprovalReviseOpen: state.planApprovalReviseOpen,
+              planApprovalReviseDraft: state.planApprovalReviseDraft,
+              // PR-13 Bug 2: question-card "Other" inline-textarea
+              // state, mirroring the revise pattern. Cancel returns to
+              // the option list instead of (perceptibly) exiting the
+              // sequence (was: window.prompt that lost the card on
+              // cancel/blur).
+              planApprovalQuestionOtherOpen: state.planApprovalQuestionOtherOpen,
+              planApprovalQuestionOtherDraft: state.planApprovalQuestionOtherDraft,
+              onPlanApprovalDecision: (decision, feedback) =>
+                state.handlePlanApprovalDecision(decision, feedback),
+              // PR-10 AskUserQuestion: route the chosen answer back
+              // through the same approval-card surface.
+              onPlanApprovalAnswer: (answer) => state.handlePlanApprovalAnswer(answer),
+              onPlanApprovalReviseOpen: () => state.handlePlanApprovalReviseOpen(),
+              onPlanApprovalReviseCancel: () => state.handlePlanApprovalReviseCancel(),
+              onPlanApprovalReviseDraftChange: (text) =>
+                state.handlePlanApprovalReviseDraftChange(text),
+              onPlanApprovalQuestionOtherOpen: () => state.handlePlanApprovalQuestionOtherOpen(),
+              onPlanApprovalQuestionOtherCancel: () =>
+                state.handlePlanApprovalQuestionOtherCancel(),
+              onPlanApprovalQuestionOtherDraftChange: (text) =>
+                state.handlePlanApprovalQuestionOtherDraftChange(text),
+              onPlanApprovalQuestionOtherSubmit: () =>
+                state.handlePlanApprovalQuestionOtherSubmit(),
+              onOpenPlanInSidebar: (request) => {
+                // Render the proposed plan as a markdown document and
+                // hand it to the existing markdown-sidebar viewer (same
+                // surface tool-output details use).
+                //
+                // PR-10 review fix (Copilot #3104741606): build the
+                // strikethrough as `~~${label}~~` (no space between
+                // `~~` and the label) so the rendered output is clean
+                // markdown. Pre-fix the marker `"[ ] ~~"` left a
+                // leading space inside the strikethrough that
+                // produced inconsistent rendering vs other markdown
+                // surfaces.
+                const stepLines = request.plan
+                  .map((step, i) => {
+                    const label =
+                      step.status === "in_progress" && step.activeForm
+                        ? step.activeForm
+                        : step.step;
+                    if (step.status === "completed") {
+                      return `${i + 1}. [x] ${label}`;
+                    }
+                    if (step.status === "cancelled") {
+                      return `${i + 1}. [ ] ~~${label}~~ (cancelled)`;
+                    }
+                    return `${i + 1}. [ ] ${label}`;
+                  })
+                  .join("\n");
+                const md = `# ${request.summary || "Proposed plan"}\n\n${stepLines}\n`;
+                state.handleOpenSidebar({ kind: "markdown", content: md });
+              },
             })
           : nothing}
         ${renderConfigTabForActiveTab()}

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -265,6 +265,24 @@ export type FallbackStatus = {
   occurredAt: number;
 };
 
+/**
+ * Live-test iteration 1 Bug 3: bottom-of-chat toast surface for the
+ * "subagents still running" feedback when the user clicks Approve on
+ * a plan while subagents are in flight. Mirrors `FallbackStatus` so
+ * the chat-controls render path can use the same toast region (the
+ * only toast surface the user has actually seen working in webchat).
+ *
+ * Set by `app.ts:handlePlanApprovalDecision()` when the gateway
+ * returns error code `PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS`. Auto-
+ * dismisses after 8 seconds (matches model-fallback toast cadence).
+ */
+export type SubagentBlockingStatus = {
+  message: string;
+  /** In-flight subagent runIds the gateway reported (for tooltip). */
+  openSubagentRunIds: string[];
+  occurredAt: number;
+};
+
 type CompactionHost = ToolStreamHost & {
   compactionStatus?: CompactionStatus | null;
   compactionClearTimer?: number | null;
@@ -447,6 +465,342 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
   }, FALLBACK_TOAST_DURATION_MS);
 }
 
+/**
+ * PR-8 / #67721: plan approval request emitted from the runtime when
+ * the agent calls `exit_plan_mode`. Stored on the host so the chat
+ * view can render an Approve/Reject/Edit overlay tied to the active
+ * session.
+ */
+export type PlanApprovalRequest = {
+  approvalId: string;
+  sessionKey: string;
+  toolCallId?: string;
+  title: string;
+  summary?: string;
+  plan: Array<{ step: string; status: string; activeForm?: string }>;
+  receivedAt: number;
+  // PR-10 plan-archetype fields. All optional and additive — the
+  // approval card / sidebar render them when present.
+  analysis?: string;
+  assumptions?: string[];
+  risks?: Array<{ risk: string; mitigation: string }>;
+  verification?: string[];
+  references?: string[];
+  /**
+   * PR-10 AskUserQuestion: when present, this approval is a question
+   * (not a plan submission). The plan-approval card renders a question
+   * prompt + one button per option instead of the standard
+   * Approve/Revise/Reject triad.
+   */
+  question?: {
+    prompt: string;
+    options: string[];
+    allowFreetext?: boolean;
+    questionId?: string;
+  };
+};
+
+type PlanApprovalHost = ToolStreamHost & {
+  planApprovalRequest: PlanApprovalRequest | null;
+  planApprovalReviseOpen?: boolean;
+  planApprovalReviseDraft?: string;
+  planApprovalQuestionOtherOpen?: boolean;
+  planApprovalQuestionOtherDraft?: string;
+  planApprovalError?: string | null;
+  /**
+   * Optional auto-open hook — when the runtime emits a fresh plan
+   * approval, also pop the full plan into the right sidebar so the
+   * user doesn't have to click "Open plan" first.
+   */
+  openPlanInSidebar?: (request: PlanApprovalRequest) => void;
+  /**
+   * Optional live-plan hook — fires every time the agent calls
+   * update_plan. The host re-renders the sidebar content with the
+   * current plan state so the user always sees the latest checklist
+   * (boxes ticking off as the agent steps through after approval).
+   */
+  refreshLivePlanSidebar?: (plan: PlanApprovalRequest["plan"], summary?: string) => void;
+};
+
+function setPlanApprovalRequest(host: PlanApprovalHost, next: PlanApprovalRequest | null): void {
+  const previous = host.planApprovalRequest;
+  const previousQuestionId = previous?.question?.questionId;
+  const nextQuestionId = next?.question?.questionId;
+  const changedInteraction =
+    previous?.approvalId !== next?.approvalId ||
+    previousQuestionId !== nextQuestionId ||
+    Boolean(previous?.question) !== Boolean(next?.question);
+  host.planApprovalRequest = next;
+  if (!changedInteraction) {
+    return;
+  }
+  if ("planApprovalReviseOpen" in host) {
+    host.planApprovalReviseOpen = false;
+  }
+  if ("planApprovalReviseDraft" in host) {
+    host.planApprovalReviseDraft = "";
+  }
+  if ("planApprovalQuestionOtherOpen" in host) {
+    host.planApprovalQuestionOtherOpen = false;
+  }
+  if ("planApprovalQuestionOtherDraft" in host) {
+    host.planApprovalQuestionOtherDraft = "";
+  }
+  if ("planApprovalError" in host) {
+    host.planApprovalError = null;
+  }
+}
+
+/**
+ * Detect update_plan tool calls in the live tool-event stream and
+ * emit the parsed plan steps. We listen on the start phase (when
+ * args are present) since that's when the plan payload is freshest.
+ */
+function maybeForwardLivePlanUpdate(host: PlanApprovalHost, payload: AgentEventPayload): void {
+  const data = payload.data ?? {};
+  if (data.name !== "update_plan") {
+    return;
+  }
+  if (data.phase !== "start" && data.phase !== "result") {
+    return;
+  }
+  // PR-10 review fix (Codex P2 #3104743333 — option C selected):
+  // under `update_plan { merge: true }` the tool INPUT is a delta,
+  // not the merged result. Reading `data.args.plan` would refresh
+  // the sidebar with stale partial data. The fix path is on the
+  // separate `stream: "plan"` channel — see the new
+  // maybeForwardMergedPlanEvent handler below — which carries the
+  // structured `mergedSteps` field with the full merged plan.
+  // For non-merge calls, the input == output so the legacy path
+  // here still works as a fallback.
+  const args = (data.args ?? data.params) as Record<string, unknown> | undefined;
+  if (!args || typeof args !== "object") {
+    return;
+  }
+  // Skip the legacy refresh entirely on merge calls — the plan-event
+  // handler below has the authoritative merged result.
+  if ((args as { merge?: unknown }).merge === true) {
+    return;
+  }
+  const rawPlan = (args as { plan?: unknown }).plan;
+  if (!Array.isArray(rawPlan) || rawPlan.length === 0) {
+    return;
+  }
+  const plan: PlanApprovalRequest["plan"] = [];
+  for (const entry of rawPlan) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const step = (entry as Record<string, unknown>).step;
+    const status = (entry as Record<string, unknown>).status;
+    const activeForm = (entry as Record<string, unknown>).activeForm;
+    if (typeof step !== "string" || typeof status !== "string") {
+      continue;
+    }
+    plan.push({
+      step,
+      status,
+      ...(typeof activeForm === "string" && activeForm.trim() ? { activeForm } : {}),
+    });
+  }
+  if (plan.length === 0) {
+    return;
+  }
+  try {
+    host.refreshLivePlanSidebar?.(plan, undefined);
+  } catch {
+    // ignore — sidebar refresh is best-effort
+  }
+}
+
+/**
+ * PR-10 review fix (Codex P2 #3104743333): authoritative live-plan
+ * sidebar refresh path that handles merge-mode correctly.
+ *
+ * Subscribes to `stream: "plan"` events (emitted by `update-plan-tool.ts`
+ * after `mergeSteps()` runs). The `mergedSteps` field carries the FULL
+ * merged plan with status/activeForm/criteria fields, so the sidebar
+ * refresh always reflects the actual post-merge state — never the
+ * delta-only tool input.
+ */
+function maybeForwardMergedPlanEvent(host: PlanApprovalHost, payload: AgentEventPayload): void {
+  if (payload.stream !== "plan") {
+    return;
+  }
+  const data = payload.data ?? {};
+  if (data.phase !== "update" && data.phase !== "completed") {
+    return;
+  }
+  const rawMerged = (data as { mergedSteps?: unknown }).mergedSteps;
+  if (!Array.isArray(rawMerged) || rawMerged.length === 0) {
+    return;
+  }
+  const plan: PlanApprovalRequest["plan"] = [];
+  for (const entry of rawMerged) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const step = (entry as Record<string, unknown>).step;
+    const status = (entry as Record<string, unknown>).status;
+    const activeForm = (entry as Record<string, unknown>).activeForm;
+    if (typeof step !== "string" || typeof status !== "string") {
+      continue;
+    }
+    plan.push({
+      step,
+      status,
+      ...(typeof activeForm === "string" && activeForm.trim() ? { activeForm } : {}),
+    });
+  }
+  if (plan.length === 0) {
+    return;
+  }
+  try {
+    host.refreshLivePlanSidebar?.(plan, undefined);
+  } catch {
+    // ignore — best-effort
+  }
+}
+
+function handlePlanApprovalEvent(host: PlanApprovalHost, payload: AgentEventPayload): void {
+  const data = payload.data ?? {};
+  if (data.kind !== "plugin" || data.phase !== "requested") {
+    return;
+  }
+  const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
+  if (!sessionKey || sessionKey !== host.sessionKey) {
+    return;
+  }
+  // PR-10 AskUserQuestion: question approvals carry `question` but
+  // emit with `plan: []` (questions don't have plan steps). Detect this
+  // BEFORE the plan-empty early-return so the question card renders.
+  // Without this guard, both ask_user_question and the future
+  // mode-state-transition events would be dropped silently.
+  const isQuestionEvent = data.question != null && typeof data.question === "object";
+  const rawPlan = data.plan;
+  if (!isQuestionEvent && (!Array.isArray(rawPlan) || rawPlan.length === 0)) {
+    return;
+  }
+  const plan: PlanApprovalRequest["plan"] = [];
+  if (Array.isArray(rawPlan)) {
+    for (const entry of rawPlan) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const step = (entry as Record<string, unknown>).step;
+      const status = (entry as Record<string, unknown>).status;
+      const activeForm = (entry as Record<string, unknown>).activeForm;
+      if (typeof step !== "string" || typeof status !== "string") {
+        continue;
+      }
+      plan.push({
+        step,
+        status,
+        ...(typeof activeForm === "string" && activeForm.trim() ? { activeForm } : {}),
+      });
+    }
+  }
+  // For non-question events, an empty parsed plan still means "drop
+  // the event" — a malformed step list is worse than no card. Question
+  // events bypass this gate (their plan IS expected to be empty).
+  if (!isQuestionEvent && plan.length === 0) {
+    return;
+  }
+  const approvalId =
+    typeof data.approvalId === "string" && data.approvalId.trim() ? data.approvalId : "";
+  if (!approvalId) {
+    return;
+  }
+  const title = typeof data.title === "string" && data.title.trim() ? data.title : "Plan approval";
+  const summary =
+    typeof data.summary === "string" && data.summary.trim() ? data.summary : undefined;
+  const toolCallId =
+    typeof data.toolCallId === "string" && data.toolCallId.trim() ? data.toolCallId : undefined;
+  // PR-10 archetype fields. Defensive-parsed (drop blanks).
+  const cleanStrArr = (v: unknown): string[] | undefined => {
+    if (!Array.isArray(v)) {
+      return undefined;
+    }
+    const c = v
+      .filter((e): e is string => typeof e === "string")
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0);
+    return c.length > 0 ? c : undefined;
+  };
+  const analysis =
+    typeof data.analysis === "string" && data.analysis.trim() ? data.analysis.trim() : undefined;
+  const assumptions = cleanStrArr(data.assumptions);
+  const verification = cleanStrArr(data.verification);
+  const references = cleanStrArr(data.references);
+  let risks: PlanApprovalRequest["risks"];
+  if (Array.isArray(data.risks)) {
+    const c: NonNullable<PlanApprovalRequest["risks"]> = [];
+    for (const e of data.risks) {
+      if (!e || typeof e !== "object") {
+        continue;
+      }
+      const r = (e as Record<string, unknown>).risk;
+      const m = (e as Record<string, unknown>).mitigation;
+      if (typeof r === "string" && typeof m === "string" && r.trim() && m.trim()) {
+        c.push({ risk: r.trim(), mitigation: m.trim() });
+      }
+    }
+    if (c.length > 0) {
+      risks = c;
+    }
+  }
+  // PR-10 AskUserQuestion: if data.question is present, this approval
+  // is a clarifying question (not a plan submission). The card UI
+  // detects question and renders one button per option instead of
+  // the standard Approve/Revise/Reject triad.
+  let question: PlanApprovalRequest["question"];
+  if (data.question && typeof data.question === "object") {
+    const q = data.question as Record<string, unknown>;
+    const promptText = typeof q.prompt === "string" ? q.prompt.trim() : "";
+    const opts = cleanStrArr(q.options);
+    if (promptText && opts && opts.length > 0) {
+      question = {
+        prompt: promptText,
+        options: opts,
+        ...(typeof q.allowFreetext === "boolean" ? { allowFreetext: q.allowFreetext } : {}),
+        ...(typeof q.questionId === "string" && q.questionId.trim()
+          ? { questionId: q.questionId.trim() }
+          : {}),
+      };
+    }
+  }
+  const next: PlanApprovalRequest = {
+    approvalId,
+    sessionKey,
+    title,
+    plan,
+    receivedAt: Date.now(),
+    ...(summary ? { summary } : {}),
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(analysis ? { analysis } : {}),
+    ...(assumptions ? { assumptions } : {}),
+    ...(risks ? { risks } : {}),
+    ...(verification ? { verification } : {}),
+    ...(references ? { references } : {}),
+    ...(question ? { question } : {}),
+  };
+  setPlanApprovalRequest(host, next);
+  // Auto-open the full plan in the right sidebar so the user can read
+  // it without clicking "Open plan" first. The card itself surfaces
+  // Accept/Edit/Reject; the sidebar shows the full markdown.
+  //
+  // PR-10 deep-dive review: skip the auto-open for question events
+  // (request.question present) — there's no plan to render, and
+  // popping an empty sidebar with just a header is a confusing UX.
+  if (!isQuestionEvent) {
+    try {
+      host.openPlanInSidebar?.(next);
+    } catch {
+      // ignore — sidebar open is a best-effort affordance
+    }
+  }
+}
+
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload) {
   if (!payload) {
     return;
@@ -469,6 +823,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+  if (payload.stream === "approval") {
+    handlePlanApprovalEvent(host as PlanApprovalHost, payload);
+    return;
+  }
+
   if (payload.stream !== "tool") {
     return;
   }
@@ -480,6 +839,16 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   if (sessionKey && sessionKey !== host.sessionKey) {
     return;
   }
+
+  // PR-8 follow-up: forward live update_plan calls to the sidebar
+  // refresh hook so the user always sees the current plan state
+  // (boxes ticking off as the agent steps through after approval).
+  // Runs alongside the normal tool-stream path; doesn't replace it.
+  maybeForwardLivePlanUpdate(host as PlanApprovalHost, payload);
+  // PR-10 review fix (Codex P2 #3104743333): authoritative refresh
+  // for merge-mode plans via the agent_plan_event stream's
+  // `mergedSteps` field. See maybeForwardMergedPlanEvent for the why.
+  maybeForwardMergedPlanEvent(host as PlanApprovalHost, payload);
 
   const data = payload.data ?? {};
   const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,5 +1,9 @@
 import type { EventLogEntry } from "./app-events.ts";
-import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
+import type {
+  CompactionStatus,
+  FallbackStatus,
+  SubagentBlockingStatus,
+} from "./app-tool-stream.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
@@ -84,6 +88,10 @@ export type AppViewState = {
   chatSideResultTerminalRuns: Set<string>;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
+  /** Live-test iteration 1 Bug 3: bottom-toast state for the
+   * "subagents still running" feedback when user clicks Approve while
+   * subagents are in flight. */
+  subagentBlockingStatus: SubagentBlockingStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
   chatModelOverrides: Record<string, ChatModelOverride | null>;
@@ -114,6 +122,40 @@ export type AppViewState = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
   execApprovalError: string | null;
+  /**
+   * PR-8 / #67721: pending plan-approval request emitted by the runtime
+   * when the agent calls `exit_plan_mode`. Exactly one approval is
+   * tracked at a time per session — re-emits replace the prior request
+   * (the agent just minted a fresh approvalId so the old card is stale).
+   */
+  planApprovalRequest: import("./app-tool-stream.ts").PlanApprovalRequest | null;
+  planApprovalBusy: boolean;
+  planApprovalError: string | null;
+  /** Inline-revise textarea state (no popup). */
+  planApprovalReviseOpen: boolean;
+  planApprovalReviseDraft: string;
+  /**
+   * PR-13 Bug 2: question-card "Other" inline-textarea state. Mirrors
+   * the revise pattern; replaces the prior `window.prompt` approach so
+   * Cancel returns to the option list instead of (perceptibly) exiting
+   * the sequence. Caller owns the state so it survives renders.
+   */
+  planApprovalQuestionOtherOpen: boolean;
+  planApprovalQuestionOtherDraft: string;
+  /**
+   * PR-8 follow-up: most recent live-plan markdown rendered into the
+   * sidebar, kept in sync by `refreshLivePlanSidebar()`. Surfaced so the
+   * chat-controls "Plan view" button + `/plan view` slash command can
+   * re-open the sidebar with current content even if the user closed it.
+   * `null` until the agent calls `update_plan` at least once.
+   */
+  latestPlanMarkdown: string | null;
+  /**
+   * Toggle the plan-view sidebar — opens with the current `latestPlanMarkdown`
+   * (or a placeholder when no plan exists yet), closes if it's already showing.
+   * Used by the chat-controls Plan view button and `/plan view` slash command.
+   */
+  togglePlanViewSidebar: () => void;
   pendingGatewayUrl: string | null;
   configLoading: boolean;
   configRaw: string;
@@ -391,6 +433,36 @@ export type AppViewState = {
     handleNostrProfileImport: () => Promise<void>;
     handleNostrProfileToggleAdvanced: () => void;
     handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+    /** PR-8 / #67721: resolve a pending plan-approval. */
+    handlePlanApprovalDecision: (
+      decision: "approve" | "reject" | "edit",
+      feedback?: string,
+    ) => Promise<void>;
+    /** Inline-revise textarea control (no popup). */
+    handlePlanApprovalReviseOpen: () => void;
+    handlePlanApprovalReviseCancel: () => void;
+    handlePlanApprovalReviseDraftChange: (text: string) => void;
+    /**
+     * PR-13 Bug 2: question-card "Other" inline-textarea handlers.
+     * Mirrors the revise pattern. Cancel does NOT clear the request,
+     * so users can back out of typing a free-text answer and return
+     * to the option list.
+     */
+    handlePlanApprovalQuestionOtherOpen: () => void;
+    handlePlanApprovalQuestionOtherCancel: () => void;
+    handlePlanApprovalQuestionOtherDraftChange: (text: string) => void;
+    handlePlanApprovalQuestionOtherSubmit: () => Promise<void>;
+    /**
+     * PR-10 ask_user_question: route the chosen answer back through
+     * the same approval-card surface. Persists via
+     * sessions.patch { planApproval: { action: "answer", answer }} and
+     * injects `[QUESTION_ANSWER]: <answer text>` as a synthetic user
+     * message (PR-10 hardening canonical format with COLON, mirroring
+     * `[PLAN_DECISION]: ...`) so the agent's next turn can act on it.
+     * Plan-mode state is NOT transitioned — the agent stays in plan
+     * mode while waiting on follow-on planning steps.
+     */
+    handlePlanApprovalAnswer: (answer: string) => Promise<void>;
     handleGatewayUrlConfirm: () => void;
     handleGatewayUrlCancel: () => void;
     handleConfigLoad: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -51,10 +51,12 @@ import {
   type ToolStreamEntry,
   type CompactionStatus,
   type FallbackStatus,
+  type SubagentBlockingStatus,
 } from "./app-tool-stream.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
+import { resumePendingPlanInteraction } from "./chat/plan-resume.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import {
   loadToolsEffective as loadToolsEffectiveInternal,
@@ -129,6 +131,135 @@ function resolveOnboardingMode(): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+/**
+ * Build the synthetic user-turn message sent to the agent after the
+/**
+ * PR-8 follow-up Round 2: shared placeholder content for the plan-view
+ * sidebar when no `update_plan` event has fired yet on this session.
+ * Module-level so `togglePlanViewSidebar` and other consumers can do
+ * an identity check (===) against the same string instance.
+ */
+const PLAN_VIEW_PLACEHOLDER_MARKDOWN =
+  "# No active plan\n\nThe agent hasn't called `update_plan` yet on this session. Once it does, the current plan will render here and tick off live as the agent steps through.\n";
+
+/**
+ * PR-8 follow-up Round 2: build the live-plan markdown checklist from
+ * a plan-step array. Shared between the live-stream path (refresh on
+ * every `agent_plan_event`) and the refresh-restore path (rebuild from
+ * persisted `SessionEntry.planMode.lastPlanSteps` when the page mounts).
+ * Keeps both surfaces byte-identical so the toggle's identity check
+ * (`sidebarContent.content === latestPlanMarkdown`) works after either.
+ *
+ * PR-9 Wave A2: derive "Plan complete" header automatically when every
+ * step is terminal — the runtime auto-flips planMode to "normal" via
+ * the gateway-side persister, and the sidebar reflects that visually
+ * without the user having to compare statuses by eye.
+ */
+function buildPlanViewMarkdown(
+  plan: ReadonlyArray<{
+    step: string;
+    status: string;
+    activeForm?: string;
+    acceptanceCriteria?: string[];
+    verifiedCriteria?: string[];
+  }>,
+  summary?: string,
+  archetype?: {
+    analysis?: string;
+    assumptions?: string[];
+    risks?: ReadonlyArray<{ risk: string; mitigation: string }>;
+    verification?: string[];
+    references?: string[];
+  },
+  /**
+   * Live-test iteration 1 Bug 2: plan title persisted on
+   * SessionEntry.planMode.title (set by plan-snapshot-persister when
+   * `exit_plan_mode` fires). Takes precedence over `summary` for the
+   * header so the side panel ANCHORS on the actual plan name through
+   * the entire lifecycle (planning → submitted → approved → executing
+   * → completed). Pre-`exit_plan_mode` (only `update_plan` has fired):
+   * undefined → header falls back to `(planning)`.
+   */
+  title?: string,
+): string {
+  const stepLines = plan
+    .map((step, i) => {
+      const marker =
+        step.status === "completed" ? "[x]" : step.status === "cancelled" ? "[ ] ~~" : "[ ]";
+      const close = step.status === "cancelled" ? "~~" : "";
+      const label = step.status === "in_progress" && step.activeForm ? step.activeForm : step.step;
+      const lines = [`${i + 1}. ${marker} ${label}${close}`];
+      // PR-9 Wave B1: render acceptance criteria as a nested checklist
+      // beneath each step. Verified criteria render as `[x]`, unverified
+      // as `[ ]`. Skipped entirely when no criteria are declared so
+      // existing simple plans render unchanged.
+      if (step.acceptanceCriteria && step.acceptanceCriteria.length > 0) {
+        const verifiedSet = new Set(step.verifiedCriteria ?? []);
+        for (const criterion of step.acceptanceCriteria) {
+          const cMarker = verifiedSet.has(criterion) ? "[x]" : "[ ]";
+          lines.push(`    - ${cMarker} ${criterion}`);
+        }
+      }
+      return lines.join("\n");
+    })
+    .join("\n");
+  const allTerminal =
+    plan.length > 0 && plan.every((s) => s.status === "completed" || s.status === "cancelled");
+  // Live-test iteration 1 Bug 2: title (the persisted plan name) wins
+  // over summary so the side panel ANCHORS on the actual plan name. The
+  // pre-submission state shows `(planning)` (honest signal that a real
+  // title hasn't been set yet) instead of the misleading `Active plan`
+  // generic label that previously made every mid-investigation plan
+  // look like the same nameless thing.
+  const header = title ?? summary ?? (allTerminal ? "Plan complete \u2713" : "(planning)");
+  const sections: string[] = [`# ${header}`, ""];
+  // PR-10 archetype: render rich plan sections when present. Markdown
+  // structure mirrors the persisted file format (title → analysis →
+  // plan checklist → assumptions → risks → verification → references).
+  // Sections only appear when populated so simple plans render
+  // identically to today.
+  if (archetype?.analysis) {
+    sections.push("## Analysis", "", archetype.analysis, "");
+  }
+  sections.push("## Plan", "", stepLines, "");
+  if (archetype?.assumptions && archetype.assumptions.length > 0) {
+    sections.push("## Assumptions", "");
+    for (const a of archetype.assumptions) {
+      sections.push(`- ${a}`);
+    }
+    sections.push("");
+  }
+  if (archetype?.risks && archetype.risks.length > 0) {
+    sections.push("## Risks", "");
+    sections.push("| Risk | Mitigation |");
+    sections.push("| --- | --- |");
+    for (const r of archetype.risks) {
+      sections.push(`| ${escapeMarkdownCell(r.risk)} | ${escapeMarkdownCell(r.mitigation)} |`);
+    }
+    sections.push("");
+  }
+  if (archetype?.verification && archetype.verification.length > 0) {
+    sections.push("## Verification", "");
+    for (const v of archetype.verification) {
+      sections.push(`- ${v}`);
+    }
+    sections.push("");
+  }
+  if (archetype?.references && archetype.references.length > 0) {
+    sections.push("## References", "");
+    for (const r of archetype.references) {
+      sections.push(`- ${r}`);
+    }
+    sections.push("");
+  }
+  return sections.join("\n");
+}
+
+/** PR-10: minimal cell-escape so risk/mitigation text doesn't break the markdown table. */
+function escapeMarkdownCell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\n+/g, " ").trim();
+}
+
 @customElement("openclaw-app")
 export class OpenClawApp extends LitElement {
   private i18nController = new I18nController(this);
@@ -180,6 +311,18 @@ export class OpenClawApp extends LitElement {
   @state() chatSideResult: ChatSideResult | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
+  /**
+   * Live-test iteration 1 Bug 3: bottom-of-chat toast state for the
+   * "subagents still running" feedback when the user clicks Approve
+   * on a plan while subagents are mid-flight. Set in
+   * `handlePlanApprovalDecision()` when the gateway returns error
+   * code `PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS`. Auto-cleared after 8s
+   * (matches `FALLBACK_TOAST_DURATION_MS`) — render-time check
+   * compares occurredAt; the timer below schedules a re-render so
+   * the toast disappears even if no other state changes.
+   */
+  @state() subagentBlockingStatus: SubagentBlockingStatus | null = null;
+  subagentBlockingClearTimer: number | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
   @state() chatModelOverrides: Record<string, ChatModelOverride | null> = {};
@@ -214,6 +357,38 @@ export class OpenClawApp extends LitElement {
   @state() execApprovalQueue: ExecApprovalRequest[] = [];
   @state() execApprovalBusy = false;
   @state() execApprovalError: string | null = null;
+  // PR-8 / #67721: plan approval card state — populated by handleAgentEvent
+  // when the runtime emits an `approval` stream event with kind:"plugin"
+  // and a plan payload.
+  @state() planApprovalRequest: import("./app-tool-stream.ts").PlanApprovalRequest | null = null;
+  @state() planApprovalBusy = false;
+  @state() planApprovalError: string | null = null;
+  // PR #68939 follow-up (stale-state re-render fix): once the user
+  // clicks Approve/Revise/Reject and the server returns a stale-state
+  // rejection (`requires a pending approval`, `current state: none`,
+  // etc.), we dismiss the dialog locally — but the next sessionsResult
+  // refresh tick re-runs `hydratePlanApprovalFromSession` which can
+  // re-create the popup from the stale local cache snapshot. User
+  // perceives "I clicked Approve and nothing happened" because the
+  // popup blinks closed → re-creates → blinks open. Track the
+  // approvalIds we've already given up on so hydration ignores them.
+  // Cleared on session change (resetPlanApprovalLocalState).
+  @state() planApprovalDismissedApprovalIds = new Set<string>();
+  // Inline-revise textarea state (no popup). Open + draft live on the
+  // host so the textarea survives chat re-renders.
+  @state() planApprovalReviseOpen = false;
+  @state() planApprovalReviseDraft = "";
+  // PR-13 Bug 2: question-card "Other" inline-textarea state. Replaces
+  // the prior window.prompt approach so backing out returns to the
+  // option list instead of (perceptibly) exiting the sequence.
+  @state() planApprovalQuestionOtherOpen = false;
+  @state() planApprovalQuestionOtherDraft = "";
+  // PR-8 follow-up: latest known plan content (rendered as markdown).
+  // Updated whenever the agent calls update_plan (regardless of whether
+  // the sidebar is open). The chat-controls "Plan view" button reads
+  // this to render the current plan on demand and the `/plan view`
+  // slash command opens the same content in the sidebar.
+  @state() latestPlanMarkdown: string | null = null;
   @state() pendingGatewayUrl: string | null = null;
   pendingGatewayToken: string | null = null;
 
@@ -549,6 +724,13 @@ export class OpenClawApp extends LitElement {
         case "export":
           exportChatMarkdown(this.chatMessages, this.assistantName);
           break;
+        case "toggle-plan-view":
+          // PR-8 follow-up: `/plan view` slash command — mirrors the
+          // chat-controls Plan view button. Opens the sidebar with the
+          // latest live plan markdown (or a placeholder if none has
+          // been emitted yet), or closes it if already showing.
+          this.togglePlanViewSidebar();
+          break;
         case "refresh-tools-effective": {
           void refreshVisibleToolsEffectiveForCurrentSessionInternal(this);
           break;
@@ -571,6 +753,15 @@ export class OpenClawApp extends LitElement {
 
   protected updated(changed: Map<PropertyKey, unknown>) {
     handleUpdated(this as unknown as Parameters<typeof handleUpdated>[0], changed);
+    // PR-8 follow-up Round 2: when sessions list updates OR the active
+    // session changes, hydrate the plan-view markdown from
+    // SessionEntry.planMode.lastPlanSteps. Restores the sidebar state
+    // after a hard refresh — without this, the button shows the
+    // placeholder until a fresh `update_plan` event fires.
+    if (changed.has("sessionsResult") || changed.has("sessionKey")) {
+      this.hydratePlanViewFromSession();
+      this.hydratePlanApprovalFromSession();
+    }
     if (!changed.has("sessionKey") || this.agentsPanel !== "tools") {
       return;
     }
@@ -763,6 +954,286 @@ export class OpenClawApp extends LitElement {
     }
   }
 
+  /**
+   * PR-8 / #67721: resolve a pending plan-approval card.
+   *
+   * Flow:
+   *   1. Snapshot the active request + clear UI state OPTIMISTICALLY so
+   *      the card disappears immediately. Avoids the stale-card-double-click
+   *      scenario where users click Accept twice and the second click
+   *      hits "planApproval requires an active plan-mode session".
+   *   2. POST sessions.patch { planApproval } so the server transitions
+   *      SessionEntry.planMode via resolvePlanApproval (#67538).
+   *   3. On success, send a follow-up message to the agent so it
+   *      auto-continues without the user having to type "go". This is
+   *      the [APPROVED_PLAN] / [PLAN_DECISION] context injection
+   *      from the original PR-8 design, delivered via sessions.send
+   *      (which the chat surface already uses for user messages).
+   *   4. On failure, restore the card so the user can retry.
+   */
+  async handlePlanApprovalDecision(
+    decision: "approve" | "reject" | "edit",
+    feedback?: string,
+  ): Promise<void> {
+    const active = this.planApprovalRequest;
+    if (!active || !this.client || this.planApprovalBusy) {
+      return;
+    }
+    this.planApprovalBusy = true;
+    this.planApprovalError = null;
+    // Optimistic dismissal — clear card BEFORE the round-trip so a
+    // second click can't fire while the first is in-flight.
+    const snapshotRequest = active;
+    const snapshotReviseDraft = this.planApprovalReviseDraft;
+    this.planApprovalRequest = null;
+    this.planApprovalReviseOpen = false;
+    this.planApprovalReviseDraft = "";
+    try {
+      const params: Record<string, unknown> = {
+        key: active.sessionKey,
+        planApproval: {
+          action: decision,
+          ...(active.approvalId ? { approvalId: active.approvalId } : {}),
+          ...(feedback && feedback.trim() ? { feedback: feedback.trim() } : {}),
+        },
+        // After approve/edit, also CLEAR session-level permission
+        // overrides so the chip falls back to "Default permissions"
+        // (whatever's in agents.defaults / per-agent config). User
+        // feedback: post-plan-mode shouldn't lock into Ask just
+        // because Ask was active before. Reject leaves overrides
+        // alone (still in plan mode, no permission change needed).
+        ...(decision === "approve" || decision === "edit"
+          ? { execSecurity: null, execAsk: null }
+          : {}),
+      };
+      await this.client.request("sessions.patch", params);
+      await resumePendingPlanInteraction(this.client, active.sessionKey);
+    } catch (err) {
+      // Bug 5 fix: gracefully dismiss the dialog when the server
+      // reports the approval is no longer pending (e.g., another
+      // surface resolved it, OR the auto-close fired due to a
+      // race with subagent return / update_plan-with-all-terminal).
+      // Without this, the user is stuck with an undismissable dialog
+      // and forced to refresh the page.
+      const errMsg = String(err);
+      const errCode =
+        err && typeof err === "object" && "code" in err
+          ? (err as { code?: unknown }).code
+          : undefined;
+      const errDetails =
+        err && typeof err === "object" && "details" in err
+          ? (err as { details?: unknown }).details
+          : undefined;
+      // Bug B (C1 follow-up): PLAN_APPROVAL_EXPIRED is the canonical
+      // code for "session is no longer in plan mode" (timeout, /plan
+      // off, resolved on another channel, compaction loss). Keep the
+      // message-substring fallbacks for transports that flatten the
+      // error to a string.
+      const staleStateError =
+        errCode === "PLAN_APPROVAL_EXPIRED" ||
+        errMsg.includes("PLAN_APPROVAL_EXPIRED") ||
+        errMsg.includes("requires an active plan-mode session") ||
+        errMsg.includes("requires a pending approval") ||
+        errMsg.includes("current state: none") ||
+        errMsg.includes("stale approvalId") ||
+        errMsg.includes("terminal approval state");
+      // Live-test iteration 1 Bug 3: detect the approval-side
+      // subagent gate. Error code is the canonical signal; the
+      // message-substring fallback handles transports that flatten
+      // the error to a string (no structured code surfaced).
+      const subagentBlockedError =
+        errCode === "PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS" ||
+        errMsg.includes("PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS") ||
+        errMsg.includes("subagent(s) you spawned");
+      const gateStateUnavailableError =
+        errCode === "PLAN_APPROVAL_GATE_STATE_UNAVAILABLE" ||
+        errMsg.includes("PLAN_APPROVAL_GATE_STATE_UNAVAILABLE");
+      if (subagentBlockedError) {
+        // Restore the card so the user can re-click Approve once the
+        // subagents return (the agent's plan-mode session keeps
+        // running in the background). Surface the message via the
+        // bottom toast region (mirroring the model-fallback toast)
+        // so it's visible without blocking the card.
+        this.planApprovalRequest = snapshotRequest;
+        this.planApprovalReviseDraft = snapshotReviseDraft;
+        this.planApprovalError = null;
+        const openIds =
+          errDetails && typeof errDetails === "object" && "openSubagentRunIds" in errDetails
+            ? ((errDetails as { openSubagentRunIds?: unknown }).openSubagentRunIds ?? [])
+            : [];
+        const openIdsArr = Array.isArray(openIds)
+          ? openIds.filter((s) => typeof s === "string")
+          : [];
+        this.subagentBlockingStatus = {
+          message: "Subagents still running — try again after subagent results return",
+          openSubagentRunIds: openIdsArr,
+          occurredAt: Date.now(),
+        };
+        // Schedule a re-render so the toast disappears at the 8s
+        // mark even if nothing else changes. Mirror of the
+        // fallback-status pattern in app-tool-stream.ts.
+        if (this.subagentBlockingClearTimer != null) {
+          window.clearTimeout(this.subagentBlockingClearTimer);
+        }
+        this.subagentBlockingClearTimer = window.setTimeout(() => {
+          this.subagentBlockingStatus = null;
+          this.subagentBlockingClearTimer = null;
+        }, 8000);
+      } else if (gateStateUnavailableError) {
+        this.planApprovalRequest = snapshotRequest;
+        this.planApprovalReviseDraft = snapshotReviseDraft;
+        this.planApprovalError =
+          "Approval could not resume safely because subagent gate state was lost. Refresh the session or ask the agent to resubmit the plan.";
+      } else if (staleStateError) {
+        // Clear the dialog + show a transient toast-style message.
+        // The plan was already resolved on another surface (or was
+        // structurally closed by a plan-event race); don't fight it,
+        // just dismiss + tell the user.
+        this.planApprovalRequest = null;
+        this.planApprovalReviseDraft = "";
+        this.planApprovalReviseOpen = false;
+        // PR #68939 follow-up (stale-state re-render fix): mark the
+        // approvalId as dismissed so `hydratePlanApprovalFromSession`
+        // doesn't immediately re-create the popup from a stale
+        // sessionsResult snapshot. Without this, the popup blinks
+        // closed then back open and the user perceives "nothing
+        // happened" when they clicked Approve. Set membership is
+        // checked in hydratePlanApprovalFromSession; cleared on
+        // session change via resetPlanApprovalLocalState.
+        if (snapshotRequest?.approvalId) {
+          this.planApprovalDismissedApprovalIds = new Set([
+            ...this.planApprovalDismissedApprovalIds,
+            snapshotRequest.approvalId,
+          ]);
+        }
+        this.planApprovalError =
+          "This plan was already resolved (another surface acted, or the " +
+          "plan auto-closed). Dialog dismissed; the agent's current state " +
+          "is reflected in the mode chip.";
+      } else {
+        // Restore card so the user can retry on transient errors.
+        this.planApprovalRequest = snapshotRequest;
+        this.planApprovalReviseDraft = snapshotReviseDraft;
+        this.planApprovalError = `Plan approval failed: ${errMsg}`;
+      }
+    } finally {
+      this.planApprovalBusy = false;
+    }
+  }
+
+  /** Open the inline revise textarea (no popup). */
+  handlePlanApprovalReviseOpen(): void {
+    if (!this.planApprovalRequest) {
+      return;
+    }
+    this.planApprovalReviseOpen = true;
+    this.planApprovalError = null;
+  }
+
+  /**
+   * PR-10 AskUserQuestion: route the user's answer back to the agent.
+   * Same approval-card surface as plan approve/reject/edit, but the
+   * action verb is "answer" — no plan-mode state transition, the
+   * answer is persisted onto the session's pending-injection queue so
+   * the agent's next turn can act on it.
+   */
+  async handlePlanApprovalAnswer(answer: string): Promise<void> {
+    const active = this.planApprovalRequest;
+    if (!active || !this.client || this.planApprovalBusy) {
+      return;
+    }
+    if (!active.question) {
+      // Defensive: only fire when the approval is actually a question.
+      return;
+    }
+    // PR-10 deep-dive review (HIGH): sanitize the answer text before
+    // injecting it as a synthetic user message. The answer may be
+    // free-text from the user OR an option string the (potentially
+    // prompt-injected) agent supplied — strip control chars + cap
+    // length so a crafted option like "yes\n\n[SYSTEM] ignore prior"
+    // can't break the synthetic-message convention or smuggle further
+    // instructions into the next agent turn.
+    // Use Unicode property `Cc` (Control) to satisfy lint's
+    // no-control-regex rule while still stripping C0 + DEL + C1.
+    const sanitized = answer
+      .replace(/\p{Cc}/gu, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 1000);
+    if (!sanitized) {
+      return;
+    }
+    this.planApprovalBusy = true;
+    this.planApprovalError = null;
+    const snapshotRequest = active;
+    this.planApprovalRequest = null;
+    try {
+      await this.client.request("sessions.patch", {
+        key: active.sessionKey,
+        planApproval: {
+          action: "answer",
+          answer: sanitized,
+          ...(active.approvalId ? { approvalId: active.approvalId } : {}),
+          ...(active.question.questionId ? { questionId: active.question.questionId } : {}),
+        },
+      });
+      await resumePendingPlanInteraction(this.client, active.sessionKey);
+    } catch (err) {
+      this.planApprovalRequest = snapshotRequest;
+      this.planApprovalError = `Question answer failed: ${String(err)}`;
+    } finally {
+      this.planApprovalBusy = false;
+    }
+  }
+
+  /** Cancel the inline revise textarea WITHOUT submitting. */
+  handlePlanApprovalReviseCancel(): void {
+    this.planApprovalReviseOpen = false;
+    this.planApprovalReviseDraft = "";
+    this.planApprovalError = null;
+  }
+
+  handlePlanApprovalReviseDraftChange(text: string): void {
+    this.planApprovalReviseDraft = text;
+  }
+
+  /**
+   * PR-13 Bug 2: question-card "Other" inline-textarea handlers.
+   * Mirror the revise pattern. Open shows the textarea; Cancel returns
+   * to the option list (does NOT clear planApprovalRequest); Submit
+   * routes through the existing handlePlanApprovalAnswer with the
+   * typed text.
+   */
+  handlePlanApprovalQuestionOtherOpen(): void {
+    if (!this.planApprovalRequest?.question) {
+      return;
+    }
+    this.planApprovalQuestionOtherOpen = true;
+    this.planApprovalError = null;
+  }
+
+  handlePlanApprovalQuestionOtherCancel(): void {
+    this.planApprovalQuestionOtherOpen = false;
+    this.planApprovalQuestionOtherDraft = "";
+    this.planApprovalError = null;
+  }
+
+  handlePlanApprovalQuestionOtherDraftChange(text: string): void {
+    this.planApprovalQuestionOtherDraft = text;
+  }
+
+  async handlePlanApprovalQuestionOtherSubmit(): Promise<void> {
+    const draft = this.planApprovalQuestionOtherDraft.trim();
+    if (!draft) {
+      return;
+    }
+    // Clear the local textarea state before routing — handlePlanApprovalAnswer
+    // owns clearing the request itself.
+    this.planApprovalQuestionOtherOpen = false;
+    this.planApprovalQuestionOtherDraft = "";
+    await this.handlePlanApprovalAnswer(draft);
+  }
+
   handleGatewayUrlConfirm() {
     const nextGatewayUrl = this.pendingGatewayUrl;
     if (!nextGatewayUrl) {
@@ -790,9 +1261,292 @@ export class OpenClawApp extends LitElement {
       window.clearTimeout(this.sidebarCloseTimer);
       this.sidebarCloseTimer = null;
     }
+    // Capture the chat thread's scroll position before opening the
+    // sidebar — the layout reflow on .chat-main flex change otherwise
+    // resets the chat container scroll to top, yanking the user away
+    // from where they were reading. Restore on the next animation
+    // frame after Lit re-renders.
+    const threadEl = this.renderRoot?.querySelector?.(".chat-thread");
+    const savedScrollTop = threadEl instanceof HTMLElement ? threadEl.scrollTop : null;
+    const wasNearBottom =
+      threadEl instanceof HTMLElement
+        ? threadEl.scrollHeight - threadEl.scrollTop - threadEl.clientHeight < 60
+        : false;
     this.sidebarContent = content;
     this.sidebarError = null;
     this.sidebarOpen = true;
+    if (savedScrollTop !== null) {
+      // Defer to after the layout reflow completes.
+      requestAnimationFrame(() => {
+        const after = this.renderRoot?.querySelector?.(".chat-thread");
+        if (!(after instanceof HTMLElement)) {
+          return;
+        }
+        if (wasNearBottom) {
+          // Sticky bottom — pin to the new bottom after reflow.
+          after.scrollTop = after.scrollHeight;
+        } else {
+          after.scrollTop = savedScrollTop;
+        }
+      });
+    }
+  }
+
+  /**
+   * PR-8 follow-up: live update_plan refresh — every time the agent
+   * calls update_plan during execution, re-render the sidebar
+   * markdown so the user sees the latest checklist (boxes ticking off
+   * as the agent steps through). No-op if the sidebar isn't currently
+   * open with markdown content (don't yank focus from a different
+   * view the user is on).
+   */
+  refreshLivePlanSidebar(
+    plan: import("./app-tool-stream.ts").PlanApprovalRequest["plan"],
+    summary?: string,
+  ): void {
+    // Live-test iteration 1 Bug 2: read the persisted plan title for
+    // the active session so the live-update render keeps the title
+    // sticky. Without this, every `update_plan` tick would re-render
+    // the sidebar with header `(planning)` instead of the actual
+    // submitted plan name.
+    const activeSessionKey = this.sessionKey;
+    const row = activeSessionKey
+      ? this.sessionsResult?.sessions.find((s) => s.key === activeSessionKey)
+      : undefined;
+    const persistedTitle = (row?.planMode as { title?: unknown } | undefined)?.title;
+    const titleForView = typeof persistedTitle === "string" ? persistedTitle : undefined;
+    const md = buildPlanViewMarkdown(plan, summary, undefined, titleForView);
+    // ALWAYS track latest plan so the chat-controls "Plan view" button
+    // and `/plan view` slash command can re-open the sidebar with current
+    // content. Sidebar content is only updated if it's already showing
+    // a markdown plan (don't yank focus from a different open view).
+    this.latestPlanMarkdown = md;
+    if (this.sidebarOpen && this.sidebarContent?.kind === "markdown") {
+      this.sidebarContent = { kind: "markdown", content: md };
+    }
+  }
+
+  /**
+   * PR-8 follow-up Round 2: rebuild `latestPlanMarkdown` from the
+   * persisted `SessionEntry.planMode.lastPlanSteps` snapshot for the
+   * current session. Called when the sessions list updates so the
+   * Plan view button shows the latest plan after a hard refresh —
+   * before this hydrates, only stream events would update the markdown
+   * and a fresh subscription doesn't replay prior `update_plan` events.
+   *
+   * No-op when no snapshot exists for the active session (button still
+   * shows the placeholder) or when a snapshot is already loaded with
+   * the same content (avoids stomping fresher live-stream state).
+   */
+  hydratePlanViewFromSession(): void {
+    const activeSessionKey = this.sessionKey;
+    if (!activeSessionKey || !this.sessionsResult) {
+      return;
+    }
+    const row = this.sessionsResult.sessions.find((s) => s.key === activeSessionKey);
+    const snapshot = row?.planMode?.lastPlanSteps;
+    if (!snapshot || snapshot.length === 0) {
+      return;
+    }
+    // Live-test iteration 1 Bug 2: pass the persisted plan title so
+    // the sidebar header anchors on the actual plan name (not "Active
+    // plan"). Title is undefined pre-`exit_plan_mode` — the markdown
+    // builder falls back to "(planning)".
+    const persistedTitle = (row?.planMode as { title?: unknown } | undefined)?.title;
+    const titleForView = typeof persistedTitle === "string" ? persistedTitle : undefined;
+    const md = buildPlanViewMarkdown(snapshot, undefined, undefined, titleForView);
+    if (md === this.latestPlanMarkdown) {
+      return;
+    }
+    this.latestPlanMarkdown = md;
+    // If the sidebar is currently showing the placeholder for THIS
+    // session, swap it for the real plan. Don't yank focus from a
+    // different view the user is on.
+    if (
+      this.sidebarOpen &&
+      this.sidebarContent?.kind === "markdown" &&
+      this.sidebarContent.content === PLAN_VIEW_PLACEHOLDER_MARKDOWN
+    ) {
+      this.sidebarContent = { kind: "markdown", content: md };
+    }
+  }
+
+  private resetPlanApprovalLocalState(): void {
+    this.planApprovalReviseOpen = false;
+    this.planApprovalReviseDraft = "";
+    this.planApprovalQuestionOtherOpen = false;
+    this.planApprovalQuestionOtherDraft = "";
+    this.planApprovalError = null;
+    // PR #68939 follow-up (stale-state re-render fix): clear the
+    // dismissed-set when the interaction changes (new approvalId,
+    // different session, etc.) so a genuinely-new approval card on the
+    // same session can still appear. Without this clear, dismissing
+    // approval A would also block the eventual approval B in the same
+    // session.
+    if (this.planApprovalDismissedApprovalIds.size > 0) {
+      this.planApprovalDismissedApprovalIds = new Set<string>();
+    }
+  }
+
+  private buildHydratedPlanApprovalRequest(
+    row: NonNullable<NonNullable<typeof this.sessionsResult>["sessions"][number]>,
+  ): import("./app-tool-stream.ts").PlanApprovalRequest | null {
+    const pending = row.pendingInteraction;
+    if (!pending || pending.status !== "pending") {
+      return null;
+    }
+    const plan = (row.planMode?.lastPlanSteps ?? []).map((step) =>
+      Object.assign(
+        { step: step.step, status: step.status },
+        step.activeForm ? { activeForm: step.activeForm } : {},
+      ),
+    );
+    if (pending.kind === "plan") {
+      if (row.planMode?.approval !== "pending") {
+        return null;
+      }
+      return {
+        approvalId: pending.approvalId,
+        sessionKey: row.key,
+        title: pending.title,
+        plan,
+        receivedAt: pending.createdAt,
+      };
+    }
+    return {
+      approvalId: pending.approvalId,
+      sessionKey: row.key,
+      title: pending.title,
+      plan,
+      receivedAt: pending.createdAt,
+      question: {
+        prompt: pending.prompt,
+        options: pending.options,
+        allowFreetext: pending.allowFreetext,
+        ...(pending.questionId ? { questionId: pending.questionId } : {}),
+      },
+    };
+  }
+
+  hydratePlanApprovalFromSession(): void {
+    if (this.planApprovalBusy) {
+      return;
+    }
+    const activeSessionKey = this.sessionKey;
+    const row = this.sessionsResult?.sessions.find((session) => session.key === activeSessionKey);
+    const nextRequest = row ? this.buildHydratedPlanApprovalRequest(row) : null;
+    const previous = this.planApprovalRequest;
+    const previousQuestionId = previous?.question?.questionId;
+    const nextQuestionId = nextRequest?.question?.questionId;
+    const changedInteraction =
+      previous?.sessionKey !== nextRequest?.sessionKey ||
+      previous?.approvalId !== nextRequest?.approvalId ||
+      previousQuestionId !== nextQuestionId ||
+      Boolean(previous?.question) !== Boolean(nextRequest?.question);
+    if (!nextRequest) {
+      if (previous) {
+        this.planApprovalRequest = null;
+        this.resetPlanApprovalLocalState();
+      }
+      return;
+    }
+    // PR #68939 follow-up (stale-state re-render fix): if the user
+    // already got a stale-state rejection on this approvalId, do NOT
+    // re-create the popup. The local sessionsResult cache may still
+    // show approval=pending for an approvalId the server has since
+    // cleared; without this guard, the popup re-creates on every
+    // hydrate tick and the user sees their click do nothing visible.
+    // The dismissed set is cleared when the session changes (via
+    // resetPlanApprovalLocalState below + the !nextRequest branch
+    // above), so a genuinely-new approvalId on the same session still
+    // creates a fresh popup.
+    if (
+      nextRequest.approvalId &&
+      this.planApprovalDismissedApprovalIds.has(nextRequest.approvalId)
+    ) {
+      if (previous) {
+        this.planApprovalRequest = null;
+      }
+      return;
+    }
+    this.planApprovalRequest = nextRequest;
+    if (changedInteraction) {
+      this.resetPlanApprovalLocalState();
+    }
+  }
+
+  /**
+   * PR-8 follow-up: open the most-recent active plan in the right
+   * sidebar. Used by both the chat-controls "Plan view" button and
+   * the `/plan view` slash command. If the sidebar is already showing
+   * the plan (or the placeholder), toggle it closed. If no plan has
+   * been tracked yet, render the placeholder so the user knows the
+   * affordance exists.
+   *
+   * Round 2 fix: previously the close-check required
+   * `latestPlanMarkdown !== null`, but opening with the placeholder
+   * doesn't populate that field, so the second click never matched
+   * the close branch. Now the close branch fires when the sidebar
+   * shows EITHER the live plan markdown OR the shared placeholder
+   * constant, so the toggle is symmetric for both states.
+   */
+  togglePlanViewSidebar(): void {
+    const sidebarMd =
+      this.sidebarOpen && this.sidebarContent?.kind === "markdown"
+        ? this.sidebarContent.content
+        : null;
+    const isShowingPlanContent =
+      sidebarMd !== null &&
+      (sidebarMd === this.latestPlanMarkdown || sidebarMd === PLAN_VIEW_PLACEHOLDER_MARKDOWN);
+    if (isShowingPlanContent) {
+      this.handleCloseSidebar();
+      return;
+    }
+    this.handleOpenSidebar({
+      kind: "markdown",
+      content: this.latestPlanMarkdown ?? PLAN_VIEW_PLACEHOLDER_MARKDOWN,
+    });
+  }
+
+  /**
+   * PR-8 follow-up: render the proposed plan as markdown and open it
+   * in the right sidebar (read-only viewer, same path tool-output
+   * details use). Called both from the inline card's "Open plan"
+   * button AND auto-fired by handlePlanApprovalEvent when a fresh
+   * approval arrives so the user sees the full plan immediately.
+   */
+  openPlanInSidebar(request: import("./app-tool-stream.ts").PlanApprovalRequest): void {
+    // PR-9 Tier 1: prefer the agent-supplied title (filtered the same
+    // way as the inline-card headline) over summary, then fall back to
+    // "Proposed plan" so pre-Tier-1 agents render unchanged.
+    const rawTitle = request.title?.trim();
+    const isGenericTitle =
+      !rawTitle || rawTitle === "Plan approval requested" || rawTitle.startsWith("Plan approval —");
+    const headerCandidate = !isGenericTitle ? rawTitle : request.summary || "Proposed plan";
+    // PR-10: pass archetype fields so the sidebar markdown shows the
+    // full plan structure (analysis / assumptions / risks / verification
+    // / references) instead of just the step checklist.
+    // Live-test iteration 1 Bug 2: pass the trimmed agent-supplied
+    // title as the title param too (and keep the existing `summary`
+    // fallback path). The new param takes precedence in the markdown
+    // builder so the side panel header anchors on the actual plan
+    // name as soon as the approval card opens. `headerCandidate` is
+    // kept as the `summary` arg for backward-compat with pre-Tier-1
+    // agents whose request.title is generic.
+    const titleForView = !isGenericTitle && rawTitle ? rawTitle : undefined;
+    const md = buildPlanViewMarkdown(
+      request.plan,
+      headerCandidate,
+      {
+        ...(request.analysis ? { analysis: request.analysis } : {}),
+        ...(request.assumptions ? { assumptions: request.assumptions } : {}),
+        ...(request.risks ? { risks: request.risks } : {}),
+        ...(request.verification ? { verification: request.verification } : {}),
+        ...(request.references ? { references: request.references } : {}),
+      },
+      titleForView,
+    );
+    this.handleOpenSidebar({ kind: "markdown", content: md });
   }
 
   handleCloseSidebar() {

--- a/ui/src/ui/chat/mode-switcher.test.ts
+++ b/ui/src/ui/chat/mode-switcher.test.ts
@@ -1,0 +1,388 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import {
+  handleModeShortcut,
+  MODE_DEFINITIONS,
+  renderModeSwitcher,
+  resolveCurrentMode,
+} from "./mode-switcher.js";
+
+describe("resolveCurrentMode", () => {
+  it("returns Ask permissions for allowlist + on-miss", () => {
+    const mode = resolveCurrentMode("allowlist", "on-miss");
+    expect(mode.id).toBe("ask");
+  });
+
+  it("returns Accept edits for allowlist + off", () => {
+    const mode = resolveCurrentMode("allowlist", "off");
+    expect(mode.id).toBe("accept");
+  });
+
+  it("returns Bypass permissions for full + off", () => {
+    const mode = resolveCurrentMode("full", "off");
+    expect(mode.id).toBe("bypass");
+  });
+
+  it("returns Plan mode when planMode='plan' (overrides permission mode display)", () => {
+    const mode = resolveCurrentMode("allowlist", "off", "plan");
+    expect(mode.id).toBe("plan");
+  });
+
+  it("ignores planMode='normal' (falls through to permission mode)", () => {
+    const mode = resolveCurrentMode("allowlist", "off", "normal");
+    expect(mode.id).toBe("accept");
+  });
+
+  it("PR-10: returns Plan ⚡ when planMode='plan' AND autoApprove=true", () => {
+    const mode = resolveCurrentMode("allowlist", "off", "plan", true);
+    expect(mode.id).toBe("plan-auto");
+    expect(mode.planMode).toBe("plan");
+    expect(mode.planAutoApprove).toBe(true);
+    expect(mode.shortLabel).toBe("Plan ⚡");
+  });
+
+  it("PR-10: returns plain Plan when planMode='plan' AND autoApprove=false", () => {
+    const mode = resolveCurrentMode("allowlist", "off", "plan", false);
+    expect(mode.id).toBe("plan");
+  });
+
+  it("PR-10: ignores autoApprove when planMode is not 'plan' (auto only applies in plan mode)", () => {
+    // Pre-armed auto-approve before entering plan mode shouldn't make
+    // the chip lie about being in plan mode. The flag is meaningful
+    // only AFTER planMode is "plan".
+    const mode = resolveCurrentMode("allowlist", "off", "normal", true);
+    expect(mode.id).toBe("accept");
+  });
+
+  it("returns a Custom mode for unknown combos (was: forced Ask)", () => {
+    const mode = resolveCurrentMode("unknown", "unknown");
+    expect(mode.id).toBe("custom");
+    expect(mode.shortLabel).toBe("Custom");
+    expect(mode.execSecurity).toBe("unknown");
+    expect(mode.execAsk).toBe("unknown");
+  });
+
+  it("returns Default for undefined inputs (Default is the explicit no-override entry)", () => {
+    // PR-8 follow-up: the Default mode entry has both execSecurity and
+    // execAsk undefined (it's the "clear overrides" intent). So
+    // resolveCurrentMode(undefined, undefined) now MATCHES the Default
+    // entry rather than falling through to Custom. Pre-PR-8 this was
+    // Custom (no preset matched undefined/undefined).
+    const mode = resolveCurrentMode(undefined, undefined);
+    expect(mode.id).toBe("default");
+    expect(mode.execSecurity).toBeUndefined();
+    expect(mode.execAsk).toBeUndefined();
+  });
+
+  it("returns Custom for sandbox-backed deny security (real-world non-preset state)", () => {
+    // Codex P1 evidence: resolveExecDefaults commonly yields security=deny
+    // for sandbox-backed sessions; previously this displayed as Ask and
+    // could be unintentionally loosened on menu interaction.
+    const mode = resolveCurrentMode("deny", "off");
+    expect(mode.id).toBe("custom");
+    expect(mode.execSecurity).toBe("deny");
+    expect(mode.execAsk).toBe("off");
+  });
+});
+
+describe("handleModeShortcut", () => {
+  function makeKeyEvent(
+    key: string,
+    ctrl = false,
+    meta = false,
+    shift = false,
+    alt = false,
+  ): KeyboardEvent {
+    return {
+      key,
+      ctrlKey: ctrl,
+      metaKey: meta,
+      shiftKey: shift,
+      altKey: alt,
+      preventDefault: () => {},
+    } as unknown as KeyboardEvent;
+  }
+
+  it("returns correct mode for Ctrl+<shortcut> across every MODE_DEFINITIONS entry", () => {
+    for (const mode of MODE_DEFINITIONS) {
+      const result = handleModeShortcut(makeKeyEvent(mode.shortcut, true, false));
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(mode.id);
+    }
+  });
+
+  it("Ctrl+4 returns Plan mode", () => {
+    const result = handleModeShortcut(makeKeyEvent("4", true, false));
+    expect(result?.id).toBe("plan");
+    expect(result?.planMode).toBe("plan");
+  });
+
+  it("PR-10: Ctrl+5 returns Plan ⚡ (auto-approve) mode", () => {
+    const result = handleModeShortcut(makeKeyEvent("5", true, false));
+    expect(result?.id).toBe("plan-auto");
+    expect(result?.planMode).toBe("plan");
+    expect(result?.planAutoApprove).toBe(true);
+  });
+
+  it("Ctrl+6 returns Bypass mode", () => {
+    const result = handleModeShortcut(makeKeyEvent("6", true, false));
+    expect(result?.id).toBe("bypass");
+  });
+
+  it("returns null for Ctrl+7 (no matching mode)", () => {
+    expect(handleModeShortcut(makeKeyEvent("7", true, false))).toBeNull();
+  });
+
+  it("returns null for Cmd+1 on macOS (preserves browser tab switching)", () => {
+    expect(handleModeShortcut(makeKeyEvent("1", false, true))).toBeNull();
+  });
+
+  it("returns null for Ctrl+Cmd+1 (metaKey blocks)", () => {
+    expect(handleModeShortcut(makeKeyEvent("1", true, true))).toBeNull();
+  });
+
+  it("returns null for plain digit without modifier", () => {
+    expect(handleModeShortcut(makeKeyEvent("1", false, false))).toBeNull();
+  });
+
+  it("returns null for Ctrl+Shift+1 (extra modifier blocks)", () => {
+    expect(handleModeShortcut(makeKeyEvent("1", true, false, true, false))).toBeNull();
+  });
+
+  it("returns null for Ctrl+Alt+1 (extra modifier blocks)", () => {
+    expect(handleModeShortcut(makeKeyEvent("1", true, false, false, true))).toBeNull();
+  });
+
+  it("calls preventDefault when a mode matches", () => {
+    let prevented = false;
+    const e = {
+      key: "1",
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as unknown as KeyboardEvent;
+    handleModeShortcut(e);
+    expect(prevented).toBe(true);
+  });
+
+  it("does NOT call preventDefault when no mode matches", () => {
+    let prevented = false;
+    const e = {
+      key: "9",
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as unknown as KeyboardEvent;
+    handleModeShortcut(e);
+    expect(prevented).toBe(false);
+  });
+});
+
+describe("focus guard (input/textarea/contenteditable)", () => {
+  function makeKeyEvent(key: string): KeyboardEvent {
+    return {
+      key,
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: () => {},
+    } as unknown as KeyboardEvent;
+  }
+
+  it("returns null when an <input> has focus", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    try {
+      expect(handleModeShortcut(makeKeyEvent("1"))).toBeNull();
+    } finally {
+      input.remove();
+    }
+  });
+
+  it("returns null when a <textarea> has focus", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.focus();
+    try {
+      expect(handleModeShortcut(makeKeyEvent("1"))).toBeNull();
+    } finally {
+      ta.remove();
+    }
+  });
+
+  it("returns null when a contenteditable element has focus", () => {
+    const div = document.createElement("div");
+    div.setAttribute("contenteditable", "true");
+    div.tabIndex = 0;
+    // jsdom doesn't fully implement isContentEditable from the contenteditable
+    // attribute, so set the property directly to simulate browser behavior.
+    Object.defineProperty(div, "isContentEditable", {
+      value: true,
+      configurable: true,
+    });
+    document.body.appendChild(div);
+    div.focus();
+    try {
+      expect(handleModeShortcut(makeKeyEvent("1"))).toBeNull();
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("works normally when no input has focus", () => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    // Ctrl+1 is "Default permissions" since the default-mode addition
+    // (PR-8 follow-up). Pre-PR-8 this was "Ask"; the label moved when
+    // Default became the post-plan-mode fallback target.
+    const result = handleModeShortcut(makeKeyEvent("1"));
+    expect(result?.id).toBe("default");
+  });
+
+  it("returns null when focus is inside a Shadow DOM root (input nested in a Web Component)", () => {
+    // Adversarial regression: prior implementation only checked
+    // document.activeElement, which returns the Shadow host (the custom
+    // element) — not the inner <input>. So Ctrl+1-4 would steal
+    // keystrokes the user meant for a Lit composer's internal input.
+    // The Shadow-DOM-aware traversal walks .shadowRoot.activeElement
+    // until it bottoms out at the real focus target.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const input = document.createElement("input");
+    shadow.appendChild(input);
+    // jsdom needs both the focus call AND a manual activeElement set on
+    // the shadow root for the property to reflect; setting via focus()
+    // is sufficient in real browsers.
+    input.focus();
+    try {
+      expect(handleModeShortcut(makeKeyEvent("1"))).toBeNull();
+    } finally {
+      host.remove();
+    }
+  });
+
+  it("returns null when focus is inside nested Shadow DOM roots (depth 2)", () => {
+    // Defense-in-depth: a Web Component containing another Web Component
+    // (e.g. <chat-composer> hosting <token-counter-input>) should still
+    // bail. Verify the traversal handles depth > 1.
+    const outerHost = document.createElement("div");
+    document.body.appendChild(outerHost);
+    const outerShadow = outerHost.attachShadow({ mode: "open" });
+    const innerHost = document.createElement("div");
+    outerShadow.appendChild(innerHost);
+    const innerShadow = innerHost.attachShadow({ mode: "open" });
+    const ta = document.createElement("textarea");
+    innerShadow.appendChild(ta);
+    ta.focus();
+    try {
+      expect(handleModeShortcut(makeKeyEvent("1"))).toBeNull();
+    } finally {
+      outerHost.remove();
+    }
+  });
+});
+
+describe("renderModeSwitcher (jsdom render)", () => {
+  function renderToHost(params: Parameters<typeof renderModeSwitcher>[0]): HTMLElement {
+    const host = document.createElement("div");
+    render(renderModeSwitcher(params), host);
+    return host;
+  }
+
+  it("renders a chip button with the current mode's short label", () => {
+    const ask = MODE_DEFINITIONS.find((m) => m.id === "ask")!;
+    const host = renderToHost({
+      currentMode: ask,
+      menuOpen: false,
+      onToggleMenu: () => {},
+      onSelectMode: () => {},
+    });
+    const chip = host.querySelector("button.agent-chat__mode-chip");
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("Ask");
+    expect(chip?.getAttribute("aria-haspopup")).toBe("menu");
+    expect(chip?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("toggles aria-expanded when menuOpen=true", () => {
+    const ask = MODE_DEFINITIONS.find((m) => m.id === "ask")!;
+    const host = renderToHost({
+      currentMode: ask,
+      menuOpen: true,
+      onToggleMenu: () => {},
+      onSelectMode: () => {},
+    });
+    expect(host.querySelector("button.agent-chat__mode-chip")?.getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    // Menu container is rendered when open. We deliberately do NOT
+    // declare role="menu" because we don't implement the WAI-ARIA menu
+    // keyboard contract (arrow nav, Home/End, focus trap). Plain
+    // <button> children give native focus + Escape-on-chip without
+    // making a false ARIA promise (PR #67721 ARIA-semantics fix).
+    const menu = host.querySelector(".agent-chat__mode-menu");
+    expect(menu).not.toBeNull();
+    expect(menu?.getAttribute("role")).toBeNull();
+  });
+
+  it("renders one button per MODE_DEFINITIONS entry when menu is open", () => {
+    const ask = MODE_DEFINITIONS.find((m) => m.id === "ask")!;
+    const host = renderToHost({
+      currentMode: ask,
+      menuOpen: true,
+      onToggleMenu: () => {},
+      onSelectMode: () => {},
+    });
+    const items = host.querySelectorAll(".agent-chat__mode-menu__item");
+    expect(items).toHaveLength(MODE_DEFINITIONS.length);
+    // Active item gets the active class.
+    const labels = Array.from(items).map(
+      (el) => el.querySelector(".agent-chat__mode-menu__label")?.textContent,
+    );
+    // The "ask" entry's label is "Ask each mutation" (vs "Ask
+    // permissions" in older copy). Assert against the live label so a
+    // future copy tweak keeps the test honest.
+    expect(labels).toContain(ask.label);
+    const activeItems = host.querySelectorAll(".agent-chat__mode-menu__item--active");
+    expect(activeItems).toHaveLength(1);
+    expect(activeItems[0].textContent).toContain(ask.label);
+  });
+
+  it("does NOT render the menu container when menuOpen=false", () => {
+    const ask = MODE_DEFINITIONS.find((m) => m.id === "ask")!;
+    const host = renderToHost({
+      currentMode: ask,
+      menuOpen: false,
+      onToggleMenu: () => {},
+      onSelectMode: () => {},
+    });
+    expect(host.querySelector(".agent-chat__mode-menu")).toBeNull();
+  });
+
+  it("invokes onSelectMode with the chosen mode definition", () => {
+    const ask = MODE_DEFINITIONS.find((m) => m.id === "ask")!;
+    let chosen: { id: string } | null = null;
+    const host = renderToHost({
+      currentMode: ask,
+      menuOpen: true,
+      onToggleMenu: () => {},
+      onSelectMode: (m) => {
+        chosen = { id: m.id };
+      },
+    });
+    const items = host.querySelectorAll<HTMLButtonElement>(".agent-chat__mode-menu__item");
+    const planItem = Array.from(items).find((el) => el.textContent?.includes("Plan mode"));
+    expect(planItem).toBeDefined();
+    planItem!.click();
+    expect(chosen).not.toBeNull();
+    expect(chosen!.id).toBe("plan");
+  });
+});

--- a/ui/src/ui/chat/mode-switcher.ts
+++ b/ui/src/ui/chat/mode-switcher.ts
@@ -1,0 +1,424 @@
+/**
+ * Mode switcher for the chat input toolbar.
+ *
+ * Renders a pill/chip showing the current execution mode with a dropdown
+ * menu for switching between modes.
+ *
+ * Permission modes (Ask/Accept/Bypass) map to the existing session fields
+ * `execSecurity` + `execAsk`, so no protocol schema change is required for
+ * those.
+ *
+ * Plan mode is its own dimension — it sets `planMode: "plan"` via
+ * `sessions.patch` (added in PR-8) and activates the runtime mutation gate
+ * from #67538b. NOT mapped to execSecurity (that would block read-only exec
+ * which plan mode explicitly needs for research). Permission mode and plan
+ * mode coexist: a session can be in plan-mode-with-allowlist, etc.
+ */
+
+import { html, nothing, type TemplateResult } from "lit";
+
+export interface ModeDefinition {
+  id: string;
+  label: string;
+  shortLabel: string;
+  shortcut: string;
+  /**
+   * Permission mode mapping (Ask/Accept/Bypass only).
+   * Plan mode does NOT set these — see `planMode` field instead.
+   */
+  execSecurity?: string;
+  execAsk?: string;
+  /**
+   * Plan mode toggle. When set to "plan", selecting this mode calls
+   * sessions.patch with `planMode: "plan"`, activating the runtime
+   * mutation gate from #67538b. PR-8 wires the RPC dispatch.
+   */
+  planMode?: "plan" | "normal";
+  /**
+   * PR-10 auto mode. When `planMode === "plan"` and this is true,
+   * selecting the mode also patches `planApproval.action: "auto"` with
+   * `autoEnabled: true`, arming the session's auto-approve flag so
+   * future plan submissions resolve as "approve" without user
+   * confirmation. Selecting plain "Plan" (planMode set, autoApprove
+   * unset) clears the flag so the user can drop back to manual
+   * approval mid-session.
+   */
+  planAutoApprove?: boolean;
+  icon: TemplateResult;
+}
+
+const shieldIcon = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+</svg>`;
+const checkIcon = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+  <path d="M22 4 12 14.01l-3-3" />
+</svg>`;
+const unlockIcon = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+  <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+</svg>`;
+const planIcon = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M9 11l3 3L22 4" />
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+</svg>`;
+// PR-10 plan-auto icon: lightning bolt over the plan checkmark to
+// distinguish "auto-approving plan" from plain "plan mode."
+const planAutoIcon = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M13 2L3 14h7l-1 8 11-12h-7l1-8z" />
+</svg>`;
+
+export const MODE_DEFINITIONS: ModeDefinition[] = [
+  // "Default" clears the per-session execSecurity/execAsk overrides so
+  // the runtime falls back to whatever's in agents.defaults / per-agent
+  // config (the "normal agentic" mode the operator configured). This
+  // is the truer post-plan-mode fallback than locking back to Ask —
+  // most operator configs don't want every-mutation prompts.
+  // Implementation note: handlers detect undefined execSecurity/execAsk
+  // on this entry and DELETE the session-side overrides via patch.
+  {
+    id: "default",
+    label: "Default permissions",
+    shortLabel: "Default",
+    shortcut: "1",
+    icon: shieldIcon,
+  },
+  {
+    id: "ask",
+    label: "Ask each mutation",
+    shortLabel: "Ask",
+    shortcut: "2",
+    execSecurity: "allowlist",
+    execAsk: "on-miss",
+    icon: shieldIcon,
+  },
+  {
+    id: "accept",
+    label: "Accept edits",
+    shortLabel: "Accept",
+    shortcut: "3",
+    execSecurity: "allowlist",
+    execAsk: "off",
+    icon: checkIcon,
+  },
+  // Plan mode: own dimension (not a permission permutation). Selecting Plan
+  // calls sessions.patch with planMode:"plan" — wired in PR-8. The runtime
+  // mutation gate from #67538b activates server-side. This entry has no
+  // execSecurity/execAsk because plan mode coexists with whatever permission
+  // mode is current. The mode switcher will show Plan as the active label
+  // while plan mode is on; switching to any non-plan mode patches back to
+  // planMode:"normal".
+  {
+    id: "plan",
+    label: "Plan mode",
+    shortLabel: "Plan",
+    shortcut: "4",
+    planMode: "plan",
+    icon: planIcon,
+  },
+  // PR-10 plan-auto: same plan mode (mutation gate active, exit_plan_mode
+  // still required) but the runtime auto-resolves submitted plans as
+  // "approve" without user confirmation. Useful for long-running unattended
+  // sessions where the user trusts the agent to plan + execute its own
+  // checkpoints. Selecting plain "Plan" clears the flag.
+  {
+    id: "plan-auto",
+    label: "Plan (auto-approve)",
+    shortLabel: "Plan ⚡",
+    shortcut: "5",
+    planMode: "plan",
+    planAutoApprove: true,
+    icon: planAutoIcon,
+  },
+  {
+    id: "bypass",
+    label: "Bypass permissions",
+    shortLabel: "Bypass",
+    shortcut: "6",
+    execSecurity: "full",
+    execAsk: "off",
+    icon: unlockIcon,
+  },
+];
+
+/**
+ * Synthetic "Custom" mode displayed when the current
+ * `(execSecurity, execAsk)` pair doesn't match any preset.
+ *
+ * Carries the actual values via `execSecurity`/`execAsk` so a future
+ * tooltip/devtools surface can show the live state, and so picking a
+ * preset from the menu makes the user's intent explicit (instead of
+ * silently coercing the unrecognized state to a preset).
+ */
+const CUSTOM_MODE_ICON = html`<svg
+  width="14"
+  height="14"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <circle cx="12" cy="12" r="3" />
+  <path
+    d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+  />
+</svg>`;
+
+/**
+ * Derives the current mode from session state.
+ *
+ * Plan mode wins when active — the chip displays "Plan" regardless of
+ * the underlying permission mode, because plan mode is the most specific
+ * signal about agent behavior.
+ *
+ * If `(execSecurity, execAsk)` matches no preset (e.g. `security=deny`
+ * for sandbox-backed sessions, or `ask=always` set elsewhere), a
+ * synthetic "Custom" `ModeDefinition` is returned that carries the
+ * actual values — instead of silently mislabeling the chip as "Ask".
+ *
+ * Bug-fix history (PR #67721): the prior fallback to
+ * `MODE_DEFINITIONS[0]` (Ask) made the UI report Ask for valid
+ * non-preset states and could quietly rewrite those states when the
+ * user picked from the menu.
+ */
+export function resolveCurrentMode(
+  execSecurity?: string,
+  execAsk?: string,
+  planMode?: "plan" | "normal",
+  planAutoApprove?: boolean,
+): ModeDefinition {
+  if (planMode === "plan") {
+    // PR-10: prefer the "plan-auto" entry when the session's
+    // autoApprove flag is set so the chip surfaces the auto state.
+    // Falls back to plain "plan" when the flag is absent so existing
+    // sessions render unchanged.
+    if (planAutoApprove === true) {
+      const autoEntry = MODE_DEFINITIONS.find((m) => m.id === "plan-auto");
+      if (autoEntry) {
+        return autoEntry;
+      }
+    }
+    const planEntry = MODE_DEFINITIONS.find((m) => m.id === "plan");
+    if (planEntry) {
+      return planEntry;
+    }
+  }
+  const match = MODE_DEFINITIONS.find(
+    (m) => !m.planMode && m.execSecurity === execSecurity && m.execAsk === execAsk,
+  );
+  if (match) {
+    return match;
+  }
+  // No preset match — fabricate a "Custom" entry instead of forcing Ask.
+  // Synthesizing a fresh object means selecting another mode from the
+  // menu is a real state change (currentMode.id !== chosen.id) and can
+  // be intentionally confirmed by the caller.
+  return {
+    id: "custom",
+    label: "Custom permissions",
+    shortLabel: "Custom",
+    shortcut: "",
+    icon: CUSTOM_MODE_ICON,
+    ...(execSecurity !== undefined ? { execSecurity } : {}),
+    ...(execAsk !== undefined ? { execAsk } : {}),
+  };
+}
+
+export interface ModeSwitcherState {
+  menuOpen: boolean;
+}
+
+/**
+ * Renders the mode switcher chip + dropdown menu.
+ */
+export function renderModeSwitcher(params: {
+  currentMode: ModeDefinition;
+  menuOpen: boolean;
+  onToggleMenu: () => void;
+  onSelectMode: (mode: ModeDefinition) => void;
+}): TemplateResult {
+  const { currentMode, menuOpen, onToggleMenu, onSelectMode } = params;
+
+  return html`
+    <div class="agent-chat__mode-switcher" aria-label="Execution mode selector">
+      <button
+        type="button"
+        class="agent-chat__mode-chip"
+        @click=${onToggleMenu}
+        @keydown=${(e: KeyboardEvent) => {
+          if (e.key === "Escape" && menuOpen) {
+            e.preventDefault();
+            onToggleMenu();
+          }
+        }}
+        title="Switch mode (Ctrl+1-6)"
+        aria-haspopup="menu"
+        aria-expanded="${menuOpen ? "true" : "false"}"
+      >
+        ${currentMode.icon}
+        <span class="agent-chat__mode-chip-label">${currentMode.shortLabel}</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      ${menuOpen
+        ? html`
+            <div class="agent-chat__mode-menu">
+              <!--
+                ARIA accessibility note (PR #67721): previously declared
+                role="menu" / role="menuitem" but did NOT implement the
+                WAI-ARIA menu keyboard contract (arrow nav, Home/End,
+                roving tabindex, focus trap). Per WAI-ARIA, claiming the
+                menu role without those keyboard semantics misleads
+                assistive tech. Rather than ship a partial menu, we
+                expose this surface as a popover of plain <button>s —
+                native button focus + Escape-on-chip already gives
+                keyboard users a usable interaction with no false ARIA
+                promise.
+              -->
+              ${MODE_DEFINITIONS.map(
+                (mode) => html`
+                  <button
+                    type="button"
+                    class="agent-chat__mode-menu__item ${mode.id === currentMode.id
+                      ? "agent-chat__mode-menu__item--active"
+                      : ""}"
+                    @click=${() => {
+                      onSelectMode(mode);
+                    }}
+                  >
+                    <span class="agent-chat__mode-menu__label">${mode.label}</span>
+                    <kbd class="agent-chat__mode-menu__shortcut">Ctrl+${mode.shortcut}</kbd>
+                  </button>
+                `,
+              )}
+            </div>
+          `
+        : nothing}
+    </div>
+  `;
+}
+
+/**
+ * Handles keyboard shortcuts for mode switching (Ctrl+1 through Ctrl+4).
+ * Returns the selected mode if a shortcut matched, or null.
+ *
+ * Focus guard: when the user is typing in an input/textarea/contenteditable
+ * surface, Ctrl+digit should not steal the keystroke. This prevents the
+ * shortcut from interfering with users typing in the chat composer or
+ * any other text field.
+ */
+/**
+ * Walks the active-element chain across Shadow DOM roots to find the
+ * deepest focused element. `document.activeElement` only returns the
+ * first host along the path; for Lit / Web Component composer surfaces
+ * with internal `<input>` / `<textarea>` / `[contenteditable]`, the
+ * naive read returns the host (e.g. `<openclaw-chat-composer>`) and
+ * misses the real focus target — so the focus guard would NOT bail and
+ * Ctrl+1..N (where N covers every MODE_DEFINITIONS entry) would steal
+ * keystrokes the user meant for the input.
+ *
+ * Returns `null` when no element is focused.
+ */
+function getDeepActiveElement(): Element | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  let active: Element | null = document.activeElement;
+  // Cap the traversal to avoid runaway loops on pathological component trees.
+  for (let depth = 0; depth < 32 && active; depth += 1) {
+    const root = (active as Element & { shadowRoot?: ShadowRoot | null }).shadowRoot;
+    if (!root || !root.activeElement) {
+      return active;
+    }
+    if (root.activeElement === active) {
+      // Stable fixed point — done.
+      return active;
+    }
+    active = root.activeElement;
+  }
+  return active;
+}
+
+export function handleModeShortcut(e: KeyboardEvent): ModeDefinition | null {
+  // Only bare Ctrl+digit — exclude Cmd (macOS tab switch), Shift, and Alt modifiers.
+  if (!e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) {
+    return null;
+  }
+  // Focus guard: skip when user is typing. Use a Shadow-DOM-aware traversal
+  // so focus inside a Web Component's internal input also bails the shortcut.
+  const active = getDeepActiveElement();
+  if (active) {
+    const tag = active.tagName?.toLowerCase();
+    if (tag === "input" || tag === "textarea" || (active as HTMLElement).isContentEditable) {
+      return null;
+    }
+  }
+  const mode = MODE_DEFINITIONS.find((m) => m.shortcut === e.key);
+  if (mode) {
+    e.preventDefault();
+    return mode;
+  }
+  return null;
+}

--- a/ui/src/ui/chat/plan-cards.test.ts
+++ b/ui/src/ui/chat/plan-cards.test.ts
@@ -1,0 +1,159 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { formatPlanAsMarkdown, type PlanCardData, renderPlanCard } from "./plan-cards.js";
+
+describe("formatPlanAsMarkdown", () => {
+  const basePlan: PlanCardData = {
+    title: "Deploy Pipeline",
+    explanation: "Standard deployment checklist",
+    steps: [
+      { text: "Run tests", status: "completed" },
+      { text: "Build artifacts", status: "in_progress", activeForm: "Building artifacts" },
+      { text: "Deploy to staging", status: "pending" },
+      { text: "Fix broken migration", status: "cancelled" },
+    ],
+  };
+
+  it("renders title as h2", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("## Deploy Pipeline");
+  });
+
+  it("renders explanation in italics", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("_Standard deployment checklist_");
+  });
+
+  it("renders completed steps with [x]", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("- [x] Run tests");
+  });
+
+  it("renders pending steps with [ ]", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("- [ ] Deploy to staging");
+  });
+
+  it("renders cancelled steps with strikethrough and label", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("- [ ] ~~Fix broken migration~~ (cancelled)");
+  });
+
+  it("renders in_progress steps with bold and label", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("- [ ] **Building artifacts** (in progress)");
+  });
+
+  it("uses activeForm for in_progress steps when present", () => {
+    const md = formatPlanAsMarkdown(basePlan);
+    expect(md).toContain("Building artifacts");
+    expect(md).not.toContain("Build artifacts");
+  });
+
+  it("uses step text when activeForm is absent", () => {
+    const plan: PlanCardData = {
+      title: "Test",
+      steps: [{ text: "Run lint", status: "in_progress" }],
+    };
+    const md = formatPlanAsMarkdown(plan);
+    expect(md).toContain("**Run lint**");
+  });
+
+  it("omits explanation when not provided", () => {
+    const plan: PlanCardData = {
+      title: "Quick Plan",
+      steps: [{ text: "Step 1", status: "pending" }],
+    };
+    const md = formatPlanAsMarkdown(plan);
+    expect(md).not.toContain("_");
+    expect(md).toContain("## Quick Plan");
+    expect(md).toContain("- [ ] Step 1");
+  });
+
+  it("handles empty steps array", () => {
+    const plan: PlanCardData = { title: "Empty", steps: [] };
+    const md = formatPlanAsMarkdown(plan);
+    expect(md).toContain("## Empty");
+    expect(md.split("\n").filter((l) => l.startsWith("- "))).toHaveLength(0);
+  });
+});
+
+describe("renderPlanCard (jsdom render)", () => {
+  function renderToHost(plan: PlanCardData): HTMLElement {
+    const host = document.createElement("div");
+    render(renderPlanCard(plan), host);
+    return host;
+  }
+
+  it("renders <details>/<summary> structure with title and meta", () => {
+    const host = renderToHost({
+      title: "Deploy Pipeline",
+      steps: [
+        { text: "A", status: "completed" },
+        { text: "B", status: "pending" },
+      ],
+    });
+    const details = host.querySelector("details.chat-plan-card");
+    expect(details).not.toBeNull();
+    const summary = details?.querySelector("summary");
+    expect(summary?.textContent).toContain("Deploy Pipeline");
+    // Meta line shows N/M done.
+    expect(summary?.textContent).toContain("1/2 done");
+  });
+
+  it("renders explanation block when present", () => {
+    const host = renderToHost({
+      title: "T",
+      explanation: "Why we are doing this",
+      steps: [{ text: "S", status: "pending" }],
+    });
+    const explanation = host.querySelector(".chat-plan-card__explanation");
+    expect(explanation?.textContent).toBe("Why we are doing this");
+  });
+
+  it("omits explanation block when absent", () => {
+    const host = renderToHost({
+      title: "T",
+      steps: [{ text: "S", status: "pending" }],
+    });
+    expect(host.querySelector(".chat-plan-card__explanation")).toBeNull();
+  });
+
+  it("renders one li per step with status-specific class", () => {
+    const host = renderToHost({
+      title: "T",
+      steps: [
+        { text: "A", status: "completed" },
+        { text: "B", status: "in_progress" },
+        { text: "C", status: "pending" },
+        { text: "D", status: "cancelled" },
+      ],
+    });
+    const steps = host.querySelectorAll("li.chat-plan-card__step");
+    expect(steps).toHaveLength(4);
+    expect(steps[0].classList.contains("chat-plan-card__step--completed")).toBe(true);
+    expect(steps[1].classList.contains("chat-plan-card__step--in-progress")).toBe(true);
+    expect(steps[2].classList.contains("chat-plan-card__step--pending")).toBe(true);
+    expect(steps[3].classList.contains("chat-plan-card__step--cancelled")).toBe(true);
+  });
+
+  it("uses activeForm for in_progress steps when present", () => {
+    const host = renderToHost({
+      title: "T",
+      steps: [{ text: "Build", status: "in_progress", activeForm: "Building artifacts" }],
+    });
+    expect(host.textContent).toContain("Building artifacts");
+    expect(host.textContent).not.toContain("Build artifacts"); // step text shadowed
+  });
+
+  it("shows N steps meta when nothing is completed", () => {
+    const host = renderToHost({
+      title: "T",
+      steps: [
+        { text: "A", status: "pending" },
+        { text: "B", status: "pending" },
+      ],
+    });
+    expect(host.querySelector("summary")?.textContent).toContain("2 steps");
+  });
+});

--- a/ui/src/ui/chat/plan-cards.ts
+++ b/ui/src/ui/chat/plan-cards.ts
@@ -1,0 +1,122 @@
+/**
+ * Plan card rendering for the webchat message thread.
+ *
+ * Renders agent plan events as expandable cards with step checklists.
+ * Uses the same <details>/<summary> pattern as tool cards for consistency.
+ */
+
+import { html, nothing, type TemplateResult } from "lit";
+
+export interface PlanCardData {
+  title: string;
+  explanation?: string;
+  steps: PlanCardStep[];
+  source?: string;
+}
+
+export interface PlanCardStep {
+  text: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  activeForm?: string;
+}
+
+const STATUS_MARKERS: Record<PlanCardStep["status"], string> = {
+  pending: "⬚",
+  in_progress: "⏳",
+  completed: "✅",
+  cancelled: "❌",
+};
+
+const PLAN_ICON = html`<svg
+  class="chat-plan-card__icon"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M9 11l3 3L22 4" />
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+</svg>`;
+
+const CHEVRON_ICON = html`<svg
+  class="chat-plan-card__chevron"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M9 18l6-6-6-6" />
+</svg>`;
+
+/**
+ * Renders a plan card as an expandable <details> element.
+ */
+export function renderPlanCard(plan: PlanCardData): TemplateResult {
+  const stepCount = plan.steps.length;
+  const completedCount = plan.steps.filter((s) => s.status === "completed").length;
+  const meta = completedCount > 0 ? `${completedCount}/${stepCount} done` : `${stepCount} steps`;
+
+  return html`
+    <details class="chat-plan-card">
+      <summary>
+        ${PLAN_ICON}
+        <span class="chat-plan-card__title">${plan.title}</span>
+        <span class="chat-plan-card__meta">${meta}</span>
+        ${CHEVRON_ICON}
+      </summary>
+      <div class="chat-plan-card__body">
+        ${plan.explanation
+          ? html`<div class="chat-plan-card__explanation">${plan.explanation}</div>`
+          : nothing}
+        <ul class="chat-plan-card__steps">
+          ${plan.steps.map((step) => renderPlanStep(step))}
+        </ul>
+      </div>
+    </details>
+  `;
+}
+
+function renderPlanStep(step: PlanCardStep): TemplateResult {
+  const label = step.status === "in_progress" && step.activeForm ? step.activeForm : step.text;
+  const marker = STATUS_MARKERS[step.status] ?? "⬚";
+  const statusClass = `chat-plan-card__step--${step.status.replace("_", "-")}`;
+
+  return html`
+    <li class="chat-plan-card__step ${statusClass}">
+      <span class="chat-plan-card__step-marker">${marker}</span>
+      <span>${label}</span>
+    </li>
+  `;
+}
+
+/**
+ * Formats a plan as markdown for sidebar/detail view.
+ */
+export function formatPlanAsMarkdown(plan: PlanCardData): string {
+  const clean = (s: string) => s.replace(/[\n\r]+/g, " ").trim();
+  const lines = [`## ${clean(plan.title)}`];
+  if (plan.explanation) {
+    lines.push("", `_${clean(plan.explanation)}_`);
+  }
+  lines.push("");
+  for (const step of plan.steps) {
+    const rawLabel = step.status === "in_progress" && step.activeForm ? step.activeForm : step.text;
+    const label = clean(rawLabel);
+    if (step.status === "completed") {
+      lines.push(`- [x] ${label}`);
+    } else if (step.status === "cancelled") {
+      lines.push(`- [ ] ~~${label}~~ (cancelled)`);
+    } else if (step.status === "in_progress") {
+      lines.push(`- [ ] **${label}** (in progress)`);
+    } else {
+      lines.push(`- [ ] ${label}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/ui/src/ui/chat/plan-resume.node.test.ts
+++ b/ui/src/ui/chat/plan-resume.node.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../uuid.ts", () => ({
+  generateUUID: () => "uuid-fixed",
+}));
+
+import { resumePendingPlanInteraction } from "./plan-resume.ts";
+
+describe("resumePendingPlanInteraction", () => {
+  it("sends a hidden continue message with a stable plan-resume idempotency prefix", async () => {
+    const request = vi.fn(async () => undefined);
+    await resumePendingPlanInteraction(
+      {
+        request,
+      } as unknown as Parameters<typeof resumePendingPlanInteraction>[0],
+      "agent:main:user:abc",
+    );
+
+    expect(request).toHaveBeenCalledWith("chat.send", {
+      sessionKey: "agent:main:user:abc",
+      message: "continue",
+      deliver: false,
+      idempotencyKey: "plan-resume-uuid-fixed",
+    });
+  });
+});

--- a/ui/src/ui/chat/plan-resume.ts
+++ b/ui/src/ui/chat/plan-resume.ts
@@ -1,0 +1,21 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import { generateUUID } from "../uuid.ts";
+
+/**
+ * Trigger a follow-up agent run after a plan approval/question answer
+ * lands in session state. The authoritative decision/answer context is
+ * already persisted in `pendingAgentInjections`; this hidden send only
+ * resumes the run without echoing synthetic control text into the chat
+ * UI.
+ */
+export async function resumePendingPlanInteraction(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+): Promise<void> {
+  await client.request("chat.send", {
+    sessionKey,
+    message: "continue",
+    deliver: false,
+    idempotencyKey: `plan-resume-${generateUUID()}`,
+  });
+}

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -1045,3 +1045,163 @@ describe("executeSlashCommand /redirect (hard kill-and-restart)", () => {
     expect(result.content).toBe("Failed to redirect: Error: connection lost");
   });
 });
+
+describe("executeSlashCommand /plan auto (PR-10)", () => {
+  it("/plan auto with no arg defaults to 'on'", async () => {
+    const calls: Array<{ method: string; payload: unknown }> = [];
+    const request = vi.fn(async (method: string, payload?: unknown) => {
+      calls.push({ method, payload });
+      return {};
+    });
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "auto",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("sessions.patch");
+    expect(calls[0].payload).toMatchObject({
+      planApproval: { action: "auto", autoEnabled: true },
+    });
+    expect(result.content).toContain("auto-approve **enabled**");
+    expect(result.action).toBe("refresh");
+  });
+
+  it("/plan auto on explicitly enables", async () => {
+    const request = vi.fn(async () => ({}));
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "auto on",
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      planApproval: { action: "auto", autoEnabled: true },
+    });
+    expect(result.content).toContain("**enabled**");
+  });
+
+  it("/plan auto off explicitly disables", async () => {
+    const request = vi.fn(async () => ({}));
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "auto off",
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      planApproval: { action: "auto", autoEnabled: false },
+    });
+    expect(result.content).toContain("**disabled**");
+  });
+
+  it("/plan auto bogus rejects with usage hint", async () => {
+    const request = vi.fn();
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "auto bogus",
+    );
+    expect(request).not.toHaveBeenCalled();
+    expect(result.content).toContain("Unrecognized auto value");
+  });
+
+  it("/plan auto reports config-disabled error legibly", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("plan mode is disabled at the config level");
+    });
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "auto on",
+    );
+    expect(result.content).toContain("Plan mode is disabled at the config level");
+  });
+
+  it("/plan status mentions the new auto option", async () => {
+    const request = vi.fn();
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "",
+    );
+    expect(request).not.toHaveBeenCalled();
+    expect(result.content).toContain("auto");
+  });
+});
+
+describe("executeSlashCommand /plan approvals (stacked follow-up)", () => {
+  it("/plan accept returns the hidden resume directive", async () => {
+    const request = vi.fn(async () => ({}));
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "accept",
+      {
+        sessionsResult: {
+          sessions: [
+            row("agent:main:main", {
+              planMode: {
+                mode: "plan",
+                approval: "pending",
+                approvalId: "plan-1",
+                rejectionCount: 0,
+              },
+            }),
+          ],
+        } as SessionsListResult,
+      },
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      planApproval: { action: "approve", approvalId: "plan-1" },
+    });
+    expect(result.resumePlanInteraction).toBe(true);
+  });
+
+  it("/plan answer uses pendingInteraction questionId and returns the hidden resume directive", async () => {
+    const request = vi.fn(async () => ({}));
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "plan",
+      "answer Option A",
+      {
+        sessionsResult: {
+          sessions: [
+            row("agent:main:main", {
+              pendingInteraction: {
+                kind: "question",
+                approvalId: "question-1",
+                questionId: "q-1",
+                title: "Agent has a question",
+                prompt: "Pick one",
+                options: ["Option A", "Option B"],
+                allowFreetext: false,
+                createdAt: 1,
+                status: "pending",
+              },
+            }),
+          ],
+        } as SessionsListResult,
+      },
+    );
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      planApproval: {
+        action: "answer",
+        answer: "Option A",
+        approvalId: "question-1",
+        questionId: "q-1",
+      },
+    });
+    expect(result.resumePlanInteraction).toBe(true);
+  });
+});

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -46,6 +46,7 @@ export type SlashCommandResult = {
     | "stop"
     | "clear"
     | "toggle-focus"
+    | "toggle-plan-view"
     | "navigate-usage";
   /** Optional session-level directive changes that the caller should mirror locally. */
   sessionPatch?: {
@@ -55,6 +56,14 @@ export type SlashCommandResult = {
   trackRunId?: string;
   /** When set, the caller should surface a visible pending item tied to the current run. */
   pendingCurrentRun?: boolean;
+  /**
+   * When true, the caller should trigger the hidden plan-resume path
+   * after the patch lands. The authoritative decision/answer context
+   * already lives in the gateway-owned pending injection queue; the
+   * resume call only wakes the next turn without echoing synthetic
+   * control text into visible chat history.
+   */
+  resumePlanInteraction?: boolean;
 };
 
 export type SlashCommandContext = {
@@ -122,8 +131,325 @@ export async function executeSlashCommand(
       return await executeSteer(client, sessionKey, args, context);
     case "redirect":
       return await executeRedirect(client, sessionKey, args, context);
+    case "plan":
+      return await executePlan(client, sessionKey, args, context);
     default:
       return { content: `Unknown command: \`/${commandName}\`` };
+  }
+}
+
+/**
+ * `/plan on|off|status|view|auto [on|off]` — manage plan-mode session state.
+ *
+ * - `on` / `off`: toggle planMode via `setSessionPlanMode`
+ * - `view`: UI-only sidebar toggle (no gateway round-trip)
+ * - `status`: print usage / discoverability helper
+ * - `auto on|off`: PR-10 — toggle the session's autoApprove flag via
+ *   `sessions.patch { planApproval: { action: "auto", autoEnabled }}`.
+ *   When ON, future `exit_plan_mode` submissions auto-resolve as
+ *   "approve" without user confirmation (Cloud Code parity for
+ *   long-running unattended sessions).
+ *
+ * All paths are validated against the gateway's
+ * `agents.defaults.planMode.enabled` opt-in gate.
+ */
+/**
+ * PR-11 review: shared error mapper for the universal /plan
+ * subcommands. Maps gateway errors to friendly chat messages.
+ */
+function mapPlanCommandError(err: unknown, verb: string): SlashCommandResult {
+  const msg = String(err);
+  if (msg.includes("plan mode is disabled")) {
+    return {
+      content:
+        "Plan mode is disabled at the config level. Set `agents.defaults.planMode.enabled: true` and restart the gateway.",
+    };
+  }
+  if (msg.includes("stale approvalId") || msg.includes("terminal approval state")) {
+    return {
+      content:
+        "Plan was already resolved (likely a duplicate command). Use `/plan status` to see the current state.",
+    };
+  }
+  if (msg.includes("requires an active plan-mode session")) {
+    return {
+      content: `No pending plan to ${verb} — the agent hasn't submitted a plan via exit_plan_mode yet, or the previous one was already resolved.`,
+    };
+  }
+  if (msg.includes("PLAN_APPROVAL_GATE_STATE_UNAVAILABLE")) {
+    return {
+      content:
+        "Plan approval could not be resumed safely because the subagent gate state was lost. Refresh the session or ask the agent to resubmit the plan.",
+    };
+  }
+  return { content: `Failed to ${verb}: ${msg}` };
+}
+
+/**
+ * Codex P1 review #68939 (2026-04-19): look up the live `approvalId`
+ * for a session from the cached `sessionsResult` snapshot so the
+ * webchat /plan accept|revise|answer paths can include it in the
+ * `sessions.patch` call. Pre-fix, the webchat patches omitted
+ * `approvalId` entirely — letting a stale `/plan accept` typed AFTER
+ * the previous plan was resolved silently approve a freshly-submitted
+ * one (race window between approval landing and the next plan
+ * submission). Mirrors the backend `commands-plan.ts` handler which
+ * always threads `planMode.approvalId` (see line 431/447 in that file).
+ *
+ * Returns `undefined` when no live planMode is cached or when no
+ * pending approval exists. The gateway-side handler still validates
+ * `approvalId` server-side; passing `undefined` preserves the prior
+ * looser behavior so this fix is non-breaking when the snapshot is
+ * stale or absent.
+ */
+function resolvePendingApprovalIdFromContext(
+  sessionKey: string,
+  context: SlashCommandContext,
+): string | undefined {
+  const rows = context.sessionsResult?.sessions;
+  if (!Array.isArray(rows)) {
+    return undefined;
+  }
+  for (const row of rows) {
+    if (row?.key === sessionKey) {
+      const pm = row.planMode;
+      if (pm && pm.approval === "pending" && typeof pm.approvalId === "string" && pm.approvalId) {
+        return pm.approvalId;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Codex P2 review #68939 (2026-04-19): the question approval is a
+ * separate id namespace from the plan approval. Pre-fix, the webchat
+ * `/plan answer` path called `resolvePendingApprovalIdFromContext`
+ * which only returns `planMode.approvalId` (the PLAN id) — the
+ * gateway-side answer-guard validates against
+ * `pendingQuestionApprovalId` (the QUESTION id) and would reject
+ * the patch as a stale token. New helper reads the question-specific
+ * id from the cached session row (now exposed via
+ * `GatewaySessionRow.pendingQuestionApprovalId` per the third-wave
+ * companion change in `session-utils.ts`).
+ *
+ * Returns `undefined` when no question is pending; caller surfaces
+ * a friendly "no pending question" message in that case.
+ */
+function resolvePendingQuestionFromContext(
+  sessionKey: string,
+  context: SlashCommandContext,
+): { approvalId?: string; questionId?: string } {
+  const rows = context.sessionsResult?.sessions;
+  if (!Array.isArray(rows)) {
+    return {};
+  }
+  for (const row of rows) {
+    if (row?.key === sessionKey) {
+      if (row.pendingInteraction?.kind === "question") {
+        return {
+          approvalId: row.pendingInteraction.approvalId,
+          questionId: row.pendingInteraction.questionId,
+        };
+      }
+      const id = row.pendingQuestionApprovalId;
+      if (typeof id === "string" && id) {
+        return { approvalId: id };
+      }
+      return {};
+    }
+  }
+  return {};
+}
+
+async function executePlan(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+  context: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const raw = normalizeLowercaseStringOrEmpty(args);
+  // PR-8 follow-up: `/plan view` is a UI-only toggle that opens the
+  // plan-view sidebar with the most recent live plan (or a placeholder
+  // when none has been emitted yet). Mirrors the chat-controls Plan
+  // view button — handled by the host via the `toggle-plan-view`
+  // action; no gateway round-trip.
+  if (raw === "view") {
+    return {
+      content: "Toggling plan view sidebar.",
+      action: "toggle-plan-view",
+    };
+  }
+  // PR-10: `/plan auto on|off` toggles autoApprove. Without an
+  // explicit on/off arg, defaults to on (matches the chip's "switch
+  // INTO Plan ⚡" intent).
+  if (raw === "auto" || raw.startsWith("auto ")) {
+    const tail = raw.slice(4).trim();
+    let autoEnabled: boolean;
+    if (!tail || tail === "on") {
+      autoEnabled = true;
+    } else if (tail === "off") {
+      autoEnabled = false;
+    } else {
+      return {
+        content: `Unrecognized auto value "${tail}". Valid: on, off.`,
+      };
+    }
+    try {
+      await setSessionPlanAutoApprove(client, sessionKey, autoEnabled);
+      return {
+        content: autoEnabled
+          ? "Plan auto-approve **enabled** — future plan submissions resolve as approved without confirmation."
+          : "Plan auto-approve **disabled** — plan submissions require manual confirmation.",
+        action: "refresh",
+      };
+    } catch (err) {
+      const msg = String(err);
+      if (msg.includes("plan mode is disabled")) {
+        return {
+          content:
+            "Plan mode is disabled at the config level. Set `agents.defaults.planMode.enabled: true` and restart the gateway.",
+        };
+      }
+      return { content: `Failed to set plan auto-approve: ${msg}` };
+    }
+  }
+  // PR-11 review fix (Copilot #3105169610): the universal /plan
+  // subcommands (accept | accept edits | revise <feedback> | restate |
+  // answer <text>) were intercepted by the local executor's old
+  // "on/off/status/view/auto only" gate and rejected before reaching
+  // the backend handler. Route them to the same sessions.patch shapes
+  // that backend `commands-plan.ts` uses so webchat has parity with
+  // every other channel (Telegram/Discord/Slack/etc).
+  if (raw === "accept" || raw.startsWith("accept ")) {
+    const allowEdits = raw === "accept edits" || raw === "accept edit";
+    const approvalId = resolvePendingApprovalIdFromContext(sessionKey, context);
+    try {
+      await client.request("sessions.patch", {
+        key: sessionKey,
+        planApproval: {
+          action: allowEdits ? "edit" : "approve",
+          ...(approvalId ? { approvalId } : {}),
+        },
+      });
+      return {
+        content: allowEdits
+          ? "Plan **accepted with edits** — agent may adjust steps as it executes."
+          : "Plan **accepted** — agent will execute as proposed.",
+        action: "refresh",
+        resumePlanInteraction: true,
+      };
+    } catch (err) {
+      return mapPlanCommandError(err, "accept");
+    }
+  }
+  if (raw === "revise" || raw.startsWith("revise ")) {
+    const feedback = args.trim().slice(6).trim();
+    if (!feedback) {
+      return {
+        content:
+          "Usage: `/plan revise <feedback>` — give the agent something to revise toward, e.g. `/plan revise add error handling for the websocket reconnect`.",
+      };
+    }
+    const approvalId = resolvePendingApprovalIdFromContext(sessionKey, context);
+    try {
+      await client.request("sessions.patch", {
+        key: sessionKey,
+        planApproval: { action: "reject", feedback, ...(approvalId ? { approvalId } : {}) },
+      });
+      return {
+        content: `Plan returned for revision with feedback: "${feedback}"`,
+        action: "refresh",
+        resumePlanInteraction: true,
+      };
+    } catch (err) {
+      return mapPlanCommandError(err, "revise");
+    }
+  }
+  if (raw === "answer" || raw.startsWith("answer ")) {
+    const answer = args.trim().slice(6).trim();
+    if (!answer) {
+      return {
+        content: "Usage: `/plan answer <text>` — answer the agent's `ask_user_question` prompt.",
+      };
+    }
+    // Codex P2 review #68939 (2026-04-19): use the
+    // QUESTION-specific approvalId, not the plan approvalId. The
+    // gateway-side answer-guard validates against
+    // `pendingQuestionApprovalId` (a separate token namespace from
+    // `planMode.approvalId`); pre-fix, the webchat `/plan answer`
+    // path threaded the plan id and the patch was rejected as a
+    // stale token.
+    const pendingQuestion = resolvePendingQuestionFromContext(sessionKey, context);
+    const questionApprovalId = pendingQuestion.approvalId;
+    if (!questionApprovalId) {
+      return {
+        content:
+          "No pending `ask_user_question` for this session — `/plan answer` requires an active question.",
+      };
+    }
+    try {
+      await client.request("sessions.patch", {
+        key: sessionKey,
+        planApproval: {
+          action: "answer",
+          answer,
+          approvalId: questionApprovalId,
+          ...(pendingQuestion.questionId ? { questionId: pendingQuestion.questionId } : {}),
+        },
+      });
+      return {
+        content: `Question answered: "${answer}"`,
+        action: "refresh",
+        resumePlanInteraction: true,
+      };
+    } catch (err) {
+      return mapPlanCommandError(err, "answer");
+    }
+  }
+  if (raw === "restate") {
+    // Webchat already shows the live plan in the sidebar; redirect to
+    // /plan view rather than duplicating the rendered plan in chat.
+    return {
+      content:
+        "On webchat, use `/plan view` (or click the Plan view button in the chat controls) to see the active plan in the sidebar.",
+      action: "toggle-plan-view",
+    };
+  }
+
+  if (!raw || raw === "status") {
+    return {
+      content: formatDirectiveOptions(
+        "Usage: `/plan on` to enter plan mode, `/plan off` to exit, `/plan view` to toggle the sidebar, `/plan auto on|off` to toggle auto-approve, `/plan accept`/`/plan accept edits`/`/plan revise <feedback>`/`/plan answer <text>` to resolve.",
+        "on, off, status, view, auto, accept, revise, answer",
+      ),
+    };
+  }
+  if (raw !== "on" && raw !== "off") {
+    return {
+      content: `Unrecognized plan-mode value "${args.trim()}". Valid: on, off, status, view, auto, accept, revise, answer.`,
+    };
+  }
+  const mode: "plan" | "normal" = raw === "on" ? "plan" : "normal";
+  try {
+    await setSessionPlanMode(client, sessionKey, mode);
+    return {
+      content:
+        mode === "plan"
+          ? "Plan mode **enabled** — write/edit/exec tools blocked until plan approved."
+          : "Plan mode **disabled** — mutations unblocked.",
+      action: "refresh",
+    };
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("plan mode is disabled")) {
+      return {
+        content:
+          "Plan mode is disabled at the config level. Set `agents.defaults.planMode.enabled: true` and restart the gateway.",
+      };
+    }
+    return { content: `Failed to set plan mode: ${msg}` };
   }
 }
 
@@ -370,6 +696,54 @@ async function executeFast(
   } catch (err) {
     return { content: `Failed to set fast mode: ${String(err)}` };
   }
+}
+
+/**
+ * Set the session's plan-mode flag on the backend (PR-8).
+ *
+ * - `"plan"`: arms the runtime mutation gate — write/edit/exec/etc. are
+ *   blocked until the user approves a plan via the approval flow OR the
+ *   user toggles back to `"normal"`.
+ * - `"normal"`: clears any pending plan-mode state and unblocks mutations.
+ *
+ * Mirrors the `thinkingLevel` / `fastMode` patch pattern above so
+ * consumers (the mode switcher chip, `/plan` slash command if we add
+ * one later) get a single helper they can call without knowing the
+ * wire shape. Throws on patch failure so callers can surface an error
+ * rather than silently failing state updates.
+ */
+export async function setSessionPlanMode(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  mode: "plan" | "normal",
+): Promise<void> {
+  await client.request("sessions.patch", { key: sessionKey, planMode: mode });
+}
+
+/**
+ * PR-10: toggle the session's plan-mode autoApprove flag.
+ *
+ * - `true`: future `exit_plan_mode` submissions auto-resolve as
+ *   "approve" without user confirmation. The plan-snapshot persister's
+ *   auto-approve branch (`autoApproveIfEnabled`) reads this flag and
+ *   fires the approve action immediately on emission.
+ * - `false`: clears the flag. Pending plans surfaced after this point
+ *   wait for manual confirmation through the inline approval card or
+ *   channel-native buttons (PR-11).
+ *
+ * The patch handler accepts the toggle even when no plan-mode session
+ * is currently active — this lets users pre-arm auto-approve before
+ * entering plan mode, matching the chip's "Plan ⚡" intent.
+ */
+export async function setSessionPlanAutoApprove(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  autoEnabled: boolean,
+): Promise<void> {
+  await client.request("sessions.patch", {
+    key: sessionKey,
+    planApproval: { action: "auto", autoEnabled },
+  });
 }
 
 async function executeUsage(

--- a/ui/src/ui/chat/slash-commands.ts
+++ b/ui/src/ui/chat/slash-commands.ts
@@ -96,6 +96,7 @@ const LOCAL_COMMANDS = new Set([
   "kill",
   "steer",
   "redirect",
+  "plan",
 ]);
 
 const UI_ONLY_COMMANDS: SlashCommandDef[] = [
@@ -117,6 +118,16 @@ const UI_ONLY_COMMANDS: SlashCommandDef[] = [
     category: "agents",
     executeLocal: true,
     tier: "power",
+  },
+  {
+    key: "plan",
+    name: "plan",
+    description: "Toggle plan mode (blocks write/edit/exec until approved)",
+    args: "<on|off|status|view|auto>",
+    icon: "book",
+    category: "session",
+    executeLocal: true,
+    argOptions: ["on", "off", "status", "view", "auto"],
   },
 ];
 
@@ -141,6 +152,7 @@ const CATEGORY_OVERRIDES: Partial<Record<string, SlashCommandCategory>> = {
   compact: "session",
   focus: "session",
   unfocus: "session",
+  plan: "session",
   model: "model",
   models: "model",
   think: "model",

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -431,6 +431,78 @@ export type GatewaySessionRow = {
   contextTokens?: number;
   compactionCheckpointCount?: number;
   latestCompactionCheckpoint?: SessionCompactionCheckpoint;
+  // PR-8 / #67721: permission-mode + plan-mode fields exposed to the UI
+  // so the chat toolbar's mode chip can render the current session
+  // state. Backend writes these via `sessions.patch`; gateway includes
+  // them in `sessions.list` payloads when present on `SessionEntry`.
+  execSecurity?: "deny" | "allowlist" | "full";
+  execAsk?: "off" | "on-miss" | "always";
+  planMode?: {
+    mode: "plan" | "normal";
+    approval: "none" | "pending" | "approved" | "edited" | "rejected" | "timed_out";
+    approvalId?: string;
+    cycleId?: string;
+    enteredAt?: number;
+    confirmedAt?: number;
+    updatedAt?: number;
+    feedback?: string;
+    rejectionCount?: number;
+    /**
+     * PR-8 follow-up Round 2: most-recent plan snapshot persisted by the
+     * runtime after each `update_plan` tool call. Lets the Control UI
+     * rebuild the live-plan sidebar after a hard refresh — without this,
+     * `latestPlanMarkdown` lives only in in-memory `@state()` and is
+     * lost on page reload.
+     */
+    lastPlanSteps?: Array<{
+      step: string;
+      status: string;
+      activeForm?: string;
+      // PR-9 Wave B1 — closure-gate fields (optional, backwards-compatible).
+      acceptanceCriteria?: string[];
+      verifiedCriteria?: string[];
+    }>;
+    lastPlanUpdatedAt?: number;
+    blockingSubagentRunIds?: string[];
+    lastSubagentSettledAt?: number;
+    /**
+     * PR-10 auto-mode: when true, future plan submissions auto-resolve
+     * as "approve" without waiting for the user. Toggle via the chip
+     * or `/plan auto` slash command.
+     */
+    autoApprove?: boolean;
+  };
+  pendingInteraction?:
+    | {
+        kind: "plan";
+        approvalId: string;
+        title: string;
+        createdAt: number;
+        status: "pending" | "resolved";
+        cycleId?: string;
+      }
+    | {
+        kind: "question";
+        approvalId: string;
+        questionId?: string;
+        title: string;
+        prompt: string;
+        options: string[];
+        allowFreetext: boolean;
+        createdAt: number;
+        status: "pending" | "resolved";
+        cycleId?: string;
+      };
+  /**
+   * Codex P2 review #68939 (2026-04-19): mirror of the
+   * `pendingQuestionApprovalId` server-side field so the webchat
+   * `/plan answer` path can thread the question approvalId into the
+   * `sessions.patch { planApproval }` payload. The server-side
+   * answer-guard requires it; pre-fix, the webchat path used the
+   * plan-approval id (which is a different namespace) and answers
+   * were rejected.
+   */
+  pendingQuestionApprovalId?: string;
 };
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,7 +1,12 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
-import type { CompactionStatus, FallbackStatus } from "../app-tool-stream.ts";
+import type {
+  CompactionStatus,
+  FallbackStatus,
+  SubagentBlockingStatus,
+} from "../app-tool-stream.ts";
+import type { PlanApprovalRequest } from "../app-tool-stream.ts";
 import {
   CHAT_ATTACHMENT_ACCEPT,
   isSupportedChatAttachmentMimeType,
@@ -16,6 +21,21 @@ import {
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
 import { InputHistory } from "../chat/input-history.ts";
+import { extractTextCached } from "../chat/message-extract.ts";
+import {
+  isToolResultMessage,
+  normalizeMessage,
+  normalizeRoleForGrouping,
+} from "../chat/message-normalizer.ts";
+import {
+  // handleModeShortcut TODO(PR-8 follow-up): wire Ctrl+1-4 keyboard
+  // shortcuts on the chat surface. Skipping in this iteration since the
+  // chip menu + /plan slash command already cover the path; the
+  // shortcut needs a window-level keydown listener wired in app.ts.
+  type ModeDefinition,
+  renderModeSwitcher,
+  resolveCurrentMode,
+} from "../chat/mode-switcher.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
 import { renderChatRunControls } from "../chat/run-controls.ts";
@@ -42,6 +62,7 @@ import type { SessionsListResult } from "../types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { agentLogoUrl, resolveChatAvatarRenderUrl } from "./agents-utils.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
+import { renderInlinePlanApproval } from "./plan-approval-inline.ts";
 import "../components/resizable-divider.ts";
 
 export type ChatProps = {
@@ -55,6 +76,9 @@ export type ChatProps = {
   canAbort?: boolean;
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
+  /** Live-test iteration 1 Bug 3: bottom-toast for "subagents still running"
+   * when user clicks Approve while subagents are mid-flight. */
+  subagentBlockingStatus?: SubagentBlockingStatus | null;
   messages: unknown[];
   sideResult?: ChatSideResult | null;
   toolMessages: unknown[];
@@ -110,6 +134,49 @@ export type ChatProps = {
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
   basePath?: string;
+  /**
+   * PR-8 / #67721: invoked when the user picks a mode from the chip menu
+   * (or hits the Ctrl+1-4 keyboard shortcut). The host translates the
+   * `ModeDefinition` into the appropriate `sessions.patch` calls
+   * (planMode for plan, execSecurity/execAsk for permission modes).
+   * Optional so existing callers that don't yet wire it stay compiling.
+   */
+  onSetMode?: (mode: ModeDefinition) => void;
+  // PR-8 follow-up: inline plan approval card wiring. Optional so non-
+  // plan-mode embeddings of renderChat (tests, alt apps) keep compiling.
+  planApprovalRequest?: PlanApprovalRequest | null;
+  planApprovalBusy?: boolean;
+  planApprovalError?: string | null;
+  onPlanApprovalDecision?: (
+    decision: "approve" | "reject" | "edit",
+    feedback?: string,
+  ) => void | Promise<void>;
+  // PR-10 AskUserQuestion: route the user's answer to sessions.patch
+  // { planApproval: { action: "answer", answer: <text> }} via the
+  // host. Same approval-card surface, different action verb.
+  onPlanApprovalAnswer?: (answer: string) => void | Promise<void>;
+  /** Open the full plan content in the right sidebar (read-only viewer). */
+  onOpenPlanInSidebar?: (request: PlanApprovalRequest) => void;
+  /**
+   * Inline-revise textarea state owned by the host. When the user
+   * clicks Revise we open an inline textarea (no popup) — this state
+   * tracks open/draft so the textarea survives chat re-renders.
+   */
+  planApprovalReviseOpen?: boolean;
+  planApprovalReviseDraft?: string;
+  onPlanApprovalReviseOpen?: () => void;
+  onPlanApprovalReviseCancel?: () => void;
+  onPlanApprovalReviseDraftChange?: (text: string) => void;
+  /**
+   * PR-13 Bug 2: question-card "Other" inline-textarea props.
+   * Mirrors the revise pattern. Cancel returns to the option list.
+   */
+  planApprovalQuestionOtherOpen?: boolean;
+  planApprovalQuestionOtherDraft?: string;
+  onPlanApprovalQuestionOtherOpen?: () => void;
+  onPlanApprovalQuestionOtherCancel?: () => void;
+  onPlanApprovalQuestionOtherDraftChange?: (text: string) => void;
+  onPlanApprovalQuestionOtherSubmit?: () => void | Promise<void>;
 };
 
 // Persistent instances keyed by session
@@ -150,6 +217,8 @@ interface ChatEphemeralState {
   searchOpen: boolean;
   searchQuery: string;
   pinnedExpanded: boolean;
+  /** PR-8 / #67721: mode-switcher chip menu open state. */
+  modeMenuOpen: boolean;
 }
 
 function createChatEphemeralState(): ChatEphemeralState {
@@ -166,6 +235,7 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchOpen: false,
     searchQuery: "",
     pinnedExpanded: false,
+    modeMenuOpen: false,
   };
 }
 
@@ -187,6 +257,162 @@ export const cleanupChatModuleState = resetChatViewState;
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
   el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+}
+
+function syncToolCardExpansionState(
+  sessionKey: string,
+  items: Array<ChatItem | MessageGroup>,
+  autoExpandToolCalls: boolean,
+) {
+  const expanded = getExpandedToolCards(sessionKey);
+  const initialized = getInitializedToolCards(sessionKey);
+  const previousAutoExpand = lastAutoExpandPrefBySession.get(sessionKey) ?? false;
+  const currentToolCardIds = new Set<string>();
+  for (const item of items) {
+    if (item.kind !== "group") {
+      continue;
+    }
+    for (const entry of item.messages) {
+      const cards = extractToolCards(entry.message, entry.key);
+      for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+        const disclosureId = `${entry.key}:toolcard:${cardIndex}`;
+        currentToolCardIds.add(disclosureId);
+        if (initialized.has(disclosureId)) {
+          continue;
+        }
+        expanded.set(disclosureId, autoExpandToolCalls);
+        initialized.add(disclosureId);
+      }
+      const messageRecord = entry.message as Record<string, unknown>;
+      const role = typeof messageRecord.role === "string" ? messageRecord.role : "unknown";
+      const normalizedRole = normalizeRoleForGrouping(role);
+      const isToolMessage =
+        isToolResultMessage(entry.message) ||
+        normalizedRole === "tool" ||
+        role.toLowerCase() === "toolresult" ||
+        role.toLowerCase() === "tool_result" ||
+        typeof messageRecord.toolCallId === "string" ||
+        typeof messageRecord.tool_call_id === "string";
+      if (!isToolMessage) {
+        continue;
+      }
+      const disclosureId = `toolmsg:${entry.key}`;
+      currentToolCardIds.add(disclosureId);
+      if (initialized.has(disclosureId)) {
+        continue;
+      }
+      expanded.set(disclosureId, autoExpandToolCalls);
+      initialized.add(disclosureId);
+    }
+  }
+  if (autoExpandToolCalls && !previousAutoExpand) {
+    for (const toolCardId of currentToolCardIds) {
+      expanded.set(toolCardId, true);
+    }
+  }
+  lastAutoExpandPrefBySession.set(sessionKey, autoExpandToolCalls);
+}
+
+function renderCompactionIndicator(status: CompactionStatus | null | undefined) {
+  if (!status) {
+    return nothing;
+  }
+  if (status.phase === "active" || status.phase === "retrying") {
+    return html`
+      <div
+        class="compaction-indicator compaction-indicator--active"
+        role="status"
+        aria-live="polite"
+      >
+        ${icons.loader} Compacting context...
+      </div>
+    `;
+  }
+  if (status.completedAt) {
+    const elapsed = Date.now() - status.completedAt;
+    if (elapsed < COMPACTION_TOAST_DURATION_MS) {
+      return html`
+        <div
+          class="compaction-indicator compaction-indicator--complete"
+          role="status"
+          aria-live="polite"
+        >
+          ${icons.check} Context compacted
+        </div>
+      `;
+    }
+  }
+  return nothing;
+}
+
+/**
+ * Live-test iteration 1 Bug 3: bottom-of-chat toast that fires when
+ * the user clicks Approve on a plan while the parent agent run still
+ * has open subagents. Mirrors the model-fallback toast pattern (CSS
+ * class `compaction-indicator--fallback`, 8s auto-dismiss, polite
+ * aria-live) so the user sees it in the same region as the fallback
+ * toast they already recognize.
+ */
+function renderSubagentBlockingIndicator(status: SubagentBlockingStatus | null | undefined) {
+  if (!status) {
+    return nothing;
+  }
+  const elapsed = Date.now() - status.occurredAt;
+  if (elapsed >= FALLBACK_TOAST_DURATION_MS) {
+    return nothing;
+  }
+  const tooltip =
+    status.openSubagentRunIds.length > 0
+      ? `Open subagents: ${status.openSubagentRunIds.slice(0, 5).join(", ")}${
+          status.openSubagentRunIds.length > 5
+            ? ` and ${status.openSubagentRunIds.length - 5} more`
+            : ""
+        }`
+      : status.message;
+  return html`
+    <div
+      class="compaction-indicator compaction-indicator--fallback"
+      role="status"
+      aria-live="polite"
+      title=${tooltip}
+    >
+      ${icons.brain} ${status.message}
+    </div>
+  `;
+}
+
+function renderFallbackIndicator(status: FallbackStatus | null | undefined) {
+  if (!status) {
+    return nothing;
+  }
+  const phase = status.phase ?? "active";
+  const elapsed = Date.now() - status.occurredAt;
+  if (elapsed >= FALLBACK_TOAST_DURATION_MS) {
+    return nothing;
+  }
+  const details = [
+    `Selected: ${status.selected}`,
+    phase === "cleared" ? `Active: ${status.selected}` : `Active: ${status.active}`,
+    phase === "cleared" && status.previous ? `Previous fallback: ${status.previous}` : null,
+    status.reason ? `Reason: ${status.reason}` : null,
+    status.attempts.length > 0 ? `Attempts: ${status.attempts.slice(0, 3).join(" | ")}` : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const message =
+    phase === "cleared"
+      ? `Fallback cleared: ${status.selected}`
+      : `Fallback active: ${status.active}`;
+  const className =
+    phase === "cleared"
+      ? "compaction-indicator compaction-indicator--fallback-cleared"
+      : "compaction-indicator compaction-indicator--fallback";
+  const icon = phase === "cleared" ? icons.check : icons.brain;
+  return html`
+    <div class=${className} role="status" aria-live="polite" title=${details}>
+      ${icon} ${message}
+    </div>
+  `;
 }
 
 function generateAttachmentId(): string {
@@ -1143,6 +1369,7 @@ export function renderChat(props: ChatProps) {
         : nothing}
       ${renderSideResult(props.sideResult, props.onDismissSideResult)}
       ${renderFallbackIndicator(props.fallbackStatus)}
+      ${renderSubagentBlockingIndicator(props.subagentBlockingStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
       ${props.showNewMessages
@@ -1152,104 +1379,152 @@ export function renderChat(props: ChatProps) {
             </button>
           `
         : nothing}
+      ${props.planApprovalRequest &&
+      props.planApprovalRequest.sessionKey === activeSession?.key &&
+      props.onPlanApprovalDecision
+        ? renderInlinePlanApproval({
+            request: props.planApprovalRequest,
+            connected: props.connected,
+            busy: props.planApprovalBusy ?? false,
+            error: props.planApprovalError ?? null,
+            reviseOpen: props.planApprovalReviseOpen ?? false,
+            reviseDraft: props.planApprovalReviseDraft ?? "",
+            onApprove: () => void props.onPlanApprovalDecision!("approve"),
+            onAcceptWithEdits: () => void props.onPlanApprovalDecision!("edit"),
+            onReviseOpen: () => props.onPlanApprovalReviseOpen?.(),
+            onReviseCancel: () => props.onPlanApprovalReviseCancel?.(),
+            onReviseDraftChange: (text) => props.onPlanApprovalReviseDraftChange?.(text),
+            onReviseSubmit: () => {
+              const draft = (props.planApprovalReviseDraft ?? "").trim();
+              // Codex P2 review #68939 (2026-04-19): block empty
+              // submits client-side. The wire schema's reject
+              // variant now requires `feedback: minLength: 1`
+              // (closes the "reject with no guidance" loophole),
+              // so passing `undefined` for empty drafts would
+              // produce a server-side validation error and the
+              // user would see a confusing "request failed" toast
+              // instead of the expected "type something" affordance.
+              // The textarea remains visible for the user to type
+              // into; only the submit is suppressed when empty.
+              if (!draft) {
+                return;
+              }
+              void props.onPlanApprovalDecision!("reject", draft);
+            },
+            onOpenPlan: () => {
+              if (
+                props.planApprovalRequest &&
+                props.planApprovalRequest.sessionKey === activeSession?.key &&
+                props.onOpenPlanInSidebar
+              ) {
+                props.onOpenPlanInSidebar(props.planApprovalRequest);
+              }
+            },
+            // PR-10 AskUserQuestion routing.
+            onAnswerOption: props.onPlanApprovalAnswer
+              ? (answer) => void props.onPlanApprovalAnswer!(answer)
+              : undefined,
+            // PR-13 Bug 2: inline-textarea "Other" path props.
+            questionOtherOpen: props.planApprovalQuestionOtherOpen ?? false,
+            questionOtherDraft: props.planApprovalQuestionOtherDraft ?? "",
+            onQuestionOtherOpen: () => props.onPlanApprovalQuestionOtherOpen?.(),
+            onQuestionOtherCancel: () => props.onPlanApprovalQuestionOtherCancel?.(),
+            onQuestionOtherDraftChange: (text) =>
+              props.onPlanApprovalQuestionOtherDraftChange?.(text),
+            onQuestionOtherSubmit: () => void props.onPlanApprovalQuestionOtherSubmit?.(),
+          })
+        : nothing}
 
-      <!-- Input bar -->
-      <div class="agent-chat__input">
-        ${renderSlashMenu(requestUpdate, props)} ${renderAttachmentPreview(props)}
+      <!--
+        Hide the chat input while a plan-approval card is showing —
+        prevents the user from typing into the wrong surface during
+        the approval moment. The card's own Revise textarea handles
+        feedback collection in-place.
 
-        <input
-          type="file"
-          accept=${CHAT_ATTACHMENT_ACCEPT}
-          multiple
-          class="agent-chat__file-input"
-          @change=${(e: Event) => handleFileSelect(e, props)}
-        />
+        PR-7 review fix (Copilot #3105170553 / #3105219639): only hide
+        the input when BOTH planApprovalRequest AND
+        onPlanApprovalDecision are present. Otherwise the user would
+        see neither the card (which requires the handler) nor the
+        input — leaving them with no way to interact. When the
+        decision handler isn't wired, leave the input visible so the
+        user can still chat.
+      -->
+      ${props.planApprovalRequest &&
+      props.planApprovalRequest.sessionKey === activeSession?.key &&
+      props.onPlanApprovalDecision
+        ? nothing
+        : html`
+            <!-- Input bar -->
+            <div class="agent-chat__input">
+              ${renderSlashMenu(requestUpdate, props)} ${renderAttachmentPreview(props)}
 
-        ${vs.sttRecording && vs.sttInterimText
-          ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
-          : nothing}
+              <input
+                type="file"
+                accept=${CHAT_ATTACHMENT_ACCEPT}
+                multiple
+                class="agent-chat__file-input"
+                @change=${(e: Event) => handleFileSelect(e, props)}
+              />
 
-        <textarea
-          ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
-          .value=${props.draft}
-          dir=${detectTextDirection(props.draft)}
-          ?disabled=${!props.connected}
-          @keydown=${handleKeyDown}
-          @input=${handleInput}
-          @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
-          placeholder=${vs.sttRecording ? "Listening..." : placeholder}
-          rows="1"
-        ></textarea>
+              ${vs.sttRecording && vs.sttInterimText
+                ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
+                : nothing}
 
-        <div class="agent-chat__toolbar">
-          <div class="agent-chat__toolbar-left">
-            <button
-              class="agent-chat__input-btn"
-              @click=${() => {
-                document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
-              }}
-              title="Attach file"
-              aria-label="Attach file"
-              ?disabled=${!props.connected}
-            >
-              ${icons.paperclip}
-            </button>
+              <textarea
+                ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
+                .value=${props.draft}
+                dir=${detectTextDirection(props.draft)}
+                ?disabled=${!props.connected}
+                @keydown=${handleKeyDown}
+                @input=${handleInput}
+                @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
+                placeholder=${vs.sttRecording ? "Listening..." : placeholder}
+                rows="1"
+              ></textarea>
 
-            ${isSttSupported()
-              ? html`
-                  <button
-                    class="agent-chat__input-btn ${vs.sttRecording
-                      ? "agent-chat__input-btn--recording"
-                      : ""}"
-                    @click=${() => {
-                      if (vs.sttRecording) {
-                        stopStt();
-                        vs.sttRecording = false;
-                        vs.sttInterimText = "";
+              <div class="agent-chat__toolbar">
+                <div class="agent-chat__toolbar-left">
+                  ${(() => {
+                    // PR-8 / #67721: mode chip lives at the LEFT edge of the
+                    // toolbar (before paperclip) per user feedback — it's the
+                    // most-frequently-touched control on the input row.
+                    if (!props.onSetMode) {
+                      return nothing;
+                    }
+                    const currentMode = resolveCurrentMode(
+                      activeSession?.execSecurity,
+                      activeSession?.execAsk,
+                      activeSession?.planMode?.mode,
+                      // PR-10: surface "Plan ⚡" when the session has
+                      // auto-approve armed so the chip + tooltip match
+                      // the live runtime state.
+                      activeSession?.planMode?.autoApprove,
+                    );
+                    return renderModeSwitcher({
+                      currentMode,
+                      menuOpen: vs.modeMenuOpen,
+                      onToggleMenu: () => {
+                        vs.modeMenuOpen = !vs.modeMenuOpen;
                         requestUpdate();
-                      } else {
-                        const started = startStt({
-                          onTranscript: (text, isFinal) => {
-                            if (isFinal) {
-                              const current = getDraft();
-                              const sep = current && !current.endsWith(" ") ? " " : "";
-                              props.onDraftChange(current + sep + text);
-                              vs.sttInterimText = "";
-                            } else {
-                              vs.sttInterimText = text;
-                            }
-                            requestUpdate();
-                          },
-                          onStart: () => {
-                            vs.sttRecording = true;
-                            requestUpdate();
-                          },
-                          onEnd: () => {
-                            vs.sttRecording = false;
-                            vs.sttInterimText = "";
-                            requestUpdate();
-                          },
-                          onError: () => {
-                            vs.sttRecording = false;
-                            vs.sttInterimText = "";
-                            requestUpdate();
-                          },
-                        });
-                        if (started) {
-                          vs.sttRecording = true;
-                          requestUpdate();
-                        }
-                      }
+                      },
+                      onSelectMode: (mode) => {
+                        vs.modeMenuOpen = false;
+                        props.onSetMode!(mode);
+                        requestUpdate();
+                      },
+                    });
+                  })()}
+                  <button
+                    class="agent-chat__input-btn"
+                    @click=${() => {
+                      document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
                     }}
-                    title=${vs.sttRecording ? "Stop recording" : "Voice input"}
+                    title="Attach file"
+                    aria-label="Attach file"
                     ?disabled=${!props.connected}
                   >
-                    ${vs.sttRecording ? icons.micOff : icons.mic}
+                    ${icons.paperclip}
                   </button>
-                `
-              : nothing}
-            ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
-          </div>
 
           ${renderChatRunControls({
             canAbort,

--- a/ui/src/ui/views/plan-approval-inline.test.ts
+++ b/ui/src/ui/views/plan-approval-inline.test.ts
@@ -1,0 +1,295 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderInlinePlanApproval, type InlinePlanApprovalProps } from "./plan-approval-inline.ts";
+
+function createProps(overrides: Partial<InlinePlanApprovalProps> = {}): InlinePlanApprovalProps {
+  return {
+    request: {
+      approvalId: "approval-1",
+      sessionKey: "agent:main:user:abc",
+      title: "Agent proposed a plan",
+      plan: [{ step: "Verify state", status: "pending" }],
+      receivedAt: 0,
+    },
+    connected: true,
+    busy: false,
+    error: null,
+    reviseOpen: false,
+    reviseDraft: "",
+    onApprove: vi.fn(),
+    onAcceptWithEdits: vi.fn(),
+    onReviseOpen: vi.fn(),
+    onReviseCancel: vi.fn(),
+    onReviseDraftChange: vi.fn(),
+    onReviseSubmit: vi.fn(),
+    onOpenPlan: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("renderInlinePlanApproval", () => {
+  it("renders nothing when there is no pending request", () => {
+    const container = document.createElement("div");
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          request: null,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("uses the fallback headline for generic titles and keeps the summary visible", () => {
+    const container = document.createElement("div");
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          request: {
+            approvalId: "approval-1",
+            sessionKey: "agent:main:user:abc",
+            title: "Plan approval requested",
+            summary: "Investigate and patch the lifecycle edge cases",
+            plan: [{ step: "Check state", status: "pending" }],
+            receivedAt: 0,
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Agent proposed a plan");
+    expect(container.textContent).toContain("Investigate and patch the lifecycle edge cases");
+    expect(container.textContent).toContain("1 step");
+  });
+
+  it("wires plan action buttons to the provided handlers", () => {
+    const container = document.createElement("div");
+    const onApprove = vi.fn();
+    const onAcceptWithEdits = vi.fn();
+    const onReviseOpen = vi.fn();
+    const onOpenPlan = vi.fn();
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          onApprove,
+          onAcceptWithEdits,
+          onReviseOpen,
+          onOpenPlan,
+        }),
+      ),
+      container,
+    );
+
+    const buttons = [...container.querySelectorAll<HTMLButtonElement>("button")];
+    buttons.find((button) => button.textContent?.includes("Open plan"))?.click();
+    buttons.find((button) => button.textContent?.includes("Accept, allow edits"))?.click();
+    buttons.find((button) => button.textContent?.trim() === "Accept")?.click();
+    buttons.find((button) => button.textContent?.trim() === "Revise")?.click();
+
+    expect(onOpenPlan).toHaveBeenCalledOnce();
+    expect(onAcceptWithEdits).toHaveBeenCalledOnce();
+    expect(onApprove).toHaveBeenCalledOnce();
+    expect(onReviseOpen).toHaveBeenCalledOnce();
+  });
+
+  it("renders the revise editor and routes draft updates plus keyboard shortcuts", () => {
+    const container = document.createElement("div");
+    const onReviseDraftChange = vi.fn();
+    const onReviseSubmit = vi.fn();
+    const onReviseCancel = vi.fn();
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          reviseOpen: true,
+          reviseDraft: "Please tighten the rollback path",
+          onReviseDraftChange,
+          onReviseSubmit,
+          onReviseCancel,
+        }),
+      ),
+      container,
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      ".plan-inline-card__revise-input",
+    );
+    expect(textarea).not.toBeNull();
+    textarea!.value = "Updated feedback";
+    textarea!.dispatchEvent(new Event("input"));
+    textarea!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true }));
+    textarea!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(onReviseDraftChange).toHaveBeenCalledWith("Updated feedback");
+    expect(onReviseSubmit).toHaveBeenCalledOnce();
+    expect(onReviseCancel).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain("Send revision");
+  });
+
+  it("shows an offline warning and disables plan actions when disconnected", () => {
+    const container = document.createElement("div");
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          connected: false,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Reconnect to resolve this plan.");
+    const buttons = [
+      ...container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn"),
+    ];
+    expect(buttons).not.toHaveLength(0);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+  });
+
+  it("renders a warning and disables options when the question handler is missing", () => {
+    const container = document.createElement("div");
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          request: {
+            approvalId: "approval-q",
+            sessionKey: "agent:main:user:abc",
+            title: "Agent has a question",
+            plan: [],
+            receivedAt: 0,
+            question: {
+              prompt: "Which option should we choose?",
+              options: ["A", "B"],
+            },
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Question handler not wired");
+    const optionButtons = [
+      ...container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn"),
+    ];
+    expect(optionButtons).not.toHaveLength(0);
+    expect(optionButtons.every((button) => button.disabled)).toBe(true);
+  });
+
+  it("shows the question offline warning and disables answer buttons when disconnected", () => {
+    const container = document.createElement("div");
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          connected: false,
+          request: {
+            approvalId: "approval-q",
+            sessionKey: "agent:main:user:abc",
+            title: "Agent has a question",
+            plan: [],
+            receivedAt: 0,
+            question: {
+              prompt: "Which option should we choose?",
+              options: ["A", "B"],
+            },
+          },
+          onAnswerOption: vi.fn(),
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Reconnect to answer this question.");
+    const optionButtons = [
+      ...container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn"),
+    ];
+    expect(optionButtons).not.toHaveLength(0);
+    expect(optionButtons.every((button) => button.disabled)).toBe(true);
+  });
+
+  it("routes question option clicks and the Other affordance through the supplied handlers", () => {
+    const container = document.createElement("div");
+    const onAnswerOption = vi.fn();
+    const onQuestionOtherOpen = vi.fn();
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          request: {
+            approvalId: "approval-q",
+            sessionKey: "agent:main:user:abc",
+            title: "Agent has a question",
+            plan: [],
+            receivedAt: 0,
+            question: {
+              prompt: "Which option should we choose?",
+              options: ["A", "B"],
+              allowFreetext: true,
+            },
+          },
+          onAnswerOption,
+          onQuestionOtherOpen,
+        }),
+      ),
+      container,
+    );
+
+    const buttons = [
+      ...container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn"),
+    ];
+    buttons.find((button) => button.textContent?.trim() === "A")?.click();
+    buttons.find((button) => button.textContent?.includes("Other"))?.click();
+
+    expect(onAnswerOption).toHaveBeenCalledWith("A");
+    expect(onQuestionOtherOpen).toHaveBeenCalledOnce();
+  });
+
+  it("renders the free-text answer editor and routes submit plus cancel", () => {
+    const container = document.createElement("div");
+    const onQuestionOtherDraftChange = vi.fn();
+    const onQuestionOtherSubmit = vi.fn();
+    const onQuestionOtherCancel = vi.fn();
+    render(
+      renderInlinePlanApproval(
+        createProps({
+          request: {
+            approvalId: "approval-q",
+            sessionKey: "agent:main:user:abc",
+            title: "Agent has a question",
+            plan: [],
+            receivedAt: 0,
+            question: {
+              prompt: "Which option should we choose?",
+              options: ["A", "B"],
+              allowFreetext: true,
+            },
+          },
+          onAnswerOption: vi.fn(),
+          questionOtherOpen: true,
+          questionOtherDraft: "Custom answer",
+          onQuestionOtherDraftChange,
+          onQuestionOtherSubmit,
+          onQuestionOtherCancel,
+        }),
+      ),
+      container,
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      ".plan-inline-card__revise-input",
+    );
+    expect(textarea).not.toBeNull();
+    textarea!.value = "Updated custom answer";
+    textarea!.dispatchEvent(new Event("input"));
+    textarea!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }));
+    textarea!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn").item(0).click();
+    container.querySelectorAll<HTMLButtonElement>("button.plan-inline-card__btn").item(1).click();
+
+    expect(onQuestionOtherDraftChange).toHaveBeenCalledWith("Updated custom answer");
+    expect(onQuestionOtherSubmit).toHaveBeenCalledTimes(2);
+    expect(onQuestionOtherCancel).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Back to options");
+  });
+});

--- a/ui/src/ui/views/plan-approval-inline.ts
+++ b/ui/src/ui/views/plan-approval-inline.ts
@@ -1,0 +1,306 @@
+/**
+ * Inline plan-approval card (PR-8 follow-up).
+ *
+ * Renders ABOVE the chat input bar, mimicking Claude Code's
+ * "Claude proposed a plan" affordance: compact title strip + 3 buttons
+ * (Accept / Accept allow edits / Revise) + an "Open plan" link that
+ * pops the full checklist into the right sidebar via the same path
+ * tool-output details use.
+ *
+ * Revise opens an inline textarea in-place (no popup), matching
+ * Claude Code's revision UX. The chat input bar is hidden by the
+ * caller (via `planApprovalRequest != null`) while this card is
+ * showing so users don't accidentally type into the wrong surface.
+ */
+import { html, nothing, type TemplateResult } from "lit";
+import type { PlanApprovalRequest } from "../app-tool-stream.ts";
+
+export interface InlinePlanApprovalProps {
+  request: PlanApprovalRequest | null;
+  connected: boolean;
+  busy: boolean;
+  error: string | null;
+  /** Local "revise textarea open" state — caller owns it so it survives renders. */
+  reviseOpen: boolean;
+  reviseDraft: string;
+  onApprove: () => void;
+  onAcceptWithEdits: () => void;
+  onReviseOpen: () => void;
+  onReviseCancel: () => void;
+  onReviseDraftChange: (text: string) => void;
+  onReviseSubmit: () => void;
+  /** Pop the full plan into the right sidebar (read-only). */
+  onOpenPlan: () => void;
+  // PR-10 AskUserQuestion: required when request.question is present.
+  // Routed by the host to sessions.patch { planApproval: { action:
+  // "answer", answer: <text> } }. Same approval-card shell renders the
+  // question prompt + one button per option (and optional Other field).
+  onAnswerOption?: (answer: string) => void;
+  /**
+   * PR-13 Bug 2: question-card "Other" inline-textarea state. Caller
+   * owns these (mirrors the reviseOpen/reviseDraft pattern) so backing
+   * out of the textarea returns to the option list instead of (as
+   * window.prompt cancellation did) appearing to exit the sequence.
+   */
+  questionOtherOpen?: boolean;
+  questionOtherDraft?: string;
+  onQuestionOtherOpen?: () => void;
+  onQuestionOtherCancel?: () => void;
+  onQuestionOtherDraftChange?: (text: string) => void;
+  onQuestionOtherSubmit?: () => void;
+}
+
+export function renderInlinePlanApproval(
+  props: InlinePlanApprovalProps,
+): TemplateResult | typeof nothing {
+  if (!props.request) {
+    return nothing;
+  }
+  const { request, busy, error, reviseOpen } = props;
+  const actionsDisabled = busy || !props.connected;
+  // PR-10 AskUserQuestion: when the approval payload carries a
+  // question, render a different card shape (question prompt + N
+  // option buttons) instead of the standard plan approval triad.
+  if (request.question) {
+    return renderInlineQuestion(props);
+  }
+  const stepCount = request.plan.length;
+  const stepLabel = stepCount === 1 ? "step" : "steps";
+  const summary = request.summary?.trim();
+  // PR-9 Tier 1: prefer the agent's explicit title (set via
+  // exit_plan_mode { title: "..." }) when it's distinct from the
+  // generic boilerplate. Falls back to "Agent proposed a plan" so
+  // pre-Tier-1 agents that only supply summary still render cleanly.
+  const rawTitle = request.title?.trim();
+  const isGenericTitle =
+    !rawTitle || rawTitle === "Plan approval requested" || rawTitle.startsWith("Plan approval —");
+  const headline = isGenericTitle ? "Agent proposed a plan" : rawTitle;
+  return html`
+    <div class="plan-inline-card" role="region" aria-label="Plan approval">
+      <div class="plan-inline-card__header">
+        <div class="plan-inline-card__title">
+          ${summary
+            ? html`<strong>${headline}</strong>
+                <span class="plan-inline-card__summary">— ${summary}</span>`
+            : html`<strong>${headline}</strong>`}
+        </div>
+        <button
+          class="plan-inline-card__open"
+          type="button"
+          @click=${props.onOpenPlan}
+          title="Open the full plan in the side panel"
+        >
+          Open plan
+        </button>
+      </div>
+      <div class="plan-inline-card__meta">${stepCount} ${stepLabel}</div>
+      ${error ? html`<div class="plan-inline-card__error">${error}</div>` : nothing}
+      ${!props.connected
+        ? html`<div class="plan-inline-card__error">
+            Reconnect to resolve this plan. The approval stays pending while offline.
+          </div>`
+        : nothing}
+      ${reviseOpen
+        ? html`
+            <textarea
+              class="plan-inline-card__revise-input"
+              placeholder="What should change? (optional, sent to the agent as feedback)"
+              rows="3"
+              .value=${props.reviseDraft}
+              ?disabled=${actionsDisabled}
+              @input=${(e: Event) =>
+                props.onReviseDraftChange((e.target as HTMLTextAreaElement).value)}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  props.onReviseSubmit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  props.onReviseCancel();
+                }
+              }}
+            ></textarea>
+            <div class="plan-inline-card__actions">
+              <button
+                class="plan-inline-card__btn plan-inline-card__btn--primary"
+                type="button"
+                ?disabled=${actionsDisabled}
+                @click=${props.onReviseSubmit}
+              >
+                Send revision
+              </button>
+              <button
+                class="plan-inline-card__btn"
+                type="button"
+                ?disabled=${actionsDisabled}
+                @click=${props.onReviseCancel}
+              >
+                Cancel
+              </button>
+            </div>
+          `
+        : html`
+            <div class="plan-inline-card__actions">
+              <button
+                class="plan-inline-card__btn plan-inline-card__btn--primary"
+                type="button"
+                ?disabled=${actionsDisabled}
+                @click=${props.onApprove}
+                title="Execute the plan as proposed — no edits"
+              >
+                Accept
+              </button>
+              <button
+                class="plan-inline-card__btn"
+                type="button"
+                ?disabled=${actionsDisabled}
+                @click=${props.onAcceptWithEdits}
+                title="Approve and let the agent adjust steps as it goes"
+              >
+                Accept, allow edits
+              </button>
+              <button
+                class="plan-inline-card__btn plan-inline-card__btn--danger"
+                type="button"
+                ?disabled=${actionsDisabled}
+                @click=${props.onReviseOpen}
+                title="Send back for revision; agent stays in plan mode"
+              >
+                Revise
+              </button>
+            </div>
+          `}
+    </div>
+  `;
+}
+
+/**
+ * PR-10: question variant of the inline approval card. Same visual
+ * shell as the plan approval card but renders the question prompt +
+ * one button per option (plus an optional "Other..." textarea when
+ * `allowFreetext` is true). Click → onAnswerOption(text).
+ */
+function renderInlineQuestion(props: InlinePlanApprovalProps): TemplateResult {
+  const { request, busy, error } = props;
+  const question = request!.question!;
+  // PR-13 Bug 2: render the "Other" inline textarea when the user has
+  // clicked Other and not yet submitted/cancelled. Mirrors the revise
+  // UX so backing out (Cancel button or Escape key) returns to the
+  // option list instead of (as window.prompt cancellation appeared to
+  // do) exiting the entire sequence.
+  const otherOpen = props.questionOtherOpen === true;
+  // PR-11 review fix (Copilot #3104741709): the props interface types
+  // `onAnswerOption` as optional + uses optional-chaining at the call
+  // site, so a host that forgets to wire `onPlanApprovalAnswer`
+  // would render interactive-looking buttons that silently no-op.
+  // When the handler is missing, disable the buttons + surface a
+  // visible warning so the wiring gap is obvious instead of mute.
+  const answerHandlerMissing = typeof props.onAnswerOption !== "function";
+  const answerButtonsDisabled = busy || !props.connected || answerHandlerMissing;
+  return html`
+    <div class="plan-inline-card" role="region" aria-label="Agent question">
+      <div class="plan-inline-card__header">
+        <div class="plan-inline-card__title">
+          <strong>Agent has a question</strong>
+          <span class="plan-inline-card__summary">— ${question.prompt}</span>
+        </div>
+      </div>
+      <div class="plan-inline-card__meta">
+        ${question.options.length} options${question.allowFreetext ? " + free text" : ""}
+      </div>
+      ${error ? html`<div class="plan-inline-card__error">${error}</div>` : nothing}
+      ${!props.connected
+        ? html`<div class="plan-inline-card__error">
+            Reconnect to answer this question. The prompt stays pending while offline.
+          </div>`
+        : nothing}
+      ${answerHandlerMissing
+        ? html`<div class="plan-inline-card__error">
+            ⚠️ Question handler not wired (host did not pass
+            <code>onPlanApprovalAnswer</code>). Buttons disabled.
+          </div>`
+        : nothing}
+      ${otherOpen
+        ? html`
+            <textarea
+              class="plan-inline-card__revise-input"
+              placeholder="Type your answer to the question above…"
+              rows="3"
+              .value=${props.questionOtherDraft ?? ""}
+              ?disabled=${busy || !props.connected}
+              @input=${(e: Event) =>
+                props.onQuestionOtherDraftChange?.((e.target as HTMLTextAreaElement).value)}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  props.onQuestionOtherSubmit?.();
+                } else if (e.key === "Escape") {
+                  // PR-13 Bug 2: Escape returns to options, doesn't
+                  // dismiss the card.
+                  e.preventDefault();
+                  props.onQuestionOtherCancel?.();
+                }
+              }}
+            ></textarea>
+            <div class="plan-inline-card__actions">
+              <button
+                class="plan-inline-card__btn plan-inline-card__btn--primary"
+                type="button"
+                ?disabled=${busy ||
+                !props.connected ||
+                !(props.questionOtherDraft && props.questionOtherDraft.trim().length > 0)}
+                @click=${() => props.onQuestionOtherSubmit?.()}
+                title="Send the typed answer"
+              >
+                Send answer
+              </button>
+              <button
+                class="plan-inline-card__btn"
+                type="button"
+                ?disabled=${busy || !props.connected}
+                @click=${() => props.onQuestionOtherCancel?.()}
+                title="Back to the option list"
+              >
+                Back to options
+              </button>
+            </div>
+          `
+        : html`
+            <div class="plan-inline-card__actions plan-inline-card__actions--question">
+              ${question.options.map(
+                (option, idx) => html`
+                  <button
+                    class="plan-inline-card__btn ${idx === 0
+                      ? "plan-inline-card__btn--primary"
+                      : ""}"
+                    type="button"
+                    ?disabled=${answerButtonsDisabled}
+                    @click=${() => props.onAnswerOption?.(option)}
+                    title=${answerHandlerMissing
+                      ? "Disabled: question handler not wired"
+                      : `Answer: ${option}`}
+                  >
+                    ${option}
+                  </button>
+                `,
+              )}
+              ${question.allowFreetext
+                ? html`
+                    <button
+                      class="plan-inline-card__btn plan-inline-card__btn--secondary"
+                      type="button"
+                      ?disabled=${answerButtonsDisabled}
+                      @click=${() => props.onQuestionOtherOpen?.()}
+                      title=${answerHandlerMissing
+                        ? "Disabled: question handler not wired"
+                        : "Type a free-text answer"}
+                    >
+                      Other…
+                    </button>
+                  `
+                : nothing}
+            </div>
+          `}
+    </div>
+  `;
+}


### PR DESCRIPTION
**📋 Umbrella tracker:** [#70101](https://github.com/openclaw/openclaw/issues/70101) — master tracker for the 9-PR plan-mode rollout. See it for status of all parts + suggested merge order + carry-forward backlog.

---

> **📋 Stack position**: This is **[Plan Mode 4/6]**, the fourth part of a 6-PR per-part decomposition of the original umbrella #68939 (closed).
>
> - **Previous in stack**: `[Plan Mode 3/6] Advanced plan interactions`
> - **Next in stack**: `[Plan Mode 5/6] Text channels + Telegram`
> - **Integration bundle**: `[Plan Mode FULL]` — green-CI bundle of all parts + automation + executing-state lifecycle
>
> ⚠️ **CI on this PR will be RED**: this part adds UI components that reference plan-mode types (`PlanModeSessionState`, `PlanStep`) from `[Plan Mode 1/6]` + `[Plan Mode 2/6]`. CI will pass once earlier parts merge in order, OR review the green-CI integrated state in [Plan Mode FULL].
>
> **Ways to land this feature** (maintainer choice):
> - Per-part review + sequential merge of 1/6 → 6/6
> - Single bundle merge via [Plan Mode FULL]

---

## Executive summary

This PR ships the **web UI surface** of plan mode: the visual layer a webchat user actually touches when a session enters plan mode. It adds (a) **plan cards** that render the agent's proposed checklist inline in the message thread with per-step status, (b) a **mode-switcher chip** in the chat input toolbar that lets users toggle plan-vs-normal (and the PR-10 "Plan ⚡" auto-approve variant) with both pointer and keyboard, (c) an **inline plan-approval card** above the chat input — Accept / Accept-allow-edits / Revise — that doubles as the surface for `AskUserQuestion` interactions, and (d) **plan-resume** wiring that sends a hidden `chat.send` after a web-side approval/answer lands so the agent run continues without echoing a synthetic `"continue"` into the visible transcript.

Integration with the rest of the stack is intentionally narrow. The UI is a **pure consumer** of state shapes from 2/6 (`planMode`, `planApproval`, `pendingAgentInjections`) and tool contracts from 3/6 (`AskUserQuestion`, `exit_plan_mode`). The chip writes via `sessions.patch`; the approval card writes via `sessions.patch { planApproval: { action } }`; resume sends `chat.send { deliver: false }` so the runtime can pick up the persisted decision/answer without the user seeing an extra message bubble. Nothing in this PR adds new RPCs or new state — it surfaces what 2/6 + 3/6 already manage.

The four core component files (`plan-cards.ts`, `mode-switcher.ts`, `plan-resume.ts`, `plan-approval-inline.ts`) total 873 LoC, with 1067 LoC of tests against them. The remaining ~4.7k lines of the diff is integration glue in `views/chat.ts` (host wiring), `app-tool-stream.ts` (event-stream side detection of plan-related tool events), `app.ts` / `app-chat.ts` / `app-render.ts` / `app-view-state.ts` (top-level app state machine extensions for the approval-card local state), CSS (plan-card visuals + chat-shell layout adjustments), the slash-command executor for `/plan`, and the i18n cleanup deletions described below. The components themselves are small, pure, and testable in isolation — by design.

## TL;DR

- **Scope**: 4 new UI components (`plan-cards.ts`, `mode-switcher.ts`, `plan-resume.ts`, `plan-approval-inline.ts`) + their CSS + their tests; integration into `views/chat.ts`, `app-chat.ts`, `app-render.ts`, `app-tool-stream.ts`; plan-mode entries in `tool-display.json`; one new i18n key (`planViewToggle`) across 13 locales.
- **i18n languages covered (13)**: `en`, `de`, `es`, `fr`, `id`, `ja-JP`, `ko`, `pl`, `pt-BR`, `tr`, `uk`, `zh-CN`, `zh-TW`. Plus the i18n cleanup deletions described below.
- **Accessibility**: `:focus-visible` outline on plan-card `<summary>` (Copilot review fix from #68939, [`plan-cards.css:46-50`](#)), `aria-haspopup="menu"` + `aria-expanded` on the mode chip, `role="region"` + `aria-label` on the approval card, deliberate **non-claim of `role="menu"`** on the dropdown so the WAI-ARIA menu keyboard contract isn't falsely advertised ([`mode-switcher.ts:328-339`](#)).
- **Keyboard**: Ctrl+1..6 mode shortcuts with a Shadow-DOM-aware focus guard that walks `.shadowRoot.activeElement` so Lit composers' inner inputs don't have their keystrokes stolen ([`mode-switcher.ts:384-402`](#)).
- **Offline-resilient**: approval card disables every action button + surfaces a "Reconnect to resolve this plan. The approval stays pending while offline." banner when `connected === false` ([`plan-approval-inline.ts:98-102`](#); test [`plan-approval-inline.test.ts:133-150`](#)).
- **Tests**: 4 component test files (1067 LoC of tests for ~873 LoC of components — ~1.2× coverage by line count); all jsdom-rendered and assert real DOM state, not snapshot strings.

## Web UI component tree

How the new pieces slot into the existing webchat layout. Bold = added by this PR; everything else is the existing chat shell from `views/chat.ts`.

```mermaid
graph TD
  Root["chat view (views/chat.ts)"]
  Root --> Header["chat header"]
  Root --> Thread["message thread"]
  Root --> Composer["composer area"]
  Root --> Sidebar["right sidebar"]

  Header --> ModeChip["<b>mode-switcher chip</b><br/>(mode-switcher.ts)"]
  ModeChip --> ModeMenu["<b>mode menu popover</b><br/>Default / Ask / Accept /<br/>Plan / Plan ⚡ / Bypass"]

  Thread --> ToolCards["tool-cards (existing)"]
  Thread --> PlanCard["<b>plan-cards.ts</b><br/>&lt;details&gt;/&lt;summary&gt; with<br/>per-step status markers"]

  Composer --> ApprovalCard["<b>plan-approval-inline.ts</b><br/>shown ABOVE composer when<br/>planApprovalRequest != null"]
  ApprovalCard --> PlanVariant["plan variant:<br/>Accept / Accept-allow-edits / Revise"]
  ApprovalCard --> QuestionVariant["question variant (PR-10):<br/>1 button per option + Other…"]
  Composer --> Input["chat input (hidden when card open)"]

  Sidebar --> PlanPane["plan pane (formatted via<br/>formatPlanAsMarkdown())"]

  classDef new fill:#1e293b,stroke:#6366f1,stroke-width:2px,color:#e2e8f0
  class ModeChip,ModeMenu,PlanCard,ApprovalCard,PlanVariant,QuestionVariant new
```

## Plan-resume on web reconnect

Why the resume primitive exists: when a web client approves a plan or answers a question, the authoritative decision lands in session state via `sessions.patch` (handled by 2/6). But the agent run that produced the approval request is paused. Something has to **kick the run back into life** without echoing a synthetic `"continue"` into the visible transcript or duplicating the decision the user already made.

```mermaid
sequenceDiagram
  participant U as User (web)
  participant W as Webchat client
  participant G as Gateway
  participant R as Runtime
  participant S as Session state

  U->>W: clicks "Accept" on approval card
  W->>G: sessions.patch { planApproval: { action: "approve" } }
  G->>S: persist decision in pendingAgentInjections
  G-->>W: 200 OK
  Note over W: card vanishes; composer<br/>re-enables
  W->>G: chat.send { message: "continue", deliver: false,<br/>idempotencyKey: "plan-resume-<uuid>" }
  Note right of W: hidden — does NOT post a<br/>visible "continue" bubble<br/>(plan-resume.ts:11-21)
  G->>R: dispatch run with persisted decision context
  R->>S: read pendingAgentInjections, drain
  R-->>W: streams agent output (now executing the approved plan)
```

The resume primitive is one function: [`resumePendingPlanInteraction(client, sessionKey)`](#) at `ui/src/ui/chat/plan-resume.ts:11-21`. Three things matter about its shape:

1. **`deliver: false`** — the gateway records the message in the session log but does NOT broadcast it to the channel as a user-visible bubble. Without this, every plan approval would inject a stray `"continue"` into the transcript.
2. **`idempotencyKey: "plan-resume-<uuid>"`** — the `plan-resume-` prefix is the load-bearing piece. Server-side correlation (in 2/6) treats any send carrying this prefix as a resume signal rather than a normal user message, which short-circuits the `pendingAgentInjections` drain logic.
3. **Pure UI primitive** — no decision logic lives here. The function is dumb: it fires the resume RPC. The decision-making (when to call it) belongs to the host `views/chat.ts`, which fires it after the `sessions.patch` for an approval/answer resolves.

The single test ([`plan-resume.node.test.ts:9-26`](#)) pins the contract: the call shape is `chat.send { sessionKey, message: "continue", deliver: false, idempotencyKey: "plan-resume-uuid-fixed" }`. If a future refactor changes the prefix, the runtime correlation breaks silently — this test is the canary.

## Mode-switcher state

The chip has a small derived-state machine driven by three independent session fields: `(execSecurity, execAsk, planMode, planAutoApprove)`. The derivation is centralised in [`resolveCurrentMode()`](#) at `mode-switcher.ts:237-278`.

```mermaid
stateDiagram-v2
  [*] --> Default: execSec=undef<br/>execAsk=undef<br/>planMode=undef
  Default --> Ask: pick "Ask" / Ctrl+2
  Default --> Accept: pick "Accept" / Ctrl+3
  Default --> Plan: pick "Plan" / Ctrl+4
  Default --> PlanAuto: pick "Plan ⚡" / Ctrl+5
  Default --> Bypass: pick "Bypass" / Ctrl+6

  Ask --> Plan: planMode→"plan"<br/>(perm-mode preserved)
  Accept --> Plan: planMode→"plan"
  Bypass --> Plan: planMode→"plan"

  Plan --> PlanAuto: pick "Plan ⚡"<br/>(planAutoApprove=true)
  PlanAuto --> Plan: pick plain "Plan"<br/>(autoApprove cleared)

  Plan --> Default: pick "Default" → planMode→"normal"<br/>+ clear execSec/execAsk overrides
  PlanAuto --> Default: pick "Default"

  Default --> Custom: server returns<br/>(execSec="deny", …) or other<br/>non-preset combo

  note right of Plan
    Plan WINS over permission mode
    in chip display — chip shows
    "Plan" regardless of underlying
    (execSec, execAsk).
  end note

  note right of Custom
    Synthetic mode for non-preset
    (execSec, execAsk) combos.
    Was: silently mislabeled as Ask
    (PR #67721 fix).
  end note
```

The state machine has three load-bearing rules:

- **Plan wins over permission mode in display** — when `planMode === "plan"`, the chip shows "Plan" (or "Plan ⚡") regardless of the underlying `(execSecurity, execAsk)`. Test: [`mode-switcher.test.ts:26-29`](#).
- **`planAutoApprove` is meaningful only when `planMode === "plan"`** — pre-arming auto-approve while still in normal mode does NOT make the chip lie about being in plan mode. Test: [`mode-switcher.test.ts:49-55`](#).
- **Non-preset combos are synthesized as "Custom"**, not silently coerced to "Ask" (the prior bug from PR #67721). Sandbox-backed sessions commonly yield `(execSecurity="deny", execAsk="off")` which is a valid non-preset state, and showing "Ask" there would let the user accidentally loosen permissions. Test: [`mode-switcher.test.ts:77-86`](#).

## Note on i18n surface area (Codex P2 review)

In addition to the plan-mode UI work, this PR's diff includes mechanical cleanup of 12 locale files (`ui/src/i18n/locales/*.ts` + corresponding `.i18n/*.meta.json`) that **delete unused auth/pairing/login/docs strings** unrelated to plan mode. The pattern per locale file is:
- **+1 line**: the new `planViewToggle: "Toggle plan view sidebar"` plan-mode key (this is the actual plan-mode work)
- **-30 lines**: deletions of unused keys like `passwordPlaceholder`, `showToken`/`hideToken`/`toggleTokenVisibility`, `scopeUpgradeTitle`/`scopeUpgradeSummary`/`roleUpgradeTitle`, `authDocsTitle`/`tailscaleDocsTitle`/etc.

[Codex review](https://github.com/openclaw/openclaw/issues/70101#issuecomment-4295128968) flagged the deletions as stylistically misplaced (they belong in a separate housekeeping PR). We considered surgically removing them but the i18n CI check (`pnpm ui:i18n:check`) requires the `.meta.json` totals/hashes to match the `.ts` content; mechanically reverting the deletions risks breaking the check without a regen step.

**Maintainer call**: the deletions are valid (those keys are genuinely unused — verified by absence of references in the UI source) but they're stylistically separate from plan-mode UI work. Two acceptable resolutions:
1. **Accept as-is** — net effect on `main` is identical to landing the plan-mode key separately. ~518 LoC of cleanup is a bonus side effect.
2. **Pre-merge**: revert the deletions on this branch (keep just the `planViewToggle` addition) and ship the deletions in a follow-up housekeeping PR after this rolls out. We'd need a `pnpm ui:i18n:regen` step (or its equivalent) to keep `.meta.json` consistent.

Tracking either decision in umbrella [#70101](https://github.com/openclaw/openclaw/issues/70101).

## How it wires into `views/chat.ts`

The four UI primitives are pure functions; the integration glue lives in `ui/src/ui/views/chat.ts` (already large; +371 net lines in this PR). The relevant block at [`chat.ts:1382-1456`](#) is the contract worth eyeballing:

```ts
${props.planApprovalRequest &&
props.planApprovalRequest.sessionKey === activeSession?.key &&
props.onPlanApprovalDecision
  ? renderInlinePlanApproval({
      request: props.planApprovalRequest,
      connected: props.connected,
      busy: props.planApprovalBusy ?? false,
      // … 17 props total covering:
      //   - plan-variant: onApprove / onAcceptWithEdits / onReviseOpen / …
      //   - question-variant (PR-10): onAnswerOption
      //   - "Other…" textarea (PR-13 Bug 2): questionOtherOpen / Draft / handlers
      //   - sidebar handoff: onOpenPlan
      onReviseSubmit: () => {
        const draft = (props.planApprovalReviseDraft ?? "").trim();
        // Codex P2 review #68939 (2026-04-19): block empty client-side
        // submits — the wire schema's reject variant requires
        // feedback: minLength: 1, so empty would produce a confusing
        // server-side validation error. The textarea stays visible.
        if (!draft) return;
        void props.onPlanApprovalDecision!("reject", draft);
      },
      // …
    })
  : nothing}

<!-- PR-7 review fix (Copilot #3105170553 / #3105219639):
     hide the input only when BOTH planApprovalRequest AND
     onPlanApprovalDecision are present. Otherwise the user would see
     neither the card (which requires the handler) nor the input. -->
${props.planApprovalRequest && /* … */ props.onPlanApprovalDecision
  ? nothing
  : html`<div class="agent-chat__input">…composer…</div>`}
```

Three things to notice in that block, all of which are review-debt receipts rather than fresh design choices:

1. **`sessionKey === activeSession?.key` gate** — the same `planApprovalRequest` could (in theory) belong to a session the user has navigated away from. The card only renders for the active session; this prevents an approval from leaking across session contexts.
2. **Empty-revise client-side block** — the wire schema's reject variant requires `feedback: minLength: 1` (closes the "reject with no guidance" loophole from earlier iters of plan mode). The host short-circuits the submit so the user sees the textarea remain in place to type into, instead of a confusing server-side validation error toast.
3. **Both-or-neither input visibility** — the original implementation hid the input whenever a `planApprovalRequest` was present. Copilot review #3105170553 / #3105219639 flagged that if the host forgets to wire `onPlanApprovalDecision`, the user gets neither the card (which checks the handler) nor the input. The fixed predicate gates on BOTH being present.

The mode-switcher integration is similarly defensive at [`chat.ts:1503`](#):

```ts
return renderModeSwitcher({
  currentMode: resolveCurrentMode(
    activeSession?.execSecurity,
    activeSession?.execAsk,
    activeSession?.planMode,
    activeSession?.planAutoApprove,
  ),
  menuOpen: props.modeMenuOpen,
  onToggleMenu: props.onToggleModeMenu,
  onSelectMode: props.onSelectMode,
});
```

— derivation runs every render, so the chip stays in sync with whatever `sessions.patch` events the gateway streams down.

## Per-file deep dive

### `ui/src/ui/chat/plan-cards.ts` (122 LoC)

Inline plan rendering for the message thread. Two exports: `renderPlanCard(plan)` and `formatPlanAsMarkdown(plan)`.

**Shape** — `PlanCardData = { title, explanation?, steps: PlanCardStep[], source? }`; `PlanCardStep = { text, status: "pending"|"in_progress"|"completed"|"cancelled", activeForm? }`. Status-marker glyphs at [`plan-cards.ts:23-28`](#) are deliberately monospaced-friendly (⬚ ⏳ ✅ ❌) so terminal-style operators reading raw markdown via the sidebar's "Copy as markdown" still get a parseable checklist.

**Markdown formatter** — `formatPlanAsMarkdown()` at [`plan-cards.ts:101-122`](#) renders for the right-sidebar pane and clipboard export. Cancelled steps render `~~strikethrough~~ (cancelled)`; in-progress steps render `**bold** (in progress)` and use `activeForm` (the ongoing-tense label, e.g. "Building artifacts") instead of `text` ("Build artifacts"). All step text passes through a single newline-stripping `clean()` so multi-line text from the agent doesn't break the bullet structure.

**`<details>`/`<summary>` rendering** — the `summary` shows `<plan-icon> <title> <N/M done | N steps> <chevron>`. Native `::-webkit-details-marker` and Firefox's `::marker` are both suppressed (`plan-cards.css:25-33`) so the custom chevron isn't doubled. Focus-visible outline on the summary at `plan-cards.css:46-50` (Copilot review fix from umbrella #68939).

**Test coverage** — [`plan-cards.test.ts`](#) (159 LoC). Splits into a `formatPlanAsMarkdown` group (markdown-shape assertions including the activeForm-shadowing edge case at line 47-51) and a `renderPlanCard (jsdom render)` group that asserts real DOM structure: `<details>` exists, summary text contains "1/2 done" or "2 steps" depending on completion state, one `<li>` per step with the right status class, activeForm shadows text in in-progress rows.

### `ui/src/ui/chat/mode-switcher.ts` (424 LoC)

The chip + dropdown menu in the chat input toolbar. Three exports drive the host: `MODE_DEFINITIONS` (the catalog), `resolveCurrentMode(execSecurity, execAsk, planMode, planAutoApprove)` (state derivation), `renderModeSwitcher(...)` (Lit template), `handleModeShortcut(e)` (Ctrl+1..6 dispatcher).

**Mode catalog** — `MODE_DEFINITIONS` at [`mode-switcher.ts:121-192`](#) carries six entries: Default (Ctrl+1), Ask (Ctrl+2), Accept (Ctrl+3), Plan (Ctrl+4), Plan ⚡ (Ctrl+5), Bypass (Ctrl+6). The `Default` entry has both `execSecurity` and `execAsk` undefined — the host treats undefined as "DELETE the per-session overrides via patch", so picking Default returns the session to whatever the operator configured at `agents.defaults`. Without this, the post-plan-mode fallback would lock back to Ask, which most operator configs don't want.

**Plan as a dimension, not a permutation** — the file-level header comment ([`mode-switcher.ts:1-16`](#)) explains why `planMode` is NOT mapped onto `execSecurity`: plan mode needs read-only exec for research, so blocking exec via `execSecurity=allowlist` would defeat its purpose. Plan mode + permission mode coexist, and `resolveCurrentMode` lets plan WIN for display purposes only.

**Shadow-DOM-aware focus guard** — `getDeepActiveElement()` at [`mode-switcher.ts:384-402`](#) walks `document.activeElement.shadowRoot.activeElement` recursively (capped at depth 32) until it bottoms out at the real focus target. Without this, focus inside a `<openclaw-chat-composer>` Web Component's internal `<input>` returns the host element, the focus guard fails to bail, and Ctrl+1..6 steal keystrokes the user meant for typing. Two regression tests cover depth-1 ([`mode-switcher.test.ts:249-270`](#)) and depth-2 ([`mode-switcher.test.ts:272-290`](#)) Shadow DOM nesting.

**Deliberate non-claim of `role="menu"`** — [`mode-switcher.ts:328-339`](#) explains why the dropdown does NOT declare `role="menu"`: claiming the menu role without implementing arrow-nav, Home/End, roving tabindex, and focus trap would mislead assistive tech (per WAI-ARIA spec). Plain `<button>`s give native focus + Escape-on-chip, which is a real usable interaction with no false ARIA promise. Test asserting the role is absent: [`mode-switcher.test.ts:331-334`](#).

**Test coverage** — [`mode-switcher.test.ts`](#) (388 LoC). Four describe blocks: `resolveCurrentMode` (10 cases including the PR-10 plan-auto interaction, the PR-8 Default/undefined handling, the sandbox `deny` regression), `handleModeShortcut` (8 cases for the modifier-exclusion matrix — Ctrl alone OK, Cmd/Shift/Alt all bail), `focus guard` (5 cases with the Shadow-DOM regression coverage), `renderModeSwitcher (jsdom render)` (5 DOM-shape cases).

### `ui/src/ui/chat/plan-resume.ts` (21 LoC)

Single function, single test. Covered above in the "Plan-resume on web reconnect" section. The 21 LoC is the entire UI side of plan resume — everything else (decision persistence, runtime drain, idempotency-key correlation) lives in 2/6.

### `ui/src/ui/views/plan-approval-inline.ts` (306 LoC)

The card that appears ABOVE the chat input bar when `planApprovalRequest != null`. Two visual variants share the same shell: the **plan variant** (3-button triad: Accept / Accept-allow-edits / Revise + an "Open plan" link) and the **question variant** (PR-10, AskUserQuestion: 1 button per option + optional "Other…" textarea).

**Plan variant** — `renderInlinePlanApproval()` at [`plan-approval-inline.ts:53-175`](#). Buttons map to `sessions.patch { planApproval: { action: "approve" | "approve-with-edits" | "revise" } }`, fired by the host. The "Revise" button opens an inline textarea (matching Claude Code's web revision UX) with Ctrl/Cmd+Enter to submit and Escape to cancel; the chat input is hidden by the caller while the card is showing so users don't accidentally type into the wrong surface.

**Title fallback** — [`plan-approval-inline.ts:73-77`](#): when the agent's `exit_plan_mode` call carries an explicit `title` (PR-9 Tier 1 contract), use it; when it's the generic "Plan approval requested" boilerplate or the legacy "Plan approval — …" prefix, fall back to "Agent proposed a plan". This means agents that don't yet emit Tier-1 titles still get a sensible headline. Test at [`plan-approval-inline.test.ts:47-68`](#).

**Question variant** — `renderInlineQuestion()` at [`plan-approval-inline.ts:183-306`](#). Same shell, different actions row. Carries a defensive guard: if the host forgets to wire `onAnswerOption`, the buttons render as `disabled` and a visible warning appears (`⚠️ Question handler not wired (host did not pass onPlanApprovalAnswer). Buttons disabled.`) — instead of mute no-op buttons that look interactive ([`plan-approval-inline.ts:196-222`](#)). This was a Copilot review fix (#3104741709) on the umbrella.

**Offline behavior** — when `connected === false`, every button across both variants is disabled and a banner appears ("Reconnect to resolve this plan. The approval stays pending while offline." for plans; analogous for questions). Tests assert disabled state at [`plan-approval-inline.test.ts:133-150`](#) (plan) and [`plan-approval-inline.test.ts:181-210`](#) (question).

**"Other…" textarea state** — PR-13 Bug 2 fix: caller owns `questionOtherOpen` / `questionOtherDraft` so the textarea state survives across re-renders, and Escape returns to the option list (instead of dismissing the entire card, which a `window.prompt`-based implementation would have done). Test at [`plan-approval-inline.test.ts:248-294`](#).

**Test coverage** — [`plan-approval-inline.test.ts`](#) (295 LoC). 10 cases: nothing-when-no-request, generic-title fallback, button wiring, revise-editor draft+keyboard, offline plan, missing-handler warning, offline question, option click + Other handoff, free-text submit + cancel.

### Supporting files (the rest of the diff)

- **`apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json`** (+29 lines) — adds 5 plan-mode tool entries the native apps render: `update_plan` (🗺️), `enter_plan_mode` (🧭), `exit_plan_mode` (✅), `plan_mode_status` (🔍), `ask_user_question` (❓). Each carries `detailKeys` so the native side knows which payload fields to render in the tool card. The web UI doesn't read this file directly — it has its own `tool-display-config.ts` mirror — but native apps depend on this catalog being in sync.
- **`ui/src/styles/chat/plan-cards.css`** (+134 lines) — accent-bordered card with status-marker glyphs. Both `::-webkit-details-marker` (Chromium/Safari) and `::marker` (Firefox) suppressed so the custom chevron isn't doubled. `:focus-visible` outline added on `<summary>` (Copilot review fix from umbrella).
- **`ui/src/styles/chat/layout.css`** (+228 lines) — chat shell layout adjustments to make room for the inline approval card (it sits between the message thread bottom and the composer top, with deliberate top/bottom margins so the card visually associates with the composer it replaces, not the most-recent message).
- **`ui/src/styles/chat.css`** (+1) — single `@import` line wiring `plan-cards.css` into the chat bundle.
- **`ui/src/ui/chat/slash-command-executor.ts`** (+374) + **`.node.test.ts`** (+160) — `/plan on|off|status` slash-command handlers; pre-existing executor stub gets the plan-mode action arms. Tests pin the patch shape (`{ planMode: "plan" | "normal" }`) and the chip-state side effects.
- **`ui/src/ui/chat/slash-commands.ts`** (+12) — registers `/plan` in the slash-command catalog so it autocompletes from the `/` menu.
- **`ui/src/ui/chat/grouped-render.test.ts`** (+309 / -79) — extends the grouped-render fixture set with plan-card cases so the message-thread renderer's grouping logic correctly de-dupes consecutive plan events into a single rendered card.
- **`ui/src/ui/views/chat.ts`** (+477 / -106) — the integration host detailed above.
- **`ui/src/ui/app-render.ts`** + **`app-tool-stream.ts`** + **`app-chat.ts`** + **`app-view-state.ts`** + **`app.ts`** (~1300 lines net additions) — wires plan-approval-request lifecycle into the top-level chat app: stream-side detection of `exit_plan_mode` / `ask_user_question` events, view-state shape extensions for the approval-card local state (revise textarea, "Other…" textarea), patch-and-resume sequencing on approve/answer/reject.

## Accessibility + i18n

**Accessibility** — six concrete things, all asserted by tests:

| Concern | Implementation | Evidence |
|---|---|---|
| Keyboard focus on plan card | `:focus-visible` outline on `<summary>` using accent token | `plan-cards.css:46-50` |
| Mode-chip semantics | `aria-haspopup="menu"` + `aria-expanded` toggle | `mode-switcher.ts:308-309`; test `mode-switcher.test.ts:308-311` |
| Honest dropdown ARIA | Deliberately omit `role="menu"` (no false promise of WAI-ARIA contract) | `mode-switcher.ts:328-339`; test `mode-switcher.test.ts:331-334` |
| Approval card landmark | `role="region"` + `aria-label="Plan approval"` / `"Agent question"` | `plan-approval-inline.ts:79`, `:201` |
| Keyboard composer protection | Shadow-DOM-aware focus guard for Ctrl+1..6 | `mode-switcher.ts:384-402`; tests `:249-290` |
| Revise textarea keyboard contract | Ctrl/Cmd+Enter submits, Escape cancels (does NOT dismiss card) | `plan-approval-inline.ts:113-121`, `:233-243` |

**i18n** — exactly **one new key** carries the plan-mode UI work: `planViewToggle: "Toggle plan view sidebar"`, present in all 13 locale files (`en`, `de`, `es`, `fr`, `id`, `ja-JP`, `ko`, `pl`, `pt-BR`, `tr`, `uk`, `zh-CN`, `zh-TW`). The plan card / approval card / mode menu surface strings are *not* yet i18n'd in this PR — they're rendered from English literals in the Lit templates. This is intentional: extracting the approval/menu strings is a follow-up that depends on settling the user-facing copy after iter-3 of the umbrella. Tracking in #70101 carry-forward.

## Edge cases + review-debt receipts

These are the non-obvious behaviors hardened by previous review cycles on the umbrella that survive into this PR. Calling them out so a reviewer doesn't unwittingly "simplify" them away:

| Edge case | Behavior | Provenance |
|---|---|---|
| Approval card visible but `onPlanApprovalDecision` not wired | Composer stays visible (was: BOTH hidden, leaving the user with no surface to interact). | Copilot #3105170553 / #3105219639; `chat.ts:1444-1450` |
| Empty Revise submit | Client-side short-circuit; textarea remains visible for the user to type into. | Codex P2 #68939 (2026-04-19); `chat.ts:1399-1411` |
| Question card with missing `onAnswerOption` handler | Buttons render `disabled` + visible warning banner ("⚠️ Question handler not wired…"). | Copilot #3104741709; `plan-approval-inline.ts:196-222` |
| `(execSecurity, execAsk)` combo not in the preset table | Synthesizes a "Custom" mode entry instead of silently mislabeling as Ask. | PR #67721; `mode-switcher.ts:259-278`; test `:77-86` |
| Pre-armed `planAutoApprove` while `planMode !== "plan"` | Chip displays the underlying permission mode; the auto-approve flag is meaningful only AFTER planMode is "plan". | `mode-switcher.ts:243-258`; test `:49-55` |
| Ctrl+1..6 with focus inside a Web Component's inner `<input>` | Focus guard walks `.shadowRoot.activeElement` recursively (depth ≤ 32) and bails. | `mode-switcher.ts:384-402`; tests `:249-290` |
| Cmd+1 on macOS (browser tab switch) | Returns null; modifier-exclusion matrix accepts ONLY bare Ctrl. | `mode-switcher.ts:406-408`; test `:136-138` |
| Plan-approval card while disconnected | Every action button disabled + banner ("Reconnect to resolve this plan…"). The approval persists server-side; user can resolve after reconnect. | `plan-approval-inline.ts:98-102`; test `:133-150` |
| "Other…" textarea Escape | Returns to the option list (does NOT dismiss the entire card the way a `window.prompt` cancel would have). | PR-13 Bug 2; `plan-approval-inline.ts:237-243` |
| Generic "Plan approval requested" boilerplate title | Falls back to "Agent proposed a plan"; honors agent-supplied Tier-1 titles when distinct. | PR-9 Tier 1; `plan-approval-inline.ts:73-77`; test `:47-68` |
| Firefox vs Chromium `<details>` marker | BOTH `::-webkit-details-marker` and `::marker` suppressed; without the latter, Firefox doubles the disclosure triangle alongside the custom chevron. | `plan-cards.css:25-33` |
| Multi-line agent-supplied step text in markdown export | `clean()` strips newlines + trims so bullet structure doesn't break in clipboard markdown. | `plan-cards.ts:101-122` |

## Test coverage matrix

| File | Tests | LoC ratio | Coverage focus |
|---|---|---|---|
| `plan-cards.test.ts` | 16 cases | 1.30× | Markdown formatter (status mapping, activeForm shadowing); jsdom render (DOM shape, status classes, meta line, explanation conditional) |
| `mode-switcher.test.ts` | 28 cases | 0.92× | `resolveCurrentMode` derivation matrix incl. Plan/Plan ⚡/Custom; Ctrl+1..6 modifier-exclusion matrix; Shadow-DOM focus guard depth 1+2; render assertions for chip + menu + active-class; non-claim of `role="menu"` |
| `plan-resume.node.test.ts` | 1 case | 1.24× | Pins the `chat.send` call shape — `deliver: false`, `plan-resume-` idempotency-key prefix, "continue" message (load-bearing for runtime correlation in 2/6) |
| `plan-approval-inline.test.ts` | 10 cases | 0.96× | Both variants (plan + question); button wiring; revise-editor draft + keyboard (Cmd+Enter, Escape); offline disable + banner; missing-handler warning; "Other…" textarea submit/cancel |

All tests use `vitest` with jsdom (`@vitest-environment jsdom`) and assert against real rendered DOM rather than snapshot strings, so a CSS-class rename or template restructuring doesn't accidentally pass. The test-LoC ratio (1067 / 873 ≈ 1.22×) is in line with the umbrella's UI test density.

## Styling + CSS tokens

The new components use existing design tokens rather than introducing new color variables — every `var()` call falls back to a sensible literal so the components render correctly on a fresh checkout before theme tokens are loaded:

| Token | Used by | Fallback |
|---|---|---|
| `--accent` | plan card border, focus-visible outline, plan icon color, mode chip active state | `#6366f1` (indigo) |
| `--border` | plan card outer border | (theme-defined) |
| `--card`, `--bg-hover` | plan card background, summary hover | `#1a1a2e`, `rgba(255,255,255,.04)` |
| `--text-secondary` | plan card meta line | `#a0a0b0` |
| `--radius-md` | plan card border radius | `8px` |

The accent-bordered-left treatment on plan cards (3px left border, 1px elsewhere) deliberately mirrors `tool-cards.css` so plan cards visually associate with tool output rather than reading as a separate UI surface. The approval card uses a warmer surface (caller-supplied) with a danger-button variant for Revise — `--danger` for the destructive action remains the standard system token.

The new layout adjustments in `layout.css` (+228 lines) carve out vertical space for the inline approval card by:
- Reserving a min-height region above the composer that grows when `.plan-inline-card` is present.
- Setting the composer's bottom-anchor offset to account for the card's measured height (CSS-only, no JS measurement).
- Ensuring the card doesn't overlap the message thread's scroll-bottom indicator (the "↓ New messages" jump button) by giving it a stacking-context that sits beneath that floating affordance.

## Parity benchmark callout

Earlier prompt-parity benchmarking (same prompts hit OpenClaw + Codex + Claude Code) measured **~90% parity on response quality** and **~95% parity on session lengths** across the corpus, on top of plan mode landing. For UI specifically, two patterns in this PR are deliberate convergences:

- **Inline plan-approval card** — the "card above the composer with Accept / Accept-allow-edits / Revise" shape mirrors Claude Code's web UX. The Revise → inline textarea (rather than popup) is also lifted from there. Header comment at `plan-approval-inline.ts:1-14` documents the parity intent.
- **Mode-switcher chip** — the chip-with-dropdown in the chat header matches Codex's run-mode toggle pattern (single chip showing current mode, dropdown to change, kbd shortcuts displayed in the menu). The 6-mode catalog (Default/Ask/Accept/Plan/Plan ⚡/Bypass) is OpenClaw-specific — the Plan ⚡ entry is the PR-10 auto-approve variant which is novel to this stack.

The convergences are about UX expectations (users coming from those tools find familiar surfaces) rather than implementation lifting — the underlying state model (plan as its own dimension coexisting with permission mode, the synthesized "Custom" mode for non-preset combos) is OpenClaw-specific and has no analogue in either source.

## What a reviewer can verify in <30 min

Concrete checklist that exercises every load-bearing surface in this PR. Assumes the merge order is 1/6 → 2/6 → 3/6 → 4/6 (or that you're reviewing on the FULL bundle):

1. **Spin up the gateway + open webchat** (~3 min) — `pnpm dev` or equivalent; navigate to `/chat`.
2. **Mode chip renders** (~2 min) — chip should show "Default" with the shield icon. Click it; menu should show all 6 modes with Ctrl+1..6 hints. Press Escape; menu closes. Ctrl+4 (with focus NOT in the composer); chip switches to "Plan" with the checkmark-checkbox icon.
3. **Focus guard works** (~2 min) — click into the composer; type "ctrl+4" (literally). Should type the characters, NOT switch modes. (Exercises the Shadow-DOM-aware guard.)
4. **Plan card renders inline** (~5 min) — with a plan-mode-capable agent, send "make a 3-step plan to refactor the login component". The agent's `update_plan` event should render an expandable `<details>` card in the thread; click the summary to expand; verify `1/3 done` style meta updates as the agent runs.
5. **Approval card flow** (~5 min) — when the agent calls `exit_plan_mode`, the inline approval card appears ABOVE the composer. Composer input hides. Click "Open plan" — the right sidebar opens with the formatted markdown. Click "Revise" — inline textarea opens; type feedback; Cmd+Enter submits; card vanishes; agent receives the revision via `pendingAgentInjections` and continues in plan mode.
6. **Plan resume on reconnect** (~5 min) — with a plan approval pending, kill the gateway. Card buttons disable; banner shows "Reconnect to resolve this plan…". Restart the gateway. Buttons re-enable. Click Accept; verify in network tab that `chat.send` fires with `deliver: false` + `idempotencyKey: "plan-resume-<uuid>"` (this is the `plan-resume.ts` primitive). Agent run resumes; no synthetic "continue" bubble appears in the transcript.
7. **Question variant** (~3 min) — with an `AskUserQuestion`-capable agent, ask something that triggers the tool. The same approval-card shell renders with one button per option (and Other… if `allowFreetext: true`). Click an option; verify the `sessions.patch { planApproval: { action: "answer", answer: <text> } }` fires.
8. **i18n spot-check** (~2 min) — switch the UI locale to (say) `ja-JP` or `zh-CN`; verify the plan-view toggle tooltip uses the localized string from `planViewToggle`.

Total: ~25 min for a full happy-path + offline + question + i18n sweep.

## Suggested commands for reviewers

```bash
# Run the four new component test files in isolation:
pnpm --filter ui test -- ui/src/ui/chat/plan-cards.test.ts \
                        ui/src/ui/chat/mode-switcher.test.ts \
                        ui/src/ui/chat/plan-resume.node.test.ts \
                        ui/src/ui/views/plan-approval-inline.test.ts

# Sanity-check the i18n cleanup (verify deleted keys are genuinely unreferenced):
pnpm ui:i18n:check

# Spin up the gateway + open webchat for the manual smoke pass:
pnpm dev   # then open http://localhost:<gateway-port>/chat
```

The four-file test command above runs in <2s on a warm vitest cache and is the tightest smoke check that exercises every component-level invariant in this PR.

## What This PR Does NOT Include

- **Channel integration** (`/plan` slash commands across text channels, Telegram attachment delivery) → `[Plan Mode 5/6] Text channels + Telegram`
- **Automation + subagent follow-ups** → `[Plan Mode AUTOMATION]` (#70089) + bundled in `[Plan Mode FULL]` (#70071)
- **Docs (architecture, operator runbook) + QA scenarios** → `[Plan Mode 6/6] Docs, QA, and help`
- **Mobile (iOS/macOS/Android) plan UI** — the UI here is web-only. Native apps consume the same `tool-display.json` plan-mode entries added in this PR but render their own approval cards.
- **Accessibility audit for the approval card** — basic `role="region"` + `aria-label` ship here; full audit (screen-reader walkthrough, contrast verification on the danger button, focus-ring on the textarea) is a follow-up cycle in #70101.
- **i18n extraction of approval-card / menu strings** — only the `planViewToggle` key is i18n'd here; copy for the approval card buttons and the mode menu labels is still English literals, pending iter-3 copy-finalization.

## Carry-forward / deferred (tracked in #70101)

- **Mobile (iOS/macOS/Android) plan UI** — native apps consume the plan-mode entries added to `tool-display.json` here, but render their own approval cards. The native counterpart of `plan-approval-inline.ts` is a follow-up; the contract (Accept / Accept-allow-edits / Revise + Open plan, plus the question variant with N options + Other) is settled by this PR and can be ported as-is.
- **Accessibility audit** — basic landmarks (`role="region"` + `aria-label`) and keyboard contracts (focus-visible on the disclosure summary, Ctrl/Cmd+Enter to submit, Escape to cancel) ship here. A full screen-reader pass — including SR announcement of "approval pending" when the card appears, the contrast ratio of the danger-button variant on the dark card surface, and the focus-ring on the textarea — is a follow-up cycle.
- **i18n extraction of approval-card / mode-menu strings** — only the `planViewToggle` key is i18n'd in this PR. The approval card buttons ("Accept", "Accept, allow edits", "Revise", "Send revision", "Send answer", "Back to options") and the mode-menu labels ("Default permissions", "Ask each mutation", etc.) are still English literals. Extraction is queued behind iter-3 copy-finalization so we don't churn translators with copy that may still change.
- **Tool-display strings i18n** — the 5 plan-mode entries in `tool-display.json` carry English titles; localized variants will land with the broader tool-display i18n pass tracked separately.

## Issue references

- Refs #68939 plan UI surface area
- Master tracker #70101
- Depends on #70031 (1/6), #70066 (2/6), #70067 (3/6)
- Surfaces consumed: `PlanModeSessionState` + `planApproval` (2/6), `AskUserQuestion` + `exit_plan_mode` Tier-1 contract (3/6)
- Native-app counterpart (mobile UI): tracked in #70101 carry-forward
