### PR TITLE
fix(discord): use resolveDiscordChannelParentIdSafe in voice command path

### DIFF
--- a/extensions/discord/src/voice/command.ts
+++ b/extensions/discord/src/voice/command.ts
@@ -14,7 +14,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug } from "../monitor/allow-list.js";
-import { resolveDiscordChannelParentIdSafe } from "../monitor/channel-access.js";
+import {
+  resolveDiscordChannelNameSafe,
+  resolveDiscordChannelParentIdSafe,
+} from "../monitor/channel-access.js";
 import { resolveDiscordChannelInfo } from "../monitor/message-utils.js";
 import { resolveDiscordSenderIdentity } from "../monitor/sender-identity.js";
 import { resolveDiscordThreadParentInfo } from "../monitor/threading.js";
@@ -201,7 +204,7 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
       const access = await authorizeVoiceCommand(interaction, params, {
         channelOverride: {
           id: channel.id,
-          name: "name" in channel ? (channel.name as string) : undefined,
+          name: resolveDiscordChannelNameSafe(channel),
           parentId: resolveDiscordChannelParentIdSafe(channel),
         },
       });

--- a/extensions/discord/src/voice/command.ts
+++ b/extensions/discord/src/voice/command.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug } from "../monitor/allow-list.js";
+import { resolveDiscordChannelParentIdSafe } from "../monitor/channel-access.js";
 import { resolveDiscordChannelInfo } from "../monitor/message-utils.js";
 import { resolveDiscordSenderIdentity } from "../monitor/sender-identity.js";
 import { resolveDiscordThreadParentInfo } from "../monitor/threading.js";
@@ -201,10 +202,7 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
         channelOverride: {
           id: channel.id,
           name: "name" in channel ? (channel.name as string) : undefined,
-          parentId:
-            "parentId" in channel
-              ? ((channel as { parentId?: string }).parentId ?? undefined)
-              : undefined,
+          parentId: resolveDiscordChannelParentIdSafe(channel),
         },
       });
       if (!access.ok) {


### PR DESCRIPTION
## Summary

Follow-up to #69908, which fixed the partial-channel `parentId` getter throw for native slash commands, listeners, and the native model picker. `extensions/discord/src/voice/command.ts` still reads `channel.parentId` through the unsafe `"parentId" in channel ? (channel.parentId ?? undefined) : undefined` pattern, so invoking voice `/join` from inside a thread on `@buape/carbon` ≥0.16 throws `Cannot access rawData on partial Channel`.

## Root cause

Same as #69908. `"parentId" in channel` returns `true` for partial channels because the getter is defined on the prototype, but invoking it reads `_rawData` which is `null` on partial channels and throws. The `in` operator does not prevent this — it only checks for the getter's existence, not whether the getter will succeed.

## Fix

Route the voice command callsite through the existing `resolveDiscordChannelParentIdSafe` helper added in #69908. Behavior for fully hydrated channels is unchanged; partial channels return `undefined`, which is already handled downstream by `authorizeVoiceCommand` refetching via `resolveDiscordChannelInfo(interaction.client, channelId)`.

## Changes

- `extensions/discord/src/voice/command.ts`: replace inline `"parentId" in channel` read with `resolveDiscordChannelParentIdSafe(channel)` and add the import.

## Test plan

- [x] `pnpm test extensions/discord/src/voice` — 7 files, 24 tests pass (2.25s)
- [x] `pnpm tsgo:all` — 0 new errors (25 pre-existing errors unchanged across `gateway-plugin.ts`, `qa-lab`, `qqbot`, `slack`, `tokenjuice`, unrelated to this change)

## Repro

Any voice slash command (`/join`, etc.) invoked from inside a Discord thread with `@buape/carbon` ≥0.16 installed will throw:

```
Error: Cannot access rawData on partial Channel. Use fetch() to populate data.
    at GuildThreadChannel.get rawData [as rawData] (@buape/carbon/dist/src/abstracts/BaseChannel.js:37:19)
    at GuildThreadChannel.get parentId [as parentId] (@buape/carbon/dist/src/abstracts/BaseGuildChannel.js:27:19)
    at createDiscordVoiceCommand (extensions/discord/src/voice/command.ts:205)
```

The Discord interaction then hangs at "thinking..." because the command handler throws before calling `interaction.defer()` or `interaction.reply()`.