### PR TITLE
fix(tasks): tolerate tiny audit timestamp jitter

### DIFF
--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -99,4 +99,44 @@ describe("task-registry audit", () => {
 
     expect(findings.map((finding) => finding.code)).toEqual(["lost"]);
   });
+
+  it("ignores tiny startedAt jitter before createdAt", () => {
+    const createdAt = Date.parse("2026-03-30T00:00:00.007Z");
+    const findings = listTaskAuditFindings({
+      tasks: [
+        createTask({
+          status: "succeeded",
+          createdAt,
+          startedAt: createdAt - 1,
+          endedAt: createdAt + 100,
+          cleanupAfter: createdAt + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("still reports larger timestamp inversions", () => {
+    const createdAt = Date.parse("2026-03-30T00:00:00.020Z");
+    const findings = listTaskAuditFindings({
+      now: createdAt,
+      tasks: [
+        createTask({
+          status: "succeeded",
+          createdAt,
+          startedAt: createdAt - 25,
+          endedAt: createdAt + 100,
+          cleanupAfter: createdAt + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        code: "inconsistent_timestamps",
+        detail: "startedAt is earlier than createdAt",
+      }),
+    ]);
+  });
 });

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -17,6 +17,7 @@ export type TaskAuditOptions = {
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
+const TIMESTAMP_JITTER_TOLERANCE_MS = 10;
 export { createEmptyTaskAuditSummary };
 export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
 
@@ -47,7 +48,10 @@ function taskReferenceAt(task: TaskRecord): number {
 }
 
 function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
-  if (task.startedAt && task.startedAt < task.createdAt) {
+  if (
+    typeof task.startedAt === "number" &&
+    task.startedAt + TIMESTAMP_JITTER_TOLERANCE_MS < task.createdAt
+  ) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -55,7 +59,11 @@ function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
       detail: "startedAt is earlier than createdAt",
     });
   }
-  if (task.endedAt && task.startedAt && task.endedAt < task.startedAt) {
+  if (
+    typeof task.endedAt === "number" &&
+    typeof task.startedAt === "number" &&
+    task.endedAt + TIMESTAMP_JITTER_TOLERANCE_MS < task.startedAt
+  ) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",


### PR DESCRIPTION
Fixes #70203

## Summary
- tolerate up to 10ms of timestamp jitter before flagging task audit inconsistencies
- keep warning on larger startedAt/endedAt ordering errors
- add focused audit coverage for tolerated jitter and real inversions