### PR TITLE
fix(auto-reply): persist CLI turn transcript after successful reply

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -11,6 +11,7 @@ import {
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
+import { persistCliTurnTranscript } from "../../agents/command/attempt-execution.runtime.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -934,6 +935,34 @@ export async function runAgentTurnWithFallback(params: {
                     stream: "assistant",
                     data: { text: cliText },
                   });
+                }
+
+                // Persist the user+assistant turn into the session transcript so
+                // that later turns have the conversation history available when
+                // Claude CLI rotates its own session file. The CLI branch inside
+                // agent-command.ts already does this for direct agent invocations;
+                // the auto-reply path bypasses agent-command by calling runCliAgent
+                // directly, so we mirror the same persist call here.
+                const persistSessionKey = params.sessionKey ?? params.followupRun.run.sessionId;
+                try {
+                  const persistedEntry = await persistCliTurnTranscript({
+                    body: params.commandBody,
+                    result,
+                    sessionId: params.followupRun.run.sessionId,
+                    sessionKey: persistSessionKey,
+                    sessionEntry: params.getActiveSessionEntry(),
+                    sessionStore: params.activeSessionStore,
+                    storePath: params.storePath,
+                    sessionAgentId: params.followupRun.run.agentId,
+                    sessionCwd: params.followupRun.run.workspaceDir,
+                  });
+                  if (persistedEntry && params.activeSessionStore && params.sessionKey) {
+                    params.activeSessionStore[params.sessionKey] = persistedEntry;
+                  }
+                } catch (error) {
+                  logVerbose(
+                    `CLI transcript persistence failed for ${persistSessionKey}: ${formatErrorMessage(error)}`,
+                  );
                 }
 
                 emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -954,6 +954,7 @@ export async function runAgentTurnWithFallback(params: {
                     sessionStore: params.activeSessionStore,
                     storePath: params.storePath,
                     sessionAgentId: params.followupRun.run.agentId,
+                    threadId: params.followupRun.originatingThreadId,
                     sessionCwd: params.followupRun.run.workspaceDir,
                   });
                   if (persistedEntry && params.activeSessionStore && params.sessionKey) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1472,7 +1472,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
 });
 
 describe("runReplyAgent claude-cli routing", () => {
-  function createRun() {
+  function createRun(overrides: { originatingThreadId?: string | number } = {}) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "webchat",
@@ -1485,6 +1485,7 @@ describe("runReplyAgent claude-cli routing", () => {
       prompt: "hello",
       summaryLine: "hello",
       enqueuedAt: Date.now(),
+      originatingThreadId: overrides.originatingThreadId,
       run: {
         sessionId: "session",
         sessionKey: "main",
@@ -1589,6 +1590,24 @@ describe("runReplyAgent claude-cli routing", () => {
 
     expect(persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ text: "ok" });
+  });
+
+  it("forwards originatingThreadId to the CLI transcript persist call", async () => {
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "opus-4.5",
+        },
+      },
+    });
+
+    await createRun({ originatingThreadId: "1739142736.000100" });
+
+    expect(persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    const [persistArgs] = persistCliTurnTranscriptMock.mock.calls[0];
+    expect(persistArgs).toMatchObject({ threadId: "1739142736.000100" });
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -34,6 +34,7 @@ function createCliBackendTestConfig() {
 
 const runEmbeddedPiAgentMock = vi.fn();
 const runCliAgentMock = vi.fn();
+const persistCliTurnTranscriptMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
 const abortEmbeddedPiRunMock = vi.fn();
@@ -75,6 +76,10 @@ vi.mock("../../agents/pi-embedded.js", () => {
 
 vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
+}));
+
+vi.mock("../../agents/command/attempt-execution.runtime.js", () => ({
+  persistCliTurnTranscript: (...args: unknown[]) => persistCliTurnTranscriptMock(...args),
 }));
 
 vi.mock("../../runtime.js", () => {
@@ -142,6 +147,8 @@ beforeEach(() => {
   replyRunRegistryTesting.resetReplyRunRegistry();
   runEmbeddedPiAgentMock.mockClear();
   runCliAgentMock.mockClear();
+  persistCliTurnTranscriptMock.mockReset();
+  persistCliTurnTranscriptMock.mockResolvedValue(undefined);
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
   abortEmbeddedPiRunMock.mockClear();
@@ -1537,6 +1544,50 @@ describe("runReplyAgent claude-cli routing", () => {
 
     expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ text: "ok" });
+  });
+
+  it("persists the CLI turn transcript after a successful CLI run", async () => {
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "opus-4.5",
+        },
+      },
+    });
+
+    await createRun();
+
+    expect(persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    const [persistArgs] = persistCliTurnTranscriptMock.mock.calls[0];
+    expect(persistArgs).toMatchObject({
+      body: "hello",
+      sessionId: "session",
+      sessionKey: "session",
+      sessionCwd: "/tmp",
+    });
+    expect(persistArgs.result?.payloads?.[0]?.text).toBe("ok");
+  });
+
+  it("does not surface persistence failures to the caller", async () => {
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "opus-4.5",
+        },
+      },
+    });
+    persistCliTurnTranscriptMock.mockRejectedValueOnce(
+      new Error("disk full — transcript write failed"),
+    );
+
+    const result = await createRun();
+
+    expect(persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ text: "ok" });
   });
 });


### PR DESCRIPTION
## Summary

The auto-reply path (`runAgentTurnWithFallback` in `src/auto-reply/reply/agent-runner-execution.ts`) invokes `runCliAgent` directly, bypassing `agent-command.ts` where `persistCliTurnTranscript` is already called on the CLI branch.

As a result, turns delivered through channels that use the auto-reply pipeline (Telegram, Discord, Slack, etc.) never land in the session transcript. When the Claude CLI rotates its own session file mid-conversation, the harness-owned replay path has nothing to read — the next turn arrives with no conversation history.

## Fix

Mirror the `persistCliTurnTranscript` call on the successful-result branch of the auto-reply handler. Wrap it in try/catch so a transcript write failure (e.g. disk full) cannot fail a reply that has already been delivered to the user — the persistence is best-effort, matching the posture of the existing `agent-command.ts` call site.

Import is from `../../agents/command/attempt-execution.runtime.js` (the runtime-only re-export), matching what the rest of the auto-reply runtime already pulls from that module.

## Test plan

- [x] Added two cases to `runReplyAgent claude-cli routing`:
  - asserts the persist call fires with the expected `{ body, result, sessionId, sessionKey, sessionCwd }` shape
  - asserts a rejected persist promise does not surface to the caller (reply still resolves with the CLI text)
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — 33/33 pass
- [x] Pre-commit `vitest.auto-reply.config.ts` — 1131/1131 pass

## Scope

+80 lines (28 impl, 52 test). No changes to `agent-command.ts` or `attempt-execution.ts`; only the auto-reply call site is touched.