### PR TITLE
fix(reply): fail loudly when reply media is lost

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -27,15 +27,33 @@ async function expectSameTargetRepliesSuppressed(params: { provider: string; to:
 }
 
 describe("buildReplyPayloads media filter integration", () => {
-  it("strips media URL from payload when in messagingToolSentMediaUrls", async () => {
+  it("strips media URL from payload when in messagingToolSentMediaUrls for the same target", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "hello", mediaUrl: "file:///tmp/photo.jpg" }],
+      messageProvider: "telegram",
+      originatingTo: "telegram:123",
       messagingToolSentMediaUrls: ["file:///tmp/photo.jpg"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "telegram:123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("preserves MEDIA directive when sent media lacks same-target proof", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "[[reply_to_current]] Here it is.\n\nMEDIA:/tmp/clip.mp4" }],
+      currentMessageId: "msg-123",
+      messagingToolSentMediaUrls: ["file:///tmp/clip.mp4"],
     });
 
     expect(replyPayloads).toHaveLength(1);
-    expect(replyPayloads[0].mediaUrl).toBeUndefined();
+    expect(replyPayloads[0]).toMatchObject({
+      text: "Here it is.",
+      mediaUrl: "/tmp/clip.mp4",
+      mediaUrls: ["/tmp/clip.mp4"],
+    });
   });
 
   it("preserves media URL when not in messagingToolSentMediaUrls", async () => {
@@ -49,7 +67,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0].mediaUrl).toBe("file:///tmp/photo.jpg");
   });
 
-  it("normalizes sent media URLs before deduping normalized reply media", async () => {
+  it("normalizes sent media URLs before deduping normalized reply media for the same target", async () => {
     const normalizeMediaPaths = async (payload: { mediaUrl?: string; mediaUrls?: string[] }) => {
       const normalizeMedia = (value?: string) =>
         value === "./out/photo.jpg" ? "/tmp/workspace/out/photo.jpg" : value;
@@ -63,16 +81,14 @@ describe("buildReplyPayloads media filter integration", () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "hello", mediaUrl: "./out/photo.jpg" }],
+      messageProvider: "telegram",
+      originatingTo: "telegram:123",
       messagingToolSentMediaUrls: ["./out/photo.jpg"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "telegram:123" }],
       normalizeMediaPaths,
     });
 
-    expect(replyPayloads).toHaveLength(1);
-    expect(replyPayloads[0]).toMatchObject({
-      text: "hello",
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    expect(replyPayloads).toHaveLength(0);
   });
 
   it("converts reply media normalization failures into visible error payloads", async () => {
@@ -132,15 +148,18 @@ describe("buildReplyPayloads media filter integration", () => {
     });
   });
 
-  it("applies media filter after text filter", async () => {
+  it("applies media filter after text filter for the same target", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       payloads: [{ text: "hello world!", mediaUrl: "file:///tmp/photo.jpg" }],
+      messageProvider: "telegram",
+      originatingTo: "telegram:123",
       messagingToolSentTexts: ["hello world!"],
       messagingToolSentMediaUrls: ["file:///tmp/photo.jpg"],
+      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "telegram:123" }],
     });
 
-    // Text filter removes the payload entirely (text matched), so nothing remains.
+    // Same-target tool sends suppress the final reply entirely.
     expect(replyPayloads).toHaveLength(0);
   });
 

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { ReplyMediaNormalizationError } from "./reply-media-paths.js";
 
 const baseParams = {
   isHeartbeat: false,
@@ -74,7 +75,41 @@ describe("buildReplyPayloads media filter integration", () => {
     });
   });
 
-  it("drops only invalid media when reply media normalization fails", async () => {
+  it("converts reply media normalization failures into visible error payloads", async () => {
+    const normalizeMediaPaths = async (payload: { mediaUrl?: string; replyToId?: string }) => {
+      if (payload.mediaUrl === "./bad.png") {
+        throw new ReplyMediaNormalizationError({
+          attemptedMedia: ["./bad.png"],
+          failedMedia: ["./bad.png"],
+          cause: new Error("Path escapes sandbox root"),
+        });
+      }
+      return payload;
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [
+        { text: "keep text", mediaUrl: "./bad.png", audioAsVoice: true, replyToId: "msg-1" },
+        { text: "keep second" },
+      ],
+      normalizeMediaPaths,
+    });
+
+    expect(replyPayloads).toHaveLength(2);
+    expect(replyPayloads[0]).toMatchObject({
+      text: expect.stringContaining("I couldn't attach the requested media"),
+      isError: true,
+    });
+    expect(replyPayloads[0]?.mediaUrl).toBeUndefined();
+    expect(replyPayloads[0]?.mediaUrls).toBeUndefined();
+    expect(replyPayloads[0]?.audioAsVoice).toBeUndefined();
+    expect(replyPayloads[1]).toMatchObject({
+      text: "keep second",
+    });
+  });
+
+  it("still strips media for generic normalization failures", async () => {
     const normalizeMediaPaths = async (payload: { mediaUrl?: string }) => {
       if (payload.mediaUrl === "./bad.png") {
         throw new Error("Path escapes sandbox root");
@@ -84,22 +119,16 @@ describe("buildReplyPayloads media filter integration", () => {
 
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
-      payloads: [
-        { text: "keep text", mediaUrl: "./bad.png", audioAsVoice: true },
-        { text: "keep second" },
-      ],
+      payloads: [{ text: "keep text", mediaUrl: "./bad.png", audioAsVoice: true }],
       normalizeMediaPaths,
     });
 
-    expect(replyPayloads).toHaveLength(2);
+    expect(replyPayloads).toHaveLength(1);
     expect(replyPayloads[0]).toMatchObject({
       text: "keep text",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
-    });
-    expect(replyPayloads[1]).toMatchObject({
-      text: "keep second",
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -14,6 +14,10 @@ import {
   resolveOriginMessageTo,
 } from "./origin-routing.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
+import {
+  buildReplyMediaNormalizationFailurePayload,
+  ReplyMediaNormalizationError,
+} from "./reply-media-paths.js";
 import { applyReplyThreading, isRenderablePayload } from "./reply-payloads-base.js";
 
 let replyPayloadsDedupeRuntimePromise: Promise<
@@ -37,6 +41,9 @@ async function normalizeReplyPayloadMedia(params: {
     return await params.normalizeMediaPaths(params.payload);
   } catch (err) {
     logVerbose(`reply payload media normalization failed: ${String(err)}`);
+    if (err instanceof ReplyMediaNormalizationError) {
+      return buildReplyMediaNormalizationFailurePayload(params.payload, err);
+    }
     return {
       ...params.payload,
       mediaUrl: undefined,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -194,12 +194,10 @@ export async function buildReplyPayloads(params: {
         originatingAccountId: params.accountId,
       }),
     }) ?? false;
-  // Only dedupe against messaging tool sends for the same origin target.
-  // Cross-target sends (for example posting to another channel) must not
-  // suppress the current conversation's final reply.
-  // If target metadata is unavailable, keep legacy dedupe behavior.
-  const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+  // Only dedupe against messaging tool sends when we can prove they targeted
+  // the current origin conversation. Missing target metadata is ambiguous and
+  // must not strip MEDIA directives from the assistant's final reply.
+  const dedupeMessagingToolPayloads = suppressMessagingToolReplies;
   const messagingToolSentMediaUrls = dedupeMessagingToolPayloads
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.messagingToolSentMediaUrls ?? [],

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -6,6 +6,7 @@ import {
   createBlockReplyDeliveryHandler,
   normalizeReplyPayloadDirectives,
 } from "./reply-delivery.js";
+import { ReplyMediaNormalizationError } from "./reply-media-paths.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 type BlockReplyPipelineLike = NonNullable<
@@ -172,6 +173,38 @@ describe("createBlockReplyDeliveryHandler", () => {
       replyToCurrent: false,
       replyToTag: false,
       audioAsVoice: false,
+    });
+  });
+
+  it("sends a visible error block reply when media normalization fails loudly", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply,
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      normalizeMediaPaths: async () => {
+        throw new ReplyMediaNormalizationError({
+          attemptedMedia: ["./image.png"],
+          failedMedia: ["./image.png"],
+          cause: new Error("Path escapes sandbox root"),
+        });
+      },
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "Result\nMEDIA: ./image.png", replyToCurrent: true });
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: expect.stringContaining("I couldn't attach the requested media"),
+      isError: true,
+      replyToCurrent: true,
+      replyToId: undefined,
+      replyToTag: false,
     });
   });
 

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -6,6 +6,10 @@ import type { BlockReplyContext, ReplyPayload } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import { parseReplyDirectives } from "./reply-directives.js";
+import {
+  buildReplyMediaNormalizationFailurePayload,
+  ReplyMediaNormalizationError,
+} from "./reply-media-paths.js";
 import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
@@ -116,9 +120,29 @@ export function createBlockReplyDeliveryHandler(params: {
       parseMode: "auto",
     });
 
-    const mediaNormalizedPayload = params.normalizeMediaPaths
-      ? await params.normalizeMediaPaths(normalized.payload)
-      : normalized.payload;
+    let mediaNormalizedPayload: ReplyPayload;
+    try {
+      mediaNormalizedPayload = params.normalizeMediaPaths
+        ? await params.normalizeMediaPaths(normalized.payload)
+        : normalized.payload;
+    } catch (err) {
+      if (err instanceof ReplyMediaNormalizationError) {
+        const failurePayload = carryReplyPayloadMetadata(
+          payload,
+          params.applyReplyToMode(
+            buildReplyMediaNormalizationFailurePayload(normalized.payload, err),
+          ),
+        );
+        await sendDirectBlockReply({
+          onBlockReply: params.onBlockReply,
+          directlySentBlockKeys: params.directlySentBlockKeys,
+          trackingPayload: failurePayload,
+          payload: failurePayload,
+        });
+        return;
+      }
+      throw err;
+    }
     const blockPayload = carryReplyPayloadMetadata(
       payload,
       params.applyReplyToMode(mediaNormalizedPayload),

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -17,7 +17,10 @@ vi.mock("../../media/read-capability.js", () => ({
   resolveAgentScopedOutboundMediaAccess,
 }));
 
-import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
+import {
+  createReplyMediaPathNormalizer,
+  ReplyMediaNormalizationError,
+} from "./reply-media-paths.js";
 
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
@@ -94,7 +97,7 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
-  it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
+  it("fails fast when sandbox-mapped media staging fails", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -106,14 +109,14 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["./out/photo.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["./out/photo.png"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["./out/photo.png"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
     expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledTimes(1);
     expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
@@ -122,25 +125,25 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
-  it("drops host file URLs when no sandbox mapping applies", async () => {
+  it("fails fast for host file URLs when no sandbox mapping applies", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["file:///Users/peter/Documents/report.pdf"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops host file URLs even when sandbox exists", async () => {
+  it("fails fast for host file URLs even when sandbox exists", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -151,18 +154,18 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["file:///Users/peter/Documents/report.pdf"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops absolute host-local media paths when sandbox mapping fails", async () => {
+  it("fails fast for absolute host-local media paths when sandbox mapping fails", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -173,15 +176,42 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/agent-workspace",
     });
 
+    await expect(
+      normalize({
+        mediaUrls: ["/Users/peter/Documents/report.pdf"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["/Users/peter/Documents/report.pdf"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("maps absolute workspace media paths into the host sandbox workspace before staging", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { agents: { defaults: { mediaMaxMb: 8 } } },
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+    });
+
     const result = await normalize({
-      mediaUrls: ["/Users/peter/Documents/report.pdf"],
+      mediaUrls: [absolutePath],
     });
 
     expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
+      mediaUrl: "/tmp/outbound-media/chart.png",
+      mediaUrls: ["/tmp/outbound-media/chart.png"],
     });
-    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      "/tmp/sandboxes/session-1/exports/images/chart.png",
+      8 * 1024 * 1024,
+      expect.any(Object),
+    );
   });
 
   it("stages absolute workspace media paths so the PR scenario now works", async () => {
@@ -240,25 +270,25 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
-  it("drops workspace-relative media paths that escape the agent workspace", async () => {
+  it("fails fast when workspace-relative media paths escape the agent workspace", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["../../etc/passwd"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["../../etc/passwd"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["../../etc/passwd"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops sandbox-relative media paths that escape both sandbox and workspace", async () => {
+  it("fails fast when sandbox-relative media paths escape both sandbox and workspace", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -269,14 +299,14 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["../../etc/passwd"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["../../etc/passwd"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["../../etc/passwd"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
@@ -299,7 +329,7 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops host-local media when shared outbound attachment policy rejects it", async () => {
+  it("fails fast when shared outbound attachment policy rejects host-local media", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
       new Error("Local media path is not under an allowed directory"),
     );
@@ -309,14 +339,14 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: ["/Users/peter/secrets/photo.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
+    await expect(
+      normalize({
+        mediaUrls: ["/Users/peter/secrets/photo.png"],
+      }),
+    ).rejects.toMatchObject({
+      name: "ReplyMediaNormalizationError",
+      failedMedia: ["/Users/peter/secrets/photo.png"],
+    } satisfies Partial<ReplyMediaNormalizationError>);
   });
 
   it("threads requester context into shared outbound media access", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -48,6 +48,56 @@ function getPayloadMediaList(payload: ReplyPayload): string[] {
   return resolveSendableOutboundReplyParts(payload).mediaUrls;
 }
 
+export class ReplyMediaNormalizationError extends Error {
+  readonly attemptedMedia: string[];
+  readonly failedMedia: string[];
+
+  constructor(params: { attemptedMedia: string[]; failedMedia: string[]; cause?: unknown }) {
+    const count = params.failedMedia.length;
+    super(`Failed to normalize ${count} reply media item${count === 1 ? "" : "s"}.`, {
+      cause: params.cause,
+    });
+    this.name = "ReplyMediaNormalizationError";
+    this.attemptedMedia = [...params.attemptedMedia];
+    this.failedMedia = [...params.failedMedia];
+  }
+}
+
+function describeReplyMediaNormalizationFailure(err: unknown): string {
+  const cause = err instanceof ReplyMediaNormalizationError ? err.cause : err;
+  const message =
+    cause instanceof Error ? cause.message.trim() : typeof cause === "string" ? cause.trim() : "";
+  if (/host-local media file urls are blocked/i.test(message)) {
+    return "Host file URLs are blocked in normal replies.";
+  }
+  if (/sandbox root/i.test(message)) {
+    return "The requested file path resolves outside the allowed sandbox.";
+  }
+  if (/allowed directory|allowed media/i.test(message)) {
+    return "The requested file path is outside the allowed media directories.";
+  }
+  if (/enoent|no such file/i.test(message)) {
+    return "The requested file no longer exists.";
+  }
+  if (/too large|exceeds|larger than/i.test(message)) {
+    return "The requested file is larger than the allowed attachment limit.";
+  }
+  return "OpenClaw couldn't stage the attachment.";
+}
+
+export function buildReplyMediaNormalizationFailurePayload(
+  payload: ReplyPayload,
+  err: unknown,
+): ReplyPayload {
+  return {
+    text: `⚠️ I couldn't attach the requested media, so I didn't send a text-only fallback. ${describeReplyMediaNormalizationFailure(err)}`,
+    isError: true,
+    replyToId: payload.replyToId,
+    replyToTag: payload.replyToTag,
+    replyToCurrent: payload.replyToCurrent,
+  };
+}
+
 function resolveReplyMediaMaxBytes(params: {
   cfg: OpenClawConfig;
   channel?: string;
@@ -150,6 +200,23 @@ export function createReplyMediaPathNormalizer(params: {
     return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
   };
 
+  const resolveWorkspaceAbsoluteMediaInSandbox = (
+    media: string,
+    sandboxRoot: string,
+  ): string | undefined => {
+    if (FILE_URL_RE.test(media) || media.startsWith("~")) {
+      return undefined;
+    }
+    const isAbsoluteLocalMedia = path.isAbsolute(media) || WINDOWS_DRIVE_RE.test(media);
+    if (!isAbsoluteLocalMedia) {
+      return undefined;
+    }
+    const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
+      cwd: params.workspaceDir,
+    });
+    return resolvePathFromInput(relativeWorkspacePath, sandboxRoot);
+  };
+
   const normalizeMediaSource = async (raw: string): Promise<string> => {
     const media = raw.trim();
     if (!media) {
@@ -167,6 +234,10 @@ export function createReplyMediaPathNormalizer(params: {
       !WINDOWS_DRIVE_RE.test(media);
     const sandboxRoot = await resolveSandboxRoot();
     if (sandboxRoot) {
+      const sandboxWorkspaceMedia = resolveWorkspaceAbsoluteMediaInSandbox(media, sandboxRoot);
+      if (sandboxWorkspaceMedia) {
+        return await persistLocalReplyMedia(sandboxWorkspaceMedia);
+      }
       let sandboxResolvedMedia: string;
       try {
         sandboxResolvedMedia = await resolveSandboxedMediaSource({
@@ -212,7 +283,11 @@ export function createReplyMediaPathNormalizer(params: {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
         logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
-        continue;
+        throw new ReplyMediaNormalizationError({
+          attemptedMedia: mediaList,
+          failedMedia: [media],
+          cause: err,
+        });
       }
       if (!normalized || seen.has(normalized)) {
         continue;


### PR DESCRIPTION
## Summary
- fail loudly when reply media path normalization or staging breaks instead of silently dropping the attachment
- only dedupe messaging-tool media when we can prove it targeted the same origin conversation
- preserve final `MEDIA:` replies when sent-media metadata lacks same-target proof

## Testing
- `pnpm vitest src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/reply-media-paths.test.ts`