### PR TITLE
Fix Claude CLI session continuity after token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI Codex: add a ChatGPT device-code auth option beside browser OAuth, so headless or callback-hostile setups can sign in without relying on the localhost browser callback. (#69557) Thanks @vincentkoc.
 - CLI sessions: keep provider-owned CLI sessions through implicit daily expiry while preserving explicit reset behavior, and retain Claude CLI binding metadata across gateway agent requests. (#70106) Thanks @obviyus.
 - fix(config): accept truncateAfterCompaction (#68395). Thanks @MonkeyLeeT
+- CLI/Claude: keep Claude CLI session bindings stable across OAuth access-token refreshes, so gateway restarts continue the same Claude conversation instead of minting a fresh one. (#70132) Thanks @obviyus.
 
 ## 2026.4.21
 

--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -30,20 +30,42 @@ describe("resolveCliAuthEpoch", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("changes when claude cli credentials change", async () => {
+  it("keeps claude cli oauth epochs stable across access-token refreshes", async () => {
     let access = "access-a";
+    let expires = 1;
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({
         type: "oauth",
         provider: "anthropic",
         access,
         refresh: "refresh",
-        expires: 1,
+        expires,
       }),
     });
 
     const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
     access = "access-b";
+    expires = 2;
+    const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
+
+    expect(first).toBeDefined();
+    expect(second).toBe(first);
+  });
+
+  it("changes claude cli oauth epochs when the refresh token changes", async () => {
+    let refresh = "refresh-a";
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "anthropic",
+        access: "access",
+        refresh,
+        expires: 1,
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
+    refresh = "refresh-b";
     const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
 
     expect(first).toBeDefined();
@@ -51,7 +73,7 @@ describe("resolveCliAuthEpoch", () => {
     expect(second).not.toBe(first);
   });
 
-  it("changes when auth profile credentials change", async () => {
+  it("keeps oauth auth-profile epochs stable across access-token refreshes", async () => {
     let store: AuthProfileStore = {
       version: 1,
       profiles: {
@@ -80,6 +102,48 @@ describe("resolveCliAuthEpoch", () => {
           provider: "anthropic",
           access: "access-b",
           refresh: "refresh",
+          expires: 2,
+        },
+      },
+    };
+    const second = await resolveCliAuthEpoch({
+      provider: "google-gemini-cli",
+      authProfileId: "anthropic:work",
+    });
+
+    expect(first).toBeDefined();
+    expect(second).toBe(first);
+  });
+
+  it("changes oauth auth-profile epochs when the refresh token changes", async () => {
+    let store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh-a",
+          expires: 1,
+        },
+      },
+    };
+    setCliAuthEpochTestDeps({
+      loadAuthProfileStoreForRuntime: () => store,
+    });
+
+    const first = await resolveCliAuthEpoch({
+      provider: "google-gemini-cli",
+      authProfileId: "anthropic:work",
+    });
+    store = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access",
+          refresh: "refresh-b",
           expires: 1,
         },
       },
@@ -96,13 +160,14 @@ describe("resolveCliAuthEpoch", () => {
 
   it("mixes local codex and auth-profile state", async () => {
     let access = "local-access-a";
+    let localRefresh = "local-refresh-a";
     let refresh = "profile-refresh-a";
     setCliAuthEpochTestDeps({
       readCodexCliCredentialsCached: () => ({
         type: "oauth",
         provider: "openai-codex",
         access,
-        refresh: "local-refresh",
+        refresh: localRefresh,
         expires: 1,
         accountId: "acct-1",
       }),
@@ -129,17 +194,23 @@ describe("resolveCliAuthEpoch", () => {
       provider: "codex-cli",
       authProfileId: "openai:work",
     });
-    refresh = "profile-refresh-b";
+    localRefresh = "local-refresh-b";
     const third = await resolveCliAuthEpoch({
+      provider: "codex-cli",
+      authProfileId: "openai:work",
+    });
+    refresh = "profile-refresh-b";
+    const fourth = await resolveCliAuthEpoch({
       provider: "codex-cli",
       authProfileId: "openai:work",
     });
 
     expect(first).toBeDefined();
-    expect(second).toBeDefined();
     expect(third).toBeDefined();
-    expect(second).not.toBe(first);
+    expect(fourth).toBeDefined();
+    expect(second).toBe(first);
     expect(third).not.toBe(second);
+    expect(fourth).not.toBe(third);
   });
 
   it("can ignore local codex state when the backend is profile-owned", async () => {

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -23,6 +23,8 @@ const defaultCliAuthEpochDeps: CliAuthEpochDeps = {
 
 const cliAuthEpochDeps: CliAuthEpochDeps = { ...defaultCliAuthEpochDeps };
 
+export const CLI_AUTH_EPOCH_VERSION = 2;
+
 export function setCliAuthEpochTestDeps(overrides: Partial<CliAuthEpochDeps>): void {
   Object.assign(cliAuthEpochDeps, overrides);
 }
@@ -41,24 +43,16 @@ function encodeUnknown(value: unknown): string {
 
 function encodeClaudeCredential(credential: ClaudeCliCredential): string {
   if (credential.type === "oauth") {
-    return JSON.stringify([
-      "oauth",
-      credential.provider,
-      credential.access,
-      credential.refresh,
-      credential.expires,
-    ]);
+    return JSON.stringify(["oauth", credential.provider, credential.refresh]);
   }
-  return JSON.stringify(["token", credential.provider, credential.token, credential.expires]);
+  return JSON.stringify(["token", credential.provider, credential.token]);
 }
 
 function encodeCodexCredential(credential: CodexCliCredential): string {
   return JSON.stringify([
     credential.type,
     credential.provider,
-    credential.access,
     credential.refresh,
-    credential.expires,
     credential.accountId ?? null,
   ]);
 }
@@ -81,7 +75,6 @@ function encodeAuthProfileCredential(credential: AuthProfileCredential): string 
         credential.provider,
         credential.token ?? null,
         encodeUnknown(credential.tokenRef),
-        credential.expires ?? null,
         credential.email ?? null,
         credential.displayName ?? null,
       ]);
@@ -89,12 +82,9 @@ function encodeAuthProfileCredential(credential: AuthProfileCredential): string 
       return JSON.stringify([
         "oauth",
         credential.provider,
-        credential.access,
         credential.refresh,
-        credential.expires,
         credential.clientId ?? null,
         credential.email ?? null,
-        credential.displayName ?? null,
         credential.enterpriseUrl ?? null,
         credential.projectId ?? null,
         credential.accountId ?? null,

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -55,6 +55,7 @@ function buildPreparedContext(params?: {
     systemPrompt: "You are a helpful assistant.",
     systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
     bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
   };
 }
 

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -111,6 +111,7 @@ function buildPreparedCliRunContext(params: {
     systemPrompt: "You are a helpful assistant.",
     systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
     bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
   };
 }
 
@@ -170,6 +171,7 @@ describe("runCliAgent spawn path", () => {
       systemPrompt: "You are a helpful assistant.",
       systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
       bootstrapPromptWarningLines: [],
+      authEpochVersion: 2,
     };
     await executePreparedCliRun(context);
 

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -72,6 +72,7 @@ export async function runPreparedCliAgent(
                     ? { authProfileId: context.effectiveAuthProfileId }
                     : {}),
                   ...(context.authEpoch ? { authEpoch: context.authEpoch } : {}),
+                  authEpochVersion: context.authEpochVersion,
                   ...(context.extraSystemPromptHash
                     ? { extraSystemPromptHash: context.extraSystemPromptHash }
                     : {}),

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -21,7 +21,7 @@ import {
   makeBootstrapWarn as makeBootstrapWarnImpl,
   resolveBootstrapContextForRun as resolveBootstrapContextForRunImpl,
 } from "../bootstrap-files.js";
-import { resolveCliAuthEpoch } from "../cli-auth-epoch.js";
+import { CLI_AUTH_EPOCH_VERSION, resolveCliAuthEpoch } from "../cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
@@ -188,15 +188,16 @@ export async function prepareCliRunContext(
     modelId,
     authProfileId: effectiveAuthProfileId,
   });
+  const skipLocalCredentialEpoch = shouldSkipLocalCliCredentialEpoch({
+    authEpochMode: backendResolved.authEpochMode,
+    authProfileId: effectiveAuthProfileId,
+    authCredential,
+    preparedExecution,
+  });
   const authEpoch = await resolveCliAuthEpoch({
     provider: params.provider,
     authProfileId: effectiveAuthProfileId,
-    skipLocalCredential: shouldSkipLocalCliCredentialEpoch({
-      authEpochMode: backendResolved.authEpochMode,
-      authProfileId: effectiveAuthProfileId,
-      authCredential,
-      preparedExecution,
-    }),
+    skipLocalCredential: skipLocalCredentialEpoch,
   });
   const preparedBackendEnv =
     preparedExecution?.env && Object.keys(preparedExecution.env).length > 0
@@ -232,6 +233,7 @@ export async function prepareCliRunContext(
         binding: params.cliSessionBinding,
         authProfileId: effectiveAuthProfileId,
         authEpoch,
+        authEpochVersion: CLI_AUTH_EPOCH_VERSION,
         extraSystemPromptHash,
         mcpConfigHash: preparedBackendFinal.mcpConfigHash,
         mcpResumeHash: preparedBackendFinal.mcpResumeHash,
@@ -332,6 +334,7 @@ export async function prepareCliRunContext(
     bootstrapPromptWarningLines: bootstrapPromptWarning.lines,
     heartbeatPrompt,
     authEpoch,
+    authEpochVersion: CLI_AUTH_EPOCH_VERSION,
     extraSystemPromptHash,
   };
 }

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -68,5 +68,6 @@ export type PreparedCliRunContext = {
   bootstrapPromptWarningLines: string[];
   heartbeatPrompt?: string;
   authEpoch?: string;
+  authEpochVersion: number;
   extraSystemPromptHash?: string;
 };

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -47,9 +47,12 @@ describe("cli-session helpers", () => {
       claudeCliSessionId: "legacy-session",
     };
 
-    expect(resolveCliSessionReuse({ binding: getCliSessionBinding(entry, "claude-cli") })).toEqual({
-      sessionId: "legacy-session",
-    });
+    expect(
+      resolveCliSessionReuse({
+        binding: getCliSessionBinding(entry, "claude-cli"),
+        authEpochVersion: 2,
+      }),
+    ).toEqual({ sessionId: "legacy-session" });
   });
 
   it("invalidates legacy bindings when auth, prompt, or MCP state changes", () => {
@@ -64,18 +67,21 @@ describe("cli-session helpers", () => {
     expect(
       resolveCliSessionReuse({
         binding,
+        authEpochVersion: 2,
         authProfileId: "anthropic:work",
       }),
     ).toEqual({ invalidatedReason: "auth-profile" });
     expect(
       resolveCliSessionReuse({
         binding,
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-hash",
       }),
     ).toEqual({ invalidatedReason: "system-prompt" });
     expect(
       resolveCliSessionReuse({
         binding,
+        authEpochVersion: 2,
         mcpConfigHash: "mcp-hash",
       }),
     ).toEqual({ invalidatedReason: "mcp" });

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -20,6 +20,7 @@ describe("cli-session helpers", () => {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
       authEpoch: "auth-epoch",
+      authEpochVersion: 2,
       extraSystemPromptHash: "prompt-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
@@ -31,6 +32,7 @@ describe("cli-session helpers", () => {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
       authEpoch: "auth-epoch",
+      authEpochVersion: 2,
       extraSystemPromptHash: "prompt-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
@@ -84,6 +86,7 @@ describe("cli-session helpers", () => {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
       authEpoch: "auth-epoch-a",
+      authEpochVersion: 2,
       extraSystemPromptHash: "prompt-a",
       mcpConfigHash: "mcp-a",
     };
@@ -93,6 +96,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:personal",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
@@ -102,6 +106,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-b",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
@@ -111,6 +116,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-b",
         mcpConfigHash: "mcp-a",
       }),
@@ -120,17 +126,18 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-b",
       }),
     ).toEqual({ invalidatedReason: "mcp" });
   });
 
-  it("does not treat model changes as a session mismatch", () => {
+  it("accepts unversioned auth epochs for binding upgrades", () => {
     const binding = {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
-      authEpoch: "auth-epoch-a",
+      authEpoch: "previous-auth-epoch",
       extraSystemPromptHash: "prompt-a",
       mcpConfigHash: "mcp-a",
     };
@@ -140,6 +147,29 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
+        extraSystemPromptHash: "prompt-a",
+        mcpConfigHash: "mcp-a",
+      }),
+    ).toEqual({ sessionId: "cli-session-1" });
+  });
+
+  it("does not treat model changes as a session mismatch", () => {
+    const binding = {
+      sessionId: "cli-session-1",
+      authProfileId: "anthropic:work",
+      authEpoch: "auth-epoch-a",
+      authEpochVersion: 2,
+      extraSystemPromptHash: "prompt-a",
+      mcpConfigHash: "mcp-a",
+    };
+
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        authProfileId: "anthropic:work",
+        authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
@@ -151,6 +181,7 @@ describe("cli-session helpers", () => {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
       authEpoch: "auth-epoch-a",
+      authEpochVersion: 2,
       extraSystemPromptHash: "prompt-a",
       mcpConfigHash: "mcp-config-a",
       mcpResumeHash: "mcp-resume-a",
@@ -161,6 +192,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-config-b",
         mcpResumeHash: "mcp-resume-a",
@@ -171,6 +203,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-config-a",
         mcpResumeHash: "mcp-resume-b",
@@ -183,6 +216,7 @@ describe("cli-session helpers", () => {
       sessionId: "cli-session-1",
       authProfileId: "anthropic:work",
       authEpoch: "auth-epoch-a",
+      authEpochVersion: 2,
       extraSystemPromptHash: "prompt-a",
       mcpConfigHash: "mcp-config-a",
     };
@@ -192,6 +226,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-config-a",
         mcpResumeHash: "mcp-resume-a",
@@ -202,6 +237,7 @@ describe("cli-session helpers", () => {
         binding,
         authProfileId: "anthropic:work",
         authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-config-b",
         mcpResumeHash: "mcp-resume-a",

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -126,7 +126,7 @@ export function resolveCliSessionReuse(params: {
   binding?: CliSessionBinding;
   authProfileId?: string;
   authEpoch?: string;
-  authEpochVersion?: number;
+  authEpochVersion: number;
   extraSystemPromptHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -28,6 +28,7 @@ export function getCliSessionBinding(
       sessionId: bindingSessionId,
       authProfileId: normalizeOptionalString(fromBindings?.authProfileId),
       authEpoch: normalizeOptionalString(fromBindings?.authEpoch),
+      authEpochVersion: fromBindings?.authEpochVersion,
       extraSystemPromptHash: normalizeOptionalString(fromBindings?.extraSystemPromptHash),
       mcpConfigHash: normalizeOptionalString(fromBindings?.mcpConfigHash),
       mcpResumeHash: normalizeOptionalString(fromBindings?.mcpResumeHash),
@@ -78,6 +79,9 @@ export function setCliSessionBinding(
       ...(normalizeOptionalString(binding.authEpoch)
         ? { authEpoch: normalizeOptionalString(binding.authEpoch) }
         : {}),
+      ...(typeof binding.authEpochVersion === "number" && Number.isFinite(binding.authEpochVersion)
+        ? { authEpochVersion: binding.authEpochVersion }
+        : {}),
       ...(normalizeOptionalString(binding.extraSystemPromptHash)
         ? { extraSystemPromptHash: normalizeOptionalString(binding.extraSystemPromptHash) }
         : {}),
@@ -122,6 +126,7 @@ export function resolveCliSessionReuse(params: {
   binding?: CliSessionBinding;
   authProfileId?: string;
   authEpoch?: string;
+  authEpochVersion?: number;
   extraSystemPromptHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;
@@ -144,7 +149,10 @@ export function resolveCliSessionReuse(params: {
     return { invalidatedReason: "auth-profile" };
   }
   const storedAuthEpoch = normalizeOptionalString(binding?.authEpoch);
-  if (storedAuthEpoch !== currentAuthEpoch) {
+  if (
+    binding?.authEpochVersion === params.authEpochVersion &&
+    storedAuthEpoch !== currentAuthEpoch
+  ) {
     return { invalidatedReason: "auth-epoch" };
   }
   const storedExtraSystemPromptHash = normalizeOptionalString(binding?.extraSystemPromptHash);

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -72,6 +72,7 @@ export type CliSessionBinding = {
   sessionId: string;
   authProfileId?: string;
   authEpoch?: string;
+  authEpochVersion?: number;
   extraSystemPromptHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;


### PR DESCRIPTION
Fixes Claude CLI sessions being discarded after a normal OAuth token refresh and gateway restart.

What changed:
- hash stable OAuth identity material for CLI session auth epochs
- version stored auth epochs so existing bindings upgrade without one-time session loss
- add regression coverage for refresh-stable epochs and binding reuse

Verification:
- pnpm check:changed
