### PR TITLE
fix(whatsapp): default to unavailable presence to prevent phone notification suppression

### DIFF
--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -24,6 +24,7 @@ export type ResolvedWhatsAppAccount = {
   authDir: string;
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
+  announcePresence?: boolean;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
@@ -139,6 +140,7 @@ export function resolveWhatsAppAccount(params: {
     authDir,
     isLegacyAuthDir: isLegacy,
     selfChatMode: merged.selfChatMode,
+    announcePresence: merged.announcePresence,
     dmPolicy: merged.dmPolicy,
     allowFrom: merged.allowFrom,
     groupAllowFrom: merged.groupAllowFrom,

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -253,6 +253,7 @@ export async function monitorWebChannel(
               authDir: account.authDir,
               mediaMaxMb: account.mediaMaxMb,
               selfChatMode: account.selfChatMode,
+              announcePresence: account.announcePresence,
               sendReadReceipts: account.sendReadReceipts,
               debounceMs: inboundDebounceMs,
               shouldDebounce,

--- a/extensions/whatsapp/src/config-ui-hints.ts
+++ b/extensions/whatsapp/src/config-ui-hints.ts
@@ -13,6 +13,10 @@ export const whatsAppChannelConfigUiHints = {
     label: "WhatsApp Self-Phone Mode",
     help: "Same-phone setup (bot uses your personal WhatsApp number).",
   },
+  announcePresence: {
+    label: "WhatsApp Announce Online Presence",
+    help: "Announce online presence on connect (default: false). When false, the gateway stays 'unavailable' so the phone continues receiving push notifications.",
+  },
   debounceMs: {
     label: "WhatsApp Message Debounce (ms)",
     help: "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -65,7 +65,7 @@ export type MonitorWebInboxOptions = {
   authDir: string;
   onMessage: (msg: WebInboundMessage) => Promise<void>;
   mediaMaxMb?: number;
-  /** Keep the global presence unavailable so self-chat sessions do not mute phone pushes. */
+  /** Same-phone setup (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;
   /** Announce online presence on connect (default: false). When false, the gateway stays "unavailable" so the phone continues receiving push notifications. */
   announcePresence?: boolean;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -67,6 +67,8 @@ export type MonitorWebInboxOptions = {
   mediaMaxMb?: number;
   /** Keep the global presence unavailable so self-chat sessions do not mute phone pushes. */
   selfChatMode?: boolean;
+  /** Announce online presence on connect (default: false). When false, the gateway stays "unavailable" so the phone continues receiving push notifications. */
+  announcePresence?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
@@ -121,7 +123,7 @@ export async function attachWebInboxToSocket(
     onCloseResolve = null;
     resolver(reason);
   };
-  const presence = options.selfChatMode ? "unavailable" : "available";
+  const presence = options.announcePresence ? "available" : "unavailable";
 
   try {
     await sock.sendPresenceUpdate(presence);

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -86,7 +86,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "unavailable");
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -152,7 +152,7 @@ describe("web monitor inbox", () => {
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "unavailable");
     const messageId = nextMessageId("stream");
     const upsert = buildNotifyMessageUpsert({
       id: messageId,
@@ -176,7 +176,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",
@@ -191,6 +191,16 @@ describe("web monitor inbox", () => {
     });
 
     expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "unavailable");
+
+    await listener.close();
+  });
+
+  it("announces available presence when announcePresence is true", async () => {
+    const { listener, sock } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage, {
+      announcePresence: true,
+    });
+
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
 
     await listener.close();
   });
@@ -210,7 +220,7 @@ describe("web monitor inbox", () => {
     const { listener } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage);
 
     expect(sock.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
-    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
+    expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "unavailable");
 
     await listener.close();
   });

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -15005,6 +15005,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         selfChatMode: {
           type: "boolean",
         },
+        announcePresence: {
+          type: "boolean",
+        },
         allowFrom: {
           type: "array",
           items: {
@@ -15273,6 +15276,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 enum: ["pairing", "allowlist", "open", "disabled"],
               },
               selfChatMode: {
+                type: "boolean",
+              },
+              announcePresence: {
                 type: "boolean",
               },
               allowFrom: {
@@ -15552,6 +15558,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       selfChatMode: {
         label: "WhatsApp Self-Phone Mode",
         help: "Same-phone setup (bot uses your personal WhatsApp number).",
+      },
+      announcePresence: {
+        label: "WhatsApp Announce Online Presence",
+        help: "Announce online presence on connect (default: false). When false, the gateway stays 'unavailable' so the phone continues receiving push notifications.",
       },
       debounceMs: {
         label: "WhatsApp Message Debounce (ms)",

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -56,6 +56,8 @@ type WhatsAppSharedConfig = {
   dmPolicy?: DmPolicy;
   /** Same-phone setup (bot uses your personal WhatsApp number). */
   selfChatMode?: boolean;
+  /** Announce online presence on connect (default: false). When false, the gateway stays "unavailable" so the phone continues receiving push notifications. */
+  announcePresence?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -60,6 +60,7 @@ function buildWhatsAppCommonShape(params: { useDefaults: boolean }) {
       ? DmPolicySchema.optional().default("pairing")
       : DmPolicySchema.optional(),
     selfChatMode: z.boolean().optional(),
+    announcePresence: z.boolean().optional(),
     allowFrom: z.array(z.string()).optional(),
     defaultTo: z.string().optional(),
     groupAllowFrom: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Addresses #30286

When OpenClaw connects to WhatsApp via Baileys, the gateway previously announced `"available"` presence on connect, causing WhatsApp to suppress **all** push notifications on the phone — not just monitored chats.

This is a known Baileys behavior: the WhatsApp protocol interprets a linked device announcing online presence as "this user is actively using WhatsApp" and routes messages silently to that device.

## Changes

- Add `announcePresence` boolean account config (default: `false`)
- Default global presence to `"unavailable"` on connect
- Decouple presence logic from `selfChatMode` (which has other implications for message routing and read receipts)
- Add config-ui hint and generated metadata for the new option
- Update test expectations: default presence is now `"unavailable"`
- Add test for `announcePresence: true` opt-in path

## How it works

`"unavailable"` does **not** mean offline. The device remains connected, can send/receive messages, and per-chat composing indicators still work. This is the same approach used by Beeper (also Baileys-based).

Users who explicitly want online presence can opt in:
```json
{
  "channels": {
    "whatsapp": {
      "accounts": {
        "default": {
          "announcePresence": true
        }
      }
    }
  }
}
```

## Files changed

| File | Change |
|---|---|
| `extensions/whatsapp/src/inbound/monitor.ts` | Presence logic: `announcePresence ? "available" : "unavailable"` |
| `extensions/whatsapp/src/accounts.ts` | Add `announcePresence` to resolved account type |
| `extensions/whatsapp/src/auto-reply/monitor.ts` | Pass `announcePresence` to inbox options |
| `extensions/whatsapp/src/config-ui-hints.ts` | UI hint for new config option |
| `extensions/whatsapp/src/account-config.ts` | Config resolution (via generated metadata) |
| `src/config/types.whatsapp.ts` | TypeScript type for new field |
| `src/config/zod-schema.providers-whatsapp.ts` | Zod validation schema |
| `src/config/bundled-channel-config-metadata.generated.ts` | Generated config metadata |
| `*.test.ts` (2 files) | Updated expectations + new test |

---

**AI-assisted PR.** Changes lightly tested (type-checked, test expectations updated). Code understood and reviewed.