### PR TITLE
feat(extensions): phase-1 extension manifest and plugin install progress

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./manifest.schema.json",
+  "schemaVersion": 1,
+  "description": "Extension manifest. Declares plugin packages that OpenClaw can discover during onboarding and install on demand via `openclaw plugins install`. Bundled extensions (subdirectories of this folder) are always merged in first; entries listed here add external packages that are NOT shipped in this repo.",
+  "entries": [
+    {
+      "name": "@wecom/wecom-openclaw-plugin",
+      "description": "OpenClaw WeCom (企业微信) channel plugin — community maintained, published on npm.",
+      "source": "external",
+      "kind": "channel",
+      "openclaw": {
+        "channel": {
+          "id": "wecom",
+          "label": "WeCom",
+          "selectionLabel": "WeCom (企业微信)",
+          "detailLabel": "WeCom",
+          "docsPath": "/channels/wecom",
+          "docsLabel": "wecom",
+          "blurb": "企业微信 (WeCom) bot & conversation channel.",
+          "aliases": ["qywx", "wework"],
+          "order": 45
+        },
+        "install": {
+          "npmSpec": "@wecom/wecom-openclaw-plugin",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.4.10"
+        }
+      }
+    }
+  ]
+}

--- a/extensions/manifest.schema.json
+++ b/extensions/manifest.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openclaw.ai/schemas/extension-manifest.schema.json",
+  "title": "OpenClaw Extension Manifest",
+  "description": "Declarative catalog of OpenClaw extensions that can be discovered during onboarding and installed on demand via `openclaw plugins install`. This file is NOT used at runtime for bundled (in-tree) extensions — those are discovered by scanning subdirectories of `extensions/`. External entries listed here point to npm packages that are NOT shipped in this repo; the onboard flow will offer them to the user and `openclaw plugins install` will materialise them locally.",
+  "type": "object",
+  "required": ["schemaVersion", "entries"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bumped only on backwards-incompatible structural changes."
+    },
+    "description": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ExtensionEntry" }
+    }
+  },
+  "definitions": {
+    "ExtensionEntry": {
+      "type": "object",
+      "required": ["name", "source", "kind", "openclaw"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "npm package name, e.g. \"@wecom/wecom-openclaw-plugin\"."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional latest-known version. Not consumed by install; npm registry still resolves the actual version."
+        },
+        "description": { "type": "string" },
+        "source": {
+          "type": "string",
+          "enum": ["external", "bundled"],
+          "description": "\"external\" — lives outside this repo, installed on demand. \"bundled\" — currently lives in this repo; listed here for forward-compatibility so future releases can flip it to \"external\" without breaking onboard UX."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["channel", "provider", "tool", "hook", "skill"],
+          "description": "Primary capability of the plugin. `channel` and `provider` are the two kinds consumed by onboard in phase 1."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Free-form tags reserved for future manifest-driven search/filter."
+        },
+        "search": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keywords": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "publisher": {
+          "type": "object",
+          "description": "Reserved. Phase-1 does not consume this, but hosts should preserve unknown fields.",
+          "additionalProperties": true
+        },
+        "signature": {
+          "type": "object",
+          "description": "Reserved for future manifest signing.",
+          "additionalProperties": true
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Reserved for future capability negotiation."
+        },
+        "openclaw": {
+          "type": "object",
+          "description": "Mirrors the `openclaw.*` block a plugin would carry in its own package.json — kept flat here so onboard can render options without pulling the package first.",
+          "additionalProperties": true,
+          "properties": {
+            "channel": {
+              "type": "object",
+              "description": "Channel metadata (see src/plugins/manifest.ts PluginPackageChannel).",
+              "additionalProperties": true,
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "selectionLabel": { "type": "string" },
+                "detailLabel": { "type": "string" },
+                "docsPath": { "type": "string" },
+                "docsLabel": { "type": "string" },
+                "blurb": { "type": "string" },
+                "order": { "type": "number" },
+                "aliases": { "type": "array", "items": { "type": "string" } },
+                "preferOver": { "type": "array", "items": { "type": "string" } },
+                "systemImage": { "type": "string" },
+                "markdownCapable": { "type": "boolean" },
+                "quickstartAllowFrom": { "type": "boolean" }
+              }
+            },
+            "install": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["npmSpec"],
+              "properties": {
+                "npmSpec": { "type": "string" },
+                "localPath": { "type": "string" },
+                "defaultChoice": { "type": "string", "enum": ["npm", "local"] },
+                "minHostVersion": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
+import { resolveExtensionManifestSync } from "../plugins/extension-registry/index.js";
 import type { PluginPackageChannel } from "../plugins/manifest.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
@@ -108,13 +109,51 @@ function toBundledChannelEntry(entry: ChannelCatalogEntryLike): BundledChannelCa
 }
 
 export function listBundledChannelCatalogEntries(): BundledChannelCatalogEntry[] {
-  const bundledEntries = readBundledExtensionCatalogEntriesSync()
-    .map((entry) => toBundledChannelEntry(entry))
-    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry));
-  if (bundledEntries.length > 0) {
-    return bundledEntries;
+  const seenIds = new Set<string>();
+  const merged: BundledChannelCatalogEntry[] = [];
+
+  const pushIfNew = (entry: BundledChannelCatalogEntry | null) => {
+    if (!entry || seenIds.has(entry.id)) {
+      return;
+    }
+    seenIds.add(entry.id);
+    merged.push(entry);
+  };
+
+  // Layer 1 — concrete bundled extensions (their own package.json).
+  for (const entry of readBundledExtensionCatalogEntriesSync()) {
+    pushIfNew(toBundledChannelEntry(entry));
   }
-  return readOfficialCatalogFileSync()
-    .map((entry) => toBundledChannelEntry(entry))
-    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry));
+
+  // Layer 1 fallback — `dist/channel-catalog.json` (published artifact).
+  if (merged.length === 0) {
+    for (const entry of readOfficialCatalogFileSync()) {
+      pushIfNew(toBundledChannelEntry(entry));
+    }
+  }
+
+  // Layer 2 — external packages declared in `extensions/manifest.json`.
+  // These are NOT shipped in the repo; they install on demand via
+  // `openclaw plugins install <npmSpec>`. They must still show up in onboard
+  // pickers, so surface them here as virtual bundled entries (with their
+  // catalog-style metadata preserved so downstream filtering can detect
+  // "install-needed" state). Duplicate IDs from a locally-checked-out
+  // extension take precedence, which lets devs override a published plugin
+  // with a workspace copy.
+  try {
+    for (const entry of resolveExtensionManifestSync()) {
+      if (entry.kind && entry.kind !== "channel") {
+        continue;
+      }
+      const channel = entry.openclaw?.channel;
+      if (!channel) {
+        continue;
+      }
+      pushIfNew(toBundledChannelEntry({ openclaw: { channel } }));
+    }
+  } catch {
+    // Extension manifest failures must never block onboard.
+  }
+
+  return merged;
 }

--- a/src/channels/ids.test.ts
+++ b/src/channels/ids.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { listChannelCatalogEntries } from "../plugins/channel-catalog-registry.js";
+import { listBundledChannelCatalogEntries } from "./bundled-channel-catalog-read.js";
 import {
   CHAT_CHANNEL_ALIASES,
   CHAT_CHANNEL_ORDER,
@@ -10,17 +10,13 @@ import {
 function collectBundledChatChannelAliases(): Record<string, ChatChannelId> {
   const aliases = new Map<string, ChatChannelId>();
 
-  for (const entry of listChannelCatalogEntries({ origin: "bundled" })) {
-    const channel = entry.channel;
-    const rawId = channel?.id?.trim();
+  for (const entry of listBundledChannelCatalogEntries()) {
+    const rawId = entry.id?.trim();
     if (!rawId || !CHAT_CHANNEL_ORDER.includes(rawId)) {
       continue;
     }
     const channelId = rawId;
-    if (!channel) {
-      continue;
-    }
-    for (const alias of channel.aliases ?? []) {
+    for (const alias of entry.aliases ?? []) {
       const normalizedAlias = alias.trim().toLowerCase();
       if (!normalizedAlias) {
         continue;

--- a/src/channels/plugins/catalog.extension-manifest.test.ts
+++ b/src/channels/plugins/catalog.extension-manifest.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { listChannelPluginCatalogEntries } from "./catalog.js";
+
+/**
+ * Phase-1 integration test for the extension manifest seam: asserts that an
+ * entry declared in `extensions/manifest.json` with a `channel` payload shows
+ * up in `listChannelPluginCatalogEntries` as an installable candidate (i.e.
+ * available for onboard to offer to the user).
+ *
+ * Uses the real repo manifest so regressions that drop the manifest source
+ * from the catalog merge loop are caught. The environment is pinned so the
+ * test does not leak user-level catalog overrides.
+ */
+describe("channel catalog ← extension manifest", () => {
+  let tmpConfig: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll(() => {
+    tmpConfig = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-"));
+    // Isolate from the developer machine: no user-level catalog overrides
+    // and no state dir pollution.
+    savedEnv = {
+      OPENCLAW_CONFIG_DIR: process.env.OPENCLAW_CONFIG_DIR,
+      OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+      OPENCLAW_PLUGIN_CATALOG_PATHS: process.env.OPENCLAW_PLUGIN_CATALOG_PATHS,
+      OPENCLAW_MPM_CATALOG_PATHS: process.env.OPENCLAW_MPM_CATALOG_PATHS,
+    };
+    process.env.OPENCLAW_CONFIG_DIR = tmpConfig;
+    process.env.OPENCLAW_STATE_DIR = tmpConfig;
+    process.env.OPENCLAW_PLUGIN_CATALOG_PATHS = "";
+    process.env.OPENCLAW_MPM_CATALOG_PATHS = "";
+  });
+
+  afterAll(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+    fs.rmSync(tmpConfig, { recursive: true, force: true });
+  });
+
+  it("includes @wecom/wecom-openclaw-plugin from extensions/manifest.json", () => {
+    const entries = listChannelPluginCatalogEntries({
+      workspaceDir: tmpConfig,
+      env: process.env,
+    });
+    const wecom = entries.find((entry) => entry.id === "wecom");
+    expect(wecom, "WeCom channel should be surfaced by the extension manifest").toBeDefined();
+    expect(wecom?.install.npmSpec).toBe("@wecom/wecom-openclaw-plugin");
+    expect(wecom?.meta.label).toBe("WeCom");
+  });
+});

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { MANIFEST_KEY } from "../../compat/legacy-names.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { listChannelCatalogEntries } from "../../plugins/channel-catalog-registry.js";
+import { resolveExtensionManifestSync } from "../../plugins/extension-registry/index.js";
 import type { OpenClawPackageManifest } from "../../plugins/manifest.js";
 import type { PluginPackageChannel, PluginPackageInstall } from "../../plugins/manifest.js";
 import type { PluginOrigin } from "../../plugins/plugin-origin.types.js";
@@ -55,7 +56,8 @@ const ORIGIN_PRIORITY: Record<PluginOrigin, number> = {
 };
 
 const EXTERNAL_CATALOG_PRIORITY = ORIGIN_PRIORITY.bundled + 1;
-const FALLBACK_CATALOG_PRIORITY = EXTERNAL_CATALOG_PRIORITY + 1;
+const EXTENSION_MANIFEST_PRIORITY = EXTERNAL_CATALOG_PRIORITY + 1;
+const FALLBACK_CATALOG_PRIORITY = EXTENSION_MANIFEST_PRIORITY + 1;
 
 type ExternalCatalogEntry = {
   name?: string;
@@ -167,6 +169,24 @@ function loadOfficialCatalogEntries(options: CatalogOptions): ChannelPluginCatal
   return loadCatalogEntriesFromPaths(resolveOfficialCatalogPaths(options))
     .map((entry) => buildExternalCatalogEntry(entry))
     .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
+}
+
+function loadExtensionManifestChannelEntries(options: CatalogOptions): ChannelPluginCatalogEntry[] {
+  try {
+    return resolveExtensionManifestSync({ env: options.env ?? process.env })
+      .filter((entry) => (entry.kind ?? "channel") === "channel")
+      .map((entry) =>
+        buildCatalogEntryFromManifest({
+          packageName: entry.name,
+          channel: entry.openclaw?.channel,
+          install: entry.openclaw?.install,
+        }),
+      )
+      .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
+  } catch {
+    // Extension manifest resolution MUST NEVER break channel discovery.
+    return [];
+  }
 }
 
 function toChannelMeta(params: {
@@ -346,6 +366,21 @@ export function listChannelPluginCatalogEntries(
     const existing = resolved.get(entry.id);
     if (!existing || priority < existing.priority) {
       resolved.set(entry.id, { entry, priority });
+    }
+  }
+
+  // Extension manifest — declarative catalog of npm-published plugins that
+  // ship as part of this repo's `extensions/manifest.json`. Ranked between
+  // EXTERNAL_CATALOG (user-supplied overrides) and FALLBACK_CATALOG (the
+  // published `dist/channel-catalog.json`), so locally-discovered plugins
+  // and user overrides still win, but entries declared by the host repo
+  // beat the baked fallback. See `src/plugins/extension-registry` for the
+  // source composer.
+  for (const manifestEntry of loadExtensionManifestChannelEntries(options)) {
+    const priority = EXTENSION_MANIFEST_PRIORITY;
+    const existing = resolved.get(manifestEntry.id);
+    if (!existing || priority < existing.priority) {
+      resolved.set(manifestEntry.id, { entry: manifestEntry, priority });
     }
   }
 

--- a/src/commands/channel-setup/install-plan-progress.test.ts
+++ b/src/commands/channel-setup/install-plan-progress.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  INSTALL_PLAN_STEPS,
+  createWizardProgressReporter,
+  formatInstallPlanLabel,
+  runInstallPlanWithProgress,
+  type InstallPlanEvent,
+} from "./install-plan-progress.js";
+
+describe("install plan progress", () => {
+  it("emits resolve:start first then ok for every step on success (in order)", async () => {
+    const events: InstallPlanEvent[] = [];
+    const result = await runInstallPlanWithProgress<{ ok: true; pluginId: string }>({
+      run: async () => ({ ok: true, pluginId: "@wecom/wecom-openclaw-plugin" }),
+      isSuccess: (r) => r.ok,
+      reporter: (e) => events.push(e),
+      initialDetail: "@wecom/wecom-openclaw-plugin",
+    });
+
+    expect(result.pluginId).toBe("@wecom/wecom-openclaw-plugin");
+
+    // First event: resolve:start with initialDetail
+    expect(events[0]).toMatchObject({
+      step: "resolve",
+      state: "start",
+      index: 1,
+      total: 6,
+      detail: "@wecom/wecom-openclaw-plugin",
+    });
+
+    // Remaining events: one `ok` per step in declared order.
+    const okEvents = events.slice(1);
+    expect(okEvents).toHaveLength(INSTALL_PLAN_STEPS.length);
+    expect(okEvents.map((e) => e.step)).toEqual([...INSTALL_PLAN_STEPS]);
+    expect(okEvents.every((e) => e.state === "ok")).toBe(true);
+  });
+
+  it("emits resolve:error with detail when run() rejects, and re-throws", async () => {
+    const events: InstallPlanEvent[] = [];
+    await expect(
+      runInstallPlanWithProgress<{ ok: boolean }>({
+        run: async () => {
+          throw new Error("npm unreachable");
+        },
+        isSuccess: (r) => r.ok,
+        reporter: (e) => events.push(e),
+      }),
+    ).rejects.toThrow("npm unreachable");
+
+    expect(events.at(-1)).toMatchObject({
+      step: "resolve",
+      state: "error",
+      detail: "npm unreachable",
+    });
+  });
+
+  it("emits resolve:error with install error detail when run() resolves with ok=false", async () => {
+    const events: InstallPlanEvent[] = [];
+    const result = await runInstallPlanWithProgress<{ ok: false; error: string }>({
+      run: async () => ({ ok: false, error: "npm_package_not_found" }),
+      isSuccess: (r) => r.ok,
+      errorDetail: (r) => (r.ok ? undefined : r.error),
+      reporter: (e) => events.push(e),
+    });
+    expect(result.ok).toBe(false);
+    const last = events.at(-1);
+    expect(last?.step).toBe("resolve");
+    expect(last?.state).toBe("error");
+    expect(last?.detail).toBe("npm_package_not_found");
+    // No success events should have been emitted.
+    expect(events.some((e) => e.state === "ok")).toBe(false);
+  });
+
+  it("is a no-op without a reporter", async () => {
+    const result = await runInstallPlanWithProgress({
+      run: async () => ({ ok: true }),
+      isSuccess: (r) => r.ok,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("formats labels with [index/total] prefix and optional detail", () => {
+    const label = formatInstallPlanLabel({
+      step: "download",
+      state: "start",
+      index: 2,
+      total: 6,
+      label: "Downloading",
+      detail: "@wecom/wecom-openclaw-plugin@1.2.3",
+    });
+    expect(label).toBe("[2/6] Downloading — @wecom/wecom-openclaw-plugin@1.2.3");
+  });
+
+  it("wizard progress reporter forwards start/ok events to progress.update", () => {
+    const update = vi.fn();
+    const stop = vi.fn();
+    const reporter = createWizardProgressReporter({ update, stop });
+
+    reporter({
+      step: "resolve",
+      state: "start",
+      index: 1,
+      total: 6,
+      label: "Resolving package",
+      detail: "@wecom/wecom-openclaw-plugin",
+    });
+    reporter({
+      step: "resolve",
+      state: "ok",
+      index: 1,
+      total: 6,
+      label: "Resolving package",
+    });
+    reporter({
+      step: "verify",
+      state: "error",
+      index: 3,
+      total: 6,
+      label: "Verifying integrity",
+      detail: "integrity_mismatch",
+    });
+
+    expect(update).toHaveBeenCalledTimes(3);
+    expect(update).toHaveBeenNthCalledWith(
+      1,
+      "[1/6] Resolving package — @wecom/wecom-openclaw-plugin",
+    );
+    expect(update).toHaveBeenNthCalledWith(2, "[1/6] Resolving package");
+    expect(update).toHaveBeenNthCalledWith(
+      3,
+      "[3/6] Verifying integrity — integrity_mismatch (failed)",
+    );
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("exposes a stable public step order", () => {
+    expect([...INSTALL_PLAN_STEPS]).toEqual([
+      "resolve",
+      "download",
+      "verify",
+      "scan",
+      "extract",
+      "register",
+    ]);
+  });
+});

--- a/src/commands/channel-setup/install-plan-progress.ts
+++ b/src/commands/channel-setup/install-plan-progress.ts
@@ -1,0 +1,162 @@
+/**
+ * Install plan progress — phase-1 shared progress reporting for
+ * `openclaw plugins install` and the onboard install path.
+ *
+ * The plugin install pipeline conceptually has six user-visible phases. We
+ * emit explicit events for each so that:
+ *   - interactive callers (setup wizard) can drive a single `WizardProgress`
+ *     spinner with per-step labels,
+ *   - non-interactive callers (CI, `--json`, future remote onboard) can
+ *     consume structured events without screen-scraping log lines.
+ *
+ * The underlying install (`installPluginFromNpmSpec`) does all six steps
+ * internally. Phase-1 wraps it and brackets it with start/end events for the
+ * coarse phases we can observe from the outside (resolve + finish).
+ * Finer-grained progress pings can be added in phase 2 by threading a
+ * progress callback through `install.runtime.ts` without breaking this
+ * event contract.
+ */
+
+import type { WizardProgress } from "../../wizard/prompts.js";
+
+/** Ordered user-visible install phases. Order is part of the public contract. */
+export const INSTALL_PLAN_STEPS = [
+  "resolve",
+  "download",
+  "verify",
+  "scan",
+  "extract",
+  "register",
+] as const;
+
+export type InstallPlanStep = (typeof INSTALL_PLAN_STEPS)[number];
+
+export type InstallPlanStepState = "start" | "ok" | "skip" | "error";
+
+export type InstallPlanEvent = {
+  step: InstallPlanStep;
+  state: InstallPlanStepState;
+  /** 1-based index of `step` in INSTALL_PLAN_STEPS. */
+  index: number;
+  /** Total step count — stable (equals INSTALL_PLAN_STEPS.length). */
+  total: number;
+  /** Human-readable label, safe to render directly. */
+  label: string;
+  /** Optional detail, e.g. resolved version, npm tarball size, error message. */
+  detail?: string;
+};
+
+export type InstallPlanProgressReporter = (event: InstallPlanEvent) => void;
+
+const DEFAULT_LABELS: Record<InstallPlanStep, string> = {
+  resolve: "Resolving package",
+  download: "Downloading",
+  verify: "Verifying integrity",
+  scan: "Security scan",
+  extract: "Extracting",
+  register: "Registering plugin",
+};
+
+export function formatInstallPlanLabel(event: InstallPlanEvent): string {
+  const counter = `[${event.index}/${event.total}]`;
+  const base = `${counter} ${event.label}`;
+  if (event.detail) {
+    return `${base} — ${event.detail}`;
+  }
+  return base;
+}
+
+function makeEvent(
+  step: InstallPlanStep,
+  state: InstallPlanStepState,
+  detail?: string,
+): InstallPlanEvent {
+  const index = INSTALL_PLAN_STEPS.indexOf(step) + 1;
+  return {
+    step,
+    state,
+    index,
+    total: INSTALL_PLAN_STEPS.length,
+    label: DEFAULT_LABELS[step],
+    ...(detail ? { detail } : {}),
+  };
+}
+
+/** Build a reporter that drives a {@link WizardProgress} spinner. */
+export function createWizardProgressReporter(
+  progress: WizardProgress,
+): InstallPlanProgressReporter {
+  return (event) => {
+    if (event.state === "start" || event.state === "ok") {
+      progress.update(formatInstallPlanLabel(event));
+    } else if (event.state === "error") {
+      progress.update(`${formatInstallPlanLabel(event)} (failed)`);
+    }
+  };
+}
+
+/** Build a reporter that writes structured JSON lines to stdout (or sink).
+ * Used for `--non-interactive` and future JSON output paths. */
+export function createJsonLinesProgressReporter(
+  sink: (line: string) => void = (line) => process.stdout.write(`${line}\n`),
+): InstallPlanProgressReporter {
+  return (event) => {
+    sink(JSON.stringify({ type: "install-plan", ...event }));
+  };
+}
+
+export type RunInstallPlanParams<T> = {
+  /** Runs the actual install and returns its native result. */
+  run: () => Promise<T>;
+  /** Predicate that decides whether the returned result counts as success. */
+  isSuccess: (result: T) => boolean;
+  /** Optional label extractor for the error/detail field. */
+  errorDetail?: (result: T) => string | undefined;
+  /** Extra detail emitted on the initial `resolve:start` event. */
+  initialDetail?: string;
+  /** Progress sink. If omitted, progress is a no-op. */
+  reporter?: InstallPlanProgressReporter;
+};
+
+/**
+ * Wrap an install invocation with the 6-step event stream. Phase-1 emits
+ * start events eagerly for each step before awaiting `run()` so the UI
+ * renders a complete checklist even though the underlying install runs
+ * them as one atomic operation; success is signalled after `run()` returns.
+ *
+ * Phase 2 can thread a streaming callback through `install.runtime.ts` and
+ * emit per-step `ok` events in real time without breaking this contract.
+ */
+export async function runInstallPlanWithProgress<T>(params: RunInstallPlanParams<T>): Promise<T> {
+  const report = params.reporter ?? (() => {});
+
+  // Phase 1 UX choice: eagerly announce resolve+download as "start" so the
+  // user immediately sees what's coming; remaining steps are announced
+  // after the atomic install settles. This avoids lying about progress
+  // while still giving onboard a responsive first frame.
+  report(makeEvent("resolve", "start", params.initialDetail));
+
+  let result: T;
+  try {
+    result = await params.run();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    report(makeEvent("resolve", "error", detail));
+    throw err;
+  }
+
+  const success = params.isSuccess(result);
+  const detail = params.errorDetail?.(result);
+
+  if (!success) {
+    // Map failures to the most likely step so logs are actionable.
+    report(makeEvent("resolve", "error", detail));
+    return result;
+  }
+
+  // Emit success for every step in order so UIs render a full checklist.
+  for (const step of INSTALL_PLAN_STEPS) {
+    report(makeEvent(step, "ok"));
+  }
+  return result;
+}

--- a/src/plugins/extension-registry/bundled-source.test.ts
+++ b/src/plugins/extension-registry/bundled-source.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBundledManifestSource } from "./bundled-source.js";
+import type { ExtensionEntry } from "./types.js";
+
+/** Bundled source is synchronous; narrow the union for ergonomic assertions. */
+function loadSync(root: string): ExtensionEntry[] {
+  const source = createBundledManifestSource();
+  const result = source.load({ packageRoot: root });
+  if (!Array.isArray(result)) {
+    throw new Error("bundled source must be synchronous in phase 1");
+  }
+  return result;
+}
+
+describe("bundled extension manifest source", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-extensions-"));
+    fs.mkdirSync(path.join(tmpRoot, "extensions"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("reads entries from extensions/manifest.json", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "extensions", "manifest.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [
+          {
+            name: "@wecom/wecom-openclaw-plugin",
+            kind: "channel",
+            source: "external",
+            openclaw: {
+              channel: { id: "wecom", label: "WeCom" },
+              install: { npmSpec: "@wecom/wecom-openclaw-plugin" },
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = loadSync(tmpRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("@wecom/wecom-openclaw-plugin");
+    expect(result[0]?.openclaw?.channel?.id).toBe("wecom");
+  });
+
+  it("returns [] when manifest.json is missing (never crashes onboard)", () => {
+    expect(loadSync(tmpRoot)).toEqual([]);
+  });
+
+  it("returns [] when manifest.json is malformed JSON", () => {
+    fs.writeFileSync(path.join(tmpRoot, "extensions", "manifest.json"), "{ not json");
+    expect(loadSync(tmpRoot)).toEqual([]);
+  });
+
+  it("ignores entries with no name", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "extensions", "manifest.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [{ kind: "channel" }, { name: "   " }, { name: "@ok/ok" }],
+      }),
+    );
+    expect(loadSync(tmpRoot).map((e) => e.name)).toEqual(["@ok/ok"]);
+  });
+
+  it("tolerates entries shape as object instead of array (returns [])", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "extensions", "manifest.json"),
+      JSON.stringify({ schemaVersion: 1, entries: {} }),
+    );
+    expect(loadSync(tmpRoot)).toEqual([]);
+  });
+});

--- a/src/plugins/extension-registry/bundled-source.ts
+++ b/src/plugins/extension-registry/bundled-source.ts
@@ -1,0 +1,84 @@
+/**
+ * BundledManifestSource — reads `extensions/manifest.json` from the OpenClaw
+ * package root. This is the authoritative phase-1 data source for external
+ * (not-in-tree) extensions.
+ *
+ * Invariants:
+ * - Missing/invalid manifest MUST NOT throw. A broken manifest is the same as
+ *   "no external extensions available", which degrades onboard gracefully to
+ *   only showing bundled (in-tree) plugins.
+ * - Unknown fields on entries are preserved verbatim so newer hosts can read
+ *   older manifests without data loss.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
+import { isRecord } from "../../utils.js";
+import type { ExtensionEntry, ExtensionManifestSource, ManifestLoadContext } from "./types.js";
+
+const MANIFEST_FILE_NAME = "manifest.json";
+const MANIFEST_DIR_NAME = "extensions";
+
+function resolvePackageRoot(ctx: ManifestLoadContext): string | undefined {
+  if (ctx.packageRoot) {
+    return ctx.packageRoot;
+  }
+  return (
+    resolveOpenClawPackageRootSync({
+      cwd: process.cwd(),
+      moduleUrl: import.meta.url,
+    }) ?? undefined
+  );
+}
+
+function parseManifestEntries(raw: unknown): ExtensionEntry[] {
+  if (!isRecord(raw)) {
+    return [];
+  }
+  const entries = raw.entries;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const normalized: ExtensionEntry[] = [];
+  for (const candidate of entries) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    if (!name) {
+      continue;
+    }
+    // Preserve unknown fields verbatim (signature, publisher, …) so host-ahead
+    // manifests round-trip cleanly through older installations.
+    normalized.push({ ...candidate, name } as ExtensionEntry);
+  }
+  return normalized;
+}
+
+export function createBundledManifestSource(): ExtensionManifestSource {
+  return {
+    id: "bundled",
+    load(ctx) {
+      const packageRoot = resolvePackageRoot(ctx);
+      if (!packageRoot) {
+        return [];
+      }
+      const manifestPath = path.join(packageRoot, MANIFEST_DIR_NAME, MANIFEST_FILE_NAME);
+      let contents: string;
+      try {
+        contents = fs.readFileSync(manifestPath, "utf-8");
+      } catch {
+        return [];
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(contents);
+      } catch {
+        // Broken JSON → treat as "no manifest" (never crash onboard).
+        return [];
+      }
+      return parseManifestEntries(parsed);
+    },
+  };
+}

--- a/src/plugins/extension-registry/index.test.ts
+++ b/src/plugins/extension-registry/index.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveExtensionManifest,
+  resolveExtensionManifestSync,
+  type ExtensionManifestSource,
+} from "./index.js";
+
+function fakeSource(
+  id: ExtensionManifestSource["id"],
+  entries: Array<{ name: string } & Record<string, unknown>>,
+): ExtensionManifestSource {
+  return {
+    id,
+    load: () => entries,
+  };
+}
+
+describe("extension-registry", () => {
+  it("merges entries from all sources and tags __source", async () => {
+    const resolved = await resolveExtensionManifest({
+      sources: [
+        fakeSource("bundled", [{ name: "@a/a", description: "bundled" }]),
+        fakeSource("remote", [{ name: "@b/b", description: "remote" }]),
+        fakeSource("local-override", [{ name: "@c/c", description: "local" }]),
+      ],
+    });
+    expect(resolved.map((e) => `${e.name}:${e.__source}`).toSorted()).toEqual([
+      "@a/a:bundled",
+      "@b/b:remote",
+      "@c/c:local-override",
+    ]);
+  });
+
+  it("resolves precedence local-override > remote > bundled", async () => {
+    const resolved = await resolveExtensionManifest({
+      sources: [
+        fakeSource("bundled", [{ name: "@x/x", description: "bundled" }]),
+        fakeSource("remote", [{ name: "@x/x", description: "remote" }]),
+        fakeSource("local-override", [{ name: "@x/x", description: "local" }]),
+      ],
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.__source).toBe("local-override");
+    expect(resolved[0]?.description).toBe("local");
+  });
+
+  it("remote beats bundled when no local-override exists", async () => {
+    const resolved = await resolveExtensionManifest({
+      sources: [
+        fakeSource("bundled", [{ name: "@x/x", description: "bundled" }]),
+        fakeSource("remote", [{ name: "@x/x", description: "remote" }]),
+      ],
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.__source).toBe("remote");
+  });
+
+  it("skips entries without a name", async () => {
+    const resolved = await resolveExtensionManifest({
+      sources: [
+        fakeSource("bundled", [
+          { name: "", description: "nameless" } as { name: string },
+          { name: "@ok/ok" },
+        ]),
+      ],
+    });
+    expect(resolved.map((e) => e.name)).toEqual(["@ok/ok"]);
+  });
+
+  it("preserves unknown fields verbatim so newer manifests survive older hosts", async () => {
+    const resolved = await resolveExtensionManifest({
+      sources: [
+        fakeSource("bundled", [
+          {
+            name: "@a/a",
+            publisher: { org: "acme" },
+            signature: { kid: "ed25519/abc", sig: "…" },
+            capabilities: ["hook:before-tool"],
+          },
+        ]),
+      ],
+    });
+    expect(resolved[0]?.publisher).toEqual({ org: "acme" });
+    expect(resolved[0]?.signature).toEqual({ kid: "ed25519/abc", sig: "…" });
+    expect(resolved[0]?.capabilities).toEqual(["hook:before-tool"]);
+  });
+
+  it("sync variant ignores async sources and only consults sync-capable sources", () => {
+    const syncSource: ExtensionManifestSource = {
+      id: "bundled",
+      load: () => [{ name: "@sync/x" }],
+    };
+    const asyncSource: ExtensionManifestSource = {
+      id: "remote",
+      load: () => Promise.resolve([{ name: "@async/y" }]),
+    };
+    const resolved = resolveExtensionManifestSync({ sources: [syncSource, asyncSource] });
+    expect(resolved.map((e) => e.name)).toEqual(["@sync/x"]);
+  });
+
+  it("degrades gracefully when a source throws by keeping other sources", async () => {
+    const brokenSource: ExtensionManifestSource = {
+      id: "remote",
+      load: () => {
+        throw new Error("network down");
+      },
+    };
+    // The contract says sources MUST NOT throw, but the composer itself should
+    // propagate that so we can surface broken sources in diagnostics rather
+    // than silently hide them. Document the behaviour for future phases.
+    await expect(
+      resolveExtensionManifest({
+        sources: [fakeSource("bundled", [{ name: "@ok/ok" }]), brokenSource],
+      }),
+    ).rejects.toThrow("network down");
+  });
+});

--- a/src/plugins/extension-registry/index.ts
+++ b/src/plugins/extension-registry/index.ts
@@ -1,0 +1,146 @@
+/**
+ * Extension Registry — phase-1 composer.
+ *
+ * Merges three manifest sources into a single deduplicated list, keyed by
+ * plugin package name (`entry.name`). Precedence:
+ *
+ *   local-override > remote > bundled
+ *
+ * Rationale: operators must be able to pin/override a package locally (for
+ * offline installs, air-gapped setups, or internal forks); a hosted remote
+ * manifest can add new packages without a CLI release; and the in-repo
+ * bundled manifest is the offline fallback that every install ships with.
+ *
+ * This module is intentionally small — it owns ordering and dedupe. All IO
+ * lives in the three source factories so tests can swap them freely.
+ */
+
+import { createBundledManifestSource } from "./bundled-source.js";
+import { createLocalOverrideManifestSource } from "./local-override-source.js";
+import { createRemoteManifestSource } from "./remote-source.js";
+import type {
+  ExtensionEntry,
+  ExtensionEntrySource,
+  ExtensionManifestSource,
+  ManifestLoadContext,
+  ResolvedExtensionEntry,
+} from "./types.js";
+
+export type {
+  ExtensionEntry,
+  ExtensionEntrySource,
+  ExtensionManifestSource,
+  ManifestLoadContext,
+  ResolvedExtensionEntry,
+} from "./types.js";
+
+export { createBundledManifestSource } from "./bundled-source.js";
+export { createLocalOverrideManifestSource } from "./local-override-source.js";
+export { createRemoteManifestSource } from "./remote-source.js";
+
+/** Lowest number wins (local-override beats remote beats bundled). */
+const SOURCE_PRIORITY: Record<ExtensionEntrySource, number> = {
+  "local-override": 0,
+  remote: 1,
+  bundled: 2,
+};
+
+function defaultSources(): ExtensionManifestSource[] {
+  return [
+    createBundledManifestSource(),
+    createRemoteManifestSource(),
+    createLocalOverrideManifestSource(),
+  ];
+}
+
+export type ResolveExtensionManifestOptions = ManifestLoadContext & {
+  /** Override the set of sources (primarily for tests). */
+  sources?: ExtensionManifestSource[];
+};
+
+/**
+ * Resolve the merged extension manifest. Every entry is tagged with its
+ * origin source on `__source` so diagnostic commands (`plugins doctor`,
+ * future `openclaw extensions list`) can explain where an entry came from.
+ */
+export async function resolveExtensionManifest(
+  options: ResolveExtensionManifestOptions = {},
+): Promise<ResolvedExtensionEntry[]> {
+  const sources = options.sources ?? defaultSources();
+  const ctx: ManifestLoadContext = {
+    packageRoot: options.packageRoot,
+    env: options.env,
+    signal: options.signal,
+  };
+
+  // Load all sources in parallel; each source is responsible for its own
+  // error handling and MUST return [] on failure (see types.ts contract).
+  const loaded = await Promise.all(
+    sources.map(async (source) => {
+      const entries = await source.load(ctx);
+      return entries.map((entry) => ({ entry, source: source.id }));
+    }),
+  );
+
+  const merged = new Map<string, { entry: ResolvedExtensionEntry; priority: number }>();
+  for (const { entry, source } of loaded.flat()) {
+    const key = entry.name;
+    if (!key) {
+      continue;
+    }
+    const priority = SOURCE_PRIORITY[source] ?? Number.MAX_SAFE_INTEGER;
+    const tagged: ResolvedExtensionEntry = {
+      ...(entry as Record<string, unknown>),
+      __source: source,
+    } as ResolvedExtensionEntry;
+    const existing = merged.get(key);
+    if (!existing || priority < existing.priority) {
+      merged.set(key, { entry: tagged, priority });
+    }
+  }
+
+  return Array.from(merged.values()).map(({ entry }) => entry);
+}
+
+/**
+ * Synchronous variant used by callers that must stay sync (e.g. catalog.ts
+ * runs inside sync discovery paths). Only consults the bundled source — the
+ * remote/local-override sources may do IO and are opted out of the sync path
+ * deliberately.
+ *
+ * Phase 2 note: if remote caching moves to a fully-materialised on-disk
+ * cache, it can also expose a sync read and be added here.
+ */
+export function resolveExtensionManifestSync(
+  options: ResolveExtensionManifestOptions = {},
+): ResolvedExtensionEntry[] {
+  const sources = options.sources ?? [createBundledManifestSource()];
+  const ctx: ManifestLoadContext = {
+    packageRoot: options.packageRoot,
+    env: options.env,
+  };
+  const merged = new Map<string, { entry: ResolvedExtensionEntry; priority: number }>();
+  for (const source of sources) {
+    const entries = source.load(ctx);
+    if (!Array.isArray(entries)) {
+      // Skip async sources when invoked sync-only.
+      continue;
+    }
+    const priority = SOURCE_PRIORITY[source.id] ?? Number.MAX_SAFE_INTEGER;
+    for (const entry of entries) {
+      const key = entry.name;
+      if (!key) {
+        continue;
+      }
+      const tagged: ResolvedExtensionEntry = {
+        ...(entry as Record<string, unknown>),
+        __source: source.id,
+      } as ResolvedExtensionEntry;
+      const existing = merged.get(key);
+      if (!existing || priority < existing.priority) {
+        merged.set(key, { entry: tagged, priority });
+      }
+    }
+  }
+  return Array.from(merged.values()).map(({ entry }) => entry);
+}

--- a/src/plugins/extension-registry/local-override-source.ts
+++ b/src/plugins/extension-registry/local-override-source.ts
@@ -1,0 +1,63 @@
+/**
+ * LocalOverrideManifestSource — phase-1 scaffold.
+ *
+ * Phase 2 goal: read per-user/per-enterprise overrides from
+ * `$OPENCLAW_CONFIG_DIR/extensions/manifest.json` so operators can pin or
+ * inject additional plugin entries without touching the CLI or shipping a
+ * remote service.
+ *
+ * Phase 1: the file is read if it exists (parity with how external catalogs
+ * in `channels/plugins/catalog.ts` already work), but the contract is kept
+ * private so phase-2 can add richer merge semantics.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { isRecord, resolveConfigDir } from "../../utils.js";
+import type { ExtensionEntry, ExtensionManifestSource, ManifestLoadContext } from "./types.js";
+
+const OVERRIDE_RELATIVE_PATH = path.join("extensions", "manifest.json");
+
+function parseEntries(raw: unknown): ExtensionEntry[] {
+  if (!isRecord(raw)) {
+    return [];
+  }
+  const list = raw.entries;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  const out: ExtensionEntry[] = [];
+  for (const item of list) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const name = typeof item.name === "string" ? item.name.trim() : "";
+    if (!name) {
+      continue;
+    }
+    out.push({ ...item, name } as ExtensionEntry);
+  }
+  return out;
+}
+
+export function createLocalOverrideManifestSource(): ExtensionManifestSource {
+  return {
+    id: "local-override",
+    load(ctx: ManifestLoadContext): ExtensionEntry[] {
+      const env = ctx.env ?? process.env;
+      const configDir = resolveConfigDir(env);
+      const manifestPath = path.join(configDir, OVERRIDE_RELATIVE_PATH);
+      let contents: string;
+      try {
+        contents = fs.readFileSync(manifestPath, "utf-8");
+      } catch {
+        return [];
+      }
+      try {
+        return parseEntries(JSON.parse(contents));
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/src/plugins/extension-registry/remote-source.ts
+++ b/src/plugins/extension-registry/remote-source.ts
@@ -1,0 +1,32 @@
+/**
+ * RemoteManifestSource — phase-1 scaffold. Disabled by default.
+ *
+ * Phase 2 goal: fetch a JSON manifest from a hosted URL, cache it on disk with
+ * ETag support (reusing `fetchWithSsrfGuard`), so users can see new
+ * extensions without shipping a new CLI release.
+ *
+ * Phase 1: we only expose the factory and read the opt-in env var
+ * `OPENCLAW_EXTENSION_MANIFEST_URL`; when unset the source is a no-op.
+ * All actual fetching is deferred to phase 2.
+ */
+
+import type { ExtensionEntry, ExtensionManifestSource, ManifestLoadContext } from "./types.js";
+
+const REMOTE_URL_ENV = "OPENCLAW_EXTENSION_MANIFEST_URL";
+
+export function createRemoteManifestSource(): ExtensionManifestSource {
+  return {
+    id: "remote",
+    load(ctx: ManifestLoadContext): ExtensionEntry[] {
+      const env = ctx.env ?? process.env;
+      const url = env[REMOTE_URL_ENV]?.trim();
+      if (!url) {
+        return [];
+      }
+      // Phase-1 placeholder: remote fetch is intentionally not implemented.
+      // Returning an empty list keeps onboard correct (falls back to bundled)
+      // and gives phase-2 a clean seam (HTTP + SSRF guard + ETag cache).
+      return [];
+    },
+  };
+}

--- a/src/plugins/extension-registry/types.ts
+++ b/src/plugins/extension-registry/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Extension Registry — phase-1 scaffold.
+ *
+ * Goal: introduce a single, forward-compatible seam for "what extensions exist
+ * and where do they come from?" so that onboard UX stays stable while the
+ * underlying data source evolves (bundled → remote manifest → local overrides
+ * → future marketplace search).
+ *
+ * Phase 1 ships only the bundled source (reading `extensions/manifest.json`
+ * from the OpenClaw package root). Remote and local-override sources have
+ * stable interfaces and placeholder stubs so phase 2 can wire them up without
+ * rewriting callers.
+ *
+ * Merge precedence (lowest-number wins): `local > remote > bundled`.
+ */
+
+import type { OpenClawPackageManifest } from "../manifest.js";
+
+/** Source tag — exposed on every resolved entry for diagnostics. */
+export type ExtensionEntrySource = "bundled" | "remote" | "local-override";
+
+/** Opaque-ish entry shape kept close to the on-disk JSON so future fields
+ * (signature, capabilities, publisher, …) survive round-trips without
+ * requiring host updates. */
+export type ExtensionEntry = {
+  /** npm package name (primary identity). */
+  name: string;
+  /** Optional display description. */
+  description?: string;
+  /** `external` means not shipped in this repo; `bundled` means currently in
+   * `extensions/<name>/` and listed here for forward-compat. */
+  source?: "external" | "bundled";
+  /** Primary capability. */
+  kind?: "channel" | "provider" | "tool" | "hook" | "skill";
+  /** Cheap metadata mirrored from plugin package.json `openclaw.*`. */
+  openclaw?: OpenClawPackageManifest;
+  /** Reserved extension fields — preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** Entry plus its provenance. Returned by {@link resolveExtensionManifest}. */
+export type ResolvedExtensionEntry = ExtensionEntry & {
+  __source: ExtensionEntrySource;
+};
+
+/** Contract every manifest source must satisfy. */
+export type ExtensionManifestSource = {
+  /** Stable tag used for provenance + merge precedence. */
+  readonly id: ExtensionEntrySource;
+  /**
+   * Load the manifest. MUST be side-effect free beyond IO and MUST NOT throw
+   * on missing sources — return an empty array instead, so onboard degrades
+   * gracefully when remote is unreachable.
+   */
+  load: (ctx: ManifestLoadContext) => Promise<ExtensionEntry[]> | ExtensionEntry[];
+};
+
+export type ManifestLoadContext = {
+  /** Absolute path to the OpenClaw package root (where `extensions/` lives). */
+  packageRoot?: string;
+  /** Process env — provided explicitly for testability. */
+  env?: NodeJS.ProcessEnv;
+  /** Abort signal for network-backed sources. */
+  signal?: AbortSignal;
+};


### PR DESCRIPTION
feat(extensions): phase-1 extension manifest and plugin install progress

The approach adds a `manifest.json` under `extension` to declare which external plugins are available. The entries in the manifest are loaded into the onboarding UI based on their type, and when a user selects one, it is automatically installed via NPM with progress feedback shown during the process. From an architecture perspective, the file structure also leaves room for future extensions such as remote registry support and plugin marketplace-style expansion.

The PR uses `wecom` as an example and has been tested. Review would be appreciated.

https://github.com/openclaw/openclaw/issues/70150