### PR TITLE
fix(telegram): lower webhook callback timeout to 5s to prevent Telegram read timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/webhooks: lower the grammY webhook callback timeout to 5s so Telegram gets an early 200 response instead of retrying long-running updates as read timeouts. (#70146) Thanks @friday-james.
 - Telegram/polling: rebuild the polling HTTP transport after `getUpdates` 409 conflicts, so retries use a fresh TCP connection instead of looping on a Telegram-terminated keep-alive socket. (#69873) Thanks @hclsys.
 - Slack/files: resolve `downloadFile` bot tokens from the runtime config when callers provide `cfg` without an explicit token or prebuilt client, preserving cfg-only file downloads outside the action runtime path. (#70160) Thanks @martingarramon.
 - Slack/HTTP: dispatch registered Request URL webhooks through the same handler registry used by Slack monitor setup, so HTTP-mode Slack events no longer 404 after successful route registration. (#70275) Thanks @FroeMic.

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -455,7 +455,7 @@ describe("startTelegramWebhook", () => {
           {
             secretToken: TELEGRAM_SECRET,
             onTimeout: "return",
-            timeoutMilliseconds: 10_000,
+            timeoutMilliseconds: 5_000,
           },
         );
         expect(runtimeLog).toHaveBeenCalledWith(

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -28,6 +28,7 @@ import { createTelegramBot } from "./bot.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+// Keep below Telegram/proxy read timeouts; grammY returns early while the handler continues.
 const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 5_000;
 const InputFileCtor: typeof grammy.InputFile =
   typeof grammy.InputFile === "function"

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -28,7 +28,7 @@ import { createTelegramBot } from "./bot.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
-const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 10_000;
+const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 5_000;
 const InputFileCtor: typeof grammy.InputFile =
   typeof grammy.InputFile === "function"
     ? grammy.InputFile


### PR DESCRIPTION
## Problem

Telegram webhook deliveries to OpenClaw in webhook mode intermittently fail with `last_error_message: "Read timeout expired"` and `pending_update_count > 0` in `getWebhookInfo`, even with `onTimeout: "return"` in place from #16763.

The cause: #16763 set `timeoutMilliseconds: 10_000`, which is grammY's default. Telegram's webhook servers abort the read well before 10s when handler latency is LLM-bound (OpenAI/Anthropic p95 of 2-10s). The gateway keeps the socket open for the full 10s window while `bot.handleUpdate()` runs, Telegram's read times out mid-flight, the update re-queues as pending, and retries cascade into multi-minute reply delays or no reply at all.

## Evidence

Reproducible A/B test on identical container infra, same region, same Telegram bot token:

- **Minimal Python echo bot** (stdlib `http.server`, ~88 lines, acks 200 immediately): 5 back-to-back webhook round trips 341-642ms, `getWebhookInfo` clean, no pending updates.
- **OpenClaw current `main`**: intermittent `Read timeout expired`, pending updates accumulate, 1-5 min reply latency.

Only variable is the application. The existing `onTimeout: "return"` change ensures 200 OK is eventually sent, but only after the 10s window — by which point Telegram has already given up on the socket.

Related open issues:
- #57403 — 429 rate limit causes Telegram webhook timeout and message re-delivery
- #59113 — inbound message duplication under slow webhook responses

## Fix

Lower `TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS` from `10_000` to `5_000`. grammY will reply 200 OK to Telegram after at most 5 seconds while `bot.handleUpdate()` continues processing in the background — exactly what #16763 established, just with a tighter window that fits inside Telegram's observed read tolerance.

5s is the value suggested in [grammY's webhook deployment guide](https://grammy.dev/guide/deployment-types) for long-running handlers.

No new config surface, no behavioral change beyond the constant. The handler still runs to completion; only the Telegram-facing ack is sooner.

## Testing

- Updated the `webhook.test.ts` assertion that already pins `webhookCallback` options to reflect `timeoutMilliseconds: 5_000`.
- Verified end-to-end against a live deploy: after patching, `getWebhookInfo` stays clean under the same load that previously produced `Read timeout expired`.
- Broadly applicable to any grammY-based Telegram bot where handlers may exceed a few seconds (LLM calls, external APIs, etc.).

## Follow-ups (out of scope here)

If a configurable timeout is wanted, the stale #7754 had a proposal — can revisit as a follow-up. Keeping this PR to the minimum diff.