### PR TITLE
fix(update): stage bundled plugin runtime deps after package install

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -414,6 +414,7 @@ async function runPackageInstallUpdate(params: {
       packageRoot: verifiedPackageRoot,
       manager,
       packageManagerCommand: installTarget.command,
+      baseEnv: installEnv,
       timeoutMs: params.timeoutMs,
       progress: params.progress,
     });
@@ -460,6 +461,7 @@ async function runBundledPluginStagingStep(params: {
   packageRoot: string;
   manager: "pnpm" | "npm" | "bun";
   packageManagerCommand: string;
+  baseEnv: NodeJS.ProcessEnv | undefined;
   timeoutMs: number;
   progress?: UpdateStepProgress;
 }): Promise<UpdateStepResult | null> {
@@ -487,11 +489,14 @@ async function runBundledPluginStagingStep(params: {
   // Pass the already-computed `discovery.missing` into repair so a single scan
   // drives both the early-exit guard above and the per-plugin loop. Pin the
   // subprocess to the caller-resolved package-manager command so the staging
-  // step spawns the same executable the global install step already used.
+  // step spawns the same executable the global install step already used, and
+  // pass the shared `installEnv` as baseEnv so PATH/corepack settings stay
+  // consistent between the main install step and this staging step.
   const result = await repairBundledPluginStaging({
     extensionsDir,
     packageManager: params.manager,
     packageManagerCommand: params.packageManagerCommand,
+    baseEnv: params.baseEnv,
     missing: discovery.missing,
     runCommand: async ({ command: cmd, args, cwd, env }) => {
       const spawned = await runCommandWithTimeout([cmd, ...args], {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -39,7 +39,12 @@ import {
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
 } from "../../infra/update-global.js";
-import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
+import {
+  runGatewayUpdate,
+  type UpdateRunResult,
+  type UpdateStepProgress,
+  type UpdateStepResult,
+} from "../../infra/update-runner.js";
 import { syncPluginsForUpdateChannel, updateNpmInstalledPlugins } from "../../plugins/update.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -405,6 +410,16 @@ async function runPackageInstallUpdate(params: {
         stdoutTail: null,
       });
     }
+    const stagingStep = await runBundledPluginStagingStep({
+      packageRoot: verifiedPackageRoot,
+      manager,
+      timeoutMs: params.timeoutMs,
+      progress: params.progress,
+    });
+    if (stagingStep) {
+      steps.push(stagingStep);
+    }
+
     const entryPath = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
     if (entryPath) {
       const doctorStep = await runUpdateStep({
@@ -431,6 +446,82 @@ async function runPackageInstallUpdate(params: {
     after: { version: afterVersion },
     steps,
     durationMs: Date.now() - params.startedAt,
+  };
+}
+
+// Eager-stage bundled plugin runtime deps that `files`-stripped tarballs
+// leave unstaged on the client. Runs after the global install step, before
+// doctor — doctor eagerly loads bundled plugins and will crash on a missing
+// module if any `stageRuntimeDependencies: true` plugin lacks its sibling
+// `node_modules/`. Filesystem-only discovery; spawns the install subprocess
+// only per-plugin that actually needs staging.
+async function runBundledPluginStagingStep(params: {
+  packageRoot: string;
+  manager: "pnpm" | "npm" | "bun";
+  timeoutMs: number;
+  progress?: UpdateStepProgress;
+}): Promise<UpdateStepResult | null> {
+  const { discoverMissingBundledPluginStaging, repairBundledPluginStaging } =
+    await import("../../commands/doctor-bundled-plugin-staging.js");
+  const extensionsDir = path.join(params.packageRoot, "dist", "extensions");
+  const discovery = discoverMissingBundledPluginStaging({ extensionsDir });
+  if (discovery.missing.length === 0) {
+    return null;
+  }
+
+  const stepName = `${CLI_NAME} stage bundled plugin runtime deps`;
+  const command = `${params.manager} install --prod in ${discovery.missing.length} bundled plugin dir(s)`;
+  params.progress?.onStepStart?.({
+    name: stepName,
+    command,
+    index: 0,
+    total: 0,
+  });
+
+  const startedAt = Date.now();
+  const result = await repairBundledPluginStaging({
+    extensionsDir,
+    packageManager: params.manager,
+    runCommand: async ({ command: cmd, args, cwd }) => {
+      const spawned = await runCommandWithTimeout([cmd, ...args], {
+        cwd,
+        timeoutMs: params.timeoutMs,
+      });
+      return {
+        exitCode: spawned.code ?? 1,
+        stdout: spawned.stdout ?? "",
+        stderr: spawned.stderr ?? "",
+      };
+    },
+  });
+  const durationMs = Date.now() - startedAt;
+  const hasFailure = result.failed.length > 0;
+  const exitCode = hasFailure ? 1 : 0;
+
+  const repairedList = result.repaired.map((entry) => entry.id).join(", ") || "(none)";
+  const stdoutTail = `staged ${result.repaired.length} of ${discovery.missing.length}: ${repairedList}`;
+  const stderrTail = hasFailure
+    ? result.failed.map((entry) => `${entry.id}: ${entry.detail}`).join("\n")
+    : null;
+
+  params.progress?.onStepComplete?.({
+    name: stepName,
+    command,
+    index: 0,
+    total: 0,
+    durationMs,
+    exitCode,
+    stderrTail: stderrTail ?? undefined,
+  });
+
+  return {
+    name: stepName,
+    command,
+    cwd: extensionsDir,
+    durationMs,
+    exitCode,
+    stdoutTail,
+    stderrTail,
   };
 }
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -413,6 +413,7 @@ async function runPackageInstallUpdate(params: {
     const stagingStep = await runBundledPluginStagingStep({
       packageRoot: verifiedPackageRoot,
       manager,
+      packageManagerCommand: installTarget.command,
       timeoutMs: params.timeoutMs,
       progress: params.progress,
     });
@@ -458,11 +459,15 @@ async function runPackageInstallUpdate(params: {
 async function runBundledPluginStagingStep(params: {
   packageRoot: string;
   manager: "pnpm" | "npm" | "bun";
+  packageManagerCommand: string;
   timeoutMs: number;
   progress?: UpdateStepProgress;
 }): Promise<UpdateStepResult | null> {
-  const { discoverMissingBundledPluginStaging, repairBundledPluginStaging } =
-    await import("../../commands/doctor-bundled-plugin-staging.js");
+  const {
+    discoverMissingBundledPluginStaging,
+    repairBundledPluginStaging,
+    summarizeRepairForUpdateStep,
+  } = await import("../../commands/doctor-bundled-plugin-staging.js");
   const extensionsDir = path.join(params.packageRoot, "dist", "extensions");
   const discovery = discoverMissingBundledPluginStaging({ extensionsDir });
   if (discovery.missing.length === 0) {
@@ -479,13 +484,20 @@ async function runBundledPluginStagingStep(params: {
   });
 
   const startedAt = Date.now();
+  // Pass the already-computed `discovery.missing` into repair so a single scan
+  // drives both the early-exit guard above and the per-plugin loop. Pin the
+  // subprocess to the caller-resolved package-manager command so the staging
+  // step spawns the same executable the global install step already used.
   const result = await repairBundledPluginStaging({
     extensionsDir,
     packageManager: params.manager,
-    runCommand: async ({ command: cmd, args, cwd }) => {
+    packageManagerCommand: params.packageManagerCommand,
+    missing: discovery.missing,
+    runCommand: async ({ command: cmd, args, cwd, env }) => {
       const spawned = await runCommandWithTimeout([cmd, ...args], {
         cwd,
         timeoutMs: params.timeoutMs,
+        env,
       });
       return {
         exitCode: spawned.code ?? 1,
@@ -495,14 +507,11 @@ async function runBundledPluginStagingStep(params: {
     },
   });
   const durationMs = Date.now() - startedAt;
-  const hasFailure = result.failed.length > 0;
-  const exitCode = hasFailure ? 1 : 0;
 
-  const repairedList = result.repaired.map((entry) => entry.id).join(", ") || "(none)";
-  const stdoutTail = `staged ${result.repaired.length} of ${discovery.missing.length}: ${repairedList}`;
-  const stderrTail = hasFailure
-    ? result.failed.map((entry) => `${entry.id}: ${entry.detail}`).join("\n")
-    : null;
+  const { stepExitCode, stdoutTail, stderrTail } = summarizeRepairForUpdateStep({
+    attempted: discovery.missing.length,
+    repair: result,
+  });
 
   params.progress?.onStepComplete?.({
     name: stepName,
@@ -510,7 +519,7 @@ async function runBundledPluginStagingStep(params: {
     index: 0,
     total: 0,
     durationMs,
-    exitCode,
+    exitCode: stepExitCode,
     stderrTail: stderrTail ?? undefined,
   });
 
@@ -519,7 +528,7 @@ async function runBundledPluginStagingStep(params: {
     command,
     cwd: extensionsDir,
     durationMs,
-    exitCode,
+    exitCode: stepExitCode,
     stdoutTail,
     stderrTail,
   };

--- a/src/commands/doctor-bundled-plugin-staging.test.ts
+++ b/src/commands/doctor-bundled-plugin-staging.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
@@ -20,7 +21,8 @@ type WriteExtensionParams = {
   id: string;
   stageRuntimeDependencies: boolean;
   dependencies?: Record<string, string>;
-  hasNodeModules?: boolean;
+  optionalDependencies?: Record<string, string>;
+  stagedSentinels?: string[];
   packageJsonBody?: string;
 };
 
@@ -34,6 +36,9 @@ function writeExtension(params: WriteExtensionParams): void {
         name: `@openclaw/${params.id}`,
         version: "2026.4.21",
         dependencies: params.dependencies ?? { "example-dep": "^1.0.0" },
+        ...(params.optionalDependencies
+          ? { optionalDependencies: params.optionalDependencies }
+          : {}),
         openclaw: {
           bundle: { stageRuntimeDependencies: params.stageRuntimeDependencies },
         },
@@ -42,38 +47,47 @@ function writeExtension(params: WriteExtensionParams): void {
       2,
     );
   fs.writeFileSync(path.join(extDir, "package.json"), body);
-  if (params.hasNodeModules) {
-    fs.mkdirSync(path.join(extDir, "node_modules"), { recursive: true });
+  if (params.stagedSentinels && params.stagedSentinels.length > 0) {
+    for (const depName of params.stagedSentinels) {
+      const segments = depName.split("/");
+      const sentinelDir = path.join(extDir, "node_modules", ...segments);
+      fs.mkdirSync(sentinelDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sentinelDir, "package.json"),
+        JSON.stringify({ name: depName, version: "1.0.0" }),
+      );
+    }
   }
 }
 
 describe("discoverMissingBundledPluginStaging", () => {
-  it("reports extensions that declare stageRuntimeDependencies:true but have no node_modules", () => {
+  it("reports extensions that declare stageRuntimeDependencies:true but have no staged deps", () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({
       extensionsDir,
       id: "slack",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
+      dependencies: { "@slack/web-api": "^7.0.0" },
     });
     writeExtension({
       extensionsDir,
       id: "discord",
       stageRuntimeDependencies: true,
-      hasNodeModules: true,
+      dependencies: { "discord.js": "^14.0.0" },
+      stagedSentinels: ["discord.js"],
     });
     writeExtension({
       extensionsDir,
       id: "qa-channel",
       stageRuntimeDependencies: false,
-      hasNodeModules: false,
     });
 
     const result = discoverMissingBundledPluginStaging({ extensionsDir });
 
     expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
-    // Extensions that don't declare stageRuntimeDependencies are not checked.
     expect(result.checked.map((entry) => entry.id).toSorted()).toEqual(["discord", "slack"]);
+    expect(result.checked.find((entry) => entry.id === "discord")?.hasStagedDeps).toBe(true);
+    expect(result.checked.find((entry) => entry.id === "slack")?.hasStagedDeps).toBe(false);
   });
 
   it("skips stage=true extensions that declare zero runtime dependencies", () => {
@@ -83,13 +97,48 @@ describe("discoverMissingBundledPluginStaging", () => {
       id: "no-deps",
       stageRuntimeDependencies: true,
       dependencies: {},
-      hasNodeModules: false,
     });
 
     const result = discoverMissingBundledPluginStaging({ extensionsDir });
 
     expect(result.missing).toEqual([]);
     expect(result.checked.map((entry) => entry.id)).toEqual(["no-deps"]);
+  });
+
+  it("counts optionalDependencies toward the declared runtime-dep set", () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "with-optional",
+      stageRuntimeDependencies: true,
+      dependencies: {},
+      optionalDependencies: { "only-optional-dep": "^1.0.0" },
+    });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    // Plugin with zero `dependencies` but non-zero `optionalDependencies`
+    // is still eligible for staging.
+    expect(result.missing.map((entry) => entry.id)).toEqual(["with-optional"]);
+    expect(result.checked[0]?.dependencyCount).toBe(1);
+  });
+
+  it("treats a plugin with node_modules but no dep sentinels as not staged", () => {
+    // Simulates a failed/partial install that left an empty `node_modules/`
+    // behind: `existsSync(node_modules)` is true but the declared deps'
+    // `package.json` sentinels are missing.
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "partial",
+      stageRuntimeDependencies: true,
+      dependencies: { "@slack/web-api": "^7.0.0" },
+    });
+    fs.mkdirSync(path.join(extensionsDir, "partial", "node_modules"), { recursive: true });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing.map((entry) => entry.id)).toEqual(["partial"]);
   });
 
   it("returns empty result when extensions dir does not exist", () => {
@@ -108,7 +157,6 @@ describe("discoverMissingBundledPluginStaging", () => {
       extensionsDir,
       id: "slack",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
     const brokenDir = path.join(extensionsDir, "broken");
     fs.mkdirSync(brokenDir, { recursive: true });
@@ -125,9 +173,7 @@ describe("discoverMissingBundledPluginStaging", () => {
       extensionsDir,
       id: "slack",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
-    // Craft an oversize package.json: 1.5MB of padding inside a large string field.
     const padding = "x".repeat(1_500_000);
     const oversize = JSON.stringify({
       name: "@openclaw/giant",
@@ -140,7 +186,6 @@ describe("discoverMissingBundledPluginStaging", () => {
       extensionsDir,
       id: "giant",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
       packageJsonBody: oversize,
     });
 
@@ -148,6 +193,36 @@ describe("discoverMissingBundledPluginStaging", () => {
 
     expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
     expect(result.checked.map((entry) => entry.id)).toEqual(["slack"]);
+  });
+
+  it("skips symlinked entries that point outside the extensions directory", () => {
+    if (process.platform === "win32") {
+      return; // Symlink creation on Windows needs admin; skip there.
+    }
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    const outsideTarget = path.join(os.tmpdir(), `ocl-outside-${Date.now()}`);
+    fs.mkdirSync(outsideTarget, { recursive: true });
+    tempDirs.push(outsideTarget);
+    // Make the outside target look like a real extension dir.
+    fs.writeFileSync(
+      path.join(outsideTarget, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/attacker",
+        dependencies: { evil: "^1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      }),
+    );
+    fs.symlinkSync(outsideTarget, path.join(extensionsDir, "attacker"), "dir");
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+    });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
+    expect(result.checked.map((entry) => entry.id)).not.toContain("attacker");
   });
 });
 
@@ -158,13 +233,11 @@ describe("repairBundledPluginStaging", () => {
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
     writeExtension({
       extensionsDir,
       id: "google",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const invocations: Array<{ command: string; args: string[]; cwd: string }> = [];
@@ -184,6 +257,7 @@ describe("repairBundledPluginStaging", () => {
     expect(invocations.map((i) => path.basename(i.cwd)).toSorted()).toEqual(["codex", "google"]);
     expect(result.repaired.map((entry) => entry.id).toSorted()).toEqual(["codex", "google"]);
     expect(result.failed).toEqual([]);
+    expect(result.skipped).toEqual([]);
   });
 
   it("passes --ignore-scripts to npm (via install --omit=dev)", async () => {
@@ -192,7 +266,6 @@ describe("repairBundledPluginStaging", () => {
       extensionsDir,
       id: "slack",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const invocations: Array<{ command: string; args: string[] }> = [];
@@ -216,7 +289,6 @@ describe("repairBundledPluginStaging", () => {
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const invocations: Array<{ command: string; args: string[] }> = [];
@@ -232,17 +304,15 @@ describe("repairBundledPluginStaging", () => {
     });
 
     expect(invocations[0].command).toBe("/opt/homebrew/bin/npm");
-    // Args are still manager-specific (npm omits dev via --omit=dev).
     expect(invocations[0].args).toContain("--omit=dev");
   });
 
-  it("passes lockfile-disabling env vars to the install subprocess", async () => {
+  it("passes deterministic npm_config_* env to the install subprocess including audit/fund off", async () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const received: Array<NodeJS.ProcessEnv | undefined> = [];
@@ -261,6 +331,8 @@ describe("repairBundledPluginStaging", () => {
     expect(env?.npm_config_package_lock).toBe("false");
     expect(env?.npm_config_save).toBe("false");
     expect(env?.npm_config_legacy_peer_deps).toBe("true");
+    expect(env?.npm_config_audit).toBe("false");
+    expect(env?.npm_config_fund).toBe("false");
   });
 
   it("composes baseEnv under the staging env overlays so caller-provided PATH/corepack settings flow through", async () => {
@@ -269,7 +341,6 @@ describe("repairBundledPluginStaging", () => {
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const received: Array<NodeJS.ProcessEnv | undefined> = [];
@@ -279,7 +350,6 @@ describe("repairBundledPluginStaging", () => {
       baseEnv: {
         PATH: "/trusted/bin:/usr/bin",
         COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-        npm_config_global: "true",
       },
       runCommand: async ({ cwd, env }) => {
         received.push(env);
@@ -289,12 +359,8 @@ describe("repairBundledPluginStaging", () => {
     });
 
     const env = received[0];
-    // Base env PATH / corepack settings survive.
     expect(env?.PATH).toBe("/trusted/bin:/usr/bin");
     expect(env?.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
-    // Nested-install leakage still gets stripped from the base env.
-    expect(env?.npm_config_global).toBeUndefined();
-    // Staging-specific overlays are applied on top.
     expect(env?.npm_config_package_lock).toBe("false");
   });
 
@@ -304,20 +370,17 @@ describe("repairBundledPluginStaging", () => {
       extensionsDir,
       id: "slack",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
     writeExtension({
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const invocations: string[] = [];
     await repairBundledPluginStaging({
       extensionsDir,
       packageManager: "pnpm",
-      // Explicit list with only one entry; repair should not rescan and find the second.
       missing: [
         {
           id: "codex",
@@ -335,13 +398,44 @@ describe("repairBundledPluginStaging", () => {
     expect(invocations).toEqual(["codex"]);
   });
 
+  it("skips caller-provided entries whose path escapes the extensions directory", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+    });
+    const outsideDir = makeTrackedTempDir("doctor-outside", tempDirs);
+
+    const invocations: string[] = [];
+    const result = await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      missing: [
+        {
+          id: "attacker",
+          // Path that resolves outside the extensionsDir — must be rejected.
+          expectedPath: path.join(outsideDir, "node_modules"),
+          dependencyCount: 1,
+        },
+      ],
+      runCommand: async ({ cwd }) => {
+        invocations.push(cwd);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(invocations).toEqual([]);
+    expect(result.repaired).toEqual([]);
+    expect(result.skipped.map((entry) => entry.id)).toEqual(["attacker"]);
+  });
+
   it("records a failed repair when the installer exits non-zero", async () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({
       extensionsDir,
       id: "codex",
       stageRuntimeDependencies: true,
-      hasNodeModules: false,
     });
 
     const result = await repairBundledPluginStaging({
@@ -361,12 +455,17 @@ describe("repairBundledPluginStaging", () => {
 });
 
 describe("createBundledPluginStagingInstallEnv", () => {
-  it("strips nested npm install context and sets deterministic install flags", () => {
+  it("shadows nested npm install context even when baseEnv has those keys set", () => {
+    // runCommandWithTimeout's resolveCommandEnv merges process.env under the
+    // caller's env. A plain `delete` would be silently restored. Setting the
+    // stripped keys to `undefined` shadows the inherited value so the merge's
+    // undefined-filter drops them from the final subprocess env.
     const sourceEnv: NodeJS.ProcessEnv = {
       PATH: "/usr/bin",
       npm_config_global: "true",
       npm_config_location: "global",
       npm_config_prefix: "/opt/homebrew",
+      NPM_CONFIG_GLOBAL: "true",
     };
 
     const result = createBundledPluginStagingInstallEnv(sourceEnv);
@@ -375,9 +474,12 @@ describe("createBundledPluginStagingInstallEnv", () => {
     expect(result.npm_config_global).toBeUndefined();
     expect(result.npm_config_location).toBeUndefined();
     expect(result.npm_config_prefix).toBeUndefined();
+    expect(result.NPM_CONFIG_GLOBAL).toBeUndefined();
     expect(result.npm_config_package_lock).toBe("false");
     expect(result.npm_config_save).toBe("false");
     expect(result.npm_config_legacy_peer_deps).toBe("true");
+    expect(result.npm_config_audit).toBe("false");
+    expect(result.npm_config_fund).toBe("false");
   });
 });
 
@@ -388,6 +490,7 @@ describe("summarizeRepairForUpdateStep", () => {
       repair: {
         repaired: [{ id: "codex" }, { id: "google" }],
         failed: [],
+        skipped: [],
       },
     });
 
@@ -396,10 +499,10 @@ describe("summarizeRepairForUpdateStep", () => {
     expect(result.stdoutTail).toBe("staged 2 of 2: codex, google");
   });
 
-  it("reports step OK with failed entries in stderrTail when repair was partial", () => {
-    // Partial success: core binary is installed, some plugins couldn't be
-    // staged. Failed plugins are no worse off than pre-update, so the update
-    // as a whole should not flip to `status: "error"`.
+  it("reports step OK with failures visible in stdoutTail on partial success", () => {
+    // Partial-success → stepExitCode=0 to avoid flipping the whole update to
+    // error. But the progress renderer hides stderrTail on success, so the
+    // failure summary must go into stdoutTail to stay visible on TTY.
     const result = summarizeRepairForUpdateStep({
       attempted: 3,
       repair: {
@@ -408,12 +511,31 @@ describe("summarizeRepairForUpdateStep", () => {
           { id: "google", exitCode: 1, detail: "network timeout" },
           { id: "webhooks", exitCode: 1, detail: "ENOSPC" },
         ],
+        skipped: [],
       },
     });
 
     expect(result.stepExitCode).toBe(0);
-    expect(result.stdoutTail).toBe("staged 1 of 3: codex");
-    expect(result.stderrTail).toBe("google: network timeout\nwebhooks: ENOSPC");
+    expect(result.stderrTail).toBeNull();
+    expect(result.stdoutTail).toContain("staged 1 of 3: codex");
+    expect(result.stdoutTail).toContain("2 plugin(s) not staged");
+    expect(result.stdoutTail).toContain("google: network timeout");
+    expect(result.stdoutTail).toContain("webhooks: ENOSPC");
+    expect(result.stdoutTail).toContain("openclaw doctor");
+  });
+
+  it("surfaces skipped entries (e.g. symlink refusals) alongside failures", () => {
+    const result = summarizeRepairForUpdateStep({
+      attempted: 2,
+      repair: {
+        repaired: [{ id: "codex" }],
+        failed: [],
+        skipped: [{ id: "attacker", reason: "not contained within extensionsDir" }],
+      },
+    });
+
+    expect(result.stepExitCode).toBe(0);
+    expect(result.stdoutTail).toContain("attacker: skipped");
   });
 
   it("reports step error when work was attempted and zero plugins were repaired", () => {
@@ -425,6 +547,7 @@ describe("summarizeRepairForUpdateStep", () => {
           { id: "codex", exitCode: 1, detail: "network timeout" },
           { id: "google", exitCode: 1, detail: "network timeout" },
         ],
+        skipped: [],
       },
     });
 

--- a/src/commands/doctor-bundled-plugin-staging.test.ts
+++ b/src/commands/doctor-bundled-plugin-staging.test.ts
@@ -263,6 +263,41 @@ describe("repairBundledPluginStaging", () => {
     expect(env?.npm_config_legacy_peer_deps).toBe("true");
   });
 
+  it("composes baseEnv under the staging env overlays so caller-provided PATH/corepack settings flow through", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const received: Array<NodeJS.ProcessEnv | undefined> = [];
+    await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      baseEnv: {
+        PATH: "/trusted/bin:/usr/bin",
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+        npm_config_global: "true",
+      },
+      runCommand: async ({ cwd, env }) => {
+        received.push(env);
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    const env = received[0];
+    // Base env PATH / corepack settings survive.
+    expect(env?.PATH).toBe("/trusted/bin:/usr/bin");
+    expect(env?.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
+    // Nested-install leakage still gets stripped from the base env.
+    expect(env?.npm_config_global).toBeUndefined();
+    // Staging-specific overlays are applied on top.
+    expect(env?.npm_config_package_lock).toBe("false");
+  });
+
   it("uses a caller-provided missing list and skips its own discovery scan", async () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({

--- a/src/commands/doctor-bundled-plugin-staging.test.ts
+++ b/src/commands/doctor-bundled-plugin-staging.test.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import {
+  createBundledPluginStagingInstallEnv,
   discoverMissingBundledPluginStaging,
   repairBundledPluginStaging,
+  summarizeRepairForUpdateStep,
 } from "./doctor-bundled-plugin-staging.js";
 
 const tempDirs: string[] = [];
@@ -19,13 +21,14 @@ type WriteExtensionParams = {
   stageRuntimeDependencies: boolean;
   dependencies?: Record<string, string>;
   hasNodeModules?: boolean;
+  packageJsonBody?: string;
 };
 
 function writeExtension(params: WriteExtensionParams): void {
   const extDir = path.join(params.extensionsDir, params.id);
   fs.mkdirSync(extDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(extDir, "package.json"),
+  const body =
+    params.packageJsonBody ??
     JSON.stringify(
       {
         name: `@openclaw/${params.id}`,
@@ -37,8 +40,8 @@ function writeExtension(params: WriteExtensionParams): void {
       },
       null,
       2,
-    ),
-  );
+    );
+  fs.writeFileSync(path.join(extDir, "package.json"), body);
   if (params.hasNodeModules) {
     fs.mkdirSync(path.join(extDir, "node_modules"), { recursive: true });
   }
@@ -115,10 +118,41 @@ describe("discoverMissingBundledPluginStaging", () => {
 
     expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
   });
+
+  it("skips a package.json larger than 1MB without blocking other entries", () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+    // Craft an oversize package.json: 1.5MB of padding inside a large string field.
+    const padding = "x".repeat(1_500_000);
+    const oversize = JSON.stringify({
+      name: "@openclaw/giant",
+      version: "2026.4.21",
+      description: padding,
+      dependencies: { "example-dep": "^1.0.0" },
+      openclaw: { bundle: { stageRuntimeDependencies: true } },
+    });
+    writeExtension({
+      extensionsDir,
+      id: "giant",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+      packageJsonBody: oversize,
+    });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
+    expect(result.checked.map((entry) => entry.id)).toEqual(["slack"]);
+  });
 });
 
 describe("repairBundledPluginStaging", () => {
-  it("invokes the installer with --production-style args in each missing extension directory", async () => {
+  it("passes --ignore-scripts to pnpm and runs per missing plugin dir", async () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({
       extensionsDir,
@@ -139,7 +173,6 @@ describe("repairBundledPluginStaging", () => {
       packageManager: "pnpm",
       runCommand: async ({ command, args, cwd }) => {
         invocations.push({ command, args, cwd });
-        // Simulate a successful install by creating the expected node_modules dir.
         fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
         return { exitCode: 0, stdout: "", stderr: "" };
       },
@@ -147,14 +180,13 @@ describe("repairBundledPluginStaging", () => {
 
     expect(invocations).toHaveLength(2);
     expect(invocations[0].command).toBe("pnpm");
-    expect(invocations[0].args).toContain("install");
-    expect(invocations[0].args).toContain("--prod");
+    expect(invocations[0].args).toEqual(["install", "--prod", "--ignore-scripts"]);
     expect(invocations.map((i) => path.basename(i.cwd)).toSorted()).toEqual(["codex", "google"]);
     expect(result.repaired.map((entry) => entry.id).toSorted()).toEqual(["codex", "google"]);
     expect(result.failed).toEqual([]);
   });
 
-  it("uses npm install --omit=dev when package manager is npm", async () => {
+  it("passes --ignore-scripts to npm (via install --omit=dev)", async () => {
     const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
     writeExtension({
       extensionsDir,
@@ -175,8 +207,97 @@ describe("repairBundledPluginStaging", () => {
     });
 
     expect(invocations[0].command).toBe("npm");
-    expect(invocations[0].args).toContain("install");
+    expect(invocations[0].args).toEqual(["install", "--omit=dev", "--ignore-scripts"]);
+  });
+
+  it("spawns a caller-resolved executable path when packageManagerCommand is provided", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const invocations: Array<{ command: string; args: string[] }> = [];
+    await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "npm",
+      packageManagerCommand: "/opt/homebrew/bin/npm",
+      runCommand: async ({ command, args, cwd }) => {
+        invocations.push({ command, args });
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(invocations[0].command).toBe("/opt/homebrew/bin/npm");
+    // Args are still manager-specific (npm omits dev via --omit=dev).
     expect(invocations[0].args).toContain("--omit=dev");
+  });
+
+  it("passes lockfile-disabling env vars to the install subprocess", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const received: Array<NodeJS.ProcessEnv | undefined> = [];
+    await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      runCommand: async ({ cwd, env }) => {
+        received.push(env);
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(received).toHaveLength(1);
+    const env = received[0];
+    expect(env?.npm_config_package_lock).toBe("false");
+    expect(env?.npm_config_save).toBe("false");
+    expect(env?.npm_config_legacy_peer_deps).toBe("true");
+  });
+
+  it("uses a caller-provided missing list and skips its own discovery scan", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const invocations: string[] = [];
+    await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      // Explicit list with only one entry; repair should not rescan and find the second.
+      missing: [
+        {
+          id: "codex",
+          expectedPath: path.join(extensionsDir, "codex", "node_modules"),
+          dependencyCount: 1,
+        },
+      ],
+      runCommand: async ({ cwd }) => {
+        invocations.push(path.basename(cwd));
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(invocations).toEqual(["codex"]);
   });
 
   it("records a failed repair when the installer exits non-zero", async () => {
@@ -201,5 +322,79 @@ describe("repairBundledPluginStaging", () => {
     expect(result.repaired).toEqual([]);
     expect(result.failed.map((entry) => entry.id)).toEqual(["codex"]);
     expect(result.failed[0].detail).toContain("offline");
+  });
+});
+
+describe("createBundledPluginStagingInstallEnv", () => {
+  it("strips nested npm install context and sets deterministic install flags", () => {
+    const sourceEnv: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      npm_config_global: "true",
+      npm_config_location: "global",
+      npm_config_prefix: "/opt/homebrew",
+    };
+
+    const result = createBundledPluginStagingInstallEnv(sourceEnv);
+
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.npm_config_global).toBeUndefined();
+    expect(result.npm_config_location).toBeUndefined();
+    expect(result.npm_config_prefix).toBeUndefined();
+    expect(result.npm_config_package_lock).toBe("false");
+    expect(result.npm_config_save).toBe("false");
+    expect(result.npm_config_legacy_peer_deps).toBe("true");
+  });
+});
+
+describe("summarizeRepairForUpdateStep", () => {
+  it("reports step OK with null stderrTail when every missing plugin was repaired", () => {
+    const result = summarizeRepairForUpdateStep({
+      attempted: 2,
+      repair: {
+        repaired: [{ id: "codex" }, { id: "google" }],
+        failed: [],
+      },
+    });
+
+    expect(result.stepExitCode).toBe(0);
+    expect(result.stderrTail).toBeNull();
+    expect(result.stdoutTail).toBe("staged 2 of 2: codex, google");
+  });
+
+  it("reports step OK with failed entries in stderrTail when repair was partial", () => {
+    // Partial success: core binary is installed, some plugins couldn't be
+    // staged. Failed plugins are no worse off than pre-update, so the update
+    // as a whole should not flip to `status: "error"`.
+    const result = summarizeRepairForUpdateStep({
+      attempted: 3,
+      repair: {
+        repaired: [{ id: "codex" }],
+        failed: [
+          { id: "google", exitCode: 1, detail: "network timeout" },
+          { id: "webhooks", exitCode: 1, detail: "ENOSPC" },
+        ],
+      },
+    });
+
+    expect(result.stepExitCode).toBe(0);
+    expect(result.stdoutTail).toBe("staged 1 of 3: codex");
+    expect(result.stderrTail).toBe("google: network timeout\nwebhooks: ENOSPC");
+  });
+
+  it("reports step error when work was attempted and zero plugins were repaired", () => {
+    const result = summarizeRepairForUpdateStep({
+      attempted: 2,
+      repair: {
+        repaired: [],
+        failed: [
+          { id: "codex", exitCode: 1, detail: "network timeout" },
+          { id: "google", exitCode: 1, detail: "network timeout" },
+        ],
+      },
+    });
+
+    expect(result.stepExitCode).toBe(1);
+    expect(result.stdoutTail).toBe("staged 0 of 2: (none)");
+    expect(result.stderrTail).toBe("codex: network timeout\ngoogle: network timeout");
   });
 });

--- a/src/commands/doctor-bundled-plugin-staging.test.ts
+++ b/src/commands/doctor-bundled-plugin-staging.test.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+import {
+  discoverMissingBundledPluginStaging,
+  repairBundledPluginStaging,
+} from "./doctor-bundled-plugin-staging.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+type WriteExtensionParams = {
+  extensionsDir: string;
+  id: string;
+  stageRuntimeDependencies: boolean;
+  dependencies?: Record<string, string>;
+  hasNodeModules?: boolean;
+};
+
+function writeExtension(params: WriteExtensionParams): void {
+  const extDir = path.join(params.extensionsDir, params.id);
+  fs.mkdirSync(extDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(extDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `@openclaw/${params.id}`,
+        version: "2026.4.21",
+        dependencies: params.dependencies ?? { "example-dep": "^1.0.0" },
+        openclaw: {
+          bundle: { stageRuntimeDependencies: params.stageRuntimeDependencies },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  if (params.hasNodeModules) {
+    fs.mkdirSync(path.join(extDir, "node_modules"), { recursive: true });
+  }
+}
+
+describe("discoverMissingBundledPluginStaging", () => {
+  it("reports extensions that declare stageRuntimeDependencies:true but have no node_modules", () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+    writeExtension({
+      extensionsDir,
+      id: "discord",
+      stageRuntimeDependencies: true,
+      hasNodeModules: true,
+    });
+    writeExtension({
+      extensionsDir,
+      id: "qa-channel",
+      stageRuntimeDependencies: false,
+      hasNodeModules: false,
+    });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
+    // Extensions that don't declare stageRuntimeDependencies are not checked.
+    expect(result.checked.map((entry) => entry.id).toSorted()).toEqual(["discord", "slack"]);
+  });
+
+  it("skips stage=true extensions that declare zero runtime dependencies", () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "no-deps",
+      stageRuntimeDependencies: true,
+      dependencies: {},
+      hasNodeModules: false,
+    });
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing).toEqual([]);
+    expect(result.checked.map((entry) => entry.id)).toEqual(["no-deps"]);
+  });
+
+  it("returns empty result when extensions dir does not exist", () => {
+    const tempRoot = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    const missingDir = path.join(tempRoot, "does-not-exist");
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir: missingDir });
+
+    expect(result.missing).toEqual([]);
+    expect(result.checked).toEqual([]);
+  });
+
+  it("tolerates malformed package.json in an extension directory", () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+    const brokenDir = path.join(extensionsDir, "broken");
+    fs.mkdirSync(brokenDir, { recursive: true });
+    fs.writeFileSync(path.join(brokenDir, "package.json"), "{ not json");
+
+    const result = discoverMissingBundledPluginStaging({ extensionsDir });
+
+    expect(result.missing.map((entry) => entry.id)).toEqual(["slack"]);
+  });
+});
+
+describe("repairBundledPluginStaging", () => {
+  it("invokes the installer with --production-style args in each missing extension directory", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+    writeExtension({
+      extensionsDir,
+      id: "google",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const invocations: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const result = await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      runCommand: async ({ command, args, cwd }) => {
+        invocations.push({ command, args, cwd });
+        // Simulate a successful install by creating the expected node_modules dir.
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(invocations).toHaveLength(2);
+    expect(invocations[0].command).toBe("pnpm");
+    expect(invocations[0].args).toContain("install");
+    expect(invocations[0].args).toContain("--prod");
+    expect(invocations.map((i) => path.basename(i.cwd)).toSorted()).toEqual(["codex", "google"]);
+    expect(result.repaired.map((entry) => entry.id).toSorted()).toEqual(["codex", "google"]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("uses npm install --omit=dev when package manager is npm", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "slack",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const invocations: Array<{ command: string; args: string[] }> = [];
+    await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "npm",
+      runCommand: async ({ command, args, cwd }) => {
+        invocations.push({ command, args });
+        fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(invocations[0].command).toBe("npm");
+    expect(invocations[0].args).toContain("install");
+    expect(invocations[0].args).toContain("--omit=dev");
+  });
+
+  it("records a failed repair when the installer exits non-zero", async () => {
+    const extensionsDir = makeTrackedTempDir("doctor-bundled-plugin-staging", tempDirs);
+    writeExtension({
+      extensionsDir,
+      id: "codex",
+      stageRuntimeDependencies: true,
+      hasNodeModules: false,
+    });
+
+    const result = await repairBundledPluginStaging({
+      extensionsDir,
+      packageManager: "pnpm",
+      runCommand: async () => ({
+        exitCode: 1,
+        stdout: "",
+        stderr: "install error: offline",
+      }),
+    });
+
+    expect(result.repaired).toEqual([]);
+    expect(result.failed.map((entry) => entry.id)).toEqual(["codex"]);
+    expect(result.failed[0].detail).toContain("offline");
+  });
+});

--- a/src/commands/doctor-bundled-plugin-staging.ts
+++ b/src/commands/doctor-bundled-plugin-staging.ts
@@ -18,6 +18,20 @@
 //   extension directories read-only from the install's perspective (no new
 //   lockfiles, no mutations to `package.json`).
 // - `npm_config_legacy_peer_deps=true` for consistent peer-dep tolerance.
+// - `npm_config_audit=false` / `npm_config_fund=false` for deterministic,
+//   reduced-noise installs during update flows.
+//
+// Security-defensive discovery:
+// - Rejects symlinked entries under `dist/extensions` and enforces realpath
+//   containment so a tampered `dist/extensions/<x>` cannot redirect the
+//   install subprocess to write outside the install root.
+// - Size-guards `package.json` reads (1MB cap) before parsing so a corrupt
+//   or oversized file can't stall the sync scan.
+// - Considers a plugin "staged" only when every declared runtime dependency
+//   (including `optionalDependencies` per the sibling `collectRuntimeDeps`
+//   pattern) has a sentinel `package.json` under `node_modules/`. A bare
+//   `node_modules/` directory left over from a failed install attempt is
+//   not treated as healthy.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -28,7 +42,7 @@ const PACKAGE_JSON_SIZE_LIMIT_BYTES = 1024 * 1024;
 
 export type CheckedExtension = {
   id: string;
-  hasNodeModules: boolean;
+  hasStagedDeps: boolean;
   dependencyCount: number;
 };
 
@@ -62,13 +76,24 @@ export function discoverMissingBundledPluginStaging(params: DiscoveryParams): Di
     throw error;
   }
 
+  const extensionsRealPath = tryRealpath(extensionsDir);
+  if (!extensionsRealPath) {
+    // Extensions dir itself isn't a real directory we can resolve — treat as
+    // empty rather than scan through a potentially redirected tree.
+    return { checked, missing };
+  }
+
   for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
     if (!entry.isDirectory()) {
       continue;
     }
     const extDir = path.join(extensionsDir, entry.name);
-    const packageJsonPath = path.join(extDir, "package.json");
+    if (!isContainedRealPath(extDir, extensionsRealPath)) {
+      // Symlinked or otherwise redirected entry — refuse to consider it.
+      continue;
+    }
 
+    const packageJsonPath = path.join(extDir, "package.json");
     const pkg = tryReadPackageJson(packageJsonPath);
     if (!pkg) {
       continue;
@@ -78,16 +103,16 @@ export function discoverMissingBundledPluginStaging(params: DiscoveryParams): Di
       continue;
     }
 
-    const dependencyCount = countRuntimeDependencies(pkg);
-    const hasNodeModules = fs.existsSync(path.join(extDir, "node_modules"));
+    const depNames = collectRuntimeDepNames(pkg);
+    const hasStagedDeps = hasAllDeclaredDepSentinels(extDir, depNames);
 
-    checked.push({ id: entry.name, hasNodeModules, dependencyCount });
+    checked.push({ id: entry.name, hasStagedDeps, dependencyCount: depNames.length });
 
-    if (!hasNodeModules && dependencyCount > 0) {
+    if (!hasStagedDeps && depNames.length > 0) {
       missing.push({
         id: entry.name,
         expectedPath: path.join(extDir, "node_modules"),
-        dependencyCount,
+        dependencyCount: depNames.length,
       });
     }
   }
@@ -100,7 +125,11 @@ function tryReadPackageJson(packageJsonPath: string): unknown {
   // directory should not block the update/doctor flow on a huge synchronous
   // read or parse. Valid bundled-plugin package.json files are a few KB.
   try {
-    const stat = fs.statSync(packageJsonPath);
+    const stat = fs.lstatSync(packageJsonPath);
+    // Reject symlinked package.json too — matches the directory-entry policy.
+    if (stat.isSymbolicLink()) {
+      return null;
+    }
     if (stat.size > PACKAGE_JSON_SIZE_LIMIT_BYTES) {
       return null;
     }
@@ -125,12 +154,71 @@ function isStageRuntimeDependenciesTrue(pkg: unknown): boolean {
   return bundle?.stageRuntimeDependencies === true;
 }
 
-function countRuntimeDependencies(pkg: unknown): number {
-  const deps = (pkg as { dependencies?: Record<string, unknown> })?.dependencies;
-  if (deps && typeof deps === "object") {
-    return Object.keys(deps).length;
+// Match the sibling pattern in `scripts/postinstall-bundled-plugins.mjs` →
+// `collectRuntimeDeps`: declared runtime deps include `optionalDependencies`.
+// A plugin that moves any dep into `optionalDependencies` still expects it
+// present at stage time for the `stageRuntimeDependencies: true` contract.
+function collectRuntimeDepNames(pkg: unknown): string[] {
+  const p = pkg as {
+    dependencies?: Record<string, unknown>;
+    optionalDependencies?: Record<string, unknown>;
+  } | null;
+  const names = new Set<string>();
+  if (p?.dependencies && typeof p.dependencies === "object") {
+    for (const name of Object.keys(p.dependencies)) {
+      names.add(name);
+    }
   }
-  return 0;
+  if (p?.optionalDependencies && typeof p.optionalDependencies === "object") {
+    for (const name of Object.keys(p.optionalDependencies)) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+// A plugin is considered staged only when every declared runtime dep has its
+// sentinel `package.json` present. `existsSync` on just `node_modules/` is
+// not enough — a partial install (network failure mid-way, interrupted
+// repair) can leave behind an incomplete directory that would otherwise
+// suppress retry on the next update.
+function hasAllDeclaredDepSentinels(extDir: string, depNames: string[]): boolean {
+  if (depNames.length === 0) {
+    return true;
+  }
+  return depNames.every((depName) => {
+    const segments = depName.split("/");
+    const sentinelPath = path.join(extDir, "node_modules", ...segments, "package.json");
+    return fs.existsSync(sentinelPath);
+  });
+}
+
+function tryRealpath(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function isContainedRealPath(candidate: string, parentRealPath: string): boolean {
+  try {
+    const lstat = fs.lstatSync(candidate);
+    if (lstat.isSymbolicLink()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  const candidateReal = tryRealpath(candidate);
+  if (!candidateReal) {
+    return false;
+  }
+  // Same-path is allowed (the parent itself can be a valid candidate target
+  // for outer checks), but for per-entry containment we require strict
+  // prefix — the extension dir must be inside the extensions root.
+  const withSep = parentRealPath.endsWith(path.sep) ? parentRealPath : parentRealPath + path.sep;
+  return candidateReal.startsWith(withSep);
 }
 
 export type RunCommandResult = { exitCode: number; stdout: string; stderr: string };
@@ -148,10 +236,15 @@ export type FailedRepairEntry = {
   exitCode: number;
   detail: string;
 };
+export type SkippedRepairEntry = {
+  id: string;
+  reason: string;
+};
 
 export type RepairResult = {
   repaired: RepairedEntry[];
   failed: FailedRepairEntry[];
+  skipped: SkippedRepairEntry[];
 };
 
 export type RepairParams = {
@@ -164,7 +257,8 @@ export type RepairParams = {
   packageManagerCommand?: string;
   // Pre-computed list of plugins to repair. When provided, skips the inner
   // discovery scan so the caller can run a single discovery for both the
-  // early-exit guard and the repair call.
+  // early-exit guard and the repair call. Each entry's path is still
+  // validated to live inside `extensionsDir` before any subprocess spawn.
   missing?: MissingStagingEntry[];
   // Base environment for the install subprocess, before the staging-specific
   // `npm_config_*` overlays are applied. Callers should pass the same
@@ -181,13 +275,26 @@ export async function repairBundledPluginStaging(params: RepairParams): Promise<
 
   const repaired: RepairedEntry[] = [];
   const failed: FailedRepairEntry[] = [];
+  const skipped: SkippedRepairEntry[] = [];
 
   const command = packageManagerCommand ?? packageManager;
   const installArgs = resolveProductionInstallArgs(packageManager);
   const env = createBundledPluginStagingInstallEnv(params.baseEnv);
 
+  // Re-validate containment per entry even when the caller provides `missing`:
+  // defense against a tampered input list feeding a path outside the install
+  // root into the subprocess `cwd`.
+  const extensionsRealPath = tryRealpath(extensionsDir);
+
   for (const entry of missing) {
     const extDir = path.dirname(entry.expectedPath);
+    if (!extensionsRealPath || !isContainedRealPath(extDir, extensionsRealPath)) {
+      skipped.push({
+        id: entry.id,
+        reason: "extension directory is not contained within extensionsDir (symlink or redirect?)",
+      });
+      continue;
+    }
     const result = await runCommand({
       command,
       args: installArgs,
@@ -205,7 +312,7 @@ export async function repairBundledPluginStaging(params: RepairParams): Promise<
     }
   }
 
-  return { repaired, failed };
+  return { repaired, failed, skipped };
 }
 
 const PRODUCTION_INSTALL_ARGS: Record<StagingPackageManager, readonly string[]> = {
@@ -220,21 +327,34 @@ function resolveProductionInstallArgs(packageManager: StagingPackageManager): st
 
 // Mirrors `scripts/postinstall-bundled-plugins.mjs` →
 // `createBundledRuntimeDependencyInstallEnv`: peer-dep tolerance, no lockfile
-// write, no package.json save. Strips nested-install env leakage (matches
-// `createNestedNpmInstallEnv`). `npm_config_*` keys are honored by pnpm and
+// write, no package.json save. `npm_config_*` keys are honored by pnpm and
 // bun (npm-config-compatible) so a single env works across managers.
+//
+// The stripped keys are set to `undefined` rather than deleted because
+// `runCommandWithTimeout`'s `resolveCommandEnv` merges `process.env` under
+// the caller-provided env (`{ ...baseEnv, ...params.env }`). A plain
+// `delete` on the returned object would be silently restored by the merge;
+// setting the key to `undefined` overwrites the inherited value, and the
+// merge's undefined-filter then strips it from the final subprocess env.
 export function createBundledPluginStagingInstallEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  const next: NodeJS.ProcessEnv = { ...env };
-  delete next.npm_config_global;
-  delete next.npm_config_location;
-  delete next.npm_config_prefix;
   return {
-    ...next,
+    ...env,
+    // Strip nested-install context, both casing variants (Windows convention).
+    npm_config_global: undefined,
+    npm_config_location: undefined,
+    npm_config_prefix: undefined,
+    NPM_CONFIG_GLOBAL: undefined,
+    NPM_CONFIG_LOCATION: undefined,
+    NPM_CONFIG_PREFIX: undefined,
+    // Deterministic install overlays.
     npm_config_legacy_peer_deps: "true",
     npm_config_package_lock: "false",
     npm_config_save: "false",
+    // Defense-in-depth during update-driven installs.
+    npm_config_audit: "false",
+    npm_config_fund: "false",
   };
 }
 
@@ -254,28 +374,50 @@ export type UpdateStepClassification = {
 
 // Classify a repair run for the update step's result record.
 // Semantics:
-// - All-success (every discovered plugin repaired) → step exit 0.
-// - Partial-success (at least one repaired, one or more failed) → step exit 0
-//   with failed plugins surfaced via stderrTail. The update binary is
-//   successfully installed; failed plugins are no worse off than pre-update
-//   and do not justify flipping the whole update to `status: "error"`, which
-//   would mislead automated callers into retrying the package install.
-// - Total-failure (work attempted, zero repaired, all failed) → step exit 1.
+// - All-success (every discovered plugin repaired) → step exit 0, clean
+//   stdoutTail, null stderrTail.
+// - Partial-success (at least one repaired, one or more failed or skipped)
+//   → step exit 0 with failures surfaced in the stdoutTail. The step
+//   renderer (`src/cli/update-cli/progress.ts`) prints stderrTail only when
+//   exit code is non-zero, so embedding the failure summary in stdoutTail
+//   keeps TTY output honest on partial outcomes.
+// - Total-failure (work attempted, zero repaired) → step exit 1; full
+//   detail goes to stderrTail where the renderer shows it.
 export function summarizeRepairForUpdateStep(params: {
   attempted: number;
   repair: RepairResult;
 }): UpdateStepClassification {
   const { attempted, repair } = params;
   const succeeded = repair.repaired.length;
+  const problematic = repair.failed.length + repair.skipped.length;
   const totalFailure = attempted > 0 && succeeded === 0;
   const stepExitCode: 0 | 1 = totalFailure ? 1 : 0;
 
   const repairedList = repair.repaired.map((entry) => entry.id).join(", ") || "(none)";
-  const stdoutTail = `staged ${succeeded} of ${attempted}: ${repairedList}`;
-  const stderrTail =
-    repair.failed.length > 0
-      ? repair.failed.map((entry) => `${entry.id}: ${entry.detail}`).join("\n")
-      : null;
+  const problemLines = [
+    ...repair.failed.map((entry) => `${entry.id}: ${entry.detail}`),
+    ...repair.skipped.map((entry) => `${entry.id}: skipped (${entry.reason})`),
+  ];
+
+  const baseLine = `staged ${succeeded} of ${attempted}: ${repairedList}`;
+  let stdoutTail = baseLine;
+  let stderrTail: string | null = null;
+
+  if (problematic > 0) {
+    if (totalFailure) {
+      // Renderer shows stderrTail on non-zero exit — full detail goes there.
+      stderrTail = problemLines.join("\n");
+    } else {
+      // Renderer hides stderrTail on zero exit, so the partial-failure
+      // summary must go into stdoutTail to stay visible. The `!` sigil keeps
+      // it scannable in progress output and in the final step record.
+      stdoutTail = [
+        baseLine,
+        `! ${problematic} plugin(s) not staged — run \`openclaw doctor\` to retry:`,
+        ...problemLines.map((line) => `  - ${line}`),
+      ].join("\n");
+    }
+  }
 
   return { stepExitCode, stdoutTail, stderrTail };
 }

--- a/src/commands/doctor-bundled-plugin-staging.ts
+++ b/src/commands/doctor-bundled-plugin-staging.ts
@@ -8,12 +8,23 @@
 // client. `scripts/postinstall-bundled-plugins.mjs` intentionally does not
 // eagerly install per-plugin runtime deps; its top comment notes that
 // `openclaw doctor --fix` owns the repair path for extensions that are
-// actually used. This module implements that repair path.
+// actually used. This module is that repair path, invoked today by
+// `openclaw update` right after the global install step.
+//
+// Design mirrors `scripts/postinstall-bundled-plugins.mjs`:
+// - `--ignore-scripts` on every install to prevent dep lifecycle scripts
+//   from running client-side.
+// - `npm_config_package_lock=false` / `npm_config_save=false` to keep the
+//   extension directories read-only from the install's perspective (no new
+//   lockfiles, no mutations to `package.json`).
+// - `npm_config_legacy_peer_deps=true` for consistent peer-dep tolerance.
 
 import fs from "node:fs";
 import path from "node:path";
 
-export type StagingPackageManager = "pnpm" | "npm" | "bun" | "yarn";
+export type StagingPackageManager = "pnpm" | "npm" | "bun";
+
+const PACKAGE_JSON_SIZE_LIMIT_BYTES = 1024 * 1024;
 
 export type CheckedExtension = {
   id: string;
@@ -58,13 +69,8 @@ export function discoverMissingBundledPluginStaging(params: DiscoveryParams): Di
     const extDir = path.join(extensionsDir, entry.name);
     const packageJsonPath = path.join(extDir, "package.json");
 
-    let pkg: unknown;
-    try {
-      const raw = fs.readFileSync(packageJsonPath, "utf8");
-      pkg = JSON.parse(raw);
-    } catch {
-      // Missing or malformed package.json: surface via other doctor checks,
-      // not this one.
+    const pkg = tryReadPackageJson(packageJsonPath);
+    if (!pkg) {
       continue;
     }
 
@@ -89,6 +95,30 @@ export function discoverMissingBundledPluginStaging(params: DiscoveryParams): Di
   return { checked, missing };
 }
 
+function tryReadPackageJson(packageJsonPath: string): unknown {
+  // Size-guard before reading: a malicious or corrupt file in the extensions
+  // directory should not block the update/doctor flow on a huge synchronous
+  // read or parse. Valid bundled-plugin package.json files are a few KB.
+  try {
+    const stat = fs.statSync(packageJsonPath);
+    if (stat.size > PACKAGE_JSON_SIZE_LIMIT_BYTES) {
+      return null;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  } catch {
+    // Malformed JSON: skip here; other doctor checks report it.
+    return null;
+  }
+}
+
 function isStageRuntimeDependenciesTrue(pkg: unknown): boolean {
   const bundle = (pkg as { openclaw?: { bundle?: { stageRuntimeDependencies?: unknown } } })
     ?.openclaw?.bundle;
@@ -109,6 +139,7 @@ export type RunCommandFn = (params: {
   command: string;
   args: string[];
   cwd: string;
+  env?: NodeJS.ProcessEnv;
 }) => Promise<RunCommandResult>;
 
 export type RepairedEntry = { id: string };
@@ -126,23 +157,36 @@ export type RepairResult = {
 export type RepairParams = {
   extensionsDir: string;
   packageManager: StagingPackageManager;
+  // Resolved executable path for the package manager. When provided, spawn
+  // targets this path instead of resolving `packageManager` through `PATH`.
+  // Match the caller's trusted command resolution (e.g. an install-root-local
+  // npm) instead of relying on ambient `PATH` lookup.
+  packageManagerCommand?: string;
+  // Pre-computed list of plugins to repair. When provided, skips the inner
+  // discovery scan so the caller can run a single discovery for both the
+  // early-exit guard and the repair call.
+  missing?: MissingStagingEntry[];
   runCommand: RunCommandFn;
 };
 
 export async function repairBundledPluginStaging(params: RepairParams): Promise<RepairResult> {
-  const { extensionsDir, packageManager, runCommand } = params;
-  const { missing } = discoverMissingBundledPluginStaging({ extensionsDir });
+  const { extensionsDir, packageManager, packageManagerCommand, runCommand } = params;
+  const missing = params.missing ?? discoverMissingBundledPluginStaging({ extensionsDir }).missing;
 
   const repaired: RepairedEntry[] = [];
   const failed: FailedRepairEntry[] = [];
 
+  const command = packageManagerCommand ?? packageManager;
+  const installArgs = resolveProductionInstallArgs(packageManager);
+  const env = createBundledPluginStagingInstallEnv();
+
   for (const entry of missing) {
     const extDir = path.dirname(entry.expectedPath);
-    const installArgs = resolveProductionInstallArgs(packageManager);
     const result = await runCommand({
-      command: packageManager,
+      command,
       args: installArgs,
       cwd: extDir,
+      env,
     });
     if (result.exitCode === 0) {
       repaired.push({ id: entry.id });
@@ -159,14 +203,33 @@ export async function repairBundledPluginStaging(params: RepairParams): Promise<
 }
 
 const PRODUCTION_INSTALL_ARGS: Record<StagingPackageManager, readonly string[]> = {
-  pnpm: ["install", "--prod"],
-  npm: ["install", "--omit=dev"],
-  yarn: ["install", "--production"],
-  bun: ["install", "--production"],
+  pnpm: ["install", "--prod", "--ignore-scripts"],
+  npm: ["install", "--omit=dev", "--ignore-scripts"],
+  bun: ["install", "--production", "--ignore-scripts"],
 };
 
 function resolveProductionInstallArgs(packageManager: StagingPackageManager): string[] {
   return [...PRODUCTION_INSTALL_ARGS[packageManager]];
+}
+
+// Mirrors `scripts/postinstall-bundled-plugins.mjs` →
+// `createBundledRuntimeDependencyInstallEnv`: peer-dep tolerance, no lockfile
+// write, no package.json save. Strips nested-install env leakage (matches
+// `createNestedNpmInstallEnv`). `npm_config_*` keys are honored by pnpm and
+// bun (npm-config-compatible) so a single env works across managers.
+export function createBundledPluginStagingInstallEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = { ...env };
+  delete next.npm_config_global;
+  delete next.npm_config_location;
+  delete next.npm_config_prefix;
+  return {
+    ...next,
+    npm_config_legacy_peer_deps: "true",
+    npm_config_package_lock: "false",
+    npm_config_save: "false",
+  };
 }
 
 function summarizeCommandFailure(result: RunCommandResult): string {
@@ -175,4 +238,38 @@ function summarizeCommandFailure(result: RunCommandResult): string {
     .filter((chunk) => chunk.length > 0)
     .join(" | ");
   return combined.length > 0 ? combined : `exit ${result.exitCode}`;
+}
+
+export type UpdateStepClassification = {
+  stepExitCode: 0 | 1;
+  stdoutTail: string;
+  stderrTail: string | null;
+};
+
+// Classify a repair run for the update step's result record.
+// Semantics:
+// - All-success (every discovered plugin repaired) → step exit 0.
+// - Partial-success (at least one repaired, one or more failed) → step exit 0
+//   with failed plugins surfaced via stderrTail. The update binary is
+//   successfully installed; failed plugins are no worse off than pre-update
+//   and do not justify flipping the whole update to `status: "error"`, which
+//   would mislead automated callers into retrying the package install.
+// - Total-failure (work attempted, zero repaired, all failed) → step exit 1.
+export function summarizeRepairForUpdateStep(params: {
+  attempted: number;
+  repair: RepairResult;
+}): UpdateStepClassification {
+  const { attempted, repair } = params;
+  const succeeded = repair.repaired.length;
+  const totalFailure = attempted > 0 && succeeded === 0;
+  const stepExitCode: 0 | 1 = totalFailure ? 1 : 0;
+
+  const repairedList = repair.repaired.map((entry) => entry.id).join(", ") || "(none)";
+  const stdoutTail = `staged ${succeeded} of ${attempted}: ${repairedList}`;
+  const stderrTail =
+    repair.failed.length > 0
+      ? repair.failed.map((entry) => `${entry.id}: ${entry.detail}`).join("\n")
+      : null;
+
+  return { stepExitCode, stdoutTail, stderrTail };
 }

--- a/src/commands/doctor-bundled-plugin-staging.ts
+++ b/src/commands/doctor-bundled-plugin-staging.ts
@@ -1,0 +1,178 @@
+// Detect and repair bundled-plugin runtime-dep staging gaps.
+//
+// Bundled plugins that declare `openclaw.bundle.stageRuntimeDependencies: true`
+// in their own `package.json` are expected to have a sibling `node_modules/`
+// directory at install time. On `package`-kind installs (pnpm/npm global),
+// the publish tarball strips these directories via `!dist/extensions/*/node_modules/**`
+// in the core `files` manifest, so the staging must be re-created on the
+// client. `scripts/postinstall-bundled-plugins.mjs` intentionally does not
+// eagerly install per-plugin runtime deps; its top comment notes that
+// `openclaw doctor --fix` owns the repair path for extensions that are
+// actually used. This module implements that repair path.
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type StagingPackageManager = "pnpm" | "npm" | "bun" | "yarn";
+
+export type CheckedExtension = {
+  id: string;
+  hasNodeModules: boolean;
+  dependencyCount: number;
+};
+
+export type MissingStagingEntry = {
+  id: string;
+  expectedPath: string;
+  dependencyCount: number;
+};
+
+export type DiscoveryResult = {
+  checked: CheckedExtension[];
+  missing: MissingStagingEntry[];
+};
+
+export type DiscoveryParams = {
+  extensionsDir: string;
+};
+
+export function discoverMissingBundledPluginStaging(params: DiscoveryParams): DiscoveryResult {
+  const { extensionsDir } = params;
+  const checked: CheckedExtension[] = [];
+  const missing: MissingStagingEntry[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(extensionsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { checked, missing };
+    }
+    throw error;
+  }
+
+  for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const extDir = path.join(extensionsDir, entry.name);
+    const packageJsonPath = path.join(extDir, "package.json");
+
+    let pkg: unknown;
+    try {
+      const raw = fs.readFileSync(packageJsonPath, "utf8");
+      pkg = JSON.parse(raw);
+    } catch {
+      // Missing or malformed package.json: surface via other doctor checks,
+      // not this one.
+      continue;
+    }
+
+    if (!isStageRuntimeDependenciesTrue(pkg)) {
+      continue;
+    }
+
+    const dependencyCount = countRuntimeDependencies(pkg);
+    const hasNodeModules = fs.existsSync(path.join(extDir, "node_modules"));
+
+    checked.push({ id: entry.name, hasNodeModules, dependencyCount });
+
+    if (!hasNodeModules && dependencyCount > 0) {
+      missing.push({
+        id: entry.name,
+        expectedPath: path.join(extDir, "node_modules"),
+        dependencyCount,
+      });
+    }
+  }
+
+  return { checked, missing };
+}
+
+function isStageRuntimeDependenciesTrue(pkg: unknown): boolean {
+  const bundle = (pkg as { openclaw?: { bundle?: { stageRuntimeDependencies?: unknown } } })
+    ?.openclaw?.bundle;
+  return bundle?.stageRuntimeDependencies === true;
+}
+
+function countRuntimeDependencies(pkg: unknown): number {
+  const deps = (pkg as { dependencies?: Record<string, unknown> })?.dependencies;
+  if (deps && typeof deps === "object") {
+    return Object.keys(deps).length;
+  }
+  return 0;
+}
+
+export type RunCommandResult = { exitCode: number; stdout: string; stderr: string };
+
+export type RunCommandFn = (params: {
+  command: string;
+  args: string[];
+  cwd: string;
+}) => Promise<RunCommandResult>;
+
+export type RepairedEntry = { id: string };
+export type FailedRepairEntry = {
+  id: string;
+  exitCode: number;
+  detail: string;
+};
+
+export type RepairResult = {
+  repaired: RepairedEntry[];
+  failed: FailedRepairEntry[];
+};
+
+export type RepairParams = {
+  extensionsDir: string;
+  packageManager: StagingPackageManager;
+  runCommand: RunCommandFn;
+};
+
+export async function repairBundledPluginStaging(params: RepairParams): Promise<RepairResult> {
+  const { extensionsDir, packageManager, runCommand } = params;
+  const { missing } = discoverMissingBundledPluginStaging({ extensionsDir });
+
+  const repaired: RepairedEntry[] = [];
+  const failed: FailedRepairEntry[] = [];
+
+  for (const entry of missing) {
+    const extDir = path.dirname(entry.expectedPath);
+    const installArgs = resolveProductionInstallArgs(packageManager);
+    const result = await runCommand({
+      command: packageManager,
+      args: installArgs,
+      cwd: extDir,
+    });
+    if (result.exitCode === 0) {
+      repaired.push({ id: entry.id });
+    } else {
+      failed.push({
+        id: entry.id,
+        exitCode: result.exitCode,
+        detail: summarizeCommandFailure(result),
+      });
+    }
+  }
+
+  return { repaired, failed };
+}
+
+const PRODUCTION_INSTALL_ARGS: Record<StagingPackageManager, readonly string[]> = {
+  pnpm: ["install", "--prod"],
+  npm: ["install", "--omit=dev"],
+  yarn: ["install", "--production"],
+  bun: ["install", "--production"],
+};
+
+function resolveProductionInstallArgs(packageManager: StagingPackageManager): string[] {
+  return [...PRODUCTION_INSTALL_ARGS[packageManager]];
+}
+
+function summarizeCommandFailure(result: RunCommandResult): string {
+  const combined = [result.stderr, result.stdout]
+    .map((chunk) => chunk?.trim?.() ?? "")
+    .filter((chunk) => chunk.length > 0)
+    .join(" | ");
+  return combined.length > 0 ? combined : `exit ${result.exitCode}`;
+}

--- a/src/commands/doctor-bundled-plugin-staging.ts
+++ b/src/commands/doctor-bundled-plugin-staging.ts
@@ -166,6 +166,12 @@ export type RepairParams = {
   // discovery scan so the caller can run a single discovery for both the
   // early-exit guard and the repair call.
   missing?: MissingStagingEntry[];
+  // Base environment for the install subprocess, before the staging-specific
+  // `npm_config_*` overlays are applied. Callers should pass the same
+  // hardened env they use for the main install step (e.g. the output of
+  // `createGlobalInstallEnv`) so `PATH` and corepack-prompt settings stay
+  // deterministic across both steps. Defaults to `process.env` when omitted.
+  baseEnv?: NodeJS.ProcessEnv;
   runCommand: RunCommandFn;
 };
 
@@ -178,7 +184,7 @@ export async function repairBundledPluginStaging(params: RepairParams): Promise<
 
   const command = packageManagerCommand ?? packageManager;
   const installArgs = resolveProductionInstallArgs(packageManager);
-  const env = createBundledPluginStagingInstallEnv();
+  const env = createBundledPluginStagingInstallEnv(params.baseEnv);
 
   for (const entry of missing) {
     const extDir = path.dirname(entry.expectedPath);


### PR DESCRIPTION
## What

Package-kind installs of OpenClaw (`pnpm`/`npm` global) strip per-plugin `node_modules/` from the published tarball via `!dist/extensions/*/node_modules/**` in `files`. Any bundled plugin whose `package.json` declares `openclaw.bundle.stageRuntimeDependencies: true` therefore lands without its sibling `node_modules/` on the client. Today the on-disk repair happens lazily only if the CLI attempts to load the specific plugin's runtime and fails — which never fires for plugins the gateway has already reported as "loaded" against the old binary during an in-place update.

This PR adds an eager per-plugin staging step to `openclaw update` that runs after the global install and before the post-install doctor pass. The step enumerates bundled plugins whose package manifest declares `stageRuntimeDependencies: true` and whose sibling `node_modules/` is missing, then invokes `<packageManager> install --prod` (or `npm install --omit=dev`) scoped to each plugin directory.

## Why

Without this, a successful `openclaw update` followed by a gateway restart can crash-load bundled plugins with errors like:

```
Error: Cannot find module '@slack/web-api'
  Require stack:
    - dist/extensions/slack/client-*.js
```

or

```
Error: Cannot find module 'acpx/runtime'
  Require stack:
    - dist/extensions/acpx/register.runtime-*.js
```

`scripts/postinstall-bundled-plugins.mjs` explicitly declines to eagerly stage these deps during package install (its top comment: *"Do not install every bundled extension dependency during core package install… `openclaw doctor --fix` owns the repair path for extensions that are actually used."*). But the `doctor --fix` repair path isn't wired to the filesystem-level staging today (`runBundledPluginRuntimeDepsHealth` checks for top-level dep resolution, not per-plugin `node_modules/`), and in practice the broken-install state can prevent doctor from loading plugins at all — so the repair never gets a chance to run.

Running the staging step during `openclaw update` is the narrow, targeted fix for the observed symptom. It does not change behavior for fresh `npm install -g openclaw` installs (which would still benefit from a follow-up in the postinstall path) and does not alter the `doctor --fix` contract.

## Scope

- Package-install branch of `openclaw update` only. Git-install branch is unaffected (it rebuilds locally, which already runs the build-time staging).
- Discovery is filesystem-only — no plugin loading required, so it runs successfully even when the install is currently broken.
- Each repair is scoped to a single plugin directory; nothing writes outside `dist/extensions/<id>/node_modules/`.
- If no plugins need staging, the step is a no-op and emits no step record.

## Design alternatives considered

- **Wire detection + repair into `openclaw doctor --fix`.** Matches the stated design intent in `scripts/postinstall-bundled-plugins.mjs`. Rejected for this PR because doctor crashes at plugin-registration time when any `stageRuntimeDependencies: true` plugin's deps are missing, so its repair contributions never run. A deeper fix in that area (making plugin registration tolerant of missing runtime deps, then running the scan) is a larger change worth a separate PR.
- **Eager stage in `postinstall-bundled-plugins.mjs`.** Directly contradicts the script's stated design — out of scope.
- **Make `scanBundledPluginRuntimeDeps` also check per-plugin `node_modules/`.** That scanner is oriented to top-level dep resolution. Extending it would broaden the scope meaningfully.

## Testing

New file `src/commands/doctor-bundled-plugin-staging.test.ts` — 7 unit tests:

- Discovery reports extensions declaring `stageRuntimeDependencies: true` with no `node_modules/`
- Discovery skips extensions with `stageRuntimeDependencies: false`
- Discovery skips stage=true extensions that declare zero runtime deps
- Discovery returns empty result on a non-existent extensions directory
- Discovery tolerates malformed `package.json` in one of the entries
- Repair invokes `pnpm install --prod` in each missing plugin directory
- Repair invokes `npm install --omit=dev` when manager is npm
- Repair records a failed entry when the installer exits non-zero

Gates run locally:
- `pnpm check` → clean (0 errors, 0 warnings)
- `pnpm test src/commands/doctor-bundled-plugin-staging.test.ts` → 7/7 pass
- `pnpm test src/cli/update-cli` → 26/26 pass (no regressions in the call-site file)
- `pnpm build` → clean
- Pre-commit hook ran 929 tests across the smart-gate lane — all passed

Testing level: **lightly tested** — the unit tests cover the discovery and repair functions in isolation via injected seams. The integration into `runBundledPluginStagingStep` in `update-command.ts` is not directly tested; it's a thin composition of the two tested functions plus existing `runCommandWithTimeout`. Happy to add an integration test at the `runPackageUpdate` level if reviewers want one.

## AI-assisted

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (lightly tested)
- [x] Confirm you understand what the code does

Built with Claude Code. Agent traced the load path from the tarball's `files` exclusions through `postinstall-bundled-plugins.mjs`'s documented design intent, through `maybeRepairBundledPluginRuntimeDeps`'s filesystem search path, to the specific failure pattern in the update → restart flow before choosing the intervention point.