### PR TITLE
gateway/chat: honor per-agent thinkingDefault in chat.history fallback

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -1659,13 +1659,27 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const catalog = await context.loadGatewayModelCatalog();
-      thinkingLevel = resolveThinkingDefault({
-        cfg,
-        provider: resolvedSessionModel.provider,
-        model: resolvedSessionModel.model,
-        catalog,
-      });
+      // Per-agent thinkingDefault (cfg.agents.list[].thinkingDefault) takes
+      // precedence over the model-centric fallback: reasoning models like
+      // openai-codex/gpt-5.4 would otherwise default to "low" via
+      // resolveThinkingDefaultForModel, so chat.history (and therefore the
+      // TUI / CLI) would drift below the agent's configured level. Go through
+      // resolveAgentConfig so the same id normalization as the rest of the
+      // agent-scope logic applies.
+      const perAgentThinkingDefault = sessionAgentId
+        ? resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault
+        : undefined;
+      if (perAgentThinkingDefault) {
+        thinkingLevel = perAgentThinkingDefault;
+      } else {
+        const catalog = await context.loadGatewayModelCatalog();
+        thinkingLevel = resolveThinkingDefault({
+          cfg,
+          provider: resolvedSessionModel.provider,
+          model: resolvedSessionModel.model,
+          catalog,
+        });
+      }
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
     respond(true, {

--- a/src/gateway/server.chat.thinking-fallback.test.ts
+++ b/src/gateway/server.chat.thinking-fallback.test.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { clearConfigCache } from "../config/config.js";
+import {
+  connectOk,
+  createGatewaySuiteHarness,
+  installGatewayTestHooks,
+  rpcReq,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
+type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
+let harness: GatewayHarness;
+
+beforeAll(async () => {
+  harness = await createGatewaySuiteHarness();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+async function writeGatewayConfig(config: Record<string, unknown>): Promise<void> {
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  if (!configPath) {
+    throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
+  }
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  clearConfigCache();
+}
+
+async function withHarness(
+  run: (ctx: { ws: GatewaySocket; createSessionDir: () => Promise<string> }) => Promise<void>,
+): Promise<void> {
+  const tempDirs: string[] = [];
+  const ws = await harness.openWs();
+  const createSessionDir = async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-think-"));
+    tempDirs.push(sessionDir);
+    testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+    return sessionDir;
+  };
+
+  try {
+    await run({ ws, createSessionDir });
+  } finally {
+    clearConfigCache();
+    testState.sessionStorePath = undefined;
+    ws.close();
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  }
+}
+
+type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+
+function buildAgentCfg(opts: { thinkingDefault?: ThinkLevel }): Record<string, unknown> {
+  return {
+    agents: {
+      list: [
+        {
+          id: "main",
+          model: "openai-codex/gpt-5.4",
+          ...(opts.thinkingDefault ? { thinkingDefault: opts.thinkingDefault } : {}),
+        },
+      ],
+    },
+  };
+}
+
+async function seedMainSession(
+  sessionDir: string,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  const transcriptPath = path.join(sessionDir, "sess-main.jsonl");
+  await fs.writeFile(
+    transcriptPath,
+    `${JSON.stringify({ type: "session", id: "sess-main" })}\n`,
+    "utf-8",
+  );
+  await writeSessionStore({
+    entries: {
+      main: {
+        sessionId: "sess-main",
+        sessionFile: transcriptPath,
+        updatedAt: Date.now(),
+        ...overrides,
+      },
+    },
+  });
+}
+
+async function fetchThinkingLevel(
+  ws: GatewaySocket,
+  sessionKey: string = "main",
+): Promise<unknown> {
+  const res = await rpcReq<{ thinkingLevel?: unknown }>(ws, "chat.history", {
+    sessionKey,
+    limit: 10,
+  });
+  expect(res.ok).toBe(true);
+  return res.payload?.thinkingLevel;
+}
+
+describe("chat.history thinkingLevel fallback (agent-aware)", () => {
+  test("returns per-agent thinkingDefault when the session entry has no thinkingLevel", async () => {
+    await withHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig(buildAgentCfg({ thinkingDefault: "high" }));
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      await seedMainSession(sessionDir);
+      const thinkingLevel = await fetchThinkingLevel(ws);
+      expect(thinkingLevel).toBe("high");
+    });
+  });
+
+  test("session-specific entry.thinkingLevel wins over per-agent thinkingDefault (regression guard)", async () => {
+    await withHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig(buildAgentCfg({ thinkingDefault: "high" }));
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      await seedMainSession(sessionDir, { thinkingLevel: "medium" });
+      const thinkingLevel = await fetchThinkingLevel(ws);
+      expect(thinkingLevel).toBe("medium");
+    });
+  });
+
+  test("agent without thinkingDefault still falls through to the shared resolver", async () => {
+    await withHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig(buildAgentCfg({}));
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      await seedMainSession(sessionDir);
+      const thinkingLevel = await fetchThinkingLevel(ws);
+      // Whatever resolveThinkingDefault returns for this provider/model combo,
+      // it must be a concrete ThinkLevel string, not undefined — proving the
+      // agent-aware branch did not short-circuit with a missing value.
+      expect(typeof thinkingLevel).toBe("string");
+      expect((thinkingLevel as string).length).toBeGreaterThan(0);
+    });
+  });
+
+  test("canonical webchat sessionKey 'agent:main:main' resolves the per-agent thinkingDefault", async () => {
+    await withHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig(buildAgentCfg({ thinkingDefault: "high" }));
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      await seedMainSession(sessionDir);
+      const thinkingLevel = await fetchThinkingLevel(ws, "agent:main:main");
+      expect(thinkingLevel).toBe("high");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix a display-level drift in the gateway's `chat.history` RPC response: when a session entry has no explicit `thinkingLevel` yet (fresh session, post-restart, new webchat connection), the handler falls back to the model-centric `resolveThinkingDefault`, which reads only `cfg.agents?.defaults?.thinkingDefault` and not the per-agent override in `cfg.agents.list[].thinkingDefault`. For reasoning models like `openai-codex/gpt-5.4` that fallback returns `"low"` even when the agent — for example `main` — is explicitly configured with `thinkingDefault: "high"`. The TUI picks up `"low"` from the handler response, pins it locally, and drifts below the configured level.
- Honor the per-agent override before falling through: read `resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault` and use it when present. Session-specific `entry.thinkingLevel` still wins (unchanged priority), and when neither the session nor the agent have a value the existing `resolveThinkingDefault` branch is taken verbatim.

## Scope

- Single-call-site change in `src/gateway/server-methods/chat.ts` inside the `"chat.history"` RPC handler.
- Uses the existing normalized `resolveAgentConfig(cfg, agentId)` helper from `src/agents/agent-scope.ts`, so the same id-normalization that the rest of the agent-scope logic applies covers this path too (no parallel `cfg.agents.list.find` logic).
- `resolveThinkingDefault`, the `/think` command path, `auto-reply/reply/model-selection`, `agent-command`, `cron/isolated-agent`, and plugin runtime callers are all untouched — this is strictly the chat.history display fallback.

## Priority order after the fix

1. `entry.thinkingLevel` — persisted session-specific value (from `/think` or prior runs) — unchanged.
2. `cfg.agents.list[].thinkingDefault` — per-agent override — newly honored.
3. Existing `resolveThinkingDefault(...)` chain — per-model override → `cfg.agents.defaults.thinkingDefault` → anthropic heuristics → model-centric default — unchanged as the final fallback.

## Tests

New focused suite `src/gateway/server.chat.thinking-fallback.test.ts` (4 tests, all passing locally):
- Returns per-agent `thinkingDefault` when the session entry has no `thinkingLevel`.
- Session-specific `entry.thinkingLevel` still wins over per-agent default (regression guard).
- Agent without `thinkingDefault` falls through to the shared resolver (no short-circuit).
- Canonical webchat `sessionKey: "agent:main:main"` resolves the per-agent default correctly (covers the id-normalization path).

## Test plan

- [x] `pnpm test src/gateway/server.chat.thinking-fallback.test.ts` — 4/4 PASS
- [x] Regression: `pnpm test src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts` — 33/33 PASS
- [x] `pnpm check` (tsgo core + core:test + extensions + extensions:test, oxlint, import-cycle + madge checks all green; ran via `scripts/committer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)