### PR TITLE
fix: use CJK-aware token estimation in compaction path

### DIFF
--- a/src/agents/compaction-cjk.test.ts
+++ b/src/agents/compaction-cjk.test.ts
@@ -1,0 +1,145 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { estimateMessageTokensCjkAware, estimateMessagesTokens } from "./compaction.js";
+
+/**
+ * Verify that the CJK-aware token estimator produces significantly higher
+ * token counts for CJK content compared to the previous `chars / 4` approach.
+ *
+ * See: https://github.com/OpenClaw/openclaw/issues/70052
+ */
+describe("estimateMessageTokensCjkAware", () => {
+  it("estimates ~1 token per CJK character for a user message", () => {
+    // 19 CJK characters — should produce 19 tokens, NOT 5 (19/4)
+    const msg: AgentMessage = {
+      role: "user",
+      content: "このメッセージは日本語で書かれています",
+      timestamp: 0,
+    };
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // With estimateStringChars: 19 CJK chars → 19 + 19*3 = 76 virtual chars → 76/4 = 19 tokens
+    expect(tokens).toBe(19);
+    // Confirm the old approach would have given 5 (the bug)
+    expect(Math.ceil(19 / 4)).toBe(5);
+  });
+
+  it("returns the same estimate as chars/4 for pure ASCII text", () => {
+    const msg: AgentMessage = {
+      role: "user",
+      content: "Hello world, this is a test message",
+      timestamp: 0,
+    };
+    const tokens = estimateMessageTokensCjkAware(msg);
+    const expected = Math.ceil("Hello world, this is a test message".length / 4);
+    expect(tokens).toBe(expected);
+  });
+
+  it("handles mixed ASCII and CJK content correctly", () => {
+    // "Hello " (6 ASCII) + "世界" (2 CJK) + "!" (1 ASCII)
+    const text = "Hello 世界!";
+    const msg: AgentMessage = {
+      role: "user",
+      content: text,
+      timestamp: 0,
+    };
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // estimateStringChars("Hello 世界!"):
+    //   codePointLength = 9, nonLatinCount = 2
+    //   result = 9 + 2*(4-1) = 9 + 6 = 15
+    //   tokens = ceil(15/4) = 4
+    // Old approach: ceil(9/4) = 3
+    expect(tokens).toBeGreaterThanOrEqual(4);
+    expect(tokens).toBeLessThan(10);
+  });
+
+  it("estimates Korean text correctly", () => {
+    // "안녕하세요" = 5 Hangul characters
+    const msg: AgentMessage = {
+      role: "user",
+      content: "안녕하세요",
+      timestamp: 0,
+    };
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // 5 chars * 4 weight = 20 virtual chars → 20/4 = 5 tokens
+    expect(tokens).toBe(5);
+    // Old approach: ceil(5/4) = 2
+    expect(Math.ceil(5 / 4)).toBe(2);
+  });
+
+  it("estimates Chinese text correctly", () => {
+    // "你好世界欢迎" = 6 CJK characters
+    const msg: AgentMessage = {
+      role: "user",
+      content: "你好世界欢迎",
+      timestamp: 0,
+    };
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // 6 * 4 = 24 virtual chars → 24/4 = 6 tokens
+    expect(tokens).toBe(6);
+    // Old approach: ceil(6/4) = 2
+    expect(Math.ceil(6 / 4)).toBe(2);
+  });
+
+  it("handles CJK in assistant messages", () => {
+    const msg: AgentMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "こんにちは世界" }],
+      timestamp: 0,
+    } as unknown as AgentMessage;
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // 7 CJK chars * 4 weight = 28 → 28/4 = 7
+    expect(tokens).toBe(7);
+  });
+
+  it("handles CJK in toolResult messages", () => {
+    const msg: AgentMessage = {
+      role: "toolResult",
+      content: "検索結果：見つかりました",
+      toolCallId: "call_1",
+      timestamp: 0,
+    } as unknown as AgentMessage;
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // 12 CJK chars (including colon which isn't CJK) — 11 CJK + 1 ASCII
+    // estimateStringChars: codePointLength=12, nonLatinCount=11
+    // result = 12 + 11*3 = 45, tokens = ceil(45/4) = 12
+    expect(tokens).toBeGreaterThanOrEqual(10);
+  });
+
+  it("handles user messages with array content blocks", () => {
+    const msg: AgentMessage = {
+      role: "user",
+      content: [
+        { type: "text", text: "翻訳してください" },
+        { type: "text", text: "Thank you" },
+      ],
+      timestamp: 0,
+    } as unknown as AgentMessage;
+    const tokens = estimateMessageTokensCjkAware(msg);
+    // "翻訳してください" = 8 CJK → 32 virtual + "Thank you" = 9 ASCII
+    // total = 32 + 9 = 41 → ceil(41/4) = 11
+    expect(tokens).toBeGreaterThanOrEqual(10);
+  });
+
+  it("returns 0 for unknown message roles", () => {
+    const msg = { role: "unknown_role", content: "test", timestamp: 0 } as unknown as AgentMessage;
+    expect(estimateMessageTokensCjkAware(msg)).toBe(0);
+  });
+
+  it("handles empty content", () => {
+    const msg: AgentMessage = { role: "user", content: "", timestamp: 0 };
+    expect(estimateMessageTokensCjkAware(msg)).toBe(0);
+  });
+});
+
+describe("estimateMessagesTokens CJK awareness", () => {
+  it("produces higher token counts for CJK than the old chars/4 heuristic", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "このメッセージは日本語で書かれています", timestamp: 1 },
+      { role: "user", content: "もう一つのメッセージです", timestamp: 2 },
+    ];
+    const totalTokens = estimateMessagesTokens(messages);
+    // Old approach: (19 + 11) / 4 = ~8 tokens
+    // CJK-aware: 19 + 11 = 30 CJK chars → 30 tokens
+    expect(totalTokens).toBeGreaterThan(20);
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -1,14 +1,12 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import {
-  estimateTokens,
-  generateSummary as piGenerateSummary,
-} from "@mariozechner/pi-coding-agent";
+import { generateSummary as piGenerateSummary } from "@mariozechner/pi-coding-agent";
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { retryAsync } from "../infra/retry.js";
 import { isAbortError } from "../infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isTimeoutError } from "./failover-error.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
@@ -100,10 +98,97 @@ export function buildCompactionSummarizationInstructions(
   return `${identifierPreservation}\n\nAdditional focus:\n${custom}`;
 }
 
+/**
+ * CJK-aware token estimation for a single {@link AgentMessage}.
+ *
+ * This mirrors the upstream `estimateTokens` logic from `@mariozechner/pi-coding-agent`
+ * but uses {@link estimateStringChars} for text measurement so that CJK characters
+ * (Chinese, Japanese, Korean) are weighted correctly (~1 token/char instead of
+ * the ~0.25 tokens/char that `text.length / 4` would yield).
+ *
+ * See: https://github.com/OpenClaw/openclaw/issues/70052
+ */
+export function estimateMessageTokensCjkAware(message: AgentMessage): number {
+  let chars = 0;
+  const IMAGE_CHARS = 4800; // Same as upstream: images ≈ 1200 tokens
+
+  switch (message.role) {
+    case "user": {
+      const content = (message as { content: string | Array<{ type: string; text?: string }> })
+        .content;
+      if (typeof content === "string") {
+        chars = estimateStringChars(content);
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === "text" && block.text) {
+            chars += estimateStringChars(block.text);
+          }
+        }
+      }
+      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
+    }
+    case "assistant": {
+      const assistant = message as {
+        content: Array<{
+          type: string;
+          text?: string;
+          thinking?: string;
+          name?: string;
+          arguments?: unknown;
+        }>;
+      };
+      for (const block of assistant.content) {
+        if (block.type === "text" && block.text !== undefined) {
+          chars += estimateStringChars(block.text);
+        } else if (block.type === "thinking" && block.thinking !== undefined) {
+          chars += estimateStringChars(block.thinking);
+        } else if (block.type === "toolCall") {
+          // Tool names and JSON arguments are typically ASCII, but apply
+          // CJK-awareness defensively.
+          chars += estimateStringChars(block.name ?? "");
+          chars += estimateStringChars(JSON.stringify(block.arguments ?? ""));
+        }
+      }
+      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
+    }
+    case "custom":
+    case "toolResult": {
+      const content = (message as { content: string | Array<{ type: string; text?: string }> })
+        .content;
+      if (typeof content === "string") {
+        chars = estimateStringChars(content);
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === "text" && block.text) {
+            chars += estimateStringChars(block.text);
+          }
+          if (block.type === "image") {
+            chars += IMAGE_CHARS;
+          }
+        }
+      }
+      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
+    }
+    case "bashExecution": {
+      const bash = message as { command: string; output: string };
+      chars = estimateStringChars(bash.command) + estimateStringChars(bash.output);
+      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
+    }
+    case "branchSummary":
+    case "compactionSummary": {
+      const summary = (message as { summary: string }).summary;
+      chars = estimateStringChars(summary);
+      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
+    }
+    default:
+      return 0;
+  }
+}
+
 export function estimateMessagesTokens(messages: AgentMessage[]): number {
   // SECURITY: toolResult.details can contain untrusted/verbose payloads; never include in LLM-facing compaction.
   const safe = stripToolResultDetails(messages);
-  return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
+  return safe.reduce((sum, message) => sum + estimateMessageTokensCjkAware(message), 0);
 }
 
 function estimateCompactionMessageTokens(message: AgentMessage): number {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -4,7 +4,6 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
   DefaultResourceLoader,
-  estimateTokens,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -48,6 +47,7 @@ import {
   hasMeaningfulConversationContent,
   isRealConversationMessage,
 } from "../compaction-real-conversation.js";
+import { estimateMessageTokensCjkAware } from "../compaction.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
@@ -276,7 +276,7 @@ function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessag
     contributors.push({ role, chars, tool: resolveMessageToolLabel(msg) });
     if (!tokenEstimationFailed) {
       try {
-        estTokens += estimateTokens(msg);
+        estTokens += estimateMessageTokensCjkAware(msg);
       } catch {
         tokenEstimationFailed = true;
       }
@@ -958,7 +958,7 @@ export async function compactEmbeddedPiSessionDirect(
             originalMessages,
             currentMessages: session.messages,
             observedTokenCount,
-            estimateTokensFn: estimateTokens,
+            estimateTokensFn: estimateMessageTokensCjkAware,
           });
           const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
             hookRunner,
@@ -1008,7 +1008,10 @@ export async function compactEmbeddedPiSessionDirect(
           // history subset, not the full session.
           let fullSessionTokensBefore = 0;
           try {
-            fullSessionTokensBefore = limited.reduce((sum, msg) => sum + estimateTokens(msg), 0);
+            fullSessionTokensBefore = limited.reduce(
+              (sum, msg) => sum + estimateMessageTokensCjkAware(msg),
+              0,
+            );
           } catch {
             // If token estimation throws on a malformed message, fall back to 0 so
             // the sanity check below becomes a no-op instead of crashing compaction.
@@ -1059,7 +1062,7 @@ export async function compactEmbeddedPiSessionDirect(
             messagesAfter: session.messages,
             observedTokenCount,
             fullSessionTokensBefore,
-            estimateTokensFn: estimateTokens,
+            estimateTokensFn: estimateMessageTokensCjkAware,
           });
           const messageCountAfter = session.messages.length;
           const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { estimateTokens } from "@mariozechner/pi-coding-agent";
-import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
+import {
+  SAFETY_MARGIN,
+  estimateMessageTokensCjkAware,
+  estimateMessagesTokens,
+} from "../../compaction.js";
 import {
   MIN_PROMPT_BUDGET_RATIO,
   MIN_PROMPT_BUDGET_TOKENS,
@@ -34,7 +37,7 @@ export function estimatePrePromptTokens(params: {
 
   const estimated =
     estimateMessagesTokens(messages) +
-    syntheticMessages.reduce((sum, message) => sum + estimateTokens(message), 0);
+    syntheticMessages.reduce((sum, message) => sum + estimateMessageTokensCjkAware(message), 0);
   return Math.max(0, Math.ceil(estimated * SAFETY_MARGIN));
 }
 


### PR DESCRIPTION
## Summary

Closes #70052

The compaction pipeline used `estimateTokens` from `@mariozechner/pi-coding-agent`, which divides `text.length` by 4 to estimate tokens. This works for Latin scripts (~4 chars/token) but severely **underestimates CJK content** where each character is typically ≈1 token.

**Example:** 19 Japanese characters ("このメッセージは日本語で書かれています") produce 19 tokens, but `chars/4` estimated only 5 — a **3.8× undercount**.

## Root Cause

OpenClaw already has a CJK-aware utility (`estimateStringChars` in `src/utils/cjk-chars.ts`) that weights CJK characters at ~4× their byte count, matching real tokenizer behavior. However, this utility was only used in the **context-pruning hook** — not in the compaction path, which still relied on the upstream CJK-blind heuristic.

## Fix

Introduces `estimateMessageTokensCjkAware` in `compaction.ts`, which mirrors the upstream `estimateTokens` message-walking logic but uses `estimateStringChars` for text measurement. All compaction-path consumers now use this function:

| File | Change |
|------|--------|
| `src/agents/compaction.ts` | New `estimateMessageTokensCjkAware`; `estimateMessagesTokens` now uses it |
| `src/agents/pi-embedded-runner/compact.ts` | Replaced upstream `estimateTokens` import with CJK-aware version |
| `src/agents/pi-embedded-runner/run/preemptive-compaction.ts` | Same replacement for pre-prompt estimation |

**For pure ASCII content the results are identical** (no behavior change).  
For CJK-heavy sessions the token estimate increases by ~3–4×, which prevents premature compaction triggers from underestimating context usage.

## Tests

- 11 new tests in `compaction-cjk.test.ts` covering Japanese, Chinese, Korean, mixed content, all message roles, array content blocks, and edge cases
- All 17 existing `compaction.test.ts` tests pass unchanged
- All 9 `preemptive-compaction.test.ts` tests pass unchanged