### PR TITLE
fix(telegram): align grammy version spec to installed 1.41.x

### DIFF
--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -8,7 +8,7 @@
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@sinclair/typebox": "0.34.49",
-    "grammy": "^1.42.0",
+    "grammy": "^1.41.0",
     "undici": "8.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #70137 (also tracked as #69831).

## Problem

After upgrading to v2026.4.21, the gateway crash-loops on startup with:

```
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - <root>: read failed: Error: Cannot find module 'grammy'
Require stack:
- .../dist/extensions/telegram/allowed-updates-*.js
```

## Root cause

`extensions/telegram/package.json` declares `"grammy": "^1.42.0"`, but the version actually present at install time is `1.41.1`. `scripts/stage-bundled-plugin-runtime-deps.mjs` calls `dependencyVersionSatisfied(spec, installedVersion)` before staging — the `^1.42.0` range is not satisfied by `1.41.1`, so `grammy` is silently skipped and never copied into `dist/extensions/telegram/node_modules/`. At runtime the telegram extension fails to require it.

## Fix

Change the spec to `^1.41.0` so it matches the installed version. One-line, single-file diff. Verified locally — gateway boots clean and Telegram channel comes up.

## Why a separate PR

PR #70091 already proposes the same one-line change but bundles 9 unrelated cherry-picks (~595 additions across 21 files) plus two open Greptile review findings, which will slow it down. This regression is breaking every install on v2026.4.21, so a minimal targeted fix seems worth the duplication. Happy to close this if #70091's grammy commit can be cherry-picked separately.
