### PR TITLE
feat(skills): add community-contributed QQ/Tavily/Image-Deliver/Multimodal skills

### DIFF
--- a/skills/image-gen-deliver/SKILL.md
+++ b/skills/image-gen-deliver/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: image-gen-deliver
+description: 多渠道文生图并发送的完整流程。当用户要求生成图片并发送到某个渠道时使用此技能。先用 image_generate 生成图片，然后根据渠道使用 image_sender.py 发送到对应平台。
+metadata: {"openclaw":{"emoji":"🎨","channel-aware":true}}
+---
+
+# Image Gen & Deliver - 多渠道文生图技能
+
+## 流程概述
+
+```
+用户请求 → image_generate → 解析路径 → image_sender.py → 渠道发送
+```
+
+## 步骤
+
+### 1. 生成图片
+
+使用 `image_generate` 工具：
+
+```
+image_generate(prompt="描述", size="2K", aspect="16:9")
+```
+
+工具返回结果中包含 `image_path`（图片保存路径，格式为 `/root/nanobanana_outputs/nanobanana_*.jpg`）。
+
+### 2. 确定渠道和目标
+
+根据当前会话的 `channel` 元数据判断：
+
+| channel | 渠道 | 目标ID格式 |
+|---------|------|-----------|
+| telegram | Telegram | 用户数字ID |
+| feishu | 飞书 | open_id (ou_xxx) |
+| qqbot | QQ频道 | 子频道ID |
+| openclaw-weixin | 企业微信/微信 | wxid |
+| webchat | 网页chat | 自动处理，无需发送 |
+
+### 3. 发送图片
+
+使用 `image_sender.py` 脚本：
+
+```bash
+python3 /root/.openclaw/workspace/image_sender.py <图片路径> <渠道> <目标ID> [说明文字]
+```
+
+**示例 (Telegram)**:
+```bash
+python3 /root/.openclaw/workspace/image_sender.py /root/nanobanana_outputs/nanobanana_20260406_030939.jpg telegram 8561888441
+```
+
+**示例 (Feishu)**:
+```bash
+python3 /root/.openclaw/workspace/image_sender.py /root/nanobanana_outputs/nanobanana_20260406_030939.jpg feishu ou_6f13b06ec16cbcaea7d392aa501df980
+```
+
+### 4. 各渠道处理方式
+
+#### Telegram ✅
+- 使用 `openclaw message send --media` CLI 命令
+- 图片需要先复制到 `~/.openclaw/media/outbound/`（脚本自动处理）
+- 目标ID: 用户的数字 Telegram ID
+
+#### Feishu ✅
+- 调用 Feishu 官方 API 上传图片
+- 需要有效的 tenant_access_token
+- 目标ID: 用户的 open_id
+
+#### QQ ⚠️
+- 使用 `<qqimg>图片路径</qqimg>` 标签格式
+- 通过 qqbot API 发送消息
+- 注意: 需要确认目标子频道ID
+
+#### WeChat ⚠️
+- 通过 openclaw-weixin 插件发送
+- 需要目标用户的 wxid
+- 如果 `image_sender.py` 返回需要 agent 协助，手动调用:
+  ```
+  message(action=send, channel=openclaw-weixin, target=wxid, media=图片路径)
+  ```
+
+#### Webchat ✅
+- `image_generate` 工具自动交付
+- 无需额外操作
+
+## 错误处理
+
+如果 `image_sender.py` 对某个渠道失败：
+
+1. 检查错误信息中的 `hint` 字段
+2. 按提示手动使用对应渠道的工具
+3. 如果是 Feishu token 问题，检查飞书应用配置
+4. 如果是 Telegram 路径问题，确保图片在允许的目录
+
+## 快速参考
+
+```
+# Telegram
+python3 /root/.openclaw/workspace/image_sender.py <path> telegram <user_id> [caption]
+
+# Feishu  
+python3 /root/.openclaw/workspace/image_sender.py <path> feishu <open_id> [caption]
+
+# QQ
+python3 /root/.openclaw/workspace/image_sender.py <path> qq <channel_id> [caption]
+
+# WeChat
+python3 /root/.openclaw/workspace/image_sender.py <path> weixin <wxid> [caption]
+```

--- a/skills/multimodal-messaging/SKILL.md
+++ b/skills/multimodal-messaging/SKILL.md
@@ -1,0 +1,155 @@
+# Multimodal Messaging - 多媒体消息处理技能
+
+_当用户在 QQ、微信、Telegram、飞书 发送图片、语音、文件时使用此技能。_
+
+---
+
+## 核心原则
+
+用户通过任何 IM 渠道发来的多媒体（图片/语音/文件），AI 必须主动处理并理解，不能说"无法处理"或"不支持"。每条消息都是一个交互机会。
+
+---
+
+## 图片处理
+
+### 接收
+用户发来的图片自动下载到本地，路径在会话上下文的【附件】中。
+
+### 理解
+使用 `minimax-tokenplan__understand_image` 工具：
+
+```
+prompt: "详细描述这张图片的完整内容，包括所有文字、人物、物体、场景、数据图表等细节。"
+image: "图片文件路径"
+```
+
+### QQ 发送图片
+```xml
+<qqimg>/path/to/image.jpg</qqimg>
+```
+
+### 微信发送图片
+直接发送路径或用相同标签，系统自动处理。
+
+### Telegram 发送图片
+通过 message 工具的 `media` 参数发送。
+
+### 飞书发送图片
+使用 feishu_doc 的图片上传能力，或通过 image_generate 生成后发送 URL。
+
+---
+
+## 语音处理
+
+### 接收
+用户发来的语音消息自动下载，路径在会话上下文【附件】中。
+
+### 转写
+用 faster-whisper（系统已安装），通过 exec 调用：
+
+```bash
+python3 /root/.openclaw/workspace/multimodal-agent.py voice /path/to/voice.mp3
+```
+
+返回格式示例：
+```
+【语音转写】语言: zh
+你好，我想咨询一下明天会议的时间...
+```
+
+### 基于语音内容回复
+语音转写后，把转写文本和你的回复一起发送。
+
+---
+
+## 文件处理
+
+### 支持格式
+| 类型 | 处理方式 |
+|------|---------|
+| 图片 (jpg/png/gif/webp/bmp) | MiniMax 图片理解 |
+| PDF | 文字层提取 + OCR + 内嵌图片理解 |
+| Word (docx) | OpenXML 解析文本内容 |
+| Excel (xlsx) | OpenXML 解析表格 |
+| PPT (pptx) | OpenXML 解析幻灯片文本 |
+| 文本 (txt/md/py/js/csv/json/yaml) | 直接读取内容 |
+| 音频 (mp3/wav/m4a/ogg) | 语音转写 |
+| 压缩包 (zip/rar/7z) | 列出内容 |
+
+### 处理命令
+```bash
+python3 /root/.openclaw/workspace/multimodal-agent.py file /path/to/file
+```
+
+### 返回文件（QQ）
+```xml
+<qqfile>/path/to/file</qqfile>
+```
+
+### 返回文件（微信）
+上传到临时存储，发送下载链接或直接发送文件。
+
+---
+
+## 文件修改（自然语言）
+
+当用户说"帮我修改"、"改成"、"添加内容"等，使用 modify 命令：
+
+```bash
+python3 /root/.openclaw/workspace/multimodal-agent.py modify /path/to/file "你的修改要求"
+```
+
+修改要求示例：
+- `"把标题从'会议纪要'改成'项目进度报告'"`
+- `"在最后添加一行：负责人：张三"`
+- `"删除第二段"`
+- `"把所有的'2024'替换成'2025'"`
+
+### 返回修改后的文件
+modify 命令会在原文件同目录下生成 `.modified.txt` 文件。
+
+对于代码/Python 文件，直接读取并用 exec + write 修改：
+1. 用 exec 读原文件：`cat /path/to/file`
+2. 用 AI 理解修改要求
+3. 用 write 工具写修改后的内容到原路径
+
+对于 Word/Excel 等复杂格式，输出 `.modified.txt` 文本版本，并告知用户原格式保持不变。
+
+---
+
+## 流程总结
+
+```
+用户发送图片 → minimax-tokenplan__understand_image → AI 理解后回复
+用户发送语音 → multimodal-agent.py voice → 转写 → AI 理解后回复
+用户发送文件 → multimodal-agent.py file → 提取内容 → AI 理解后回复
+用户要求修改文件 → multimodal-agent.py modify → AI 生成修改 → 写回文件 → 通知用户
+```
+
+---
+
+## 快捷命令汇总
+
+```bash
+# 图片理解（可选带 prompt）
+python3 /root/.openclaw/workspace/multimodal-agent.py image /path/to/img.jpg "额外提示"
+
+# 语音转写
+python3 /root/.openclaw/workspace/multimodal-agent.py voice /path/to/audio.mp3
+
+# 文件内容提取
+python3 /root/.openclaw/workspace/multimodal-agent.py file /path/to/file.pdf
+
+# 自然语言文件修改
+python3 /root/.openclaw/workspace/multimodal-agent.py modify /path/to/file.txt "修改指令"
+```
+
+---
+
+## 限制与注意事项
+
+1. **文件大小**：单文件处理限制 20MB，超过建议告知用户压缩
+2. **语音时长**：语音转写对超长音频（>10分钟）可能截断
+3. **Office 修改**：Word/Excel/PPT 修改仅支持文本内容，格式/样式保留有限
+4. **安全**：不执行用户上传的可执行文件（.exe/.sh/.bat/.ps1 等）
+5. **编码**：优先使用 UTF-8，失败时尝试 GBK/Big5

--- a/skills/openclaw-onebot/.clawhub/origin.json
+++ b/skills/openclaw-onebot/.clawhub/origin.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "registry": "https://clawhub.ai",
+  "slug": "openclaw-onebot",
+  "installedVersion": "1.2.8",
+  "installedAt": 1775180407549
+}

--- a/skills/openclaw-onebot/SKILL.md
+++ b/skills/openclaw-onebot/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: openclaw-onebot
+description: OneBot 11 channel plugin for QQ via NapCat/go-cqhttp. Native OpenClaw integration for private and group chat, group reactions, block streaming, voice pipeline, and allowFrom routing. 106 tests passing.
+---
+
+# OpenClaw OneBot 11 Channel Plugin
+
+[中文](#中文) | [English](#english)
+
+---
+
+## 中文
+
+OpenClaw 的 **OneBot 11 协议通道插件**，让 QQ 成为 OpenClaw 一等消息通道。
+
+支持 [NapCat](https://github.com/NapNeko/NapCatQQ)、[go-cqhttp](https://github.com/Mrs4s/go-cqhttp) 等所有兼容 OneBot 11 协议的 QQ 机器人框架。
+
+说明：
+
+- 插件 `id` 是 `openclaw-onebot`
+- 通道 `id` 仍然是 `onebot`
+- 因此 `plugins.allow` / `plugins.entries` / `plugins.installs` 使用 `openclaw-onebot`
+- `channels.onebot` 保持不变
+
+### 功能
+
+- 原生 OpenClaw ChannelPlugin 集成
+- QQ 私聊和群聊收发
+- 群聊 reaction
+- 群聊自动 reaction，默认开启
+- OpenClaw block streaming 分块回复
+- QQ 语音链路：SILK/AMR -> MP3 -> STT/TTS -> sendRecord
+- 图片、语音、文件附件发送
+- `allowFrom` 来源过滤
+- WebSocket 自动重连
+- OpenClaw 文本命令全支持（`/status`、`/help`、`/commands`、`/model`、`/new`、`/reset` 等）
+- 106 个测试用例通过
+- 覆盖率：Statements/Lines 92.11%，Branches 83.68%，Functions 95.16%
+
+### 为什么选它
+
+相对 QQ 官方 Bot API 方案：
+
+- 保留 OneBot 生态兼容性
+- 直接进入 OpenClaw 原生消息路由
+- 更适合 NapCat / go-cqhttp 现有部署
+
+相对独立 Python 桥接脚本方案：
+
+- 不需要额外 listener 或文件队列
+- 不需要自己维护消息桥接逻辑
+- block streaming、group reaction、voice pipeline 都在同一插件里
+- 测试覆盖更完整
+
+### 能力边界
+
+- 群聊 reaction 可用
+- QQ 私聊 reaction 目前不可靠，不应作为稳定能力依赖
+- streaming 这里指 OpenClaw `block streaming`
+- QQ 端表现为连续多条分块消息，不是“编辑同一条消息”
+
+### OpenClaw 侧最小配置
+
+```json
+{
+  "plugins": {
+    "allow": ["openclaw-onebot"],
+    "entries": {
+      "openclaw-onebot": {
+        "enabled": true
+      }
+    }
+  },
+  "channels": {
+    "onebot": {
+      "enabled": true,
+      "wsUrl": "ws://your-host:3001",
+      "httpUrl": "http://your-host:3001",
+      "groupAutoReact": true,
+      "groupAutoReactEmojiId": 1
+    }
+  }
+}
+```
+
+如果你希望 QQ 支持 block streaming，还需要：
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "blockStreamingDefault": "on"
+    }
+  }
+}
+```
+
+可选调优：
+
+```json
+{
+  "channels": {
+    "onebot": {
+      "blockStreamingCoalesce": {
+        "minChars": 80,
+        "idleMs": 600
+      }
+    }
+  }
+}
+```
+
+### 常用参数
+
+- `channels.onebot.wsUrl`: OneBot WebSocket 地址
+- `channels.onebot.httpUrl`: OneBot HTTP API 地址
+- `channels.onebot.accessToken`: 可选鉴权 token
+- `channels.onebot.allowFrom`: 允许的私聊/群聊来源
+- `channels.onebot.groupAutoReact`: 群聊自动 reaction 开关，默认 `true`
+- `channels.onebot.groupAutoReactEmojiId`: 默认群聊 reaction emoji id，默认 `1`
+- `agents.defaults.blockStreamingDefault`: 是否默认开启 block streaming
+
+### 目标格式
+
+- `private:<QQ号>` -> 私聊
+- `group:<群号>` -> 群聊
+- `<QQ号>` -> 自动识别为私聊
+
+### 使用前建议
+
+- 先查看 GitHub 仓库：`https://github.com/xucheng/openclaw-onebot`
+- 安装前先备份 `~/.openclaw/openclaw.json`
+- 如果要执行安装、改配置、重启 gateway，应先确认影响范围
+- 如果更在意供应链安全，建议固定到指定 tag 或 commit 再安装
+
+### 安装后建议验证
+
+```bash
+cd ~/.openclaw/local-plugins/openclaw-onebot
+npm test
+openclaw status --deep
+```
+
+成功标准：
+
+- 测试通过
+- `OneBot = ON / OK`
+- QQ 能正常收发
+- 群聊 reaction 生效
+- 开启 streaming 后日志能看到 `deliver(block)`
+
+---
+
+## English
+
+An **OpenClaw OneBot 11 channel plugin** that makes QQ a first-class OpenClaw channel.
+
+Works with [NapCat](https://github.com/NapNeko/NapCatQQ), [go-cqhttp](https://github.com/Mrs4s/go-cqhttp), and other OneBot 11 compatible QQ bot frameworks.
+
+Notes:
+
+- Plugin id: `openclaw-onebot`
+- Channel id: `onebot`
+- Use `openclaw-onebot` for `plugins.allow` / `plugins.entries` / `plugins.installs`
+- Use `channels.onebot` for runtime channel config
+
+### Features
+
+- Native OpenClaw ChannelPlugin integration
+- QQ private and group messaging
+- Group reactions
+- Automatic group reactions enabled by default
+- OpenClaw block streaming
+- Voice pipeline for QQ voice messages
+- Attachments for images, voice, and files
+- `allowFrom` filtering
+- WebSocket auto-reconnect
+- 106 tests passing
+- Coverage: Statements/Lines 92.11%, Branches 83.68%, Functions 95.16%
+
+### Why choose it
+
+Compared with the QQ official bot API route:
+
+- keeps compatibility with the OneBot ecosystem
+- plugs directly into OpenClaw native routing
+- fits existing NapCat / go-cqhttp deployments better
+
+Compared with standalone Python bridge scripts:
+
+- no extra listener or file-queue bridge
+- no custom routing glue to maintain
+- block streaming, group reactions, and voice pipeline live in one plugin
+- better test coverage
+
+### Capability boundaries
+
+- Group reactions are supported
+- Private-chat reactions are not reliable
+- Streaming here means OpenClaw `block streaming`
+- QQ receives multiple chunked messages, not in-place message edits
+
+### Minimal OpenClaw config
+
+```json
+{
+  "plugins": {
+    "allow": ["openclaw-onebot"],
+    "entries": {
+      "openclaw-onebot": {
+        "enabled": true
+      }
+    }
+  },
+  "channels": {
+    "onebot": {
+      "enabled": true,
+      "wsUrl": "ws://your-host:3001",
+      "httpUrl": "http://your-host:3001",
+      "groupAutoReact": true,
+      "groupAutoReactEmojiId": 1
+    }
+  }
+}
+```
+
+To enable block streaming:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "blockStreamingDefault": "on"
+    }
+  }
+}
+```
+
+Optional tuning:
+
+```json
+{
+  "channels": {
+    "onebot": {
+      "blockStreamingCoalesce": {
+        "minChars": 80,
+        "idleMs": 600
+      }
+    }
+  }
+}
+```
+
+### Common settings
+
+- `channels.onebot.wsUrl`: OneBot WebSocket URL
+- `channels.onebot.httpUrl`: OneBot HTTP API URL
+- `channels.onebot.accessToken`: optional auth token
+- `channels.onebot.allowFrom`: allowed private/group sources
+- `channels.onebot.groupAutoReact`: group auto-reaction switch, default `true`
+- `channels.onebot.groupAutoReactEmojiId`: default group emoji id, default `1`
+- `agents.defaults.blockStreamingDefault`: default block streaming behavior
+
+### Before installing
+
+- review the GitHub repository: `https://github.com/xucheng/openclaw-onebot`
+- back up `~/.openclaw/openclaw.json`
+- understand the effect of install/config changes/gateway restart before applying
+- if supply-chain trust matters, pin to a specific tag or commit first
+
+### Suggested verification
+
+```bash
+cd ~/.openclaw/local-plugins/openclaw-onebot
+npm test
+openclaw status --deep
+```
+
+Expected:
+
+- tests pass
+- `OneBot = ON / OK`
+- QQ messages round-trip
+- group reactions are visible
+- `deliver(block)` appears in logs when streaming is enabled

--- a/skills/openclaw-tavily-search/.clawhub/origin.json
+++ b/skills/openclaw-tavily-search/.clawhub/origin.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "registry": "https://clawhub.ai",
+  "slug": "openclaw-tavily-search",
+  "installedVersion": "0.1.0",
+  "installedAt": 1776260433593
+}

--- a/skills/openclaw-tavily-search/SKILL.md
+++ b/skills/openclaw-tavily-search/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: tavily-search
+description: "Web search via Tavily API (alternative to Brave). Use when the user asks to search the web / look up sources / find links and Brave web_search is unavailable or undesired. Returns a small set of relevant results (title, url, snippet) and can optionally include short answer summaries."
+---
+
+# Tavily Search
+
+Use the bundled script to search the web with Tavily.
+
+## Requirements
+
+- Provide API key via either:
+  - environment variable: `TAVILY_API_KEY`, or
+  - `~/.openclaw/.env` line: `TAVILY_API_KEY=...`
+
+## Commands
+
+Run from the OpenClaw workspace:
+
+```bash
+# raw JSON (default)
+python3 {baseDir}/scripts/tavily_search.py --query "..." --max-results 5
+
+# include short answer (if available)
+python3 {baseDir}/scripts/tavily_search.py --query "..." --max-results 5 --include-answer
+
+# stable schema (closer to web_search): {query, results:[{title,url,snippet}], answer?}
+python3 {baseDir}/scripts/tavily_search.py --query "..." --max-results 5 --format brave
+
+# human-readable Markdown list
+python3 {baseDir}/scripts/tavily_search.py --query "..." --max-results 5 --format md
+```
+
+## Output
+
+### raw (default)
+- JSON: `query`, optional `answer`, `results: [{title,url,content}]`
+
+### brave
+- JSON: `query`, optional `answer`, `results: [{title,url,snippet}]`
+
+### md
+- A compact Markdown list with title/url/snippet.
+
+## Notes
+
+- Keep `max-results` small by default (3–5) to reduce token/reading load.
+- Prefer returning URLs + snippets; fetch full pages only when needed.

--- a/skills/openclaw-tavily-search/scripts/tavily_search.py
+++ b/skills/openclaw-tavily-search/scripts/tavily_search.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.request
+
+TAVILY_URL = "https://api.tavily.com/search"
+
+
+def load_key():
+    key = os.environ.get("TAVILY_API_KEY")
+    if key:
+        return key.strip()
+
+    env_path = pathlib.Path.home() / ".openclaw" / ".env"
+    if env_path.exists():
+        try:
+            txt = env_path.read_text(encoding="utf-8", errors="ignore")
+            m = re.search(r"^\s*TAVILY_API_KEY\s*=\s*(.+?)\s*$", txt, re.M)
+            if m:
+                v = m.group(1).strip().strip('"').strip("'")
+                if v:
+                    return v
+        except Exception:
+            pass
+
+    return None
+
+
+def tavily_search(query: str, max_results: int, include_answer: bool, search_depth: str):
+    key = load_key()
+    if not key:
+        raise SystemExit(
+            "Missing TAVILY_API_KEY. Set env var TAVILY_API_KEY or add it to ~/.openclaw/.env"
+        )
+
+    payload = {
+        "api_key": key,
+        "query": query,
+        "max_results": max_results,
+        "search_depth": search_depth,
+        "include_answer": bool(include_answer),
+        "include_images": False,
+        "include_raw_content": False,
+    }
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        TAVILY_URL,
+        data=data,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+
+    try:
+        obj = json.loads(body)
+    except json.JSONDecodeError:
+        raise SystemExit(f"Tavily returned non-JSON: {body[:300]}")
+
+    out = {
+        "query": query,
+        "answer": obj.get("answer"),
+        "results": [],
+    }
+
+    for r in (obj.get("results") or [])[:max_results]:
+        out["results"].append(
+            {
+                "title": r.get("title"),
+                "url": r.get("url"),
+                "content": r.get("content"),
+            }
+        )
+
+    if not include_answer:
+        out.pop("answer", None)
+
+    return out
+
+
+def to_brave_like(obj: dict) -> dict:
+    # A lightweight, stable shape similar to web_search: results with title/url/snippet.
+    results = []
+    for r in obj.get("results", []) or []:
+        results.append(
+            {
+                "title": r.get("title"),
+                "url": r.get("url"),
+                "snippet": r.get("content"),
+            }
+        )
+    out = {"query": obj.get("query"), "results": results}
+    if "answer" in obj:
+        out["answer"] = obj.get("answer")
+    return out
+
+
+def to_markdown(obj: dict) -> str:
+    lines = []
+    if obj.get("answer"):
+        lines.append(obj["answer"].strip())
+        lines.append("")
+    for i, r in enumerate(obj.get("results", []) or [], 1):
+        title = (r.get("title") or "").strip() or r.get("url") or "(no title)"
+        url = r.get("url") or ""
+        snippet = (r.get("content") or "").strip()
+        lines.append(f"{i}. {title}")
+        if url:
+            lines.append(f"   {url}")
+        if snippet:
+            lines.append(f"   - {snippet}")
+    return "\n".join(lines).strip() + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--query", required=True)
+    ap.add_argument("--max-results", type=int, default=5)
+    ap.add_argument("--include-answer", action="store_true")
+    ap.add_argument(
+        "--search-depth",
+        default="basic",
+        choices=["basic", "advanced"],
+        help="Tavily search depth",
+    )
+    ap.add_argument(
+        "--format",
+        default="raw",
+        choices=["raw", "brave", "md"],
+        help="Output format: raw (default) | brave (title/url/snippet) | md (human-readable)",
+    )
+    args = ap.parse_args()
+
+    res = tavily_search(
+        query=args.query,
+        max_results=max(1, min(args.max_results, 10)),
+        include_answer=args.include_answer,
+        search_depth=args.search_depth,
+    )
+
+    if args.format == "md":
+        sys.stdout.write(to_markdown(res))
+        return
+
+    if args.format == "brave":
+        res = to_brave_like(res)
+
+    json.dump(res, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add 4 community-contributed Skills extending OpenClaw's native capabilities:

### openclaw-onebot
OneBot 11 protocol plugin for QQ Bot via NapCat/go-cqhttp. Supports private/group chat, group reactions, message cards & buttons, voice pipeline, and allowFrom routing.

### openclaw-tavily-search
Tavily Web Search provider as an alternative to Brave Search. Returns title, URL, snippet, and optional AI answer summaries.

### image-gen-deliver
Multi-channel AI image generation delivery to Feishu, Telegram, QQ, and WeChat. Uses platform-native upload APIs with proper CDN URL handling.

### multimodal-messaging
Processes incoming images, voice messages, and files from IM channels (QQ/WeChat/Telegram/Feishu) using MiniMax VL for understanding.

## Motivation

Users need native QQ integration (not just via third-party bridges), alternative search providers, and reliable multi-channel image delivery pipelines. These skills fill those gaps in a clean, channel-aware way.

## Testing

All skills tested on personal deployment. openclaw-onebot has 106 tests passing.