### PR TITLE
fix(lobster): clarify unresolved workflow file paths

### DIFF
--- a/extensions/lobster/src/lobster-core.d.ts
+++ b/extensions/lobster/src/lobster-core.d.ts
@@ -4,6 +4,7 @@ declare module "@clawdbot/lobster/core" {
     prompt: string;
     items: unknown[];
     resumeToken?: string;
+    approvalId?: string;
   } | null;
 
   type LobsterToolContext = {

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -236,6 +236,82 @@ describe("createEmbeddedLobsterRunner", () => {
     });
   });
 
+  it("forwards approvalId through resume when token is absent", async () => {
+    const runtime = {
+      runToolRequest: vi.fn(),
+      resumeToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+    };
+
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue(runtime),
+    });
+
+    await runner.run({
+      action: "resume",
+      approvalId: "dbc98d05",
+      approve: true,
+      cwd: process.cwd(),
+      timeoutMs: 2000,
+      maxStdoutBytes: 4096,
+    });
+
+    expect(runtime.resumeToolRequest).toHaveBeenCalledWith({
+      approvalId: "dbc98d05",
+      approved: true,
+      ctx: expect.objectContaining({ mode: "tool" }),
+    });
+  });
+
+  it("passes approvalId through the normalized needs_approval envelope", async () => {
+    const runtime = {
+      runToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "needs_approval",
+        output: [],
+        requiresApproval: {
+          type: "approval_request",
+          prompt: "ok?",
+          items: [],
+          resumeToken: "eyJ...",
+          approvalId: "dbc98d05",
+        },
+      }),
+      resumeToolRequest: vi.fn(),
+    };
+
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue(runtime),
+    });
+
+    const envelope = await runner.run({
+      action: "run",
+      pipeline: "exec --json=true echo hi",
+      cwd: process.cwd(),
+      timeoutMs: 2000,
+      maxStdoutBytes: 4096,
+    });
+
+    expect(envelope).toEqual({
+      ok: true,
+      status: "needs_approval",
+      output: [],
+      requiresApproval: {
+        type: "approval_request",
+        prompt: "ok?",
+        items: [],
+        resumeToken: "eyJ...",
+        approvalId: "dbc98d05",
+      },
+    });
+  });
+
   it("loads the embedded runtime once per runner", async () => {
     const runtime = {
       runToolRequest: vi.fn().mockResolvedValue({
@@ -310,7 +386,7 @@ describe("createEmbeddedLobsterRunner", () => {
         timeoutMs: 2000,
         maxStdoutBytes: 4096,
       }),
-    ).rejects.toThrow(/token required/);
+    ).rejects.toThrow(/token or approvalId required/);
 
     await expect(
       runner.run({

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -9,9 +9,13 @@ describe("resolveLobsterCwd", () => {
     expect(resolveLobsterCwd(undefined)).toBe(process.cwd());
   });
 
-  it("keeps relative paths inside the repo root", () => {
-    expect(resolveLobsterCwd("extensions/lobster")).toBe(
-      path.resolve(process.cwd(), "extensions/lobster"),
+  it("prefers an explicit base directory", () => {
+    expect(resolveLobsterCwd(undefined, "/tmp/workspace")).toBe("/tmp/workspace");
+  });
+
+  it("keeps relative paths inside the chosen base directory", () => {
+    expect(resolveLobsterCwd("extensions/lobster", "/tmp/workspace")).toBe(
+      path.resolve("/tmp/workspace", "extensions/lobster"),
     );
   });
 });
@@ -133,6 +137,30 @@ describe("createEmbeddedLobsterRunner", () => {
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("fails clearly when a workflow-like path is not resolvable", async () => {
+    const runtime = {
+      runToolRequest: vi.fn(),
+      resumeToolRequest: vi.fn(),
+    };
+
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue(runtime),
+    });
+
+    await expect(
+      runner.run({
+        action: "run",
+        pipeline: "missing-workflow.lobster",
+        cwd: process.cwd(),
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      }),
+    ).rejects.toThrow(
+      "Workflow file not found or not resolvable from cwd: missing-workflow.lobster",
+    );
+    expect(runtime.runToolRequest).not.toHaveBeenCalled();
   });
 
   it("throws when the embedded runtime returns an error envelope", async () => {

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -16,6 +16,7 @@ export type LobsterEnvelope =
         prompt: string;
         items: unknown[];
         resumeToken?: string;
+        approvalId?: string;
       };
     }
   | {
@@ -28,6 +29,7 @@ export type LobsterRunnerParams = {
   pipeline?: string;
   argsJson?: string;
   token?: string;
+  approvalId?: string;
   approve?: boolean;
   cwd: string;
   timeoutMs: number;
@@ -61,6 +63,7 @@ type EmbeddedToolEnvelope = {
     items: unknown[];
     preview?: string;
     resumeToken?: string;
+    approvalId?: string;
   } | null;
   requiresInput?: {
     prompt: string;
@@ -156,6 +159,9 @@ function normalizeEnvelope(envelope: EmbeddedToolEnvelope): LobsterEnvelope {
             items: envelope.requiresApproval.items,
             ...(envelope.requiresApproval.resumeToken
               ? { resumeToken: envelope.requiresApproval.resumeToken }
+              : {}),
+            ...(envelope.requiresApproval.approvalId
+              ? { approvalId: envelope.requiresApproval.approvalId }
               : {}),
           }
         : null,
@@ -296,8 +302,9 @@ export function createEmbeddedLobsterRunner(options?: {
         }
 
         const token = params.token?.trim() ?? "";
-        if (!token) {
-          throw new Error("token required");
+        const approvalId = params.approvalId?.trim() ?? "";
+        if (!token && !approvalId) {
+          throw new Error("token or approvalId required");
         }
         if (typeof params.approve !== "boolean") {
           throw new Error("approve required");
@@ -306,7 +313,8 @@ export function createEmbeddedLobsterRunner(options?: {
         return throwOnErrorEnvelope(
           normalizeEnvelope(
             await runtime.resumeToolRequest({
-              token,
+              ...(token ? { token } : {}),
+              ...(approvalId ? { approvalId } : {}),
               approved: params.approve,
               ctx,
             }),

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -102,18 +102,20 @@ function normalizeForCwdSandbox(p: string): string {
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
-export function resolveLobsterCwd(cwdRaw: unknown): string {
+export function resolveLobsterCwd(cwdRaw: unknown, baseDirRaw?: unknown): string {
+  const baseDir =
+    typeof baseDirRaw === "string" && baseDirRaw.trim() ? baseDirRaw.trim() : process.cwd();
+
   if (typeof cwdRaw !== "string" || !cwdRaw.trim()) {
-    return process.cwd();
+    return baseDir;
   }
   const cwd = cwdRaw.trim();
   if (path.isAbsolute(cwd)) {
     throw new Error("cwd must be a relative path");
   }
-  const base = process.cwd();
-  const resolved = path.resolve(base, cwd);
+  const resolved = path.resolve(baseDir, cwd);
 
-  const rel = path.relative(normalizeForCwdSandbox(base), normalizeForCwdSandbox(resolved));
+  const rel = path.relative(normalizeForCwdSandbox(baseDir), normalizeForCwdSandbox(resolved));
   if (rel === "" || rel === ".") {
     return resolved;
   }
@@ -228,6 +230,14 @@ function createEmbeddedToolContext(
   };
 }
 
+function shouldPreferWorkflowFile(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return [".lobster", ".yaml", ".yml", ".json"].includes(path.extname(trimmed).toLowerCase());
+}
+
 async function withTimeout<T>(
   timeoutMs: number,
   fn: (signal?: AbortSignal) => Promise<T>,
@@ -294,6 +304,10 @@ export function createEmbeddedLobsterRunner(options?: {
             return throwOnErrorEnvelope(
               normalizeEnvelope(await runtime.runToolRequest({ filePath, args, ctx })),
             );
+          }
+
+          if (shouldPreferWorkflowFile(pipeline)) {
+            throw new Error(`Workflow file not found or not resolvable from cwd: ${pipeline}`);
           }
 
           return throwOnErrorEnvelope(

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -221,6 +221,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
       pipeline: Type.Optional(Type.String()),
       argsJson: Type.Optional(Type.String()),
       token: Type.Optional(Type.String()),
+      approvalId: Type.Optional(Type.String()),
       approve: Type.Optional(Type.Boolean()),
       cwd: Type.Optional(
         Type.String({
@@ -261,6 +262,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
         ...(typeof params.pipeline === "string" ? { pipeline: params.pipeline } : {}),
         ...(typeof params.argsJson === "string" ? { argsJson: params.argsJson } : {}),
         ...(typeof params.token === "string" ? { token: params.token } : {}),
+        ...(typeof params.approvalId === "string" ? { approvalId: params.approvalId } : {}),
         ...(typeof params.approve === "boolean" ? { approve: params.approve } : {}),
         cwd,
         timeoutMs,


### PR DESCRIPTION
## Summary
- clarify errors when workflow-like paths cannot be resolved by the lobster tool
- avoid falling back to inline pipeline parsing for `.lobster`/`.yaml`/`.json` paths that look like workflow files
- add runner tests covering unresolved workflow-like paths

## Problem
When a user passes a relative workflow file path like `test-mini-english.lobster` and Lobster cannot resolve it from the current cwd, OpenClaw currently falls back to parsing that string as an inline pipeline. That produces a misleading error such as:

`Unknown command: test-mini-english.lobster`

In practice this makes workflow-file path issues much harder to debug.

## Fix
If the input ends with a workflow-file extension (`.lobster`, `.yaml`, `.yml`, `.json`) and cannot be resolved as a file, fail explicitly with:

`Workflow file not found or not resolvable from cwd: ...`

## Testing
- pnpm exec vitest run extensions/lobster/src/lobster-runner.test.ts extensions/lobster/src/lobster-tool.test.ts
