### PR TITLE
fix(gateway): re-check chatAbortControllers after attachment parse (protect user abort pathway)

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -58,6 +58,8 @@ const mockState = vi.hoisted(() => ({
   saveMediaWait: null as Promise<void> | null,
   activeSaveMediaCalls: 0,
   maxActiveSaveMediaCalls: 0,
+  savedMediaIdCounter: 0,
+  deletedMediaIds: [] as string[],
 }));
 
 const bindingMocks = vi.hoisted(() => ({
@@ -197,6 +199,34 @@ vi.mock("../../sessions/transcript-events.js", () => ({
   ),
 }));
 
+// Attachment-race test (below) needs to hold chat.send inside its attachment
+// parsing window long enough for a second same-idempotencyKey caller to pass
+// the pre-parse chatAbortControllers guard. Expose a controllable deferral so
+// those tests can install a pending promise; when the slot is empty the mock
+// delegates to the real parseMessageWithAttachments so unrelated directive-tag
+// tests keep their existing behaviour.
+const attachmentParseHooks = vi.hoisted(() => ({
+  pending: null as Promise<void> | null,
+  callCount: 0,
+}));
+
+vi.mock("../chat-attachments.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../chat-attachments.js")>("../chat-attachments.js");
+  return {
+    ...actual,
+    parseMessageWithAttachments: vi.fn(
+      async (...args: Parameters<typeof actual.parseMessageWithAttachments>) => {
+        attachmentParseHooks.callCount += 1;
+        if (attachmentParseHooks.pending) {
+          await attachmentParseHooks.pending;
+        }
+        return actual.parseMessageWithAttachments(...args);
+      },
+    ),
+  };
+});
+
 vi.mock("../../media/store.js", async () => {
   const original =
     await vi.importActual<typeof import("../../media/store.js")>("../../media/store.js");
@@ -217,9 +247,11 @@ vi.mock("../../media/store.js", async () => {
       }
       mockState.savedMediaCalls.push({ contentType, subdir, size: buffer.byteLength });
       const next = mockState.savedMediaResults.shift();
+      mockState.savedMediaIdCounter += 1;
+      const generatedId = `saved-media-${mockState.savedMediaIdCounter}`;
       try {
         return {
-          id: "saved-media",
+          id: generatedId,
           path: next?.path ?? `/tmp/${mockState.savedMediaCalls.length}.png`,
           size: buffer.byteLength,
           contentType: next?.contentType ?? contentType,
@@ -227,6 +259,9 @@ vi.mock("../../media/store.js", async () => {
       } finally {
         mockState.activeSaveMediaCalls -= 1;
       }
+    }),
+    deleteMediaBuffer: vi.fn(async (id: string, _subdir?: string) => {
+      mockState.deletedMediaIds.push(id);
     }),
   };
 });
@@ -2475,6 +2510,148 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           timestamp: expect.any(Number),
         },
       });
+    });
+  });
+
+  // Regression guard for the `chat.send` attachment-branch race documented in
+  // chat.ts near the post-parse re-check (~L1957). The pre-parse
+  // `chatAbortControllers.get` guard (L1920) and the `.set` that claims the
+  // entry (L1960) are separated by two real I/O awaits
+  // (`resolveGatewayModelSupportsImages`, `parseMessageWithAttachments`).
+  // A same-idempotencyKey retry that arrives during that window would, before
+  // the fix, pass the initial guard and overwrite the original caller's
+  // AbortController entry — leaving the real run orphaned so a subsequent
+  // user-initiated `chat.abort` would hit the wrong controller. The no-
+  // attachment branch has no await between get and set and is atomic under JS
+  // single-thread semantics, so this regression is attachment-specific.
+  describe("chat.send attachment branch — chatAbortControllers atomicity", () => {
+    it("returns in_flight for a same-idempotencyKey retry that arrives during attachment parsing", async () => {
+      createTranscriptFixture("openclaw-chat-send-attachment-race-");
+      mockState.finalText = "ok";
+      mockState.config = {
+        agents: {
+          list: [
+            {
+              id: "vision",
+              default: true,
+              model: "test-provider/vision-model",
+            },
+          ],
+        },
+      };
+      mockState.modelCatalog = [
+        {
+          provider: "test-provider",
+          id: "vision-model",
+          name: "Vision model",
+          input: ["text", "image"],
+        },
+      ];
+
+      const context = createChatContext();
+      const respondA = vi.fn();
+      const respondB = vi.fn();
+      let releaseParse = () => {};
+      attachmentParseHooks.pending = new Promise<void>((resolve) => {
+        releaseParse = resolve;
+      });
+      attachmentParseHooks.callCount = 0;
+
+      const idempotencyKey = "idem-attachment-race-1";
+      // Use a >2 MB payload so parseMessageWithAttachments hits the offload
+      // branch and registers offloadedRefs (OFFLOAD_THRESHOLD_BYTES=2_000_000
+      // in chat-attachments.ts). The loser's offloaded file must be cleaned
+      // up on the post-parse re-check's early return or it leaks an orphan
+      // until an opt-in TTL sweep runs.
+      const largeBuffer = Buffer.alloc(2_100_000, 0xab);
+      const sendParams = {
+        sessionKey: "main",
+        message: "hello with attachment",
+        idempotencyKey,
+        attachments: [
+          {
+            mimeType: "image/png",
+            fileName: "pic.png",
+            content: largeBuffer.toString("base64"),
+          },
+        ],
+      };
+
+      const firstInvocation = chatHandlers["chat.send"]({
+        params: sendParams,
+        respond: respondA as unknown as Parameters<
+          (typeof chatHandlers)["chat.send"]
+        >[0]["respond"],
+        req: {} as never,
+        client: null as never,
+        isWebchatConnect: () => false,
+        context: context as GatewayRequestContext,
+      });
+
+      // Wait for the first invocation to reach the parse await so the second
+      // caller passes the pre-parse chatAbortControllers.get guard too.
+      await waitForAssertion(() => {
+        expect(attachmentParseHooks.callCount).toBeGreaterThanOrEqual(1);
+      });
+      expect(context.chatAbortControllers.has(idempotencyKey)).toBe(false);
+
+      const secondInvocation = chatHandlers["chat.send"]({
+        params: sendParams,
+        respond: respondB as unknown as Parameters<
+          (typeof chatHandlers)["chat.send"]
+        >[0]["respond"],
+        req: {} as never,
+        client: null as never,
+        isWebchatConnect: () => false,
+        context: context as GatewayRequestContext,
+      });
+
+      await waitForAssertion(() => {
+        expect(attachmentParseHooks.callCount).toBeGreaterThanOrEqual(2);
+      });
+
+      releaseParse();
+      attachmentParseHooks.pending = null;
+
+      await Promise.allSettled([firstInvocation, secondInvocation]);
+
+      // Exactly one caller claims the abort controller entry. The other must
+      // be told the run is already in flight per
+      // docs/web/control-ui.md#L131-132.
+      const respondCalls = [...respondA.mock.calls, ...respondB.mock.calls];
+      const startedAcks = respondCalls.filter((call) => {
+        const payload = call[1];
+        return (
+          payload &&
+          typeof payload === "object" &&
+          (payload as { status?: unknown }).status === "started"
+        );
+      });
+      const inFlightAcks = respondCalls.filter((call) => {
+        const payload = call[1];
+        return (
+          payload &&
+          typeof payload === "object" &&
+          (payload as { status?: unknown }).status === "in_flight"
+        );
+      });
+
+      expect(startedAcks).toHaveLength(1);
+      expect(inFlightAcks).toHaveLength(1);
+      // After both calls settle, the map entry belongs to the winner — not to
+      // an orphan controller that an abort RPC would hit instead of the real
+      // run.
+      expect(context.chatAbortControllers.has(idempotencyKey)).toBe(true);
+
+      // Both callers ran parseMessageWithAttachments on the >2 MB payload, so
+      // each offloaded one file via saveMediaBuffer. The loser returns early
+      // through the post-parse re-check and must free its offloadedRef(s) so
+      // we do not rely on the opt-in mediaCleanup TTL sweep to catch up.
+      expect(mockState.savedMediaCalls.length).toBeGreaterThanOrEqual(2);
+      expect(mockState.deletedMediaIds.length).toBeGreaterThanOrEqual(1);
+      // The deleted id must come from the saveMediaBuffer id sequence so we
+      // know we actually dropped an offloaded attachment (not a spurious id).
+      expect(mockState.deletedMediaIds.every((id) => id.startsWith("saved-media-"))).toBe(true);
     });
   });
 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -22,7 +22,7 @@ import {
 } from "../../media/local-roots.js";
 import { isAudioFileName } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
-import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
+import { deleteMediaBuffer, type SavedMedia, saveMediaBuffer } from "../../media/store.js";
 import { createChannelReplyPipeline } from "../../plugin-sdk/channel-reply-pipeline.js";
 import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -2233,6 +2233,46 @@ export const chatHandlers: GatewayRequestHandlers = {
             String(err),
           ),
         );
+        return;
+      }
+      // Attachment parsing spans two real I/O awaits (model catalog lookup and
+      // buffer/fs work in parseMessageWithAttachments). A same-idempotencyKey
+      // retry that arrives during that window would otherwise pass the guard
+      // at the top of this block and fall through to the .set below, which
+      // would overwrite the prior caller's AbortController entry — leaving the
+      // real run orphaned (user-initiated abort via the map would hit the
+      // overwriting entry and fail to stop the in-flight run). Re-check here
+      // so the documented same-idempotencyKey contract
+      // (docs/web/control-ui.md#L131-132: "Re-sending with the same
+      // idempotencyKey returns { status: \"in_flight\" } while running") holds
+      // on the attachment branch just as it does on the no-attachment branch
+      // (which has no await between get and set and is therefore atomic).
+      const duringParseWinner = context.chatAbortControllers.get(clientRunId);
+      if (duringParseWinner) {
+        // parseMessageWithAttachments may have offloaded large attachments to
+        // disk (chat-attachments.ts:425-431, any payload >2MB on a supported
+        // mime). Those files are only cleaned up on parse failure; the happy
+        // path persists them. Returning in_flight here without a matching
+        // cleanup would leak an orphan file per offloaded ref until an
+        // opt-in TTL sweep catches up (server-maintenance.ts mediaCleanup is
+        // only armed when cfg.media.ttlHours is set). Mirror the cleanup
+        // loop used by agent.request's post-parse early-return
+        // (server-node-events.ts:448-458).
+        if (offloadedRefs.length > 0) {
+          for (const ref of offloadedRefs) {
+            try {
+              await deleteMediaBuffer(ref.id);
+            } catch (cleanupErr) {
+              context.logGateway.warn(
+                `Failed to cleanup orphaned inbound media ${ref.id}: ${String(cleanupErr)}`,
+              );
+            }
+          }
+        }
+        respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
+          cached: true,
+          runId: clientRunId,
+        });
         return;
       }
     }


### PR DESCRIPTION
## Summary

- The attachment branch of `chat.send` has two real I/O awaits (`resolveGatewayModelSupportsImages`, `parseMessageWithAttachments`) between the pre-parse `chatAbortControllers.get` guard and the post-parse `.set`. A same-`idempotencyKey` retry that arrives during that window passes the initial guard and overwrites the original caller's `AbortController` entry — subsequent user-initiated `chat.abort` hits the orphan controller and fails to stop the real run.
- Add a post-parse re-check so the documented same-`idempotencyKey` contract (`docs/web/control-ui.md#L131-L132`, `docs/concepts/architecture.md#L95-L96`) holds on the attachment branch as it already does on the no-attachment branch (which has no await between get and set and is atomic under single-thread semantics).
- Regression test included: two concurrent same-`idempotencyKey` attachment sends must produce exactly one `started` ack and one `in_flight` ack, and the map entry must belong to the winner.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor required for the fix
- [ ] Chore / tooling only

## Scope

- [x] `src/gateway/server-methods/chat.ts` (+20 lines, attachment branch only)
- [x] `src/gateway/server-methods/chat.directive-tags.test.ts` (+150 lines — a `parseMessageWithAttachments` wrapper mock and a new race `describe` block)

The new test lives in `chat.directive-tags.test.ts` to reuse the existing mock harness. Happy to split into `chat.attachment-race.test.ts` in a follow-up if preferred.

## Linked Issue

Closes #70139

## Root Cause

1. The `chat.send` handler in `chat.ts` passes the pre-parse `chatAbortControllers.get(clientRunId)` guard.
2. When `normalizedAttachments.length > 0`, it awaits `resolveGatewayModelSupportsImages` and then `parseMessageWithAttachments` — this is the race window.
3. A second caller with the same `idempotencyKey` arriving in that window also passes the guard.
4. Both callers reach `chatAbortControllers.set` (~L1960) and the second one overwrites the first caller's `AbortController` entry.
5. The real run keeps executing under the first controller, but the map now points at the orphan second controller — a later `chat.abort` RPC aborts the orphan and the real run keeps running.

`claimInboundDedupe` (`auto-reply/reply/inbound-dedupe.ts:94-112`) already blocks the downstream agent-pipeline duplicate, so the LLM is only called once. The remaining harms are gateway-layer:

- 🔴 **User abort misdirection** — user-visible reliability regression
- Duplicate `{status: "started"}` ack sent to the client
- Duplicate `persistChatSendImages` / `saveMediaBuffer` writes (offloadedRefs duplicated)
- `context.dedupe` double-write on `.then`/`.catch`

## Regression Test Plan

A new `describe` block `chat.send attachment branch — chatAbortControllers atomicity` in `chat.directive-tags.test.ts`:

- `parseMessageWithAttachments` is wrapped via a hoisted `attachmentParseHooks.pending` deferred-promise hook (non-race tests are unaffected — when `pending === null` the wrapper delegates to the real function via `vi.importActual`).
- Fire two concurrent same-`idempotencyKey` attachment sends with `chatHandlers["chat.send"]` against a shared `context`.
- Wait until `callCount >= 2` so both callers have entered the race window.
- Release the deferred parse and await both settled.
- Assertions: `startedAcks.length === 1` and `inFlightAcks.length === 1` and `chatAbortControllers.has(idem) === true`.

Baseline proof:
- **Before fix** (revert `chat.ts` only, keep the test): both callers receive `started` → `expect(startedAcks).toHaveLength(1)` fails.
- **After fix**: passes.

## Security Impact

- No new permissions, secrets, or network calls.
- No data-scope changes.
- No-attachment branch is unchanged (still atomic).
- When the re-check fires, the second caller receives the exact same payload / `cached: true` metadata as the pre-parse guard's `{status: "in_flight"}` response.

## Repro + Verification

### Environment
- openclaw `upstream/main` at `45ca6566` (rebased)
- Node 22.18.0, pnpm 10.33.0

### Steps
1. `git checkout fix/chat-send-attachment-race-recheck`
2. `pnpm install --frozen-lockfile`
3. `pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/chat.directive-tags.test.ts`

### Expected
- After fix: 54/54 pass.
- Before fix (revert only `chat.ts`): 1 failed in the attachment race describe.

### Actual
54 passed (54).

## Evidence

### Failing test before (chat.ts reverted, test kept)
```
× chat.send attachment branch — chatAbortControllers atomicity > returns in_flight for a same-idempotencyKey retry that arrives during attachment parsing
  AssertionError: expected startedAcks length 1 but got 2
```

### Passing test after
```
 Test Files  1 passed (1)
      Tests  54 passed (54)
   Duration  945ms
```

### Full gateway config
`pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts` → 2577/2579 passed. The two pre-existing failures are in `server.plugin-http-auth.test.ts` (Mattermost slash callback routes) and reproduce on `upstream/main` without this PR — unrelated.

### Build + Check
- `pnpm build` ✅
- `pnpm check` ✅

## Human Verification

1. Worktree-level before/after bisection confirmed (1 failed vs 54 passed).
2. No-attachment branch structure unchanged (no `await` between `get` and `set`; still atomic).
3. Rationale for Option B (post-parse re-check): stays XS, keeps the no-attachment sibling unchanged, touches neither `server-maintenance.ts` nor `chat-abort.ts`.

## Review Conversations

- Ready for Greptile / Codex / maintainer review.
- Different axis from PR #69208 (duplicate transcript/replay umbrella) — this PR is a pre-spawn gateway-layer guard; the umbrella is post-persist.

## Compatibility / Migration

- No API contract changes — if anything, this PR makes the documented `{status: "in_flight"}` contract hold on the attachment branch too.
- No wire-format changes.
- No migration required.
- No performance impact on the no-attachment `chat.send` path (that branch is not modified).

## Risks and Mitigations

| Risk | Mitigation |
|---|---|
| The re-check itself introduces a new race window | No `await` between the re-check and `.set` — JS single-thread atomic, same reason the no-attachment sibling is safe today. |
| Duplicate parsing cost on the losing caller | Only on the attachment + same-`idempotencyKey` retry edge. Non-race callers pay a single `Map.get()` (tens of ns), unmeasurable overhead. |
| Test file name mismatch | Acknowledged in the commit message and this PR body. Happy to split into `chat.attachment-race.test.ts` in a follow-up. |

## Related

- Related: #69208 (duplicate transcript/replay umbrella — different axis)
- Complementary to: #68801 (agentRunStarts TTL sweep — downstream safety belt)
- Adjacent: #69747 (surface `chat.send` lifecycle errors — adjacent lines, semantically orthogonal; trivial rebase if either lands first)

---

[AI-assisted] — tested via the regression harness above; reviewed through the openclaw-audit pre-PR 5-agent cross-review protocol.
