### PR TITLE
fix(memory): restrict default qmd scope to direct sessions

### DIFF
--- a/src/memory-host-sdk/host/backend-config.test.ts
+++ b/src/memory-host-sdk/host/backend-config.test.ts
@@ -81,7 +81,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(names.has("memory-dir-main")).toBe(true);
   });
 
-  it("allows direct and channel sessions in the default qmd scope", () => {
+  it("limits the default qmd scope to direct sessions", () => {
     const cfg = {
       agents: { defaults: { workspace: "/tmp/memory-test" } },
       memory: {
@@ -93,7 +93,7 @@ describe("resolveMemoryBackendConfig", () => {
 
     expect(isQmdScopeAllowed(resolved.qmd?.scope, "agent:main:discord:direct:user-123")).toBe(true);
     expect(isQmdScopeAllowed(resolved.qmd?.scope, "agent:main:discord:channel:chan-123")).toBe(
-      true,
+      false,
     );
     expect(isQmdScopeAllowed(resolved.qmd?.scope, "agent:main:discord:group:group-123")).toBe(
       false,

--- a/src/memory-host-sdk/host/backend-config.ts
+++ b/src/memory-host-sdk/host/backend-config.ts
@@ -107,10 +107,6 @@ const DEFAULT_QMD_SCOPE: SessionSendPolicyConfig = {
       action: "allow",
       match: { chatType: "direct" },
     },
-    {
-      action: "allow",
-      match: { chatType: "channel" },
-    },
   ],
 };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the default QMD scope allowed both direct and channel sessions when `memory.backend` was set to `qmd` and `memory.qmd.scope` was left unset.
- Why it matters: QMD-backed memory could be surfaced in multi-user channel sessions even when operators relied on the default scope.
- What changed: `DEFAULT_QMD_SCOPE` now only allows direct sessions, and the host config regression test now locks in channel denial by default.
- What did NOT change (scope boundary): this does not change the default memory backend (`builtin`), explicit `memory.qmd.scope` overrides, or any non-QMD memory path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the default QMD policy was broadened to include `chatType: "channel"`, so installations using the QMD backend inherited channel access unless they overrode `memory.qmd.scope`.
- Missing detection / guardrail: the host-config regression test encoded the broadened default instead of asserting a direct-only baseline.
- Contributing context (if known): QMD is opt-in, which reduces blast radius, but once enabled the default scope should still stay narrow.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/memory-host-sdk/host/backend-config.test.ts`
- Scenario the test should lock in: when `memory.backend` is `qmd` and `memory.qmd.scope` is unset, direct sessions are allowed and channel sessions are denied.
- Why this is the smallest reliable guardrail: the regression is in config resolution, so the host-config unit test is the narrowest place that exercises the effective default.
- Existing test that already covers this (if any): `src/memory-host-sdk/host/qmd-scope.test.ts` continues to cover scope evaluation semantics.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Default QMD memory exposure is reduced from direct + channel to direct-only when `memory.qmd.scope` is unset.
- Operators who intentionally want QMD memory in channel sessions must now opt in explicitly via `memory.qmd.scope`.

## Diagram (if applicable)

```text
Before:
[qmd backend enabled] -> [default qmd scope] -> [direct allowed, channel allowed]

After:
[qmd backend enabled] -> [default qmd scope] -> [direct allowed, channel denied]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: this narrows the default QMD memory exposure surface by denying channel sessions unless operators opt in with an explicit scope override.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (local dev worktree)
- Runtime/container: Node/pnpm repo checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.backend = "qmd"`, `memory.qmd.scope` unset

### Steps

1. Enable the QMD memory backend without setting `memory.qmd.scope`.
2. Resolve host backend config or run the host config unit tests.
3. Evaluate the default QMD scope for a direct session key and a channel session key.

### Expected

- Direct sessions stay allowed by default.
- Channel sessions are denied by default unless explicitly allowed in config.

### Actual

- This PR restores that behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: updated `src/memory-host-sdk/host/backend-config.test.ts` to assert channel denial by default; ran `pnpm test src/memory-host-sdk/host/backend-config.test.ts src/memory-host-sdk/host/qmd-scope.test.ts` successfully.
- Edge cases checked: confirmed the repo default memory backend remains `builtin`, so this only affects installations that explicitly choose `memory.backend: "qmd"`.
- What you did **not** verify: I did not run a full end-to-end channel session against a live QMD-backed deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Only for installations that intentionally relied on the broadened default
- If yes, exact upgrade steps: if channel QMD access is desired, add an explicit `memory.qmd.scope` rule allowing `chatType: "channel"`.

## Risks and Mitigations

- Risk: an installation that intentionally relied on implicit channel access for QMD will stop surfacing memory in channels after upgrading.
  - Mitigation: those deployments can preserve prior behavior by adding an explicit `memory.qmd.scope` override that allows channel sessions.
