### PR TITLE
fix(agent): honor sessions_spawn ACP model overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/sessions_spawn: honor explicit `model` overrides for ACP child sessions instead of silently falling back to the target agent default model. (#70210) Thanks @felix-miao.
 - CLI/Claude: hash only static extra system prompt parts when deciding whether to reuse a CLI session, so per-message inbound metadata no longer resets Claude CLI conversations on every turn. (#70122) Thanks @zijunl.
 - Hooks/Slack: standardize shared message hook routing fields (`threadId` / `replyToId`) and stop Slack outbound delivery from re-running `message_sending` inside the channel adapter, so plugins like thread-ownership make one outbound routing decision per reply. Thanks @vincentkoc.
 - Auto-reply/media: share one run-scoped reply media context between streamed block delivery and final payload filtering, so a local `MEDIA:` attachment is staged once and duplicate media sends are suppressed reliably. (#68111) Thanks @ayeshakhalid192007-dev.

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -313,7 +313,7 @@ export class AcpSessionManager {
       const runtime = backend.runtime;
       const initialRuntimeOptions = validateRuntimeOptionPatch({
         ...input.runtimeOptions,
-        cwd: input.cwd,
+        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
       });
       const requestedCwd = initialRuntimeOptions.cwd;
       this.enforceConcurrentSessionLimit({

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -311,7 +311,10 @@ export class AcpSessionManager {
     return await this.withSessionActor(sessionKey, async () => {
       const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
       const runtime = backend.runtime;
-      const initialRuntimeOptions = validateRuntimeOptionPatch({ cwd: input.cwd });
+      const initialRuntimeOptions = validateRuntimeOptionPatch({
+        ...input.runtimeOptions,
+        cwd: input.cwd,
+      });
       const requestedCwd = initialRuntimeOptions.cwd;
       this.enforceConcurrentSessionLimit({
         cfg: input.cfg,

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1330,6 +1330,45 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("preserves runtimeOptions cwd when initializeSession cwd is omitted", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+      sessionKey: "agent:codex:acp:session-cwd-runtime-options",
+      storeSessionKey: "agent:codex:acp:session-cwd-runtime-options",
+      acp: readySessionMeta({
+        runtimeOptions: {
+          cwd: "/workspace/from-runtime-options",
+        },
+        cwd: "/workspace/from-runtime-options",
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.initializeSession({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-cwd-runtime-options",
+      agent: "codex",
+      mode: "persistent",
+      runtimeOptions: {
+        cwd: "/workspace/from-runtime-options",
+      },
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:session-cwd-runtime-options",
+        cwd: "/workspace/from-runtime-options",
+      }),
+    );
+    expect(extractRuntimeOptionsFromUpserts()).toContainEqual({
+      cwd: "/workspace/from-runtime-options",
+    });
+  });
+
   it("drops cached runtime handles after tolerated close failures", async () => {
     const closeFailures = [
       {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1298,6 +1298,38 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
   });
 
+  it("persists runtime options provided during initializeSession", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.upsertAcpSessionMetaMock.mockResolvedValue({
+      sessionKey: "agent:codex:acp:session-a",
+      storeSessionKey: "agent:codex:acp:session-a",
+      acp: readySessionMeta({
+        runtimeOptions: {
+          model: "openai-codex/gpt-5.4",
+        },
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.initializeSession({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      agent: "codex",
+      mode: "persistent",
+      runtimeOptions: {
+        model: "openai-codex/gpt-5.4",
+      },
+    });
+
+    expect(extractRuntimeOptionsFromUpserts()).toContainEqual({
+      model: "openai-codex/gpt-5.4",
+    });
+  });
+
   it("drops cached runtime handles after tolerated close failures", async () => {
     const closeFailures = [
       {

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -44,6 +44,7 @@ export type AcpInitializeSessionInput = {
   agent: string;
   mode: AcpRuntimeSessionMode;
   resumeSessionId?: string;
+  runtimeOptions?: Partial<AcpSessionRuntimeOptions>;
   cwd?: string;
   backendId?: string;
 };

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -718,6 +718,30 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("passes model override into ACP session initialization", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        model: "openai-codex/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: expect.stringMatching(/^agent:codex:acp:/),
+        agent: "codex",
+        runtimeOptions: {
+          model: "openai-codex/gpt-5.4",
+        },
+      }),
+    );
+  });
+
   it("inherits subagent envelope fields onto ACP children", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -104,6 +104,7 @@ export type SpawnAcpParams = {
   label?: string;
   agentId?: string;
   resumeSessionId?: string;
+  model?: string;
   cwd?: string;
   mode?: SpawnAcpMode;
   thread?: boolean;
@@ -890,6 +891,7 @@ async function initializeAcpSpawnRuntime(params: {
   targetAgentId: string;
   runtimeMode: AcpRuntimeSessionMode;
   resumeSessionId?: string;
+  model?: string;
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
@@ -914,6 +916,7 @@ async function initializeAcpSpawnRuntime(params: {
     agent: params.targetAgentId,
     mode: params.runtimeMode,
     resumeSessionId: params.resumeSessionId,
+    runtimeOptions: params.model ? { model: params.model } : undefined,
     cwd: params.cwd,
     backendId: params.cfg.acp?.backend,
   });
@@ -1249,6 +1252,7 @@ export async function spawnAcpDirect(
       targetAgentId,
       runtimeMode,
       resumeSessionId: params.resumeSessionId,
+      model: params.model,
       cwd: runtimeCwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -247,6 +247,28 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
+  it("forwards model override to ACP runtime spawns", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-2-model", {
+      runtime: "acp",
+      task: "investigate the failing CI run",
+      agentId: "codex",
+      model: "github-copilot/claude-sonnet-4.6",
+    });
+
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "investigate the failing CI run",
+        agentId: "codex",
+        model: "github-copilot/claude-sonnet-4.6",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("adds requested role to forwarded ACP failures", async () => {
     hoisted.spawnAcpDirectMock.mockResolvedValueOnce({
       status: "forbidden",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -245,6 +245,7 @@ export function createSessionsSpawnTool(
             label: label || undefined,
             agentId: requestedAgentId,
             resumeSessionId,
+            model: modelOverride,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,


### PR DESCRIPTION
Fixes #70200

## Summary

- Problem: `sessions_spawn` accepted a `model` parameter, but the ACP runtime branch dropped it before session initialization.
- Why it matters: callers asking for ACP sessions with an explicit model silently got the agent default instead of the requested model.
- What changed: ACP spawn now forwards `model`, initializes ACP sessions with `runtimeOptions.model`, and persists those options through the existing ACP manager path.
- What did NOT change (scope boundary): this PR does not add ACP support for `thinking`; it only fixes model override handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70200
- Related #70200
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the ACP branch in `sessions_spawn` read `model` from tool input but never forwarded it into `spawnAcpDirect`, and the ACP initialize path had no way to accept initial runtime options.
- Missing detection / guardrail: ACP spawn tests covered `cwd`, `mode`, and `resumeSessionId`, but not explicit model overrides.
- Contributing context (if known): ACP already had persisted runtime-options support for per-session config, so this was a wiring gap rather than a missing backend capability.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/sessions-spawn-tool.test.ts`, `src/agents/acp-spawn.test.ts`, `src/acp/control-plane/manager.test.ts`
- Scenario the test should lock in: ACP `sessions_spawn` with `model` carries the override through tool dispatch, ACP spawn initialization, and ACP manager runtime-option persistence.
- Why this is the smallest reliable guardrail: the regression happened across the tool -> spawn -> manager seam, so each handoff now has focused coverage without requiring a live ACP backend.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

ACP `sessions_spawn` calls with `runtime="acp"` now honor explicit `model` overrides instead of silently falling back to the target agent default model.

## Diagram (if applicable)

```text
Before:
sessions_spawn(model=foo, runtime=acp) -> spawnAcpDirect() -> initializeSession() -> agent default model

After:
sessions_spawn(model=foo, runtime=acp) -> spawnAcpDirect(model=foo)
  -> initializeSession(runtimeOptions.model=foo) -> ACP session runs with requested model
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS darwin arm64
- Runtime/container: local source checkout
- Model/provider: ACP target agents, explicit model override path
- Integration/channel (if any): ACP session spawn
- Relevant config (redacted): default local dev config

### Steps

1. Call `sessions_spawn` with `runtime: "acp"` and an explicit `model`.
2. Observe the ACP child session initialization path.
3. Verify the requested model is persisted in ACP runtime options and used for the child session.

### Expected

- ACP child sessions honor the requested `model` override.

### Actual

- Before this change, ACP child sessions silently ignored `model` and used the target agent default.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran targeted tests for the sessions tool, ACP spawn path, and ACP manager path; committed through `scripts/committer`, which also ran `pnpm check:changed --staged`.
- Edge cases checked: ACP model forwarding without thread binding; runtime-option persistence during ACP session initialization.
- What you did **not** verify: live ACP backend behavior against a real external harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: ACP backends that reject model config options could still fail later when runtime controls apply.
  - Mitigation: this change only restores the documented override path and uses the existing ACP runtime-options/control plumbing that already handles backend capability checks.
