### PR TITLE
fix(cli): render real newlines in config warnings output

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1198,7 +1198,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
               `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
           )
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        deps.logger.warn(`Config warnings:\n${details}`);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = materializeRuntimeConfig(validated.config, "load");


### PR DESCRIPTION
Fixes #70140

The `deps.logger.warn` call in `src/config/io.ts:1201` used a double-escaped newline (`\\n` in template literal) which rendered as literal `\n` instead of a proper line break.

Changed `\\n` to `\n` so multi-line warnings display with actual line breaks.

File changed: `src/config/io.ts`