### PR TITLE
Fix Slack HTTP route registry dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/HTTP: dispatch registered Request URL webhooks through the same handler registry used by Slack monitor setup, so HTTP-mode Slack events no longer 404 after successful route registration. (#70275) Thanks @FroeMic.
 - CLI sessions: persist CLI session clearing through the atomic session-store merge path, so expired Claude/Codex CLI bindings are actually removed before retrying without the stale session id. (#70298) Thanks @HFConsultant.
 - ACP/sessions_spawn: honor explicit `model` overrides for ACP child sessions instead of silently falling back to the target agent default model. (#70210) Thanks @felix-miao.
 - Agents/subagents: drop bare `NO_REPLY` from the parent turn when the session still has pending spawned children, so direct-conversation surfaces such as Telegram DMs no longer rewrite the sentinel into visible fallback chatter while waiting for the child completion event. (#69942) Thanks @neeravmakwana.

--- a/extensions/slack/src/http/plugin-routes.dispatch.test.ts
+++ b/extensions/slack/src/http/plugin-routes.dispatch.test.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../../../test/helpers/plugins/plugin-api.js";
+import type { OpenClawConfig, OpenClawPluginApi } from "../runtime-api.js";
+
+function createApi(config: OpenClawConfig, registerHttpRoute = vi.fn()): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "slack",
+    config,
+    registerHttpRoute,
+  });
+}
+
+describe("registerSlackPluginHttpRoutes dispatch", () => {
+  it("uses the shared Slack HTTP handler registry", async () => {
+    vi.resetModules();
+    const staleRuntimeHandler = vi.fn(async () => false);
+    vi.doMock("./handler.runtime.js", () => ({
+      handleSlackHttpRequest: staleRuntimeHandler,
+    }));
+
+    const [{ registerSlackPluginHttpRoutes }, { registerSlackHttpHandler }] = await Promise.all([
+      import("./plugin-routes.js"),
+      import("./registry.js"),
+    ]);
+    const routeHandler = vi.fn();
+    const unregister = registerSlackHttpHandler({
+      path: "/slack/events",
+      handler: routeHandler,
+    });
+    const registerHttpRoute = vi.fn();
+
+    try {
+      registerSlackPluginHttpRoutes(createApi({}, registerHttpRoute));
+      const route = registerHttpRoute.mock.calls[0]?.[0] as
+        | {
+            handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
+          }
+        | undefined;
+      const req = { url: "/slack/events" } as IncomingMessage;
+      const res = {} as ServerResponse;
+
+      await expect(route?.handler(req, res)).resolves.toBe(true);
+
+      expect(routeHandler).toHaveBeenCalledWith(req, res);
+      expect(staleRuntimeHandler).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+      vi.doUnmock("./handler.runtime.js");
+    }
+  });
+});

--- a/extensions/slack/src/http/plugin-routes.ts
+++ b/extensions/slack/src/http/plugin-routes.ts
@@ -2,13 +2,7 @@ import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-plugin-common";
 import { listSlackAccountIds, mergeSlackAccountConfig } from "../accounts.js";
 import { normalizeSlackWebhookPath } from "./paths.js";
-
-let slackHttpHandlerRuntimePromise: Promise<typeof import("./handler.runtime.js")> | null = null;
-
-async function loadSlackHttpHandlerRuntime() {
-  slackHttpHandlerRuntimePromise ??= import("./handler.runtime.js");
-  return await slackHttpHandlerRuntimePromise;
-}
+import { handleSlackHttpRequest } from "./registry.js";
 
 export function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
   const accountIds = new Set<string>([DEFAULT_ACCOUNT_ID, ...listSlackAccountIds(api.config)]);
@@ -25,8 +19,7 @@ export function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
     api.registerHttpRoute({
       path,
       auth: "plugin",
-      handler: async (req, res) =>
-        await (await loadSlackHttpHandlerRuntime()).handleSlackHttpRequest(req, res),
+      handler: async (req, res) => await handleSlackHttpRequest(req, res),
     });
   }
 }


### PR DESCRIPTION
## Summary
- route Slack HTTP plugin dispatch through the shared handler registry used by the Slack monitor
- remove the lazy handler.runtime dispatch path that can resolve to an empty registry after bundling/runtime loading
- add regression coverage that mocks the stale runtime path and verifies the registered route still reaches the live registry handler

## Verification
- COREPACK_HOME=/tmp/openclaw-corepack corepack pnpm docs:list
- COREPACK_HOME=/tmp/openclaw-corepack corepack pnpm test extensions/slack/src/http/plugin-routes.test.ts extensions/slack/src/http/plugin-routes.dispatch.test.ts
- scripts/committer "Fix Slack HTTP route registry dispatch" extensions/slack/src/http/plugin-routes.ts extensions/slack/src/http/plugin-routes.dispatch.test.ts (file lint/format passed; commit hook then failed because plain pnpm on PATH is v9.1.4 while the repo requires pnpm v10.33.0)

## Known unrelated local gate failures
- COREPACK_HOME=/tmp/openclaw-corepack corepack pnpm check:changed fails in extension typecheck on existing errors outside this patch, including Discord SafeGatewayPlugin firstHeartbeatTimeout, missing optional extension deps for qa-lab/qqbot/tokenjuice, and an existing Slack SocketModeReceiverOptions type mismatch in provider.ts.
- COREPACK_HOME=/tmp/openclaw-corepack corepack pnpm build fails resolving @clawdbot/lobster/core from extensions/lobster/src/lobster-runner.ts.