### PR TITLE
fix(plugins): eagerly install bundled runtime deps

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -395,6 +395,39 @@ function collectRuntimeDeps(packageJson) {
   };
 }
 
+function isSafeBundledRuntimeDependencySpec(spec) {
+  if (typeof spec !== "string") {
+    return false;
+  }
+  const normalized = spec.trim();
+  if (!normalized) {
+    return false;
+  }
+  const lower = normalized.toLowerCase();
+  if (
+    lower.startsWith("file:") ||
+    lower.startsWith("link:") ||
+    lower.startsWith("workspace:") ||
+    lower.startsWith("git:") ||
+    lower.startsWith("git+") ||
+    lower.startsWith("ssh:") ||
+    lower.startsWith("http:") ||
+    lower.startsWith("https:")
+  ) {
+    return false;
+  }
+  if (normalized.includes("://") || normalized.startsWith("/") || normalized.startsWith("\\")) {
+    return false;
+  }
+  return true;
+}
+
+function assertSafeBundledRuntimeDependencySpec(depName, spec) {
+  if (!isSafeBundledRuntimeDependencySpec(spec)) {
+    throw new Error(`unsafe bundled runtime dependency spec for ${depName}: ${spec}`);
+  }
+}
+
 export function discoverBundledPluginRuntimeDeps(params = {}) {
   const extensionsDir = params.extensionsDir ?? DEFAULT_EXTENSIONS_DIR;
   const pathExists = params.existsSync ?? existsSync;
@@ -425,28 +458,36 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
     if (!pathExists(packageJsonPath)) {
       continue;
     }
+    let packageJson;
     try {
-      const packageJson = readJsonFile(packageJsonPath);
-      for (const [name, version] of Object.entries(collectRuntimeDeps(packageJson))) {
-        const existing = deps.get(name);
-        if (existing) {
-          if (existing.version !== version) {
-            continue;
-          }
-          if (!existing.pluginIds.includes(pluginId)) {
-            existing.pluginIds.push(pluginId);
-          }
+      packageJson = readJsonFile(packageJsonPath);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `[postinstall] invalid bundled plugin manifest at ${packageJsonPath}: ${detail}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    for (const [name, version] of Object.entries(collectRuntimeDeps(packageJson))) {
+      assertSafeBundledRuntimeDependencySpec(name, version);
+      const existing = deps.get(name);
+      if (existing) {
+        if (existing.version !== version) {
           continue;
         }
-        deps.set(name, {
-          name,
-          version,
-          sentinelPath: dependencySentinelPath(name),
-          pluginIds: [pluginId],
-        });
+        if (!existing.pluginIds.includes(pluginId)) {
+          existing.pluginIds.push(pluginId);
+        }
+        continue;
       }
-    } catch {
-      // Ignore malformed plugin manifests; runtime will surface those separately.
+      deps.set(name, {
+        name,
+        version,
+        sentinelPath: dependencySentinelPath(name),
+        pluginIds: [pluginId],
+      });
     }
   }
 
@@ -506,9 +547,11 @@ function installBundledPluginRuntimeDeps(params) {
       shell: npmRunner.shell,
       windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
     });
+    if (result.error) {
+      throw result.error;
+    }
     if (result.status !== 0) {
-      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
-      throw new Error(output || "npm install failed");
+      throw new Error(`npm install failed (exit ${result.status ?? "unknown"})`);
     }
     params.log.log(
       `[postinstall] installed bundled plugin deps: ${params.missingSpecs.join(", ")}`,

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -416,7 +416,18 @@ function isSafeBundledRuntimeDependencySpec(spec) {
   ) {
     return false;
   }
-  if (normalized.includes("://") || normalized.startsWith("/") || normalized.startsWith("\\")) {
+  if (
+    normalized.includes("://") ||
+    normalized.startsWith("/") ||
+    normalized.startsWith("\\") ||
+    normalized === "." ||
+    normalized.startsWith("./") ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized === "~" ||
+    normalized.startsWith("~/") ||
+    /^[A-Za-z]:[\\/]/u.test(normalized)
+  ) {
     return false;
   }
   return true;

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // Runs after install to keep packaged dist safe and compatible.
-// Bundled extension runtime dependencies are extension-owned. Do not install
-// every bundled extension dependency during core package install unless the
-// legacy eager-install escape hatch is explicitly enabled; `openclaw doctor
-// --fix` owns the repair path for extensions that are actually used.
+// Bundled extension runtime dependencies are extension-owned, but packaged
+// installs still need them available up front because bootstrap, status, and
+// onboarding can touch bundled entries before `openclaw doctor --fix` has a
+// chance to repair anything. Source checkouts still skip this eager install and
+// rely on the workspace graph instead.
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
@@ -338,6 +339,7 @@ function dependencySentinelPath(depName) {
   return join("node_modules", ...depName.split("/"), "package.json");
 }
 
+const DISABLED_EAGER_BUNDLED_PLUGIN_DEPS_VALUES = new Set(["0", "false", "off"]);
 const KNOWN_NATIVE_PLATFORMS = new Set([
   "aix",
   "android",
@@ -479,7 +481,45 @@ export function createBundledRuntimeDependencyInstallArgs(missingSpecs) {
 }
 
 function shouldEagerInstallBundledPluginDeps(env = process.env) {
-  return env?.[EAGER_BUNDLED_PLUGIN_DEPS_ENV]?.trim() === "1";
+  const normalized = env?.[EAGER_BUNDLED_PLUGIN_DEPS_ENV]?.trim().toLowerCase();
+  return !normalized || !DISABLED_EAGER_BUNDLED_PLUGIN_DEPS_VALUES.has(normalized);
+}
+
+function installBundledPluginRuntimeDeps(params) {
+  const installEnv = createBundledRuntimeDependencyInstallEnv(params.env);
+  const npmRunner =
+    params.npmRunner ??
+    resolveNpmRunner({
+      env: installEnv,
+      execPath: params.execPath,
+      existsSync: params.existsSync,
+      platform: params.platform,
+      comSpec: params.comSpec,
+      npmArgs: createBundledRuntimeDependencyInstallArgs(params.missingSpecs),
+    });
+  try {
+    const result = params.spawnSync(npmRunner.command, npmRunner.args, {
+      cwd: params.packageRoot,
+      encoding: "utf8",
+      env: npmRunner.env ?? installEnv,
+      stdio: "pipe",
+      shell: npmRunner.shell,
+      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
+    });
+    if (result.status !== 0) {
+      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+      throw new Error(output || "npm install failed");
+    }
+    params.log.log(
+      `[postinstall] installed bundled plugin deps: ${params.missingSpecs.join(", ")}`,
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[postinstall] failed to install bundled plugin deps (${params.missingSpecs.join(", ")}): ${detail}`,
+      { cause: error },
+    );
+  }
 }
 
 export function applyBaileysEncryptedStreamFinishHotfix(params = {}) {
@@ -768,35 +808,18 @@ export function runBundledPluginPostinstall(params = {}) {
     return;
   }
 
-  try {
-    const installEnv = createBundledRuntimeDependencyInstallEnv(env);
-    const npmRunner =
-      params.npmRunner ??
-      resolveNpmRunner({
-        env: installEnv,
-        execPath: params.execPath,
-        existsSync: pathExists,
-        platform: params.platform,
-        comSpec: params.comSpec,
-        npmArgs: createBundledRuntimeDependencyInstallArgs(missingSpecs),
-      });
-    const result = spawn(npmRunner.command, npmRunner.args, {
-      cwd: packageRoot,
-      encoding: "utf8",
-      env: npmRunner.env ?? installEnv,
-      stdio: "pipe",
-      shell: npmRunner.shell,
-      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
-    });
-    if (result.status !== 0) {
-      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
-      throw new Error(output || "npm install failed");
-    }
-    log.log(`[postinstall] installed bundled plugin deps: ${missingSpecs.join(", ")}`);
-  } catch (e) {
-    // Non-fatal: gateway will surface the missing dep via doctor.
-    log.warn(`[postinstall] could not install bundled plugin deps: ${String(e)}`);
-  }
+  installBundledPluginRuntimeDeps({
+    env,
+    execPath: params.execPath,
+    existsSync: pathExists,
+    platform: params.platform,
+    comSpec: params.comSpec,
+    missingSpecs,
+    npmRunner: params.npmRunner,
+    packageRoot,
+    spawnSync: spawn,
+    log,
+  });
 
   applyBundledPluginRuntimeHotfixes({
     packageRoot,

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -25,6 +25,7 @@ import {
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import validRange from "semver/ranges/valid.js";
 import { resolveNpmRunner } from "./npm-runner.mjs";
 
 export const BUNDLED_PLUGIN_INSTALL_TARGETS = [];
@@ -403,34 +404,7 @@ function isSafeBundledRuntimeDependencySpec(spec) {
   if (!normalized) {
     return false;
   }
-  const lower = normalized.toLowerCase();
-  if (
-    lower.startsWith("file:") ||
-    lower.startsWith("link:") ||
-    lower.startsWith("workspace:") ||
-    lower.startsWith("git:") ||
-    lower.startsWith("git+") ||
-    lower.startsWith("ssh:") ||
-    lower.startsWith("http:") ||
-    lower.startsWith("https:")
-  ) {
-    return false;
-  }
-  if (
-    normalized.includes("://") ||
-    normalized.startsWith("/") ||
-    normalized.startsWith("\\") ||
-    normalized === "." ||
-    normalized.startsWith("./") ||
-    normalized === ".." ||
-    normalized.startsWith("../") ||
-    normalized === "~" ||
-    normalized.startsWith("~/") ||
-    /^[A-Za-z]:[\\/]/u.test(normalized)
-  ) {
-    return false;
-  }
-  return true;
+  return validRange(normalized) !== null;
 }
 
 function assertSafeBundledRuntimeDependencySpec(depName, spec) {

--- a/src/plugins/stage-bundled-plugin-runtime-deps.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime-deps.test.ts
@@ -30,6 +30,37 @@ type BaileysHotfixResult = {
 
 type PostinstallBundledPluginsModule = {
   applyBaileysEncryptedStreamFinishHotfix: (params?: BaileysHotfixParams) => BaileysHotfixResult;
+  runBundledPluginPostinstall: (params?: {
+    env?: NodeJS.ProcessEnv;
+    packageRoot?: string;
+    extensionsDir?: string;
+    spawnSync?: typeof import("node:child_process").spawnSync;
+    existsSync?: typeof fs.existsSync;
+    readFileSync?: typeof fs.readFileSync;
+    readdirSync?: typeof fs.readdirSync;
+    rmSync?: typeof fs.rmSync;
+    mkdirSync?: typeof fs.mkdirSync;
+    writeFileSync?: typeof fs.writeFileSync;
+    runtimeDeps?: Array<{
+      name: string;
+      version: string;
+      sentinelPath: string;
+      pluginIds: string[];
+    }>;
+    log?: { log: (message: string) => void; warn: (message: string) => void };
+    npmRunner?: {
+      command: string;
+      args: string[];
+      env?: NodeJS.ProcessEnv;
+      shell?: boolean;
+      windowsVerbatimArguments?: boolean;
+    };
+    execPath?: string;
+    platform?: NodeJS.Platform;
+    comSpec?: string;
+    arch?: string;
+    readJson?: (path: string) => Record<string, unknown>;
+  }) => void;
 };
 
 async function loadStageBundledPluginRuntimeDeps(): Promise<StageBundledPluginRuntimeDeps> {
@@ -297,6 +328,105 @@ describe("stageBundledPluginRuntimeDeps", () => {
     expect(installs[0]?.devDependencies).toBeUndefined();
     expect(installs[0]?.peerDependencies).toBeUndefined();
     expect(installs[0]?.peerDependenciesMeta).toBeUndefined();
+  });
+
+  it("eagerly installs bundled runtime deps by default for packaged installs", async () => {
+    const packageRoot = makeRepoRoot("openclaw-postinstall-packaged-");
+    writeRepoFile(
+      packageRoot,
+      "dist/postinstall-inventory.json",
+      `${JSON.stringify(["dist/extensions/feishu/package.json"], null, 2)}\n`,
+    );
+    writeRepoFile(
+      packageRoot,
+      "dist/extensions/feishu/package.json",
+      `${JSON.stringify({ dependencies: { "@larksuiteoapi/node-sdk": "^1.60.0" } }, null, 2)}\n`,
+    );
+
+    const { runBundledPluginPostinstall } = await loadPostinstallBundledPluginsModule();
+    const spawnCalls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+    const logs: string[] = [];
+
+    const spawnSync = ((command: string, ...rest: unknown[]) => {
+      const args = Array.isArray(rest[0]) ? [...rest[0]] : [];
+      const options = rest[1] as { cwd?: unknown } | undefined;
+      spawnCalls.push({
+        command,
+        args,
+        cwd: typeof options?.cwd === "string" ? options.cwd : undefined,
+      });
+      return { status: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) };
+    }) as typeof import("node:child_process").spawnSync;
+
+    runBundledPluginPostinstall({
+      packageRoot,
+      env: {},
+      npmRunner: {
+        command: "npm",
+        args: ["install", "--ignore-scripts", "@larksuiteoapi/node-sdk@^1.60.0"],
+      },
+      spawnSync,
+      log: {
+        log(message) {
+          logs.push(message);
+        },
+        warn(message) {
+          logs.push(message);
+        },
+      },
+    });
+
+    expect(spawnCalls).toEqual([
+      {
+        command: "npm",
+        args: ["install", "--ignore-scripts", "@larksuiteoapi/node-sdk@^1.60.0"],
+        cwd: packageRoot,
+      },
+    ]);
+    expect(logs).toContain(
+      "[postinstall] installed bundled plugin deps: @larksuiteoapi/node-sdk@^1.60.0",
+    );
+  });
+
+  it("supports disabling eager bundled runtime dep install with OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=0", async () => {
+    const packageRoot = makeRepoRoot("openclaw-postinstall-disabled-");
+    writeRepoFile(
+      packageRoot,
+      "dist/postinstall-inventory.json",
+      `${JSON.stringify(["dist/extensions/feishu/package.json"], null, 2)}\n`,
+    );
+    writeRepoFile(
+      packageRoot,
+      "dist/extensions/feishu/package.json",
+      `${JSON.stringify({ dependencies: { "@larksuiteoapi/node-sdk": "^1.60.0" } }, null, 2)}\n`,
+    );
+
+    const { runBundledPluginPostinstall } = await loadPostinstallBundledPluginsModule();
+    let spawned = false;
+
+    const spawnSync = ((..._args: unknown[]) => {
+      spawned = true;
+      return {
+        status: 0,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        pid: 1,
+        output: [null, Buffer.alloc(0), Buffer.alloc(0)],
+        signal: null,
+      };
+    }) as unknown as typeof import("node:child_process").spawnSync;
+
+    runBundledPluginPostinstall({
+      packageRoot,
+      env: { OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "0" },
+      spawnSync,
+      log: {
+        log() {},
+        warn() {},
+      },
+    });
+
+    expect(spawned).toBe(false);
   });
 
   it("patches installed Baileys encryptedStream flush ordering for shipped runtime deps", async () => {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -736,8 +736,55 @@ describe("bundled plugin postinstall", () => {
         log: { log: vi.fn(), warn: vi.fn() },
       }),
     ).toThrow(
-      "[postinstall] failed to install bundled plugin deps (grammy@1.38.4): network unavailable",
+      "[postinstall] failed to install bundled plugin deps (grammy@1.38.4): npm install failed (exit 1)",
     );
+  });
+
+  it("surfaces spawn errors from bundled runtime dep installation", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "telegram", {
+      dependencies: {
+        grammy: "1.38.4",
+      },
+    });
+    const spawnError = new Error("spawn npm ENOENT");
+    const spawnSync = vi.fn(() => ({ status: null, error: spawnError, stderr: "", stdout: "" }));
+
+    expect(() =>
+      runBundledPluginPostinstall({
+        env: { HOME: "/tmp/home" },
+        extensionsDir,
+        packageRoot,
+        npmRunner: createBareNpmRunner(["grammy@1.38.4"]),
+        spawnSync,
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).toThrow(
+      "[postinstall] failed to install bundled plugin deps (grammy@1.38.4): spawn npm ENOENT",
+    );
+  });
+
+  it("rejects unsafe bundled runtime dependency specifiers before install", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "telegram", {
+      dependencies: {
+        grammy: "file:../../tmp/grammy.tgz",
+      },
+    });
+    const spawnSync = vi.fn();
+
+    expect(() =>
+      runBundledPluginPostinstall({
+        env: { HOME: "/tmp/home" },
+        extensionsDir,
+        packageRoot,
+        spawnSync,
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).toThrow("unsafe bundled runtime dependency spec for grammy: file:../../tmp/grammy.tgz");
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("prunes only bundled plugin package node_modules in source checkouts", async () => {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -765,12 +765,18 @@ describe("bundled plugin postinstall", () => {
     );
   });
 
-  it("rejects unsafe bundled runtime dependency specifiers before install", async () => {
+  it.each([
+    "file:../../tmp/grammy.tgz",
+    "../tmp/grammy",
+    "./grammy",
+    "~/grammy",
+    "C:\\tmp\\grammy",
+  ])("rejects unsafe bundled runtime dependency specifier %s before install", async (spec) => {
     const extensionsDir = await createExtensionsDir();
     const packageRoot = path.dirname(path.dirname(extensionsDir));
     await writePluginPackage(extensionsDir, "telegram", {
       dependencies: {
-        grammy: "file:../../tmp/grammy.tgz",
+        grammy: spec,
       },
     });
     const spawnSync = vi.fn();
@@ -783,7 +789,7 @@ describe("bundled plugin postinstall", () => {
         spawnSync,
         log: { log: vi.fn(), warn: vi.fn() },
       }),
-    ).toThrow("unsafe bundled runtime dependency spec for grammy: file:../../tmp/grammy.tgz");
+    ).toThrow(`unsafe bundled runtime dependency spec for grammy: ${spec}`);
     expect(spawnSync).not.toHaveBeenCalled();
   });
 

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -151,7 +151,7 @@ describe("bundled plugin postinstall", () => {
     });
   });
 
-  it("does not install bundled plugin deps outside of source checkouts by default", async () => {
+  it("installs bundled plugin deps outside of source checkouts by default", async () => {
     const extensionsDir = await createExtensionsDir();
     const packageRoot = path.dirname(path.dirname(extensionsDir));
     await writePluginPackage(extensionsDir, "acpx", {
@@ -159,7 +159,7 @@ describe("bundled plugin postinstall", () => {
         acpx: "0.4.1",
       },
     });
-    const spawnSync = vi.fn();
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 
     runBundledPluginPostinstall({
       env: { HOME: "/tmp/home" },
@@ -170,7 +170,7 @@ describe("bundled plugin postinstall", () => {
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(spawnSync).not.toHaveBeenCalled();
+    expectNpmInstallSpawn(spawnSync, packageRoot, ["acpx@0.4.1"]);
   });
 
   it("prunes source-checkout bundled plugin node_modules", async () => {
@@ -714,6 +714,30 @@ describe("bundled plugin postinstall", () => {
     });
 
     expectNpmInstallSpawn(spawnSync, packageRoot, ["grammy@1.38.4"]);
+  });
+
+  it("fails packaged install when bundled runtime dep installation fails", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "telegram", {
+      dependencies: {
+        grammy: "1.38.4",
+      },
+    });
+    const spawnSync = vi.fn(() => ({ status: 1, stderr: "network unavailable", stdout: "" }));
+
+    expect(() =>
+      runBundledPluginPostinstall({
+        env: { HOME: "/tmp/home" },
+        extensionsDir,
+        packageRoot,
+        npmRunner: createBareNpmRunner(["grammy@1.38.4"]),
+        spawnSync,
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).toThrow(
+      "[postinstall] failed to install bundled plugin deps (grammy@1.38.4): network unavailable",
+    );
   });
 
   it("prunes only bundled plugin package node_modules in source checkouts", async () => {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -771,6 +771,12 @@ describe("bundled plugin postinstall", () => {
     "./grammy",
     "~/grammy",
     "C:\\tmp\\grammy",
+    ".\\grammy",
+    "..\\grammy",
+    "C:tmp\\grammy",
+    "npm:evilpkg@1.0.0",
+    "github:user/repo",
+    "user/repo",
   ])("rejects unsafe bundled runtime dependency specifier %s before install", async (spec) => {
     const extensionsDir = await createExtensionsDir();
     const packageRoot = path.dirname(path.dirname(extensionsDir));


### PR DESCRIPTION
## Summary

- Problem: packaged installs could ship bundled channel/plugin entrypoints without their runtime dependencies installed, so bootstrap paths failed with `Cannot find module ...` before `openclaw doctor --fix` could help.
- Why it matters: fresh installs and updates could look successful while `openclaw status`, onboarding, or bundled channel entry loading immediately crashed.
- What changed: packaged postinstall now eagerly installs bundled plugin runtime dependencies by default, and packaged installs fail fast if that nested install fails.
- What did NOT change (scope boundary): source checkouts still skip eager bundled-runtime installation, and this PR does not change the config-recovery half of #70096.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #70008
- Closes #70093
- Closes #70099
- Related #70096
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: packaged installs excluded `dist/extensions/*/node_modules/**`, and normal postinstall runs skipped bundled runtime dependency installation unless an eager-install env var was set.
- Missing detection / guardrail: user installs did not fail when the nested install path failed, so packaged installs could silently continue with missing bundled runtime deps.
- Contributing context (if known): release-check already forces eager install under a dedicated env flag, which masked the mismatch between release validation and normal end-user installs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `test/scripts/postinstall-bundled-plugins.test.ts`
  - `src/plugins/stage-bundled-plugin-runtime-deps.test.ts`
- Scenario the test should lock in:
  - packaged installs eagerly install bundled runtime deps by default
  - packaged installs fail fast when that install step fails
  - explicit opt-out via `OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=0` still works
- Why this is the smallest reliable guardrail:
  - these tests exercise the actual postinstall decision boundary without needing a full publish/release lane.
- Existing test that already covers this (if any):
  - the packed install smoke and bundled channel entry smoke cover the installed layout verification path.
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- Fresh packaged installs and updates now install bundled plugin runtime deps by default.
- If that nested install fails, the packaged install now fails immediately with a clear postinstall error instead of warning and continuing into a broken runtime state.

## Diagram (if applicable)

```text
Before:
install package -> skip bundled runtime dep install by default -> bootstrap loads bundled entry -> Cannot find module

After:
install package -> install bundled runtime deps -> bundled entry loads successfully
               \-> install fails -> postinstall throws immediately
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Packaged install already runs postinstall. This change makes the bundled runtime dependency install path the default packaged-install behavior, using the existing npm runner and failing fast on errors instead of silently continuing.

## Repro + Verification

### Environment

- OS: macOS host verifying packaged tarball install
- Runtime/container: Node/npm packaged install smoke
- Model/provider: N/A
- Integration/channel (if any): bundled channel entry smoke (Feishu, Slack, Nostr, WhatsApp, Telegram, bundled diffs)
- Relevant config (redacted): none

### Steps

1. `pnpm test test/scripts/postinstall-bundled-plugins.test.ts src/plugins/stage-bundled-plugin-runtime-deps.test.ts`
2. `npm pack --ignore-scripts` then `npm install` the tarball into a temp prefix
3. Verify bundled runtime dep sentinels exist and run `node scripts/test-built-bundled-channel-entry-smoke.mjs --package-root <installed package root>`

### Expected

- packaged installs eagerly install bundled runtime deps
- packaged installs fail on nested bundled-runtime install failure
- bundled channel entry smoke passes from the installed layout

### Actual

- targeted tests pass
- real packed-install smoke passes
- bundled channel entry smoke passes from the installed package root

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test test/scripts/postinstall-bundled-plugins.test.ts src/plugins/stage-bundled-plugin-runtime-deps.test.ts`
  - packed tarball install now materializes bundled runtime dep sentinels for Feishu/Slack/Nostr/WhatsApp/Telegram/diffs deps
  - `OPENCLAW_DISABLE_BUNDLED_ENTRY_SOURCE_FALLBACK=1 node scripts/test-built-bundled-channel-entry-smoke.mjs --package-root <installed package root>` passes
- Edge cases checked:
  - explicit opt-out via `OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=0`
  - packaged install failure path now throws with context instead of warning and continuing
- What you did **not** verify:
  - full `pnpm check:changed` is still blocked on unrelated existing `tsgo:core:test` failures in `src/agents/pi-embedded-runner/*`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - `OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=0|false|off` now explicitly disables the default eager packaged-install behavior.

## Risks and Mitigations

- Risk: offline/air-gapped installs that cannot reach the registry now fail during packaged postinstall instead of appearing successful.
  - Mitigation: this is intentional fail-fast behavior because bundled entrypoints are expected to work immediately after install; silent success left users in a broken runtime state.
