### PR TITLE
runner: strip assistant audio payloads during overflow recovery

### DIFF
--- a/src/agents/pi-embedded-runner/assistant-audio-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/assistant-audio-recovery.test.ts
@@ -1,0 +1,339 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import {
+  ASSISTANT_AUDIO_RECOVERY_MARKER,
+  sessionLikelyHasAssistantAudioPayloads,
+  stripAssistantAudioPayloadsFromMessage,
+  stripAssistantAudioPayloadsInMessages,
+  stripAssistantAudioPayloadsInSession,
+} from "./assistant-audio-recovery.js";
+
+let tmpDir: string | undefined;
+let testTimestamp = 1;
+const nextTimestamp = () => testTimestamp++;
+
+async function createTmpDir(): Promise<string> {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "assistant-audio-recovery-test-"));
+  return tmpDir;
+}
+
+beforeEach(() => {
+  testTimestamp = 1;
+});
+
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    tmpDir = undefined;
+  }
+});
+
+function makeUserMessage(text: string): UserMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp: nextTimestamp(),
+  };
+}
+
+function makeTextAssistant(text: string): AssistantMessage {
+  return makeAgentAssistantMessage({
+    content: [{ type: "text", text }],
+    model: "gpt-5.4",
+    stopReason: "stop",
+    timestamp: nextTimestamp(),
+  });
+}
+
+function makeAudioReplyAssistant(opts: {
+  base64Bytes?: number;
+  preText?: string;
+  mediaType?: string;
+}): AssistantMessage {
+  const base64Bytes = opts.base64Bytes ?? 4096;
+  const data = "A".repeat(base64Bytes);
+  const audioPart = {
+    type: "audio" as const,
+    source: {
+      type: "base64" as const,
+      media_type: opts.mediaType ?? "audio/mp4",
+      data,
+    },
+  };
+  const content: AssistantMessage["content"] = opts.preText
+    ? [
+        { type: "text", text: opts.preText },
+        audioPart as unknown as AssistantMessage["content"][number],
+      ]
+    : [audioPart as unknown as AssistantMessage["content"][number]];
+  return makeAgentAssistantMessage({
+    content,
+    model: "gpt-5.4",
+    stopReason: "stop",
+    timestamp: nextTimestamp(),
+  });
+}
+
+function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "read",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: nextTimestamp(),
+  };
+}
+
+describe("stripAssistantAudioPayloadsFromMessage", () => {
+  it("replaces a standalone base64 audio part with the marker", () => {
+    const msg = makeAudioReplyAssistant({ base64Bytes: 10_000 });
+    const out = stripAssistantAudioPayloadsFromMessage(msg);
+    expect(out).not.toBe(msg);
+    expect(out.content).toHaveLength(1);
+    const part = out.content[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toBe(ASSISTANT_AUDIO_RECOVERY_MARKER);
+  });
+
+  it("preserves sibling text and only removes the audio part", () => {
+    const msg = makeAudioReplyAssistant({ base64Bytes: 8_000, preText: "Audio reply" });
+    const out = stripAssistantAudioPayloadsFromMessage(msg);
+    expect(out.content).toHaveLength(2);
+    expect(out.content[0]).toEqual({ type: "text", text: "Audio reply" });
+    expect(out.content[1]).toEqual({
+      type: "text",
+      text: ASSISTANT_AUDIO_RECOVERY_MARKER,
+    });
+  });
+
+  it("is idempotent: running twice does not alter the marker", () => {
+    const msg = makeAudioReplyAssistant({ base64Bytes: 5_000, preText: "Audio reply" });
+    const first = stripAssistantAudioPayloadsFromMessage(msg);
+    const second = stripAssistantAudioPayloadsFromMessage(first);
+    expect(second).toBe(first);
+  });
+
+  it("leaves text-only assistant messages untouched (reference equality)", () => {
+    const msg = makeTextAssistant("hello world");
+    const out = stripAssistantAudioPayloadsFromMessage(msg);
+    expect(out).toBe(msg);
+  });
+
+  it("does not touch audio parts without a base64 source", () => {
+    const msg = makeAgentAssistantMessage({
+      content: [
+        {
+          type: "audio",
+          source: { type: "url", url: "https://example.invalid/a.mp4" },
+        } as unknown as AssistantMessage["content"][number],
+      ],
+      model: "gpt-5.4",
+      stopReason: "stop",
+      timestamp: nextTimestamp(),
+    });
+    const out = stripAssistantAudioPayloadsFromMessage(msg);
+    expect(out).toBe(msg);
+  });
+});
+
+describe("stripAssistantAudioPayloadsInMessages", () => {
+  it("strips assistant audio while preserving other message types", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("ping"),
+      makeTextAssistant("pong"),
+      makeToolResult("tool result body"),
+      makeAudioReplyAssistant({ base64Bytes: 6_000, preText: "Audio reply" }),
+    ];
+    const { messages: out, strippedCount } = stripAssistantAudioPayloadsInMessages(messages);
+    expect(strippedCount).toBe(1);
+    expect(out[0]).toBe(messages[0]);
+    expect(out[1]).toBe(messages[1]);
+    expect(out[2]).toBe(messages[2]);
+    expect(out[3]).not.toBe(messages[3]);
+    const strippedAssistant = out[3] as AssistantMessage;
+    expect(strippedAssistant.content).toHaveLength(2);
+    expect((strippedAssistant.content[1] as { text: string }).text).toBe(
+      ASSISTANT_AUDIO_RECOVERY_MARKER,
+    );
+  });
+
+  it("returns strippedCount 0 when nothing to strip", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("ping"),
+      makeTextAssistant("pong"),
+      makeToolResult("tool result"),
+    ];
+    const { strippedCount } = stripAssistantAudioPayloadsInMessages(messages);
+    expect(strippedCount).toBe(0);
+  });
+});
+
+describe("sessionLikelyHasAssistantAudioPayloads", () => {
+  it("returns true when at least one assistant base64 audio payload is present", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("hi"),
+      makeTextAssistant("hi back"),
+      makeAudioReplyAssistant({ base64Bytes: 2_000 }),
+    ];
+    expect(sessionLikelyHasAssistantAudioPayloads(messages)).toBe(true);
+  });
+
+  it("returns false for a purely text / toolResult transcript", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("hi"),
+      makeTextAssistant("hi back"),
+      makeToolResult("result"),
+    ];
+    expect(sessionLikelyHasAssistantAudioPayloads(messages)).toBe(false);
+  });
+});
+
+describe("stripAssistantAudioPayloadsInSession", () => {
+  it("rewrites a session file to replace assistant audio payloads with the marker", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("ping"));
+    sm.appendMessage(makeTextAssistant("first reply"));
+    sm.appendMessage(makeAudioReplyAssistant({ base64Bytes: 50_000, preText: "Audio reply" }));
+    sm.appendMessage(makeUserMessage("ping again"));
+    sm.appendMessage(makeAudioReplyAssistant({ base64Bytes: 120_000, preText: "Audio reply" }));
+    const sessionFile = sm.getSessionFile()!;
+
+    const branchCharsOf = (
+      entries: ReturnType<ReturnType<typeof SessionManager.open>["getBranch"]>,
+    ) =>
+      entries.reduce((sum, entry) => {
+        if (entry.type !== "message") {
+          return sum;
+        }
+        return sum + JSON.stringify(entry.message).length;
+      }, 0);
+
+    const beforeBranchChars = branchCharsOf(SessionManager.open(sessionFile).getBranch());
+
+    const result = await stripAssistantAudioPayloadsInSession({
+      sessionFile,
+      sessionKey: "agent:test:strip",
+    });
+
+    expect(result.stripped).toBe(true);
+    expect(result.strippedCount).toBe(2);
+
+    // The session-storage rewrite mechanism branches and re-appends the
+    // suffix, so the raw file may grow even when the active branch shrinks.
+    // The correctness signal is the size of the *active* branch, not the
+    // raw jsonl byte length.
+    const after = SessionManager.open(sessionFile).getBranch();
+    const afterBranchChars = branchCharsOf(after);
+    expect(afterBranchChars).toBeLessThan(beforeBranchChars);
+    expect(beforeBranchChars - afterBranchChars).toBeGreaterThan(50_000 + 120_000 - 1_000);
+
+    const assistantEntries = after.filter(
+      (entry): entry is typeof entry & { type: "message" } =>
+        entry.type === "message" && (entry.message as { role?: string }).role === "assistant",
+    );
+    const audioStillPresent = assistantEntries.some((entry) => {
+      const content = (entry.message as AssistantMessage).content;
+      return (
+        Array.isArray(content) &&
+        content.some((part) => (part as { type: string }).type === "audio")
+      );
+    });
+    expect(audioStillPresent).toBe(false);
+
+    const markerPresent = assistantEntries.some((entry) => {
+      const content = (entry.message as AssistantMessage).content;
+      return (
+        Array.isArray(content) &&
+        content.some(
+          (part) =>
+            (part as { type: string }).type === "text" &&
+            (part as { text?: string }).text === ASSISTANT_AUDIO_RECOVERY_MARKER,
+        )
+      );
+    });
+    expect(markerPresent).toBe(true);
+  });
+
+  it("is a no-op on sessions without assistant audio (negative path)", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("ping"));
+    sm.appendMessage(makeTextAssistant("pong"));
+    sm.appendMessage(makeToolResult("x".repeat(500)));
+    const sessionFile = sm.getSessionFile()!;
+    const beforeBytes = (await fs.stat(sessionFile)).size;
+
+    const result = await stripAssistantAudioPayloadsInSession({
+      sessionFile,
+      sessionKey: "agent:test:noop",
+    });
+
+    expect(result.stripped).toBe(false);
+    expect(result.strippedCount).toBe(0);
+    expect(result.reason).toBe("no assistant audio payloads");
+
+    const afterBytes = (await fs.stat(sessionFile)).size;
+    expect(afterBytes).toBe(beforeBytes);
+
+    const after = SessionManager.open(sessionFile).getBranch();
+    const toolResults = after.filter(
+      (entry) =>
+        entry.type === "message" && (entry.message as { role?: string }).role === "toolResult",
+    );
+    expect(toolResults).toHaveLength(1);
+  });
+
+  it("is idempotent on an already-stripped session", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("ping"));
+    sm.appendMessage(makeAudioReplyAssistant({ base64Bytes: 20_000, preText: "Audio reply" }));
+    const sessionFile = sm.getSessionFile()!;
+
+    const first = await stripAssistantAudioPayloadsInSession({ sessionFile });
+    expect(first.stripped).toBe(true);
+    expect(first.strippedCount).toBe(1);
+
+    const beforeSecond = (await fs.stat(sessionFile)).size;
+    const second = await stripAssistantAudioPayloadsInSession({ sessionFile });
+    expect(second.stripped).toBe(false);
+    expect(second.strippedCount).toBe(0);
+    expect(second.reason).toBe("no assistant audio payloads");
+    const afterSecond = (await fs.stat(sessionFile)).size;
+    expect(afterSecond).toBe(beforeSecond);
+  });
+
+  it("preserves an immediately-preceding tool-result message (negative cross-type guard)", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("ping"));
+    const toolBody = "tool_result_preserved_body " + "x".repeat(200);
+    sm.appendMessage(makeToolResult(toolBody, "call_keep"));
+    sm.appendMessage(makeAudioReplyAssistant({ base64Bytes: 10_000, preText: "Audio reply" }));
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await stripAssistantAudioPayloadsInSession({ sessionFile });
+    expect(result.stripped).toBe(true);
+    expect(result.strippedCount).toBe(1);
+
+    const after = SessionManager.open(sessionFile).getBranch();
+    const toolEntry = after.find(
+      (entry) =>
+        entry.type === "message" && (entry.message as { role?: string }).role === "toolResult",
+    );
+    expect(toolEntry).toBeDefined();
+    if (toolEntry && toolEntry.type === "message") {
+      const content = (toolEntry.message as ToolResultMessage).content;
+      const textBlock = Array.isArray(content) ? (content[0] as { text?: string }) : undefined;
+      expect(textBlock?.text).toBe(toolBody);
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/assistant-audio-recovery.ts
+++ b/src/agents/pi-embedded-runner/assistant-audio-recovery.ts
@@ -1,0 +1,220 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { TranscriptRewriteReplacement } from "../../context-engine/types.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { acquireSessionWriteLock } from "../session-write-lock.js";
+import { log } from "./logger.js";
+import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
+
+/**
+ * Marker text written in place of an assistant audio payload that has been
+ * removed during context-overflow recovery. Intentionally short so it does not
+ * itself inflate the history.
+ */
+export const ASSISTANT_AUDIO_RECOVERY_MARKER = "[audio payload removed during overflow recovery]";
+
+type AudioLikePart = {
+  type: "audio";
+  source?: { type?: string; media_type?: string; data?: string };
+};
+
+type AssistantContentPart = { type?: string } & Record<string, unknown>;
+
+function isRemovableAssistantAudioPart(part: unknown): part is AudioLikePart {
+  if (!part || typeof part !== "object") {
+    return false;
+  }
+  const typed = part as AssistantContentPart;
+  if (typed.type !== "audio") {
+    return false;
+  }
+  const source = (typed as AudioLikePart).source;
+  if (!source || typeof source !== "object") {
+    return false;
+  }
+  return source.type === "base64";
+}
+
+function isAssistantMessageWithRemovableAudio(message: AgentMessage): message is AssistantMessage {
+  if ((message as { role?: string }).role !== "assistant") {
+    return false;
+  }
+  const content = (message as AssistantMessage).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((part) => isRemovableAssistantAudioPart(part));
+}
+
+function buildMarkerPart(): AssistantContentPart {
+  return { type: "text", text: ASSISTANT_AUDIO_RECOVERY_MARKER };
+}
+
+/**
+ * Returns a copy of the assistant message with every base64 audio content part
+ * replaced by a short text marker. Other parts (text, tool_use, thinking, etc.)
+ * are preserved byte-identical.
+ *
+ * Idempotent: if no audio parts exist, the original message is returned.
+ */
+export function stripAssistantAudioPayloadsFromMessage(
+  message: AssistantMessage,
+): AssistantMessage {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return message;
+  }
+  let changed = false;
+  const rewritten = content.map((part) => {
+    if (isRemovableAssistantAudioPart(part)) {
+      changed = true;
+      return buildMarkerPart();
+    }
+    return part;
+  });
+  if (!changed) {
+    return message;
+  }
+  return {
+    ...message,
+    content: rewritten as AssistantMessage["content"],
+  };
+}
+
+/**
+ * In-memory variant for unit tests / preview. Mirrors the in-session behavior
+ * without touching any SessionManager / filesystem state.
+ */
+export function stripAssistantAudioPayloadsInMessages(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  strippedCount: number;
+} {
+  let strippedCount = 0;
+  const rewritten = messages.map((msg) => {
+    if (!isAssistantMessageWithRemovableAudio(msg)) {
+      return msg;
+    }
+    const next = stripAssistantAudioPayloadsFromMessage(msg);
+    if (next !== msg) {
+      strippedCount += 1;
+    }
+    return next;
+  });
+  return { messages: rewritten, strippedCount };
+}
+
+/**
+ * Presence gate: avoid opening / rewriting the session when no removable
+ * assistant-audio payloads exist. Cheap structural check.
+ */
+export function sessionLikelyHasAssistantAudioPayloads(messages: AgentMessage[]): boolean {
+  return messages.some((msg) => isAssistantMessageWithRemovableAudio(msg));
+}
+
+type SessionBranchEntry = ReturnType<ReturnType<typeof SessionManager.open>["getBranch"]>[number];
+
+function buildAssistantAudioReplacements(
+  branch: readonly SessionBranchEntry[],
+): TranscriptRewriteReplacement[] {
+  const replacements: TranscriptRewriteReplacement[] = [];
+  for (const entry of branch) {
+    if (entry.type !== "message") {
+      continue;
+    }
+    const message = entry.message;
+    if (!isAssistantMessageWithRemovableAudio(message)) {
+      continue;
+    }
+    const rewritten = stripAssistantAudioPayloadsFromMessage(message);
+    if (rewritten === message) {
+      continue;
+    }
+    replacements.push({ entryId: entry.id, message: rewritten });
+  }
+  return replacements;
+}
+
+/**
+ * Strip assistant audio payloads on an already-open SessionManager. Internal
+ * variant used when a caller already holds a session handle.
+ */
+function stripAssistantAudioPayloadsInExistingSessionManager(params: {
+  sessionManager: ReturnType<typeof SessionManager.open>;
+  sessionFile?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): { stripped: boolean; strippedCount: number; reason?: string } {
+  const branch = params.sessionManager.getBranch();
+  if (branch.length === 0) {
+    return { stripped: false, strippedCount: 0, reason: "empty session" };
+  }
+
+  const replacements = buildAssistantAudioReplacements(branch);
+  if (replacements.length === 0) {
+    return {
+      stripped: false,
+      strippedCount: 0,
+      reason: "no assistant audio payloads",
+    };
+  }
+
+  const rewriteResult = rewriteTranscriptEntriesInSessionManager({
+    sessionManager: params.sessionManager,
+    replacements,
+  });
+  if (rewriteResult.changed && params.sessionFile) {
+    emitSessionTranscriptUpdate(params.sessionFile);
+  }
+
+  log.info(
+    `[assistant-audio-recovery] Stripped ${rewriteResult.rewrittenEntries} assistant audio payload(s) in session ` +
+      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+  );
+
+  return {
+    stripped: rewriteResult.changed,
+    strippedCount: rewriteResult.rewrittenEntries,
+    reason: rewriteResult.reason,
+  };
+}
+
+/**
+ * Recovery-only: replace assistant `type: "audio"` (source.type === "base64")
+ * content parts in the session branch with a short text marker.
+ *
+ * Intentionally scoped to assistant audio only. Does not touch:
+ *   - tool_result messages (handled by tool-result-truncation)
+ *   - assistant text / tool_use / thinking blocks
+ *   - image / video / other media parts (out of scope for this fix)
+ *
+ * Safe to call when no audio is present — returns `stripped: false` without
+ * rewriting. Idempotent: a second call is a no-op because prior runs have
+ * already replaced audio parts with text markers.
+ */
+export async function stripAssistantAudioPayloadsInSession(params: {
+  sessionFile: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): Promise<{ stripped: boolean; strippedCount: number; reason?: string }> {
+  const { sessionFile } = params;
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    sessionLock = await acquireSessionWriteLock({ sessionFile });
+    const sessionManager = SessionManager.open(sessionFile);
+    return stripAssistantAudioPayloadsInExistingSessionManager({
+      sessionManager,
+      sessionFile,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    log.warn(`[assistant-audio-recovery] Failed to strip: ${errMsg}`);
+    return { stripped: false, strippedCount: 0, reason: errMsg };
+  } finally {
+    await sessionLock?.release();
+  }
+}

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -86,6 +86,19 @@ export const mockedTruncateOversizedToolResultsInSession = vi.fn<
   reason: "no oversized tool results",
 }));
 
+type MockStripAssistantAudioPayloadsResult = {
+  stripped: boolean;
+  strippedCount: number;
+  reason?: string;
+};
+export const mockedStripAssistantAudioPayloadsInSession = vi.fn<
+  () => Promise<MockStripAssistantAudioPayloadsResult>
+>(async () => ({
+  stripped: false,
+  strippedCount: 0,
+  reason: "no assistant audio payloads",
+}));
+
 type MockFailoverErrorDescription = {
   message: string;
   reason: string | undefined;
@@ -236,6 +249,12 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
     truncated: false,
     truncatedCount: 0,
     reason: "no oversized tool results",
+  });
+  mockedStripAssistantAudioPayloadsInSession.mockReset();
+  mockedStripAssistantAudioPayloadsInSession.mockResolvedValue({
+    stripped: false,
+    strippedCount: 0,
+    reason: "no assistant audio payloads",
   });
 
   mockedCoerceToFailoverError.mockReset();
@@ -426,6 +445,10 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     resolveLiveToolResultMaxChars: mockedResolveLiveToolResultMaxChars,
     sessionLikelyHasOversizedToolResults: mockedSessionLikelyHasOversizedToolResults,
     truncateOversizedToolResultsInSession: mockedTruncateOversizedToolResultsInSession,
+  }));
+
+  vi.doMock("./assistant-audio-recovery.js", () => ({
+    stripAssistantAudioPayloadsInSession: mockedStripAssistantAudioPayloadsInSession,
   }));
 
   vi.doMock("./context-engine-maintenance.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -20,6 +20,7 @@ import {
   mockedRunContextEngineMaintenance,
   mockedRunEmbeddedAttempt,
   mockedSessionLikelyHasOversizedToolResults,
+  mockedStripAssistantAudioPayloadsInSession,
   mockedTruncateOversizedToolResultsInSession,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -431,5 +432,42 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       }),
     );
     expect(mockedResolveFailoverStatus).toHaveBeenCalledWith("rate_limit");
+  });
+
+  it("strips assistant audio payloads during overflow recovery and retries the prompt", async () => {
+    // Arrange: first attempt hits context overflow, compaction succeeds,
+    // assistant-audio strip removes 2 base64 audio payloads, retry succeeds.
+    mockOverflowRetrySuccess({
+      runEmbeddedAttempt: mockedRunEmbeddedAttempt,
+      compactDirect: mockedCompactDirect,
+    });
+    mockedStripAssistantAudioPayloadsInSession.mockResolvedValueOnce({
+      stripped: true,
+      strippedCount: 2,
+    });
+
+    // Act
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-audio-strip-recovery",
+    });
+
+    // Assert: strip ran in the real recovery path with the session identity
+    // forwarded verbatim from run params (post-compaction call site).
+    expect(mockedStripAssistantAudioPayloadsInSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: overflowBaseRunParams.sessionFile,
+        sessionId: overflowBaseRunParams.sessionId,
+        sessionKey: overflowBaseRunParams.sessionKey,
+      }),
+    );
+    expect(mockedStripAssistantAudioPayloadsInSession).toHaveBeenCalledTimes(1);
+
+    // And: the retry path was actually taken — two attempts ran, the second
+    // completed without error.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(result.meta.agentMeta).toBeDefined();
+    expect(result.meta.error).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -70,6 +70,7 @@ import {
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
+import { stripAssistantAudioPayloadsInSession } from "./assistant-audio-recovery.js";
 import { runPostCompactionSideEffects } from "./compaction-hooks.js";
 import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
 import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
@@ -1129,6 +1130,22 @@ export async function runEmbeddedPiAgent(
                     );
                   }
                 }
+                // Recovery-only: compaction-safeguard commonly writes an empty
+                // summary and the tool-result truncator only targets tool_result
+                // parts, leaving base64 assistant-audio payloads in the re-sent
+                // history. Strip them here before the next retry so the next
+                // prompt is not dominated by the same audio load.
+                const postCompactionAudioStrip = await stripAssistantAudioPayloadsInSession({
+                  sessionFile: params.sessionFile,
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                });
+                if (postCompactionAudioStrip.stripped) {
+                  log.info(
+                    `[context-overflow-recovery] post-compaction assistant-audio strip for ` +
+                      `${provider}/${modelId}; stripped ${postCompactionAudioStrip.strippedCount} payload(s)`,
+                  );
+                }
                 autoCompactionCount += 1;
                 log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
                 continue;
@@ -1174,6 +1191,22 @@ export async function runEmbeddedPiAgent(
                 log.warn(
                   `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
                 );
+              }
+              // Parallel recovery: base64 assistant-audio content parts are not
+              // touched by the tool-result truncator and not summarized by
+              // compaction. When such payloads dominate the live history, the
+              // only effective reduction at this stage is to replace them with
+              // a short text marker. Idempotent: a no-op if no audio present.
+              const audioStrip = await stripAssistantAudioPayloadsInSession({
+                sessionFile: params.sessionFile,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+              });
+              if (audioStrip.stripped) {
+                log.info(
+                  `[context-overflow-recovery] Stripped ${audioStrip.strippedCount} assistant audio payload(s); retrying prompt`,
+                );
+                continue;
               }
             }
             if (


### PR DESCRIPTION
## Summary

- Close the recovery-path blind spot where assistant base64 `audio` content parts bypass both compaction-safeguard and tool-result-truncation during a context overflow, leading to full session restarts (observed: main session hit a cascade of 3× compaction safeguards followed by tool-result truncation that only touched ~72 KB of a ~1.74 MB audio-dominated history, still overflowed, and had to restart).
- Add `src/agents/pi-embedded-runner/assistant-audio-recovery.ts` with a scoped, idempotent `stripAssistantAudioPayloadsInSession` that rewrites assistant branch entries so `type: "audio"` / `source.type === "base64"` parts become a short `[audio payload removed during overflow recovery]` text marker. Non-audio parts (text, tool_use, thinking, tool_result) are preserved byte-identical.
- Wire the strip call into the existing recovery flow in `run.ts` at two sites: (a) after the post-compaction tool-result truncation block, (b) as a parallel effort in the late recovery branch when tool-result truncation did not help.

## Scope

- Tool-result truncation pipeline is untouched — the new helper lives in its own module and uses the same `rewriteTranscriptEntriesInSessionManager` / `acquireSessionWriteLock` / `emitSessionTranscriptUpdate` seams.
- No changes to compaction, image/video handling, reappend behavior, or any auth/routing paths.
- `role: "assistant"` messages only; no user or tool_result messages are ever rewritten.

## Evidence

Tool-result-truncation uses `aggregateBudgetChars = 16000` (≈4k tokens) and only matches `role: "toolResult"`. In the observed overflow session, 10 tool results were truncated to ~35 KB total but the two assistant audio parts (441 KB + 1.3 MB) passed through unchanged; context estimator still fired and the runner restarted. The helper closes that blind spot without renegotiating the existing tool-result budget.

## Tests

New unit + integration coverage, plus sanity over the adjacent surfaces (77/77 PASS locally):
- `assistant-audio-recovery.test.ts` (13 tests): standalone + mixed-content rewrite, idempotency, negatives (text-only assistants, non-base64 audio source, tool_result preservation), session-file rewrite with active-branch byte reduction.
- `run.overflow-compaction.test.ts` (+1 integration test, 14 total): simulates context overflow → successful compaction → audio strip → retry success; asserts `stripAssistantAudioPayloadsInSession` was called with the forwarded session identity and that the retry attempt actually ran.
- `run.overflow-compaction.loop.test.ts` (15/15): unchanged.
- `tool-result-truncation.test.ts` (35/35): unchanged, confirms no semantic change to the existing truncator.

## Test plan

- [x] `pnpm test src/agents/pi-embedded-runner/assistant-audio-recovery.test.ts`
- [x] `pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
- [x] `pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
- [x] `pnpm test src/agents/pi-embedded-runner/tool-result-truncation.test.ts`
- [x] `pnpm check` (tsgo core + core:test + extensions + extensions:test, oxlint, import-cycle + madge checks all green; ran via `scripts/committer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)