### PR TITLE
channels: avoid CLI crashes from missing bundled plugin deps

### DIFF
--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -133,8 +133,27 @@ export function getBootstrapChannelPlugin(id: ChannelId): ChannelPlugin | undefi
     runtimePlugin = getBundledChannelPlugin(resolvedId);
     setupPlugin = getBundledChannelSetupPlugin(resolvedId);
   } catch {
-    registry.missingIds.add(resolvedId);
-    return undefined;
+  if (registry.missingIds.has(resolvedId)) {
+  return undefined;
+ }
+
+ let runtimePlugin: ChannelPlugin | undefined;
+ let setupPlugin: ChannelPlugin | undefined;
+
+try {
+  runtimePlugin = getBundledChannelPlugin(resolvedId);
+  setupPlugin = getBundledChannelSetupPlugin(resolvedId);
+} catch {
+  registry.missingIds.add(resolvedId);
+  return undefined;
+}
+
+const merged =
+  runtimePlugin && setupPlugin
+    ? mergeBootstrapPlugin(runtimePlugin, setupPlugin)
+    : runtimePlugin ?? setupPlugin;
+
+return merged;
   }
   const merged =
     runtimePlugin && setupPlugin

--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -127,8 +127,15 @@ export function getBootstrapChannelPlugin(id: ChannelId): ChannelPlugin | undefi
   if (registry.missingIds.has(resolvedId)) {
     return undefined;
   }
-  const runtimePlugin = getBundledChannelPlugin(resolvedId);
-  const setupPlugin = getBundledChannelSetupPlugin(resolvedId);
+  let runtimePlugin: ChannelPlugin | undefined;
+  let setupPlugin: ChannelPlugin | undefined;
+  try {
+    runtimePlugin = getBundledChannelPlugin(resolvedId);
+    setupPlugin = getBundledChannelSetupPlugin(resolvedId);
+  } catch {
+    registry.missingIds.add(resolvedId);
+    return undefined;
+  }
   const merged =
     runtimePlugin && setupPlugin
       ? mergeBootstrapPlugin(runtimePlugin, setupPlugin)

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -144,4 +144,39 @@ describe("bundled root-aware caches", () => {
       bootstrapRegistry.getBootstrapChannelSecrets("beta")?.secretTargetRegistryEntries?.[0]?.id,
     ).toBe("setup-beta-B");
   });
+
+  it("marks bundled plugin ids missing when plugin loading throws", async () => {
+    const root = makeBundledRoot("openclaw-bootstrap-throw-");
+
+    vi.doMock("./bundled-ids.js", () => ({
+      listBundledChannelPluginIdsForRoot: (cacheKey: string) =>
+        cacheKey === root.pluginsDir ? ["alpha"] : [],
+    }));
+
+    const getBundledChannelPluginMock = vi.fn(() => {
+      throw new Error("Cannot find module 'nostr-tools'");
+    });
+    const getBundledChannelSetupPluginMock = vi.fn(() => {
+      throw new Error("Cannot find module '@larksuiteoapi/node-sdk'");
+    });
+
+    vi.doMock("./bundled.js", () => ({
+      getBundledChannelPlugin: getBundledChannelPluginMock,
+      getBundledChannelSetupPlugin: getBundledChannelSetupPluginMock,
+      getBundledChannelSecrets: () => undefined,
+      getBundledChannelSetupSecrets: () => undefined,
+    }));
+
+    const bootstrapRegistry = await importFreshModule<typeof import("./bootstrap-registry.js")>(
+      import.meta.url,
+      "./bootstrap-registry.js?scope=bootstrap-load-guard",
+    );
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = root.pluginsDir;
+    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["alpha"]);
+    expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")).toBeUndefined();
+    expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")).toBeUndefined();
+    expect(getBundledChannelPluginMock).toHaveBeenCalledTimes(1);
+    expect(getBundledChannelSetupPluginMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- make bootstrap channel plugin loading best-effort when bundled runtime/setup plugin imports throw
- mark the failing plugin id missing instead of crashing commands like `openclaw status`
- add a regression test covering optional bundled dependency failures during bootstrap plugin resolution

## Testing
- `PATH=/home/chris/.openclaw/workspace/bin:$PATH pnpm --dir /home/chris/.openclaw/workspace/openclaw-upstream test -- --run src/channels/plugins/bundled-root-caches.test.ts`
- `PATH=/home/chris/.openclaw/workspace/bin:$PATH pnpm --dir /home/chris/.openclaw/workspace/openclaw-upstream test -- --run src/channels/plugins/legacy-config.test.ts`

## Context
The npm-distributed global install can have optional bundled plugin runtime deps missing (observed locally with `@larksuiteoapi/node-sdk` and `nostr-tools`). Before this change, eager bootstrap plugin loading could crash core CLI flows while resolving channel compatibility/config helpers. After this change, those plugin loads become best-effort and the CLI can continue.