### PR TITLE
fix(gateway): write restart sentinels atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Claude: keep Claude CLI session bindings stable across OAuth access-token refreshes, so gateway restarts continue the same Claude conversation instead of minting a fresh one. (#70132) Thanks @obviyus.
 - QQBot: add `INTERACTION` intent (`1 << 26`) to the gateway constants and include it in the `FULL_INTENTS` mask so interaction events are received. (#70143) Thanks @cxyhhhhh.
 - Gateway/restart: preserve one-shot continuation instructions across gateway restarts so agents can resume and reply back to the original chat after reboot. (#63406) Thanks @VACInc.
+- Gateway/restart: write restart sentinel files atomically so interrupted writes cannot leave a truncated sentinel behind. (#70225) Thanks @obviyus.
 
 ## 2026.4.21
 

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import { writeJsonAtomic } from "./json-files.js";
 
 export type RestartSentinelLog = {
   stdoutTail?: string | null;
@@ -78,9 +79,8 @@ export async function writeRestartSentinel(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const filePath = resolveRestartSentinelPath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const data: RestartSentinel = { version: 1, payload };
-  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  await writeJsonAtomic(filePath, data, { trailingNewline: true });
   return filePath;
 }
 


### PR DESCRIPTION
## Summary
- write restart sentinel JSON through the shared atomic file helper
- keep the existing trailing-newline format
- add an Unreleased changelog note

## Testing
- pnpm test src/infra/restart-sentinel.test.ts
- pnpm exec oxfmt --check CHANGELOG.md src/infra/restart-sentinel.ts
- pnpm check:changed