### PR TITLE
tasks: avoid false inconsistent_timestamps warnings for pre-started runs

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1696,6 +1696,42 @@ describe("task-registry", () => {
     });
   });
 
+  it("uses startedAt as the createdAt floor for running tasks", async () => {
+    await withTaskRegistryTempDir(async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-22T17:39:00.005Z"));
+
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "",
+        scopeKind: "system",
+        runId: "run-timestamp-floor",
+        task: "timestamp-floor",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        startedAt: Date.parse("2026-04-22T17:39:00.000Z"),
+        lastEventAt: Date.parse("2026-04-22T17:39:00.000Z"),
+      });
+
+      expect(task.createdAt).toBe(task.startedAt);
+      expect(getInspectableTaskAuditSummary()).toEqual({
+        total: 0,
+        warnings: 0,
+        errors: 0,
+        byCode: {
+          stale_queued: 0,
+          stale_running: 0,
+          lost: 0,
+          delivery_failed: 0,
+          missing_cleanup: 0,
+          inconsistent_timestamps: 0,
+        },
+      });
+      vi.useRealTimers();
+    });
+  });
+
   it("keeps background ACP progress off the foreground lane and only sends a terminal notify", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1438,6 +1438,8 @@ export function createTaskRecord(params: {
     return mergeExistingTaskForCreate(existing, params);
   }
   const now = Date.now();
+  const effectiveCreatedAt =
+    typeof params.startedAt === "number" ? Math.min(now, params.startedAt) : now;
   const taskId = crypto.randomUUID();
   const status = normalizeTaskStatus(params.status);
   const deliveryStatus =
@@ -1471,7 +1473,7 @@ export function createTaskRecord(params: {
     status,
     deliveryStatus,
     notifyPolicy,
-    createdAt: now,
+    createdAt: effectiveCreatedAt,
     startedAt: params.startedAt,
     lastEventAt,
     cleanupAfter: params.cleanupAfter,


### PR DESCRIPTION
## Summary

Fix false `inconsistent_timestamps` audit warnings caused by task records
being created a few milliseconds after their `startedAt` was already captured.

## Problem

Some detached task producers (notably cron) capture `startedAt` first and then
create the running task record. `createTaskRecord()` stamped `createdAt` with a
fresh `Date.now()`, which could make:

- `startedAt < createdAt`

by a few milliseconds.

That is not a real lifecycle bug, but the task audit treated it as a timeline
violation and produced a large amount of warning noise.

## Fix

When `startedAt` is provided during task creation, use it as a floor for
`createdAt`:

- `createdAt = min(Date.now(), startedAt)`

This preserves valid ordering while keeping true timestamp inconsistencies
detectable.

## Tests

Added a regression test verifying that a running task created shortly after a
pre-captured `startedAt`:

- keeps `createdAt` aligned with `startedAt`
- does not produce an `inconsistent_timestamps` audit warning

## Validation

- `src/tasks/task-registry.test.ts`
- `src/tasks/task-registry.audit.test.ts`
