### PR TITLE
docs(memory-wiki): fix QMD + bridge config example nesting

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -335,6 +335,9 @@ knowledge layer:
 {
   memory: {
     backend: "qmd",
+  },
+  plugins: {
+    entries: {
       "memory-wiki": {
         enabled: true,
         config: {


### PR DESCRIPTION
## Problem

The "Example: QMD + bridge mode" config block in `docs/plugins/memory-wiki.md` incorrectly nests the `memory-wiki` plugin entry inside the `memory` block:

```json5
// Before (broken)
{
  memory: {
    backend: "qmd",
      "memory-wiki": { ... }  // wrong — this is not a memory.* key
  },
}
```

`memory-wiki` config belongs under `plugins.entries`, not inside `memory`. Anyone copy-pasting this example would get a broken config.

## Fix

Move `memory-wiki` to the correct `plugins.entries` path:

```json5
// After (correct)
{
  memory: {
    backend: "qmd",
  },
  plugins: {
    entries: {
      "memory-wiki": { ... }
    },
  },
}
```

Found while setting up QMD + bridge mode on a live instance.