### PR TITLE
fix(agents): use atomic store helper for CLI session clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI sessions: persist CLI session clearing through the atomic session-store merge path, so expired Claude/Codex CLI bindings are actually removed before retrying without the stale session id. (#70298) Thanks @HFConsultant.
 - ACP/sessions_spawn: honor explicit `model` overrides for ACP child sessions instead of silently falling back to the target agent default model. (#70210) Thanks @felix-miao.
 - CLI/Claude: hash only static extra system prompt parts when deciding whether to reuse a CLI session, so per-message inbound metadata no longer resets Claude CLI conversations on every turn. (#70122) Thanks @zijunl.
 - Hooks/Slack: standardize shared message hook routing fields (`threadId` / `replyToId`) and stop Slack outbound delivery from re-running `message_sending` inside the channel adapter, so plugins like thread-ownership make one outbound routing decision per reply. Thanks @vincentkoc.

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -98,6 +98,18 @@ export async function runPreparedCliAgent(
       return buildCliRunResult({ output, effectiveCliSessionId });
     } catch (err) {
       if (isFailoverError(err)) {
+        const retryableSessionId = context.reusableCliSession.sessionId ?? params.cliSessionId;
+        // Check if this is a session expired error and we have a session to clear
+        if (err.reason === "session_expired" && retryableSessionId && params.sessionKey) {
+          // Clear the expired session ID from the session entry
+          // This requires access to the session store, which we don't have here
+          // We'll need to modify the caller to handle this case
+
+          // For now, retry without the session ID to create a new session
+          const output = await executePreparedCliRun(context, undefined);
+          const effectiveCliSessionId = output.sessionId;
+          return buildCliRunResult({ output, effectiveCliSessionId });
+        }
         throw err;
       }
       const message = formatErrorMessage(err);

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -98,18 +98,6 @@ export async function runPreparedCliAgent(
       return buildCliRunResult({ output, effectiveCliSessionId });
     } catch (err) {
       if (isFailoverError(err)) {
-        const retryableSessionId = context.reusableCliSession.sessionId ?? params.cliSessionId;
-        // Check if this is a session expired error and we have a session to clear
-        if (err.reason === "session_expired" && retryableSessionId && params.sessionKey) {
-          // Clear the expired session ID from the session entry
-          // This requires access to the session store, which we don't have here
-          // We'll need to modify the caller to handle this case
-
-          // For now, retry without the session ID to create a new session
-          const output = await executePreparedCliRun(context, undefined);
-          const effectiveCliSessionId = output.sessionId;
-          return buildCliRunResult({ output, effectiveCliSessionId });
-        }
         throw err;
       }
       const message = formatErrorMessage(err);

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -112,14 +112,14 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
     entry.cliSessionIds = Object.keys(next).length > 0 ? next : undefined;
   }
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
-    delete entry.claudeCliSessionId;
+    entry.claudeCliSessionId = undefined;
   }
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  delete entry.cliSessionBindings;
-  delete entry.cliSessionIds;
-  delete entry.claudeCliSessionId;
+  entry.cliSessionBindings = undefined;
+  entry.cliSessionIds = undefined;
+  entry.claudeCliSessionId = undefined;
 }
 
 export function resolveCliSessionReuse(params: {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -302,12 +302,13 @@ export function runAgentAttempt(params: {
           `CLI session expired, clearing from session store: provider=${sanitizeForLog(params.providerOverride)} sessionKey=${params.sessionKey}`,
         );
 
-        params.sessionEntry = await clearCliSessionInStore({
-          provider: params.providerOverride,
-          sessionKey: params.sessionKey,
-          sessionStore: params.sessionStore,
-          storePath: params.storePath,
-        });
+        params.sessionEntry =
+          (await clearCliSessionInStore({
+            provider: params.providerOverride,
+            sessionKey: params.sessionKey,
+            sessionStore: params.sessionStore,
+            storePath: params.storePath,
+          })) ?? params.sessionEntry;
 
         return runCliWithSession(undefined).then(async (result) => {
           if (

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -12,7 +12,7 @@ import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
-import { clearCliSession, getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
+import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
 import { FailoverError } from "../failover-error.js";
 import { isCliProvider } from "../model-selection.js";
 import { prepareSessionManagerForRun } from "../pi-embedded-runner/session-manager-init.js";
@@ -22,6 +22,7 @@ import { buildUsageWithNoCost } from "../stream-message-shared.js";
 import { resolveFallbackRetryPrompt } from "./attempt-execution.helpers.js";
 import { persistSessionEntry } from "./attempt-execution.shared.js";
 import { resolveAgentRunContext } from "./run-context.js";
+import { clearCliSessionInStore } from "./session-store.js";
 import type { AgentCommandOpts } from "./types.js";
 
 export {
@@ -301,22 +302,12 @@ export function runAgentAttempt(params: {
           `CLI session expired, clearing from session store: provider=${sanitizeForLog(params.providerOverride)} sessionKey=${params.sessionKey}`,
         );
 
-        const entry = params.sessionStore[params.sessionKey];
-        if (entry) {
-          const updatedEntry = { ...entry };
-          clearCliSession(updatedEntry, params.providerOverride);
-          updatedEntry.updatedAt = Date.now();
-
-          await persistSessionEntry({
-            sessionStore: params.sessionStore,
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            entry: updatedEntry,
-            clearedFields: ["cliSessionBindings", "cliSessionIds", "claudeCliSessionId"],
-          });
-
-          params.sessionEntry = updatedEntry;
-        }
+        params.sessionEntry = await clearCliSessionInStore({
+          provider: params.providerOverride,
+          sessionKey: params.sessionKey,
+          sessionStore: params.sessionStore,
+          storePath: params.storePath,
+        });
 
         return runCliWithSession(undefined).then(async (result) => {
           if (

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore } from "../../config/sessions.js";
 import type { EmbeddedPiRunResult } from "../pi-embedded.js";
-import { updateSessionStoreAfterAgentRun } from "./session-store.js";
+import { clearCliSessionInStore, updateSessionStoreAfterAgentRun } from "./session-store.js";
 import { resolveSession } from "./session.js";
 
 vi.mock("../model-selection.js", () => ({
@@ -512,6 +512,86 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       const persisted = loadSessionStore(storePath);
       expect(persisted[sessionKey]?.estimatedCostUsd).toBeCloseTo(0.25, 4);
+    });
+  });
+});
+
+describe("clearCliSessionInStore", () => {
+  it("persists cleared Claude CLI bindings through session-store merge", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-clear-claude-cli";
+      const entry: SessionEntry = {
+        sessionId: "openclaw-session-1",
+        updatedAt: 1,
+        cliSessionBindings: {
+          "claude-cli": {
+            sessionId: "claude-session-1",
+            authEpoch: "epoch-1",
+          },
+          "codex-cli": {
+            sessionId: "codex-session-1",
+          },
+        },
+        cliSessionIds: {
+          "claude-cli": "claude-session-1",
+          "codex-cli": "codex-session-1",
+        },
+        claudeCliSessionId: "claude-session-1",
+      };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf8");
+
+      const cleared = await clearCliSessionInStore({
+        provider: "claude-cli",
+        sessionKey,
+        sessionStore,
+        storePath,
+      });
+
+      expect(cleared?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(cleared?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "codex-session-1",
+      });
+      expect(cleared?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(cleared?.cliSessionIds?.["codex-cli"]).toBe("codex-session-1");
+      expect(cleared?.claudeCliSessionId).toBeUndefined();
+      expect(sessionStore[sessionKey]).toEqual(cleared);
+
+      const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(persisted?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(persisted?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "codex-session-1",
+      });
+      expect(persisted?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(persisted?.cliSessionIds?.["codex-cli"]).toBe("codex-session-1");
+      expect(persisted?.claudeCliSessionId).toBeUndefined();
+    });
+  });
+
+  it("leaves the caller snapshot intact when the session entry is missing", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const existingKey = "agent:main:explicit:existing";
+      const sessionStore: Record<string, SessionEntry> = {
+        [existingKey]: {
+          sessionId: "openclaw-session-1",
+          updatedAt: 1,
+          claudeCliSessionId: "claude-session-1",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf8");
+
+      const cleared = await clearCliSessionInStore({
+        provider: "claude-cli",
+        sessionKey: "agent:main:explicit:missing",
+        sessionStore,
+        storePath,
+      });
+
+      expect(cleared).toBeUndefined();
+      expect(sessionStore[existingKey]?.claudeCliSessionId).toBe("claude-session-1");
+      expect(
+        loadSessionStore(storePath, { skipCache: true })[existingKey]?.claudeCliSessionId,
+      ).toBe("claude-session-1");
     });
   });
 });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -5,7 +5,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { setCliSessionBinding, setCliSessionId } from "../cli-session.js";
+import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
@@ -153,4 +153,29 @@ export async function updateSessionStoreAfterAgentRun(params: {
     return merged;
   });
   sessionStore[sessionKey] = persisted;
+}
+
+export async function clearCliSessionInStore(params: {
+  provider: string;
+  sessionKey: string;
+  sessionStore: Record<string, SessionEntry>;
+  storePath: string;
+}): Promise<SessionEntry | undefined> {
+  const { provider, sessionKey, sessionStore, storePath } = params;
+  const entry = sessionStore[sessionKey];
+  if (!entry) {
+    return undefined;
+  }
+
+  const next = { ...entry };
+  clearCliSession(next, provider);
+  next.updatedAt = Date.now();
+
+  const persisted = await updateSessionStore(storePath, (store) => {
+    const merged = mergeSessionEntry(store[sessionKey], next);
+    store[sessionKey] = merged;
+    return merged;
+  });
+  sessionStore[sessionKey] = persisted;
+  return persisted;
 }


### PR DESCRIPTION
## What

- **Bug fix**: `clearCliSession` and `clearAllCliSessions` used `delete` to remove CLI session properties. When `mergeSessionEntry` later spreads the update object over the persisted store entry, deleted keys are absent from the spread — so stale session IDs survive the merge and the expired session is never actually cleared.

  Changed to `= undefined` so the key is explicitly present in the spread.

- **Refactor**: Extracted `clearCliSessionInStore()` in `session-store.ts` — an atomic helper that clears + persists + merges in one call, matching the existing `updateSessionStoreAfterAgentRun` pattern.

- **Dead code removal**: Removed unreachable retry logic in `cli-runner.ts` that attempted session recovery without store access (duplicated by the caller in `attempt-execution.ts`).

## Why

Without this fix, CLI sessions that expire mid-run are not properly cleared from the store. The agent keeps retrying with the stale session ID instead of creating a fresh session, causing repeated `session_expired` failures.

## Testing

- All existing agent tests pass (`vitest --project agents` — 382 files, 4000 tests)
- Specifically: `attempt-execution.cli.test.ts` covers the session-expired recovery path end-to-end
- `oxlint` + `tsc --noEmit` clean

## AI Disclosure

- [x] AI-assisted (Antigravity / Claude Opus 4.6)
- [x] Fully tested locally
- [x] Author understands the changes
- [x] No Codex access for local review