### PR TITLE
Avoid false empty-turn failures when the assistant reply lands late

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1,8 +1,14 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedLog,
@@ -357,6 +363,97 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("Please try again");
+  });
+
+  it("recovers a late assistant message from the session file before surfacing an empty-turn error", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-empty-turn-"));
+    const sessionFile = path.join(sessionDir, "session.jsonl");
+    const sessionManager = SessionManager.open(sessionFile);
+    const userMessage = {
+      role: "user",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "what model now?" }],
+    } as const satisfies AgentMessage;
+    const toolCallAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      api: "google-generative-ai",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: Date.now(),
+      content: [{ type: "toolCall", id: "call_1", name: "session_status", arguments: {} }],
+    } as const satisfies AgentMessage;
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "session_status",
+      isError: false,
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "current model: gemini-3-flash-preview" }],
+    } as const satisfies AgentMessage;
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      api: "google-generative-ai",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "I've shifted over to gemini-3-flash-preview now." }],
+    } as const satisfies AgentMessage;
+    sessionManager.appendMessage(userMessage);
+    sessionManager.appendMessage(toolCallAssistant);
+    sessionManager.appendMessage(toolResult);
+    sessionManager.appendMessage(finalAssistant);
+
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedBuildEmbeddedRunPayloads.mockImplementation((...args: unknown[]) => {
+      const params = args[0] as
+        | { lastAssistant?: { content?: Array<{ type?: string; text?: string }> } }
+        | undefined;
+      const text = params?.lastAssistant?.content?.find((part) => part.type === "text")?.text;
+      return text ? [{ text }] : [];
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        messagesSnapshot: [userMessage, toolCallAssistant, toolResult] as never,
+        lastAssistant: toolCallAssistant as never,
+        currentAttemptAssistant: toolCallAssistant as never,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      sessionFile,
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      runId: "run-empty-turn-late-assistant-recovery",
+    });
+
+    expect(result.payloads).toEqual([
+      {
+        text: "I've shifted over to gemini-3-flash-preview now.",
+      },
+    ]);
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("recovered late assistant turn after empty snapshot"),
+    );
   });
 
   it("does not retry reasoning-only turns for non-openai assistant metadata", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -188,6 +188,9 @@ export const mockedGetApiKeyForModel = vi.fn(
 );
 export const mockedResolveAuthProfileOrder = vi.fn(() => [] as string[]);
 export const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
+export const mockedBuildEmbeddedRunPayloads = vi.fn<
+  (...args: unknown[]) => Array<{ text?: string; isError?: boolean }>
+>((..._args: unknown[]) => []);
 
 export const overflowBaseRunParams = {
   sessionId: "test-session",
@@ -334,6 +337,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedResolveAuthProfileOrder.mockReturnValue([]);
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReset();
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReturnValue(false);
+  mockedBuildEmbeddedRunPayloads.mockReset();
+  mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
   mockedRunPostCompactionSideEffects.mockReset();
   mockedRunPostCompactionSideEffects.mockResolvedValue(undefined);
 }
@@ -505,7 +510,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   }));
 
   vi.doMock("./run/payloads.js", () => ({
-    buildEmbeddedRunPayloads: vi.fn(() => []),
+    buildEmbeddedRunPayloads: mockedBuildEmbeddedRunPayloads,
   }));
 
   vi.doMock("./compaction-hooks.js", () => ({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,8 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveContextEngine } from "../../context-engine/registry.js";
@@ -130,6 +133,8 @@ import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accum
 type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
+const EMPTY_RESPONSE_RECOVERY_POLL_MS = 750;
+const EMPTY_RESPONSE_RECOVERY_MAX_POLLS = 3;
 
 function buildTraceToolSummary(params: {
   toolMetas: Array<{ toolName: string; meta?: string }>;
@@ -153,6 +158,42 @@ function buildTraceToolSummary(params: {
     tools,
     failures: params.hadFailure ? 1 : 0,
   };
+}
+
+function readSessionMessages(sessionFile: string): AgentMessage[] {
+  return SessionManager.open(sessionFile)
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
+
+async function recoverLateAssistantFromSessionFile(params: {
+  sessionFile: string;
+  previousSnapshotLength: number;
+  abortSignal?: AbortSignal;
+}): Promise<AssistantMessage | undefined> {
+  let previousSnapshotLength = Math.max(0, params.previousSnapshotLength);
+
+  for (let poll = 0; poll < EMPTY_RESPONSE_RECOVERY_MAX_POLLS; poll += 1) {
+    if (poll > 0) {
+      await sleepWithAbort(EMPTY_RESPONSE_RECOVERY_POLL_MS, params.abortSignal);
+    }
+    const refreshedMessages = readSessionMessages(params.sessionFile);
+    if (refreshedMessages.length <= previousSnapshotLength) {
+      continue;
+    }
+    const lateAssistant = refreshedMessages
+      .slice(previousSnapshotLength)
+      .toReversed()
+      .find((message): message is AssistantMessage => message.role === "assistant");
+    previousSnapshotLength = refreshedMessages.length;
+    if (!lateAssistant || !resolveFinalAssistantVisibleText(lateAssistant)) {
+      continue;
+    }
+    return lateAssistant;
+  }
+
+  return undefined;
 }
 
 /**
@@ -764,7 +805,7 @@ export async function runEmbeddedPiAgent(
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
           });
 
-          const {
+          let {
             aborted,
             externalAbort,
             promptError,
@@ -777,6 +818,30 @@ export async function runEmbeddedPiAgent(
             lastAssistant: sessionLastAssistant,
             currentAttemptAssistant,
           } = attempt;
+          if (
+            attempt.assistantTexts.length === 0 &&
+            !aborted &&
+            !timedOut &&
+            !attempt.lastToolError &&
+            !attempt.clientToolCall &&
+            !attempt.yieldDetected &&
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !resolveFinalAssistantVisibleText(currentAttemptAssistant ?? sessionLastAssistant)
+          ) {
+            const recoveredAssistant = await recoverLateAssistantFromSessionFile({
+              sessionFile: params.sessionFile,
+              previousSnapshotLength: attempt.messagesSnapshot.length,
+              abortSignal: params.abortSignal,
+            });
+            if (recoveredAssistant) {
+              sessionLastAssistant = recoveredAssistant;
+              currentAttemptAssistant ??= recoveredAssistant;
+              log.warn(
+                `recovered late assistant turn after empty snapshot: runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `provider=${recoveredAssistant.provider ?? provider}/${recoveredAssistant.model ?? modelId}`,
+              );
+            }
+          }
           bootstrapPromptWarningSignaturesSeen =
             attempt.bootstrapPromptWarningSignaturesSeen ??
             (attempt.bootstrapPromptWarningSignature
@@ -1615,7 +1680,7 @@ export async function runEmbeddedPiAgent(
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
+            lastAssistant: sessionLastAssistant,
             lastToolError: attempt.lastToolError,
             config: params.config,
             isCronTrigger: params.trigger === "cron",


### PR DESCRIPTION
This fixes a race in the embedded runner where OpenClaw can conclude a turn produced no payloads even though a valid assistant reply is written to the session moments later.

In the failure we investigated, the session transcript already contained a normal final assistant message, but the runner still surfaced `incomplete turn detected ... payloads=0` to the user. The problem was that the terminal empty-turn path was making its decision from a stale snapshot and then building payloads from the stale assistant reference.

What changed:
- before surfacing an empty-turn error, the runner now does a short recovery poll against the persisted session to see whether a late assistant message has arrived
- if recovery succeeds, payload construction uses the refreshed assistant message rather than the stale per-attempt assistant
- a regression test covers the exact stale-snapshot / late-assistant case

Testing:
- `npm test -- --run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- `npm run build`