### PR TITLE
fix: handle non-string values in cron list pad helper (fixes #70128)

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -156,7 +156,7 @@ const CRON_DELIVERY_PAD = 64;
 const CRON_AGENT_PAD = 10;
 const CRON_MODEL_PAD = 20;
 
-const pad = (value: string, width: number) => value.padEnd(width);
+const pad = (value: string, width: number) => String(value ?? "").padEnd(width);
 
 const truncate = (value: string, width: number) => {
   if (value.length <= width) {


### PR DESCRIPTION
## Summary
Fixes #70128

## Root Cause
The `pad` helper in `cron-cli-*.js` called `value.padEnd(width)` 
directly, which throws a TypeError when value is null, undefined, 
or a non-string type.

## Fix
Wrapped value with String() and nullish coalescing fallback:

Before:
const pad = (value, width) => value.padEnd(width);

After:
const pad = (value, width) => String(value ?? "").padEnd(width);

## Testing
- `openclaw cron list` no longer crashes when a cron entry 
  has a missing/non-string field
- `openclaw cron list --json` continues to work as before