### PR TITLE
fix(cli-runner): fire before_prompt_build hook on CLI-backend runs

### DIFF
--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -193,8 +193,11 @@ export async function executePreparedCliRun(
         })
       : undefined;
 
+  const promptWithHookPrepend = context.promptBuildHookPrependContext
+    ? `${context.promptBuildHookPrependContext}\n\n${params.prompt}`
+    : params.prompt;
   let prompt = applyPluginTextReplacements(
-    prependBootstrapPromptWarning(params.prompt, context.bootstrapPromptWarningLines, {
+    prependBootstrapPromptWarning(promptWithHookPrepend, context.bootstrapPromptWarningLines, {
       preserveExactPrompt: context.heartbeatPrompt,
     }),
     context.backendResolved.textTransforms?.input,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -3,6 +3,8 @@ import {
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
 } from "../../gateway/mcp-http.loopback-runtime.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { PluginHookAgentContext } from "../../plugins/types.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   buildBootstrapInjectionStats,
@@ -31,6 +33,10 @@ import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildSystemPrompt, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
+import {
+  applyPromptBuildHookToSystemPrompt,
+  resolveCliPromptBuildHook,
+} from "./prompt-build-hook.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
 const prepareDeps = {
@@ -211,8 +217,34 @@ export async function prepareCliRunContext(
       agentId: sessionAgentId,
       systemPrompt: builtSystemPrompt,
     }) ?? builtSystemPrompt;
+  // Invoke before_prompt_build hook (and legacy before_agent_start) so
+  // plugins can add per-turn context to CLI-backend runs, symmetric with
+  // the Pi embedded runner. Result fields:
+  //   - systemPrompt      → full override of the system prompt
+  //   - prependSystemContext / appendSystemContext → spliced around system
+  //   - prependContext    → passed through to execute() to prepend to the
+  //                         user message (per-turn, not cached)
+  const promptBuildHookCtx: PluginHookAgentContext = {
+    runId: params.runId,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir,
+    modelProviderId: params.provider,
+    modelId,
+    messageProvider: params.messageProvider,
+  };
+  const promptBuildHookResult = await resolveCliPromptBuildHook({
+    prompt: params.prompt,
+    hookCtx: promptBuildHookCtx,
+    hookRunner: getGlobalHookRunner(),
+  });
+  const systemPromptFromHook = applyPromptBuildHookToSystemPrompt({
+    systemPrompt: transformedSystemPrompt,
+    hookResult: promptBuildHookResult,
+  });
   const systemPrompt = applyPluginTextReplacements(
-    transformedSystemPrompt,
+    systemPromptFromHook,
     backendResolved.textTransforms?.input,
   );
   const systemPromptReport = buildSystemPromptReport({
@@ -253,5 +285,6 @@ export async function prepareCliRunContext(
     heartbeatPrompt,
     authEpoch,
     extraSystemPromptHash,
+    promptBuildHookPrependContext: promptBuildHookResult.prependContext,
   };
 }

--- a/src/agents/cli-runner/prompt-build-hook.test.ts
+++ b/src/agents/cli-runner/prompt-build-hook.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginHookAgentContext } from "../../plugins/types.js";
+import {
+  applyPromptBuildHookToSystemPrompt,
+  resolveCliPromptBuildHook,
+  type CliPromptBuildHookRunner,
+} from "./prompt-build-hook.js";
+
+const HOOK_CTX: PluginHookAgentContext = {
+  runId: "run-1",
+  agentId: "agent-1",
+  sessionKey: "session-1",
+  sessionId: "session-id-1",
+  workspaceDir: "/tmp/ws",
+  modelProviderId: "claude",
+  modelId: "claude/default",
+  messageProvider: "test",
+};
+
+function makeRunner(overrides: Partial<CliPromptBuildHookRunner> = {}): CliPromptBuildHookRunner {
+  return {
+    hasHooks: vi.fn(() => false),
+    runBeforePromptBuild: vi.fn(async () => undefined),
+    runBeforeAgentStart: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe("resolveCliPromptBuildHook", () => {
+  it("returns an empty-shape result when no hooks are registered", async () => {
+    const runner = makeRunner();
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: runner,
+    });
+    expect(result).toEqual({
+      systemPrompt: undefined,
+      prependContext: undefined,
+      prependSystemContext: undefined,
+      appendSystemContext: undefined,
+    });
+    expect(runner.runBeforePromptBuild).not.toHaveBeenCalled();
+    expect(runner.runBeforeAgentStart).not.toHaveBeenCalled();
+  });
+
+  it("surfaces before_prompt_build result fields verbatim", async () => {
+    const runBeforePromptBuild = vi.fn(async () => ({
+      systemPrompt: "override-system",
+      prependContext: "prompt context",
+      prependSystemContext: "prompt prepend",
+      appendSystemContext: "prompt append",
+    }));
+    const runner = makeRunner({
+      hasHooks: vi.fn((name) => name === "before_prompt_build"),
+      runBeforePromptBuild,
+    });
+
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: runner,
+    });
+
+    expect(runBeforePromptBuild).toHaveBeenCalledWith({ prompt: "hello", messages: [] }, HOOK_CTX);
+    expect(result).toEqual({
+      systemPrompt: "override-system",
+      prependContext: "prompt context",
+      prependSystemContext: "prompt prepend",
+      appendSystemContext: "prompt append",
+    });
+    expect(runner.runBeforeAgentStart).not.toHaveBeenCalled();
+  });
+
+  it("falls back to before_agent_start when before_prompt_build isn't registered", async () => {
+    const runBeforeAgentStart = vi.fn(async () => ({
+      systemPrompt: "legacy-system",
+      prependContext: "legacy context",
+    }));
+    const runner = makeRunner({
+      hasHooks: vi.fn((name) => name === "before_agent_start"),
+      runBeforeAgentStart,
+    });
+
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: runner,
+    });
+
+    expect(runner.runBeforePromptBuild).not.toHaveBeenCalled();
+    expect(runBeforeAgentStart).toHaveBeenCalledTimes(1);
+    expect(result.systemPrompt).toBe("legacy-system");
+    expect(result.prependContext).toBe("legacy context");
+  });
+
+  it("merges prompt-build and legacy fields deterministically when both are present", async () => {
+    const runner = makeRunner({
+      hasHooks: vi.fn(() => true),
+      runBeforePromptBuild: vi.fn(async () => ({
+        prependContext: "prompt context",
+        prependSystemContext: "prompt prepend",
+        appendSystemContext: "prompt append",
+      })),
+      runBeforeAgentStart: vi.fn(async () => ({
+        prependContext: "legacy context",
+        prependSystemContext: "legacy prepend",
+        appendSystemContext: "legacy append",
+      })),
+    });
+
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: runner,
+    });
+
+    expect(result.prependContext).toBe("prompt context\n\nlegacy context");
+    expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
+    expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+  });
+
+  it("swallows errors and returns empty shape when a hook throws", async () => {
+    const runner = makeRunner({
+      hasHooks: vi.fn((name) => name === "before_prompt_build"),
+      runBeforePromptBuild: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: runner,
+    });
+
+    expect(result.systemPrompt).toBeUndefined();
+    expect(result.prependContext).toBeUndefined();
+  });
+
+  it("is a no-op when hookRunner is null", async () => {
+    const result = await resolveCliPromptBuildHook({
+      prompt: "hello",
+      hookCtx: HOOK_CTX,
+      hookRunner: null,
+    });
+    expect(result).toEqual({
+      systemPrompt: undefined,
+      prependContext: undefined,
+      prependSystemContext: undefined,
+      appendSystemContext: undefined,
+    });
+  });
+});
+
+describe("applyPromptBuildHookToSystemPrompt", () => {
+  it("returns the base system prompt when the hook is empty", () => {
+    expect(
+      applyPromptBuildHookToSystemPrompt({
+        systemPrompt: "base",
+        hookResult: {},
+      }),
+    ).toBe("base");
+  });
+
+  it("replaces the base prompt when systemPrompt override is present", () => {
+    expect(
+      applyPromptBuildHookToSystemPrompt({
+        systemPrompt: "base",
+        hookResult: { systemPrompt: "override" },
+      }),
+    ).toBe("override");
+  });
+
+  it("prepends and appends around the chosen base (override takes precedence)", () => {
+    expect(
+      applyPromptBuildHookToSystemPrompt({
+        systemPrompt: "base",
+        hookResult: {
+          systemPrompt: "override",
+          prependSystemContext: "PRE",
+          appendSystemContext: "POST",
+        },
+      }),
+    ).toBe("PRE\n\noverride\n\nPOST");
+  });
+
+  it("prepends and appends around the original base when no override is given", () => {
+    expect(
+      applyPromptBuildHookToSystemPrompt({
+        systemPrompt: "base",
+        hookResult: {
+          prependSystemContext: "PRE",
+          appendSystemContext: "POST",
+        },
+      }),
+    ).toBe("PRE\n\nbase\n\nPOST");
+  });
+});

--- a/src/agents/cli-runner/prompt-build-hook.ts
+++ b/src/agents/cli-runner/prompt-build-hook.ts
@@ -1,0 +1,92 @@
+import type {
+  PluginHookAgentContext,
+  PluginHookBeforeAgentStartResult,
+  PluginHookBeforePromptBuildResult,
+} from "../../plugins/types.js";
+import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
+import { cliBackendLog } from "./log.js";
+
+/**
+ * Subset of the global hook runner surface this helper needs. Typed
+ * structurally so tests can inject a mock without wiring the full runner.
+ */
+export type CliPromptBuildHookRunner = {
+  hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
+  runBeforePromptBuild: (
+    event: { prompt: string; messages: unknown[] },
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
+  runBeforeAgentStart: (
+    event: { prompt: string; messages: unknown[] },
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeAgentStartResult | undefined>;
+};
+
+/**
+ * Invoke the `before_prompt_build` hook (and legacy `before_agent_start` as
+ * fallback) so plugins can add context to CLI-backend runs symmetrically
+ * with the Pi embedded runner. Merges prepend/append segments, passes
+ * `systemPrompt` through as an override, and preserves `prependContext` for
+ * the caller to splice into the user prompt.
+ *
+ * Failures in either hook are warned (not thrown) so a buggy plugin hook
+ * can't break the agent run. Returns an empty-shape object when no hooks
+ * are registered or all hooks errored.
+ */
+export async function resolveCliPromptBuildHook(params: {
+  prompt: string;
+  hookCtx: PluginHookAgentContext;
+  hookRunner?: CliPromptBuildHookRunner | null;
+}): Promise<PluginHookBeforePromptBuildResult> {
+  const runner = params.hookRunner ?? undefined;
+  const event = { prompt: params.prompt, messages: [] as unknown[] };
+
+  const promptBuildResult = runner?.hasHooks("before_prompt_build")
+    ? await runner.runBeforePromptBuild(event, params.hookCtx).catch((err: unknown) => {
+        cliBackendLog.warn(`before_prompt_build hook failed: ${String(err)}`);
+        return undefined;
+      })
+    : undefined;
+
+  // Legacy before_agent_start still fires in parallel (same as pi-embedded
+  // runner) so plugins that register only the older hook keep working when
+  // a newer plugin also registers before_prompt_build.
+  const legacyResult = runner?.hasHooks("before_agent_start")
+    ? await runner.runBeforeAgentStart(event, params.hookCtx).catch((err: unknown) => {
+        cliBackendLog.warn(
+          `before_agent_start hook (legacy prompt build path) failed: ${String(err)}`,
+        );
+        return undefined;
+      })
+    : undefined;
+
+  return {
+    systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    prependContext: joinPresentTextSegments([
+      promptBuildResult?.prependContext,
+      legacyResult?.prependContext,
+    ]),
+    prependSystemContext: joinPresentTextSegments([
+      promptBuildResult?.prependSystemContext,
+      legacyResult?.prependSystemContext,
+    ]),
+    appendSystemContext: joinPresentTextSegments([
+      promptBuildResult?.appendSystemContext,
+      legacyResult?.appendSystemContext,
+    ]),
+  };
+}
+
+/** Apply the hook result to a system prompt, honoring overrides + prepend/append. */
+export function applyPromptBuildHookToSystemPrompt(params: {
+  systemPrompt: string;
+  hookResult: PluginHookBeforePromptBuildResult;
+}): string {
+  const base = params.hookResult.systemPrompt ?? params.systemPrompt;
+  const withPrepend = params.hookResult.prependSystemContext
+    ? `${params.hookResult.prependSystemContext}\n\n${base}`
+    : base;
+  return params.hookResult.appendSystemContext
+    ? `${withPrepend}\n\n${params.hookResult.appendSystemContext}`
+    : withPrepend;
+}

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -67,4 +67,10 @@ export type PreparedCliRunContext = {
   heartbeatPrompt?: string;
   authEpoch?: string;
   extraSystemPromptHash?: string;
+  /**
+   * Per-turn context the `before_prompt_build` hook wants prepended to the
+   * user message (not the system prompt). Applied inside execute.ts before
+   * the prompt is handed to the CLI backend.
+   */
+  promptBuildHookPrependContext?: string;
 };


### PR DESCRIPTION
## Summary

The CLI-backend runner at `src/agents/cli-runner/prepare.ts` built the system prompt and dispatched the run without ever invoking the `before_prompt_build` hook. The Pi embedded runner already calls this hook from `src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts` (`resolvePromptBuildHookResult`), so plugins worked under the embedded runner but silently no-oped under the CLI runner.

This is the symmetric bug to #70147 (`fix(gateway): fire before_tool_call hook on loopback MCP tools/call`) — one path up the same request. Plugin authors saw both hooks register (`hasHooks(name) === true`) but their handlers never ran on CLI-backend runs, so per-turn context injection and system-prompt overrides were silently dropped.

## What changed

Added a small `src/agents/cli-runner/prompt-build-hook.ts` helper, scoped locally to avoid cross-runner coupling, that mirrors the Pi runner's merge semantics:

- `before_prompt_build` takes precedence on `systemPrompt` override
- Legacy `before_agent_start` still runs in parallel; `prependContext` / `prependSystemContext` / `appendSystemContext` are joined with `\n\n` in deterministic order
- Failures in either hook are warned (not thrown) — same policy as the Pi runner, so a buggy plugin can't break the agent run

Wired it into `prepareCliRunContext` between the transformed system prompt and the plugin text-transform step. `prependContext` is threaded through the new `PreparedCliRunContext.promptBuildHookPrependContext` field and spliced ahead of `params.prompt` inside `executePreparedCliRun`, so per-turn plugin context lands on the user message without polluting the cached system prompt.

## Tests

- New `src/agents/cli-runner/prompt-build-hook.test.ts` covers 10 scenarios:
  - `resolveCliPromptBuildHook`: no hooks registered, `before_prompt_build` surfaces verbatim, legacy `before_agent_start` fallback, deterministic merge of both hooks, errors swallowed, null `hookRunner` no-op
  - `applyPromptBuildHookToSystemPrompt`: empty hook result, `systemPrompt` override, prepend/append around override, prepend/append around original base
- Existing `src/agents/cli-runner/bundle-mcp.test.ts` continues to pass
- `pnpm tsgo` clean, `pnpm lint` clean on all touched files (11719 files, 0 warnings, 0 errors)

## Test plan

- [x] New unit tests cover the helper's merge + error-swallow behavior
- [x] Targeted `vitest run` over `src/agents/cli-runner/*.test.ts` is green
- [x] `pnpm tsgo`, `pnpm lint`, import-cycle checks clean via pre-commit hook
- [ ] Reviewer: confirm `prependContext` on the user prompt (vs system prompt) matches the intended Pi-runner parity
