### PR TITLE
fix(cron): clean up bundled mcp runtimes safely

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -15,8 +15,9 @@ import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 
 // --- Module mocks (must be hoisted before imports) ---
 
-const { countActiveDescendantRunsMock } = vi.hoisted(() => ({
+const { countActiveDescendantRunsMock, disposeSessionMcpRuntimeMock } = vi.hoisted(() => ({
   countActiveDescendantRunsMock: vi.fn().mockReturnValue(0),
+  disposeSessionMcpRuntimeMock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../config/sessions/main-session.js", () => ({
@@ -26,6 +27,10 @@ vi.mock("../../config/sessions/main-session.js", () => ({
 
 vi.mock("../../agents/subagent-registry-read.js", () => ({
   countActiveDescendantRuns: countActiveDescendantRunsMock,
+}));
+
+vi.mock("../../agents/pi-bundle-mcp-tools.js", () => ({
+  disposeSessionMcpRuntime: disposeSessionMcpRuntimeMock,
 }));
 
 vi.mock("./delivery-subagent-registry.runtime.js", () => ({
@@ -71,6 +76,7 @@ vi.mock("./subagent-followup.runtime.js", () => ({
   waitForDescendantSubagentSummary: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { disposeSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 // Import after mocks
 import { countActiveDescendantRuns } from "../../agents/subagent-registry-read.js";
 import { callGateway } from "../../gateway/call.runtime.js";
@@ -138,6 +144,7 @@ function makeBaseParams(overrides: {
     } as never,
     agentId: "main",
     agentSessionKey: "agent:main",
+    sessionId: "test-session-id",
     runStartedAt,
     runEndedAt: runStartedAt,
     timeoutMs: 30_000,
@@ -171,6 +178,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(disposeSessionMcpRuntime).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -508,6 +516,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       },
       timeoutMs: 10_000,
     });
+    expect(disposeSessionMcpRuntime).toHaveBeenCalledWith("test-session-id");
   });
 
   it("cleans up the direct cron session after text delivery when deleteAfterRun is enabled", async () => {
@@ -531,6 +540,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       },
       timeoutMs: 10_000,
     });
+    expect(disposeSessionMcpRuntime).toHaveBeenCalledWith("test-session-id");
   });
 
   it("text delivery fires exactly once (no double-deliver)", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,3 +1,4 @@
+import { disposeSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
   isSilentReplyText,
@@ -103,6 +104,7 @@ type DispatchCronDeliveryParams = {
   job: CronJob;
   agentId: string;
   agentSessionKey: string;
+  sessionId: string;
   runStartedAt: number;
   runEndedAt: number;
   timeoutMs: number;
@@ -476,6 +478,12 @@ export async function dispatchCronDelivery(
         timeoutMs: 10_000,
       });
       directCronSessionDeleted = true;
+      const sessionId = params.sessionId.trim();
+      if (sessionId) {
+        await disposeSessionMcpRuntime(sessionId).catch(() => {
+          // Best-effort; direct delivery result should still be returned.
+        });
+      }
     } catch {
       // Best-effort; direct delivery result should still be returned.
     }

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -160,9 +160,10 @@ export function createCronPromptExecutor(params: {
           sessionKey: params.agentSessionKey,
           agentId: params.agentId,
           trigger: "cron",
-          // Isolated cron runs should not keep per-run bundled MCP stdio
-          // servers alive after the scheduler turn completes.
-          cleanupBundleMcpOnRunEnd: true,
+          // Only isolated cron turns should tear down their per-run bundled MCP
+          // runtimes; persistent cron sessions must keep session-scoped MCP
+          // state across runs.
+          cleanupBundleMcpOnRunEnd: params.job.sessionTarget === "isolated",
           allowGatewaySubagentBinding: true,
           senderIsOwner: false,
           messageChannel: params.messageChannel,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -160,6 +160,9 @@ export function createCronPromptExecutor(params: {
           sessionKey: params.agentSessionKey,
           agentId: params.agentId,
           trigger: "cron",
+          // Isolated cron runs should not keep per-run bundled MCP stdio
+          // servers alive after the scheduler turn completes.
+          cleanupBundleMcpOnRunEnd: true,
           allowGatewaySubagentBinding: true,
           senderIsOwner: false,
           messageChannel: params.messageChannel,

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -5,6 +5,7 @@ import {
   setupRunCronIsolatedAgentTurnSuite,
 } from "./run.suite-helpers.js";
 import {
+  disposeSessionMcpRuntimeMock,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   resolveFastModeStateMock,
@@ -37,20 +38,24 @@ async function runFastModeCase(params: {
   configFastMode: boolean;
   expectedFastMode: boolean;
   expectedCleanupBundleMcpOnRunEnd?: boolean;
+  expectedDisposedSessionId?: string;
+  sessionId?: string;
   message: string;
+  previousSessionId?: string;
   sessionTarget?: string;
   sessionFastMode?: boolean;
 }) {
   const baseSession = makeCronSession();
   resolveCronSessionMock.mockReturnValue(
-    params.sessionFastMode === undefined
-      ? baseSession
-      : makeCronSession({
-          sessionEntry: {
-            ...baseSession.sessionEntry,
-            fastMode: params.sessionFastMode,
-          },
-        }),
+    makeCronSession({
+      ...baseSession,
+      ...(params.previousSessionId ? { previousSessionId: params.previousSessionId } : {}),
+      sessionEntry: {
+        ...baseSession.sessionEntry,
+        ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+        ...(params.sessionFastMode === undefined ? {} : { fastMode: params.sessionFastMode }),
+      },
+    }),
   );
   mockSuccessfulModelFallback();
   resolveFastModeStateMock.mockImplementation(({ cfg, sessionEntry }) => {
@@ -98,6 +103,11 @@ async function runFastModeCase(params: {
     cleanupBundleMcpOnRunEnd: params.expectedCleanupBundleMcpOnRunEnd ?? true,
     allowGatewaySubagentBinding: true,
   });
+  if (params.expectedDisposedSessionId) {
+    expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledWith(params.expectedDisposedSessionId);
+    return;
+  }
+  expect(disposeSessionMcpRuntimeMock).not.toHaveBeenCalled();
 }
 
 describe("runCronIsolatedAgentTurn — fast mode", () => {
@@ -135,6 +145,19 @@ describe("runCronIsolatedAgentTurn — fast mode", () => {
       expectedFastMode: true,
       expectedCleanupBundleMcpOnRunEnd: false,
       message: "test persistent cron session",
+      sessionTarget: "session:agent:main:main:thread:9999",
+    });
+  });
+
+  it("disposes the retired bundled MCP runtime when a persistent cron session rolls over", async () => {
+    await runFastModeCase({
+      configFastMode: true,
+      expectedFastMode: true,
+      expectedCleanupBundleMcpOnRunEnd: false,
+      expectedDisposedSessionId: "stale-session-id",
+      message: "test persistent cron session rollover",
+      previousSessionId: "stale-session-id",
+      sessionId: "rotated-session-id",
       sessionTarget: "session:agent:main:main:thread:9999",
     });
   });

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -36,7 +36,9 @@ function mockSuccessfulModelFallback() {
 async function runFastModeCase(params: {
   configFastMode: boolean;
   expectedFastMode: boolean;
+  expectedCleanupBundleMcpOnRunEnd?: boolean;
   message: string;
+  sessionTarget?: string;
   sessionFastMode?: boolean;
 }) {
   const baseSession = makeCronSession();
@@ -77,6 +79,7 @@ async function runFastModeCase(params: {
         },
       },
       job: makeIsolatedAgentTurnJob({
+        sessionTarget: params.sessionTarget ?? "isolated",
         payload: {
           kind: "agentTurn",
           message: params.message,
@@ -92,7 +95,7 @@ async function runFastModeCase(params: {
     provider: "openai",
     model: EXPECTED_OPENAI_MODEL,
     fastMode: params.expectedFastMode,
-    cleanupBundleMcpOnRunEnd: true,
+    cleanupBundleMcpOnRunEnd: params.expectedCleanupBundleMcpOnRunEnd ?? true,
     allowGatewaySubagentBinding: true,
   });
 }
@@ -123,6 +126,16 @@ describe("runCronIsolatedAgentTurn — fast mode", () => {
       expectedFastMode: true,
       message: "test fast mode session override",
       sessionFastMode: true,
+    });
+  });
+
+  it("preserves bundled MCP runtime state for persistent cron session targets", async () => {
+    await runFastModeCase({
+      configFastMode: true,
+      expectedFastMode: true,
+      expectedCleanupBundleMcpOnRunEnd: false,
+      message: "test persistent cron session",
+      sessionTarget: "session:agent:main:main:thread:9999",
     });
   });
 });

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -92,6 +92,7 @@ async function runFastModeCase(params: {
     provider: "openai",
     model: EXPECTED_OPENAI_MODEL,
     fastMode: params.expectedFastMode,
+    cleanupBundleMcpOnRunEnd: true,
     allowGatewaySubagentBinding: true,
   });
 }

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -69,6 +69,7 @@ export const resolveHeartbeatAckMaxCharsMock = createMock();
 export const resolveSessionAuthProfileOverrideMock = createMock();
 export const resolveFastModeStateMock = createMock();
 export const getChannelPluginMock = createMock();
+export const disposeSessionMcpRuntimeMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
 const resolveCronStyleNowMock = createMock();
@@ -194,6 +195,10 @@ vi.mock("./run-subagent-registry.runtime.js", () => ({
 
 vi.mock("../../agents/cli-runner.runtime.js", () => ({
   setCliSessionId: vi.fn(),
+}));
+
+vi.mock("../../agents/pi-bundle-mcp-tools.js", () => ({
+  disposeSessionMcpRuntime: disposeSessionMcpRuntimeMock,
 }));
 
 vi.mock("../../config/sessions/store.runtime.js", () => ({
@@ -433,6 +438,8 @@ function resetRunSessionMocks(): void {
   updateSessionStoreMock.mockResolvedValue(undefined);
   resolveCronSessionMock.mockReset();
   resolveCronSessionMock.mockReturnValue(makeCronSession());
+  disposeSessionMcpRuntimeMock.mockReset();
+  disposeSessionMcpRuntimeMock.mockResolvedValue(undefined);
 }
 
 export function resetRunCronIsolatedAgentTurnHarness(): void {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,4 +1,5 @@
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
+import { disposeSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.types.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -255,6 +256,25 @@ function resolveMessagingToolSentTargets(params: {
         : {}),
     },
   ];
+}
+
+async function disposeRetiredCronSessionRuntime(params: {
+  job: CronJob;
+  cronSession: MutableCronSession;
+}) {
+  if (params.job.sessionTarget === "isolated") {
+    return;
+  }
+  const previousSessionId = params.cronSession.previousSessionId?.trim();
+  const currentSessionId = params.cronSession.sessionEntry.sessionId?.trim();
+  if (!previousSessionId || previousSessionId === currentSessionId) {
+    return;
+  }
+  await disposeSessionMcpRuntime(previousSessionId).catch((error) => {
+    logWarn(
+      `[cron:${params.job.id}] Failed to dispose retired bundle MCP runtime for session ${previousSessionId}: ${String(error)}`,
+    );
+  });
 }
 
 function resolveCronToolPolicy(params: { deliveryMode: "announce" | "webhook" | "none" }) {
@@ -618,6 +638,10 @@ async function prepareCronRunContext(params: {
   } catch (err) {
     logWarn(`[cron:${input.job.id}] Failed to persist pre-run session entry: ${String(err)}`);
   }
+  await disposeRetiredCronSessionRuntime({
+    job: input.job,
+    cronSession,
+  });
   const hasSessionAuthProfileOverride = Boolean(
     cronSession.sessionEntry.authProfileOverride?.trim(),
   );
@@ -839,6 +863,7 @@ async function finalizeCronRun(params: {
     job: prepared.input.job,
     agentId: prepared.agentId,
     agentSessionKey: prepared.agentSessionKey,
+    sessionId: prepared.runSessionId,
     runStartedAt: execution.runStartedAt,
     runEndedAt: execution.runEndedAt,
     timeoutMs: prepared.timeoutMs,

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -120,6 +120,7 @@ describe("resolveCronSession", () => {
 
       expect(result.sessionEntry.sessionId).toBe("existing-session-id-123");
       expect(result.isNewSession).toBe(false);
+      expect(result.previousSessionId).toBeUndefined();
       expect(result.systemSent).toBe(true);
       expect(clearBootstrapSnapshot).not.toHaveBeenCalled();
     });
@@ -139,6 +140,7 @@ describe("resolveCronSession", () => {
 
       expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
       expect(result.isNewSession).toBe(true);
+      expect(result.previousSessionId).toBe("old-session-id");
       expect(result.systemSent).toBe(false);
       expect(result.sessionEntry.modelOverride).toBe("gpt-4.1-mini");
       expect(result.sessionEntry.providerOverride).toBe("openai");
@@ -161,6 +163,7 @@ describe("resolveCronSession", () => {
 
       expect(result.sessionEntry.sessionId).not.toBe("existing-session-id-456");
       expect(result.isNewSession).toBe(true);
+      expect(result.previousSessionId).toBe("existing-session-id-456");
       expect(result.systemSent).toBe(false);
       expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
       expect(result.sessionEntry.providerOverride).toBe("anthropic");

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -59,9 +59,10 @@ export function resolveCronSession(params: {
     systemSent = false;
   }
 
+  const previousSessionId = isNewSession ? entry?.sessionId : undefined;
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey: params.sessionKey,
-    previousSessionId: isNewSession ? entry?.sessionId : undefined,
+    previousSessionId,
   });
 
   const sessionEntry: SessionEntry = {
@@ -86,5 +87,5 @@ export function resolveCronSession(params: {
       sessionFile: undefined,
     }),
   };
-  return { storePath, store, sessionEntry, systemSent, isNewSession };
+  return { storePath, store, sessionEntry, systemSent, isNewSession, previousSessionId };
 }


### PR DESCRIPTION
## Summary

- Problem: the first cron MCP cleanup fix stopped isolated runs from leaking bundled MCP runtimes, but it also removed the only retirement path for persistent cron-session runtimes once those sessions rolled or were deleted.
- Why it matters: `session:*` cron jobs need bundled MCP state to survive normal repeated runs, but retired session IDs still need explicit teardown or the gateway can accumulate stale MCP subprocesses over time.
- What changed: isolated cron runs still clean up per-run bundled MCP runtimes; persistent cron sessions now dispose the old bundled MCP runtime when the cron session rolls to a new session ID, and direct cron `deleteAfterRun` cleanup now also disposes the session runtime after `sessions.delete`.
- What did NOT change (scope boundary): persistent `session:*` cron targets still keep bundled MCP state across normal runs, and non-cron/manual embedded-run cleanup behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64169
- Related #68406
- Related #68809
- Related #69465
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: after `1cd919d784`, cron correctly stopped forcing `cleanupBundleMcpOnRunEnd` for persistent `session:*` targets, but that left no explicit retirement path for stale bundled MCP runtimes when a persistent cron session rolled to a new session ID or when direct cron cleanup deleted the session.
- Missing detection / guardrail: there was no regression coverage for persistent cron-session rollover or `deleteAfterRun` direct cleanup of bundled MCP runtimes.
- Contributing context (if known): the bundled MCP runtime cache is keyed by `sessionId`, while persistent cron jobs keep a stable `sessionKey` that can outlive and later rotate the underlying session ID.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cron/isolated-agent/run.fast-mode.test.ts`
  - `src/cron/isolated-agent/session.test.ts`
  - `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
- Scenario the test should lock in: persistent cron session targets keep `cleanupBundleMcpOnRunEnd=false` during normal runs, but stale bundled MCP runtimes are explicitly disposed when the session rolls or when direct cron cleanup deletes the session.
- Why this is the smallest reliable guardrail: these tests exercise the cron-owned state transitions directly without needing live gateway/MCP subprocess orchestration.
- Existing test that already covers this (if any): `src/agents/pi-embedded-runner.e2e.test.ts` already covers one-shot `cleanupBundleMcpOnRunEnd` disposal for the embedded runner itself.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Persistent cron sessions now preserve bundled MCP state across normal runs without leaking stale runtimes after session rollover or direct `deleteAfterRun` cleanup.

## Diagram (if applicable)

```text
Before:
persistent cron run -> keep session-scoped MCP runtime
session rolls or is deleted -> old sessionId runtime can remain orphaned

After:
persistent cron run -> keep session-scoped MCP runtime
session rolls or is deleted -> retire stale sessionId runtime explicitly
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.5.0 (macOS host)
- Runtime/container: Node `v25.9.0`, pnpm `10.33.0`
- Model/provider: N/A
- Integration/channel (if any): cron `agentTurn` with bundled MCP enabled
- Relevant config (redacted): compared `sessionTarget="isolated"` vs persistent `sessionTarget="session:..."`

### Steps

1. Run a cron `agentTurn` with bundled MCP enabled on a persistent `session:*` target so the session-scoped MCP runtime is reused across runs.
2. Let that cron session rotate to a new session ID or delete the direct cron session via `deleteAfterRun`.
3. Observe whether the retired bundled MCP runtime is explicitly disposed while the current persistent session still preserves normal cross-run state.

### Expected

- Persistent cron sessions keep bundled MCP state across normal runs.
- Retired session IDs are explicitly cleaned up when cron rolls to a new session or deletes the direct session.

### Actual

- Before this follow-up, the old runtime could remain cached/orphaned after rollover/delete.
- With this change, the stale session runtime is retired while the live persistent-session behavior stays intact.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence used here:

- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/cron/isolated-agent/run.fast-mode.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/isolated-agent/session.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:docs`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed`
- `OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:prod`
- `codex review --base origin/main` (local Codex review rerun; the stale-runtime cleanup gap it surfaced is addressed in `c96676510c`)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - persistent cron session targets still pass `cleanupBundleMcpOnRunEnd=false`
  - rollover of a persistent cron session disposes the retired bundled MCP runtime
  - direct cron `deleteAfterRun` cleanup now disposes the deleted session runtime
  - repo-local `check`, `check:docs`, `check:changed`, and `tsgo:prod` all passed on the updated branch
- Edge cases checked:
  - silent direct-delivery cleanup path
  - text direct-delivery cleanup path
  - fresh-session vs reused-session `previousSessionId` behavior
- What you did **not** verify:
  - I did not do a fresh HAL live-host repro for this follow-up commit.
  - On this host, the top-level `OPENCLAW_LOCAL_CHECK=0 pnpm test` rerun emitted only passing shard summaries but did not return from final teardown before I stopped waiting.
  - On this host, `OPENCLAW_LOCAL_CHECK=0 pnpm build` consistently advanced through `runtime-postbuild` and then stalled without returning, so I verified the remaining post-`runtime-postbuild` steps individually instead:
    - `node --import tsx scripts/write-npm-update-compat-sidecars.ts`
    - `node scripts/build-stamp.mjs`
    - `pnpm build:plugin-sdk:dts`
    - `node --import tsx scripts/write-plugin-sdk-entry-dts.ts`
    - `node scripts/check-plugin-sdk-exports.mjs`
    - `node --import tsx scripts/canvas-a2ui-copy.ts`
    - `node --import tsx scripts/copy-hook-metadata.ts`
    - `node --import tsx scripts/copy-export-html-templates.ts`
    - `node --import tsx scripts/write-build-info.ts`
    - `node --experimental-strip-types scripts/write-cli-startup-metadata.ts`
    - `node --import tsx scripts/write-cli-compat.ts`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: disposing the wrong bundled MCP runtime would break persistent-session continuity.
  - Mitigation: cleanup is guarded by `previousSessionId !== currentSessionId`, direct cron cleanup uses the current run session ID, and regression coverage locks both transitions.

## AI Assistance

- AI-assisted: Yes (`Codex` for implementation and local review)
- Testing degree: mostly tested locally; changed-surface and broader repo-local gates passed, while the top-level full `pnpm test`/`pnpm build` runners stalled after work completed on this host
- Prompts/session logs: local Codex review rerun session `019db5b9-844d-7fa0-92cb-4cae176ab10f`; implementation session logs available on request
- I understand what the code does and manually checked the touched cron + bundled MCP cleanup paths before pushing
