### PR TITLE
Fix/heartbeat template

### DIFF
--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -7,8 +7,6 @@ read_when:
 
 # HEARTBEAT.md Template
 
-```markdown
 # Keep this file empty (or with only comments) to skip heartbeat API calls.
 
 # Add tasks below when you want the agent to check something periodically.
-```

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -202,7 +202,6 @@ describe("ensureAgentWorkspace", () => {
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
     const heartbeat = await fs.readFile(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME), "utf-8");
-    expect(heartbeat).toContain("```markdown");
     expect(heartbeat).toContain(
       "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
     );

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -196,7 +196,7 @@ describe("ensureAgentWorkspace", () => {
     await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
   });
 
-  it("writes the current fenced HEARTBEAT template body into new workspaces", async () => {
+  it("writes the current HEARTBEAT template body into new workspaces", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });


### PR DESCRIPTION

> AI-assisted PR. Fully tested locally.

## Summary

- Problem: `docs/reference/templates/HEARTBEAT.md` contains Markdown code block markers (```) that are copied verbatim into new agent workspaces.
- Why it matters: OpenClaw skips AI heartbeat requests when `HEARTBEAT.md` is missing, empty, or default. The ``` markers cause the file to be misclassified as custom content, triggering unnecessary LLM API calls.
- What changed: Removed the Markdown code block markers from the template file, and updated `src/agents/workspace.test.ts` to match the cleaned scaffold content.
- What did NOT change (scope boundary): No agent logic, gateway code, or heartbeat parsing behavior was modified. Only the static template file and its corresponding test assertion were updated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The template file was authored with Markdown code block formatting (```) for documentation readability, but this formatting is not stripped when the template is scaffolded into an agent workspace.
- Missing detection / guardrail: No template sanitization step exists to strip Markdown formatting markers during agent creation.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/workspace.test.ts`
- Scenario the test should lock in: Agent workspace scaffolding produces `HEARTBEAT.md` without Markdown fence markers.
- Why this is the smallest reliable guardrail: The unit test directly asserts the scaffolded template content; updating it ensures the template contract stays in sync.
- Existing test that already covers this (if any): `workspace.test.ts` previously asserted the presence of ``` markers; this PR updates that assertion to match the corrected template.
- If no new test is added, why not: N/A — existing test updated.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Local pnpm dev setup
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw agents add test-agent`
2. Inspect `~/.openclaw/workspace/test-agent/HEARTBEAT.md`
3. Observe the file no longer contains ``` markers
4. Run `pnpm test src/agents/workspace.test.ts` and confirm it passes

### Expected

- `HEARTBEAT.md` contains only raw template content without Markdown formatting markers.
- Default heartbeat config is correctly recognized, skipping unnecessary AI API calls.
- `workspace.test.ts` passes with the updated assertion.

### Actual

- Before fix: `HEARTBEAT.md` contained ``` markers, causing misclassification as custom content.
- After fix: Template is clean and test coverage is aligned.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`workspace.test.ts` was failing before the assertion update (expected old fenced content) and passes after.

## Human Verification (required)

- Verified scenarios: Created a new agent locally and confirmed the generated `HEARTBEAT.md` no longer contains ``` markers. Ran `pnpm test src/agents/workspace.test.ts` successfully.
- Edge cases checked: Verified the remaining template content is intact and readable.
- What you did **not** verify: End-to-end AI request skipping behavior in a live gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.