### PR TITLE
fix(plugins): use module path for bundled jiti loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Teams/security: require shared Bot Framework audience tokens to name the configured Teams app via verified `appid` or `azp`, blocking cross-bot token replay on the global audience. (#70724) Thanks @vincentkoc.
+- Plugins/startup: resolve bundled plugin Jiti loads relative to the target plugin module instead of the central loader, so Bun global installs no longer hang while discovering bundled image providers. (#70073) Thanks @yidianyiko.
 - Anthropic/CLI security: stop Claude CLI backend defaults from forcing `bypassPermissions`, and strip malformed permission-mode overrides instead of silently falling back to a bypass. (#70723) Thanks @vincentkoc.
 - Android/security: require loopback-only cleartext gateway connections on Android manual and scanned routes, so private-LAN and link-local `ws://` endpoints now fail closed unless TLS is enabled. (#70722) Thanks @vincentkoc.
 - Pairing/security: require private-IP or loopback hosts for cleartext mobile pairing, and stop treating `.local` or dotless hostnames as safe cleartext endpoints. (#70721) Thanks @vincentkoc.

--- a/src/plugins/loader.jiti-filename.test.ts
+++ b/src/plugins/loader.jiti-filename.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { importFreshModule } from "../../test/helpers/import-fresh.ts";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-loader-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeBundledPluginFixture(id: string) {
+  const pluginRoot = makeTempDir();
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id,
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(pluginRoot, "index.cjs"),
+    `module.exports = { id: ${JSON.stringify(id)}, register() {} };`,
+    "utf-8",
+  );
+  return pluginRoot;
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("./jiti-loader-cache.js");
+  delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createPluginJitiLoader", () => {
+  it("uses the bundled plugin module path as the jiti filename", async () => {
+    const jitiLoaderCalls: Array<{ modulePath: string; jitiFilename?: string }> = [];
+    vi.doMock("./jiti-loader-cache.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./jiti-loader-cache.js")>();
+      return {
+        ...actual,
+        getCachedPluginJitiLoader: vi.fn((params) => {
+          jitiLoaderCalls.push({
+            modulePath: params.modulePath,
+            jitiFilename: params.jitiFilename,
+          });
+          return vi.fn(() => ({
+            default: {
+              id: "demo",
+              register() {},
+            },
+          }));
+        }),
+      };
+    });
+
+    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
+      import.meta.url,
+      "./loader.js?scope=jiti-filename",
+    );
+
+    const pluginRoot = writeBundledPluginFixture("demo");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = pluginRoot;
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: pluginRoot,
+      onlyPluginIds: ["demo"],
+      config: {
+        plugins: {
+          entries: {
+            demo: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const bundledPluginLoad = jitiLoaderCalls.find((call) => call.modulePath.endsWith("index.cjs"));
+    expect(bundledPluginLoad).toBeDefined();
+    expect(bundledPluginLoad?.jitiFilename).toBe(bundledPluginLoad?.modulePath);
+  });
+});

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -447,7 +447,7 @@ function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResol
       cache: jitiLoaders,
       modulePath,
       importerUrl: import.meta.url,
-      jitiFilename: import.meta.url,
+      jitiFilename: modulePath,
       pluginSdkResolution: options.pluginSdkResolution,
       // Source .ts runtime shims import sibling ".js" specifiers that only exist
       // after build. Disable native loading for source entries so Jiti rewrites


### PR DESCRIPTION
## Summary

- Problem: bundled plugin runtime loads in `src/plugins/loader.ts` still passed the loader module URL as `jitiFilename`, which keeps the Bun-installed image-provider hang from #69783 reproducible on latest `main`.
- Why it matters: `openclaw infer image providers --json` can hang before any image provider registers, which makes `image_generate` look unavailable in Bun global installs.
- What changed: `createPluginJitiLoader(...)` now passes the target `modulePath` as `jitiFilename`, and a focused regression test locks that wiring in.
- What did NOT change (scope boundary): no provider-specific code, manifests, auth logic, or fallback ordering changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69783
- Related #53450
- Related #56946
- Related #61259
- Related #63080
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/plugins/loader.ts` called `getCachedPluginJitiLoader(...)` with `jitiFilename: import.meta.url` instead of the bundled plugin entry `modulePath`, so Jiti resolved bundled runtime loads relative to the loader module rather than the target plugin module.
- Missing detection / guardrail: there was no regression test asserting the `jitiFilename` passed by `createPluginJitiLoader(...)` for bundled runtime loads.
- Contributing context (if known): Bun global installs were the consistently reproducible path for the image-provider hang because that loader path was exercised while provider entrypoints themselves still imported cleanly.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.jiti-filename.test.ts`
- Scenario the test should lock in: a bundled plugin runtime load should pass the target bundled module path through as `jitiFilename` when it asks `getCachedPluginJitiLoader(...)` for a loader.
- Why this is the smallest reliable guardrail: the regression is one argument in the loader wiring; mocking `getCachedPluginJitiLoader(...)` isolates that contract without depending on a full Bun install.
- Existing test that already covers this (if any): `src/plugins/jiti-loader-cache.test.ts` covers cache behavior once the caller passes a filename, but it did not cover the caller wiring in `src/plugins/loader.ts`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Bun-installed bundled image providers now load through the plugin runtime path with the target module path as Jiti's filename base instead of the loader module URL.

## Diagram (if applicable)

```text
Before:
[bundled plugin modulePath] -> createPluginJitiLoader -> jitiFilename=loader.ts -> Jiti resolves from loader base -> bundled image provider load can hang

After:
[bundled plugin modulePath] -> createPluginJitiLoader -> jitiFilename=modulePath -> Jiti resolves from plugin base -> bundled image provider load proceeds
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.3 LTS
- Runtime/container: Node 22.22.0, Bun global install used for original repro
- Model/provider: image provider discovery path (`openai` bundled entrypoint was the direct import control sample)
- Integration/channel (if any): N/A
- Relevant config (redacted): provider auth present; no extra plugin-specific config required for the regression test

### Steps

1. On latest `main`, run `pnpm test src/plugins/loader.jiti-filename.test.ts`.
2. Observe the new test fail before the fix because `jitiFilename` is `file:///.../src/plugins/loader.ts` instead of the bundled module path.
3. Apply the one-line loader fix and rerun the targeted plugin tests.

### Expected

- Bundled runtime loads pass the bundled module path as `jitiFilename`.
- Targeted plugin loader tests pass.

### Actual

- Before the fix, the new test failed with:
  - expected: bundled module path
  - received: `file:///data/projects/openclaw/src/plugins/loader.ts`
- After the fix, the targeted tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/plugins/loader.jiti-filename.test.ts` failed before the fix on latest `main` with the wrong `jitiFilename`.
  - `pnpm test src/plugins/loader.jiti-filename.test.ts src/plugins/jiti-loader-cache.test.ts` passed after the fix.
  - `timeout 8s openclaw infer image providers --json` still hangs in the already-installed Bun global package, confirming latest published install did not already contain this fix.
- Edge cases checked:
  - Existing cache tests still pass via `src/plugins/jiti-loader-cache.test.ts`.
- What you did **not** verify:
  - `pnpm build` is still red locally on latest `main` in `scripts/stage-bundled-plugin-runtime-deps.mjs` for unrelated discord runtime-deps staging (`discord-api-types` exact-version resolution).
  - The repository's staged `check:changed` hook is also red on latest `main` from unrelated `tsgo:core` errors in `src/agents/pi-embedded-runner/compact.ts:887` and `src/agents/pi-embedded-runner/run/attempt.ts:1132`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another loader path may intentionally rely on `import.meta.url` as the Jiti filename base.
  - Mitigation: the new regression test covers the bundled runtime path specifically, and the existing cache tests still pass against the unchanged cache helper behavior.
