### PR TITLE
docs(channels): add QQvu (Pufferfish) channel page

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -212,6 +212,10 @@
     "target": "QQ Bot"
   },
   {
+    "source": "QQvu (Pufferfish)",
+    "target": "QQvu（Pufferfish）"
+  },
+  {
     "source": "Release Policy",
     "target": "发布策略"
   },

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -38,6 +38,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [WhatsApp](/channels/whatsapp) — Most popular; uses Baileys and requires QR pairing.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (bundled plugin).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (bundled plugin).
+- [QQvu (Pufferfish)](/channels/pufferfish) — External plugin for QQvu / Pufferfish IM.
 
 ## Notes
 

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -38,7 +38,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [WhatsApp](/channels/whatsapp) — Most popular; uses Baileys and requires QR pairing.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (bundled plugin).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (bundled plugin).
-- [QQvu (Pufferfish)](/channels/pufferfish) — External plugin for QQvu / Pufferfish IM.
+- [QQvu (Pufferfish)](/channels/qqvu) — External plugin for QQvu / Pufferfish IM.
 
 ## Notes
 

--- a/docs/channels/qqvu.md
+++ b/docs/channels/qqvu.md
@@ -1,0 +1,69 @@
+# QQvu
+
+## 快速开始
+ > Support OpenClaw 2026.4.15 / OpenClaw 2026.4.20. Run `openclaw -v` to check and use `openclaw update` to upgrade
+ 
+<Steps>
+    <step title="Configure the plugin">
+        ```bash
+            openclaw plugins install @qqvu/openclaw-channel
+        ```
+    </step>
+    <step title="Configure robots in openclaw.json">
+        Need to create a robot on the QQvu app now, directory: my --> Robot --> Create Robot, 
+        Copy the `UID` and `privateKey` of the robot, and replace the 【private key】 in the UID and 
+        privateKey of the following tags.
+        Here are examples of multiple robots.
+        ```bash
+                "pufferfish": {
+                  "bots":{
+                    "UID": {
+                      "privateKey": "-----BEGIN PRIVATE KEY-----\n【private key】\n-----END PRIVATE KEY-----\n",
+                      "enabled":true
+                    },
+                    "UID2": {
+                      "privateKey": "-----BEGIN PRIVATE KEY-----\n【private key】\n-----END PRIVATE KEY-----\n",
+                      "enabled":true
+                    }
+                  },
+                  "botProfilesByBotUid": {
+                    "UID": {
+                      "systemPrompt": "",
+                      "skills": []
+                    }
+                    "UID2": {
+                      "systemPrompt": "",
+                      "skills": []
+                    }
+                  }
+                }
+              },
+        ```
+        Before adding to `plugins` attribute
+        ----------------------------------------------------------------------
+        Add `skipBootsstrap` and `startupContext` to the agents tag
+        ```bash
+            {
+              "agents": {
+                "defaults": {
+                  "skipBootstrap": true,  // 👈增加
+                  "startupContext": {   // 👈增加
+                    "enabled": false
+                  }
+                }
+              }
+            }
+        ```
+    </step>
+    <step>
+        Enter the. openclaw/workspace and delete the BOOTSTRAP.md file
+    </step> 
+    <step title="Start OpenClaw">
+        Execute `openclaw gateway start`
+    </step>
+    <step title="Uninstalling plugins">
+        ···bash
+            openclaw plugins uninstall pufferfish-channel
+        ```
+    </step>
+</Steps>

--- a/docs/channels/qqvu.md
+++ b/docs/channels/qqvu.md
@@ -1,8 +1,9 @@
 # QQvu
 
 ## 快速开始
- > Support OpenClaw 2026.4.15 / OpenClaw 2026.4.20. Run `openclaw -v` to check and use `openclaw update` to upgrade
- 
+
+> Support OpenClaw 2026.4.15 / OpenClaw 2026.4.20. Run `openclaw -v` to check and use `openclaw update` to upgrade
+
 <Steps>
     <step title="Configure the plugin">
         ```bash
@@ -10,19 +11,19 @@
         ```
     </step>
     <step title="Configure robots in openclaw.json">
-        Need to create a robot on the QQvu app now, directory: my --> Robot --> Create Robot, 
-        Copy the `UID` and `privateKey` of the robot, and replace the 【private key】 in the UID and 
-        privateKey of the following tags.
+        Need to create a robot on the QQvu app now, directory: my --> Robot --> Create Robot,
+        Copy the `UID` and `privateKey` of the robot, and paste the key material into the UID's
+        `privateKey` field in the following example.
         Here are examples of multiple robots.
         ```bash
                 "pufferfish": {
                   "bots":{
                     "UID": {
-                      "privateKey": "-----BEGIN PRIVATE KEY-----\n【private key】\n-----END PRIVATE KEY-----\n",
+                      "privateKey": "<PASTE_YOUR_KEY_MATERIAL_HERE>",
                       "enabled":true
                     },
                     "UID2": {
-                      "privateKey": "-----BEGIN PRIVATE KEY-----\n【private key】\n-----END PRIVATE KEY-----\n",
+                      "privateKey": "<PASTE_YOUR_KEY_MATERIAL_HERE>",
                       "enabled":true
                     }
                   },
@@ -57,12 +58,12 @@
     </step>
     <step>
         Enter the. openclaw/workspace and delete the BOOTSTRAP.md file
-    </step> 
+    </step>
     <step title="Start OpenClaw">
         Execute `openclaw gateway start`
     </step>
     <step title="Uninstalling plugins">
-        ···bash
+        ```bash
             openclaw plugins uninstall pufferfish-channel
         ```
     </step>


### PR DESCRIPTION
## Summary
- Add QQvu (Pufferfish) external channel documentation page.
- Add entry to Channels index.

## Install
- `openclaw plugins install @qqvu/openclaw-channel`

## Security
- Document that `privateKey` is sensitive and must never be committed.