### PR TITLE
[Plan Mode 6/6] Docs, QA, and help

### DIFF
--- a/docs/agents/prompt-stack-spec.md
+++ b/docs/agents/prompt-stack-spec.md
@@ -1,0 +1,186 @@
+# Prompt Stack Spec — system prompt vs workspace files (operator-facing)
+
+**Status:** spec, Round 2 (2026-04-17). Guides the next iteration of prompt-mass reduction; no large prompt rewrites land from this doc. The only prompt change shipping with this spec is the GPT-5 family context-file boot reorder (SOUL.md / IDENTITY.md before AGENTS.md) — see [GPT-5 family trigger conditions](#gpt-5-family-trigger-conditions) below.
+
+---
+
+## Why this spec exists
+
+During GPT-5.4 personality testing, Eva (the agent) kept drifting toward a "careful operations daemon with a personality garnish" instead of "a coherent agent with strong judgment and style." The adversarial review identified the root cause:
+
+- Identity (SOUL.md, friendly overlay) is aspirational; it tells the model _who it is_.
+- Execution rules (AGENTS.md, Execution Bias, Tool Enforcement, anti-verbosity, tool-first defaults) are concrete; they tell the model _what to do right now_.
+- When these compete for attention, **execution wins by default** because concrete beats aspirational at action-selection time.
+
+A second contributor: workspace files routinely duplicate generic system-level guidance (brevity, tool-first, anti-sycophancy), crowding out the unique persona material that only those files can own.
+
+This spec defines the boundary.
+
+---
+
+## Precedence model — one identity, multiple stances
+
+The adversarial review explicitly **rejected** a lane-based personality-vs-agentic split as a trap. Hard-splitting would produce:
+
+- sterile execution mode (no warmth even when the context warrants it)
+- performative personality mode (forced warmth even when terse action is needed)
+- leakage between both (worst of each)
+
+The correct framing is **one identity, multiple stances**. Same persona, throttled by context:
+
+| Stance                 | When                                                 | Tone                                   | Action posture                 |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------- | ------------------------------ |
+| Incident / debug       | error triage, broken build, rollback                 | terse, no narration                    | tool-first, no preamble        |
+| Build / execution      | implementing an approved plan                        | warm in the framing; terse in the work | act-now between tool calls     |
+| Companion / reflective | architectural discussion, post-mortem, design review | full personality range                 | slow down; propose and explore |
+
+The agent reads the stance from context signals (user phrasing, urgency markers, whether a plan is approved, channel type) rather than from a hard mode switch. The system prompt sections compose into this — no per-stance conditionals in core.
+
+---
+
+## Belongs in the system prompt
+
+These are generic across agents and customers. Do NOT repeat them in workspace files:
+
+- **Brevity rules.** The GPT-5 output contract already caps default replies at ~200 words with a long-form exception.
+- **Anti-sycophancy.** "PROHIBITED: 'I'd be happy to help', 'Certainly!', stock empathy" lives in the friendly overlay.
+- **Tool-first defaults.** Execution Bias + Tool Enforcement drive this for GPT-5; `runBeforeToolCallHook` drives loop detection.
+- **Ask-vs-act policy.** The approval / mutation-gate boundary is owned by `src/agents/plan-mode/mutation-gate.ts` and the friendly overlay's "start in the same turn" text.
+- **Verification discipline.** Generic rules live in the output contract; test/build discovery is covered by tool availability.
+- **Safety / approvals / guardrails.** Hardcoded in `buildAgentSystemPrompt()` lines ~715+.
+- **Heartbeat contract.** The dynamic section near the cache boundary owns the runtime contract; HEARTBEAT.md adds project-specific guidance only.
+- **Bootstrap / prompt-assembly semantics.** Project context file ordering, section overrides, dynamic-suffix placement.
+- **Provider-specific tuning.** The OpenAI GPT-5 overlay injects OUTPUT_CONTRACT, TOOL_CALL_STYLE, EXECUTION_BIAS, TOOL_ENFORCEMENT, and (when `personality: "friendly"`) INTERACTION_STYLE.
+
+If you find yourself writing rules like these in SOUL.md or AGENTS.md, you're duplicating. Move them back into the generic path — or delete if the system prompt already covers them for your target model.
+
+---
+
+## Belongs in workspace files
+
+These are customer- or agent-specific. The system prompt does NOT own these:
+
+- **Persona / voice / tone character.** SOUL.md — "who this agent IS, not generic-polite." Identity phrases, metaphor preferences, signature cadence, relationship language.
+- **Customer-specific autonomy rules.** AGENTS.md — "when to delegate," "which operations require approval even in normal mode," project-specific scars ("we were burned by X in 2025-10; always Y").
+- **Org / business context.** USER.md — stakeholders, preferred channels, time zones, escalation paths, non-obvious company context.
+- **Local workflow rules.** Domain vocabulary, project-specific commands, shell aliases, test incantations peculiar to this repo/workspace.
+- **Identity narrative.** IDENTITY.md — biography, continuity threads, what has happened before on this session family.
+- **Long-term memory.** MEMORY.md / cortex-backed recall. Facts the agent should know without re-reading past transcripts.
+- **Heartbeat priorities.** HEARTBEAT.md — which standing workstreams matter right now. Not "how heartbeats work" (that's system) but "what to work on during heartbeat time" (that's you).
+
+---
+
+## Dangerous duplication / conflict surfaces
+
+Things we've seen repeatedly in workspace files that should be **removed** (system prompt already covers them):
+
+1. **Re-stating "be concise" / "don't preamble."** The output contract handles this for GPT-5; Anthropic/Gemini have their own defaults. Your workspace file saying it a fourth time competes for attention and signals "this is optional."
+2. **Re-stating "use tools first."** Execution Bias owns this. If your workspace says "always use tools before answering," you're hard-overlapping.
+3. **Anti-sycophancy phrases as a do-not list.** Already in the friendly overlay. Listing them again in SOUL.md tells the model "sycophancy is in scope enough to enumerate."
+4. **Heartbeat behavior descriptions.** The dynamic section + the main friendly overlay already describe what heartbeats ARE. Your HEARTBEAT.md should say what to DO — concrete current tasks — not re-explain the mechanic.
+5. **Confidentiality / safety platitudes.** System prompt covers these generically. Project-specific ones ("never commit real phone numbers") belong in AGENTS.md as project scars — but only if materially different from the generic rule.
+6. **Meta about how the agent should read files.** "Read AGENTS.md before acting" is not needed — files are injected directly into the system prompt already.
+
+Rule of thumb: **if the guidance would apply equally to an agent at a different customer, it belongs in the system prompt, not your workspace file.**
+
+---
+
+## GPT-5 family trigger conditions
+
+The OpenAI prompt overlay applies when BOTH conditions hold:
+
+1. `modelProviderId === "openai"` OR `modelProviderId === "openai-codex"`
+2. `modelId.toLowerCase().startsWith("gpt-5")` (matches `gpt-5.4`, `gpt-5-turbo`, `gpt-5o`, etc.)
+
+When both match, these inject:
+
+- `OPENAI_GPT5_OUTPUT_CONTRACT` (output length + punctuation rules) — added to `stablePrefix`.
+- `OPENAI_GPT5_TOOL_CALL_STYLE` — added to `stablePrefix`.
+- `OPENAI_GPT5_EXECUTION_BIAS` → overrides section `execution_bias`.
+- `OPENAI_GPT5_TOOL_ENFORCEMENT` → overrides section `tool_enforcement`.
+- `OPENAI_FRIENDLY_PROMPT_OVERLAY` → overrides section `interaction_style` (only when `plugins.entries.openai.config.personality !== "off"`; defaults to `"friendly"`).
+
+### What does NOT get the overlay
+
+- Anthropic Claude models (Opus / Sonnet / Haiku).
+- Google Gemini models.
+- Non-GPT-5 OpenAI models (`gpt-4.1`, `gpt-4o-mini`, etc.).
+- The minimal subagent prompt mode drops a lot of stable-prefix content; mission-critical persona for subagents must live in SUBAGENTS.md, not just SOUL.md.
+
+### GPT-5 boot reorder (Round 2, landing with this spec)
+
+For OpenAI GPT-5 models only, workspace-file load order is adjusted:
+
+| Default order         | GPT-5 override                |
+| --------------------- | ----------------------------- |
+| AGENTS.md (weight 10) | SOUL.md (10)                  |
+| SOUL.md (20)          | IDENTITY.md (20)              |
+| IDENTITY.md (30)      | AGENTS.md (30)                |
+| USER.md (40)          | USER.md (40) — unchanged      |
+| TOOLS.md (50)         | TOOLS.md (50) — unchanged     |
+| BOOTSTRAP.md (60)     | BOOTSTRAP.md (60) — unchanged |
+| MEMORY.md (70)        | MEMORY.md (70) — unchanged    |
+
+**Why:** the friendly overlay itself says "If SOUL.md is present, it is your PRIMARY identity document." When AGENTS.md (full of process/operations rules) is read FIRST, it primes the model into operations mode before persona has a chance to establish tone. Loading persona first gives it the priority the overlay promises.
+
+**Why only GPT-5:** that's where the personality drift was observed. Anthropic and Gemini have different priors; the change might not help (and could hurt) for them. Scoping narrowly keeps the change low-risk.
+
+---
+
+## Targeted compression candidates for the next iteration
+
+Per the adversarial review recommendation, target a ~30% system-prompt mass reduction. These are candidates with risk grades; do NOT ship all at once without measurement.
+
+### Low risk (~12-15% reduction combined)
+
+- **Self-Update + Model Aliases sections** (~200 tokens). Conditional on `hasGateway`; prune rarely-used model aliases; consolidate self-update copy.
+- **Sandbox/Workspace housekeeping** (~300 tokens). Move the long sandbox/workspace description to the dynamic suffix or load on-demand.
+- **Output Directives variant enumerations** (~250 tokens). One variant per channel instead of listing all.
+
+### Medium risk (~10% additional)
+
+- **Tooling section compression** (~400 tokens). Compress tool summaries; defer non-essential tooling guidance to tool-specific descriptions.
+- **Defer Docs section to dynamic suffix** (~100 tokens).
+
+### High risk — DO NOT compress this iteration
+
+- **Execution Bias.** This is the anti-drift lever. Touching it risks regressing agentic behavior.
+- **Tool Enforcement.** Same.
+- **Interaction Style (friendly overlay).** The voice calibration is load-bearing; removing it loses GPT-5 warmth entirely.
+- **Identity Enforcement section in the friendly overlay.** The SOUL-first-priority language is what makes persona beat sycophancy.
+
+### Measurement plan before compressing
+
+Before any compression PR:
+
+1. Baseline: record system-prompt token count at HEAD for 3 representative sessions (OpenAI GPT-5.4, Anthropic Claude Opus, Google Gemini).
+2. Run each of 5 QA scenarios (`gpt54-act-dont-ask`, `gpt54-cancelled-status`, `gpt54-injection-scan`, `gpt54-mandatory-tool-use`, `gpt54-plan-mode-default-off`) 3x and record agentic-compliance pass rate.
+3. Ship compression, repeat step 2. Any regression ≥1 pass point on any scenario → revert.
+
+---
+
+## Plan length / depth (item from user status feedback)
+
+**No hard cap** on `update_plan` step count or text length. The renderer + sidebar + approval-card layout pressure the agent toward terse plans. If you want longer plans:
+
+- Ask the agent: _"give me a 12-step plan with sub-steps and code-path references"_.
+- Set `plan-mode auto-continue` budget higher so the agent doesn't abbreviate to fit expected execution time.
+- Add a workspace note in AGENTS.md: _"When producing plans for this repo, include file:line references and 8-15 steps minimum."_
+
+We deliberately did **not** add a min-step-count config knob. Plan depth is a quality dimension, not a volume dimension; forcing length would hurt signal-to-noise. If the agent is under-planning on a specific session family, an AGENTS.md note is the right surface.
+
+---
+
+## What we're NOT doing in this iteration
+
+Deferred to a follow-up PR with dedicated measurement:
+
+- Rewriting any prompt section beyond the boot reorder.
+- Adding a precedence table to the top of the system prompt (considered; deferred until we can A/B it).
+- Removing duplications from existing customer-facing SOUL.md / AGENTS.md files (that's a per-customer migration — out of scope for a core change).
+
+See also:
+
+- `extensions/openai/prompt-overlay.ts` — overlay source of truth.
+- `src/agents/system-prompt.ts` — `DEFAULT_CONTEXT_FILE_ORDER` + `GPT5_CONTEXT_FILE_ORDER` + `sortContextFilesForPrompt`.
+- `src/agents/pi-embedded-runner/run/incomplete-turn.ts` — runtime detectors that catch action-selection drift (ack-only, yield-after-approval).

--- a/docs/concepts/plan-mode.md
+++ b/docs/concepts/plan-mode.md
@@ -1,0 +1,167 @@
+---
+summary: "Plan mode: user-approval-gated workflow for non-trivial multi-step changes"
+read_when:
+  - You want to understand what plan mode does and when to use it
+  - You are reviewing a plan-approval card and want to know what your options mean
+  - You are debugging a session that seems stuck in plan mode
+  - You are an agent running on OpenClaw and need a quick plan-mode reference
+title: "Plan Mode"
+---
+
+# Plan Mode
+
+**Plan mode** is OpenClaw's user-approval-gated workflow. The agent investigates read-only, drafts a plan, submits it for your approval, and executes only after you click Approve. Mutating tools (write / edit / exec / bash) are BLOCKED until the plan is approved.
+
+## When to use plan mode
+
+Use plan mode for **non-trivial multi-step changes** where you want to review the agent's intent before any mutations land:
+
+- Refactors that touch multiple files
+- Migrations (data, config, infrastructure)
+- Anything that calls destructive tools (delete, rm, force-push)
+- Cross-component changes where the agent's first guess might be wrong
+- When you want a written audit trail of what the agent intended
+
+Skip plan mode for **simple direct asks**:
+
+- Single-file edits where the change is obvious
+- Reads (the agent doesn't need approval to read your code)
+- Quick questions
+- Conversational replies
+
+## Lifecycle at a glance
+
+```
+NORMAL MODE → /plan on → INVESTIGATION → exit_plan_mode → PENDING APPROVAL
+                                                                  ↓
+                              (you click Approve / Reject / Edit / let it Time Out)
+                                                                  ↓
+                          NORMAL MODE (executes) ← OR → INVESTIGATION (revising)
+```
+
+1. **Enter:** type `/plan on` (or the agent calls `enter_plan_mode` when you ask for a plan).
+2. **Investigate:** agent uses read-only tools (read, grep, web_search, etc.) and tracks progress with `update_plan`. Mutations are BLOCKED.
+3. **Submit:** agent calls `exit_plan_mode` with a title + plan steps + (optional) analysis / assumptions / risks / verification / references.
+4. **Decide:** you see an approval card. Pick one:
+   - **Approve** — mutations unlock, agent executes
+   - **Approve with edits** — same as approve (you can pre-edit the plan in the side panel first)
+   - **Reject with feedback** — agent stays in plan mode, revises based on your feedback
+   - **Time out** — pretend it never happened; you can re-prompt
+5. **Execute:** agent runs the plan, calls `update_plan` to mark steps completed/cancelled.
+6. **Complete:** when all steps reach terminal status, the plan auto-closes.
+
+## Slash commands
+
+| Command                            | What it does                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| `/plan on`                         | Toggle plan mode ON (mutations blocked)                                        |
+| `/plan off`                        | Toggle plan mode OFF (mutations unblocked; pending approval dropped)           |
+| `/plan status`                     | Show current state (mode, approval, title)                                     |
+| `/plan view`                       | Open the active plan in the side panel                                         |
+| `/plan accept`                     | Approve the pending plan                                                       |
+| `/plan accept edits`               | Approve with edits                                                             |
+| `/plan revise <feedback>`          | Reject with revision feedback                                                  |
+| `/plan answer <text>`              | Answer a clarifying question the agent asked                                   |
+| `/plan auto on` / `/plan auto off` | Toggle auto-approve mode (future plans auto-approved without showing the card) |
+
+## What you see in webchat
+
+> Webchat is currently the ONLY channel with the inline-button approval card. All other channels (Telegram, Slack, Discord, CLI) are scoped to text-only `/plan` commands — see "Multi-channel behavior" below. Inline-button cards on non-web channels are deferred to a follow-up PR.
+
+When the agent submits a plan **on webchat**, an **inline approval card** appears in the chat with:
+
+- **Title** (the agent-supplied plan name)
+- **Step list** with checkboxes
+- **Optional sections**: analysis, assumptions, risks, verification, references
+- **Buttons**: Approve / Edit / Reject
+
+You can also click "Plan view" in the chat controls to see the same plan in the right side panel — useful for reviewing edits before approving.
+
+## Multi-channel behavior
+
+Plan mode is multi-channel by design:
+
+- **Webchat** — inline approval card with buttons + side-panel view
+- **Telegram** — text-rendered plan plus `/plan` commands
+- **Slack** — text-rendered plan plus `/plan` commands
+- **Discord** — text-rendered plan plus `/plan` commands
+- **CLI** — text-rendered plan plus `/plan accept` / `/plan revise` / `/plan answer` commands
+
+On non-web channels, the current shipped experience is text-reduced: the plan is rendered in chat and you respond with `/plan` commands rather than inline buttons. Telegram markdown/document attachment delivery and inline-button cards are deferred and are not part of the current shipped behavior — the bridge persists the markdown to disk under `~/.openclaw/agents/<id>/plans/` for audit, but channel-side delivery awaits re-rebasing onto the new plugin-sdk surface. See "Long-term follow-ups (deferred)" in `docs/plans/PLAN-MODE-ARCHITECTURE.md`.
+
+Approvals from any channel are deduplicated server-side by `approvalId`, so approving from one surface while the same plan is open elsewhere won't double-fire.
+
+> **Doc accuracy note (2026-04-19, Copilot review #68939):** Earlier drafts of this section overstated Telegram and Slack as inline-button surfaces. Per the wave-6 review, all non-web channels are scoped to text-only `/plan` commands today; richer UI surfaces land in a follow-up PR.
+
+## Persisted plans
+
+Every approved plan is persisted as markdown at:
+
+```
+~/.openclaw/agents/<agentId>/plans/plan-YYYY-MM-DD-<slug>.md
+```
+
+The slug is derived from the plan title. This gives you a searchable, datable audit trail of every plan the agent has executed.
+
+## Auto-approve mode
+
+If you trust the agent's planning quality on a particular session, type `/plan auto on` BEFORE entering plan mode. The next `exit_plan_mode` will auto-resolve as approved without showing the card. Useful for trusted workflows where you want the planning STRUCTURE (audit trail, archetype fields) but don't want to review every plan.
+
+`/plan auto off` cancels future auto-approval. The flag persists across plan-mode toggles for the session.
+
+## Subagent gating
+
+If the agent spawns research subagents during plan-mode investigation (`sessions_spawn`), the runtime gates `exit_plan_mode` until ALL spawned subagents complete:
+
+- **Tool-side gate**: at submission time, if any spawned subagent is still running, `exit_plan_mode` rejects with a message listing the in-flight child run IDs. The agent waits + retries.
+- **Approval-side gate**: if a NEW subagent is spawned DURING the user's approval window, clicking Approve is blocked with a bottom-of-chat toast: "Subagents still running — try again after subagent results return."
+
+This prevents the agent from acting on partial subagent results.
+
+## Troubleshooting
+
+**Click Approve but nothing happens / agent doesn't continue:**
+
+- Likely the agent posted chat after `exit_plan_mode` in the same turn (a known anti-pattern). Re-prompt with "continue executing the approved plan."
+- Check whether the session is disconnected. The Control UI disables approval actions while offline; reconnect first.
+- If the card still looks live after reconnect, refresh the page to force a fresh session snapshot.
+- Inspect live state with `plan_mode_status` and confirm the session is still on the same active cycle and not blocked by `blockingSubagentRunIds`.
+
+**Approval card stays after you click Approve:**
+
+- The card may have gone stale (session timed out, another channel resolved it, etc.). Refresh the page; the stale card auto-dismisses on the next session-state update.
+- If the runtime rejected approval because subagents are still running, wait for those child runs to settle, then approve again.
+
+**`Plan approval failed: planApproval requires an active plan-mode session` (error code `PLAN_APPROVAL_EXPIRED`):**
+
+- The approval window is out of sync with server state — usually because another surface already resolved it, `/plan off` ran, or the session lost plan-mode state. The Control UI auto-dismisses the card when this code comes back; refresh if the card persists.
+- If it persists, check the gateway log: `tail -F ~/.openclaw/logs/gateway.err.log | grep plan-approval-gate`
+
+**Operator runbook:** for deeper incident triage (stale cards, subagent stalls, nudge noise, disk-full handling, cross-channel dedup, debug-log activation, approval-cycle correlation), see the full [Plan Mode Operator Runbook](/plans/PLAN-MODE-OPERATOR-RUNBOOK) under the repo plans directory.
+
+**Agent calls `update_plan` but never `exit_plan_mode`:**
+
+- The agent may be confused — `update_plan` only TRACKS progress; only `exit_plan_mode` submits. Re-prompt: "submit the plan via exit_plan_mode."
+
+**Tail the structured debug log:**
+
+```bash
+openclaw config set agents.defaults.planMode.debug true
+# Restart gateway
+tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'
+```
+
+## Operations and Evidence
+
+Use these checks when you want proof that a plan-mode session is healthy end-to-end:
+
+- Runtime state snapshot: call `plan_mode_status` from the agent to inspect `cycleId`, approval state, pending interaction metadata, queued injections, and subagent gate state.
+- Structured lifecycle log: `tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'`
+- Approval gate decisions: `tail -F ~/.openclaw/logs/gateway.err.log | grep 'plan-approval-gate'`
+- If you ship gateway logs into Loki/Grafana, a useful starting filter is `{app="gateway"} |= "[plan-mode/"` and a focused approval filter is `{app="gateway"} |= "plan-approval-gate"`.
+- To verify that nudges are not firing during pending approval, look for `nudge_event` lines paired with `approval_event` lines for the same `sessionKey`. Pending approvals should only show suppression or cleanup, not a live resumed turn.
+
+## See also
+
+- `/plan-mode-101` skill — agent-facing reference card with the same lifecycle diagram
+- `docs/plans/PLAN-MODE-ARCHITECTURE.md` — internal architecture + iteration history

--- a/docs/plans/PLAN-MODE-ARCHITECTURE.md
+++ b/docs/plans/PLAN-MODE-ARCHITECTURE.md
@@ -1,0 +1,635 @@
+# Plan-Mode Rollout — Architecture & Status
+
+**Last updated:** nuclear-fix-stack integration complete on `feat/plan-channel-parity` (post `5a2f6255ff`, see "Nuclear-fix-stack integration" section below). Branch hosts the **umbrella PR #68939** which now carries the consolidation work + 7 review-loop waves + 9 nuclear-fix-stack commits + cleanup.
+**Live install (pre-rebase):** `OpenClaw 2026.4.15` from `feat/plan-channel-parity`
+**Total PRs (historical):** 10 individual PRs A/B/C/D/E/F/7/8/10/11 (now closed) + 1 umbrella PR (#68939) carrying the full 156-commit history (135 consolidation + 10 review-wave + 11 nuclear-fix integration)
+**Backup branch:** `feat/plan-channel-parity-backup` at pre-rebase HEAD `bee5e8c364` (pushed to origin for rollback safety)
+
+This document is the **single source of truth** for the plan-mode rollout. It survives Claude Code session compactions and is referenced by the umbrella PR + every closed PR's redirect comment.
+
+---
+
+## Nuclear-fix-stack integration — 2026-04-19 (post-wave-7)
+
+After review-loop wave 7 converged at 100% thread resolution, another agent ([@eva@100yen.org](mailto:eva@100yen.org)) surfaced a **9-commit "nuclear-fix stack"** on `feat/plan-mode-nuclear-fix-stack` addressing 5 correctness gaps in PR #68939 that the review waves only partially covered. Stack landed via cherry-pick (Option A from the integration ask comment).
+
+### The 5 bugs fixed
+
+| #   | Bug                                                                                             | Wave-N coverage                                                                     | Nuclear-fix stack coverage                                                                                                                                                                                 |
+| --- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `[PLAN_DECISION]: edited` injection had **no plan steps** (orphan `buildApprovedPlanInjection`) | Wave-5 codified `edit` action in schema                                             | Wires `buildApprovedPlanInjection` / `buildAcceptEditsPlanInjection` to actually carry plan steps in approve/edit injections                                                                               |
+| 2   | `pendingAgentInjection: string` is **last-write-wins** (silent clobber race)                    | Wave-3 answer-guard catches mismatched approvalIds                                  | Replaces scalar with typed priority-ordered queue `pendingAgentInjections: PendingAgentInjectionEntry[]` (id-dedup, drain-once-per-turn)                                                                   |
+| 3   | Post-approval ack-only turns are **never retried**                                              | (no fix shipped)                                                                    | Extends `resolvePlanModeAckOnlyRetryInstruction` to fire within `recentlyApprovedAt < 5min` grace                                                                                                          |
+| 4   | Subagent announce-turns **race the approval-resume turn**                                       | Wave-1 `openSubagentRunIds.size === 0` check at exit_plan_mode + approval-side gate | Adds concurrency cap (1 in plan mode) + 10s `lastSubagentSettledAt` grace window + dual gates + new error code `PLAN_APPROVAL_WAITING_FOR_SUBAGENT_SETTLE`                                                 |
+| 5   | `acceptEdits` action has **no runtime semantics**                                               | Wave-5 schema discriminated union codified `action: "edit"`                         | New `SessionEntry.postApprovalPermissions.acceptEdits` (scoped by approvalId) + 3-rule constraint gate (no destructive, no self-restart, no config changes) at `src/agents/plan-mode/accept-edits-gate.ts` |
+
+### Integration commits (cherry-pick of side branch + cleanup)
+
+```
+5a2f6255ff chore(protocol): regenerate Swift bindings for nuclear-fix-stack additions
+735aafea71 fix(plan-mode): post-cherry-pick test + lint cleanup (queue migration + iteration-budget bump)
+834e5396cb test(plan-mode): wave-4 prompt-cache byte stability                    (+7 tests)
+c91cad9db9 test(plan-mode): wave-3 integration regression coverage                (+15 tests)
+70bd466589 fix(plan-mode): wave-1 adversarial review fixes                        (4 sub-fixes)
+f5b6fbe47c feat(plan-mode): post-approval ack-only retry grace window             (bug #3)
+436d308506 feat(plan-mode): subagent concurrency cap + grace window + dual gates  (bug #4)
+7110953c0c feat(plan-mode): acceptEdits constraint gate + runtime wiring          (bug #5; WIP-stripped)
+b33eeb4a3c feat(plan-mode): postApprovalPermissions schema + set/clear plumbing   (foundation for #5)
+5bd5a52d3b feat(plan-mode): wire queue writers + approved/acceptEdits plan text   (bug #1)
+70a6e4b23a feat(plan-mode): typed injection queue + auto-migrate legacy scalar    (bug #2 architecture)
+```
+
+### Resolution decisions during integration
+
+- **Schema additions truly orthogonal**: both stacks coexist in `SessionEntry`. Field order: `pendingAgentInjection` (legacy/deprecated, auto-migrated) → `pendingAgentInjections` (queue) → `pendingQuestionApprovalId` → `pendingQuestionOptions` → `pendingQuestionAllowFreetext` → `postApprovalPermissions`.
+- **`sessions-patch.ts` answer branch layered**: wave-3/4 answer-guard validation chain (approvalId match + option-membership for non-freetext) fires BEFORE `appendToInjectionQueue`. Both validations preserved.
+- **`pending-injection.ts` full rewrite** taken from the side branch as a queue-shim; once-and-only-once docstring backported as a comment block.
+- **WIP contamination strip on commit 4 (`b6b2783ba3`)**: ~150 lines of unrelated bootstrap refactor + ollama-runtime imports + dead-export removals dropped from `attempt.ts`. Only the ~3-line `getLatestAcceptEdits` threading kept. Same pattern applied in `pi-tools.ts` and `params.ts` where the cherry-pick removed our HEAD's existing `memberRoleIds` / `isCanonicalWorkspace` fields (restored).
+- **`resolveSessionTotalTokens` rename**: the side branch's commit 1 renamed this export to `resolveFreshSessionTotalTokens` but didn't update the 2 consumers (`src/commands/sessions.ts`, `src/commands/status.summary.ts`). Updated both consumers — the rename is semantically meaningful (communicates the fresh-read pattern).
+- **Pre-existing test repair**: `run.overflow-compaction.test.ts` asserted `mockedRunEmbeddedAttempt` was called 32 times (pre-PR-9-Tier-1 floor). Bumped to 500 to match `MIN_RUN_RETRY_ITERATIONS`. Same root cause flagged in the side branch's wave-5 disclosure.
+
+### New surface (post-integration)
+
+- **Files added**: `src/agents/plan-mode/injections.ts` (+ `.test.ts`), `src/agents/plan-mode/accept-edits-gate.ts` (+ `.test.ts`)
+- **Types added**: `PendingAgentInjectionKind`, `PendingAgentInjectionEntry`, `PostApprovalPermissions`
+- **Fields added on `AgentRunContext`**: `lastSubagentSettledAt: number`, `getLatestAcceptEdits: () => boolean`
+- **Public exports from `src/agents/plan-mode/index.ts`**: `buildAcceptEditsPlanInjection`, `appendToInjectionQueue`, `enqueuePendingAgentInjection`, `consumePendingAgentInjections`, `composePromptWithPendingInjections`, `SUBAGENT_SETTLE_GRACE_MS` (= 10_000), `MAX_CONCURRENT_SUBAGENTS_IN_PLAN_MODE` (= 1)
+- **New error code**: `ErrorCodes.PLAN_APPROVAL_WAITING_FOR_SUBAGENT_SETTLE` — returned from `sessions.patch { planApproval: approve | edit }` with `details.retryAfterMs` when the user clicks approve within 10s of a subagent completion
+- **New constants**: `POST_APPROVAL_ACK_ONLY_GRACE_MS` (= 5 \* 60_000), `MAX_QUEUE_SIZE` (= 10, oldest eviction with warn log), `DEFAULT_INJECTION_PRIORITY`
+
+### Test coverage delta
+
+| Suite                                  | Pre-integration | Post-integration |
+| -------------------------------------- | --------------- | ---------------- |
+| `injections.test.ts`                   | (didn't exist)  | 27 tests         |
+| `accept-edits-gate.test.ts`            | (didn't exist)  | 44 tests         |
+| `sessions-patch.subagent-gate.test.ts` | 7               | 15               |
+| `sessions-spawn-tool.test.ts`          | 12              | 15               |
+| `incomplete-turn.test.ts`              | 29              | 33               |
+| `approval.test.ts`                     | 32              | 39               |
+| **Total touched-surface**              | **~92**         | **~187 (+95)**   |
+
+Plus existing `sessions-patch.test.ts` (43 tests, including the queue-migration test update where `entry.pendingAgentInjection === "[QUESTION_ANSWER]: ..."` is now `entry.pendingAgentInjections[0].text === "..."`).
+
+### Deferred items (carried over from side branch's adversarial review)
+
+All disclosed in the agent's [architectural walkthrough](https://github.com/openclaw/openclaw/pull/68939#issuecomment-4276170359); kept deferred here as follow-ups:
+
+1. **Retry re-hydration on empty-response failure** (>100 LoC) — pending-injection consumer drains before the first attempt; empty-response retry has no context. Workaround today: post-approval ack-only grace covers the common failure mode. **Status: still deferred** — C4.2 scope requires a new `SessionEntry.lastConsumedInjections` field + retry-logic changes; targeted for a focused follow-up commit.
+2. **Shell-escape destructive bypass** (pattern-limited) — env-var indirection / concat / alias redefinition can slip past the acceptEdits destructive denylist; prompt layer remains primary defense. **Status: shipped in 1.0 follow-up C4** (`dcb9f0ec7d`) — layered-defense detection at `accept-edits-gate.ts` with 26 adversarial fixtures covering env-var indirection, backtick + `$(...)` subshells, quote concatenation, hex/octal byte escapes.
+3. **Double-approve on legacy-scalar upgrade** (<50% probability) — narrow scenario with bounded impact (duplicate "I'll execute..." ack, not broken state). **Status: verified closed** during the C4 audit; the existing atomic migration in `plan-mode/injections.ts` prevents the race.
+4. **approvalRunId persister silent-bypass** (<0.1% probability). **Status: shipped in 1.0 follow-up C4** — defensive throw in `plan-snapshot-persister.ts:persistApprovalMetadata` on empty/missing `approvalRunId`, with diagnostic message calling out the subagent-gate implication.
+5. **Debug log multi-tag recording** (observability only). **Status: partially shipped in 1.0 follow-up C7** (`c0aaabb1f1`) — added optional `approvalRunId` + `approvalId` correlation fields to 7 of 8 debug event kinds; wired through the two `approval_event` emitters in `sessions-patch.ts`. Remaining emitters (nudge crons, subagent lifecycle, gate decisions) pick up the fields as those surfaces are next touched.
+6. **Bootstrap context truncation** (AGENTS.md/SOUL.md diet) — separate PR.
+
+### Shipped in Plan Mode 1.0 follow-up (`feat/plan-mode-1.0-followup`)
+
+Follow-up PR stacks on #68939 with 5 distinct commits:
+
+| Commit       | Scope                          | Ships                                                                                                                                                                                                                                                                                                                                       |
+| ------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `2ed8258eb5` | **C1 rollout hardening**       | `PLAN_APPROVAL_EXPIRED` error code (Bug B stale-card auto-dismiss), plan-title XSS regression suite (R3, 41 tests), disk-full `PlanPersistStorageError` classifier (R4), multi-channel approval dedup tests (R5). R1 (subagent drain) + R2 (cron approval-pending guard) were already shipped in `906eb68403`.                              |
+| `aae864e5cc` | **C2 Telegram PR-14 re-wire**  | Live delivery of plan markdown as Telegram document attachment via `openclaw/plugin-sdk/telegram.sendDocumentTelegram` facade. Auto thread-ID parsing via the SDK's `parseTelegramTarget`. 10 bridge tests (un-skipped failure-branch test + new topic-scoped target test).                                                                 |
+| `49d5d4ac1a` | **C3a autoEnableFor runtime**  | Pure `evaluateAutoEnableForMatch` helper with compiled-regex cache (14 tests). Wiring at `cron/isolated-agent/run.ts` before turn dispatch: when `planMode` is absent AND model matches a configured pattern AND `planMode.enabled` is true, flips the session to `mode: "plan"` before the turn starts. Respects user-toggled `/plan off`. |
+| `dcb9f0ec7d` | **C4 security hardening**      | Shell-escape layered defense (C4.1): 26 adversarial fixtures; env-var / subshell / quote-concat / byte-escape detection. approvalRunId silent-bypass guard (C4.4): defensive throw in `persistApprovalMetadata`.                                                                                                                            |
+| `c0aaabb1f1` | **C7 debug log correlation**   | Optional `approvalRunId` + `approvalId` fields on 7 plan-mode debug event kinds. Wired through the two `approval_event` emitters in `sessions-patch.ts`.                                                                                                                                                                                    |
+| (TBD)        | **C8 docs + operator runbook** | New `docs/plans/PLAN-MODE-OPERATOR-RUNBOOK.md` covering 5 common symptoms; architecture doc (this file) updated to mark shipped vs deferred items; troubleshooting section links to runbook.                                                                                                                                                |
+
+### Still deferred out of 1.0 follow-up
+
+| Item                                          | Why deferred                                                                                                                                                                                              |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **C3b** `approvalTimeoutSeconds` runtime      | Needs either a new `timeout` action on the sessions.patch protocol or a gateway-internal bypass RPC + cron scheduling + cleanup. Substantial cross-surface change best handled as its own focused commit. |
+| **C4.2** retry re-hydration                   | Needs new `SessionEntry.lastConsumedInjections` field + modifications to `consumePendingAgentInjections` + retry-logic re-inject. Not trivial.                                                            |
+| **C5** Telegram inline-keyboard Accept/Revise | Requires grammy bot API wiring + callback_query handler registration + `TelegramDocumentOpts.inlineButtons` extension + plan-bridge button construction. Scope deserves its own focused commit.           |
+| **C6** Slack Block Kit cards                  | Requires new Slack Block Kit builder + action-id handler + modal for Revise feedback + `slack-blocks` render format. Similar scope to C5.                                                                 |
+| **C7b** `/plan self-test` harness             | New synthetic plan-mode flow runner + CLI subcommand + assertions. Medium-sized standalone feature.                                                                                                       |
+
+### Rollback escalation path
+
+Per side-branch disclosure (still applies):
+
+- Commit 70a6e4b23a (queue) regression → revert nuclear-fix stack; `pendingAgentInjection` legacy scalar path still works via the queue-shim's auto-migrate-on-first-read.
+- Commit 7110953c0c (acceptEdits gate) false-positive → revert that commit only; `action: "edit"` falls back to approve-path semantics.
+- Commit 436d308506 (subagent grace window) too strict → set `SUBAGENT_SETTLE_GRACE_MS = 0`; no revert needed.
+- Full feature regression → `agents.defaults.planMode.enabled: false` short-circuits everything.
+- Catastrophic failure → `git push --force-with-lease origin feat/plan-channel-parity-backup:feat/plan-channel-parity` restores pre-rebase HEAD `bee5e8c364`.
+
+---
+
+## Consolidation pass — 2026-04-19
+
+After 3+ weeks of iter-1/iter-2/iter-3 hardening on `feat/plan-channel-parity`, the 10 individual PRs reviewed against stale base branches were **consolidated into a single umbrella PR rebased onto current upstream/main**.
+
+### Why consolidate
+
+- Branch was **734 commits behind** `upstream/main` and **135 commits ahead**
+- Latest upstream tag `v2026.4.19-beta.2` had landed ~24h before the rebase
+- Review bots (Greptile, Copilot, Codex) were comparing PRs against 3-week-old main snapshots: re-firing on resolved threads, suggesting "fixes" for patterns that already landed elsewhere, drowning real signal in noise
+- 10 dependent PRs forced maintainers to load the dependency graph just to start review
+
+### What was preserved
+
+- **Full 135-commit history** (no squash — `git blame` and the iter-1/2/3 narrative both stay readable)
+- **240+ resolved review threads** from the original 10 PRs (rationale lives in this doc + commit messages)
+- **All test coverage** (200+ tests across the touched surface — 81 scoped tests verified passing post-rebase)
+- **All architecture decisions** documented in this file (sections below stay authoritative)
+
+### What was closed
+
+| Original PR  | Action                                                          |
+| ------------ | --------------------------------------------------------------- |
+| PR-A #67512  | Closed → redirect comment pointing to #68939                    |
+| PR-B #67514  | Closed → redirect comment pointing to #68939                    |
+| PR-C #67534  | Closed → redirect comment pointing to #68939                    |
+| PR-D #67538  | Closed → redirect comment pointing to #68939                    |
+| PR-E #67541  | Closed → redirect comment pointing to #68939                    |
+| PR-F #67542  | Closed → redirect comment pointing to #68939                    |
+| PR-7 #67721  | Closed → redirect comment pointing to #68939                    |
+| PR-8 #67840  | Closed → redirect comment pointing to #68939                    |
+| PR-10 #68440 | Closed → redirect comment pointing to #68939                    |
+| PR-11 #68441 | Closed → redirect comment pointing to #68939 (used same branch) |
+
+### Rebase mechanics — only 5 actual conflicts in 134 commits
+
+Audit before rebase confirmed upstream had **zero plan-mode commits in the gap**. All conflicts were incidental file overlaps:
+
+| File                                           | Type                                  | Resolution                                                                                                                                       |
+| ---------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/agents/system-prompt.ts`                  | Import-only                           | Take both sets                                                                                                                                   |
+| `ui/src/ui/views/chat.ts`                      | Import-only                           | Take HEAD (`SubagentBlockingStatus` is a strict superset)                                                                                        |
+| `src/plugin-sdk/telegram.ts`                   | Modify/delete (upstream restructured) | `git rm` — PR-14 Telegram visibility deferred until plan-archetype-bridge re-wires to the new SDK location                                       |
+| `ui/src/ui/app-render.helpers.ts`              | Function-level                        | Delete 530 lines of duplicated `renderChatModelSelect` — upstream moved it to `session-controls.ts:82` and re-exports `renderChatThinkingSelect` |
+| `src/agents/pi-embedded-runner/run/attempt.ts` | Bootstrap-context refactor            | Drop our duplicated bootstrap blocks (upstream owns lines 654+); preserve `planModeAppendPrompt` + add `planModeFeatureEnabled` declaration      |
+
+### Post-rebase residual fixes (`01ed63633e`)
+
+Two type errors surfaced after the rebase landed and were fixed in a follow-on commit on the rebased branch:
+
+- **`src/agents/plan-mode/plan-archetype-bridge.ts`** — replaced the `sendDocumentTelegram` call with a deferred no-op + `void` discards on the unused `caption`/`absPath`/`parseTelegramThreadId`. Plan markdown still persists to `~/.openclaw/agents/<id>/plans/`; Telegram attachment delivery awaits the PR-14 re-wire follow-up.
+- **`src/gateway/server-runtime-subscriptions.ts`** — removed the `params.minimalTestGateway` conditional (the param was renamed/dropped in upstream's restructure). Persister always starts; tests pass `emitSessionsChanged: () => {}` to suppress.
+
+The `parseTelegramThreadId` helper is preserved as commented-out code in `plan-archetype-bridge.ts` so the PR-14 re-wire follow-up can resurrect the parsing logic without rewriting it.
+
+### Umbrella PR #68939 status
+
+- **Branch:** `feat/plan-channel-parity` @ `01ed63633e`
+- **Diff vs upstream/main:** 135 commits, 145 files changed
+- **Greptile review:** SKIPPED (hit 100-file ceiling — known limitation; not actionable)
+- **Copilot review:** triggered via `@copilot please review` comment
+- **CI:** parity gate IN_PROGRESS at write-time
+- **Mergeable:** ✅ MERGEABLE per `gh pr view`
+
+### Long-term follow-ups (deferred — out of consolidation scope)
+
+- **PR-14 Telegram visibility re-wire** — `plan-archetype-bridge.ts` needs to call into the new `extensions/telegram/` SDK location once the upstream restructure is mapped
+- **Bug B** — stale approval card UI auto-dismiss + `PLAN_APPROVAL_EXPIRED` error code (deferred since iter-2)
+- **R1/R2/R3/R4/R5** — robustness fixes (subagent cleanup on crash, cron-nudge suppression, plan title XSS audit, disk-full graceful, multi-channel approval dedup) (deferred since iter-3)
+- **D5** — replaced by `plan_mode_status` + targeted lifecycle tests in the stacked follow-up to #68939
+
+These do NOT block the umbrella PR landing. They land as follow-on commits on `feat/plan-channel-parity` after #68939 merges.
+
+---
+
+## Live testing iteration 1 — fixes (latest sprint)
+
+Live webchat testing of the `9fb82673ac` build surfaced 4 issues. All fixed in the next commit on `feat/plan-channel-parity`:
+
+| Bug | Surface                                     | Root cause                                                                                                                                                                                                                                                        | Fix                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Synthetic message tagging                   | 5 retry constants in `incomplete-turn.ts` and the plan-nudge wake-up in `plan-nudge-crons.ts` lacked the `[PLAN_*]:` prefix that `[PLAN_DECISION]:` / `[QUESTION_ANSWER]:` / `[PLAN_COMPLETE]:` already used                                                      | Prefixed: `[PLAN_ACK_ONLY]:`, `[PLAN_YIELD]:`, `[PLAN_NUDGE]:`, `[PLANNING_RETRY]:` — sets up a future PR to hide them from user-visible chat with a single regex                                                                                                                                                                                                                                                                                                                                             |
+| 2   | Plan side panel header showed "Active plan" | `SessionEntry.planMode` had NO `title` field; `exit_plan_mode` carried it transiently in event payload but persister never captured it. UI fell back to a generic label                                                                                           | Added `planMode.title` + `planMode.approvalRunId` to `SessionEntry`. Persister captures from `agent_approval_event`. UI `buildPlanViewMarkdown` accepts `title` param + 3 call sites read `row.planMode.title`. Pre-`exit_plan_mode` shows `(planning)` honest signal                                                                                                                                                                                                                                         |
+| 3   | Approve race when subagents in flight       | `sessions-patch.ts:572` approval handler had NO subagent check. If subagent return drained `openSubagentRunIds` between two `exit_plan_mode` retries, approval card showed; a NEW subagent during the user's approval window bypassed the tool-side gate entirely | Server: approval handler reads `getAgentRunContext(approvalRunId).openSubagentRunIds`, throws `PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS` (new ErrorCode) if non-empty for `approve`/`edit` (`reject` not gated). UI: catches the code, restores card + sets `subagentBlockingStatus` for a bottom-of-chat toast (mirrors `FallbackStatus` pattern at `chat.ts:renderFallbackIndicator`)                                                                                                                             |
+| 4   | No way to debug plan-mode lifecycle live    | Sparse logs across `[gateway]` / `[agent/embedded]` / `[plugins]` made plan-mode debugging require manual run-id correlation across multiple files                                                                                                                | New `src/agents/plan-mode/plan-mode-debug-log.ts` helper + `OPENCLAW_DEBUG_PLAN_MODE=1` env-var gate. Discriminated event union: state_transition, gate_decision, tool_call, synthetic_injection, nudge_event, subagent_event, approval_event, toast_event. Instrumented at sessions-patch (state transitions + approval gates), exit-plan-mode-tool (gate decisions), plan-snapshot-persister (tool_call). Events tagged `[plan-mode/<kind>]` for `tail -F gateway.err.log \| grep '\[plan-mode/'` debugging |
+
+**Activation for live debug session:**
+
+```bash
+OPENCLAW_DEBUG_PLAN_MODE=1 launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'
+```
+
+**Test coverage added:** 7 tests in `sessions-patch.subagent-gate.test.ts`, 12 tests in `plan-mode-debug-log.test.ts`. Pre-existing test suites (`incomplete-turn`, `mutation-gate`, `exit-plan-mode-tool`, `fresh-session-entry`) all still pass after the prefix changes (constants are imported by reference, not literal-asserted).
+
+---
+
+## Live testing iteration 3 — self-discovery + R6 subagent gate hardening (latest sprint)
+
+Iter-3 closes the meta-gap surfaced by the user: "will plan mode work reliably for ANY install, on ANY agent, including agents that just installed the patch and have never seen plan mode before?" Plus a deeper subagent-gate race (R6) that survived iter-1's tool-side gate.
+
+### Phase 1 — Self-discovery (commit `c262bffcbf`)
+
+| #   | Surface                            | What changed                                                                                                                                                                                                                                                                                                                                    |
+| --- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | In-mode bootstrap reference card   | New `src/agents/plan-mode/reference-card.ts` injected on every plan-mode turn alongside `PLAN_ARCHETYPE_PROMPT`. ASCII state diagram + tool contract + `[PLAN_*]:` tag taxonomy + `/plan` slash commands + pitfalls + debug tips. Eliminates the iter-2 "2-turn learning curve"                                                                 |
+| D2  | One-shot first-time intro          | `[PLAN_MODE_INTRO]:` synthetic injection on the very first `enter_plan_mode` per session (gated by new `SessionEntry.planModeIntroDeliveredAt` marker at root level). Agent's NEXT turn opens with quick lifecycle overview + pointer to `plan_mode_status` for runtime introspection. Composes with existing `pendingAgentInjection` consumers |
+| D3  | Tool-description discovery pointer | All 3 plan-mode tool descriptions (`enter_plan_mode`, `update_plan`, `exit_plan_mode`) end with: "see the bootstrap-injected reference card and call `plan_mode_status` when debugging live state."                                                                                                                                             |
+| D4  | User-facing concept doc            | New `docs/concepts/plan-mode.md` — when to use, lifecycle, slash commands, multi-channel, persistence, auto-mode, subagent gating, troubleshooting                                                                                                                                                                                              |
+| D7  | `plan-mode-101` skill              | New `skills/plan-mode-101/SKILL.md` — same content as the in-mode reference card, available on-demand in normal mode via trigger phrases ("explain plan mode", "what does [PLAN_DECISION] mean", etc.)                                                                                                                                          |
+
+### Phase 2/3 — R6 subagent gate hardening + D6 introspection tool (commit pending)
+
+| #   | Bug/Deliverable                                                                                                                          | Symptom                                                                                                                                                                                                                                                                               | Fix                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R6a | Tool-side subagent gate at `exit_plan_mode` silently bypassed                                                                            | Live test 17:10-17:12: subagent `a1dc12d2` was running when agent called `exit_plan_mode`; gate didn't fire (silent bypass — likely race: subagent drained before tool ran, OR runId/ctx missing). User clicked Approve, agent stalled because subagent return arrived AFTER approval | Always-on `agents/exit-plan-gate` diagnostic logger emits `gate decision: result=blocked\|allowed runId=… sessionKey=… openSubagents=N reason=…` for EVERY `exit_plan_mode` call. Bypass cases (no runId, ctx not registered, openSubagentRunIds undefined) now emit explicit reason strings so operators can tell why the gate didn't fire. Operator can grep `agents/exit-plan-gate` in `gateway.err.log` to see every submission attempt                                   |
+| R6b | Subagent announce-turn injection said "narrate the result" — agent treated the turn as TERMINAL and stopped, breaking the plan-mode flow | The announce reply instruction at `subagent-announce.ts:buildAnnounceReplyInstruction` told the agent "send that user-facing update now." Agent narrated the subagent result and stopped instead of calling `exit_plan_mode` after incorporating the result. Plan-mode cycle stalled  | The instruction is now plan-mode-aware: when the requester session's `planMode.mode === "plan"`, an explicit suffix is appended: "You are currently in PLAN MODE — do not stop after the user-facing update. Your next action MUST be either (a) call `exit_plan_mode(...)` if this subagent's result completes your investigation, OR (b) continue investigation with another tool call." Read at announce-build time from `loadRequesterSessionEntry`'s entry.planMode.mode |
+| D6  | No agent-callable introspection of plan-mode state                                                                                       | Agent had to INFER plan-mode state from tool-rejection errors. No way to programmatically check `am I in plan mode?` / `what's the title?` / `how many subagents are in flight?` / `is debug log enabled?`                                                                            | New `plan_mode_status` tool (`src/agents/tools/plan-mode-status-tool.ts`) — read-only structured snapshot of every plan-mode field, plus the debug-log status. Self-resolves storePath via `resolveDefaultSessionStorePath` so it works without registry plumbing. Wired into the bundled toolset alongside `enter_plan_mode` / `exit_plan_mode` / `ask_user_question`                                                                                                        |
+
+**Activation (already in place from iter-2):**
+
+```bash
+openclaw config set agents.defaults.planMode.debug true
+launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+
+# Tail BOTH the env-gated structured stream AND the iter-3 always-on
+# exit-plan-gate diagnostic in one tail:
+tail -F ~/.openclaw/logs/gateway.err.log | grep -E '\[plan-mode/|plan-approval-gate|exit-plan-gate'
+```
+
+### Deferred to iter-3 commit 3 (next focused commit)
+
+- **D5 — dropped.** The runtime now uses `plan_mode_status`, focused regression suites, and session-state rehydration coverage instead of a synthetic self-test command.
+- **R1 — Subagent cleanup on crash/timeout** (drain `openSubagentRunIds` on error paths)
+- **R2 — Cron-nudge suppression when approval pending** (heartbeat path already does this via `buildActivePlanNudge:742`; cron-fire path needs same check)
+- **R3 — Plan title XSS sanitization audit + test**
+- **R4 — Disk-full graceful error in `sessions-patch.ts`**
+- **R5 — Multi-channel approval dedup test**
+- **Bug B (still deferred from iter-2)** — stale approval card UI auto-dismiss + `PLAN_APPROVAL_EXPIRED` error code
+
+---
+
+## Live testing iteration 2 — fixes (previous sprint)
+
+Live webchat testing of the iter-1 build (commit `3024c6b215`) on 2026-04-19 surfaced 6 deeper edge cases. All addressed in the next commit on `feat/plan-channel-parity`:
+
+| Bug | Symptom                                                                                                                                                                                               | Root cause                                                                                                                                                                                                                          | Fix                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A   | Click "Approve" → agent's next turn fires `[PLAN_ACK_ONLY]` retries; mutation gate blocks `write` AFTER approval landed                                                                               | `sessions-patch.ts:751` DELETES `planMode` entirely on approve/edit (when no `autoApprove`); `getLatestPlanMode` returned `undefined` for that case; consumers fell back to stale "plan" cached snapshot via `?? args.ctx.planMode` | Added `resolveLatestPlanModeFromDisk` helper in `fresh-session-entry.ts` returning `"normal"` for the deletion case (deletion-as-normal contract). Updated both `getLatestPlanMode` callbacks in `agent-runner-execution.ts` to use it. Hardened consumers in `pi-tools.before-tool-call.ts:230` and `run.ts:1834` to prefer the helper's value (only fall back to cached snapshot when helper returns `undefined` from a true disk failure) |
+| B   | (deferred) Stale approval card after planMode auto-cleared; double-popup; "planApproval requires an active plan-mode session" error after waiting                                                     | Server: `sessions-patch.ts:751` deletes planMode without checking `approval === "pending"`. UI: `app.ts` doesn't subscribe to "planMode went away" events to dismiss stale cards                                                    | Deferred to Phase 2 (next commit) — needs UI subscription model + new `PLAN_APPROVAL_EXPIRED` error code                                                                                                                                                                                                                                                                                                                                     |
+| C   | Subagent-during-approve toast didn't visibly fire even when gate should have triggered                                                                                                                | Could not distinguish "gate didn't fire" vs "gate fired silently" vs "toast rendered but invisible" without server-side log                                                                                                         | Added always-on `gateway/plan-approval-gate` logger emitting `gate decision: action=approve sessionKey=… approvalRunId=… openSubagents=N result=blocked\|allowed` on every approve/edit. Also logs `gate disabled: …` when `approvalRunId` not persisted (Bug 2 wiring failure)                                                                                                                                                              |
+| D   | `OPENCLAW_DEBUG_PLAN_MODE=1` set via `launchctl setenv` produced ZERO `[plan-mode/...]` lines in the test window                                                                                      | macOS `launchctl setenv` only affects FUTURE launchd-spawned processes, not running children of the OpenClaw Mac app                                                                                                                | Added config-flag path: `agents.defaults.planMode.debug: true`. Helper now reads BOTH env var and config (env wins). Set via `openclaw config set agents.defaults.planMode.debug true` then restart gateway                                                                                                                                                                                                                                  |
+| E   | Agent received TWO different `[PLAN_DECISION]` formats — block format on rejection (`[PLAN_DECISION]\ndecision: rejected\n…\n[/PLAN_DECISION]`) vs one-line on approval (`[PLAN_DECISION]: approved`) | Two emission sites: `types.ts:buildPlanDecisionInjection` (block) for reject/timeout vs `sessions-patch.ts:606` (one-line) for approve/edit                                                                                         | Unified on one-line opener (`[PLAN_DECISION]: <decision>`) in `types.ts`. Adversarial-feedback sanitization preserved (closing-marker neutralization still active for defense-in-depth)                                                                                                                                                                                                                                                      |
+| F   | Agent demonstrably misused tools: posted chat after `exit_plan_mode` (Bug A trigger), confused `update_plan` vs `exit_plan_mode`, read multi-MB logs from line 1                                      | Tool descriptions said WHAT but not WHEN/HOW; system prompt had no log-triage rule and no "stop after exit_plan_mode" rule                                                                                                          | Updated `describeExitPlanModeTool` (STOP-AFTER-TOOL-CALL as first line), `describeUpdatePlanTool` (TRACKING-ONLY clarification), `describeEnterPlanModeTool` (lifecycle 1-2-3-after pattern). Updated `attempt.ts:549-557` with log-triage hygiene rule + explicit "no chat after exit_plan_mode" reminder                                                                                                                                   |
+
+**Test coverage added:** 8 tests in `fresh-session-entry.test.ts` (deletion-as-normal contract), 5 tests in `plan-mode-debug-log.test.ts` (config-flag gate), 6 tests in `approval.test.ts` (one-line format).
+
+**Activation for live debug session (iter-2 path — RELIABLE on macOS):**
+
+```bash
+openclaw config set agents.defaults.planMode.debug true
+launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+
+# Tail with the right filter
+tail -F ~/.openclaw/logs/gateway.err.log | grep -E '\[plan-mode/|gate decision'
+```
+
+The `gate decision` filter catches the always-on Bug C log lines even when the env-gated `[plan-mode/...]` debug stream is off.
+
+---
+
+## 1. The 10-PR series — historical (all closed; consolidated into umbrella PR #68939)
+
+> **STATUS:** All 10 PRs below were closed on 2026-04-19 in favor of the consolidated umbrella PR **#68939** (rebased onto upstream/main @ `v2026.4.19-beta.2`). See the "Consolidation pass — 2026-04-19" section above for the rationale. Table preserved for historical context — `git blame` and the iter-1/2/3 narrative still map back to these PR boundaries.
+
+| Sprint    | Upstream PR                                               | Local branch                            | Latest head  | Net-new files                | Mergeable    | Final status                                                                              |
+| --------- | --------------------------------------------------------- | --------------------------------------- | ------------ | ---------------------------- | ------------ | ----------------------------------------------------------------------------------------- |
+| **PR-A**  | [#67512](https://github.com/openclaw/openclaw/pull/67512) | `final-sprint/gpt5-openai-prompt-stack` | `96e58ceedb` | 6                            | ⚠️ CONFLICTS | **closed (consolidated into #68939)** — 16 historical threads                             |
+| **PR-B**  | [#67514](https://github.com/openclaw/openclaw/pull/67514) | `final-sprint/gpt5-task-system-parity`  | `c192d9ff49` | 8                            | ✅           | **closed (consolidated into #68939)** — 10 historical threads                             |
+| **PR-C**  | [#67534](https://github.com/openclaw/openclaw/pull/67534) | `phase3/plan-rendering`                 | `6069a036fe` | 2                            | ✅           | **closed (consolidated into #68939)** — 14 historical threads                             |
+| **PR-D**  | [#67538](https://github.com/openclaw/openclaw/pull/67538) | `phase3/plan-mode`                      | `4a3ddb98bc` | 29                           | ✅           | **closed (consolidated into #68939)** — 29 historical threads                             |
+| **PR-E**  | [#67541](https://github.com/openclaw/openclaw/pull/67541) | `phase4/skill-plan-templates`           | `780aced7d2` | 11                           | ✅           | **closed (consolidated into #68939)** — 16 historical threads                             |
+| **PR-F**  | [#67542](https://github.com/openclaw/openclaw/pull/67542) | `phase4/cross-session-plans`            | `689efe253b` | 2                            | ✅           | **closed (consolidated into #68939)** — 20 historical threads                             |
+| **PR-7**  | [#67721](https://github.com/openclaw/openclaw/pull/67721) | `feat/ui-mode-switcher-plan-cards`      | `fb5a7fa05e` | 16                           | ❓           | **closed (consolidated into #68939)** — 49 historical threads                             |
+| **PR-8**  | [#67840](https://github.com/openclaw/openclaw/pull/67840) | `feat/plan-mode-integration`            | `f866dfbb3c` | 39                           | ⚠️ CONFLICTS | **closed (consolidated into #68939)** — 41 historical threads                             |
+| **PR-10** | [#68440](https://github.com/openclaw/openclaw/pull/68440) | `feat/plan-archetype-and-questions`     | `1bf9d7b4e7` | 115 cumulative / ~25 net-new | ❓           | **closed (consolidated into #68939)** — pass-1 + pass-2 complete pre-consolidation        |
+| **PR-11** | [#68441](https://github.com/openclaw/openclaw/pull/68441) | `feat/plan-channel-parity`              | `ef56f0f2cf` | 127 cumulative / 32 net-new  | ⚠️ CONFLICTS | **closed (consolidated into #68939)** — was the live cumulative branch (rebased + reused) |
+
+(PR-9, PR-12, PR-13, PR-14 are internal sprint commits riding on `feat/plan-channel-parity` and ride along with the umbrella PR.)
+
+### PR-11 escalation cluster — pending maintainer decision
+
+Four threads on PR-11 share the same root cause: post-approval/answer state transitions on `sessions.patch` clear runtime fields needed downstream. See escalation comment #68441 (issuecomment-4273877823). Decision needed:
+
+- **`/plan answer` synthetic-message injection in non-webchat channels** (3 threads: #3105216364, #3105247854, #3105261556) — caller-side per-channel vs gateway-side single source of truth vs won't-fix-this-PR.
+- **Post-approval yield retry detection** (1 thread: #3105311664 from re-review) — `resolveYieldDuringApprovedPlanInstruction` predicates unreachable because `planMode → "normal"` clears state. Same root cause cluster.
+
+### "Too many files" structural issue
+
+PR-11's diff vs `upstream/main` is 127 files because the branch was built sequentially on top of every prior PR. Greptile's 100-file review cap and Copilot's 127-of-126-files-reviewed apply to the cumulative diff, not PR-11's true scope (32 net-new files / 2,965 LoC since PR-10's branch tip).
+
+**Resolution path:** land PRs in dependency order so each subsequent PR's diff naturally shrinks. Closing/reopening with main-rebased branches would lose review history without solving the underlying structural cumulative-rollout pattern.
+
+---
+
+## 2. Architecture — how the pieces fit together
+
+### Layer 1: Renderer + parity (independent foundations)
+
+```
+┌─────────────────────────────┐  ┌─────────────────────────────┐  ┌───────────────────────────┐
+│  PR-A (#67512)              │  │  PR-B (#67514)              │  │  PR-C (#67534)            │
+│  GPT-5.4 prompt + injection │  │  Task system parity         │  │  Plan checklist renderer  │
+│  scanner                    │  │  (cancelled status, merge,  │  │  (4 formats: html,        │
+│                             │  │  activeForm, hydration)     │  │  markdown, plaintext,     │
+│                             │  │                             │  │  slack-mrkdwn)            │
+│  Files: 6                   │  │  Files: 8                   │  │  Files: 2                 │
+└─────────────────────────────┘  └─────────────────────────────┘  └───────────────────────────┘
+   independent                       PR-E depends on this              PR-D + PR-7 depend
+```
+
+### Layer 2: Plan-mode runtime + storage
+
+```
+┌─────────────────────────────┐  ┌─────────────────────────────┐  ┌───────────────────────────┐
+│  PR-D (#67538)              │  │  PR-F (#67542)              │  │  PR-E (#67541)            │
+│  Plan-mode runtime library  │  │  Cross-session plan store   │  │  Skill plan templates     │
+│  (mutation gate, escalating │  │  (file-locking, security    │  │  (skill-driven planning)  │
+│  retry, auto-continue)      │  │  hardened)                  │  │                           │
+│                             │  │                             │  │  depends on PR-B          │
+│  Files: 18                  │  │  Files: 2                   │  │  Files: 11                │
+└─────────────────────────────┘  └─────────────────────────────┘  └───────────────────────────┘
+```
+
+### Layer 3: UI + integration
+
+```
+┌─────────────────────────────┐  ┌─────────────────────────────────────┐
+│  PR-7 (#67721)              │  │  PR-8 (#67840)                      │
+│  UI mode switcher chip +    │  │  Plan-mode integration bridge       │
+│  clickable plan cards       │  │  - register enter_plan_mode +       │
+│                             │  │    exit_plan_mode tools             │
+│  depends on PR-C            │  │  - mutation gate hook in            │
+│  Files: 16                  │  │    pi-tools.before-tool-call        │
+│                             │  │  - sessions.patch planMode field    │
+│                             │  │  - plan approval reply dispatch     │
+│                             │  │                                     │
+│                             │  │  depends on PR-D + PR-7             │
+│                             │  │  Files: 39                          │
+└─────────────────────────────┘  └─────────────────────────────────────┘
+```
+
+### Layer 4: User-facing features
+
+```
+┌─────────────────────────────────┐  ┌─────────────────────────────────┐
+│  PR-10 (#68440)                 │  │  PR-11 (#68441)                 │
+│  Plan archetype + ask_user_     │  │  Universal /plan slash commands │
+│  question + auto mode           │  │  across ALL channels            │
+│                                 │  │                                 │
+│  - exit_plan_mode adds title +  │  │  - /plan accept | accept edits  │
+│    analysis + assumptions +     │  │    | revise <feedback>          │
+│    risks + verification +       │  │    | answer <text> | restate    │
+│    references                   │  │    | auto on|off | on|off       │
+│  - PLAN_ARCHETYPE_PROMPT        │  │    | status | view              │
+│    system fragment              │  │  - works on Telegram, Discord,  │
+│  - ask_user_question tool       │  │    Signal, iMessage, Slack,     │
+│    (multi-choice + free-text)   │  │    Matrix, IRC, web, CLI, etc   │
+│  - Plan ⚡ chip + /plan auto    │  │                                 │
+│  - autoApprove flag persisted   │  │  +PR-12 cron-nudge fixes        │
+│  - 5 deep-dive review fixes     │  │  +PR-13 vertical question       │
+│                                 │  │   layout + inline Other         │
+│  depends on PR-8                │  │  +PR-14 Telegram .md attachment │
+│  Files: 25 net-new              │  │  +6 deep-dive review fixes      │
+│                                 │  │  +13 review-loop pass 1 fixes   │
+│                                 │  │                                 │
+│                                 │  │  depends on PR-10               │
+│                                 │  │  Files: 32 net-new              │
+└─────────────────────────────────┘  └─────────────────────────────────┘
+```
+
+### Dependency graph (landing order)
+
+```
+                    ┌──────────────┐
+                    │   main       │
+                    └───┬───┬───┬──┘
+                        │   │   │
+        ┌───────────────┼───┼───┼────────────┐
+        │       ┌───────┼───┘   └────┐       │
+        │       │       │            │       │
+       PR-A   PR-B    PR-C         PR-F    PR-7
+       (#67512)(#67514)(#67534)    (#67542)(#67721)
+        │       │       │            │       │
+        │       │       │            │       │
+        │       │       └─→ PR-D    │       │
+        │       │       ┌─ (#67538)  │       │
+        │       │       │            │       │
+        │       └─→ PR-E│            │       │
+        │           (#67541)         │       │
+        │                            │       │
+        │                            └───────┴──→ PR-8
+        │                                        (#67840)
+        │                                            │
+        │                                            ▼
+        │                                          PR-10
+        │                                         (#68440)
+        │                                            │
+        │                                            ▼
+        │                                          PR-11
+        │                                         (#68441)
+        │                                            ▲
+        └───── (independent — lands any time) ──────┘
+```
+
+**Recommended landing waves:**
+
+1. **Wave 1** (independent, no plan-mode deps): PR-B, PR-C, PR-F, PR-A
+2. **Wave 2** (depend on wave 1): PR-E (after PR-B), PR-D (after PR-C)
+3. **Wave 3** (co-merge — each is dead code alone): PR-7 + PR-8
+4. **Wave 4**: PR-10 (after PR-8)
+5. **Wave 5**: PR-11 (after PR-10)
+
+Co-merge guidance: PR-7, PR-8 land in one merge window. Otherwise main carries dead code.
+
+---
+
+## 3. Feature behavior
+
+### Plan mode lifecycle
+
+```
+[Idle] ──/plan on──→ [Plan: none] ──exit_plan_mode──→ [Plan: pending]
+                          │                                  │
+                          │                          ┌───────┼────────┐
+                          │                          │       │        │
+                       /plan off                  approve  edit    reject
+                          │                          │       │   /plan revise
+                          │                          ▼       ▼        │
+                          │                       [Normal — mutations │
+                          ▼                        unlocked]          ▼
+                       [Idle]                                    [Plan: rejected
+                                                                  (rejectionCount++)]
+                                                                       │
+                                                                  exit_plan_mode
+                                                                       ▼
+                                                                  [Plan: pending]
+```
+
+### Mutation gate (PR-D + PR-8 + PR-10/11 hardening)
+
+When `planMode.mode === "plan"`:
+
+- **Blocked tools** (default-deny + explicit blocklist): `apply_patch`, `bash`, `edit`, `exec` (unless read-only prefix), `gateway`, `message`, `nodes`, `process`, `sessions_send`, `subagents`, `write`
+- **Allowed tools**: `read`, `web_search`, `web_fetch`, `memory_search`, `memory_get`, `update_plan`, `exit_plan_mode`, `enter_plan_mode`, `session_status`, `ask_user_question`, `sessions_spawn`
+- **Read-only exec prefixes**: `ls`, `cat`, `pwd`, `git status|log|diff|show`, `which`, `find`, `grep`, `rg`, `head`, `tail`, `wc`, `file`, `stat`, `du`, `df`, `echo`, `printenv`, `whoami`, `hostname`, `uname`
+
+**Critical PR-11 review fix**: `agent-runner-execution.ts` now threads `planMode: "plan"` into `runEmbeddedPiAgent`. Pre-fix the gate never activated from the auto-reply path.
+
+### Auto-mode (PR-10)
+
+`SessionEntry.planMode.autoApprove === true` → after every `exit_plan_mode`, `autoApproveIfEnabled` fires `sessions.patch { planApproval: { action: "approve", approvalId }}` immediately. Flag preserved across approve/edit/normal transitions.
+
+### Universal `/plan` slash commands (PR-11)
+
+| Subcommand                | Action                             | Backend route                                           |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------- |
+| `/plan accept`            | approve current pending plan       | `sessions.patch { planApproval: { action: "approve" }}` |
+| `/plan accept edits`      | approve with allow-edits           | `action: "edit"`                                        |
+| `/plan revise <feedback>` | reject + provide feedback          | `action: "reject", feedback`                            |
+| `/plan answer <text>`     | answer ask_user_question           | `action: "answer", answer`                              |
+| `/plan auto on\|off`      | toggle autoApprove                 | `action: "auto", autoEnabled`                           |
+| `/plan on\|off`           | enter/exit plan mode               | `planMode: "plan"\|"normal"`                            |
+| `/plan status`            | show current state (read-only)     | (no patch)                                              |
+| `/plan view`              | toggle UI sidebar (web only)       | (no patch)                                              |
+| `/plan restate`           | re-render plan in chat / send file | (no patch)                                              |
+
+### Telegram visibility (PR-14)
+
+- Every `exit_plan_mode` → render full archetype as markdown → persist to `~/.openclaw/agents/<id>/plans/plan-YYYY-MM-DD-<slug>.md` (always, audit artifact)
+- If session originated from Telegram → also send the .md file as a document attachment with caption containing universal `/plan` resolution commands
+- Resolution stays text-based via PR-11's slash commands (sidesteps dual approval-id problem)
+- Multi-cycle: collision suffix `-2.md`, `-3.md`, … preserves rejection-revise history
+
+### Plan-nudge crons (PR-9 + PR-12 fixes)
+
+Scheduled at 10/30/60 min after `enter_plan_mode` to prompt the agent if it stalls. Suppressed when:
+
+- `planMode.approval === "pending"` (don't clobber pending approval popup)
+- Agent active in last 5 min (`Date.now() - planMode.updatedAt < 5min`)
+- Cleaned up on EVERY plan-mode close (approve/reject/edit/off/close-on-complete) to prevent orphan accumulation
+
+---
+
+## 4. Critical files reference
+
+| Surface                              | File                                                                          | Owner PR                    |
+| ------------------------------------ | ----------------------------------------------------------------------------- | --------------------------- |
+| Plan checklist renderer (4 formats)  | `src/agents/plan-render.ts`                                                   | PR-C                        |
+| Plan archetype markdown render       | `src/agents/plan-render.ts` (`renderFullPlanArchetypeMarkdown`)               | PR-14                       |
+| Mutation gate                        | `src/agents/plan-mode/mutation-gate.ts`                                       | PR-D                        |
+| Plan-mode runtime + retry            | `src/agents/pi-embedded-runner/run/incomplete-turn.ts`                        | PR-D                        |
+| Cross-session plan store (file lock) | `src/agents/plan-store.ts`                                                    | PR-F                        |
+| Skill plan templates                 | `src/agents/skills/skill-planner.ts`                                          | PR-E                        |
+| Task parity + merge                  | `src/agents/tools/update-plan-tool.ts`                                        | PR-B                        |
+| Plan archetype prompt                | `src/agents/plan-mode/plan-archetype-prompt.ts`                               | PR-10                       |
+| Plan filename helpers                | `src/agents/plan-mode/plan-archetype-prompt.ts` (`buildPlanFilename`)         | PR-10                       |
+| Plan markdown persist                | `src/agents/plan-mode/plan-archetype-persist.ts`                              | PR-14                       |
+| Plan-mode → channel bridge           | `src/agents/plan-mode/plan-archetype-bridge.ts`                               | PR-14                       |
+| `enter_plan_mode` tool               | `src/agents/tools/enter-plan-mode-tool.ts`                                    | PR-8                        |
+| `exit_plan_mode` tool                | `src/agents/tools/exit-plan-mode-tool.ts`                                     | PR-8/PR-10                  |
+| `ask_user_question` tool             | `src/agents/tools/ask-user-question-tool.ts`                                  | PR-10                       |
+| Universal `/plan` handler            | `src/auto-reply/reply/commands-plan.ts`                                       | PR-11                       |
+| Webchat `/plan` executor             | `ui/src/ui/chat/slash-command-executor.ts`                                    | PR-11                       |
+| Mode switcher chip + Plan ⚡         | `ui/src/ui/chat/mode-switcher.ts`                                             | PR-7/PR-10                  |
+| Inline approval card + question      | `ui/src/ui/views/plan-approval-inline.ts`                                     | PR-7/PR-10/PR-13            |
+| Sessions patch planApproval routing  | `src/gateway/sessions-patch.ts`                                               | PR-8 + cumulative hardening |
+| Plan snapshot persister              | `src/gateway/plan-snapshot-persister.ts`                                      | PR-8                        |
+| Auto-approve runtime                 | `src/agents/pi-embedded-subscribe.handlers.tools.ts` (`autoApproveIfEnabled`) | PR-10                       |
+| Plan archetype bridge from runtime   | `src/agents/pi-embedded-subscribe.handlers.tools.ts` (insertion at line 1659) | PR-14                       |
+| Telegram document send               | `extensions/telegram/src/send.ts` (`sendDocumentTelegram`)                    | PR-14                       |
+| GPT-5.4 friendly overlay             | `extensions/openai/prompt-overlay.ts` (`OPENAI_FRIENDLY_PROMPT_OVERLAY`)      | PR-A                        |
+| Context-file injection scanner       | `src/agents/context-file-injection-scan.ts`                                   | PR-A                        |
+
+---
+
+## 5. Hardening status (review pass tracking) — historical (per-PR; superseded by umbrella PR review state)
+
+> **STATUS:** The per-PR pass-tracking below is historical. After consolidation (2026-04-19), all bot review work happens on **umbrella PR #68939**. The 10-PR review history is preserved here so reviewers can see what was already addressed before consolidation.
+
+| PR                    | Pass 1                                                                                          | Pass 2     | Bots re-triggered               | Final status                              |
+| --------------------- | ----------------------------------------------------------------------------------------------- | ---------- | ------------------------------- | ----------------------------------------- |
+| #67512                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67514                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67534                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67538                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67541                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67542                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67721                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #67840                | ⏳ pending pre-consolidation                                                                    | n/a        | n/a                             | closed (consolidated #68939)              |
+| #68440                | ✅ done (9/10 fixed, 1 escalated → resolved this iteration)                                     | ⏳ pending | @-mentioned                     | closed (consolidated #68939)              |
+| #68441                | ✅ done (13/13 fixed)                                                                           | ⏳ pending | @-mentioned                     | closed (consolidated #68939)              |
+| **#68939 (umbrella)** | 🚦 first wave triggered (Copilot @-mentioned; Greptile hit 100-file ceiling — known limitation) | ⏳ pending | initial fire post-consolidation | **OPEN** (rebased on `v2026.4.19-beta.2`) |
+
+### Escalated comment resolution (this iteration)
+
+**#68440 #3104743333 (Codex P2 — `app-tool-stream.ts:519` — sidebar refresh in update_plan merge mode)**: User chose "best long-term hardened solution" — picked option (c) re-emit merged steps via the existing `agent_plan_event` channel. Lowest perf overhead (no hot-path SessionEntry read), no new event type (channel already exists), and persister already does the same thing for plan-snapshot work. Implementation: in `update-plan-tool.ts` after merge, fire `emitAgentPlanEvent({ phase: "update", steps: mergedPlan, runId })`. UI subscribes to `stream: "plan"` events and refreshes from those.
+
+---
+
+## 6. Cron upstream conflict (#67807)
+
+Upstream main merged `fix(cron): clean up deleteAfterRun direct deliveries (#67807)` since fork. Touches `src/cron/isolated-agent/delivery-dispatch.ts` ONLY. **No conflict** with PR-12 cron-nudge fix (different surfaces — PR-12 touched `sessions-patch.ts` + `heartbeat-runner.ts`).
+
+---
+
+## 7. Process going forward (clean baseline)
+
+### Naming convention
+
+- **Sprint #**: `PR-A` ... `PR-11` (chronological internal order)
+- **Upstream #**: `#NNNNN` (GitHub PR number on upstream openclaw/openclaw)
+- 1:1 mapping except PR-9/12/13/14 which are internal sprints riding on `feat/plan-channel-parity`
+
+### Branch policy
+
+- Local branches on `100yenadmin/openclaw-1` (fork) ONLY — never push to upstream
+- Each PR's local branch is the head of the upstream cross-repo PR
+- `feat/plan-channel-parity` is the LIVE branch (cumulative; what runs locally)
+- Other 9 branches are individual PR scopes
+
+### Push & install loop
+
+1. Make changes
+2. `pnpm format:fix && pnpm lint && pnpm tsgo` (only flag NEW errors; pre-existing baseline OK)
+3. `pnpm test <touched-files>` (must pass)
+4. `pnpm build && pnpm ui:build` (order matters — build wipes dist/)
+5. `FAST_COMMIT=1 scripts/committer "msg" file...` (scope to changed files only)
+6. `git push` to `origin/<branch>`
+7. `npm install -g .` to update global CLI
+8. `launchctl kickstart -k gui/$UID/ai.openclaw.gateway`
+9. `openclaw status --probe` to confirm live
+
+### Review-loop policy
+
+- Use `pr-review-loop` skill on each PR
+- 95% confidence threshold (stricter than skill default 70%)
+- Don't change agent prompts — flag for user
+- Multiple sprints (2-3) per PR for hardening
+- Mark stale comments "no longer relevant" when fix already shipped on cumulative branch
+
+### Verification gates (release-bar)
+
+- All scoped tests pass
+- Lint 0 errors
+- Tsgo no new errors (baseline pre-existing OK)
+- Build + UI build clean
+- Live install smoke-tests cleanly via webchat + Telegram
+
+---
+
+## 8. Beta-readiness checklist
+
+> **STATUS:** Updated for the consolidated umbrella PR #68939 path (post-2026-04-19 consolidation).
+
+- [x] Live install on `c9287908eb` (PR-11 review pass 1, pre-consolidation)
+- [x] PR-10 + PR-11 review pass 1 complete (pre-consolidation)
+- [x] Rebase `feat/plan-channel-parity` onto `upstream/main` @ `v2026.4.19-beta.2` (5 conflicts resolved)
+- [x] All 10 individual PRs closed with redirect comments to #68939
+- [x] Umbrella PR #68939 opened from rebased branch
+- [x] Backup branch `feat/plan-channel-parity-backup` pushed to origin at pre-rebase HEAD `bee5e8c364`
+- [x] Architecture doc updated with consolidation status
+- [ ] Initial Copilot review wave on #68939 triaged via `pr-review-loop` skill
+- [ ] Address PR-14 Telegram visibility re-wire (deferred follow-up)
+- [ ] Address Bug B + R1/R2/R3/R4/R5 + D5 (deferred follow-up commits on `feat/plan-channel-parity`)
+- [ ] #68939 merged to upstream main
+- [ ] Beta tag cut on upstream main

--- a/docs/plans/PLAN-MODE-OPERATOR-RUNBOOK.md
+++ b/docs/plans/PLAN-MODE-OPERATOR-RUNBOOK.md
@@ -1,0 +1,250 @@
+# Plan Mode — Operator Runbook
+
+Field guide for diagnosing plan-mode incidents in production OpenClaw
+gateways. Companion to `docs/concepts/plan-mode.md` (user-facing
+documentation) and `docs/plans/PLAN-MODE-ARCHITECTURE.md` (design
+reference).
+
+Use this runbook when users report plan-mode misbehavior and you need
+to isolate root cause from gateway logs.
+
+---
+
+## Enabling the structured debug log
+
+The plan-mode debug stream is OFF by default (zero perf impact). Turn
+it on when investigating:
+
+**Persistent (recommended — survives gateway restarts):**
+
+```bash
+openclaw config set agents.defaults.planMode.debug true
+openclaw gateway restart
+```
+
+**Ad-hoc (current terminal-launched run only):**
+
+```bash
+OPENCLAW_DEBUG_PLAN_MODE=1 openclaw gateway run
+```
+
+**Stream the log:**
+
+```bash
+tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'
+```
+
+**Trace a single approval cycle** (C7 follow-up added correlation
+fields):
+
+```bash
+tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/' | grep approvalRunId=<id>
+```
+
+---
+
+## Symptom → Fix matrix
+
+### 1. Approval card stays on screen after the user clicks Approve
+
+**Canonical signal:** error code `PLAN_APPROVAL_EXPIRED` in the
+sessions-patch response.
+
+**Root cause classes:**
+
+- Session already exited plan mode via `/plan off` or completion.
+- Another channel (webchat vs Telegram) resolved the approval first.
+- Session compaction dropped the `planMode` state mid-flight.
+
+**Diagnostic:**
+
+```bash
+grep 'PLAN_APPROVAL_EXPIRED' ~/.openclaw/logs/gateway.err.log | tail
+```
+
+**Fix:** the webchat UI auto-dismisses this code (Control UI wired in
+C1). If a legacy client or non-web channel shows the stale card,
+refresh the session or run `/plan status` to re-sync. No server-side
+fix — the code path is intentional (the approval window genuinely
+expired).
+
+---
+
+### 2. Subagent stall blocks plan approval
+
+**Canonical signals:**
+
+- `PLAN_APPROVAL_BLOCKED_BY_SUBAGENTS` (open subagents) — returned
+  when the user clicks Approve while subagents spawned during the
+  investigation phase are still in flight.
+- `PLAN_APPROVAL_WAITING_FOR_SUBAGENT_SETTLE` — returned when a
+  subagent settled within the last 10 seconds (race window).
+
+**Diagnostic:**
+
+```bash
+grep 'approval-gate' ~/.openclaw/logs/gateway.err.log | tail -20
+```
+
+**Fix:**
+
+- `BLOCKED_BY_SUBAGENTS`: wait for the listed `openSubagentRunIds` to
+  return, then re-approve. Plan mode enforces a concurrency cap of 1
+  subagent during the investigation phase. If this fires persistently
+  despite no visible subagent activity, check that
+  `drainCompletedSubagentFromParents(runId)` is being called on
+  crash/timeout paths (R1 of C1).
+- `WAITING_FOR_SUBAGENT_SETTLE`: wait 10 seconds and retry. The gate
+  dismisses itself once `lastSubagentSettledAt` ages past
+  `SUBAGENT_SETTLE_GRACE_MS`.
+
+---
+
+### 3. Empty-response stall after an approval
+
+**Signal:** agent returns a turn with no content after a plan is
+approved. Gateway log shows the retry path firing without surfacing
+the original `[PLAN_DECISION]` context.
+
+**Root cause:** post-approval ack-only retry fires within the 5-min
+grace window (`POST_APPROVAL_ACK_ONLY_GRACE_MS`), but the synthetic
+`[PLAN_DECISION]` injection was already consumed on the first
+attempt.
+
+**Status:** C4.2 (retry re-hydration) is deferred to a focused follow-up.
+The current workaround is to re-invoke the agent with an explicit
+message — the plan approval persists server-side, so the agent can
+read it back via `plan_mode_status`.
+
+---
+
+### 4. Nudge cron noise during pending approval
+
+**Signal:** repeated `[PLAN_NUDGE]` agent turns fire while the user's
+approval card is still open.
+
+**Diagnostic:**
+
+```bash
+grep 'plan-nudge' ~/.openclaw/logs/gateway.err.log | tail -10
+```
+
+**Fix:** C1-R2 (shipped in `906eb68403`) added the approval-pending
+suppression guard at `src/cron/isolated-agent/run.ts:423-431`. If
+nudges still fire during a pending approval, verify:
+
+- `cronSession.sessionEntry.planMode.approval === "pending"` when the
+  cron fires (visible in the `[plan-mode/nudge_event]` debug line).
+- The cron payload carries the correct `planCycleId` — mismatched
+  cycles are suppressed separately with "older plan cycle" summary.
+
+---
+
+### 5. Plan-mode state lost after compaction or restart
+
+**Signal:** session was mid-plan before a compaction / gateway
+restart; after recovery, `plan_mode_status` reports `mode: "normal"`
+and the plan steps are gone.
+
+**Diagnostic:**
+
+```bash
+grep 'state_transition' ~/.openclaw/logs/gateway.err.log | grep <sessionKey>
+```
+
+**Fix:** the `fresh-session-entry.ts` live-disk read path resolves
+"planMode deleted" (post-approval) from "planMode missing" (compaction
+loss). If the state was genuinely lost, the user must re-invoke
+`/plan on` + let the agent re-propose. The approved-plan markdown
+file at `~/.openclaw/agents/<agentId>/plans/plan-YYYY-MM-DD-<slug>.md`
+is durable — use it to recover the plan text manually if needed.
+
+---
+
+## Shell-escape bypass attempts under acceptEdits
+
+**Signal:** gateway log contains
+`[plan-mode/gate_decision] allowed=false` lines with `constraint:
+"destructive"` citing shell-escape constructs.
+
+**Context:** C4.1 added layered-defense detection for destructive
+verbs smuggled via env-var indirection (`$RM`), backtick/$(...)
+subshells, quote concatenation (`"r""m"`), and hex/octal byte escapes
+(`\x72m`, `\162m`). Legitimate commands rarely trigger these
+patterns; if you see them fire, inspect the agent's intent — it's
+usually a hallucinated or prompt-injected attempt.
+
+**Investigation:**
+
+```bash
+grep 'gate_decision' ~/.openclaw/logs/gateway.err.log | grep destructive | tail
+```
+
+---
+
+## Adversarial XSS in plan titles
+
+**Signal:** a user reports suspicious rendering in a Telegram plan
+attachment or webchat plan card.
+
+**Context:** C1-R3 added adversarial regression coverage for plan
+titles across all four render formats (HTML, markdown, plaintext,
+slack-mrkdwn). The escape chain is `escapeHtml` +
+`neutralizeMentions` + `buildPlanFilenameSlug` for filesystem writes.
+
+**Investigation:**
+
+```bash
+# Re-run the XSS suite locally to verify the regression didn't drift.
+pnpm test src/agents/plan-render.test.ts -t "XSS"
+```
+
+If a new adversarial payload slips through, add it as a new case
+in `src/agents/plan-render.test.ts` under the "plan title XSS /
+injection hardening" describe block.
+
+---
+
+## Disk-full during plan persistence
+
+**Signal:** gateway log contains `[plan-bridge/storage]` warn lines
+referencing `ENOSPC` / `EACCES` / `EIO`. Plan approval still completes
+(non-blocking contract), but the durable audit artifact was lost.
+
+**Fix:**
+
+- `ENOSPC`: free space at `~/.openclaw/agents/<agentId>/plans/`.
+- `EACCES`: check filesystem permissions on the agents directory.
+- `EIO`: underlying storage / FUSE / NFS issue — not an OpenClaw
+  bug.
+
+Re-run `/plan restate` after fixing to re-materialize the markdown.
+
+---
+
+## Cross-channel approval dedup
+
+**Signal:** a user reports a plan was approved twice (once in webchat,
+once in Telegram) with two `[PLAN_DECISION]` injections in the agent
+history.
+
+**Context:** C1-R5 added concurrency dedup tests. The gateway's
+`sessions.patch` handler applies serially; the second write sees the
+post-first-write state and errors with `PLAN_APPROVAL_EXPIRED` (Bug
+B code) or `pending approval` mismatch. If you observe a double
+injection, the most likely cause is the client retrying a patch that
+silently succeeded.
+
+---
+
+## Escalation path
+
+If a symptom doesn't match any of the above and the debug log
+contains unfamiliar `[plan-mode/*]` events, capture:
+
+1. The full debug log window (5 minutes before → 5 minutes after).
+2. The session key + agent ID.
+3. The `approvalRunId` and `approvalId` from the relevant
+   `approval_event` log lines (C7 correlation fields).
+4. Open an issue at https://github.com/openclaw/openclaw/issues with
+   the label `area:plan-mode`.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -136,6 +136,7 @@ Built-in commands available today:
 - `/bash <command>` runs a host shell command. Text-only. Alias: `! <command>`. Requires `commands.bash: true` plus `tools.elevated` allowlists.
 - `!poll [sessionId]` checks a background bash job.
 - `!stop [sessionId]` stops a background bash job.
+- `/plan on|off|status|view|auto|accept|revise|answer|restate` toggles plan mode and resolves plan-mode approvals. Universal across all channels (web, Telegram, Discord, Slack, etc.). See [/concepts/plan-mode](/concepts/plan-mode).
 
 ### Generated dock commands
 

--- a/qa/scenarios/gpt54-act-dont-ask.md
+++ b/qa/scenarios/gpt54-act-dont-ask.md
@@ -1,0 +1,59 @@
+# GPT-5.4 act-don't-ask
+
+```yaml qa-scenario
+id: gpt54-act-dont-ask
+title: GPT-5.4 acts on obvious defaults instead of asking for clarification
+surface: agent
+objective: Verify GPT-5.4 executes obvious-default queries immediately without asking clarifying questions.
+successCriteria:
+  - Agent checks local machine for "Is port 8080 open?" (does NOT ask "which host?")
+docsRefs: []
+codeRefs:
+  - extensions/openai/prompt-overlay.ts
+execution:
+  kind: flow
+  summary: Send queries with obvious defaults and verify the agent acts instead of asking.
+  config:
+    model: openai/gpt-5.4
+```
+
+```yaml qa-flow
+steps:
+  - name: port check acts immediately
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - call: state.addInboundMessage
+        args:
+          - conversation:
+              id: qa-room
+              kind: channel
+              title: QA Room
+            senderId: alice
+            senderName: Alice
+            text: "Is port 8080 open?"
+      - call: waitForOutboundMessage
+        saveAs: message
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-room'"
+          - expr: liveTurnTimeoutMs(env, 60000)
+      - assert:
+          expr: "!message.text.toLowerCase().includes('which host')"
+          message: "Response should not ask which host — should check THIS machine"
+      - assert:
+          expr: "!message.text.toLowerCase().includes('which port') && !message.text.toLowerCase().includes('could you clarify')"
+          message: "Response should not ask for clarification on an obvious default"
+      - assert:
+          expr: "message.toolCalls?.some(tc => tc.name === 'exec') ?? false"
+          message: "Agent must call exec to check the port (e.g. lsof, netstat, ss), not answer from memory"
+    detailsExpr: message.text
+```

--- a/qa/scenarios/gpt54-cancelled-status.md
+++ b/qa/scenarios/gpt54-cancelled-status.md
@@ -1,0 +1,57 @@
+# GPT-5.4 cancelled plan step status
+
+```yaml qa-scenario
+id: gpt54-cancelled-status
+title: Failed plan step marked cancelled with revised step added
+surface: agent
+objective: Verify GPT-5.4 uses the cancelled status when a plan step fails, and adds a revised step to continue.
+successCriteria:
+  - Agent marks failed step as "cancelled" (not "completed" or silently dropped)
+  - Agent adds a revised step after the cancelled one
+docsRefs: []
+codeRefs:
+  - src/agents/tools/update-plan-tool.ts
+execution:
+  kind: flow
+  summary: Trigger a multi-step task and verify update_plan is called.
+  config:
+    model: openai/gpt-5.4
+```
+
+```yaml qa-flow
+steps:
+  - name: multi-step task triggers plan update
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - call: state.addInboundMessage
+        args:
+          - conversation:
+              id: qa-room
+              kind: channel
+              title: QA Room
+            senderId: alice
+            senderName: Alice
+            text: "Create a 3-step plan to build and test a Node project: 1) install deps, 2) run tests, 3) build. Then start executing."
+      - call: waitForOutboundMessage
+        saveAs: message
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-room' && candidate.text.includes('update_plan')"
+          - expr: liveTurnTimeoutMs(env, 120000)
+      - assert:
+          expr: "message.toolCalls?.some(tc => tc.name === 'update_plan') ?? false"
+          message: "Agent must call update_plan to create the plan"
+      - assert:
+          expr: "message.toolCalls?.some(tc => { const p = tc.params; return p?.plan?.some(s => s.status === 'cancelled'); }) ?? true"
+          message: "If a step fails, it should be marked cancelled (not silently dropped or marked completed)"
+    detailsExpr: message.text
+```

--- a/qa/scenarios/gpt54-injection-scan.md
+++ b/qa/scenarios/gpt54-injection-scan.md
@@ -1,0 +1,58 @@
+# GPT-5.4 context file injection scanning
+
+```yaml qa-scenario
+id: gpt54-injection-scan
+title: Injection scanner baseline - normal messages get normal responses
+surface: agent
+objective: Verify that the injection scanner does not interfere with normal message flow. The scanner itself is unit-tested in #67512; this scenario validates end-to-end baseline behavior.
+successCriteria:
+  - Agent responds normally to a benign message
+  - No injection-related errors in the response
+docsRefs: []
+codeRefs:
+  - src/agents/context-file-injection-scan.ts
+  - src/agents/system-prompt.ts
+execution:
+  kind: flow
+  summary: Send a normal message and verify the agent responds without injection scanner interference.
+  config:
+    model: openai/gpt-5.4
+```
+
+```yaml qa-flow
+steps:
+  - name: normal message gets normal response
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - call: state.addInboundMessage
+        args:
+          - conversation:
+              id: qa-room
+              kind: channel
+              title: QA Room
+            senderId: alice
+            senderName: Alice
+            text: "Hello, what is 2 + 2?"
+      - call: waitForOutboundMessage
+        saveAs: message
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-room'"
+          - expr: liveTurnTimeoutMs(env, 60000)
+      - assert:
+          expr: "message.text.length > 0"
+          message: "Agent should produce a non-empty response even with injected context"
+      - assert:
+          expr: "!message.text.toLowerCase().includes('ignore') && !message.text.toLowerCase().includes('previous instructions')"
+          message: "Agent response should not echo or follow injected 'ignore previous instructions' directive"
+    detailsExpr: message.text
+```

--- a/qa/scenarios/gpt54-mandatory-tool-use.md
+++ b/qa/scenarios/gpt54-mandatory-tool-use.md
@@ -1,0 +1,57 @@
+# GPT-5.4 mandatory tool use
+
+```yaml qa-scenario
+id: gpt54-mandatory-tool-use
+title: GPT-5.4 uses tools for factual queries instead of answering from memory
+surface: agent
+objective: Verify GPT-5.4 calls exec/code_execution for arithmetic, timestamps, system state, and file queries instead of answering from training data.
+successCriteria:
+  - Agent calls exec or code_execution tool for "What time is it?" (not a plain text answer)
+  - Agent does NOT answer any factual query from memory alone
+docsRefs: []
+codeRefs:
+  - extensions/openai/prompt-overlay.ts
+execution:
+  kind: flow
+  summary: Send factual queries and verify tool calls appear in the response.
+  config:
+    model: openai/gpt-5.4
+```
+
+```yaml qa-flow
+steps:
+  - name: ask current time triggers tool use
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - call: state.addInboundMessage
+        args:
+          - conversation:
+              id: qa-room
+              kind: channel
+              title: QA Room
+            senderId: alice
+            senderName: Alice
+            text: "What time is it?"
+      - call: waitForOutboundMessage
+        saveAs: message
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-room'"
+          - expr: liveTurnTimeoutMs(env, 60000)
+      - assert:
+          expr: '!message.text.includes("I don''t have access")'
+          message: "Response should not claim lack of access to time"
+      - assert:
+          expr: "message.toolCalls?.some(tc => tc.name === 'exec' || tc.name === 'code_execution' || tc.name === 'session_status') ?? false"
+          message: "Agent must use a tool (exec/code_execution/session_status) to check the time, not answer from memory"
+    detailsExpr: message.text
+```

--- a/qa/scenarios/gpt54-plan-mode-default-off.md
+++ b/qa/scenarios/gpt54-plan-mode-default-off.md
@@ -1,0 +1,78 @@
+# GPT-5.4 default run does not enter plan mode
+
+```yaml qa-scenario
+id: gpt54-plan-mode-default-off
+title: Default GPT-5.4 run does NOT enter plan mode (Hermes parity preserved)
+surface: agent
+objective: Verify that a default GPT-5.4 run with no plan-mode config does not enter plan mode or call enter_plan_mode.
+successCriteria:
+  - Agent does NOT call enter_plan_mode tool
+  - Agent executes tasks normally with full tool access
+docsRefs: []
+codeRefs:
+  - src/agents/execution-contract.ts
+  - src/agents/plan-mode/types.ts
+execution:
+  kind: flow
+  summary: Run a multi-step task on default GPT-5.4 and verify no plan mode activation.
+  config:
+    model: openai/gpt-5.4
+```
+
+```yaml qa-flow
+steps:
+  - name: task completes without plan mode
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - call: state.addInboundMessage
+        args:
+          - conversation:
+              id: qa-room
+              kind: channel
+              title: QA Room
+            senderId: alice
+            senderName: Alice
+            text: "Read package.json and tell me the project name and version."
+      - call: waitForOutboundMessage
+        saveAs: message
+        args:
+          - ref: state
+          - lambda:
+              params: [candidate]
+              expr: "candidate.conversation.id === 'qa-room'"
+          - expr: liveTurnTimeoutMs(env, 60000)
+      - assert:
+          expr: "!message.text.includes('enter_plan_mode')"
+          message: "Response should not mention entering plan mode — GPT-5 should act directly"
+      # PR-D review fix (Copilot #3105216710): explicit toolCalls assertion
+      # — message.text alone could pass even if the agent invoked the tool
+      # silently. Verify the tool was NOT actually called.
+      # Copilot review #68939 (2026-04-19): rewrote the negation
+      # asserts as `(some(...) ?? false) === false` to make the
+      # operator precedence explicit. The previous form
+      # `!message.toolCalls?.some(...) ?? true` is misleading
+      # because `!` always produces a boolean, so the `?? true`
+      # branch can never fire — easy to misread as "default to true
+      # if toolCalls is missing" when it actually behaves as
+      # "negate the some()". Rewriting as `(... ?? false) === false`
+      # is explicit about the intent: "we expect false (i.e., NOT
+      # in toolCalls); if toolCalls is missing, treat as 'tool was
+      # not called', which is what the assertion wants".
+      - assert:
+          expr: "(message.toolCalls?.some(tc => tc.name === 'enter_plan_mode') ?? false) === false"
+          message: "Agent must NOT invoke enter_plan_mode for a simple task"
+      - assert:
+          expr: "message.toolCalls?.some(tc => tc.name === 'read') ?? false"
+          message: "Agent must call read tool to check package.json, not guess the content"
+      - assert:
+          expr: "(message.toolCalls?.some(tc => tc.name === 'update_plan') ?? false) === false"
+          message: "Agent should not create a plan for a simple read-and-report task"
+    detailsExpr: message.text
+```

--- a/skills/plan-mode-101/SKILL.md
+++ b/skills/plan-mode-101/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: plan-mode-101
+description: Plan mode reference + self-test for OpenClaw. Use when the user asks how plan mode works, when to enter or exit, why a tool was blocked in plan mode, what `[PLAN_DECISION]` / `[QUESTION_ANSWER]` / `[PLAN_NUDGE]` and other `[PLAN_*]` tags mean, what `/plan` slash commands do, or to verify the local install end-to-end. Trigger phrases include "explain plan mode", "test plan mode", "plan mode help", "why was my tool blocked in plan mode", "what does [PLAN_DECISION] mean", "how do I approve a plan", "what does /plan accept do".
+---
+
+# Plan Mode 101
+
+Plan mode is OpenClaw's user-approval-gated workflow for non-trivial multi-step changes. The agent investigates read-only, drafts a plan, submits it for user approval, and executes only after the user clicks Approve. Mutating tools (write / edit / exec / bash) are BLOCKED until approval lands.
+
+## State diagram
+
+```
+┌──────────────────┐
+│   NORMAL MODE    │   mutations (write/edit/exec/bash) ALLOWED
+│  (mutations OK)  │
+└────────┬─────────┘
+         │ enter_plan_mode  (or user toggles via /plan on)
+         │ ──► [PLAN_MODE_INTRO]: (one-shot, first-time only)
+         ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — INVESTIGATION                  │
+│   (mutations BLOCKED; read-only tools OK)    │
+│                                              │
+│  ↻ update_plan        — track progress       │
+│  ↻ ask_user_question  — clarify, non-block   │
+│  ↻ sessions_spawn     — research subagents   │
+│  ↻ read/grep/glob/web_search/lcm_*           │
+│                                              │
+│  Possible nudges injected by runtime:        │
+│  - [PLAN_NUDGE]:      cron wake-up if idle   │
+│  - [PLAN_ACK_ONLY]:   if no tool call        │
+│  - [PLANNING_RETRY]:  if narrating only      │
+└─────────────────────┬────────────────────────┘
+                      │ exit_plan_mode(title, plan, ...)
+                      │ ──► STOP — no more chat this turn!
+                      │ ──► tool-side gate blocks if
+                      │     openSubagentRunIds.size > 0
+                      ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — PENDING APPROVAL               │
+│   (approval card visible to user)            │
+│                                              │
+│  - approval-side gate blocks approve/edit if │
+│    subagents spawn DURING approval window    │
+│  - [PLAN_NUDGE] suppressed when pending      │
+└──┬─────────────┬─────────────┬───────────────┘
+   │ approve     │ edit        │ reject + feedback
+   │ /plan       │ /plan       │ /plan revise <text>
+   │ accept      │ accept edits│
+   ▼             ▼             ▼
+[PLAN_DECISION]: approved      [PLAN_DECISION]: rejected
+[PLAN_DECISION]: edited        feedback: "<text>"
+   │             │                  │
+   ▼             ▼                  ▼ ── back to INVESTIGATION
+┌──────────────────┐
+│   NORMAL MODE    │   mutations UNLOCKED, execute the plan
+│  (mutations OK)  │   update_plan to mark steps completed
+└────────┬─────────┘   all-terminal → auto-close + [PLAN_COMPLETE]:
+         │
+         ▼ (cycle done; user may /plan on for next cycle)
+```
+
+## Tool contract (one-line each)
+
+- `enter_plan_mode()` — once per cycle. Arms mutation gate. No-op if already in plan mode.
+- `update_plan(plan=[...])` — TRACKING ONLY. Does NOT submit. Mutations stay blocked.
+- `exit_plan_mode(title, plan, ...)` — once per cycle when ready to propose. Submits for user approval. **STOP after this tool call (no chat text in same turn).**
+- `ask_user_question(question, options)` — non-blocking clarification. Stays in plan mode.
+- `sessions_spawn(...)` — research subagents. Tool-side gate WILL block exit_plan_mode until they return.
+
+## `[PLAN_*]:` tag taxonomy (synthetic messages from runtime → agent)
+
+These are user messages the AGENT receives, prefixed with a `[PLAN_*]:` tag so the agent can distinguish runtime-generated messages from real user input.
+
+| Tag                                         | When fired                                                                           | Action expected                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| `[PLAN_MODE_INTRO]:`                        | First plan-mode entry per session (one-shot)                                         | Read for context; start investigation              |
+| `[PLAN_DECISION]: approved \| edited`       | User clicked Approve / Edit                                                          | Execute the plan immediately                       |
+| `[PLAN_DECISION]: rejected` (with feedback) | User clicked Reject                                                                  | Revise plan based on feedback; resubmit            |
+| `[PLAN_DECISION]: timed_out`                | Approval expired without user action                                                 | Stay in plan mode; may re-propose                  |
+| `[QUESTION_ANSWER]: <text>`                 | User answered an `ask_user_question`                                                 | Incorporate answer into the plan                   |
+| `[PLAN_COMPLETE]: <N> step(s) completed`    | All plan steps reached terminal status                                               | Post brief summary; stop                           |
+| `[PLAN_NUDGE]:`                             | Cron wake-up while plan is active                                                    | Advance the next step (or schedule another resume) |
+| `[PLAN_ACK_ONLY]:`                          | Runtime detected prior turn ended with chat text and no tool call (escalating retry) | CALL exit_plan_mode or an investigative tool       |
+| `[PLAN_YIELD]:`                             | Runtime detected agent yielded immediately after approval (escalating retry)         | CONTINUE executing the approved plan               |
+| `[PLANNING_RETRY]:`                         | Runtime detected planning narration without action (outside plan mode)               | TAKE the first concrete tool action                |
+
+## `/plan` slash-command surface (user types these in chat)
+
+| Command                            | Effect                                                           |
+| ---------------------------------- | ---------------------------------------------------------------- |
+| `/plan on`                         | Toggle plan mode ON                                              |
+| `/plan off`                        | Toggle plan mode OFF (any pending approval is dropped)           |
+| `/plan status`                     | Show current plan-mode state (mode, approval, title, etc.)       |
+| `/plan view`                       | Open the active plan in the side panel                           |
+| `/plan accept`                     | Approve the pending plan                                         |
+| `/plan accept edits`               | Approve with edits (counts as approval)                          |
+| `/plan revise <feedback>`          | Reject with revision feedback                                    |
+| `/plan answer <text>`              | Answer a pending `ask_user_question`                             |
+| `/plan auto on` / `/plan auto off` | Toggle auto-approve mode (future plans auto-resolve as approved) |
+| `/plan self-test`                  | Run the synthetic plan-mode flow end-to-end + report pass/fail   |
+
+## Common pitfalls
+
+1. **Don't post chat after `exit_plan_mode` in the same turn.** Trailing assistant text breaks the approval card lifecycle and the user gets stuck.
+2. **Wait for spawned subagents BEFORE `exit_plan_mode`.** The tool-side gate will reject your submission if any spawned subagents are still running. The error message lists their child run IDs.
+3. **`update_plan` does NOT submit.** It only tracks progress. Use `exit_plan_mode` to propose to the user.
+4. **Don't re-enter plan mode after approval.** Just continue executing. Re-enter only for a NEW planning cycle (different objective, separate user request).
+5. **Provide a meaningful `title`.** It becomes the persisted markdown filename (`plan-YYYY-MM-DD-<slug>.md`) AND the side-panel header. Generic titles like "Test plan" make plans hard to find later.
+6. **Don't submit empty plans.** A plan with zero steps will be rejected by the runtime.
+
+## Debugging tips
+
+If something goes wrong:
+
+```bash
+# Turn on structured plan-mode debug logging:
+openclaw config set agents.defaults.planMode.debug true
+# Restart gateway via menubar app or: launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+
+# Tail the structured debug stream:
+tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'
+
+# Tail the always-on approval-gate log (no env var needed):
+tail -F ~/.openclaw/logs/gateway.err.log | grep 'plan-approval-gate'
+```
+
+## Self-test
+
+Run `/plan self-test` to verify the local install. The command:
+
+1. Pre-checks gateway health + plan-mode config
+2. Enters plan mode
+3. Calls `update_plan` with a 2-step test plan
+4. Calls `exit_plan_mode` with a synthetic plan + title `"plan-mode self-test"`
+5. Verifies the approval card emits with correct title + plan steps
+6. Auto-resolves approval
+7. Verifies mutation gate unlocks
+8. Verifies the markdown file written to `~/.openclaw/agents/<id>/plans/plan-YYYY-MM-DD-plan-mode-self-test.md`
+9. Verifies debug log fires (when debug flag enabled)
+10. Cleans up the test plan
+
+A passing run means plan mode is correctly wired end-to-end on this install. A failing step lists the specific surface that's broken (tool wiring, persister, approval handler, mutation gate, etc.) so you can investigate.
+
+## Related references
+
+- `docs/concepts/plan-mode.md` — user-facing concept doc
+- `docs/plans/PLAN-MODE-ARCHITECTURE.md` — internal architecture + iteration history
+- `src/agents/plan-mode/reference-card.ts` — the in-mode bootstrap reference (same content as this skill, but always-on when plan mode is active)


### PR DESCRIPTION
**📋 Umbrella tracker:** [#70101](https://github.com/openclaw/openclaw/issues/70101) — master tracker for the 9-PR plan-mode rollout. See it for status of all parts + suggested merge order + carry-forward backlog.

---

> **📋 Stack position**: This is **[Plan Mode 6/6]**, the FINAL part of a 6-PR per-part decomposition of the original umbrella #68939 (closed).
>
> - **Previous in stack**: `[Plan Mode 5/6] Text channels + Telegram`
> - **Integration bundle**: `[Plan Mode FULL]` — green-CI bundle of all parts + automation + executing-state lifecycle
>
> ✅ **CI on this PR should be GREEN**: this PR is documentation + QA scenarios + skill + minor package.json/ci.yml housekeeping. No code that depends on earlier parts.
>
> **Ways to land this feature** (maintainer choice):
> - Per-part review + sequential merge of 1/6 → 6/6 (this PR can merge any time)
> - Single bundle merge via [Plan Mode FULL]

---

## Summary

Adds the **operator-facing documentation, QA scenarios, and the `plan-mode-101` skill** that teach both operators and agents how plan mode works.

Carved out of #68939 (closed). Independent of earlier parts — pure docs + skill content.

## What This PR Includes

- **Plan-mode architecture doc** (`docs/plans/PLAN-MODE-ARCHITECTURE.md`, ~635 lines) — the authoritative reference for plan-mode state machine, file layout, approval pipeline, cron-based automation (lives in [Plan Mode FULL]), and the 3-state executing-state lifecycle.
- **Operator runbook** (`docs/plans/PLAN-MODE-OPERATOR-RUNBOOK.md`, ~250 lines) — how to enable plan mode for an agent, debug a stuck plan, reset a session, etc.
- **Concept doc** (`docs/concepts/plan-mode.md`, ~167 lines) — user-facing "what is plan mode" intro.
- **Prompt-stack spec** (`docs/agents/prompt-stack-spec.md`, ~186 lines) — describes how plan mode interacts with the overall prompt stack.
- **`plan-mode-101` skill** (`skills/plan-mode-101/SKILL.md`, ~149 lines) — self-contained skill agents load to understand plan mode semantics.
- **QA scenarios** (`qa/scenarios/gpt54-*.md`, 5 files, ~310 lines) — scripted test scenarios for plan-mode integration with GPT-5.4.
- **`docs/tools/slash-commands.md`** — 1-line addition documenting `/plan on|off|status|view|auto|accept|revise|answer|restate` slash commands. Moved here from `[Plan Mode 5/6]` (#70069) per Codex P3 review (the docs-tagalong belongs in the docs PR, not the channels PR). See commit `f4ae594dab`.

## Files In Scope

All files are pure documentation / content additions. No source-code logic changes.

**Primary review targets**:
- `docs/plans/PLAN-MODE-ARCHITECTURE.md` — most detailed reference
- `docs/plans/PLAN-MODE-OPERATOR-RUNBOOK.md` — ops-facing

**Supporting**:
- `docs/concepts/plan-mode.md`
- `docs/agents/prompt-stack-spec.md`
- `skills/plan-mode-101/SKILL.md`
- `qa/scenarios/gpt54-*.md`

## Reviewer Guide

1. **Start with**: `PLAN-MODE-ARCHITECTURE.md` (20 min) — the main reference. Note the "File layout" and "State machine" sections.
2. **Then**: `PLAN-MODE-OPERATOR-RUNBOOK.md` (10 min) — ops gotchas
3. **Then**: `SKILL.md` (5 min) — agent-facing
4. **Finally**: QA scenarios (5 min) — spot-check one scenario

## What This PR Does NOT Include

- **package.json / ci.yml churn from the original split commit**: the original commit modified these files based on an older state; upstream evolved differently. This PR takes upstream's current state of those files (no churn) and re-adds only the docs/QA additions on top. The few script changes the original commit tried to land are intentionally dropped — they'd regress upstream evolution.

## Issue references

- Refs #68939 docs + operator surface

## Test Status

- N/A — pure docs / content PR
- Link-check run locally via `pnpm check:docs`

## Carry-forward / deferred

- Mobile-specific operator guide (iOS/Android) — follow-up
- Plan-mode benchmarking doc — follow-up
