### PR TITLE
fix(wiki): register memory publicArtifacts in CLI-metadata mode

### DIFF
--- a/extensions/memory-core/cli-metadata.ts
+++ b/extensions/memory-core/cli-metadata.ts
@@ -1,10 +1,20 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { listMemoryCorePublicArtifacts } from "./src/public-artifacts.js";
 
 export default definePluginEntry({
   id: "memory-core",
   name: "Memory (Core)",
   description: "File-backed memory search tools and CLI",
+  kind: "memory",
   register(api) {
+    // Register public artifacts provider so that wiki bridge import can
+    // discover memory artifacts when running from the CLI process.
+    api.registerMemoryCapability({
+      publicArtifacts: {
+        listArtifacts: listMemoryCorePublicArtifacts,
+      },
+    });
+
     api.registerCli(
       async ({ program }) => {
         const { registerMemoryCli } = await import("./src/cli.js");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -73,6 +73,7 @@ import {
   getMemoryRuntime,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  registerMemoryCapability,
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -2881,10 +2882,29 @@ export async function loadOpenClawPluginCliRegistry(
       resolvePath: (input) => resolveUserPath(input),
       handlers: {
         registerCli: (registrar, opts) => registerCli(record, registrar, opts),
+        registerMemoryCapability: (capability) => {
+          if (!hasKind(record.kind, "memory")) {
+            return;
+          }
+          if (
+            Array.isArray(record.kind) &&
+            record.kind.length > 1 &&
+            !record.memorySlotSelected
+          ) {
+            return;
+          }
+          registerMemoryCapability(record.id, capability);
+        },
       },
     });
 
     const registrySnapshot = snapshotPluginRegistry(registry);
+    const previousMemoryCapability = getMemoryCapabilityRegistration();
+    const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
+    const previousMemoryPromptSupplements = listMemoryPromptSupplements();
+    const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
+    const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
+    const previousMemoryRuntime = getMemoryRuntime();
     try {
       withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
         runPluginRegisterSync(register, api),
@@ -2893,6 +2913,14 @@ export async function loadOpenClawPluginCliRegistry(
       seenIds.set(pluginId, candidate.origin);
     } catch (err) {
       restorePluginRegistry(registry, registrySnapshot);
+      restoreMemoryPluginState({
+        capability: previousMemoryCapability,
+        corpusSupplements: previousMemoryCorpusSupplements,
+        promptSupplements: previousMemoryPromptSupplements,
+        promptBuilder: previousMemoryPromptBuilder,
+        flushPlanResolver: previousMemoryFlushPlanResolver,
+        runtime: previousMemoryRuntime,
+      });
       recordPluginError({
         logger,
         registry,


### PR DESCRIPTION
## Problem

`openclaw wiki bridge import` always returns **0 artifacts / 0 workspaces** and destructively removes previously-synced bridge sources — even though the in-process runtime bridge works perfectly with 155+ artifacts.

### Root cause

The CLI process loads plugin `cli-metadata.ts` entries (lightweight) instead of the full `index.ts`. The memory-core `cli-metadata.ts` only registered CLI commands and never called `registerMemoryCapability()`, so `memoryPluginState.capability` stayed empty. When the wiki bridge called `listActiveMemoryPublicArtifacts()`, it got nothing back.

Additionally, the CLI-metadata plugin loader in `loader.ts` only wired `registerCli` as a handler — `registerMemoryCapability` defaulted to a no-op, so even if the plugin tried to register, it would be silently swallowed.

## Fix

Two changes:

1. **`extensions/memory-core/cli-metadata.ts`**: Register the `publicArtifacts` provider (via `listMemoryCorePublicArtifacts`) and declare `kind: "memory"` so the memory slot resolution accepts it.

2. **`src/plugins/loader.ts`**: Wire `registerMemoryCapability` in the CLI-metadata `buildPluginApi` handlers (with the same `hasKind` guard used in full registration) so the call actually reaches `memoryPluginState`.

## Testing

- All 6 `bridge.test.ts` tests pass ✅
- All 105 `loader.test.ts` tests pass ✅
- Zero new type errors (6 pre-existing errors in `pi-embedded-runner` are unrelated)

Fixes #70181