### PR TITLE
fix(pairing): clear stale requests on device removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - QQBot: add `INTERACTION` intent (`1 << 26`) to the gateway constants and include it in the `FULL_INTENTS` mask so interaction events are received. (#70143) Thanks @cxyhhhhh.
 - Gateway/restart: preserve one-shot continuation instructions across gateway restarts so agents can resume and reply back to the original chat after reboot. (#63406) Thanks @VACInc.
 - Gateway/restart: write restart sentinel files atomically so interrupted writes cannot leave a truncated sentinel behind. (#70225) Thanks @obviyus.
+- Pairing: remove stale pending requests for a device when that paired device is deleted, so an old repair approval cannot recreate the removed device from leftover state.
 
 ## 2026.4.21
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1013,6 +1013,46 @@ describe("device pairing tokens", () => {
     await expect(removePairedDevice("device-1", baseDir)).resolves.toBeNull();
   });
 
+  test("removing a paired device clears pending requests for that device only", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+
+    const staleRepair = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1-rotated",
+        role: "operator",
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    const otherPending = await requestDevicePairing(
+      {
+        deviceId: "device-2",
+        publicKey: "public-key-2",
+        role: "node",
+        scopes: [],
+      },
+      baseDir,
+    );
+
+    await expect(removePairedDevice("device-1", baseDir)).resolves.toEqual({
+      deviceId: "device-1",
+    });
+
+    const pending = (await listDevicePairing(baseDir)).pending;
+    expect(pending.map((entry) => entry.requestId)).not.toContain(staleRepair.request.requestId);
+    expect(pending.map((entry) => entry.requestId)).toContain(otherPending.request.requestId);
+    await expect(
+      approveDevicePairing(
+        staleRepair.request.requestId,
+        { callerScopes: ["operator.read"] },
+        baseDir,
+      ),
+    ).resolves.toBeNull();
+    await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
   test("clears paired device state by device id", async () => {
     const baseDir = await makeDevicePairingDir();
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -758,6 +758,11 @@ export async function removePairedDevice(
       return null;
     }
     delete state.pairedByDeviceId[normalized];
+    for (const [requestId, pending] of Object.entries(state.pendingById)) {
+      if (pending.deviceId === normalized) {
+        delete state.pendingById[requestId];
+      }
+    }
     await persistState(state, baseDir);
     return { deviceId: normalized };
   });


### PR DESCRIPTION
# fix(pairing): clear stale requests on device removal

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: removing a paired device deleted the paired record but left same-device pending pairing requests behind.
- Why it matters: approving one of those stale requests could recreate the removed device and mint fresh role tokens after the operator had already removed it.
- What changed: `removePairedDevice()` now deletes pending requests for the removed device, and `src/infra/device-pairing.test.ts` now locks in that stale approvals fail closed while unrelated pending requests survive.
- What did NOT change (scope boundary): the gateway RPC flow, approval logic for valid pending requests, and token formats were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes <operator to fill>
- Related NVIDIA-dev/openclaw-tracking#496
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `removePairedDevice()` removed `pairedByDeviceId[deviceId]` but did not clear `pendingById` entries for that same device.
- Missing detection / guardrail: the existing removal test only verified that the paired record disappeared, not that same-device pending requests were invalidated.
- Contributing context (if known): `approveDevicePairing()` correctly rebuilds a device from any surviving pending request, so stale pending entries remained approvable after removal.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/device-pairing.test.ts`
- Scenario the test should lock in: removing a paired device deletes stale pending requests for that device, leaves unrelated pending requests intact, and makes approval of the removed device's old request return `null`.
- Why this is the smallest reliable guardrail: the bug lives entirely inside the pairing state transition under `withLock`, so the infra unit test exercises the real persistence and approval behavior without extra gateway setup.
- Existing test that already covers this (if any): `removes paired devices by device id` only covered paired-record deletion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Removing a paired device now also invalidates older pending pairing requests for that same device.
- Operators must submit a fresh pairing request after removal instead of approving an older repair request.

## Diagram (if applicable)

```text
Before:
[repair request pending] -> [device removed] -> [old request still approvable] -> [device recreated]

After:
[repair request pending] -> [device removed] -> [same-device pending cleared] -> [old approval returns null]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64 GNU/Linux
- Runtime/container: Node.js v22.14.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Create and approve an initial pairing for `device-1`.
2. Create a new pending repair request for `device-1`, plus an unrelated pending request for `device-2`.
3. Remove `device-1`, inspect pending pairing state, and try to approve the old `device-1` request.

### Expected

- Same-device stale pending request is removed.
- Unrelated pending request remains.
- Approving the removed device's old request returns `null`.

### Actual

- Matches expected behavior after the patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/device-pairing.test.ts --reporter=verbose`

- Result: `1` test file passed, `37` tests passed, including `removing a paired device clears pending requests for that device only`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the infra Vitest file directly; confirmed the new regression passes; confirmed the existing removal test still passes; confirmed formatting on the two touched files with `pnpm exec oxfmt --check src/infra/device-pairing.ts src/infra/device-pairing.test.ts`.
- Edge cases checked: stale request for the removed device is cleared; unrelated pending request remains; approving the stale request after removal returns `null`.
- What you did **not** verify: gateway-level pairing RPC tests were not rerun; the broader staged `check:changed` hook was blocked by an unrelated pre-existing `src/infra/git-commit.test.ts` failure caused by an invalid git object for `.agents/skills/blacksmith-testbox/SKILL.md`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? No
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Operators who accidentally remove a device can no longer approve an older pending repair request for that same device.
  - Mitigation: this restores the intended removal boundary, and submitting a fresh pairing request remains available; unrelated device requests are preserved.