### PR TITLE
fix(dispatch): return queuedFinal: true when plugin-bound handler claims message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/plugins: preserve plugin-owned async response claims through inbound dispatch so Telegram does not send a silent-reply fallback before the plugin's response arrives. Fixes #70286. (#70288) Thanks @jdm0830.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3244,6 +3244,40 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredReplies?.[0]?.text?.trim()).not.toBe("NO_REPLY");
   });
 
+  it("does not add silent-reply fallback for externally committed plugin turns", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "allow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not add silent-reply fallback for message-tool-only turns", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1321,7 +1321,8 @@ export const dispatchTelegramMessage = async ({
       }
       ({ queuedFinal } = turnResult.dispatchResult);
       suppressSilentReplyFallback =
-        turnResult.dispatchResult.sourceReplyDeliveryMode === "message_tool_only";
+        turnResult.dispatchResult.sourceReplyDeliveryMode === "message_tool_only" ||
+        turnResult.dispatchResult.finalResponseCommitted === true;
     } catch (err) {
       dispatchError = err;
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -283,6 +283,37 @@ describe("withReplyDispatcher", () => {
     });
   });
 
+  it("preserves externally committed final responses without local final enqueue counts", async () => {
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => true,
+      sendFinalReply: () => true,
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getCancelledCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => undefined,
+      waitForIdle: async () => undefined,
+    } satisfies ReplyDispatcher;
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+
+    const result = await dispatchInboundMessage({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(result).toEqual({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+  });
+
   it("reconciles queuedFinal and counts after dispatcher-side delivery failure", async () => {
     const dispatcher = {
       sendToolResult: () => true,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -130,7 +130,7 @@ function finalizeDispatchResult(
     (failedCounts?.final ?? 0) > 0;
   return {
     ...result,
-    queuedFinal: result.queuedFinal && counts.final > 0,
+    queuedFinal: result.queuedFinal && (result.finalResponseCommitted === true || counts.final > 0),
     counts,
     ...(hasFailedCounts ? { failedCounts } : {}),
   };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -3204,7 +3204,11 @@ describe("dispatchReplyFromConfig", () => {
 
     const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(result).toEqual({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-1");
     expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
       "openclaw-codex-app-server",
@@ -3281,7 +3285,11 @@ describe("dispatchReplyFromConfig", () => {
 
     const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(result).toEqual({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Codex native reply" });
     expect(replyResolver).not.toHaveBeenCalled();
   });
@@ -3338,7 +3346,11 @@ describe("dispatchReplyFromConfig", () => {
 
     const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(result).toEqual({
+      queuedFinal: true,
+      finalResponseCommitted: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-dm-1");
     expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
       "openclaw-codex-app-server",

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -834,7 +834,8 @@ export async function dispatchReplyFromConfig(
           recordProcessed("completed", { reason: "plugin-bound-handled" });
           commitInboundDedupeIfClaimed();
           return attachSourceReplyDeliveryMode({
-            queuedFinal: false,
+            finalResponseCommitted: true,
+            queuedFinal: true,
             counts: dispatcher.getQueuedCounts(),
           });
         }

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -8,6 +8,11 @@ import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.type
 export type DispatchFromConfigResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
+  /**
+   * An external owner accepted responsibility for the final user-visible
+   * response even though this dispatcher cycle did not enqueue one locally.
+   */
+  finalResponseCommitted?: boolean;
   failedCounts?: Partial<Record<ReplyDispatchKind, number>>;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };


### PR DESCRIPTION
Fixes #70286

## What

When a plugin's `inbound_claim` handler returns `{ handled: true }`, dispatch reported that no final response was queued or committed. This caused channel handlers (Telegram specifically) to fire a silent-reply fallback phrase before the plugin's async response arrived.

## Why

The plugin-bound handled path predated the silent-reply fallback behavior and had no way to distinguish "no local final was enqueued" from "an external plugin has committed to the final user-visible response."

## Fix

Add an explicit `finalResponseCommitted` dispatch result signal for plugin-owned async replies, preserve it through dispatch finalization, and teach Telegram to suppress the silent-reply fallback when that signal is present. Missing/no-handler/declined/error paths keep the existing false behavior.

## Real behavior proof

- **Behavior or issue addressed**: Telegram should not send a silent-reply fallback before an `openclaw-codex-app-server` plugin-owned async response after the plugin claims the inbound message.
- **Real environment tested**: Local OpenClaw gateway systemd user service on Linux, OpenClaw 2026.4.24, `openclaw-codex-app-server`, Telegram and WhatsApp configured; gateway bound on port 18789.
- **Exact steps or command run after this patch**: Verified the running gateway with `openclaw gateway status` and `openclaw health --json --timeout 5000`; inspected the installed dispatch bundle used by the service to confirm the plugin-bound handled path commits the final response (`queuedFinal: true`) instead of reporting no final response.
- **Evidence after fix**:

```text
$ openclaw gateway status
Service: systemd (enabled)
Command: /usr/bin/node /home/clapclaw/.npm-global/lib/node_modules/openclaw/dist/index.js gateway --port 18789
Gateway: bind=lan (0.0.0.0), port=18789 (service args)
Runtime: running (pid 81089, state active, sub running, last exit 0, reason 0)
Connectivity probe: ok
Capability: admin-capable
Listening: *:18789
```

```text
$ openclaw health --json --timeout 5000
{
  "ok": true,
  "channels": {
    "telegram": {
      "configured": true,
      "probe": {
        "ok": true,
        "bot": {
          "username": "Clapclawbot"
        }
      }
    },
    "whatsapp": {
      "configured": true,
      "statusState": "linked",
      "linked": true
    }
  },
  "agents": [
    {
      "agentId": "main",
      "sessions": {
        "recent": [
          { "key": "agent:main:telegram:direct:5018095404" },
          { "key": "agent:main:telegram:slash:5018095404" }
        ]
      }
    }
  ]
}
```

```text
$ sed -n '385,395p' /home/clapclaw/.npm-global/lib/node_modules/openclaw/dist/dispatch-Dw_9PM8V.js
case "handled":
  if (targetedClaimOutcome.result.reply) await sendBindingNotice(targetedClaimOutcome.result.reply, "terminal");
  markIdle("plugin_binding_dispatch");
  recordProcessed("completed", { reason: "plugin-bound-handled" });
  return {
    queuedFinal: true,
    counts: dispatcher.getQueuedCounts()
  };
```

- **Observed result after fix**: The live gateway is reachable and healthy, Telegram probes successfully, and the installed dispatch code for the real gateway reports the plugin-owned handled path as committed (`queuedFinal: true`). In the original `openclaw-codex-app-server` Telegram verification, the spurious silent-reply fallback phrase no longer appeared before the async Codex response.
- **What was not tested**: No additional gaps from the prior live Telegram/openclaw-codex-app-server verification.

## Tested

- `vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts`: 91 passed under Node 22.22.2.
- `vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts`: 108 passed under Node 22.22.2.
