### PR TITLE
fix(gateway): allow silent metadata-upgrade pairing for loopback CLI clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/pairing: shared-secret loopback CLI clients now silently auto-approve `metadata-upgrade` pairing (platform / device family refresh) instead of being disconnected with `1008 pairing required`. This matches the scope-upgrade and role-upgrade behavior added in #69431 and unblocks non-interactive CLI automation when a paired-device record has a stale platform string (e.g. device key replicated across hosts, install migrated between OSes, or platform-string format changed between OpenClaw versions). Browser / Control-UI clients keep the existing approval-required flow for metadata changes.
 - Gateway/pairing: treat any forwarded-header evidence (`Forwarded`, `X-Forwarded-*`, or `X-Real-IP`) as proxied WebSocket traffic before pairing locality checks, so reverse-proxy topologies cannot use the loopback shared-secret helper auto-pairing path.
 - Gateway/pairing webchat: render `/pair qr` replies as structured media instead of raw markdown text, preserve inline reply threading and silent-control handling on media replies, avoid persisting sensitive QR images into transcript history, and keep local webchat media embedding behind internal-only trust markers. (#70047) Thanks @BunsDev.
 - Codex harness: default app-server runs to unchained local execution, so OpenAI heartbeats can use network and shell tools without stalling behind native Codex approvals or the workspace-write sandbox.

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -541,7 +541,7 @@ describe("handshake auth helpers", () => {
     ).toBe("remote");
   });
 
-  it("allows silent scope-upgrade for shared_secret_loopback_local", () => {
+  it("allows silent scope-upgrade, role-upgrade, and metadata-upgrade for shared_secret_loopback_local", () => {
     expect(
       shouldAllowSilentLocalPairing({
         locality: "shared_secret_loopback_local",
@@ -560,6 +560,8 @@ describe("handshake auth helpers", () => {
         reason: "role-upgrade",
       }),
     ).toBe(true);
+    // metadata-upgrade now auto-approves for shared_secret_loopback_local
+    // (extended allowlist — see shouldAllowSilentLocalPairing).
     expect(
       shouldAllowSilentLocalPairing({
         locality: "shared_secret_loopback_local",
@@ -568,7 +570,57 @@ describe("handshake auth helpers", () => {
         isWebchat: false,
         reason: "metadata-upgrade",
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  describe("shouldAllowSilentLocalPairing — metadata-upgrade reason", () => {
+    it("allows silent metadata-upgrade for cli_container_local CLI clients", () => {
+      expect(
+        shouldAllowSilentLocalPairing({
+          locality: "cli_container_local",
+          hasBrowserOriginHeader: false,
+          isControlUi: false,
+          isWebchat: false,
+          reason: "metadata-upgrade",
+        }),
+      ).toBe(true);
+    });
+
+    it("allows silent metadata-upgrade for shared_secret_loopback_local CLI clients", () => {
+      expect(
+        shouldAllowSilentLocalPairing({
+          locality: "shared_secret_loopback_local",
+          hasBrowserOriginHeader: false,
+          isControlUi: false,
+          isWebchat: false,
+          reason: "metadata-upgrade",
+        }),
+      ).toBe(true);
+    });
+
+    it("still requires approval for metadata-upgrade from remote clients", () => {
+      expect(
+        shouldAllowSilentLocalPairing({
+          locality: "remote",
+          hasBrowserOriginHeader: false,
+          isControlUi: false,
+          isWebchat: false,
+          reason: "metadata-upgrade",
+        }),
+      ).toBe(false);
+    });
+
+    it("still requires approval for metadata-upgrade from browser_container_local (Control UI)", () => {
+      expect(
+        shouldAllowSilentLocalPairing({
+          locality: "browser_container_local",
+          hasBrowserOriginHeader: true,
+          isControlUi: true,
+          isWebchat: false,
+          reason: "metadata-upgrade",
+        }),
+      ).toBe(false);
+    });
   });
 
   it("prefers cli_container_local over shared_secret_loopback_local for CLI clients", () => {

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -79,13 +79,34 @@ export function shouldAllowSilentLocalPairing(params: {
   isWebchat: boolean;
   reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade";
 }): boolean {
-  return (
-    params.locality !== "remote" &&
-    (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" ||
-      params.reason === "scope-upgrade" ||
-      params.reason === "role-upgrade")
-  );
+  if (params.locality === "remote") {
+    return false;
+  }
+  if (params.hasBrowserOriginHeader && !params.isControlUi && !params.isWebchat) {
+    return false;
+  }
+  if (
+    params.reason === "not-paired" ||
+    params.reason === "scope-upgrade" ||
+    params.reason === "role-upgrade"
+  ) {
+    return true;
+  }
+  // metadata-upgrade auto-approves only for shared-secret loopback CLI clients.
+  // On those paths the connection has already proved possession of a token or
+  // password over loopback, so allowing the pinned platform/deviceFamily to be
+  // refreshed on reconnect matches the "Reconnects can update access metadata"
+  // comment in message-handler.ts. Browser / Control-UI clients keep the
+  // existing approval-required flow — metadata pinning there is a real
+  // anti-tampering surface.
+  if (
+    params.reason === "metadata-upgrade" &&
+    (params.locality === "cli_container_local" ||
+      params.locality === "shared_secret_loopback_local")
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function isCliContainerLocalEquivalent(params: {


### PR DESCRIPTION
## Summary

- **Problem:** On v2026.4.20+, loopback CLI clients with valid shared-secret auth hit an infinite `metadata-upgrade` pairing loop — every `openclaw agent` invocation triggers a fresh `device metadata change pending approval` request that no non-interactive caller can clear. Root cause: platform/deviceFamily pinning compares raw strings (e.g. `"darwin"` vs `"linux"`) that are not stable across OpenClaw surfaces (CLI, Control UI, native app all stamp different formats), and `shouldAllowSilentLocalPairing` does not include `metadata-upgrade` in its reason allowlist, so even the `shared_secret_loopback_local` locality added by #69431 can't silently refresh a pinned platform.
- **Why it matters:** Breaks every non-interactive `openclaw agent` use and — more consequentially — **every skill whose agent flow routes through gateway-registered exec**, which is the canonical OpenClaw skill invocation pattern (`openclaw agent -m "/<skill-slash-cmd>"` → narrative-model routing → skill-provided binary exec → structured result envelope to stdout). Affected surfaces: CI pipelines, cron-scheduled agents, fleet deployments that replicate a paired device key across hosts, and any skill whose agent pathway exec's anything via the skills workspace. No recovery path — Control UI does not have a metadata-upgrade approval card, and `exec-policy yolo` does not cover the pre-exec handshake rejection. Every call also leaves a stale pending-approval row behind, poisoning the queue.
- **What changed:** Extended `shouldAllowSilentLocalPairing` to silently approve `metadata-upgrade` reason for `cli_container_local` and `shared_secret_loopback_local` localities. Browser / Control-UI / remote paths keep existing approval-required behavior. Widened the reason param type. Added 4 unit tests (2 positive, 2 negative).
- **What did NOT change (scope boundary):** No changes to `message-handler.ts` trigger logic, platform normalization, Control UI approval surface, paired device schema, or pending-request persistence. `shouldAllowSilentLocalPairing` behavior for `not-paired | scope-upgrade | role-upgrade` is identical. Remote and browser-origin handling unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs (CHANGELOG)
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #69397 (scope-upgrade variant of same bug shape — fixed separately)
- Related: #69431 (added `shared_secret_loopback_local` locality; scoped to non-metadata reasons)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `shouldAllowSilentLocalPairing` in `src/gateway/server/ws-connection/handshake-auth-helpers.ts` accepts only `not-paired | scope-upgrade | role-upgrade` as reasons eligible for silent local pairing. The `metadata-upgrade` reason — triggered whenever the paired device record's `platform` or `deviceFamily` string does not `===` what the current CLI claims — is not in that allowlist. For shared-secret loopback CLI clients (where we already trust the connection enough to silently approve scope/role upgrades), the metadata-pin check becomes an unrecoverable handshake rejection because the Control UI has no approval surface for this reason and the connection is closed with `1008 pairing required` before any application-level retry / recovery can run.
- **Missing detection / guardrail:** The scope of #69431 deliberately excluded the metadata-upgrade reason from the auto-approval allowlist ("the existing reason allowlist … not metadata — is preserved unchanged") to keep the fix surface minimal. No regression test existed for metadata-upgrade under the new `shared_secret_loopback_local` locality.
- **Contributing context:** OpenClaw components stamp `platform` inconsistently — CLI uses `process.platform` (`"darwin"` / `"linux"`), Control UI uses `navigator.platform` (`"MacIntel"`), native app uses display strings (`"macOS 26.5.0"`). Any cross-surface or cross-host paired record is liable to mismatch on raw `===`. Normalizing the comparison is tracked as a follow-up; this PR fixes the immediate handshake dead-end.

## Regression Test Plan

- Coverage: Unit test.
- Target test or file: `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- Scenarios locked in:
  - `shared_secret_loopback_local` + `metadata-upgrade` → silent (true)
  - `cli_container_local` + `metadata-upgrade` → silent (true)
  - `remote` + `metadata-upgrade` → requires approval (false)
  - `browser_container_local` + `metadata-upgrade` → requires approval (false)
- Why this is the smallest reliable guardrail: the decision is pure logic on `(locality, hasBrowserOriginHeader, isControlUi, isWebchat, reason)` with no I/O. Existing file already exhaustively covers the decision table for non-metadata reasons; we're just extending by one reason × four localities.

## User-visible / Behavior Changes

- `openclaw agent`, `openclaw cron`, and any other CLI/node-host clients connecting from loopback with a valid token/password will no longer be disconnected with `1008 pairing required` when their paired device record's platform or deviceFamily string changes. The pinned metadata is silently refreshed on reconnect (matching existing scope/role-upgrade behavior and the comment in `message-handler.ts`: "Reconnects can update access metadata").
- Browser / Control UI / remote clients retain existing approval-required behavior for metadata changes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (handshake rejection happens before exec policy)
- Data access scope changed? `No` — metadata is the pinned platform/deviceFamily string, not auth scopes. Scope and role changes still require their respective pairing flows. The client has already passed `sharedAuthOk` before this gate runs.

## Repro + Verification

### Environment

- OS: Debian 13 / Linux 6.12.74. Also reproduces on macOS and other Linux variants — the bug is a string-equality issue in the handshake, not OS-specific.
- Runtime: Node.js v22.22.2, OpenClaw v2026.4.21 (f788c88).
- Gateway bind: loopback (127.0.0.1:18789). Auth mode: token + password.

### Steps to repro (on any machine running v2026.4.20+)

1. On host A, pair an `openclaw` CLI; `~/.openclaw/devices/paired.json` records the device with `platform` set to whatever `process.platform` returns at pair time.
2. Manually edit that device record to set `platform` to any value that differs from the current `process.platform` (e.g. change `"darwin"` → `"linux"`, or vice versa). This simulates the stale-pin condition that occurs naturally when a paired key is replicated across hosts or migrated across platforms.
3. `openclaw gateway restart`
4. `openclaw agent -m "ping"`
5. Observe: `Error: gateway closed (1008): pairing required: device identity changed and must be re-approved`. Gateway log shows `reason=metadata-upgrade claimedPlatform=<X> pinnedPlatform=<Y>`.
6. `openclaw devices list` shows Pending (1) with status `re-approval, repair`. Every subsequent `openclaw agent` or `openclaw devices list` call spawns a fresh pending request with a new `requestId`.

### Expected after fix

- Step 4 succeeds: handshake completes, gateway log records `reason=metadata-upgrade claimedPlatform=<X> pinnedPlatform=<Y>` **AND** the pinned platform is silently updated to the claimed value via the existing `updatePairedDeviceMetadata(device.id, clientAccessMetadata)` call in `message-handler.ts`.
- Pending queue remains clean — no new metadata-upgrade row added.
- Browser / Control UI pairing behavior unchanged.

## Evidence

Local repro (v2026.4.21 on Linux loopback, device key pinned as `darwin`):

```
security audit: device metadata upgrade requested reason=metadata-upgrade
  device=3388abe04a79a640…  claimedPlatform=linux  pinnedPlatform=darwin
  client=gateway-client
```

10/10 consecutive CLI calls produce identical audit entries with distinct `requestId`s. `openclaw devices list` shows the device in Paired with full operator scopes while a fresh Pending row regenerates with each call.

After applying the patch locally and restarting the gateway, the first `openclaw agent` call silently refreshes the pinned platform (`updatePairedDeviceMetadata` runs on the success path), the handshake completes, and subsequent calls connect without a pending row.

## Human Verification

- Verified the silent-pairing decision path under all four (locality × `metadata-upgrade`) combinations via the new unit tests.
- Verified against a live v2026.4.21 gateway with a paired CLI whose `platform` pin was deliberately stale (`"darwin"` vs claimed `"linux"`) — patched build completes handshake and updates the pin; unpatched build loops on `1008 pairing required`.
- Did **not** verify the broader platform-string normalization question (tracked as follow-up; out of scope for this PR).

## Compatibility / Migration

- Backward compatible? `Yes` — the change widens auto-approval. Existing behavior for `remote` and browser-origin clients is unchanged.
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** A compromised loopback shared-secret (e.g. token leak on a shared host) could silently refresh the pinned platform, masking the fact that the paired device now reports from a different OS.
- **Mitigation:** Loopback + valid shared-secret auth is already the basis for auto-approving scope and role upgrades (PR #69431). A platform string is strictly less sensitive than a scope grant. Additionally: the gateway still writes a `security audit: device metadata upgrade requested` log line on every such refresh (already in `message-handler.ts`), so operators can detect anomalous refreshes via log review / alerting. Remote and browser paths — where token exposure risk is materially higher — are unchanged.
- **Follow-up not in this PR:** Platform-string normalization would reduce the frequency of benign refreshes, making anomalous refreshes stand out more clearly in audit logs. Log-based alerting on frequent metadata-upgrade events per-device is another possible follow-up.
