### PR TITLE
fix(gateway): fire before_tool_call hook on loopback MCP tools/call

### DIFF
--- a/src/gateway/mcp-http.handlers.test.ts
+++ b/src/gateway/mcp-http.handlers.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
+
+const callGatewayTool = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/tools/gateway.js", () => ({
+  callGatewayTool,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  callGatewayTool.mockReset();
+  resetGlobalHookRunner();
+});
+
+describe("handleMcpJsonRpc tools/call", () => {
+  it("invokes registered before_tool_call hook and blocks on approval", async () => {
+    let hookCalls = 0;
+    const execute = vi.fn().mockResolvedValue({ content: "should not dispatch" });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          handler: async () => {
+            hookCalls += 1;
+            return {
+              requireApproval: {
+                pluginId: "test-plugin",
+                title: "Approval required",
+                description: "Approval required",
+              },
+            };
+          },
+        },
+      ]),
+    );
+    callGatewayTool.mockRejectedValueOnce(new Error("gateway unavailable"));
+    const tool = {
+      name: "memory_store",
+      description: "Store memory",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const result = (await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "memory_store", arguments: { text: "hello" } },
+      },
+      tools: [tool],
+      toolSchema: [],
+    })) as { result: { content: Array<{ type: string; text: string }>; isError: boolean } };
+
+    expect(hookCalls).toBe(1);
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content).toEqual([expect.objectContaining({ type: "text" })]);
+    expect(result.result.content[0].text).toMatch(/approval/i);
+  });
+
+  it("dispatches tool.execute normally when no hooks are registered", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const tool = {
+      name: "plain_tool",
+      description: "Plain tool",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const result = (await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "plain_tool", arguments: {} },
+      },
+      tools: [tool],
+      toolSchema: [],
+    })) as { result: { content: Array<{ type: string; text: string }>; isError: boolean } };
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.result.isError).toBe(false);
+    expect(result.result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("passes through allowed calls when before_tool_call returns no block", async () => {
+    let hookCalls = 0;
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "dispatched" }],
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          handler: async () => {
+            hookCalls += 1;
+            return {}; // no block, no params rewrite
+          },
+        },
+      ]),
+    );
+    const tool = {
+      name: "plain_tool",
+      description: "Plain tool",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const result = (await handleMcpJsonRpc({
+      message: {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "plain_tool", arguments: {} },
+      },
+      tools: [tool],
+      toolSchema: [],
+    })) as { result: { content: Array<{ type: string; text: string }>; isError: boolean } };
+
+    expect(hookCalls).toBe(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.result.isError).toBe(false);
+    expect(result.result.content).toEqual([{ type: "text", text: "dispatched" }]);
+  });
+});

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -1,4 +1,8 @@
 import crypto from "node:crypto";
+import {
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "../agents/pi-tools.before-tool-call.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   MCP_LOOPBACK_SERVER_NAME,
@@ -69,8 +73,17 @@ export async function handleMcpJsonRpc(params: {
         });
       }
       const toolCallId = `mcp-${crypto.randomUUID()}`;
+      // Run the same pre-execution hook boundary as the agent and HTTP
+      // tool-invoke paths, so plugins that register `before_tool_call`
+      // (for policy, approval, rewriting params, etc.) also see tool
+      // invocations coming in through the loopback MCP bridge. Without
+      // this wrap, plugin-registered tools dispatched to Claude Code /
+      // Codex / other MCP clients via this server skip hooks entirely.
+      const wrappedTool = isToolWrappedWithBeforeToolCallHook(tool)
+        ? tool
+        : wrapToolWithBeforeToolCallHook(tool);
       try {
-        const result = await tool.execute(toolCallId, toolArgs);
+        const result = await wrappedTool.execute(toolCallId, toolArgs);
         return jsonRpcResult(id, {
           content: normalizeToolCallContent(result),
           isError: false,


### PR DESCRIPTION
## Summary

The loopback MCP handler at [`src/gateway/mcp-http.handlers.ts`](src/gateway/mcp-http.handlers.ts) calls `tool.execute(...)` directly, skipping the `before_tool_call` hook wrap that both the agent path and the ACPX MCP bridge apply. Plugins that register `before_tool_call` (for policy, approval gates, or parameter rewriting) see those hooks fire for some dispatch paths but not others — specifically, any tool invoked through the loopback MCP bridge (what `openclaw agent --local` exposes to Claude Code / Codex / any MCP client via the `openclaw` server) skips hooks entirely.

Concretely:

| Dispatch path | File | `before_tool_call` fires? |
|---|---|---|
| Pi embedded agent | `src/agents/pi-tools.before-tool-call.ts` | ✅ |
| Gateway HTTP tool-invoke | `src/gateway/tools-invoke-http.ts:273` | ✅ |
| ACPX MCP bridge | `src/mcp/plugin-tools-handlers.ts:22-29` | ✅ |
| Loopback MCP `tools/call` | `src/gateway/mcp-http.handlers.ts:73` | ❌ (this PR) |

The practical effect: workflow-enforcement / guardrail plugins have their enforcement silently bypassed for tool calls dispatched via the loopback — the most common path for Claude Code users running `openclaw agent --local`.

## The fix

Apply the same idempotent-wrap pattern the ACPX bridge already uses, at the loopback's `tools/call` handler:

```ts
const wrappedTool = isToolWrappedWithBeforeToolCallHook(tool)
  ? tool
  : wrapToolWithBeforeToolCallHook(tool);
const result = await wrappedTool.execute(toolCallId, toolArgs);
```

One-file production change. `+14 / -1` in `mcp-http.handlers.ts`.

## Test plan

- [x] New `src/gateway/mcp-http.handlers.test.ts` — three scenarios mirroring `src/mcp/plugin-tools-serve.test.ts`:
  - `before_tool_call` blocks via `requireApproval` → `execute` not called, response surfaces approval reason as an `isError` result
  - No hooks registered → plain dispatch path, `execute` called once
  - Hook returns `{}` (no block, no params rewrite) → pass-through, `execute` called once
- [x] Existing `src/gateway/mcp-http.test.ts` (13 tests) passes
- [x] Existing `src/gateway/tools-invoke-http.test.ts` (23 tests) passes
- [x] `pnpm run lint` clean
- [x] `madge` import-cycle check clean (pre-commit hook)

## Why this matters beyond the specific bug

I hit this while building a workflow-enforcement plugin that registers `before_tool_call` to snap an agent back when it tries to deviate from a declared workflow graph. The plugin behaved correctly on the agent path and the HTTP tool-invoke path, but silently no-op'd for any tool dispatched to Claude Code via the loopback — even though `hasHooks("before_tool_call")` returned `true` and the registration was live. Tracking down this gap took roughly an hour of runtime diagnostics (adding `[HOOK-PROBE]` to the plugin, comparing loopback vs direct-MCP dispatch paths in the source) before the four-file `wrap`-symmetry story came into focus.

I have an equivalent gap in `src/agents/cli-runner/` for `runBeforePromptBuild` — plugin-provided `prependContext` / `prependSystemContext` don't propagate in the Claude CLI backend path (`runBeforePromptBuild` is only invoked from `src/agents/pi-embedded-runner/`). Happy to open a follow-up PR for that once this lands, since the fix shape is different (prompt construction rather than tool dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)