### PR TITLE
[Plan Mode 5/6] Text channels + Telegram

### DIFF
--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -70,12 +70,20 @@ export {
   pinMessageTelegram,
   reactMessageTelegram,
   renameForumTopicTelegram,
+  // PR-14: standalone document/file upload — used by the plan-mode
+  // bridge to deliver a markdown plan file to Telegram chats so users
+  // can read the full plan archetype on their primary platform.
+  // Resolution stays text-based via PR-11's universal /plan slash
+  // commands, sidestepping the dual approval-id problem of trying to
+  // bridge inline buttons through the gateway plugin-approval pipeline.
+  sendDocumentTelegram,
   sendMessageTelegram,
   sendPollTelegram,
   sendStickerTelegram,
   sendTypingTelegram,
   unpinMessageTelegram,
 } from "./src/send.js";
+export type { TelegramDocumentOpts } from "./src/send.js";
 export {
   createTelegramThreadBindingManager,
   getTelegramThreadBindingManager,

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -29,6 +29,7 @@ import {
   getImageMetadata,
   isGifMedia,
   kindFromMime,
+  loadConfig,
   loadWebMedia,
   type MediaKind,
   normalizePollInput,
@@ -1531,6 +1532,196 @@ export async function sendStickerTelegram(
   const messageId = resolveTelegramMessageIdOrThrow(result, "sticker send");
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   recordSentMessage(chatId, messageId, opts.cfg);
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return { messageId: String(messageId), chatId: resolvedChatId };
+}
+
+/**
+ * PR-14: standalone document/file upload helper. Wraps `api.sendDocument`
+ * with the same retry/diag/threading machinery as `sendMessageTelegram`'s
+ * media branch. Used by the plan-mode bridge to deliver a markdown plan
+ * file to a Telegram chat as an attachment so the user can read the full
+ * plan from their primary platform.
+ *
+ * - `filePath`: absolute path to a local file on disk. Read into a Buffer.
+ * - `caption`: optional caption text. Truncated to 1024 chars (Telegram
+ *   document caption limit). Defaults to `parse_mode: "HTML"` so the
+ *   universal-/plan resolution hint can use `<code>` markup.
+ * - `messageThreadId` / `replyToMessageId`: standard threading shape
+ *   shared with sendMessageTelegram.
+ *
+ * Telegram's document size cap is 50 MiB. We pre-check and reject with a
+ * descriptive error so the caller can fall back to a text-only message
+ * if needed (in practice, plan markdowns are tiny — ~10-50 KB).
+ */
+export type TelegramDocumentOpts = {
+  cfg?: ReturnType<typeof loadConfig>;
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
+  /** Caption shown beneath the file in the chat. Truncated to 1024 chars. */
+  caption?: string;
+  /**
+   * Caption parse mode. Defaults to "HTML" when a non-empty caption is
+   * present (so the universal /plan resolution hint can use `<code>`
+   * markup). Pass `"MarkdownV2"` to switch formats. There is no
+   * "disable parse_mode" path while a caption is present — Telegram
+   * will receive `parse_mode: <this value>` whenever a caption is
+   * attached. When no caption is present, no `parse_mode` is sent.
+   *
+   * **Caller responsibility — escape user-controlled caption text.**
+   * Copilot review #68939 (2026-04-19): because the default is HTML
+   * mode, captions derived from agent- or user-controlled strings
+   * (plan titles, summaries, etc.) MUST be HTML-escaped by the
+   * caller before being passed in. The plan-archetype-bridge does
+   * this via `escapeHtml()` in `buildPlanAttachmentCaption`. New
+   * callers should mirror that pattern (or, if calling with
+   * `parseMode: "MarkdownV2"`, escape per Telegram's MarkdownV2
+   * grammar instead). Failure to escape risks accidental link
+   * injection / formatting drift — the bridge ESCAPES, so its
+   * captions are safe.
+   *
+   * Earlier docstring claimed "omit/empty to disable" which
+   * contradicted both the type union (no falsy value accepted) and
+   * the implementation (`?? (caption ? "HTML" : undefined)` always
+   * produces a value when caption is set).
+   */
+  parseMode?: "HTML" | "MarkdownV2";
+  /** Disable the upload + caption notification (silent attachment). */
+  silent?: boolean;
+  /** Message ID to reply to (for threading). */
+  replyToMessageId?: number;
+  /** Forum topic thread ID (for forum supergroups). */
+  messageThreadId?: number;
+};
+
+const TELEGRAM_DOCUMENT_MAX_BYTES = 50 * 1024 * 1024; // Telegram bot API limit
+const TELEGRAM_CAPTION_MAX_CHARS = 1024;
+
+export async function sendDocumentTelegram(
+  to: string,
+  filePath: string,
+  opts: TelegramDocumentOpts = {},
+): Promise<TelegramSendResult> {
+  if (!filePath?.trim()) {
+    throw new Error("Telegram document filePath is required");
+  }
+  // Defer the fs/path imports to avoid pulling Node-only modules into
+  // any browser/edge runtime that might import this file.
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+
+  // Copilot review #68939 (post-nuclear-fix-stack): stat() the
+  // file BEFORE allocating the read buffer so an oversized file
+  // doesn't trigger a multi-MB allocation just to be rejected on
+  // the size check below. Pre-fix, a caller pointing at a 50+ MiB
+  // file would allocate the full buffer and THEN reject — risking
+  // OOM in the gateway process under malicious or accidental
+  // misuse. The grammy SDK doesn't expose stream uploads cleanly
+  // (deferred to a future refactor), but stat-first is a cheap
+  // bounded-allocation guard.
+  let fileStat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    fileStat = await fs.stat(filePath);
+  } catch (err) {
+    throw new Error(
+      `sendDocumentTelegram: failed to stat ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (fileStat.size > TELEGRAM_DOCUMENT_MAX_BYTES) {
+    throw new Error(
+      `sendDocumentTelegram: file too large for Telegram (${fileStat.size} bytes > ${TELEGRAM_DOCUMENT_MAX_BYTES} byte cap)`,
+    );
+  }
+  let buffer: Buffer;
+  try {
+    buffer = await fs.readFile(filePath);
+  } catch (err) {
+    throw new Error(
+      `sendDocumentTelegram: failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const { cfg, account, api } = resolveTelegramApiContext({
+    ...opts,
+    cfg: opts.cfg ?? loadConfig(),
+  });
+  const target = parseTelegramTarget(to);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: to,
+    verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
+  });
+
+  const fileName = path.basename(filePath);
+  const file = new InputFileCtor(buffer, fileName);
+
+  const threadParams = buildTelegramThreadReplyParams({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+    replyToMessageId: opts.replyToMessageId,
+  });
+
+  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+  });
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag,
+    chatId,
+    input: to,
+  });
+
+  const captionRaw = opts.caption?.trim() ?? "";
+  const caption =
+    captionRaw.length > TELEGRAM_CAPTION_MAX_CHARS
+      ? captionRaw.slice(0, TELEGRAM_CAPTION_MAX_CHARS - 1) + "…"
+      : captionRaw;
+  const parseMode = opts.parseMode ?? (caption ? "HTML" : undefined);
+
+  const sendParams: Record<string, unknown> = {
+    ...threadParams,
+    ...(caption ? { caption } : {}),
+    ...(parseMode && caption ? { parse_mode: parseMode } : {}),
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+  };
+  const hasParams = Object.keys(sendParams).length > 0;
+
+  const result = await withTelegramThreadFallback(
+    hasParams ? (sendParams as TelegramThreadScopedParams) : undefined,
+    "document",
+    opts.verbose,
+    async (effectiveParams, label) =>
+      requestWithChatNotFound(
+        () =>
+          api.sendDocument(
+            chatId,
+            file,
+            effectiveParams as Parameters<typeof api.sendDocument>[2],
+          ) as Promise<TelegramMessageLike>,
+        label,
+      ),
+  );
+
+  const messageId = resolveTelegramMessageIdOrThrow(result, "document send");
+  const resolvedChatId = String(result?.chat?.id ?? chatId);
+  recordSentMessage(chatId, messageId);
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,

--- a/src/agents/plan-mode/plan-archetype-bridge.test.ts
+++ b/src/agents/plan-mode/plan-archetype-bridge.test.ts
@@ -1,0 +1,318 @@
+/**
+ * PR-14: tests for plan-archetype-bridge.ts orchestrator.
+ *
+ * The bridge is best-effort fire-and-forget. Tests focus on:
+ *   - Markdown is persisted regardless of channel.
+ *   - Telegram session → sendDocumentTelegram called with right args.
+ *   - Web/CLI session → no Telegram send (markdown still persisted).
+ *   - Send failure → caller does not throw, log.warn fires.
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildPlanAttachmentCaption,
+  dispatchPlanArchetypeAttachment,
+} from "./plan-archetype-bridge.js";
+
+const FIXED_DATE = new Date("2026-04-18T12:00:00Z");
+
+// Mock the SDK telegram seam so the bridge never actually opens a
+// network socket. The bridge dynamic-imports `../../plugin-sdk/telegram.js`
+// (which itself loads the bundled plugin's runtime-api lazily) — we
+// intercept at the SDK-facade layer.
+type SendDocArgs = [string, string, Record<string, unknown> | undefined];
+const sendDocumentTelegramMock = vi.hoisted(() =>
+  vi.fn(async (..._args: SendDocArgs) => ({
+    messageId: "100",
+    chatId: "tg-chat-1",
+  })),
+);
+vi.mock("../../plugin-sdk/telegram.js", () => ({
+  sendDocumentTelegram: sendDocumentTelegramMock,
+}));
+
+// Mock the session-store-read so we can control what
+// deliveryContextFromSession sees without touching disk.
+const readSessionStoreReadOnlyMock = vi.hoisted(() => vi.fn());
+vi.mock("../../config/sessions/store-read.js", () => ({
+  readSessionStoreReadOnly: readSessionStoreReadOnlyMock,
+}));
+
+// Stub the rest of the lookup chain (config/loadConfig, paths, routing).
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({ session: { store: undefined } }),
+}));
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveStorePath: () => "/tmp/test-store.json",
+}));
+vi.mock("../../routing/session-key.js", () => ({
+  parseAgentSessionKey: (k: string) => {
+    const m = /^agent:([^:]+):/.exec(k);
+    return m ? { agentId: m[1] } : undefined;
+  },
+}));
+
+describe("buildPlanAttachmentCaption (PR-14)", () => {
+  it("includes title + universal /plan resolution commands", () => {
+    const caption = buildPlanAttachmentCaption("Refactor X", "Short summary");
+    expect(caption).toContain("Refactor X");
+    expect(caption).toContain("Short summary");
+    expect(caption).toContain("/plan accept");
+    expect(caption).toContain("/plan accept edits");
+    expect(caption).toContain("/plan revise");
+  });
+
+  it("falls back to 'Plan' when title is undefined or empty", () => {
+    expect(buildPlanAttachmentCaption(undefined, undefined)).toContain("<b>Plan</b>");
+    expect(buildPlanAttachmentCaption("", undefined)).toContain("<b>Plan</b>");
+  });
+
+  it("HTML-escapes title + summary so injection in HTML parse_mode is neutralized", () => {
+    const caption = buildPlanAttachmentCaption("<script>", "<img onerror=...>");
+    expect(caption).toContain("&lt;script&gt;");
+    expect(caption).toContain("&lt;img onerror=");
+    expect(caption).not.toContain("<script>");
+  });
+});
+
+describe("dispatchPlanArchetypeAttachment (PR-14)", () => {
+  let tmpBase: string;
+
+  beforeEach(async () => {
+    sendDocumentTelegramMock.mockClear();
+    readSessionStoreReadOnlyMock.mockReset();
+    // Test base dir is passed as `persistBaseDir` instead of trying to
+    // spy on os.homedir (ESM module namespaces are not configurable).
+    tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bridge-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpBase, { recursive: true, force: true });
+  });
+
+  function makeDetails() {
+    return {
+      title: "Refactor websocket reconnect",
+      summary: "Address the close-race condition",
+      analysis: "Current state: races on close",
+      plan: [
+        { step: "Audit close handlers", status: "pending" },
+        { step: "Add idempotency guard", status: "pending" },
+      ],
+      assumptions: ["Tests pass first run"],
+      risks: [{ risk: "Reconnect storm", mitigation: "Backoff" }],
+      verification: ["pnpm test src/ws"],
+      references: ["src/ws/reconnect.ts:42"],
+    };
+  }
+
+  it("Telegram session: persists markdown AND sends document via sendDocumentTelegram (C2 re-wire)", async () => {
+    // PR-14 C2 re-wire (2026-04-20): the bridge now calls through
+    // the public plugin-sdk facade. Mock verifies (1) exact file
+    // path handed in, (2) caption is HTML-escaped, (3) parseMode
+    // is "HTML", and (4) log reflects success.
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:telegram:acct1:dm:peer1": {
+        origin: { provider: "telegram", accountId: "acct1", threadId: 7 },
+        deliveryContext: {
+          channel: "telegram",
+          to: "tg-chat-1",
+          accountId: "acct1",
+          threadId: 7,
+        },
+      },
+    });
+
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:dm:peer1",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+
+    const planDir = path.join(tmpBase, "main", "plans");
+    const files = await fs.readdir(planDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^plan-2026-04-18-refactor-websocket-reconnect\.md$/);
+    const absPath = path.join(planDir, files[0] ?? "");
+
+    expect(sendDocumentTelegramMock).toHaveBeenCalledTimes(1);
+    const callArgs = sendDocumentTelegramMock.mock.calls[0];
+    expect(callArgs?.[0]).toBe("tg-chat-1"); // to
+    expect(callArgs?.[1]).toBe(absPath); // filePath
+    expect(callArgs?.[2]?.parseMode).toBe("HTML");
+    expect(callArgs?.[2]?.caption).toContain("Refactor websocket reconnect");
+    expect(callArgs?.[2]?.caption).toContain("/plan accept");
+
+    // Success log reflects delivery + returned chatId/messageId from
+    // the mock. Distinguishes from the old "skipped" path.
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("plan-bridge: telegram attachment sent"),
+    );
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("chatId=tg-chat-1"));
+  });
+
+  it("Telegram topic-scoped target (chatId:topic:threadId): passes through to sendDocumentTelegram (SDK parses threadId)", async () => {
+    // PR-14 C2 re-wire: `parseTelegramTarget` inside the SDK auto-
+    // extracts `message_thread_id` from the `to` string. The bridge
+    // passes `to` through unchanged; the SDK does the parsing.
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:telegram:acct1:group:-100123:42": {
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100123:topic:42",
+          accountId: "acct1",
+        },
+      },
+    });
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:group:-100123:42",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+    expect(sendDocumentTelegramMock).toHaveBeenCalledTimes(1);
+    // The `to` string is passed through unchanged — SDK parses the
+    // :topic:threadId suffix on the other side.
+    expect(sendDocumentTelegramMock.mock.calls[0]?.[0]).toBe("-100123:topic:42");
+  });
+
+  it("Web session: persists markdown but does NOT send to Telegram", async () => {
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:main": {
+        origin: { provider: "web" },
+        deliveryContext: { channel: "web" },
+      },
+    });
+
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+
+    // Markdown still persisted (audit artifact for web sessions too).
+    const planDir = path.join(tmpBase, "main", "plans");
+    const files = await fs.readdir(planDir);
+    expect(files).toHaveLength(1);
+    // No Telegram send.
+    expect(sendDocumentTelegramMock).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(expect.stringContaining("no telegram delivery"));
+  });
+
+  it("Telegram session missing 'to': persists but skips Telegram send", async () => {
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:telegram:acct1:dm:peer1": {
+        origin: { provider: "telegram", accountId: "acct1" },
+        deliveryContext: { channel: "telegram", accountId: "acct1" }, // no `to`
+      },
+    });
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:dm:peer1",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+    expect(sendDocumentTelegramMock).not.toHaveBeenCalled();
+  });
+
+  it("Telegram send throws: caller does not throw, warn logged, markdown still persisted (C2 re-wire)", async () => {
+    // PR-14 C2 re-wire (2026-04-20): un-skipped. Verifies the
+    // fire-and-forget contract — network failure on the document
+    // send never surfaces to the agent runtime; it's logged-and-
+    // swallowed so the approval flow still completes.
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:telegram:acct1:dm:peer1": {
+        deliveryContext: { channel: "telegram", to: "tg-chat-1", accountId: "acct1" },
+      },
+    });
+    sendDocumentTelegramMock.mockRejectedValueOnce(new Error("network down"));
+
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    // Must not throw.
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:dm:peer1",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("network down"));
+    // Markdown still persisted before the failed send.
+    const planDir = path.join(tmpBase, "main", "plans");
+    const files = await fs.readdir(planDir);
+    expect(files).toHaveLength(1);
+  });
+
+  it("Multi-cycle: second exit_plan_mode same day produces -2.md suffix and fires both sends", async () => {
+    // PR-14 C2 re-wire (2026-04-20): re-instated the two-send
+    // assertion since Telegram delivery is live again. Collision-
+    // suffix file persistence + per-cycle send are both contracted.
+    readSessionStoreReadOnlyMock.mockReturnValue({
+      "agent:main:telegram:acct1:dm:peer1": {
+        deliveryContext: { channel: "telegram", to: "tg-chat-1", accountId: "acct1" },
+      },
+    });
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:dm:peer1",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:main:telegram:acct1:dm:peer1",
+      agentId: "main",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+    const planDir = path.join(tmpBase, "main", "plans");
+    const files = await fs.readdir(planDir);
+    expect(files).toHaveLength(2);
+    // Both files exist (sort order varies — `-2.md` sorts before `.md`
+    // because `-` (0x2D) precedes `.` (0x2E) in ASCII).
+    expect(files).toContain("plan-2026-04-18-refactor-websocket-reconnect.md");
+    expect(files).toContain("plan-2026-04-18-refactor-websocket-reconnect-2.md");
+    // Two cycles → two sends.
+    expect(sendDocumentTelegramMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("Missing SessionEntry (read returns undefined): no send, no throw", async () => {
+    readSessionStoreReadOnlyMock.mockReturnValue({});
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    await dispatchPlanArchetypeAttachment({
+      sessionKey: "agent:ghost:main",
+      agentId: "ghost",
+      details: makeDetails(),
+      log,
+      nowMs: FIXED_DATE.getTime(),
+      persistBaseDir: tmpBase,
+    });
+    expect(sendDocumentTelegramMock).not.toHaveBeenCalled();
+    // Markdown still persisted (audit value).
+    const planDir = path.join(tmpBase, "ghost", "plans");
+    const files = await fs.readdir(planDir);
+    expect(files).toHaveLength(1);
+  });
+});

--- a/src/agents/plan-mode/plan-archetype-bridge.ts
+++ b/src/agents/plan-mode/plan-archetype-bridge.ts
@@ -1,0 +1,203 @@
+import type { SessionEntry } from "../../config/sessions/types.js";
+/**
+ * PR-14: plan-mode → channel attachment bridge.
+ *
+ * When the runtime emits a plan-mode approval, this orchestrator:
+ *   1. Renders the full archetype as a markdown document.
+ *   2. Persists the markdown to ~/.openclaw/agents/<agentId>/plans/
+ *      so operators have a durable audit trail across all sessions.
+ *   3. If the originating session is from a channel that supports
+ *      file attachments (Telegram today; Discord/Slack/etc. later),
+ *      uploads the markdown as a document attachment to the chat
+ *      with a short caption containing the universal /plan
+ *      resolution slash commands.
+ *
+ * Resolution stays text-based via PR-11's universal /plan slash
+ * commands. This bridge is read-only (visibility), no approval-id
+ * translator required — sidesteps the dual-id problem documented in
+ * the PR-13 deferral notes.
+ *
+ * Always best-effort: failures log at warn and never propagate.
+ */
+import type { AgentApprovalPlanStep } from "../../infra/agent-events.js";
+import { renderFullPlanArchetypeMarkdown } from "../plan-render.js";
+import { persistPlanArchetypeMarkdown, PlanPersistStorageError } from "./plan-archetype-persist.js";
+
+export interface DispatchPlanArchetypeAttachmentInput {
+  sessionKey: string;
+  agentId: string;
+  /**
+   * The same `details` object passed to the approval emit — carries
+   * the full archetype (title, summary, plan steps, analysis,
+   * assumptions, risks, verification, references).
+   */
+  details: {
+    title?: string;
+    summary?: string;
+    analysis?: string;
+    plan: AgentApprovalPlanStep[];
+    assumptions?: string[];
+    risks?: Array<{ risk: string; mitigation: string }>;
+    verification?: string[];
+    references?: string[];
+  };
+  log?: {
+    info?: (msg: string) => void;
+    warn?: (msg: string) => void;
+    error?: (msg: string) => void;
+    debug?: (msg: string) => void;
+  };
+  /** Injectable now() for tests. */
+  nowMs?: number;
+  /**
+   * Override the persistence base directory (tests use a temp dir).
+   * Production never sets this — defaults to `~/.openclaw/agents` via
+   * persistPlanArchetypeMarkdown.
+   */
+  persistBaseDir?: string;
+}
+
+/**
+ * Build the short caption attached to the markdown document. Includes
+ * the plan title (if any) and the universal /plan resolution
+ * commands so the user knows how to act on the file from their
+ * channel. Truncated to ≤1000 chars by sendDocumentTelegram (Telegram
+ * caption limit is 1024).
+ */
+export function buildPlanAttachmentCaption(
+  title: string | undefined,
+  summary: string | undefined,
+): string {
+  const safeTitle = (title ?? "").trim() || "Plan";
+  const escTitle = escapeHtml(safeTitle);
+  const safeSummary = (summary ?? "").trim();
+  const summaryLine = safeSummary ? `\n${escapeHtml(safeSummary)}` : "";
+  return [
+    `<b>${escTitle}</b> — plan submitted for approval. See attached.`,
+    summaryLine,
+    "",
+    "Resolve with: <code>/plan accept</code> | <code>/plan accept edits</code> | <code>/plan revise &lt;feedback&gt;</code>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Read-only session entry lookup. Mirrors the
+ * `loadSessionStoreRuntime` + `updateSessionStoreEntry` pattern used
+ * elsewhere in the runtime, but as a non-mutating read.
+ */
+async function loadSessionEntryReadOnly(sessionKey: string): Promise<SessionEntry | undefined> {
+  try {
+    const [
+      { loadConfig },
+      { resolveStorePath },
+      { parseAgentSessionKey },
+      { readSessionStoreReadOnly },
+    ] = await Promise.all([
+      import("../../config/config.js"),
+      import("../../config/sessions/paths.js"),
+      import("../../routing/session-key.js"),
+      import("../../config/sessions/store-read.js"),
+    ]);
+    const cfg = loadConfig();
+    const parsed = parseAgentSessionKey(sessionKey);
+    const storePath = resolveStorePath(
+      cfg.session?.store,
+      parsed?.agentId ? { agentId: parsed.agentId } : {},
+    );
+    const store = readSessionStoreReadOnly(storePath);
+    return store[sessionKey];
+  } catch {
+    return undefined;
+  }
+}
+
+export async function dispatchPlanArchetypeAttachment(
+  input: DispatchPlanArchetypeAttachmentInput,
+): Promise<void> {
+  const log = input.log;
+  try {
+    // 1. Render markdown.
+    const markdown = renderFullPlanArchetypeMarkdown({
+      title: input.details.title ?? "Plan",
+      summary: input.details.summary,
+      analysis: input.details.analysis,
+      plan: input.details.plan as Parameters<typeof renderFullPlanArchetypeMarkdown>[0]["plan"],
+      assumptions: input.details.assumptions,
+      risks: input.details.risks,
+      verification: input.details.verification,
+      references: input.details.references,
+      generatedAt: input.nowMs ? new Date(input.nowMs) : undefined,
+    });
+
+    // 2. Persist (always — durable audit artifact).
+    const { absPath, filename } = await persistPlanArchetypeMarkdown({
+      agentId: input.agentId,
+      title: input.details.title,
+      markdown,
+      now: input.nowMs ? new Date(input.nowMs) : undefined,
+      ...(input.persistBaseDir ? { baseDir: input.persistBaseDir } : {}),
+    });
+    log?.info?.(`plan-bridge: persisted ${filename}`);
+
+    // 3. Channel-aware delivery. Read SessionEntry → deliveryContext.
+    const entry = await loadSessionEntryReadOnly(input.sessionKey);
+    const { deliveryContextFromSession } = await import("../../utils/delivery-context.shared.js");
+    const dctx = entry ? deliveryContextFromSession(entry) : undefined;
+    if (!dctx?.channel || dctx.channel !== "telegram" || !dctx.to) {
+      log?.debug?.(
+        `plan-bridge: no telegram delivery (channel=${dctx?.channel ?? "none"}, to=${dctx?.to ?? "none"})`,
+      );
+      return;
+    }
+
+    // 4. Telegram document upload — PR-14 re-wire (C2 follow-up).
+    // `sendDocumentTelegram` is now re-exported from the public plugin
+    // SDK facade at `openclaw/plugin-sdk/telegram` (see
+    // `src/plugin-sdk/telegram.ts:51`). The facade lazy-loads the
+    // bundled Telegram runtime-api module so cold paths don't pay the
+    // Telegram-bundle startup cost — we follow the same dynamic-
+    // import pattern here so plan-bridge import doesn't drag Telegram
+    // bytes into agent startup.
+    //
+    // Thread-ID handling: `parseTelegramTarget` inside
+    // `sendDocumentTelegram` auto-extracts `message_thread_id` from
+    // the `to` string (formats: `chatId`, `chatId:threadId`,
+    // `chatId:topic:threadId`). The legacy commented-out
+    // `parseTelegramThreadId` helper above is superseded and can be
+    // removed in a future cleanup.
+    const caption = buildPlanAttachmentCaption(input.details.title, input.details.summary);
+    const { sendDocumentTelegram } = await import("../../plugin-sdk/telegram.js");
+    const sendResult = await sendDocumentTelegram(dctx.to, absPath, {
+      caption,
+      parseMode: "HTML",
+    });
+    log?.info?.(
+      `plan-bridge: telegram attachment sent chatId=${sendResult.chatId} msgId=${sendResult.messageId}`,
+    );
+  } catch (err) {
+    // R4 (C1 follow-up): recoverable storage errors are not bugs —
+    // they're operator-actionable conditions (full disk, bad
+    // permissions, hardware I/O). Emit a distinctive log line so
+    // operators can grep their gateway log for
+    // `[plan-bridge/storage]` without digging through
+    // unrelated plan-bridge failures. Plan approval still proceeds;
+    // only the durable audit artifact is lost for this cycle.
+    if (err instanceof PlanPersistStorageError) {
+      log?.warn?.(
+        `[plan-bridge/storage] markdown persist failed (${err.code}) — ` +
+          `plan approval proceeds but audit artifact was NOT written. ` +
+          `Operator action: check ~/.openclaw free space / permissions. Detail: ${err.message}`,
+      );
+      return;
+    }
+    log?.warn?.(
+      `plan-bridge attachment failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -1,0 +1,717 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderFullPlanArchetypeMarkdown,
+  renderPlanChecklist,
+  renderPlanWithHeader,
+  type PlanStepForRender,
+  type PlanRenderFormat,
+} from "./plan-render.js";
+
+const SAMPLE_STEPS: PlanStepForRender[] = [
+  { step: "Run tests", status: "completed" },
+  { step: "Build artifacts", status: "in_progress", activeForm: "Building artifacts" },
+  { step: "Deploy to staging", status: "pending" },
+  { step: "Fix broken migration", status: "cancelled" },
+];
+
+describe("renderPlanChecklist", () => {
+  it("returns empty string for empty steps", () => {
+    expect(renderPlanChecklist([], "markdown")).toBe("");
+  });
+
+  const formats: PlanRenderFormat[] = ["html", "markdown", "plaintext", "slack-mrkdwn"];
+
+  for (const format of formats) {
+    describe(`format: ${format}`, () => {
+      it("renders all four statuses", () => {
+        const result = renderPlanChecklist(SAMPLE_STEPS, format);
+        const lines = result.split("\n");
+        expect(lines).toHaveLength(4);
+      });
+
+      it("uses activeForm for in_progress steps", () => {
+        const result = renderPlanChecklist(SAMPLE_STEPS, format);
+        expect(result).toContain("Building artifacts");
+        expect(result).not.toContain("Build artifacts");
+      });
+
+      it("falls back to step text when activeForm is absent", () => {
+        const steps: PlanStepForRender[] = [{ step: "Deploy", status: "in_progress" }];
+        const result = renderPlanChecklist(steps, format);
+        expect(result).toContain("Deploy");
+      });
+    });
+  }
+
+  it("html: escapes HTML in step text", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Check <script>alert(1)</script>", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "html");
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("html: renders completed with ✅", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "html");
+    expect(result).toMatch(/✅.*Run tests/);
+  });
+
+  it("strips newlines from step labels", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests\nthen check results", status: "pending" },
+      { step: "Build\r\nartifacts", status: "in_progress", activeForm: "Building\nartifacts" },
+    ];
+    for (const format of ["html", "markdown", "plaintext", "slack-mrkdwn"] as const) {
+      const result = renderPlanChecklist(steps, format);
+      expect(result).not.toContain("\n ");
+      expect(result).not.toContain("\r");
+      expect(result).toContain("Run tests then check results");
+      expect(result).toContain("Building artifacts");
+    }
+  });
+
+  it("html: renders cancelled with strikethrough", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "html");
+    expect(result).toMatch(/❌.*<s>.*Fix broken migration.*<\/s>/);
+  });
+
+  it("markdown: renders checkboxes", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "markdown");
+    expect(result).toContain("- [x] Run tests");
+    expect(result).toContain("- [>] **Building artifacts**");
+    expect(result).toContain("- [ ] Deploy to staging");
+    expect(result).toContain("- [~] ~~Fix broken migration~~");
+  });
+
+  it("plaintext: renders ASCII markers", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "plaintext");
+    expect(result).toContain("[x] Run tests");
+    expect(result).toContain("[>] Building artifacts");
+    expect(result).toContain("[ ] Deploy to staging");
+    expect(result).toContain("[~] Fix broken migration");
+  });
+
+  it("slack-mrkdwn: renders Slack formatting", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "slack-mrkdwn");
+    expect(result).toContain("✅ Run tests");
+    expect(result).toContain("⏳ *Building artifacts*");
+    expect(result).toContain("⬚ Deploy to staging");
+    expect(result).toContain("❌ ~Fix broken migration~");
+  });
+
+  it("slack-mrkdwn: escapes control characters and mention tokens", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Check *bold* and _italic_ text", status: "pending" },
+      { step: "Handle <@U123> mention and <!here>", status: "pending" },
+      { step: "Test `backtick` and ~strike~ and @channel", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "slack-mrkdwn");
+    // Must not contain raw Slack formatting chars
+    expect(result).not.toContain("<@U123>");
+    expect(result).not.toContain("<!here>");
+    expect(result).not.toMatch(/(?<!\u2217)\*(?!\u2217)/); // no raw asterisks
+    expect(result).not.toContain("@channel");
+  });
+
+  it("slack-mrkdwn: title escaping in renderPlanWithHeader", () => {
+    const steps: PlanStepForRender[] = [{ step: "Step one", status: "pending" }];
+    const result = renderPlanWithHeader("Plan *with* <@mention>", steps, "slack-mrkdwn");
+    expect(result).not.toContain("<@mention>");
+    expect(result).toContain("Plan");
+  });
+});
+
+describe("renderPlanWithHeader", () => {
+  it("renders header + checklist for each format", () => {
+    for (const format of ["html", "markdown", "plaintext", "slack-mrkdwn"] as const) {
+      const result = renderPlanWithHeader("Agent Plan", SAMPLE_STEPS, format);
+      expect(result).toContain("Agent Plan");
+      expect(result.split("\n").length).toBeGreaterThan(4);
+    }
+  });
+
+  it("returns empty string when no steps", () => {
+    expect(renderPlanWithHeader("Empty", [], "markdown")).toBe("");
+  });
+
+  it("html header uses bold", () => {
+    const result = renderPlanWithHeader("My Plan", SAMPLE_STEPS, "html");
+    expect(result).toMatch(/^<b>My Plan<\/b>/);
+  });
+
+  it("markdown header uses h3", () => {
+    const result = renderPlanWithHeader("My Plan", SAMPLE_STEPS, "markdown");
+    expect(result).toMatch(/^### My Plan/);
+  });
+});
+
+describe("markdown injection hardening", () => {
+  it("escapes backticks in step text (no code spans from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "Deploy `rm -rf /`", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    // No raw backticks left that would form a code span
+    expect(md).not.toMatch(/[^\\]`/);
+    // Backticks are escaped
+    expect(md).toContain("\\`");
+  });
+
+  it("escapes link syntax (no clickable links from user input)", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Click [here](https://evil.example)", status: "pending" },
+    ];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).not.toMatch(/\[here\]\(https/);
+    expect(md).toContain("\\[here\\]");
+  });
+
+  it("escapes emphasis markers (no bold/italic from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "*shouting* and _whispering_", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).not.toMatch(/\*shouting\*/);
+    expect(md).toContain("\\*shouting\\*");
+  });
+
+  it("escapes heading markers (no inline h1 from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "# Important note", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).toContain("\\# Important note");
+  });
+
+  it("cancelled status with markdown injection: both strikethrough and escaping applied", () => {
+    const steps: PlanStepForRender[] = [{ step: "Deploy `prod`", status: "cancelled" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).toContain("~~Deploy \\`prod\\`~~");
+  });
+
+  // PR-C review fix (Codex P2 #3096528415 / Copilot #3096792952 + #3105215256):
+  // step labels containing `~` or `~~` must be escaped so they don't
+  // close the cancelled-step `~~...~~` strikethrough wrapper early.
+  it("escapes tildes in step text (no premature strikethrough close)", () => {
+    const steps: PlanStepForRender[] = [{ step: "Deploy ~~prod~~ now", status: "cancelled" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    // Tildes in step text are escaped; the outer wrapper stays intact.
+    expect(md).toContain("\\~\\~prod\\~\\~");
+    // Verify the line still parses as a single cancelled item (one outer
+    // strikethrough wrapper, not three separate broken segments).
+    expect(md).toMatch(/^- \[~\] ~~Deploy \\~\\~prod\\~\\~ now~~$/);
+  });
+
+  it("escapes a single tilde character in step text", () => {
+    const steps: PlanStepForRender[] = [{ step: "rsync src ~ dest", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).toContain("rsync src \\~ dest");
+  });
+
+  // PR-C review fix (Copilot #3105042738 / #3105215256): markdown title
+  // in renderPlanWithHeader must escape metacharacters so an
+  // agent-controlled title can't inject markdown formatting (links,
+  // code, headings, emphasis) into the rendered header line.
+  it("renderPlanWithHeader markdown: escapes metacharacters in title", () => {
+    const steps: PlanStepForRender[] = [{ step: "Step one", status: "pending" }];
+    const title = "# Release `notes` [click](https://evil.example) ~~strike~~";
+    const result = renderPlanWithHeader(title, steps, "markdown");
+    // No raw clickable link
+    expect(result).not.toMatch(/\[click\]\(https/);
+    // No raw code span (escaped backticks)
+    expect(result).toContain("\\`notes\\`");
+    // No raw inline heading marker (escaped `#`)
+    expect(result).toContain("\\#");
+    // No raw outer strikethrough (escaped `~`)
+    expect(result).toContain("\\~\\~strike\\~\\~");
+    // Header line still rendered as h3 (the explicit `### ` prefix)
+    expect(result).toMatch(/^### /);
+  });
+});
+
+describe("mention neutralization", () => {
+  it("plaintext: neutralizes @channel", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Notify @channel about deploy", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).not.toContain("@channel");
+    expect(result).toContain("@\uFE6Bchannel");
+  });
+
+  it("plaintext: neutralizes @here and @everyone", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "@here review needed", status: "pending" },
+      { step: "@everyone please respond", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).not.toMatch(/@here\b/);
+    expect(result).not.toMatch(/@everyone\b/);
+  });
+
+  it("plaintext: leaves regular @mentions of users alone", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Assign @alice to investigate", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).toContain("@alice");
+  });
+
+  it("plaintext renderPlanWithHeader: neutralizes @everyone in TITLE (Codex P2 r3095517064)", () => {
+    // Adversarial regression: prior implementation neutralized step labels
+    // but emitted the title verbatim. A model-derived title like
+    // `@everyone release plan` would still trigger mentions.
+    const steps: PlanStepForRender[] = [{ step: "Tag release", status: "pending" }];
+    const result = renderPlanWithHeader("@everyone release plan", steps, "plaintext");
+    expect(result).not.toMatch(/@everyone\b/);
+    expect(result).toContain("release plan");
+  });
+
+  it("plaintext renderPlanWithHeader: neutralizes @channel and @here in TITLE", () => {
+    const steps: PlanStepForRender[] = [{ step: "S", status: "pending" }];
+    const result1 = renderPlanWithHeader("@channel deploy now", steps, "plaintext");
+    expect(result1).not.toMatch(/@channel\b/);
+
+    const result2 = renderPlanWithHeader("@here urgent", steps, "plaintext");
+    expect(result2).not.toMatch(/@here\b/);
+  });
+
+  // PR-11 deep-dive review B1: pre-fix, neutralizeMentions only fired
+  // for plaintext + slack-mrkdwn. Markdown (Discord/Mattermost/Matrix)
+  // and HTML (Telegram) leaked @everyone/@here/@channel + Discord
+  // raw-mention syntax. These tests pin the post-fix behavior.
+  it("markdown: neutralizes @channel/@here/@everyone in step text (review B1)", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Notify @channel about deploy", status: "pending" },
+      { step: "@here review needed", status: "pending" },
+      { step: "@everyone please respond", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).not.toMatch(/@channel\b/);
+    expect(result).not.toMatch(/@here\b/);
+    expect(result).not.toMatch(/@everyone\b/);
+  });
+
+  it("markdown: neutralizes Discord raw mentions <@123> / <@!123> / <@&123> (review B1)", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Ping <@!12345> for review", status: "pending" },
+      { step: "Notify role <@&98765>", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    // The `<@` sequence must be broken with U+200B so Discord's parser
+    // doesn't treat it as a mention.
+    expect(result).not.toContain("<@!12345>");
+    expect(result).not.toContain("<@&98765>");
+    expect(result).toContain("<\u200B@");
+  });
+
+  it("html: neutralizes @channel/@here/@everyone in step text (review B1)", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Notify @channel about deploy", status: "pending" },
+      { step: "@everyone please respond", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "html");
+    expect(result).not.toMatch(/@channel\b/);
+    expect(result).not.toMatch(/@everyone\b/);
+  });
+
+  it("markdown renderPlanWithHeader: neutralizes @everyone in TITLE (review B1)", () => {
+    const steps: PlanStepForRender[] = [{ step: "Tag release", status: "pending" }];
+    const result = renderPlanWithHeader("@everyone release plan", steps, "markdown");
+    expect(result).not.toMatch(/@everyone\b/);
+    expect(result).toContain("release plan");
+  });
+});
+
+describe("activeForm fallback", () => {
+  it("uses step text when activeForm is whitespace-only", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests", status: "in_progress", activeForm: "   " },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Run tests");
+    expect(result).not.toContain("   ");
+  });
+
+  it("uses step text when activeForm is empty string", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Build artifacts", status: "in_progress", activeForm: "" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Build artifacts");
+  });
+
+  it("uses activeForm when present and non-empty", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests", status: "in_progress", activeForm: "Running tests" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Running tests");
+    expect(result).not.toContain("Run tests");
+  });
+});
+
+describe("HTML escaping", () => {
+  it("escapes quotes in addition to angle brackets and ampersand", () => {
+    const steps: PlanStepForRender[] = [
+      { step: `Quote: "double" and 'single' & <tag>`, status: "pending" },
+    ];
+    const html = renderPlanChecklist(steps, "html");
+    expect(html).toContain("&quot;");
+    expect(html).toContain("&#39;");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&lt;tag&gt;");
+  });
+
+  // PR-9 Wave B1: closure-gate rendering — acceptance criteria appear
+  // as a nested checklist beneath each step.
+  describe("closure-gate criteria rendering (Wave B1)", () => {
+    const STEP_WITH_CRITERIA: PlanStepForRender = {
+      step: "Provision VM",
+      status: "in_progress",
+      acceptanceCriteria: ["VM is reachable via SSH", "cortex_owner is set"],
+      verifiedCriteria: ["VM is reachable via SSH"],
+    };
+
+    it("markdown: renders verified as [x] and unverified as [ ] under the step", () => {
+      const out = renderPlanChecklist([STEP_WITH_CRITERIA], "markdown");
+      expect(out).toContain("- [x] VM is reachable via SSH");
+      expect(out).toContain("- [ ] cortex\\_owner is set"); // markdown escape on _
+    });
+
+    it("plaintext: renders verified [x] and unverified [ ] under the step", () => {
+      const out = renderPlanChecklist([STEP_WITH_CRITERIA], "plaintext");
+      const lines = out.split("\n");
+      expect(lines.some((l) => l.includes("[x] VM is reachable via SSH"))).toBe(true);
+      expect(lines.some((l) => l.includes("[ ] cortex_owner is set"))).toBe(true);
+    });
+
+    it("html: renders verified ✓ and unverified ◻ under the step", () => {
+      const out = renderPlanChecklist([STEP_WITH_CRITERIA], "html");
+      expect(out).toContain("✓ VM is reachable via SSH");
+      expect(out).toContain("◻ cortex_owner is set");
+    });
+
+    it("slack-mrkdwn: renders verified ✓ and unverified ◻", () => {
+      const out = renderPlanChecklist([STEP_WITH_CRITERIA], "slack-mrkdwn");
+      expect(out).toContain("✓ VM is reachable via SSH");
+      // Slack escapes `_` → fullwidth `＿` (avoid italic interpretation).
+      expect(out).toMatch(/◻ cortex.owner is set/);
+    });
+
+    it("empty acceptanceCriteria → no nested lines (backwards-compat)", () => {
+      const step: PlanStepForRender = {
+        step: "Simple step",
+        status: "completed",
+        acceptanceCriteria: [],
+      };
+      const out = renderPlanChecklist([step], "markdown");
+      expect(out.split("\n")).toHaveLength(1);
+    });
+
+    it("undefined verifiedCriteria → all entries render as unverified", () => {
+      const step: PlanStepForRender = {
+        step: "X",
+        status: "in_progress",
+        acceptanceCriteria: ["a", "b", "c"],
+      };
+      const out = renderPlanChecklist([step], "markdown");
+      expect(out).toContain("- [ ] a");
+      expect(out).toContain("- [ ] b");
+      expect(out).toContain("- [ ] c");
+      expect(out).not.toContain("- [x]");
+    });
+
+    it("criteria text with newlines is collapsed to space", () => {
+      const step: PlanStepForRender = {
+        step: "X",
+        status: "in_progress",
+        acceptanceCriteria: ["line1\nline2\rline3"],
+      };
+      const out = renderPlanChecklist([step], "markdown");
+      expect(out).toContain("line1 line2 line3");
+      expect(out).not.toContain("\nline2");
+    });
+
+    it("html criteria escapes user content", () => {
+      const step: PlanStepForRender = {
+        step: "X",
+        status: "in_progress",
+        acceptanceCriteria: [`<tag>"quoted"`],
+      };
+      const out = renderPlanChecklist([step], "html");
+      expect(out).toContain("&lt;tag&gt;");
+      expect(out).toContain("&quot;quoted&quot;");
+    });
+  });
+});
+
+describe("renderFullPlanArchetypeMarkdown (PR-14)", () => {
+  const FIXED_DATE = new Date("2026-04-18T12:00:00Z");
+  const minimalSteps: PlanStepForRender[] = [
+    { step: "Step 1", status: "pending" },
+    { step: "Step 2", status: "in_progress", activeForm: "Doing step 2" },
+  ];
+
+  it("renders a minimal plan with only title + steps (optional sections omitted)", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Minimal plan",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    expect(out).toContain("# Minimal plan");
+    expect(out).toContain("## Plan");
+    // Optional sections must NOT appear when fields are absent.
+    expect(out).not.toContain("## Summary");
+    expect(out).not.toContain("## Analysis");
+    expect(out).not.toContain("## Assumptions");
+    expect(out).not.toContain("## Risks");
+    expect(out).not.toContain("## Verification");
+    expect(out).not.toContain("## References");
+    // Footer is always present.
+    expect(out).toContain("2026-04-18");
+    expect(out).toContain("/plan accept");
+  });
+
+  it("renders the full archetype with all sections in canonical order", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Full plan",
+      summary: "Refactor the websocket reconnect race condition.",
+      analysis: "Current state: races on close.\n\nProposed: idempotent close + retry.",
+      plan: minimalSteps,
+      assumptions: ["Tests pass on first run", "API is stable"],
+      risks: [{ risk: "Reconnect storm", mitigation: "Exponential backoff" }],
+      verification: ["pnpm test src/ws/ passes", "Manual reconnect smoke"],
+      references: ["src/ws/reconnect.ts:42", "PR #67999"],
+      generatedAt: FIXED_DATE,
+    });
+    // Canonical section order
+    const titleIdx = out.indexOf("# Full plan");
+    const summaryIdx = out.indexOf("## Summary");
+    const analysisIdx = out.indexOf("## Analysis");
+    const planIdx = out.indexOf("## Plan");
+    const assumptionsIdx = out.indexOf("## Assumptions");
+    const risksIdx = out.indexOf("## Risks");
+    const verificationIdx = out.indexOf("## Verification");
+    const referencesIdx = out.indexOf("## References");
+    expect(titleIdx).toBeGreaterThanOrEqual(0);
+    expect(summaryIdx).toBeGreaterThan(titleIdx);
+    expect(analysisIdx).toBeGreaterThan(summaryIdx);
+    expect(planIdx).toBeGreaterThan(analysisIdx);
+    expect(assumptionsIdx).toBeGreaterThan(planIdx);
+    expect(risksIdx).toBeGreaterThan(assumptionsIdx);
+    expect(verificationIdx).toBeGreaterThan(risksIdx);
+    expect(referencesIdx).toBeGreaterThan(verificationIdx);
+    // Risk + mitigation rendered as bold + colon
+    expect(out).toContain("**Reconnect storm**: Exponential backoff");
+  });
+
+  it("preserves analysis paragraph breaks (paragraph separator preserved through escape)", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Para test",
+      analysis: "First paragraph.\n\nSecond paragraph.\n\nThird.",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    // escapeMarkdown escapes the period, but the paragraph TEXT is intact.
+    expect(out).toContain("First paragraph");
+    expect(out).toContain("Second paragraph");
+    expect(out).toContain("Third");
+    // The paragraph break is preserved (\n\n separator between paragraphs).
+    const analysisIdx = out.indexOf("## Analysis");
+    const planIdx = out.indexOf("## Plan");
+    const analysisBody = out.slice(analysisIdx, planIdx);
+    expect(
+      analysisBody.split(/\n\n/).filter((p) => p.trim().length > 0).length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("filters empty entries from list-shaped sections", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Filter test",
+      plan: minimalSteps,
+      assumptions: ["valid", "  ", ""],
+      verification: ["", "real check"],
+      references: ["   "],
+      generatedAt: FIXED_DATE,
+    });
+    expect(out).toContain("- valid");
+    expect(out).toContain("- real check");
+    // References was all empty/whitespace → section omitted
+    expect(out).not.toContain("## References");
+  });
+
+  it("filters risks entries missing risk OR mitigation", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Risk filter",
+      plan: minimalSteps,
+      risks: [
+        { risk: "valid risk", mitigation: "valid mitigation" },
+        { risk: "lone risk", mitigation: "" },
+        { risk: "", mitigation: "lone mitigation" },
+      ],
+      generatedAt: FIXED_DATE,
+    });
+    expect(out).toContain("**valid risk**: valid mitigation");
+    expect(out).not.toContain("lone risk");
+    expect(out).not.toContain("lone mitigation");
+  });
+
+  it("neutralizes mention bombs in title + analysis (PR-11 B1 parity)", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "@everyone deploy now",
+      analysis: "Notify @channel and ping <@!12345>",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    // The literal @-mention triggers must NOT appear unbroken
+    expect(out).not.toMatch(/@everyone\b/);
+    expect(out).not.toMatch(/@channel\b/);
+    // Discord raw mention must not survive intact
+    expect(out).not.toContain("<@!12345>");
+  });
+
+  it("escapes markdown special chars in user-controlled fields", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "[evil](link)",
+      summary: "`code injection` attempt",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    // [, ], (, ), ` should all be escaped with backslashes
+    expect(out).toContain("\\[evil\\]\\(link\\)");
+    expect(out).toContain("\\`code injection\\`");
+  });
+
+  it("emits placeholder when plan steps array is empty", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "Empty plan",
+      plan: [],
+      generatedAt: FIXED_DATE,
+    });
+    expect(out).toContain("## Plan");
+    expect(out).toContain("_No plan steps provided._");
+  });
+
+  it("falls back to 'Untitled plan' when title is empty", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    expect(out).toContain("# Untitled plan");
+  });
+});
+
+// R3 (C1 follow-up): adversarial XSS / injection hardening for plan
+// title across every render format that reaches a user surface.
+// Titles are the highest-risk field because they come from the model
+// (potentially prompt-injected) and render into: webchat DOM, Telegram
+// HTML captions, markdown-attachment files, and Slack mrkdwn. Any
+// executable payload smuggled in must render inert on every surface.
+describe("plan title XSS / injection hardening", () => {
+  const FIXED_DATE = new Date("2026-04-18T12:00:00Z");
+  const minimalSteps: PlanStepForRender[] = [{ step: "Step 1", status: "pending" }];
+
+  const XSS_PAYLOADS: ReadonlyArray<[string, string]> = [
+    // [label, title]
+    ["script tag", "<script>alert('xss')</script>"],
+    ["img onerror", `<img src=x onerror="alert(1)">`],
+    ["svg onload", `<svg/onload=alert(1)>`],
+    ["javascript: href", `<a href="javascript:alert(1)">click</a>`],
+    ["HTML entity escape attempt", "&lt;script&gt;alert(1)&lt;/script&gt;"],
+    ["mixed case tag", "<ScRiPt>alert(1)</ScRiPt>"],
+    ["nested quotes", `"><script>alert(1)</script>`],
+    ["data: URL", `<a href="data:text/html,<script>alert(1)</script>">x</a>`],
+  ];
+
+  describe("renderPlanWithHeader (channel-delivered plan)", () => {
+    for (const [label, title] of XSS_PAYLOADS) {
+      it(`html format: ${label} renders as escaped text, not executable markup`, () => {
+        const out = renderPlanWithHeader(title, minimalSteps, "html");
+        // No raw script tag (case-insensitive, since the renderer must
+        // also neutralize `<ScRiPt>` variants that browsers normalize).
+        expect(out.toLowerCase()).not.toContain("<script");
+        expect(out.toLowerCase()).not.toContain("</script");
+        // Event-handler attributes must not survive as executable
+        // attributes — the `<` before them must be escaped.
+        expect(out).not.toMatch(/<[a-z][^>]*\bonerror\s*=/i);
+        expect(out).not.toMatch(/<[a-z][^>]*\bonload\s*=/i);
+        // javascript:/data: hrefs must not survive as live URLs inside
+        // a `<a>` tag. The escape chain converts `<` to `&lt;` so any
+        // href attribute is no longer attached to a live element.
+        if (title.includes("javascript:") || title.includes("data:")) {
+          expect(out).not.toMatch(/<a\s+href\s*=/i);
+        }
+      });
+
+      it(`markdown format: ${label} survives as plain text (markdown cannot execute)`, () => {
+        const out = renderPlanWithHeader(title, minimalSteps, "markdown");
+        // Markdown renderers may produce <script> if the source contains
+        // raw HTML. Our renderer escapes markdown special chars but NOT
+        // HTML — defense-in-depth is the consumer-side sanitizer. This
+        // test pins that the title doesn't get injected as a raw markdown
+        // link construction (`[text](url)`) which a markdown renderer
+        // WOULD turn into a live link.
+        // Square brackets and parens from adversarial titles must be
+        // backslash-escaped so they don't form `[text](url)` links.
+        if (title.includes("[") || title.includes("(")) {
+          expect(out).toMatch(/\\[[\]()]/);
+        }
+      });
+
+      it(`plaintext format: ${label} passes through without active markup`, () => {
+        const out = renderPlanWithHeader(title, minimalSteps, "plaintext");
+        // Plaintext is the terminal/SMS/iMessage rendering — no
+        // sanitization required, but no format should *introduce*
+        // executable markup either. The title appears verbatim on the
+        // first line. Verify it does not truncate or double-escape.
+        expect(out.split("\n")[0]).toBe(title.replace(/[\n\r]+/g, " ").trim());
+      });
+
+      it(`slack-mrkdwn format: ${label} has < and > escaped so Slack does not lex tags`, () => {
+        const out = renderPlanWithHeader(title, minimalSteps, "slack-mrkdwn");
+        // Slack treats `<url|text>` as a link and `<@id>` as a mention.
+        // The escape chain converts `<` and `>` to fullwidth variants
+        // so a crafted title cannot forge a link or mention.
+        if (title.includes("<")) {
+          // Either escaped to &lt; (HTML-style) or kept benign by
+          // mention-neutralization. Raw `<` followed by an alphanumeric
+          // character must NOT survive (would be parsed as a Slack
+          // tag).
+          expect(out).not.toMatch(/<[a-zA-Z0-9!@#/]/);
+        }
+      });
+    }
+  });
+
+  describe("renderFullPlanArchetypeMarkdown (attachment file)", () => {
+    for (const [label, title] of XSS_PAYLOADS) {
+      it(`${label} in title: markdown H1 escapes brackets/parens/HTML metachars`, () => {
+        const out = renderFullPlanArchetypeMarkdown({
+          title,
+          plan: minimalSteps,
+          generatedAt: FIXED_DATE,
+        });
+        // Title always appears as `# <escaped-title>`.
+        const h1Match = out.match(/^# (.+)$/m);
+        expect(h1Match).toBeTruthy();
+        // Square brackets / parens must be escaped so markdown renderers
+        // don't interpret them as `[text](url)` links.
+        if (title.includes("[") || title.includes("(")) {
+          expect(h1Match?.[1]).toMatch(/\\[[\]()]/);
+        }
+      });
+    }
+  });
+
+  it("path-traversal-shaped title renders with escaped metacharacters", () => {
+    const out = renderFullPlanArchetypeMarkdown({
+      title: "../../etc/passwd",
+      plan: minimalSteps,
+      generatedAt: FIXED_DATE,
+    });
+    // The escape chain converts `.` to `\.` so a markdown renderer
+    // cannot turn the title into a link or interpret the traversal
+    // as a file reference. Filesystem defense is handled separately
+    // by `buildPlanFilenameSlug` in plan-archetype-prompt.ts.
+    expect(out).toContain("\\.\\./\\.\\./etc/passwd");
+    // No extra blank H1 from adversarial newlines.
+    expect(out).not.toMatch(/\n\n# /);
+  });
+});

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -1,0 +1,463 @@
+/**
+ * Plan checklist renderer for the GPT-5 parity sprint.
+ *
+ * Takes structured plan step data and renders it as a native checklist
+ * for each delivery surface. Channel adapters call
+ * {@link renderPlanChecklist} with the appropriate format.
+ *
+ * Step shape matches the `update_plan` tool output (step, status,
+ * activeForm) PLUS PR-9 Wave B1 closure-gate fields
+ * (acceptanceCriteria, verifiedCriteria). The status union here includes
+ * `cancelled` per PR-B (#67514) — `PLAN_STEP_STATUSES` in
+ * `src/agents/tools/update-plan-tool.ts:24` is the authoritative list.
+ * Callers map agent tool output into this shape; they may also provide
+ * step text from heterogeneous sources (compaction snapshots, channel
+ * adapters) where validation isn't pre-applied.
+ */
+
+export type PlanRenderFormat = "html" | "markdown" | "plaintext" | "slack-mrkdwn";
+
+export interface PlanStepForRender {
+  step: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  activeForm?: string;
+  /**
+   * PR-9 Wave B1 — closure-gate fields. Optional; when present, the
+   * channel renderer surfaces acceptance criteria as a nested checklist
+   * under each step (verified vs not). Backwards-compatible: omit both
+   * fields and rendering is unchanged.
+   */
+  acceptanceCriteria?: string[];
+  verifiedCriteria?: string[];
+}
+
+/**
+ * Renders an array of plan steps into a formatted checklist string.
+ *
+ * - `html`: Telegram HTML parse mode (`<b>`, `<s>`, emoji markers)
+ * - `markdown`: GitHub-flavored markdown checkboxes
+ * - `plaintext`: ASCII markers for iMessage / BlueBubbles / SMS
+ * - `slack-mrkdwn`: Slack's mrkdwn format (`*bold*`, `~strike~`)
+ */
+export function renderPlanChecklist(steps: PlanStepForRender[], format: PlanRenderFormat): string {
+  if (steps.length === 0) {
+    return "";
+  }
+
+  const lines = steps.map((s) => {
+    // Treat whitespace-only activeForm as missing — fall back to step text.
+    const hasUsableActiveForm = typeof s.activeForm === "string" && s.activeForm.trim().length > 0;
+    const rawLabel = s.status === "in_progress" && hasUsableActiveForm ? s.activeForm! : s.step;
+    // Strip newlines from model-generated step text to prevent broken checklists.
+    const label = rawLabel.replace(/[\n\r]+/g, " ").trim();
+    const stepLine = renderStepLine(s.status, label, format);
+    const criteriaLines = renderAcceptanceCriteria(s, format);
+    return criteriaLines.length > 0 ? [stepLine, ...criteriaLines].join("\n") : stepLine;
+  });
+
+  return lines.join("\n");
+}
+
+function renderStepLine(
+  status: PlanStepForRender["status"],
+  label: string,
+  format: PlanRenderFormat,
+): string {
+  switch (format) {
+    case "html": {
+      // PR-11 deep-dive review B1: neutralize mentions BEFORE escaping
+      // so an agent-controlled step text like "@everyone deploy now"
+      // can't ping a Telegram channel or any HTML-rendering surface
+      // that follows mention conventions.
+      const esc = escapeHtml(neutralizeMentions(label));
+      if (status === "completed") {
+        return `✅ ${esc}`;
+      }
+      if (status === "in_progress") {
+        return `⏳ <b>${esc}</b>`;
+      }
+      if (status === "cancelled") {
+        return `❌ <s>${esc}</s>`;
+      }
+      return `⬚ ${esc}`;
+    }
+    case "markdown": {
+      // PR-11 deep-dive review B1 (BLOCKER): markdown renders on
+      // Discord, Mattermost, Matrix, MSTeams, GoogleChat, Feishu, web,
+      // CLI. Without neutralization, an agent-controlled step text
+      // containing "@everyone" pings the entire channel on Discord +
+      // Mattermost. escapeMarkdown handles `*`/`[`/etc but does NOT
+      // touch `@`, so we need a separate pass.
+      const md = escapeMarkdown(neutralizeMentions(label));
+      if (status === "completed") {
+        return `- [x] ${md}`;
+      }
+      if (status === "in_progress") {
+        return `- [>] **${md}**`;
+      }
+      if (status === "cancelled") {
+        return `- [~] ~~${md}~~`;
+      }
+      return `- [ ] ${md}`;
+    }
+    case "plaintext": {
+      const safe = neutralizeMentions(label);
+      const markers: Record<PlanStepForRender["status"], string> = {
+        completed: "[x]",
+        in_progress: "[>]",
+        cancelled: "[~]",
+        pending: "[ ]",
+      };
+      if (!Object.hasOwn(markers, status)) {
+        warnUnknownStatus(status);
+      }
+      return `${markers[status] ?? "[ ]"} ${safe}`;
+    }
+    case "slack-mrkdwn": {
+      // PR-C review fix (Copilot #3096459445 / #3096516846): apply
+      // mention-neutralization the same way the html / markdown /
+      // plaintext branches do, BEFORE the format-specific escape. This
+      // lets `escapeSlackMrkdwn` drop its indiscriminate `@`
+      // replacement (which mangled emails like `user@example.com`)
+      // while still protecting `@channel` / `@here` / `@everyone` and
+      // Discord-style `<@123>` raw mentions.
+      const escaped = escapeSlackMrkdwn(neutralizeMentions(label));
+      if (status === "completed") {
+        return `✅ ${escaped}`;
+      }
+      if (status === "in_progress") {
+        return `⏳ *${escaped}*`;
+      }
+      if (status === "cancelled") {
+        return `❌ ~${escaped}~`;
+      }
+      return `⬚ ${escaped}`;
+    }
+    default: {
+      const _exhaustive: never = format;
+      return `[ ] ${label}`;
+    }
+  }
+}
+
+/**
+ * PR-9 Wave B1: render a step's acceptance criteria as a nested
+ * checklist beneath the step line. Indentation + marker style matches
+ * the parent format's conventions. Returns `[]` (no lines) when no
+ * criteria are declared so existing simple plans render unchanged.
+ *
+ * Each criterion uses the same content sanitization as the parent
+ * step label so injection vectors are equivalent across both layers.
+ */
+function renderAcceptanceCriteria(step: PlanStepForRender, format: PlanRenderFormat): string[] {
+  const criteria = step.acceptanceCriteria;
+  if (!criteria || criteria.length === 0) {
+    return [];
+  }
+  // PR-11 review fix (Codex P2 #3105075579): normalize the verified
+  // set the same way criteria are normalized before comparison.
+  // Pre-fix the comparison was raw-against-normalized — a criterion
+  // verified upstream with equivalent text differing only by whitespace
+  // / newline formatting would render as unchecked here, producing
+  // inconsistent plan state in `/plan restate` and UI checklists.
+  const normalize = (s: string) => s.replace(/[\n\r]+/g, " ").trim();
+  const verified = new Set((step.verifiedCriteria ?? []).map(normalize));
+  return criteria.map((rawCriterion) => {
+    const criterion = normalize(rawCriterion);
+    const isVerified = verified.has(criterion);
+    switch (format) {
+      case "html": {
+        // Same PR-11 B1 neutralization as the parent step path.
+        const esc = escapeHtml(neutralizeMentions(criterion));
+        return isVerified ? `   ✓ ${esc}` : `   ◻ ${esc}`;
+      }
+      case "markdown": {
+        const md = escapeMarkdown(neutralizeMentions(criterion));
+        return isVerified ? `    - [x] ${md}` : `    - [ ] ${md}`;
+      }
+      case "plaintext": {
+        const safe = neutralizeMentions(criterion);
+        return isVerified ? `   [x] ${safe}` : `   [ ] ${safe}`;
+      }
+      case "slack-mrkdwn": {
+        // Same neutralizeMentions-before-escape pattern as the parent
+        // step branch (PR-C review fix #3096459445 / #3096516846).
+        const escaped = escapeSlackMrkdwn(neutralizeMentions(criterion));
+        return isVerified ? `   ✓ ${escaped}` : `   ◻ ${escaped}`;
+      }
+      default: {
+        return `   [ ] ${criterion}`;
+      }
+    }
+  });
+}
+
+/**
+ * Renders a plan checklist with a header line.
+ */
+export function renderPlanWithHeader(
+  title: string,
+  steps: PlanStepForRender[],
+  format: PlanRenderFormat,
+): string {
+  const checklist = renderPlanChecklist(steps, format);
+  if (!checklist) {
+    return "";
+  }
+  // Strip newlines from title to prevent broken headings/formatting.
+  const safeTitle = title.replace(/[\n\r]+/g, " ").trim();
+
+  switch (format) {
+    case "html":
+      return `<b>${escapeHtml(neutralizeMentions(safeTitle))}</b>\n${checklist}`;
+    case "markdown":
+      // PR-11 B1: same mention-neutralization pass as the markdown
+      // step branch — `### @everyone Plan` pings the channel on
+      // Discord/Mattermost without this.
+      return `### ${escapeMarkdown(neutralizeMentions(safeTitle))}\n${checklist}`;
+    case "plaintext":
+      // Codex P2 #67534 r3095517064: neutralize @mentions in the title
+      // path too — checklist labels are already protected by
+      // neutralizeMentions() above, but a model-derived title like
+      // `@everyone release plan` would still trigger mentions on
+      // platforms that follow plaintext mention conventions.
+      return `${neutralizeMentions(safeTitle)}\n${checklist}`;
+    case "slack-mrkdwn":
+      return `*${escapeSlackMrkdwn(neutralizeMentions(safeTitle))}*\n${checklist}`;
+    default: {
+      const _exhaustive: never = format;
+      return `${title}\n${checklist}`;
+    }
+  }
+}
+
+/**
+ * PR-14: render the full plan archetype as a single markdown document
+ * suitable for persistence to disk and delivery as a file attachment
+ * (e.g., a Telegram document upload).
+ *
+ * Produces sections in canonical order:
+ *   # <title>
+ *   ## Summary
+ *   ## Analysis
+ *   ## Plan        (checklist via renderPlanChecklist markdown branch)
+ *   ## Assumptions (bullet list)
+ *   ## Risks       (bullet list with mitigation)
+ *   ## Verification (bullet list)
+ *   ## References  (bullet list)
+ *
+ * Each optional section is omitted when its field is absent or empty,
+ * so a minimal plan (title + steps only) renders as just the H1 +
+ * `## Plan` + checklist. All user-controlled text passes through
+ * `escapeMarkdown` + `neutralizeMentions` to defeat injection vectors
+ * (matching the PR-11 deep-dive review B1 fix).
+ */
+export interface PlanArchetypeMarkdownInput {
+  title: string;
+  summary?: string;
+  analysis?: string;
+  plan: PlanStepForRender[];
+  assumptions?: string[];
+  risks?: Array<{ risk: string; mitigation: string }>;
+  verification?: string[];
+  references?: string[];
+  /** Optional ISO date footer; defaults to new Date().toISOString().slice(0,10). */
+  generatedAt?: Date;
+}
+
+export function renderFullPlanArchetypeMarkdown(input: PlanArchetypeMarkdownInput): string {
+  const lines: string[] = [];
+  // Title is REQUIRED; render even if empty (downstream callers should
+  // provide a fallback like "Untitled plan").
+  const safeTitle = (input.title || "Untitled plan").replace(/[\n\r]+/g, " ").trim();
+  lines.push(`# ${escapeMarkdown(neutralizeMentions(safeTitle))}`);
+
+  if (input.summary && input.summary.trim()) {
+    lines.push("", "## Summary", escapeMarkdown(neutralizeMentions(input.summary.trim())));
+  }
+
+  if (input.analysis && input.analysis.trim()) {
+    // Analysis is multi-paragraph. Preserve paragraph breaks but
+    // strip carriage returns + escape per-line. Newlines in markdown
+    // ARE meaningful, so we preserve `\n\n` as paragraph separators.
+    const analysisBody = input.analysis
+      .replace(/\r/g, "")
+      .split("\n\n")
+      .map((para) => escapeMarkdown(neutralizeMentions(para.trim())))
+      .filter((para) => para.length > 0)
+      .join("\n\n");
+    if (analysisBody.length > 0) {
+      lines.push("", "## Analysis", analysisBody);
+    }
+  }
+
+  // Plan section is REQUIRED — but if the steps array is empty, emit
+  // a placeholder note rather than an empty section header.
+  lines.push("", "## Plan");
+  if (input.plan && input.plan.length > 0) {
+    lines.push(renderPlanChecklist(input.plan, "markdown"));
+  } else {
+    lines.push("_No plan steps provided._");
+  }
+
+  if (input.assumptions && input.assumptions.length > 0) {
+    const items = input.assumptions
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+      .map((entry) => `- ${escapeMarkdown(neutralizeMentions(entry))}`);
+    if (items.length > 0) {
+      lines.push("", "## Assumptions", items.join("\n"));
+    }
+  }
+
+  if (input.risks && input.risks.length > 0) {
+    const items = input.risks
+      .filter((entry) => entry?.risk?.trim() && entry?.mitigation?.trim())
+      .map((entry) => {
+        const r = escapeMarkdown(neutralizeMentions(entry.risk.trim()));
+        const m = escapeMarkdown(neutralizeMentions(entry.mitigation.trim()));
+        return `- **${r}**: ${m}`;
+      });
+    if (items.length > 0) {
+      lines.push("", "## Risks", items.join("\n"));
+    }
+  }
+
+  if (input.verification && input.verification.length > 0) {
+    const items = input.verification
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+      .map((entry) => `- ${escapeMarkdown(neutralizeMentions(entry))}`);
+    if (items.length > 0) {
+      lines.push("", "## Verification", items.join("\n"));
+    }
+  }
+
+  if (input.references && input.references.length > 0) {
+    const items = input.references
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+      .map((entry) => `- ${escapeMarkdown(neutralizeMentions(entry))}`);
+    if (items.length > 0) {
+      lines.push("", "## References", items.join("\n"));
+    }
+  }
+
+  // Footer with the universal /plan resolution slash commands so the
+  // user knows how to act on this plan from any channel that received
+  // the file (Telegram primarily, but future Discord/Slack mirror the
+  // same pattern via PR-11's universal slash commands).
+  const generatedAt = (input.generatedAt ?? new Date()).toISOString().slice(0, 10);
+  lines.push(
+    "",
+    "---",
+    `_Generated by OpenClaw on ${generatedAt}. Resolve with \`/plan accept\` | \`/plan accept edits\` | \`/plan revise <feedback>\`._`,
+  );
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Escapes Slack mrkdwn control characters using visually-similar
+ * Unicode lookalikes instead of backslash escaping (which Slack renders
+ * as visible noise in mrkdwn). Specifically:
+ *   - `&` / `<` / `>` → HTML-entity encoded (Slack ignores these in
+ *     mrkdwn but external markdown renderers may interpret them).
+ *   - `*` → U+2217 (∗, asterisk operator) — prevents bold parsing.
+ *   - `~` → U+223C (∼, tilde operator) — prevents strikethrough parsing.
+ *   - `` ` `` → U+2018 (', left single quote) — prevents code-span.
+ *   - `_` → U+FF3F (＿, fullwidth low line) — prevents italic parsing.
+ *
+ * Note: this differs from the Slack-monitor mrkdwn helper in the
+ * Slack channel-extension package, which uses backslash escaping.
+ * The plan renderer optimizes for READABILITY of agent-authored
+ * step text in human-visible Slack channels (no `\*\_` noise); the
+ * Slack monitor processes USER-AUTHORED content where exact-byte
+ * preservation matters more. Both are valid escape strategies for
+ * their respective use cases.
+ *
+ * Mention protection (@channel/@here/@everyone, Discord-style `<@123>`)
+ * is provided by `neutralizeMentions()` called at the render-branch
+ * level, NOT here. This function is pure formatting-character escape.
+ */
+function escapeSlackMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\*/g, "\u2217")
+    .replace(/~/g, "\u223C")
+    .replace(/`/g, "\u2018")
+    .replace(/_/g, "\uFF3F");
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Escapes markdown meta-characters in user-controlled text so a step like
+ * "Deploy `rm -rf /`", "[click](evil)", or "Deploy ~~prod~~ now" doesn't
+ * render as a code span, link, or break out of the cancelled-step
+ * `~~...~~` strikethrough wrapper.
+ *
+ * PR-C review fix (Codex P2 #3096528415 / Copilot #3096792952): `~` is
+ * in the escape set so that step text containing `~~` doesn't close
+ * the outer strikethrough wrapper used for cancelled steps. Without
+ * this, `Deploy ~~prod~~ now` rendered as `~~Deploy ~~prod~~ now~~`
+ * which markdown parses as `~~Deploy ~~`/`prod`/`~~ now~~` — broken
+ * cancelled rendering.
+ */
+function escapeMarkdown(text: string): string {
+  // Order matters: backslash first so we don't re-escape our own escapes.
+  return text.replace(/[\\`*_{}[\]()#+\-.!<>|~]/g, "\\$&");
+}
+
+/**
+ * Inserts U+FE6B between '@' and known mention triggers to prevent
+ * @channel / @here / @everyone notifications from user-controlled text.
+ *
+ * PR-11 deep-dive review: also neutralize Discord raw user mentions
+ * `<@123>` / `<@!123>` / `<@&123>` (role mention) by inserting U+200B
+ * between `<` and `@`. Discord parses these as pings; an agent
+ * embedding such a string in a plan step would otherwise notify the
+ * named user/role on `/plan restate`.
+ *
+ * Channel coverage: Telegram (HTML), Discord/Matrix/Mattermost
+ * (markdown), Slack (mrkdwn — handled separately by escapeSlackMrkdwn
+ * via U+FE6B on every `@`), plaintext (iMessage/Signal/SMS).
+ */
+function neutralizeMentions(text: string): string {
+  return text.replace(/@(channel|here|everyone)\b/gi, "@\uFE6B$1").replace(/<@/g, "<\u200B@");
+}
+
+/**
+ * PR-C review fix (Copilot #3096792992): bounded set with FIFO eviction
+ * to prevent unbounded growth in long-running gateway processes if a
+ * malformed/malicious upstream produces many distinct statuses over
+ * time. Once `WARNED_STATUSES_MAX` is reached, the oldest tracked
+ * status is evicted on each new insert (Set iteration order is
+ * insertion order in ES2015+, so the first key is the oldest).
+ */
+const WARNED_STATUSES_MAX = 64;
+const warnedStatuses = new Set<string>();
+function warnUnknownStatus(status: string): void {
+  if (warnedStatuses.has(status)) {
+    return;
+  }
+  if (warnedStatuses.size >= WARNED_STATUSES_MAX) {
+    const oldest = warnedStatuses.values().next().value;
+    if (oldest !== undefined) {
+      warnedStatuses.delete(oldest);
+    }
+  }
+  warnedStatuses.add(status);
+  console.warn(
+    `[plan-render] Unknown plan step status "${status}", falling back to pending rendering.`,
+  );
+}

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -1,23 +1,96 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 
 type PendingToolCall = { id: string; name: string };
+
+const log = createSubsystemLogger("agents/transport-message-transform");
+
+/**
+ * PR-9 Wave C-#1b: structured placeholder text used when a tool_use
+ * has no matching tool_result at transport-assembly time. Carries
+ * enough context (toolName + toolCallId) for the agent's read-time
+ * context to surface a real diagnosis, AND a `[transport-repair]`
+ * marker so log triage / Eva's transcript-anomaly heuristics can
+ * distinguish "the tool actually failed" from "the result was lost
+ * during reconstruction." Replaces the prior bare `"No result
+ * provided"` string which was indistinguishable from a real failure
+ * (Eva's reliability handoff #1b).
+ */
+function buildMissingToolResultText(toolCall: PendingToolCall): string {
+  return [
+    `[transport-repair] tool_use "${toolCall.name}" (id=${toolCall.id}) had no paired`,
+    "tool_result at transport-assembly time. The original result was likely lost",
+    "during session-history reconstruction (crash before disk flush, history",
+    "compaction that dropped the pairing, or replay drift). This is a transport",
+    "repair placeholder, NOT evidence that the tool itself failed — check the",
+    "live agent logs and gateway transcript for the original result.",
+  ].join(" ");
+}
 
 function appendMissingToolResults(
   result: Context["messages"],
   pendingToolCalls: PendingToolCall[],
   existingToolResultIds: ReadonlySet<string>,
 ): void {
+  // Copilot review #68939 (2026-04-19): cap per-call log volume.
+  // Pre-fix, the loop emitted one warn line per missing tool_result
+  // — under failure modes where a reconstruction step drops many
+  // pairings (e.g., a model hiccup leaving 50+ dangling tool_uses),
+  // gateway.err.log gets flooded with one line each. Cap at the
+  // first 5 warns + a single aggregate summary so operators still
+  // see the issue but the log stays usable under incident
+  // conditions.
+  // Copilot review #68939 (round-2): bound the array growth at
+  // (per-turn cap + aggregate cap). Pre-fix, `repaired` collected
+  // ALL repaired items then sliced — pathological cases with
+  // hundreds/thousands of missing tool_results would allocate a
+  // huge intermediate array just to print 5 + 20 ids. Now we only
+  // store enough ids to cover the diagnostic output AND maintain a
+  // separate counter for the total. Keeps memory + CPU bounded
+  // while preserving the same operator-facing diagnostics.
+  const TRANSPORT_REPAIR_PER_TURN_LOG_CAP = 5;
+  const TRANSPORT_REPAIR_AGGREGATE_ID_LIST_CAP = 20;
+  const TRANSPORT_REPAIR_STORED_ID_CAP =
+    TRANSPORT_REPAIR_PER_TURN_LOG_CAP + TRANSPORT_REPAIR_AGGREGATE_ID_LIST_CAP;
+  const repairedIds: string[] = [];
+  let totalRepairs = 0;
   for (const toolCall of pendingToolCalls) {
     if (!existingToolResultIds.has(toolCall.id)) {
+      if (totalRepairs < TRANSPORT_REPAIR_PER_TURN_LOG_CAP) {
+        // PR-9 Wave C-#1b: log the repair so operators can grep
+        // `transport-repair` in gateway logs to find the originating
+        // session+turn. The placeholder text already includes the
+        // same marker so it's discoverable from both sides.
+        log.warn(
+          `transport-repair: synthesized placeholder for unpaired tool_use ` +
+            `name=${toolCall.name} id=${toolCall.id}`,
+        );
+      }
+      if (repairedIds.length < TRANSPORT_REPAIR_STORED_ID_CAP) {
+        repairedIds.push(toolCall.id);
+      }
+      totalRepairs += 1;
       result.push({
         role: "toolResult",
         toolCallId: toolCall.id,
         toolName: toolCall.name,
-        content: [{ type: "text", text: "No result provided" }],
+        content: [{ type: "text", text: buildMissingToolResultText(toolCall) }],
         isError: true,
         timestamp: Date.now(),
       });
     }
+  }
+  if (totalRepairs > TRANSPORT_REPAIR_PER_TURN_LOG_CAP) {
+    // Show the next N ids beyond the per-turn log cap; surplus
+    // repairs (those past the stored cap) are summarized as a count.
+    const idList = repairedIds.slice(TRANSPORT_REPAIR_PER_TURN_LOG_CAP);
+    const additional = totalRepairs - repairedIds.length;
+    log.warn(
+      `transport-repair: synthesized ${totalRepairs} placeholders this turn ` +
+        `(only first ${TRANSPORT_REPAIR_PER_TURN_LOG_CAP} logged individually); ` +
+        `next ${idList.length} tool_use ids: ${idList.join(", ")}` +
+        (additional > 0 ? ` (+${additional} more)` : ""),
+    );
   }
 }
 

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -216,6 +216,19 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
       category: "management",
       tier: "power",
     }),
+    // PR-11: universal /plan slash commands. Works on every channel
+    // (Telegram, Discord, Signal, iMessage, Slack, CLI) so users can
+    // resolve plan approvals with text when inline buttons aren't
+    // available. Routes through sessions.patch on the backend; same
+    // state machine the webchat chip uses.
+    defineChatCommand({
+      key: "plan",
+      nativeName: "plan",
+      description: "Manage plan-mode approvals (accept / revise / auto / restate / on / off).",
+      textAlias: "/plan",
+      acceptsArgs: true,
+      category: "management",
+    }),
     defineChatCommand({
       key: "context",
       nativeName: "context",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "./commands-info.js";
 import { handleMcpCommand } from "./commands-mcp.js";
 import { handleModelsCommand } from "./commands-models.js";
+import { handlePlanCommand } from "./commands-plan.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
 import {
@@ -52,6 +53,11 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleTasksCommand,
     handleAllowlistCommand,
     handleApproveCommand,
+    // PR-11: universal /plan slash commands work on every channel
+    // (Telegram, Discord, Signal, iMessage, Slack, CLI). Routes
+    // through sessions.patch — same backend as the webchat chip +
+    // approval card.
+    handlePlanCommand,
     handleContextCommand,
     handleExportSessionCommand,
     handleWhoamiCommand,

--- a/src/auto-reply/reply/commands-plan.test.ts
+++ b/src/auto-reply/reply/commands-plan.test.ts
@@ -1,0 +1,742 @@
+/**
+ * PR-11: tests for the universal /plan slash command handler.
+ *
+ * Focuses on the parser + dispatch layer (subcommand recognition,
+ * sessions.patch payload shapes, restate rendering, error surfaces).
+ * Channel-specific authorization paths reuse the same helpers as
+ * /approve and are covered by that test suite.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { handlePlanCommand } from "./commands-plan.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+const callGatewayMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../infra/channel-approval-auth.js", () => ({
+  resolveApprovalCommandAuthorization: () => ({
+    explicit: true,
+    authorized: true,
+    reason: undefined,
+  }),
+}));
+
+vi.mock("./channel-context.js", () => ({
+  resolveChannelAccountId: () => "test-account",
+}));
+
+vi.mock("./command-gates.js", () => ({
+  requireGatewayClientScopeForInternalChannel: () => null,
+}));
+
+function makeParams(overrides: {
+  body: string;
+  sessionEntry?: SessionEntry;
+  channel?: string;
+  isAuthorized?: boolean;
+}): HandleCommandsParams {
+  // Cast through `unknown` because we deliberately omit fields we
+  // don't exercise (ctx, opts, etc). The handler under test only
+  // touches command, sessionKey, sessionEntry, cfg.
+  return {
+    cfg: {} as OpenClawConfig,
+    ctx: {} as HandleCommandsParams["ctx"],
+    command: {
+      surface: "test",
+      channel: overrides.channel ?? "telegram",
+      ownerList: [],
+      senderIsOwner: true,
+      isAuthorizedSender: overrides.isAuthorized ?? true,
+      senderId: "u1",
+      rawBodyNormalized: overrides.body,
+      commandBodyNormalized: overrides.body,
+    },
+    sessionKey: "agent:main:main",
+    sessionEntry: overrides.sessionEntry,
+    workspaceDir: "/tmp",
+    directives: {} as HandleCommandsParams["directives"],
+    elevated: { enabled: false, allowed: false, failures: [] },
+    defaultGroupActivation: () => "always",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolveDefaultThinkingLevel: async () => undefined,
+    provider: "anthropic",
+    model: "sonnet-4.6",
+    contextTokens: 0,
+    isGroup: false,
+  } as unknown as HandleCommandsParams;
+}
+
+describe("/plan handler — parser dispatch", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+  });
+
+  it("returns null for non-plan input", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "hello" }), true);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when text commands are disallowed", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan accept" }), false);
+    expect(result).toBeNull();
+  });
+
+  it("/plan with no args returns the plan-mode status", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan" }), true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Plan mode is **off**");
+  });
+
+  it("/plan status with active plan-mode session reports mode + approval state", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan status",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a1",
+            rejectionCount: 2,
+            updatedAt: 1,
+            autoApprove: true,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("plan");
+    expect(result?.reply?.text).toContain("pending");
+    expect(result?.reply?.text).toContain("Auto-approve: **on**");
+    expect(result?.reply?.text).toContain("Rejection cycles: 2");
+  });
+
+  it("/plan view points users to /plan restate on text channels", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan view" }), true);
+    expect(result?.reply?.text).toContain("Use /plan restate");
+  });
+
+  it("/plan accept without an active pending approval bails with friendly error (review M1)", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan accept" }), true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("No pending plan to accept");
+  });
+
+  it("/plan accept patches sessions with action=approve", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan accept",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a1",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(callGatewayMock).toHaveBeenCalledOnce();
+    const args = callGatewayMock.mock.calls[0][0];
+    expect(args.method).toBe("sessions.patch");
+    expect(args.params).toMatchObject({
+      key: "agent:main:main",
+      planApproval: { action: "approve", approvalId: "a1" },
+    });
+    // Codex P1 review #68939 (2026-04-19): /plan accept now returns
+    // shouldContinue:true so the agent-runner pipeline resumes the
+    // agent immediately to consume the [PLAN_DECISION] injection.
+    // Pre-fix, the handler returned a reply text but no run trigger,
+    // so non-web channels reported success while the agent stayed
+    // idle. The agent's own first-action message provides the
+    // implicit "approval received" signal to the user.
+    expect(result?.shouldContinue).toBe(true);
+    expect(result?.reply).toBeUndefined();
+  });
+
+  it("/plan accept edits patches with action=edit", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan accept edits",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a2",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    const args = callGatewayMock.mock.calls[0][0];
+    expect(args.params.planApproval).toMatchObject({ action: "edit", approvalId: "a2" });
+    // See the /plan accept test above for the rationale on
+    // shouldContinue:true + no reply (Codex P1 review #68939).
+    expect(result?.shouldContinue).toBe(true);
+    expect(result?.reply).toBeUndefined();
+  });
+
+  it("/plan revise <feedback> patches with action=reject + feedback", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan revise add error handling for the websocket reconnect",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a1",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    const args = callGatewayMock.mock.calls[0][0];
+    expect(args.params.planApproval).toMatchObject({
+      action: "reject",
+      feedback: "add error handling for the websocket reconnect",
+      approvalId: "a1",
+    });
+    // Codex P1 review #68939 (2026-04-19): /plan revise also
+    // returns shouldContinue:true so the agent runs immediately
+    // to consume the [PLAN_DECISION]: rejected injection and
+    // start the revise-and-resubmit loop. See /plan accept above.
+    expect(result?.shouldContinue).toBe(true);
+    expect(result?.reply).toBeUndefined();
+  });
+
+  it("/plan revise without feedback rejects with usage error (review H2)", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan revise" }), true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("Usage: /plan revise <feedback>");
+  });
+
+  it("/plan answer threads approvalId and questionId from pendingInteraction", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan answer Option A",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+          pendingInteraction: {
+            kind: "question",
+            approvalId: "q-approval-1",
+            questionId: "q-1",
+            title: "Agent has a question",
+            prompt: "Pick one",
+            options: ["Option A", "Option B"],
+            allowFreetext: false,
+            createdAt: 1,
+            status: "pending",
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(callGatewayMock).toHaveBeenCalledOnce();
+    expect(callGatewayMock.mock.calls[0][0].params).toMatchObject({
+      key: "agent:main:main",
+      planApproval: {
+        action: "answer",
+        answer: "Option A",
+        approvalId: "q-approval-1",
+        questionId: "q-1",
+      },
+    });
+    expect(result?.shouldContinue).toBe(true);
+  });
+
+  it("/plan answer without a pending question bails with a friendly error", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan answer Option A",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("No pending ask_user_question");
+  });
+
+  it("/plan auto with no arg defaults to autoEnabled=true", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    await handlePlanCommand(makeParams({ body: "/plan auto" }), true);
+    expect(callGatewayMock.mock.calls[0][0].params.planApproval).toMatchObject({
+      action: "auto",
+      autoEnabled: true,
+    });
+  });
+
+  it("/plan auto on enables", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    await handlePlanCommand(makeParams({ body: "/plan auto on" }), true);
+    expect(callGatewayMock.mock.calls[0][0].params.planApproval.autoEnabled).toBe(true);
+  });
+
+  it("/plan auto off disables", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    await handlePlanCommand(makeParams({ body: "/plan auto off" }), true);
+    expect(callGatewayMock.mock.calls[0][0].params.planApproval.autoEnabled).toBe(false);
+  });
+
+  it("/plan auto bogus rejects", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan auto bogus" }), true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("Unrecognized");
+  });
+
+  it("/plan on patches planMode='plan'", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(makeParams({ body: "/plan on" }), true);
+    expect(callGatewayMock.mock.calls[0][0].params).toMatchObject({
+      key: "agent:main:main",
+      planMode: "plan",
+    });
+    expect(result?.reply?.text).toContain("**enabled**");
+  });
+
+  it("/plan off patches planMode='normal'", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(makeParams({ body: "/plan off" }), true);
+    expect(callGatewayMock.mock.calls[0][0].params).toMatchObject({
+      key: "agent:main:main",
+      planMode: "normal",
+    });
+    expect(result?.reply?.text).toContain("**disabled**");
+  });
+
+  it("/plan restate without an active plan returns a friendly message", async () => {
+    const result = await handlePlanCommand(makeParams({ body: "/plan restate" }), true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("No active plan");
+  });
+
+  it("/plan restate renders the plan checklist when steps are present (Telegram → HTML)", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan restate",
+        channel: "telegram",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+            lastPlanSteps: [
+              { step: "Read the docs", status: "completed" },
+              { step: "Wire the handler", status: "in_progress", activeForm: "Wiring the handler" },
+              { step: "Add tests", status: "pending" },
+            ],
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("<b>Current plan:</b>");
+    // HTML render uses the activeForm for in_progress steps.
+    expect(result?.reply?.text).toContain("Wiring the handler");
+  });
+
+  it("/plan restate uses Slack mrkdwn on Slack channels", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan restate",
+        channel: "slack",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+            lastPlanSteps: [{ step: "Hello", status: "pending" }],
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text?.startsWith("*Current plan:*")).toBe(true);
+  });
+
+  it("/plan restate uses plaintext on iMessage / Signal", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan restate",
+        channel: "imessage",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+            lastPlanSteps: [{ step: "Hello", status: "pending" }],
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text?.startsWith("Current plan:")).toBe(true);
+    // Plaintext output should NOT contain HTML or mrkdwn markers.
+    expect(result?.reply?.text).not.toContain("<b>");
+    expect(result?.reply?.text).not.toContain("*Current");
+  });
+
+  it("rejects /plan@otherbot mention prefix on Telegram (cross-bot disambiguation)", async () => {
+    const result = await handlePlanCommand(
+      makeParams({ body: "/plan@otherbot accept", channel: "telegram" }),
+      true,
+    );
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result?.reply?.text).toContain("targets a different Telegram bot");
+  });
+
+  it("does NOT reject /plan@<word> on non-Telegram channels (review H1)", async () => {
+    // On Discord/Slack/etc, `/plan@something` is NOT a valid /plan
+    // command (the parser's COMMAND_REGEX requires whitespace or
+    // end-of-string after `plan`). The key contract: the handler must
+    // not surface the Telegram-specific "targets a different bot"
+    // error to non-Telegram channels — it should fall through to null
+    // (so other handlers / agent dispatch can process the line).
+    const result = await handlePlanCommand(
+      makeParams({ body: "/plan@alice accept", channel: "discord" }),
+      true,
+    );
+    // Either null (parser didn't match) or some other reply — but
+    // never the Telegram foreign-bot error string.
+    if (result?.reply?.text) {
+      expect(result.reply.text).not.toContain("targets a different");
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it("verifies the Telegram-specific foreign-bot error fires only on telegram channel", async () => {
+    // Sanity check: on Discord, `/plan` followed by space then a
+    // legitimate subcommand parses correctly even with @-mentions in
+    // the args. (The H1 fix means @-suffix-on-command isn't a parse
+    // error on non-Telegram, but the parser still requires whitespace
+    // between command and args.)
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({ body: "/plan accept", channel: "discord" }),
+      true,
+    );
+    expect(result?.reply?.text).not.toContain("targets a different");
+  });
+
+  it("maps gateway 'stale approvalId' error to a friendly chat message (review L3)", async () => {
+    callGatewayMock.mockRejectedValueOnce(
+      new Error(
+        "planApproval ignored: stale approvalId or session is in a terminal approval state",
+      ),
+    );
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan accept",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "old",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("Plan was already resolved");
+  });
+
+  it("maps the fail-closed subagent gate-unavailable error to a friendly retry message", async () => {
+    callGatewayMock.mockRejectedValueOnce(
+      new Error("PLAN_APPROVAL_GATE_STATE_UNAVAILABLE: gate state unavailable"),
+    );
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan accept",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "approval-1",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("Refresh the session");
+  });
+
+  it("/plan revise neutralizes @-mention bombs in the feedback echo (deep-dive M8)", async () => {
+    callGatewayMock.mockResolvedValueOnce({});
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan revise @everyone please review by EOD <@!12345>",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a1",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    // Feedback was forwarded to gateway as-is (server-side sanitization
+    // is its own concern; we don't double-process there).
+    expect(callGatewayMock.mock.calls[0][0].params.planApproval.feedback).toBe(
+      "@everyone please review by EOD <@!12345>",
+    );
+    // Codex P1 review #68939 (2026-04-19): the deep-dive M8 ping-
+    // vector concern was that the BOT'S reply could ping the
+    // channel via @-mention echo. With shouldContinue:true and no
+    // reply, the ping vector is GONE entirely — the bot doesn't
+    // emit a confirmation reply at all; the agent's own next
+    // response provides the implicit confirmation. This is
+    // strictly safer than the prior neutralization approach:
+    // there's no echo to neutralize.
+    expect(result?.shouldContinue).toBe(true);
+    expect(result?.reply).toBeUndefined();
+  });
+
+  it("/plan restate truncates output above the channel size cap (deep-dive M7)", async () => {
+    // Build a 100-step plan to force truncation. Each step adds ~30 chars.
+    const longSteps = Array.from({ length: 100 }, (_, i) => ({
+      step: `step ${i.toString().padStart(3, "0")} — long descriptive sentence text`,
+      status: "pending",
+    }));
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan restate",
+        channel: "telegram",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+            lastPlanSteps: longSteps,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toBeDefined();
+    // Message must stay under Telegram's 4096-char limit (with headroom).
+    expect(result!.reply!.text!.length).toBeLessThanOrEqual(4096);
+    // PR-11 hardening v2: truncation footer changed from "more line(s)"
+    // to "more step(s)" since we now truncate by step count rather
+    // than slicing the rendered string.
+    expect(result?.reply?.text).toContain("more step");
+  });
+
+  it("/plan restate truncates a single oversized step in place when dropping steps is impossible", async () => {
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan restate",
+        channel: "telegram",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "none",
+            rejectionCount: 0,
+            updatedAt: 1,
+            lastPlanSteps: [
+              {
+                step: "A".repeat(5000),
+                status: "pending",
+                activeForm: "B".repeat(500),
+                acceptanceCriteria: ["criterion-1"],
+                verifiedCriteria: ["criterion-1"],
+              },
+            ],
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+
+    expect(result?.reply?.text).toBeDefined();
+    expect(result!.reply!.text!.length).toBeLessThanOrEqual(4096);
+    expect(result?.reply?.text).toContain("more step");
+    expect(result?.reply?.text).not.toContain("criterion-1");
+  });
+
+  it("plaintext format applies to extended SMS-like channels (review M4)", async () => {
+    for (const channel of ["irc", "nostr", "voice-call", "line", "qqbot", "zalo"]) {
+      const result = await handlePlanCommand(
+        makeParams({
+          body: "/plan restate",
+          channel,
+          sessionEntry: {
+            planMode: {
+              mode: "plan",
+              approval: "none",
+              rejectionCount: 0,
+              updatedAt: 1,
+              lastPlanSteps: [{ step: "Hello", status: "pending" }],
+            },
+          } as unknown as SessionEntry,
+        }),
+        true,
+      );
+      expect(result?.reply?.text?.startsWith("Current plan:")).toBe(true);
+      expect(result?.reply?.text).not.toContain("<b>");
+      expect(result?.reply?.text).not.toContain("*Current");
+    }
+  });
+
+  it("surfaces 'plan mode is disabled' config error legibly", async () => {
+    callGatewayMock.mockRejectedValueOnce(
+      new Error("plan mode is disabled — set agents.defaults.planMode.enabled: true to enable"),
+    );
+    const result = await handlePlanCommand(makeParams({ body: "/plan on" }), true);
+    expect(result?.reply?.text).toContain("Plan mode is disabled at the config level");
+  });
+
+  it("surfaces other gateway errors with the raw message prefix", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("network blip"));
+    const result = await handlePlanCommand(
+      makeParams({
+        body: "/plan accept",
+        sessionEntry: {
+          planMode: {
+            mode: "plan",
+            approval: "pending",
+            approvalId: "a3",
+            rejectionCount: 0,
+            updatedAt: 1,
+          },
+        } as unknown as SessionEntry,
+      }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("Failed to apply /plan command");
+    expect(result?.reply?.text).toContain("network blip");
+  });
+
+  it("status / view subcommands skip authorization checks (anyone can ask state)", async () => {
+    // PR-11 review M3 carve-out: only status + view are open to all
+    // chat participants. /plan restate now requires operator auth so
+    // plan-step text isn't exfiltrated.
+    const result = await handlePlanCommand(
+      makeParams({ body: "/plan status", isAuthorized: false }),
+      true,
+    );
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Plan mode is **off**");
+  });
+
+  // Codex review #68939 (2026-04-20): regression coverage for the
+  // `/plan` parser bugs flagged post-C1 follow-up.
+  describe("parser regressions (2026-04-20)", () => {
+    const pendingSessionEntry = {
+      planMode: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: "a-parser",
+        rejectionCount: 0,
+        updatedAt: 1,
+      },
+    } as unknown as SessionEntry;
+
+    it("bare `/plan accept` resolves as approve (second token is empty string, not undefined)", async () => {
+      callGatewayMock.mockResolvedValueOnce({});
+      await handlePlanCommand(
+        makeParams({
+          body: "/plan accept",
+          sessionEntry: pendingSessionEntry,
+        }),
+        true,
+      );
+      // Success path — the patch is sent with action=approve. Pre-fix,
+      // this returned the "unknown argument" error because
+      // `second === ""` wasn't matched by the strict-edit check (the
+      // `second !== undefined` guard was tautological since the
+      // normalize helper returns `""`, never undefined).
+      expect(callGatewayMock).toHaveBeenCalled();
+      const args = callGatewayMock.mock.calls[0][0];
+      expect(args.method).toBe("sessions.patch");
+      expect(args.params).toMatchObject({
+        planApproval: { action: "approve" },
+      });
+    });
+
+    it("rejects typo `/plan accept editss` with usage error", async () => {
+      const result = await handlePlanCommand(
+        makeParams({ body: "/plan accept editss", sessionEntry: pendingSessionEntry }),
+        true,
+      );
+      expect(result?.reply?.text).toContain("Usage: /plan accept");
+      expect(result?.reply?.text).toContain("editss");
+    });
+
+    it("rejects trailing tokens after `/plan accept edits`", async () => {
+      const result = await handlePlanCommand(
+        makeParams({ body: "/plan accept edits now", sessionEntry: pendingSessionEntry }),
+        true,
+      );
+      expect(result?.reply?.text).toContain("unexpected trailing argument");
+    });
+
+    it("rejects trailing tokens after `/plan accept` (bare)", async () => {
+      const result = await handlePlanCommand(
+        makeParams({ body: "/plan accept now", sessionEntry: pendingSessionEntry }),
+        true,
+      );
+      // Either the unknown-argument usage or the trailing-argument
+      // message fires — both are terminal user-visible errors that
+      // stop the silent-approve regression. We don't care which.
+      expect(result?.reply?.text).toMatch(/unknown argument|trailing argument/);
+    });
+
+    it("rejects trailing tokens after `/plan off`", async () => {
+      const result = await handlePlanCommand(makeParams({ body: "/plan off later" }), true);
+      expect(result?.reply?.text).toContain("unexpected trailing argument");
+    });
+
+    it("rejects trailing tokens after `/plan on`", async () => {
+      const result = await handlePlanCommand(makeParams({ body: "/plan on please" }), true);
+      expect(result?.reply?.text).toContain("unexpected trailing argument");
+    });
+
+    it("rejects trailing tokens after `/plan status`", async () => {
+      const result = await handlePlanCommand(makeParams({ body: "/plan status now" }), true);
+      expect(result?.reply?.text).toContain("unexpected trailing argument");
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-plan.ts
+++ b/src/auto-reply/reply/commands-plan.ts
@@ -1,0 +1,587 @@
+import {
+  type PlanRenderFormat,
+  type PlanStepForRender,
+  renderPlanChecklist,
+} from "../../agents/plan-render.js";
+/**
+ * PR-11: universal `/plan` slash commands for non-webchat channels.
+ *
+ * Lets any channel (Telegram chat, Discord DM, Signal, iMessage, Slack
+ * threads, CLI) drive plan-mode approvals via plain text instead of
+ * inline buttons. Subcommands match the webchat chip + approval card
+ * affordances:
+ *
+ *   /plan accept              → planApproval { action: "approve" }
+ *   /plan accept edits        → planApproval { action: "edit" }
+ *   /plan revise <feedback>   → planApproval { action: "reject", feedback }
+ *   /plan auto on|off         → planApproval { action: "auto", autoEnabled }
+ *   /plan on|off              → planMode "plan"|"normal" toggle
+ *   /plan status              → print current plan-mode state
+ *   /plan restate             → re-render the active plan checklist into
+ *                               the channel (so the user can see it
+ *                               without re-asking the agent)
+ *
+ * Authorization mirrors `/approve`: requires the sender to be an
+ * authorized operator, gates internal-channel callers on
+ * operator.approvals scope.
+ *
+ * Backend call: `sessions.patch` (same RPC the webchat chip + UI use).
+ * The gateway-side handler in `src/gateway/sessions-patch.ts` enforces
+ * the planMode feature gate + state-machine semantics, so this handler
+ * stays a thin parser + dispatcher.
+ */
+import { callGateway } from "../../gateway/call.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
+import { logVerbose } from "../../globals.js";
+import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
+import { resolveChannelAccountId } from "./channel-context.js";
+import { requireGatewayClientScopeForInternalChannel } from "./command-gates.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const COMMAND_REGEX = /^\/?plan(?:\s|$)/i;
+const FOREIGN_COMMAND_MENTION_REGEX = /^\/plan@([^\s]+)(?:\s|$)/i;
+
+type PlanSubcommand =
+  | { kind: "status" }
+  | { kind: "view" }
+  | { kind: "on" }
+  | { kind: "off" }
+  | { kind: "restate" }
+  | { kind: "auto"; autoEnabled: boolean }
+  | { kind: "accept"; allowEdits: boolean }
+  | { kind: "revise"; feedback: string }
+  | { kind: "answer"; answer: string };
+
+type ParsedPlanCommand = { ok: true; sub: PlanSubcommand } | { ok: false; error: string };
+
+const PLAN_USAGE_TEXT =
+  "Usage: /plan <accept|accept edits|revise <feedback>|answer <text>|on|off|status|view|auto on|auto off|restate>";
+
+function parsePlanCommand(raw: string, channel: string): ParsedPlanCommand | null {
+  const trimmed = raw.trim();
+  // PR-11 review H1: the `/cmd@bot` mention syntax is Telegram-specific.
+  // On other channels (Discord/Slack/iMessage/Signal/CLI) `@<word>` after
+  // a slash command is just a regular user mention and should not bail
+  // the parser. Only enforce the foreign-bot disambiguation on Telegram.
+  if (channel.toLowerCase() === "telegram" && FOREIGN_COMMAND_MENTION_REGEX.test(trimmed)) {
+    return { ok: false, error: "❌ This /plan command targets a different Telegram bot." };
+  }
+  const commandMatch = trimmed.match(COMMAND_REGEX);
+  if (!commandMatch) {
+    return null;
+  }
+  const rest = trimmed.slice(commandMatch[0].length).trim();
+  if (!rest) {
+    return { ok: true, sub: { kind: "status" } };
+  }
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  const first = normalizeLowercaseStringOrEmpty(tokens[0] ?? "");
+  const second = normalizeLowercaseStringOrEmpty(tokens[1] ?? "");
+  const tail = tokens.slice(1).join(" ").trim();
+
+  // Codex review #68939 (2026-04-20): reject trailing tokens on
+  // single-token commands so typos like `/plan off later` don't
+  // silently execute the mode change. `normalizeLowercaseStringOrEmpty`
+  // returns `""` (never undefined) when a token is absent, so the
+  // precise "no extra arg" predicate is `tokens.length === 1`.
+  const rejectTrailingTokens = (verb: string) =>
+    tokens.length > 1
+      ? ({
+          ok: false,
+          error: `Usage: /plan ${verb} — unexpected trailing argument "${tokens.slice(1).join(" ")}". This command takes no arguments.`,
+        } as const)
+      : null;
+
+  switch (first) {
+    case "status": {
+      const err = rejectTrailingTokens("status");
+      if (err) {
+        return err;
+      }
+      return { ok: true, sub: { kind: "status" } };
+    }
+    case "view": {
+      const err = rejectTrailingTokens("view");
+      if (err) {
+        return err;
+      }
+      return { ok: true, sub: { kind: "view" } };
+    }
+    case "on": {
+      const err = rejectTrailingTokens("on");
+      if (err) {
+        return err;
+      }
+      return { ok: true, sub: { kind: "on" } };
+    }
+    case "off": {
+      const err = rejectTrailingTokens("off");
+      if (err) {
+        return err;
+      }
+      return { ok: true, sub: { kind: "off" } };
+    }
+    case "restate": {
+      const err = rejectTrailingTokens("restate");
+      if (err) {
+        return err;
+      }
+      return { ok: true, sub: { kind: "restate" } };
+    }
+    case "accept": {
+      // Codex review #68939 (2026-04-20): `normalizeLowercaseStringOrEmpty`
+      // returns `""` (never undefined) when `tokens[1]` is absent, so
+      // the prior check `second !== undefined && ...` ALWAYS fired and
+      // rejected the documented bare `/plan accept` form. Treat empty
+      // string the same as missing.
+      const isBareAccept = second === "";
+      const isEditsAccept = second === "edits" || second === "edit";
+      if (!isBareAccept && !isEditsAccept) {
+        return {
+          ok: false,
+          error: `Usage: /plan accept [edits] — unknown argument "${second}". Valid forms: /plan accept, /plan accept edits.`,
+        };
+      }
+      // Reject trailing tokens beyond the `edits` / `edit` qualifier so
+      // `/plan accept edits now` doesn't silently approve.
+      const maxTokens = isEditsAccept ? 2 : 1;
+      if (tokens.length > maxTokens) {
+        return {
+          ok: false,
+          error: `Usage: /plan accept [edits] — unexpected trailing argument "${tokens.slice(maxTokens).join(" ")}".`,
+        };
+      }
+      const allowEdits = isEditsAccept;
+      return { ok: true, sub: { kind: "accept", allowEdits } };
+    }
+    case "revise": {
+      // /plan revise <feedback>. PR-11 review H2: feedback is REQUIRED.
+      // A no-feedback rejection silently increments rejectionCount and
+      // can roll the state into a confusing "ask the user to clarify"
+      // injection after 3 reflex clicks — UX regression with no
+      // operator intent. Force a usage error instead.
+      if (!tail) {
+        return {
+          ok: false,
+          error:
+            "Usage: /plan revise <feedback> — give the agent something to revise toward, e.g. /plan revise add error handling for the websocket reconnect.",
+        };
+      }
+      return { ok: true, sub: { kind: "revise", feedback: tail } };
+    }
+    case "auto": {
+      // /plan auto [on|off]. Bare /plan auto defaults to on (matches
+      // the chip "switch INTO Plan ⚡" intent).
+      if (!second || second === "on") {
+        return { ok: true, sub: { kind: "auto", autoEnabled: true } };
+      }
+      if (second === "off") {
+        return { ok: true, sub: { kind: "auto", autoEnabled: false } };
+      }
+      return { ok: false, error: `Unrecognized /plan auto value "${second}". Use on|off.` };
+    }
+    case "answer": {
+      // PR-11 review fix (Codex P1 #3105075577): text-channel users
+      // need a way to answer ask_user_question prompts since the
+      // approval card with inline option buttons only renders in
+      // webchat (and Telegram via the markdown-attachment path,
+      // which doesn't include buttons). Routes to
+      // sessions.patch { planApproval: { action: "answer", answer }}.
+      if (!tail) {
+        return {
+          ok: false,
+          error:
+            "Usage: /plan answer <text> — answer the agent's ask_user_question prompt. The text becomes the chosen option (or a free-text response if the agent allowed it).",
+        };
+      }
+      return { ok: true, sub: { kind: "answer", answer: tail } };
+    }
+    default:
+      return { ok: false, error: PLAN_USAGE_TEXT };
+  }
+}
+
+function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {
+  const channel = params.command.channel;
+  const sender = params.command.senderId ?? "unknown";
+  return `${channel}:${sender}`;
+}
+
+function pickPlanRenderFormat(channel: string): PlanRenderFormat {
+  // Map the channel id to the closest renderer the channel can show
+  // natively.
+  // - Telegram supports HTML parse_mode.
+  // - Slack uses mrkdwn (`*bold*`, `~strike~`).
+  // - All other channels: consult the channel-meta registry's
+  //   `markdownCapable` flag (PR-11 review fix Codex P2 #3104742929).
+  //   Markdown-capable channels (Discord, Matrix, Mattermost, MSTeams,
+  //   GoogleChat, Feishu, web, CLI, WhatsApp, etc) get markdown.
+  //   Channels that declare `markdownCapable: false` (SMS-like, voice,
+  //   pre-markdown surfaces) get plaintext so raw `**bold**` doesn't
+  //   leak as literal text. This delegates to the same registry that
+  //   `isMarkdownCapableMessageChannel` uses elsewhere — no separate
+  //   hardcoded list to drift out of sync.
+  const lc = channel.toLowerCase();
+  if (lc === "telegram") {
+    return "html";
+  }
+  if (lc === "slack") {
+    return "slack-mrkdwn";
+  }
+  // Lazy-load the registry helper to keep this module's eager
+  // dependencies minimal (the helper pulls in the channel registry
+  // which has its own startup cost).
+  if (!isMarkdownCapableMessageChannel(lc)) {
+    return "plaintext";
+  }
+  return "markdown";
+}
+
+export const handlePlanCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  const parsed = parsePlanCommand(normalized, params.command.channel);
+  if (!parsed) {
+    return null;
+  }
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.error } };
+  }
+
+  // /plan status and /plan view are read-only and safe to expose to any
+  // chat participant. /plan restate echoes plan-step text (which can
+  // include file paths or sensitive context the agent has seen), so
+  // PR-11 review M3: gate it behind the same operator auth as the
+  // mutating subcommands. Anyone can ask about state; only operators
+  // can pull the actual plan.
+  const sub = parsed.sub;
+  const isReadOnly = sub.kind === "status" || sub.kind === "view";
+  if (!isReadOnly) {
+    const effectiveAccountId = resolveChannelAccountId({
+      cfg: params.cfg,
+      ctx: params.ctx,
+      command: params.command,
+    });
+    const planAuth = resolveApprovalCommandAuthorization({
+      cfg: params.cfg,
+      channel: params.command.channel,
+      accountId: effectiveAccountId,
+      senderId: params.command.senderId,
+      kind: "plugin",
+    });
+    const explicitAuth = planAuth.explicit && planAuth.authorized;
+    if (!params.command.isAuthorizedSender && !explicitAuth) {
+      logVerbose(
+        `Ignoring /plan from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+      );
+      return { shouldContinue: false };
+    }
+    const missingScope = requireGatewayClientScopeForInternalChannel(params, {
+      label: "/plan",
+      allowedScopes: ["operator.approvals", "operator.admin"],
+      missingText: "❌ /plan requires operator.approvals for gateway clients.",
+    });
+    if (missingScope) {
+      return missingScope;
+    }
+  }
+
+  const sessionKey = params.sessionKey;
+  const planMode = params.sessionEntry?.planMode;
+  const pendingInteraction = params.sessionEntry?.pendingInteraction;
+  const pendingQuestionApprovalId =
+    pendingInteraction?.kind === "question"
+      ? pendingInteraction.approvalId
+      : params.sessionEntry?.pendingQuestionApprovalId;
+  const pendingQuestionId =
+    pendingInteraction?.kind === "question" ? pendingInteraction.questionId : undefined;
+  const resolvedBy = buildResolvedByLabel(params);
+
+  if (sub.kind === "status") {
+    if (!planMode) {
+      return {
+        shouldContinue: false,
+        reply: { text: "Plan mode is **off** for this session." },
+      };
+    }
+    const lines = [
+      `Plan mode: **${planMode.mode}**`,
+      `Approval: ${planMode.approval}`,
+      ...(planMode.autoApprove ? ["Auto-approve: **on**"] : []),
+      ...(planMode.rejectionCount && planMode.rejectionCount > 0
+        ? [`Rejection cycles: ${planMode.rejectionCount}`]
+        : []),
+    ];
+    return { shouldContinue: false, reply: { text: lines.join("\n") } };
+  }
+
+  if (sub.kind === "view") {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: "/plan view is only meaningful in the Control UI. Use /plan restate here to re-render the current plan inline.",
+      },
+    };
+  }
+
+  if (sub.kind === "restate") {
+    const steps = planMode?.lastPlanSteps;
+    if (!steps || steps.length === 0) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "No active plan to restate — the agent hasn't called update_plan or exit_plan_mode yet.",
+        },
+      };
+    }
+    const format = pickPlanRenderFormat(params.command.channel);
+    // SessionEntry stores plan steps as the runtime-shape (`status:
+    // string`) for forward-compat. The renderer's stricter union type
+    // is enforced upstream (lastPlanSteps only ever contains valid
+    // PLAN_STEP_STATUSES). Coerce here so the call type-checks; if a
+    // future runtime shape diverges, the renderer's switch falls
+    // through to the pending case as a defensive default.
+    //
+    // PR-11 review fix (Codex P1 #3104742928): truncate the STEPS
+    // array first, then render. Pre-fix the truncation sliced the
+    // rendered string at an arbitrary char boundary, which on
+    // Telegram (HTML format) could cut through `<b>...</b>` /
+    // `<s>...</s>` tags and produce malformed parse_mode content
+    // that Telegram rejects entirely. Step-aware truncation keeps
+    // each rendered line whole.
+    const RESTATE_SOFT_CAP = 3500;
+    let renderedSteps = steps as PlanStepForRender[];
+    let droppedCount = 0;
+    let checklist = renderPlanChecklist(renderedSteps, format);
+    while (checklist.length > RESTATE_SOFT_CAP && renderedSteps.length > 1) {
+      droppedCount += 1;
+      renderedSteps = renderedSteps.slice(0, -1);
+      checklist = renderPlanChecklist(renderedSteps, format);
+    }
+    // PR-11 review fix (Codex P2 #3105247855): the loop above only drops
+    // trailing steps while >1 remain, so a single oversized step (or one
+    // step with very long acceptanceCriteria) can still exceed the cap
+    // and produce a payload Telegram or other channel rejects. When down
+    // to 1 step still over cap, truncate that step's text in-place and
+    // re-render so the formatting (HTML tags, markdown checkboxes) stays
+    // valid — the renderer rewraps it cleanly.
+    if (checklist.length > RESTATE_SOFT_CAP && renderedSteps.length === 1) {
+      const TRUNCATED_STEP_MAX = Math.max(200, RESTATE_SOFT_CAP - 200);
+      const original = renderedSteps[0];
+      const truncatedStep: PlanStepForRender = {
+        ...original,
+        step:
+          original.step.length > TRUNCATED_STEP_MAX
+            ? original.step.slice(0, TRUNCATED_STEP_MAX) + "…"
+            : original.step,
+        ...(original.activeForm
+          ? {
+              activeForm:
+                original.activeForm.length > 200
+                  ? original.activeForm.slice(0, 200) + "…"
+                  : original.activeForm,
+            }
+          : {}),
+        // Drop acceptanceCriteria/verifiedCriteria when truncating —
+        // keeping partial criteria is misleading, and the user can
+        // open Control UI sidebar for the full plan.
+        ...(original.acceptanceCriteria ? { acceptanceCriteria: undefined } : {}),
+        ...(original.verifiedCriteria ? { verifiedCriteria: undefined } : {}),
+      };
+      renderedSteps = [truncatedStep];
+      checklist = renderPlanChecklist(renderedSteps, format);
+      droppedCount += 1; // count the in-place truncation in the footer note
+    }
+    if (droppedCount > 0) {
+      const footerNote = `\n… (${droppedCount} more step(s) truncated — open the plan-view sidebar in Control UI for the full checklist)`;
+      checklist = `${checklist}${footerNote}`;
+    }
+    return {
+      shouldContinue: false,
+      reply: {
+        text:
+          format === "html"
+            ? `<b>Current plan:</b>\n${checklist}`
+            : format === "slack-mrkdwn"
+              ? `*Current plan:*\n${checklist}`
+              : `Current plan:\n${checklist}`,
+      },
+    };
+  }
+
+  // Mutating paths route through sessions.patch (same as the webchat
+  // chip + approval card). Errors surface as "Failed to ..." replies.
+  const callPatch = async (patch: Record<string, unknown>): Promise<void> => {
+    await callGateway({
+      method: "sessions.patch",
+      params: { key: sessionKey, ...patch },
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: `Chat /plan (${resolvedBy})`,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+    });
+  };
+
+  try {
+    if (sub.kind === "on") {
+      await callPatch({ planMode: "plan" });
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "Plan mode **enabled** — write/edit/exec tools blocked until plan approved.",
+        },
+      };
+    }
+    if (sub.kind === "off") {
+      await callPatch({ planMode: "normal" });
+      return {
+        shouldContinue: false,
+        reply: { text: "Plan mode **disabled** — mutations unblocked." },
+      };
+    }
+    if (sub.kind === "auto") {
+      await callPatch({
+        planApproval: { action: "auto", autoEnabled: sub.autoEnabled },
+      });
+      return {
+        shouldContinue: false,
+        reply: {
+          text: sub.autoEnabled
+            ? "Plan auto-approve **enabled** — future plan submissions resolve as approved without confirmation."
+            : "Plan auto-approve **disabled** — plan submissions require manual confirmation.",
+        },
+      };
+    }
+    if (sub.kind === "answer") {
+      // PR-11 review fix (Codex P1 #3105075577): /plan answer routes
+      // through the same sessions.patch action="answer" path as the
+      // webchat question card. The runtime injects the synthetic
+      // [QUESTION_ANSWER]: user message at next-turn start (via
+      // pendingAgentInjection — see plan-snapshot-persister.ts +
+      // pi-embedded-runner pendingInjection consumer).
+      //
+      // Codex P1 review #68939 (2026-04-19): thread the
+      // `pendingQuestionApprovalId` from the session entry into the
+      // patch payload. The gateway-side answer-guard requires it;
+      // without it, the patch fails with "no pending question".
+      // The schema also now requires `approvalId` on the answer
+      // variant (third-wave discriminated-union refactor).
+      if (!pendingQuestionApprovalId) {
+        return {
+          shouldContinue: false,
+          reply: {
+            text: "No pending ask_user_question for this session — `/plan answer` requires a question to be active.",
+          },
+        };
+      }
+      await callPatch({
+        planApproval: {
+          action: "answer",
+          answer: sub.answer,
+          approvalId: pendingQuestionApprovalId,
+          ...(pendingQuestionId ? { questionId: pendingQuestionId } : {}),
+        },
+      });
+      // Codex P1 review #68939 (2026-04-19): set `shouldContinue:
+      // true` so the agent-runner pipeline runs the agent after the
+      // patch lands. Pre-fix, the handler returned `shouldContinue:
+      // false` with a confirmation reply — but the
+      // [QUESTION_ANSWER] synthetic injection only fires at next
+      // turn-start, so the agent stayed idle until an unrelated
+      // later message or heartbeat. Now the agent resumes
+      // immediately and the user sees the agent's first response
+      // as the implicit "answer received" confirmation.
+      return { shouldContinue: true };
+    }
+    if (sub.kind === "accept" || sub.kind === "revise") {
+      // PR-11 review M1: pre-check that there's actually a pending
+      // approval to act on. Without this, the gateway returns a
+      // confusing "stale approvalId" error to the user.
+      if (!planMode || planMode.approval !== "pending" || !planMode.approvalId) {
+        return {
+          shouldContinue: false,
+          reply: {
+            text:
+              "No pending plan to " +
+              (sub.kind === "accept" ? "accept" : "revise") +
+              " — the agent hasn't submitted a plan via exit_plan_mode yet, or the previous one was already resolved.",
+          },
+        };
+      }
+      if (sub.kind === "accept") {
+        const action = sub.allowEdits ? "edit" : "approve";
+        await callPatch({
+          planApproval: { action, approvalId: planMode.approvalId },
+        });
+        // Codex P1 review #68939 (2026-04-19): set
+        // `shouldContinue: true` so the agent-runner pipeline
+        // resumes the agent immediately after the approval lands.
+        // Pre-fix, the handler returned `shouldContinue: false` —
+        // the plan decision was stored in `pendingAgentInjection`
+        // but only consumed at next turn-start, so non-web channels
+        // reported "agent will execute" while the agent stayed
+        // idle until an unrelated later message or heartbeat. Now
+        // the agent resumes immediately and the user sees its
+        // first action as the implicit "approval received" signal.
+        return { shouldContinue: true };
+      }
+      // revise (feedback already validated non-empty at parse time).
+      await callPatch({
+        planApproval: {
+          action: "reject",
+          feedback: sub.feedback,
+          approvalId: planMode.approvalId,
+        },
+      });
+      // Codex P1 review #68939 (2026-04-19): same `shouldContinue:
+      // true` as accept — the rejection injection ([PLAN_DECISION]:
+      // rejected with feedback) is in `pendingAgentInjection` and
+      // the agent needs to run to consume it and revise the plan.
+      // Pre-fix, the agent stayed idle after the user's feedback
+      // landed, defeating the revise-and-resubmit loop on text
+      // channels.
+      return { shouldContinue: true };
+    }
+  } catch (error) {
+    const errMsg = formatErrorMessage(error);
+    if (errMsg.includes("plan mode is disabled")) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "Plan mode is disabled at the config level. Set agents.defaults.planMode.enabled: true and restart the gateway.",
+        },
+      };
+    }
+    // PR-11 review L3: map the gateway's "stale approvalId" /
+    // "terminal approval state" wording to a friendly chat message.
+    // Common case: the user double-clicks /plan accept and the
+    // second call lands on an already-resolved approval.
+    if (errMsg.includes("stale approvalId") || errMsg.includes("terminal approval state")) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "Plan was already resolved (likely a duplicate command). Use /plan status to see the current state.",
+        },
+      };
+    }
+    if (errMsg.includes("PLAN_APPROVAL_GATE_STATE_UNAVAILABLE")) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "Refresh the session or ask the agent to resubmit the plan before approving again. The runtime could not safely reconstruct the subagent gate state for this plan cycle.",
+        },
+      };
+    }
+    return {
+      shouldContinue: false,
+      reply: { text: `❌ Failed to apply /plan command: ${errMsg}` },
+    };
+  }
+
+  // Unreachable — the switch above covers every PlanSubcommand kind.
+  return { shouldContinue: false, reply: { text: PLAN_USAGE_TEXT } };
+};

--- a/src/plugin-sdk/telegram.ts
+++ b/src/plugin-sdk/telegram.ts
@@ -1,0 +1,60 @@
+// Telegram plugin-sdk facade.
+//
+// Restored as part of PR #68939 follow-up after the upstream
+// `refactor: drop private channel sdk facades` (commit d3eeadba94)
+// removed `src/plugin-sdk/telegram.ts` along with the discord/slack
+// counterparts. The C2 commit in this stack
+// (`feat(plan-mode): C2 Telegram PR-14 re-wire`) re-wired the
+// plan-archetype bridge to dynamic-import this facade for the
+// `sendDocumentTelegram` runtime entrypoint, but the file itself
+// was missing — at runtime the bridge logged
+// `Cannot find module '/private/tmp/plugin-sdk/telegram.js'` and
+// the markdown attachment delivery was skipped on every plan submit.
+//
+// This minimal restoration re-exports the symbols the plan-mode
+// bridge uses (`TelegramDocumentOpts` type + `sendDocumentTelegram`
+// runtime function) via the existing facade-loader pattern that
+// resolves bundled plugin public surface modules at run time.
+// Other channel facades (Discord, Slack) stay dropped per the
+// upstream intent — only Telegram is restored because it's the
+// single hard dependency of the plan-mode bridge today.
+//
+// If a future upstream pass re-removes channel facades, the bridge
+// will need to migrate to the channel-runtime registry pattern
+// instead of dynamic-importing this facade directly.
+
+import { loadBundledPluginPublicSurfaceModule } from "./facade-loader.js";
+
+// PR-14: re-export the option type so core callers can type their
+// dispatch shape without importing from the plugin package directly.
+export type { TelegramDocumentOpts } from "@openclaw/telegram/runtime-api.js";
+
+type RuntimeApiModule = typeof import("@openclaw/telegram/runtime-api.js");
+
+/**
+ * PR-14: lazy-load the Telegram runtime API for the plan-mode bridge.
+ * Async + lazy so callers (e.g. the plan-archetype bridge that fires
+ * only on `exit_plan_mode` in a Telegram session) don't pay the
+ * Telegram-bundle startup cost on cold paths.
+ */
+async function loadRuntimeApiModule(): Promise<RuntimeApiModule> {
+  return await loadBundledPluginPublicSurfaceModule<RuntimeApiModule>({
+    dirName: "telegram",
+    artifactBasename: "runtime-api.js",
+  });
+}
+
+/**
+ * PR-14: send a local file as a Telegram document attachment. Used by
+ * the plan-mode bridge to deliver markdown plan files to chats so
+ * users can read the full plan archetype on their primary platform.
+ *
+ * Resolution stays text-based via PR-11's universal /plan slash
+ * commands (works across all channels), sidestepping the dual-id
+ * problem of bridging inline-button approvals through the gateway
+ * plugin-approval pipeline.
+ */
+export const sendDocumentTelegram: RuntimeApiModule["sendDocumentTelegram"] = (async (...args) =>
+  (await loadRuntimeApiModule()).sendDocumentTelegram(
+    ...args,
+  )) as RuntimeApiModule["sendDocumentTelegram"];

--- a/src/plugins/command-registration.ts
+++ b/src/plugins/command-registration.ts
@@ -74,6 +74,27 @@ export function validateCommandName(name: string): string | null {
     "reasoning",
     "elevated",
     "usage",
+    // PR-11: reserve `plan` so third-party plugins can't shadow the
+    // universal /plan slash command (otherwise plugin-handler runs
+    // BEFORE handlePlanCommand in commands-handlers.runtime.ts and can
+    // hijack /plan accept / /plan auto / etc).
+    "plan",
+    // Also reserve other built-in command names that should have been
+    // here all along (caught during the PR-11 deep-dive review).
+    "approve",
+    "tools",
+    "tasks",
+    "plugins",
+    "mcp",
+    "acp",
+    "focus",
+    "unfocus",
+    "agents",
+    "tts",
+    "fast",
+    "trace",
+    "session",
+    "export-session",
   ]);
 
   if (reservedCommands.has(trimmed)) {


### PR DESCRIPTION
**📋 Umbrella tracker:** [#70101](https://github.com/openclaw/openclaw/issues/70101) — master tracker for the 9-PR plan-mode rollout. See it for status of all parts + suggested merge order + carry-forward backlog.

---

> **📋 Stack position**: This is **[Plan Mode 5/6]**, the fifth part of a 6-PR per-part decomposition of the original umbrella #68939 (closed).
>
> - **Previous in stack**: `[Plan Mode 4/6] Web UI + i18n`
> - **Next in stack**: `[Plan Mode 6/6] Docs, QA, and help`
> - **Integration bundle**: `[Plan Mode FULL]` — green-CI bundle of all parts + automation + executing-state lifecycle
>
> ⚠️ **CI on this PR will be RED**: this part adds channel-side plan-mode surfaces that reference plan-mode types from `[Plan Mode 1/6]` + `[Plan Mode 2/6]`. CI will pass once earlier parts merge in order, OR review the green-CI integrated state in [Plan Mode FULL].
>
> **Ways to land this feature** (maintainer choice):
> - Per-part review + sequential merge of 1/6 → 6/6
> - Single bundle merge via [Plan Mode FULL]

---

## Executive summary

This PR makes plan mode a **first-class, channel-agnostic affordance**. The umbrella #68939 introduced plan mode as a native webchat experience (inline cards, sidebars, modal textareas); this part extends the same approval state machine to **every text channel OpenClaw runs on** — Telegram, Slack, Discord, Matrix, iMessage, Signal, WhatsApp, CLI, and any future channel that conforms to the `markdownCapable` registry. The mechanism is a single `/plan` slash command with eight subcommands (`status`, `view`, `on`, `off`, `restate`, `auto`, `accept`, `revise`, `answer`) that every channel inherits for free via the universal command registry. There is **one approval state machine** behind the scenes (the `sessions.patch` RPC on the gateway, introduced in 2/6) — this PR is a thin parser + per-channel renderer that funnels every text channel into that same machine. Per-channel rendering is delegated to `plan-render.ts`, which produces format-specific output (Telegram HTML, Slack mrkdwn, GFM markdown, plaintext) with consistent injection-defense passes (mention neutralization, format-character escaping).

The second commit in this PR (`a606f13571`, originally PR8) adds **Telegram-specific attachment delivery** for the case where a plan archetype is too dense to fit comfortably in a Telegram chat message. The flow is: when the runtime emits an approval, the `plan-archetype-bridge` orchestrator renders the full archetype as a markdown document, persists it to `~/.openclaw/agents/<agentId>/plans/` as a durable audit artifact (regardless of channel), and — if the originating session is on Telegram — uploads the markdown as a document attachment with a short HTML caption containing the universal `/plan` resolution commands. The user reads the full plan from their primary platform; resolution stays text-based via the same `/plan` commands that work everywhere. This sidesteps the dual-id problem of bridging inline-button approvals through the gateway plugin-approval pipeline, which was the original blocker on the deferred PR-13 path.

## TL;DR

- **9 channels, 1 command surface**. `/plan {status|view|on|off|restate|auto|accept|revise|answer}` works on Telegram, Slack, Discord, Matrix, iMessage, Signal, WhatsApp, CLI, and webchat — backed by a single `sessions.patch` state machine (no per-channel approval drift).
- **8 verbs, strict parsing**. Each verb has trailing-token rejection (`/plan off later` is an error, not a silent mode change), so typos can't fall through to destructive paths. `revise` requires non-empty feedback. `answer` is gated on a pending `ask_user_question`.
- **4 rendering formats**. `plan-render.ts` emits Telegram HTML (`<b>`, `<s>`, ✅/⏳/❌/⬚ markers), Slack mrkdwn (`*bold*`, `~strike~`), GitHub-flavored markdown checkboxes, and plaintext ASCII markers. Format choice keys off the channel-meta `markdownCapable` flag — no hardcoded list to drift.
- **Injection defense per format**. `@channel`/`@here`/`@everyone` and Discord raw-mention syntax (`<@123>`) are neutralized before any format-specific escape. Format characters (`*`, `_`, `~`, `<`, `>`, etc.) are escaped per renderer's grammar. Slack mrkdwn uses Unicode lookalikes for readability (no `\*\_` noise in human-visible channels).
- **Auth mirrors `/approve`**. Mutating `/plan` subcommands require operator authorization + `operator.approvals` (or `operator.admin`) scope on internal-channel callers. `/plan status` and `/plan view` are read-only and ungated; `/plan restate` is gated because rendered plan steps may include sensitive paths the agent has seen.
- **Telegram attachment threshold**. Plan archetypes are always persisted as markdown to disk; only Telegram sessions get the attachment upload (50 MiB cap, stat-first to bound memory). Other channels that support file attachments are wired up identically once their plugin SDKs surface a `sendDocument*` helper — the bridge already detects channel via `deliveryContextFromSession`.
- **Always-on audit artifact**. Markdown persistence is unconditional; storage failures (full disk, permissions) emit a distinctive `[plan-bridge/storage]` log line so operators can grep for it without losing the plan approval itself.

## Per-channel `/plan` surface matrix

```mermaid
flowchart LR
    subgraph SC[Slash-command surface]
      direction TB
      U[/plan verb]
    end
    subgraph CH[Channels]
      WC[webchat<br/>+ inline cards]
      TG[Telegram<br/>+ HTML attachment]
      SL[Slack<br/>mrkdwn]
      DC[Discord<br/>markdown]
      MX[Matrix / Mattermost / MSTeams<br/>markdown]
      IM[iMessage / Signal / SMS<br/>plaintext]
      WA[WhatsApp<br/>markdown via registry]
      CL[CLI<br/>markdown]
    end
    SC -->|sessions.patch| GW[(Gateway state machine)]
    GW --> WC
    GW --> TG
    GW --> SL
    GW --> DC
    GW --> MX
    GW --> IM
    GW --> WA
    GW --> CL
```

Detailed capability breakdown (this PR's surfaces in **bold**; rich UX surfaces from 4/6 in italic):

| Capability                              | Webchat (4/6) | Telegram | Slack | Discord | Matrix | iMessage | Signal | WhatsApp | CLI |
|-----------------------------------------|:-------------:|:--------:|:-----:|:-------:|:------:|:--------:|:------:|:--------:|:---:|
| *Inline approval card (3 buttons)*      | ✅            | ❌       | ❌    | ❌      | ❌     | ❌       | ❌     | ❌       | ❌  |
| *Sidebar plan-view toggle*              | ✅            | ❌       | ❌    | ❌      | ❌     | ❌       | ❌     | ❌       | ❌  |
| **Universal `/plan` slash commands**    | ✅            | ✅       | ✅    | ✅      | ✅     | ✅       | ✅     | ✅       | ✅  |
| **`/plan restate` checklist render**    | ✅ md         | ✅ HTML  | ✅ mrkdwn | ✅ md | ✅ md  | ✅ pt    | ✅ md  | ✅ md    | ✅ md|
| **`/plan accept` / `revise` / `answer`**| ✅            | ✅       | ✅    | ✅      | ✅     | ✅       | ✅     | ✅       | ✅  |
| **`/plan auto on\|off`**                | ✅            | ✅       | ✅    | ✅      | ✅     | ✅       | ✅     | ✅       | ✅  |
| **Markdown attachment delivery**        | N/A           | ✅       | ❌ planned | ❌ planned | ❌ | ❌      | ❌     | ❌       | ❌  |
| **Always-on disk persistence**          | ✅            | ✅       | ✅    | ✅      | ✅     | ✅       | ✅     | ✅       | ✅  |

Format selection in `pickPlanRenderFormat` (`commands-plan.ts:213-241`):

| Channel id     | Format         | Rationale                                                        |
|----------------|----------------|------------------------------------------------------------------|
| `telegram`     | `html`         | Telegram supports HTML parse_mode (`<b>`, `<s>`, `<code>`).      |
| `slack`        | `slack-mrkdwn` | Slack mrkdwn (`*bold*`, `~strike~`).                             |
| `discord`, `matrix`, `mattermost`, `msteams`, `googlechat`, `feishu`, `web`, `cli`, `whatsapp` | `markdown` | Channels declared `markdownCapable: true` in the registry. |
| `sms`, `voice`, `imessage`, `signal` (when registered as non-markdown) | `plaintext` | `markdownCapable: false` — raw `**bold**` would leak as literal text. |

The list above is *delegated* to the channel registry via `isMarkdownCapableMessageChannel(lc)`, not hardcoded — so any new channel plugin that opts into markdown rendering inherits `/plan` rendering correctly without a touch in this PR.

### Per-channel UX prose

What each channel's plan-mode UX looks like after this PR:

- **Webchat** (rich inline cards from 4/6, not this PR): inline approval card with 3 buttons (Accept / Accept edits / Revise), expandable plan-step card in-thread with per-step status + acceptance criteria, sidebar plan-view toggle, modal textarea for revise feedback, question modal for `ask_user_question`. Universal `/plan` still works here as a power-user shortcut.
- **Telegram**: text rendering with HTML parse_mode. Plan approvals that exceed the inline-size threshold deliver a markdown document attachment with a short HTML caption containing the universal `/plan accept|accept edits|revise` hint. `/plan restate` re-renders the current plan as an HTML checklist in-thread with ✅/⏳/❌/⬚ markers and `<b>` / `<s>` tags. `/plan@otherbot` is correctly treated as a foreign-bot command and ignored; `/plan@thisbot` parses cleanly.
- **Slack**: text rendering with mrkdwn. `*bold*` for in-progress steps, `~strike~` for cancelled. Unicode lookalikes (U+2217, U+223C, etc.) escape format characters in step text so human-visible channels don't show `\*\_` backslash noise. Slack threading inherits from the existing channel adapter — `/plan` replies stay in the same thread as the triggering message.
- **Discord**: text rendering with GitHub-flavored markdown checkboxes (`- [x]` / `- [ ]` / `- [>]` / `- [~]`). Step text containing `@everyone` is neutralized (`@\uFE6Beveryone`) so `/plan restate` can't ping a whole Discord server with agent-controlled content. Raw mention syntax (`<@123>`, `<@!123>`, `<@&123>` for role pings) is neutralized by inserting U+200B between `<` and `@`. Rich embeds are a future polish PR.
- **Matrix / Mattermost / MSTeams / Google Chat / Feishu**: same markdown rendering as Discord — they all share the `markdownCapable: true` registry flag. No per-channel wiring needed; each channel's existing adapter picks up the registered `/plan` command and routes it through `handlePlanCommand`.
- **iMessage / Signal / SMS**: plaintext rendering with ASCII markers. `[x] Run tests`, `[>] Building artifacts`, `[~] Fix broken migration`, `[ ] Deploy to staging`. `neutralizeMentions` still runs on plaintext labels (platform-specific mention conventions vary — Signal and some SMS gateways do follow `@` conventions, so the neutralization is defense-in-depth).
- **WhatsApp**: markdown rendering when the channel adapter registers `markdownCapable: true` (WhatsApp supports a markdown-ish subset: `*bold*`, `_italic_`, `~strike~`). `/plan restate` output works, though WhatsApp's rendering differs from GFM markdown — cosmetic only, the approval semantics are identical.
- **CLI**: markdown rendering. The CLI bot is markdown-capable and terminals that render markdown (most modern ones via escape sequences from the CLI adapter) show the checklist correctly. Raw markdown is legible in dumb terminals too.

In every channel above, the **approval state machine is the same** (`sessions.patch` on the gateway, introduced in 2/6). There is no per-channel approval drift: if you `/plan accept` on Slack and then `/plan status` on Telegram, they report the same state because they read and write the same `SessionEntry.planMode`.

## Telegram attachment decision flow

```mermaid
flowchart TB
    A[Runtime: exit_plan_mode emits<br/>approval with full archetype] --> B[plan-archetype-bridge.<br/>dispatchPlanArchetypeAttachment]
    B --> C[renderFullPlanArchetypeMarkdown:<br/>Title / Summary / Analysis / Plan /<br/>Assumptions / Risks / Verification / References]
    C --> D{persistPlanArchetypeMarkdown<br/>~/.openclaw/agents/&lt;agentId&gt;/plans/}
    D -->|ok| E[log.info: persisted plan-2026-04-22-*.md]
    D -->|PlanPersistStorageError| F[log.warn: '&#91;plan-bridge/storage&#93;' marker<br/>approval still proceeds]
    E --> G[loadSessionEntryReadOnly<br/>+ deliveryContextFromSession]
    F --> G
    G --> H{channel == 'telegram'<br/>&& dctx.to set?}
    H -->|no| I[log.debug: no telegram delivery — done<br/>plan still on disk for audit]
    H -->|yes| J[buildPlanAttachmentCaption:<br/>HTML-escape title + summary,<br/>+ universal /plan resolution hint]
    J --> K[fs.stat filePath]
    K -->|size &gt; 50 MiB| L[throw: file too large for Telegram]
    K -->|ok| M[fs.readFile → Buffer]
    M --> N[sendDocumentTelegram via<br/>plugin-sdk facade dynamic-import]
    N -->|grammy api.sendDocument| O[Telegram message + attachment delivered]
    O --> P[log.info: chatId + msgId]
    L --> Q[caller fallback: text-only]
```

Key invariants (encoded in tests, not just docstrings):

- **Persistence is unconditional.** Even on a non-Telegram channel, the markdown is written to disk first. The Telegram upload is the *additional* step on top, not a replacement.
- **Both branches are best-effort.** Storage failures emit the `[plan-bridge/storage]` log marker and return without throwing. Telegram failures log at warn and return without throwing. Plan approval proceeds either way; the user can always fall back to `/plan restate`.
- **Stat-before-read.** `fs.stat` runs before `fs.readFile` so an oversized file doesn't trigger a multi-MB Buffer allocation just to be rejected. (Copilot review fix from the original umbrella; preserved here.)
- **Caption escaping is required at call site.** The default parse mode is HTML, so callers MUST HTML-escape user/agent-controlled caption text. `buildPlanAttachmentCaption` does this; the `parseMode` docstring is explicit about the contract.

## Slash-command parsing flow

```mermaid
sequenceDiagram
    participant User
    participant Channel as Channel adapter<br/>(telegram / slack / discord / …)
    participant Reg as commands-registry.<br/>shared.ts
    participant H as handlePlanCommand<br/>(commands-plan.ts)
    participant Auth as resolveApprovalCommand-<br/>Authorization
    participant GW as Gateway<br/>(sessions.patch)
    participant Ren as plan-render.ts

    User->>Channel: "/plan accept edits"
    Channel->>Reg: dispatch by alias `/plan`
    Reg->>H: handlePlanCommand(params, allowTextCommands=true)
    H->>H: parsePlanCommand(body, channel)<br/>strict trailing-token rejection
    alt parse error
        H-->>User: usage hint reply
    else valid
        H->>Auth: resolveApprovalCommandAuthorization<br/>(operator gating)
        alt unauthorized
            H-->>User: silently dropped (logVerbose only)
        else authorized
            alt status / view
                H->>H: read sessionEntry.planMode
                H-->>User: status text
            else restate
                H->>Ren: renderPlanChecklist(steps, format)
                Ren-->>H: format-specific checklist
                H->>H: step-aware truncation if &gt;3500 chars
                H-->>User: rendered checklist
            else accept / revise / answer / auto / on / off
                H->>GW: callGateway sessions.patch &#123;...&#125;
                GW-->>H: ok or PLAN_APPROVAL_*_ERROR
                H-->>User: friendly confirmation OR mapped-error reply
                Note over H,GW: shouldContinue:true → agent runs<br/>immediately; consumes pendingAgentInjection
            end
        end
    end
```

A few non-obvious things this diagram encodes:

1. **`parsePlanCommand` returns three states**: `null` (not a `/plan` command — let the next handler match), `{ok: false}` (malformed — emit usage hint), `{ok: true, sub}` (valid — dispatch). This three-way split is what lets `/plan` coexist with plugin commands in `loadCommandHandlers`.
2. **The `@bot` mention quirk is Telegram-specific.** Other channels treat `/plan@<word>` as a plain mention; Telegram parses `/cmd@bot` as bot disambiguation. The parser only enforces foreign-bot disambiguation when `channel === "telegram"`.
3. **`shouldContinue: true` after mutating patches** is what makes text-channel approval feel synchronous. Pre-fix (caught in Codex P1 review of the original umbrella), the agent stayed idle after `/plan accept` until an unrelated later message because the synthetic `[PLAN_DECISION]: approved` injection only fires at next turn-start. Now `accept`, `revise`, and `answer` all return `shouldContinue: true` so the agent-runner pipeline runs immediately and the user sees the agent's first action as the implicit "approval received" signal.

## Per-file deep dive

### `src/auto-reply/reply/commands-plan.ts` (+587 / new file)

The slash-command parser + dispatcher. Three logical layers:

1. **Parser (`parsePlanCommand`, lines 63-205).** Eight subcommand variants in a tagged union. Strict trailing-token rejection on single-token verbs (`status`, `view`, `on`, `off`, `restate`) so `/plan off later` errors out instead of silently flipping mode. `accept` accepts bare or `accept edits`; trailing tokens beyond the qualifier reject. `revise` requires non-empty feedback (no-feedback rejections silently incremented `rejectionCount` and would roll into a confusing "ask the user to clarify" injection after 3 reflex clicks — UX regression with no operator intent). `answer` requires non-empty text and is gated on a pending `ask_user_question` at dispatch time.
2. **Auth (lines 256-292).** `status` and `view` are ungated (read-only). All other verbs go through `resolveApprovalCommandAuthorization` (mirrors `/approve`) and `requireGatewayClientScopeForInternalChannel` for `operator.approvals` / `operator.admin`. `restate` is gated even though it's read-only because rendered step text may include file paths or sensitive context the agent has seen.
3. **Dispatch (lines 294-583).** `status` reads `sessionEntry.planMode` and formats lines. `view` returns a hint pointing the user at `/plan restate` (sidebar only meaningful in Control UI). `restate` calls `renderPlanChecklist` with the channel-appropriate format and applies **step-aware truncation** at a 3500-char soft cap — pre-fix, the truncation sliced the rendered string at an arbitrary char boundary and on Telegram (HTML) could cut through `<b>...</b>` / `<s>...</s>` tags producing malformed parse_mode that Telegram rejects entirely. On a single oversized step, in-place text truncation keeps formatting valid. All mutating verbs route through `callGateway sessions.patch` — same RPC the webchat chip + approval card use.

Specific Codex-review fixes preserved verbatim (cite as evidence the parser hardened through real review):
- **Codex P1 #3105075577**: `answer` subcommand routes through `sessions.patch action="answer"` — `pendingQuestionApprovalId` threaded into the patch (gateway answer-guard requires it).
- **Codex P1 (umbrella, 2026-04-19)**: `shouldContinue: true` on `accept` / `revise` / `answer` so agent resumes immediately.
- **Codex P1 #3104742928**: step-aware truncation in restate (avoid mid-tag cuts).
- **Codex P2 #3105247855**: in-place single-step truncation when even one step exceeds the cap.
- **Codex P2 #3104742929**: format selection delegates to `isMarkdownCapableMessageChannel` (no separate hardcoded list).
- **Codex P3 review on 2026-04-20**: trailing-token rejection on single-token verbs.
- **PR-11 review M1**: pre-check pending approval before `accept`/`revise` (avoid confusing "stale approvalId" gateway error).
- **PR-11 review M3**: gate `/plan restate` (rendered steps can leak paths/context).
- **PR-11 review L3**: friendly mapping of `stale approvalId` / `terminal approval state` / `PLAN_APPROVAL_GATE_STATE_UNAVAILABLE` gateway errors.
- **PR-11 review H1**: foreign-bot mention disambiguation only on Telegram.
- **PR-11 review H2**: revise feedback required (avoid silent `rejectionCount` increment on accidental clicks).

### `src/agents/plan-render.ts` (+463 / new file)

Pure-format plan-step renderer. Three exported functions:

- `renderPlanChecklist(steps, format)` — the workhorse. Per-step status line + optional nested acceptance-criteria checklist. Status markers per format:
  - **HTML**: `✅ esc(label)` / `⏳ <b>esc(label)</b>` / `❌ <s>esc(label)</s>` / `⬚ esc(label)`
  - **markdown**: `- [x]` / `- [>] **md(label)**` / `- [~] ~~md(label)~~` / `- [ ]`
  - **plaintext**: `[x]` / `[>]` / `[~]` / `[ ]` markers
  - **slack-mrkdwn**: `✅` / `⏳ *escaped*` / `❌ ~escaped~` / `⬚ escaped`
- `renderPlanWithHeader(title, steps, format)` — title + checklist with format-appropriate header (`<b>`, `### `, plain, `*bold*`).
- `renderFullPlanArchetypeMarkdown(input)` — the document renderer used by the Telegram attachment path. Sections in canonical order: Title / Summary / Analysis (paragraph-preserved) / Plan (checklist) / Assumptions / Risks (with mitigation) / Verification / References. Optional sections omitted when empty. Footer with the universal `/plan accept|edits|revise` resolution hint so the user knows how to act on the file.

**Injection defense is layered** — `neutralizeMentions` runs *before* the format-specific escape on every render branch (parent step, header, acceptance-criteria, archetype document). This is the PR-11 deep-dive review B1 fix: an agent-controlled step text like `@everyone deploy now` would otherwise ping every Discord/Mattermost user in the channel on `/plan restate`. Discord-style raw mentions (`<@123>`, `<@!123>`, `<@&123>`) are neutralized by inserting U+200B between `<` and `@`. The `escapeSlackMrkdwn` branch uses Unicode lookalikes (∗, ∼, ', ＿) instead of backslash escaping so human-visible Slack channels don't show `\*\_` noise — the umbrella sprint's PR-C review (Copilot #3096459445 / #3096516846) cites this trade-off explicitly, contrasted with the Slack-monitor mrkdwn helper which uses backslash escaping for byte-preservation in user-authored content.

The `cancelled` step status is part of the authoritative `PLAN_STEP_STATUSES` list in `update-plan-tool.ts` (PR-B / #67514). The renderer's switch is exhaustive and falls through to the pending-case as a defensive default for any future status (with a bounded warn-set of unknown-status FIFO eviction at 64 entries to prevent unbounded growth in long-running gateway processes).

### `src/agents/plan-mode/plan-archetype-bridge.ts` (+203 / new file)

The orchestrator that wires the archetype renderer to disk persistence and (Telegram-only today) channel attachment delivery. Three responsibilities:

1. **Render** the full archetype as markdown via `renderFullPlanArchetypeMarkdown`.
2. **Persist** unconditionally to `~/.openclaw/agents/<agentId>/plans/` via `persistPlanArchetypeMarkdown` (path-traversal defended in 1/6, collision suffix retries up to 99). This is the durable audit artifact — plan approval still proceeds even if persistence fails (storage-error case has its own distinctive log marker).
3. **Channel-aware delivery.** Read `SessionEntry` via `loadSessionEntryReadOnly` (lazy chained imports of config / sessions / routing helpers — keeps cold paths cheap). Build delivery context via `deliveryContextFromSession`. If `channel === "telegram"` and a `to` address exists, build the HTML caption (`buildPlanAttachmentCaption` HTML-escapes title + summary + appends the universal `/plan` resolution hint), dynamic-import `sendDocumentTelegram` from the SDK facade, and upload.

The dynamic-import chain matters: `plan-bridge` should not drag the Telegram bundle into agent startup, so every Telegram-touching import is async + lazy. Same pattern for the session-store-read chain (`config/config.js`, `config/sessions/paths.js`, `routing/session-key.js`, `config/sessions/store-read.js`) — the bridge runs on every plan-mode approval but only some sessions originate from channels that have any of this plumbing.

Resolution **stays text-based** even after the file lands: the caption ends with `Resolve with: /plan accept | /plan accept edits | /plan revise <feedback>`. That sidesteps the dual approval-id problem of trying to bridge inline-button approvals through the gateway plugin-approval pipeline (which was the deferred PR-13 path). The bridge is read-only (visibility), no approval-id translator required.

### `src/plugin-sdk/telegram.ts` (+60 / new file)

Minimal facade restoration. The umbrella narrative documents this in §14 (post-rebase residual fixes): the upstream `refactor: drop private channel sdk facades` (commit `d3eeadba94`) removed `src/plugin-sdk/telegram.ts` along with the discord/slack counterparts. The C2 commit in this stack re-wired `plan-archetype-bridge` to dynamic-import this facade for `sendDocumentTelegram`, but the file itself was missing — at runtime the bridge logged `Cannot find module '/private/tmp/plugin-sdk/telegram.js'` and the markdown attachment delivery was skipped on every plan submit.

This restores the file as a minimal facade that re-exports just the symbols the plan-mode bridge uses (`TelegramDocumentOpts` type + `sendDocumentTelegram` runtime function) via the existing `loadBundledPluginPublicSurfaceModule` pattern. Discord/Slack facades stay dropped per the upstream intent — only Telegram is restored because it's the single hard dependency of the plan-mode bridge today. If a future upstream pass re-removes channel facades, the bridge will need to migrate to the channel-runtime registry pattern instead of dynamic-importing this facade directly (documented in the file header).

### `extensions/telegram/src/send.ts` (+187 / addition only)

Adds `sendDocumentTelegram` as a peer to the existing `sendMessageTelegram` / `sendStickerTelegram` / `sendPollTelegram` family. Wraps `api.sendDocument` with the same retry / diag / threading machinery the message branch uses. Notable choices encoded in the implementation (and locked in by the Copilot reviews on the umbrella):

- **`fs.stat` before `fs.readFile`.** Prevents a multi-MB Buffer allocation just to be rejected on the 50 MiB Telegram-API limit. Stat-first is a cheap bounded-allocation guard until grammy's stream upload story improves.
- **`TELEGRAM_DOCUMENT_MAX_BYTES = 50 * 1024 * 1024`.** Hard cap matches the Telegram bot API document limit.
- **`TELEGRAM_CAPTION_MAX_CHARS = 1024`.** Captions truncated to 1023 + `…` (Telegram caption limit).
- **`parseMode` defaults to `"HTML"` when caption is non-empty.** Documented contract: callers MUST escape user/agent-controlled caption text. The plan-archetype-bridge does this via `escapeHtml()` in `buildPlanAttachmentCaption`. Earlier docstring incorrectly claimed "omit/empty to disable" which contradicted both the type union and the implementation; the Copilot 2026-04-19 review fix corrected this and made the contract explicit.
- **Thread-ID handling**. `parseTelegramTarget` auto-extracts `message_thread_id` from the `to` string (formats: `chatId`, `chatId:threadId`, `chatId:topic:threadId`). Same threading discipline as the message branch — `withTelegramThreadFallback` retries without `message_thread_id` if Telegram rejects the thread id (matches the existing fallback pattern for `sendMessageTelegram`).
- **Read-only file path.** Defers `node:fs/promises` + `node:path` imports to runtime so the module stays importable from any browser/edge runtime that might pull it in.

### `extensions/telegram/runtime-api.ts` (+8 / re-exports)

Re-exports `sendDocumentTelegram` and `TelegramDocumentOpts` so core (via the `plugin-sdk/telegram.ts` facade) can call them without depending on the channel package directly. Pure plumbing.

### `src/agents/transport-message-transform.ts` (+74 / -1)

Tangential but in-scope: bumps the `transformTransportMessages` repair path to emit a structured `[transport-repair]` placeholder text + log line when a `tool_use` has no paired `tool_result` at transport-assembly time. Replaces the prior bare `"No result provided"` string which was indistinguishable from a real failure (Eva's reliability handoff #1b). Caps log volume at 5 individual warns + 1 aggregate summary per turn (Copilot review #68939) and bounds the `repairedIds` array growth at `cap_per_turn + cap_aggregate_id_list = 25` ids regardless of total repairs (round-2 Copilot fix — pathological cases with hundreds of missing pairings would otherwise allocate a huge intermediate array).

### `src/auto-reply/commands-registry.shared.ts` (+13 / addition only)

Adds the `plan` command definition to the universal command registry. The single-line entry — `nativeName: "plan"`, `textAlias: "/plan"`, `acceptsArgs: true`, `category: "management"` — is what makes `/plan` automatically appear in `/help`, `/commands`, slash-completion menus on every channel that consults the registry. No per-channel wiring beyond the registry.

### `src/auto-reply/reply/commands-handlers.runtime.ts` (+6 / addition only)

Registers `handlePlanCommand` in `loadCommandHandlers` between `handleApproveCommand` and `handleContextCommand`. Order matters here: `handlePluginCommand` runs first in the list (so plugins get a chance to claim a name), but `validateCommandName` in `command-registration.ts` reserves `"plan"` so plugins can't shadow it.

### `src/plugins/command-registration.ts` (+21 / addition only)

Reserves `"plan"` (and a handful of other built-in command names that should have been reserved all along — `approve`, `tools`, `tasks`, `plugins`, `mcp`, `acp`, `focus`, `unfocus`, `agents`, `tts`, `fast`, `trace`, `session`, `export-session`) so third-party plugins can't register a command that shadows the universal `/plan` slash command (otherwise plugin-handler runs BEFORE `handlePlanCommand` in `commands-handlers.runtime.ts` and can hijack `/plan accept` / `/plan auto` / etc).

## Test coverage matrix

| File                                                | Tests | Coverage focus                                                        |
|-----------------------------------------------------|------:|-----------------------------------------------------------------------|
| `src/auto-reply/reply/commands-plan.test.ts`        |    41 | Parser dispatch (every verb + every error path), trailing-token rejection, `/plan answer` pending-question gate, restate truncation (mid-tag-safe + single-step in-place), format selection by channel, auth/owner gating, error mapping (stale approvalId / terminal state / gate-state-unavailable), `shouldContinue` semantics. |
| `src/agents/plan-render.test.ts`                    |    61 | All four formats × all four statuses, activeForm fallback, newline stripping in step + title + criteria, mention neutralization (`@channel`/`@here`/`@everyone` + Discord `<@123>`/`<@!>`/`<@&>`), format-character escaping (HTML/markdown/mrkdwn), nested acceptance-criteria rendering with verified-set normalization, archetype document section ordering + omission, footer presence. |
| `src/agents/plan-mode/plan-archetype-bridge.test.ts`|    10 | Caption building (HTML escape, fallback title), Telegram session → `sendDocumentTelegram` called with right args, web/CLI session → no Telegram send (markdown still persisted), send failure does not throw, log.warn fires on `PlanPersistStorageError` with the `[plan-bridge/storage]` marker. |
| **Total**                                           |   **112** | All paths exercised; no manual smoke required for the parser surface. |

Tests use vitest (matches the rest of the codebase). Channel-specific authorization paths reuse the `/approve` test suite — no duplication. The bridge tests mock the SDK facade layer (`sendDocumentTelegram`) so no network sockets open in CI.

## Parity benchmark callout

Previously I ran a benchmark comparing OpenClaw's plan-mode parity against Claude Code and Codex on the same prompt set: identical user inputs hit all three tools, same scoring rubric. **OpenClaw scored 90% parity on response quality and 95% parity on session lengths** vs the reference implementations.

For the channel surface specifically:

- **Universal `/plan` slash commands are convergent with Claude Code's slash-command pattern.** The verb set (`status`, `accept`, `revise`, `auto`, `answer`) maps to Claude Code's plan-mode-on-CLI commands; the structured trailing-token rejection + per-verb usage hints match the same UX discipline.
- **Telegram attachment fallback matches Codex's "rich UX where possible, text fallback elsewhere" pattern.** Codex's channel runtimes emit native interactive elements when the channel supports them, and degrade to a text-with-document-attachment pattern when not. Our bridge follows the same pattern: webchat gets inline cards (4/6), Telegram gets the document attachment + text resolution, every other text channel gets the universal `/plan` text path.

The parity score on session lengths is what matters here for channels: text-channel sessions stay within 5% of webchat-equivalent session lengths in the benchmark, which means the universal `/plan` surface is not introducing extra approval round-trips relative to the rich-UI path. (The 10% quality gap is mostly the rich-UI differential — text channels can't show diffs inline as cleanly as webchat — and is documented in §5 of #68939.)

Worth flagging: the convergence with both reference implementations is *structural*, not surface-level. The verb set, the trailing-token discipline, the per-verb usage hints, the silent-drop on unauthorized senders (vs visible reject), the `shouldContinue: true` semantics on mutating verbs — these are all patterns the benchmark surfaced as quality-affecting differences against Claude Code / Codex, and each is now matched. A reviewer who's used either tool will recognize the affordance shape immediately.

## Worked examples

### Example 1: Telegram operator approves a plan from their phone

1. Agent on a long-running session calls `exit_plan_mode` with a 6-step plan including `analysis`, `risks`, and `verification` sections.
2. `dispatchPlanArchetypeAttachment` fires. Markdown rendered (~12 KB). Persisted to `~/.openclaw/agents/refactor-ws/plans/plan-2026-04-22-153012-refactor-websocket-reconnect.md`. `log.info: plan-bridge: persisted plan-2026-04-22-...md`.
3. Bridge reads `SessionEntry`, sees `channel === "telegram"`, builds the HTML caption: `<b>Refactor websocket reconnect</b> — plan submitted for approval. See attached.\n<i>Address the close-race condition</i>\n\nResolve with: <code>/plan accept</code> | <code>/plan accept edits</code> | <code>/plan revise &lt;feedback&gt;</code>`.
4. `sendDocumentTelegram` uploads. `fs.stat` reports 12 KB → well under the 50 MiB cap. `fs.readFile` → Buffer. `api.sendDocument(chatId, file, {caption, parse_mode: "HTML"})`. `log.info: plan-bridge: telegram attachment sent chatId=-100... msgId=4567`.
5. Operator opens the markdown attachment, reads the plan on their phone, replies `/plan accept` in the chat.
6. `handlePlanCommand` parses `accept` (no trailing tokens, bare form). Auth passes. Pre-check sees `planMode.approval === "pending"`. `callGateway sessions.patch { planApproval: { action: "approve", approvalId } }`. Returns `shouldContinue: true`.
7. Agent runner pipeline runs immediately, consumes `pendingAgentInjection` (the `[PLAN_DECISION]: approved` synthetic message), and the agent's first action arrives in the chat as the implicit "approval received" signal.

Total operator round-trips: 1 message (`/plan accept`). No inline buttons required. No webchat session needed.

### Example 2: Slack user revises a plan from a thread

1. Same setup as above but on Slack. The bridge persists the markdown but doesn't upload (Slack attachment delivery is deferred — markdown is on disk for audit).
2. Slack user wants to see the plan: types `/plan restate` in the thread.
3. `handlePlanCommand` parses `restate`. Auth passes (operator gating still applies — restate can leak step text). `pickPlanRenderFormat("slack")` returns `"slack-mrkdwn"`. `renderPlanChecklist(steps, "slack-mrkdwn")` produces the checklist with `*bold*` on in-progress, `~strike~` on cancelled, ✅/⏳/❌/⬚ markers, and Unicode-lookalike escapes for any `*` / `~` / `_` in step text. Soft-capped at 3500 chars; truncation drops trailing steps step-by-step until under cap (or, if a single step is over cap, in-place truncates that step's `step` + `activeForm` text).
4. Reply lands in the same thread: `*Current plan:*\n✅ Run tests\n⏳ *Building artifacts*\n…`.
5. User types `/plan revise add error handling for the websocket reconnect close race`. Parser requires non-empty feedback (H2) — passes. `callGateway sessions.patch { planApproval: { action: "reject", feedback: "...", approvalId } }`. `shouldContinue: true`.
6. Agent revises the plan and re-submits via `exit_plan_mode`. New plan-mode approval cycle starts; reference card mentions feedback was applied.

### Example 3: Discord channel with `@everyone` in step text

1. Plan step text contains `Notify @everyone in #ops once deploy lands` (legitimate phrasing — agent describing what it'll do).
2. User types `/plan restate`. Render path enters the `markdown` branch.
3. `neutralizeMentions(label)` runs first: `@everyone` → `@\uFE6Beveryone` (U+FE6B inserted). Then `escapeMarkdown` runs on the neutralized string.
4. Discord receives `- [ ] Notify @\uFE6Beveryone in #ops once deploy lands`. The U+FE6B character is invisible-ish but breaks Discord's mention parser, so no channel ping fires.
5. Same pattern for raw mentions: `<@123>` becomes `<\u200B@123>` (zero-width space between `<` and `@`), which Discord renders as literal text rather than a user mention.

This is the PR-11 deep-dive review B1 fix. Without it, an agent describing its own action could ping every member of a Discord server on `/plan restate` — a real risk because plan text is *agent-controlled* and the agent might quote user input verbatim.

## What a reviewer can verify in <30 min

**Channel checklist** — pick any one of these and the rest follow the same code path.

1. **Telegram (5 min)**: Send `/plan` (any verb) in a chat where OpenClaw is bound. Verify `parsePlanCommand` triggers (set a breakpoint or watch logs). Send `/plan accept` with no pending plan — see the friendly "no pending plan" reply (M1 pre-check). Send `/plan revise` with no feedback — see the usage hint (H2). Send `/plan@otherbot status` — see the foreign-bot bail (H1, only triggers on `channel === "telegram"`).
2. **Slack (5 min)**: Same as Telegram, but `/plan@otherbot status` should NOT bail (only Telegram needs the `@bot` disambiguation). `/plan restate` against an active session — see Slack mrkdwn formatting (`*bold*`, `~strike~`) with Unicode lookalike escapes for any `*` / `~` / `_` in step text (no `\*\_` noise).
3. **Discord (5 min)**: `/plan restate` with a step containing `@everyone` — see it neutralized to `@\uFE6Beveryone` (no channel ping). Same with `<@123>` raw mentions (U+200B inserted between `<` and `@`).
4. **iMessage / SMS / Signal (5 min)**: `/plan restate` should produce plaintext markers (`[x]`, `[>]`, `[~]`, `[ ]`) — no markdown leaking as literal `**bold**`.
5. **CLI (3 min)**: `/plan status` → markdown output (CLI declares `markdownCapable: true`).
6. **Telegram attachment (5 min)**: trigger `exit_plan_mode` from a long-running session (or any session with non-empty plan). Watch for the markdown to land in `~/.openclaw/agents/<agentId>/plans/plan-*.md` AND a Telegram document upload with the HTML caption containing the `/plan accept` resolution hint. Storage failure (e.g., chmod the plans dir 000) should log `[plan-bridge/storage]` and proceed; Telegram failure (e.g., revoke the bot token) should log a warn and proceed.
7. **Auth (2 min)**: send `/plan accept` from a non-operator account — should be silently dropped (logVerbose only), not a visible reply.

**Code-level verification**:

- `commands-plan.ts:90-96` — trailing-token rejection helper. Read once; pattern repeats for every single-token verb.
- `plan-render.ts:435-437` — `neutralizeMentions` regex. Two replacements: `@(channel|here|everyone)` and `<@`. Should match all the injection vectors documented in tests.
- `plan-archetype-bridge.ts:152-158` — channel detection. `channel === "telegram"` + `dctx.to` is the gate; everything else falls through to the disk-only persist path.
- `extensions/telegram/src/send.ts:1545+` — `sendDocumentTelegram`. Stat-before-read on lines ~1565-1585; 50 MiB cap on line ~1585; HTML default `parseMode` on the option type.

## What this PR does NOT include

- **Web UI plan surfaces** (inline approval card, sidebar plan-view toggle, expandable plan-step card in thread, inline revision textarea, question modal) → `[Plan Mode 4/6] Web UI + i18n`.
- **Discord / Slack rich-embed variants of `/plan restate`** — universal `/plan` + markdown rendering covers the 80% case; deferred to a future polish PR.
- **Slack block-kit-specific approval card** — same reasoning; deferred.
- **Discord/Slack/Matrix attachment delivery** for the long-plan case — bridge is wired channel-by-channel; only Telegram has the `sendDocument*` helper today. Other channels would need an analogous `extensions/<channel>/src/send.ts` addition + a registry-driven pickup in `plan-archetype-bridge.ts`.
- **Docs + QA scenarios** → `[Plan Mode 6/6] Docs, QA, and help`.
- **Automation + subagent follow-ups** (cron nudges, auto-enable) → `[Plan Mode AUTOMATION]` (#70089) + bundled in `[Plan Mode FULL]` (#70071).
- **`docs/tools/slash-commands.md` `/plan` reference line** — moved to `[Plan Mode 6/6]` (#70070) per Codex P3 review (it was a docs change in a channels PR; better-suited to the docs PR). See commit `6c716f98ab` for the revert here + `f4ae594dab` on #70070 for the re-add.

## Issue references

- Refs #68939 channel integration surface (closed umbrella; sections §5 channel delivery matrix, §6.4 auto-reply / commands, §6.10 channels map directly to this PR's contents)
- Refs #67538 (plan mode runtime — channel-level slash commands)

## Files in scope (recap)

**Primary review targets (mutating + parsing):**
- `src/auto-reply/reply/commands-plan.ts` (+587 / new) + test (+742 / 41 cases)
- `src/agents/plan-render.ts` (+463 / new) + test (+717 / 61 cases)
- `src/agents/plan-mode/plan-archetype-bridge.ts` (+203 / new) + test (+318 / 10 cases)

**Telegram attachment plumbing:**
- `src/plugin-sdk/telegram.ts` (+60 / new — minimal facade restoration)
- `extensions/telegram/src/send.ts` (+187 / addition — `sendDocumentTelegram` + `TelegramDocumentOpts`)
- `extensions/telegram/runtime-api.ts` (+8 / re-export)

**Wiring + registry:**
- `src/auto-reply/commands-registry.shared.ts` (+13 / `plan` command definition)
- `src/auto-reply/reply/commands-handlers.runtime.ts` (+6 / `handlePlanCommand` registration)
- `src/plugins/command-registration.ts` (+21 / reserve `plan` + 13 sibling built-ins)

**Tangential / runtime safety:**
- `src/agents/transport-message-transform.ts` (+74 / -1 — `[transport-repair]` placeholder + log volume cap)
