### PR TITLE
fix(cli): exit after hooks inspection output

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -91,5 +91,23 @@ describe("hooks cli formatting", () => {
     expect(
       __testing.shouldForceExitAfterHooksInspection({ VITEST: "true" } as NodeJS.ProcessEnv),
     ).toBe(false);
+    expect(
+      __testing.shouldForceExitAfterHooksInspection({ VITEST: "1" } as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      __testing.shouldForceExitAfterHooksInspection({
+        VITEST_POOL_ID: "1",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      __testing.shouldForceExitAfterHooksInspection({
+        VITEST_WORKER_ID: "1",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      __testing.shouldForceExitAfterHooksInspection({
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
   });
 });

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HookStatusReport } from "../hooks/hooks-status.js";
-import { formatHookInfo, formatHooksCheck, formatHooksList } from "./hooks-cli.js";
+import { __testing, formatHookInfo, formatHooksCheck, formatHooksList } from "./hooks-cli.js";
 import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
 
 const report: HookStatusReport = {
@@ -84,5 +84,12 @@ describe("hooks cli formatting", () => {
     const output = formatHookInfo(pluginReport, "plugin-hook", {});
     expect(output).toContain("voice-call");
     expect(output).toContain("Managed by plugin");
+  });
+
+  it("force-exits one-shot hook inspection commands outside tests", () => {
+    expect(__testing.shouldForceExitAfterHooksInspection({} as NodeJS.ProcessEnv)).toBe(true);
+    expect(
+      __testing.shouldForceExitAfterHooksInspection({ VITEST: "true" } as NodeJS.ProcessEnv),
+    ).toBe(false);
   });
 });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -10,6 +10,7 @@ import {
 import { resolveHookEntries } from "../hooks/policy.js";
 import type { HookEntry } from "../hooks/types.js";
 import { loadWorkspaceHookEntries } from "../hooks/workspace.js";
+import { isVitestRuntimeEnv } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildPluginDiagnosticsReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
@@ -153,7 +154,7 @@ function writeHooksOutput(value: string, json: boolean | undefined): void {
 }
 
 function shouldForceExitAfterHooksInspection(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.VITEST !== "true";
+  return !isVitestRuntimeEnv(env);
 }
 
 function exitAfterHooksInspection(): void {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -152,12 +152,34 @@ function writeHooksOutput(value: string, json: boolean | undefined): void {
   defaultRuntime.log(value);
 }
 
+function shouldForceExitAfterHooksInspection(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.VITEST !== "true";
+}
+
+function exitAfterHooksInspection(): void {
+  if (!shouldForceExitAfterHooksInspection()) {
+    return;
+  }
+
+  const exit = () => defaultRuntime.exit(0);
+  if (process.stdout.writableLength > 0) {
+    process.stdout.write("", exit);
+    return;
+  }
+  setImmediate(exit);
+}
+
 async function runHooksCliAction(action: () => Promise<void> | void): Promise<void> {
   try {
     await action();
   } catch (err) {
     exitHooksCliWithError(err);
   }
+}
+
+async function runHooksInspectionCliAction(action: () => Promise<void> | void): Promise<void> {
+  await runHooksCliAction(action);
+  exitAfterHooksInspection();
 }
 
 /**
@@ -467,7 +489,7 @@ export function registerHooksCli(program: Command): void {
     .option("--json", "Output as JSON", false)
     .option("-v, --verbose", "Show more details including missing requirements", false)
     .action(async (opts) =>
-      runHooksCliAction(async () => {
+      runHooksInspectionCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHooksList(report, opts), opts.json);
@@ -479,7 +501,7 @@ export function registerHooksCli(program: Command): void {
     .description("Show detailed information about a hook")
     .option("--json", "Output as JSON", false)
     .action(async (name, opts) =>
-      runHooksCliAction(async () => {
+      runHooksInspectionCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHookInfo(report, name, opts), opts.json);
@@ -491,7 +513,7 @@ export function registerHooksCli(program: Command): void {
     .description("Check hooks eligibility status")
     .option("--json", "Output as JSON", false)
     .action(async (opts) =>
-      runHooksCliAction(async () => {
+      runHooksInspectionCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHooksCheck(report, opts), opts.json);
@@ -502,7 +524,7 @@ export function registerHooksCli(program: Command): void {
     .command("enable <name>")
     .description("Enable a hook")
     .action(async (name) =>
-      runHooksCliAction(async () => {
+      runHooksInspectionCliAction(async () => {
         await enableHook(name);
       }),
     );
@@ -511,7 +533,7 @@ export function registerHooksCli(program: Command): void {
     .command("disable <name>")
     .description("Disable a hook")
     .action(async (name) =>
-      runHooksCliAction(async () => {
+      runHooksInspectionCliAction(async () => {
         await disableHook(name);
       }),
     );
@@ -543,10 +565,14 @@ export function registerHooksCli(program: Command): void {
     });
 
   hooks.action(async () =>
-    runHooksCliAction(async () => {
+    runHooksInspectionCliAction(async () => {
       const config = loadConfig();
       const report = buildHooksReport(config);
       defaultRuntime.log(formatHooksList(report, {}));
     }),
   );
 }
+
+export const __testing = {
+  shouldForceExitAfterHooksInspection,
+};

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -177,7 +177,7 @@ async function runHooksCliAction(action: () => Promise<void> | void): Promise<vo
   }
 }
 
-async function runHooksInspectionCliAction(action: () => Promise<void> | void): Promise<void> {
+async function runOneShotHooksCliAction(action: () => Promise<void> | void): Promise<void> {
   await runHooksCliAction(action);
   exitAfterHooksInspection();
 }
@@ -489,7 +489,7 @@ export function registerHooksCli(program: Command): void {
     .option("--json", "Output as JSON", false)
     .option("-v, --verbose", "Show more details including missing requirements", false)
     .action(async (opts) =>
-      runHooksInspectionCliAction(async () => {
+      runOneShotHooksCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHooksList(report, opts), opts.json);
@@ -501,7 +501,7 @@ export function registerHooksCli(program: Command): void {
     .description("Show detailed information about a hook")
     .option("--json", "Output as JSON", false)
     .action(async (name, opts) =>
-      runHooksInspectionCliAction(async () => {
+      runOneShotHooksCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHookInfo(report, name, opts), opts.json);
@@ -513,7 +513,7 @@ export function registerHooksCli(program: Command): void {
     .description("Check hooks eligibility status")
     .option("--json", "Output as JSON", false)
     .action(async (opts) =>
-      runHooksInspectionCliAction(async () => {
+      runOneShotHooksCliAction(async () => {
         const config = loadConfig();
         const report = buildHooksReport(config);
         writeHooksOutput(formatHooksCheck(report, opts), opts.json);
@@ -524,7 +524,7 @@ export function registerHooksCli(program: Command): void {
     .command("enable <name>")
     .description("Enable a hook")
     .action(async (name) =>
-      runHooksInspectionCliAction(async () => {
+      runOneShotHooksCliAction(async () => {
         await enableHook(name);
       }),
     );
@@ -533,7 +533,7 @@ export function registerHooksCli(program: Command): void {
     .command("disable <name>")
     .description("Disable a hook")
     .action(async (name) =>
-      runHooksInspectionCliAction(async () => {
+      runOneShotHooksCliAction(async () => {
         await disableHook(name);
       }),
     );
@@ -565,7 +565,7 @@ export function registerHooksCli(program: Command): void {
     });
 
   hooks.action(async () =>
-    runHooksInspectionCliAction(async () => {
+    runOneShotHooksCliAction(async () => {
       const config = loadConfig();
       const report = buildHooksReport(config);
       defaultRuntime.log(formatHooksList(report, {}));


### PR DESCRIPTION
## Summary
- make one-shot hooks CLI inspection commands exit after writing their output
- cover `hooks list`, `hooks info`, `hooks check`, `hooks enable`, `hooks disable`, and bare `hooks`
- keep deprecated `hooks install` / `hooks update` behavior unchanged
- add a focused guard test for test vs non-test exit behavior

## Why
`openclaw hooks` inspection commands build plugin diagnostics, and that can execute plugin `register()` handlers. A third-party plugin can accidentally leave an interval, watcher, or socket open during registration. In that case, the CLI can print the expected output but keep the process alive.

This restores the one-shot CLI invariant: hook inspection commands should terminate after the requested report or config mutation is complete.

## Non-goals
- Does not change gateway plugin lifecycle.
- Does not change plugin diagnostic collection.
- Does not change deprecated plugin install/update wrappers.

## Tests
- `pnpm exec oxfmt --check src/cli/hooks-cli.ts src/cli/hooks-cli.test.ts`
- `pnpm exec oxlint --type-aware src/cli/hooks-cli.ts src/cli/hooks-cli.test.ts`
- `OPENCLAW_VITEST_INCLUDE_FILE=... pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts`
- `pnpm exec vitest run src/plugins/status.test.ts --config test/vitest/vitest.plugins.config.ts`
- `git commit` pre-commit hook ran `check:changed` successfully, including core typecheck, core test typecheck, core lint, import-cycle check, and the changed unit-fast test
- Smoke-tested `node --import tsx src/entry.ts hooks check --json` with a temporary plugin whose `register()` leaves `setInterval()` open; command exited with status 0

## Notes
- AI-assisted: yes. I understand what this code does.
- I attempted local `codex review --base origin/main`, but it stalled for several minutes while loading B12 context before producing findings. I will trigger GitHub Codex review on this PR instead.
