### PR TITLE
gateway/session-utils: honor per-agent thinkingDefault in buildGatewaySessionRow

### DIFF
--- a/src/gateway/session-utils.thinking-fallback.test.ts
+++ b/src/gateway/session-utils.thinking-fallback.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { listSessionsFromStore, loadGatewaySessionRow } from "./session-utils.js";
+
+type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+
+afterEach(() => {
+  resetConfigRuntimeState();
+});
+
+function makeCfg(opts: {
+  agentEntry?: {
+    id?: string;
+    thinkingDefault?: ThinkLevel;
+    model?: string;
+  };
+  defaultsThinkingDefault?: ThinkLevel;
+}): OpenClawConfig {
+  const agentId = opts.agentEntry?.id ?? "main";
+  return {
+    session: { mainKey: "main" },
+    agents: {
+      defaults: {
+        model: { primary: "openai-codex/gpt-5.4" },
+        ...(opts.defaultsThinkingDefault ? { thinkingDefault: opts.defaultsThinkingDefault } : {}),
+      },
+      list: [
+        {
+          id: agentId,
+          default: true,
+          ...(opts.agentEntry?.thinkingDefault
+            ? { thinkingDefault: opts.agentEntry.thinkingDefault }
+            : {}),
+          ...(opts.agentEntry?.model ? { model: opts.agentEntry.model } : {}),
+        },
+      ],
+    },
+  } as OpenClawConfig;
+}
+
+function listSingleMainSession(
+  cfg: OpenClawConfig,
+  entry: Partial<SessionEntry>,
+): ReturnType<typeof listSessionsFromStore>["sessions"] {
+  const storePath = "/tmp/sessions-utils-thinking-fallback.json";
+  const fullEntry = {
+    sessionId: "sess-test",
+    updatedAt: Date.now(),
+    ...entry,
+  } as SessionEntry;
+  const result = listSessionsFromStore({
+    cfg,
+    storePath,
+    store: { "agent:main:main": fullEntry },
+    opts: {},
+  });
+  return result.sessions;
+}
+
+describe("buildGatewaySessionRow → thinkingLevel fallback", () => {
+  test("entry.thinkingLevel wins over per-agent default (regression guard)", () => {
+    const cfg = makeCfg({ agentEntry: { thinkingDefault: "high" } });
+    const [row] = listSingleMainSession(cfg, { thinkingLevel: "medium" });
+    expect(row?.thinkingLevel).toBe("medium");
+  });
+
+  test("per-agent thinkingDefault fills the gap when the entry has no thinkingLevel", () => {
+    const cfg = makeCfg({ agentEntry: { thinkingDefault: "high" } });
+    const [row] = listSingleMainSession(cfg, {});
+    expect(row?.thinkingLevel).toBe("high");
+  });
+
+  test("global agents.defaults.thinkingDefault fills the gap when per-agent is unset", () => {
+    const cfg = makeCfg({ agentEntry: {}, defaultsThinkingDefault: "low" });
+    const [row] = listSingleMainSession(cfg, {});
+    expect(row?.thinkingLevel).toBe("low");
+  });
+
+  test("model-centric fallback still produces a concrete ThinkLevel string (never undefined)", () => {
+    const cfg = makeCfg({
+      agentEntry: { model: "openai-codex/gpt-5.4" /* no thinkingDefault */ },
+    });
+    const [row] = listSingleMainSession(cfg, {
+      model: "gpt-5.4",
+      modelProvider: "openai-codex",
+    });
+    expect(typeof row?.thinkingLevel).toBe("string");
+    expect((row?.thinkingLevel as string).length).toBeGreaterThan(0);
+  });
+
+  test("sessions.list and loadGatewaySessionRow stay consistent on thinkingLevel", async () => {
+    const cfg = makeCfg({ agentEntry: { thinkingDefault: "high" } });
+
+    // sessions.list path — in-memory, no state dir required.
+    const [fromListRow] = listSingleMainSession(cfg, {});
+    expect(fromListRow?.thinkingLevel).toBe("high");
+
+    // loadGatewaySessionRow path — same config, seeded through the state-dir
+    // pipeline so the live RPC behavior (used by sessions.changed broadcasts)
+    // is exercised too.
+    await withStateDirEnv("session-utils-think-fallback-consistency-", async ({ stateDir }) => {
+      const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify({
+          "agent:main:main": { sessionId: "sess-consistency", updatedAt: Date.now() },
+        }),
+        "utf8",
+      );
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const fromLoad = loadGatewaySessionRow("agent:main:main");
+      expect(fromLoad?.thinkingLevel).toBe("high");
+      expect(fromLoad?.thinkingLevel).toBe(fromListRow?.thinkingLevel);
+    });
+  });
+
+  test("canonical webchat sessionKey 'agent:main:main' resolves via normalized agent lookup", () => {
+    const cfg = makeCfg({ agentEntry: { thinkingDefault: "high" } });
+    const storePath = "/tmp/sessions-utils-thinking-fallback-canonical.json";
+    const result = listSessionsFromStore({
+      cfg,
+      storePath,
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-canonical",
+          updatedAt: Date.now(),
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+    const row = result.sessions.find((r) => r.key === "agent:main:main");
+    expect(row?.thinkingLevel).toBe("high");
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+  resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
@@ -16,6 +17,7 @@ import {
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
   resolvePersistedSelectedModelRef,
+  resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import {
   getSessionDisplaySubagentRunByChildSessionKey,
@@ -1275,7 +1277,23 @@ export function buildGatewaySessionRow(params: {
     sessionId: entry?.sessionId,
     systemSent: entry?.systemSent,
     abortedLastRun: entry?.abortedLastRun,
-    thinkingLevel: entry?.thinkingLevel,
+    // TUI footer reads state.sessionInfo.thinkingLevel, which is fed through
+    // sessions.list / sessions.changed → this SessionRow. If the session entry
+    // has no thinkingLevel yet (fresh session, post-restart), fall through in
+    // the same priority order as the chat.history handler: per-agent default
+    // first, then the shared resolveThinkingDefault chain (per-model → global
+    // default → anthropic heuristics → model-centric). Note: resolveThinkingDefault
+    // is intentionally called without a model catalog here because buildGatewaySessionRow
+    // is synchronous; the Claude-4.6 "adaptive" heuristic that depends on
+    // catalogCandidate.name therefore does not fire in this sync row-builder.
+    thinkingLevel:
+      entry?.thinkingLevel ??
+      resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault ??
+      resolveThinkingDefault({
+        cfg,
+        provider: resolvedModel.provider ?? DEFAULT_PROVIDER,
+        model: resolvedModel.model ?? DEFAULT_MODEL,
+      }),
     fastMode: entry?.fastMode,
     verboseLevel: entry?.verboseLevel,
     traceLevel: entry?.traceLevel,


### PR DESCRIPTION
## Summary

- Fix a TUI display drift that is adjacent to, but not covered by, PR #70259. The TUI footer's `state.sessionInfo.thinkingLevel` is fed through `sessions.list` / `sessions.changed`, which flow through `buildGatewaySessionRow(...)` in `src/gateway/session-utils.ts`. That builder currently reads only `entry?.thinkingLevel`, with no fallback. When a session has no persisted `thinkingLevel` (fresh session, post-restart, new webchat connection), the row's `thinkingLevel` is `undefined`, the TUI picks up whatever it defaults to (typically the model-centric default from `resolveThinkingDefaultForModel`, which for `openai-codex/gpt-5.4` is `"low"`), and drifts below the configured agent level.
- Honor the same three-step fallback chain the `chat.history` RPC handler uses (PR #70259):
  1. `entry.thinkingLevel` — persisted session value (unchanged priority).
  2. `cfg.agents.list[].thinkingDefault` via `resolveAgentConfig` — per-agent override.
  3. `resolveThinkingDefault(...)` — which internally covers per-model override, `cfg.agents.defaults.thinkingDefault`, anthropic heuristics, and the model-centric fallback.

## Scope

- Single-call-site change in `src/gateway/session-utils.ts` inside `buildGatewaySessionRow(...)`. Both RPC paths that feed the TUI — `sessions.list` (`listSessionsFromStore`) and `sessions.changed` broadcasts (`loadGatewaySessionRow` → `buildGatewaySessionRow`) — benefit from the one edit.
- Uses the existing normalized `resolveAgentConfig` helper from `src/agents/agent-scope.ts` (same one PR #70259 uses in the chat.history handler), so agent id normalization is shared.
- The `/think` command path, `auto-reply/reply/model-selection`, `agent-command`, `cron/isolated-agent`, and plugin runtime callers are untouched — this is strictly the TUI-effective SessionRow fallback.

## Deliberate design notes

- **No model catalog in the sync row-builder.** `buildGatewaySessionRow` is synchronous and is called from many places (including hot paths). `resolveThinkingDefault` accepts `catalog?` as optional. This PR intentionally calls it **without** a model catalog, which means the Claude-4.6 "adaptive" heuristic that depends on `catalogCandidate.name` does not fire in this sync row-builder. The opus-4-7 / per-model / global / model-centric branches continue to work because they do not require the catalog. Introducing async + catalog plumbing into `buildGatewaySessionRow` would be a broader refactor outside this PR's scope; it can be added later if the Claude-4.6 sonnet-adaptive case turns out to matter for the TUI footer in practice.
- **No redundancy with PR #70259.** The chat.history RPC handler still independently returns a correctly-resolved `thinkingLevel` (including the catalog-aware heuristic, because it is async and has catalog access). When the TUI issues both `sessions.list` and `chat.history` for the same session, the two paths now produce consistent values (and PR #70259 remains the authoritative, catalog-aware one for chat.history).

## Rollout / verification note

Because the TUI footer caches `state.sessionInfo.thinkingLevel` locally after the initial handshake, a live client that was already connected before this change may continue to show the stale value for its existing session. **A reconnect / TUI restart is the expected verification step after rollout** — the new SessionRow values take effect on the next `sessions.list` / `sessions.changed` delivery.

## Tests

New focused suite `src/gateway/session-utils.thinking-fallback.test.ts` — 6 tests, all passing locally:
- `entry.thinkingLevel` wins over per-agent default (regression guard).
- Per-agent `thinkingDefault` fills the gap when the entry has no `thinkingLevel`.
- Global `agents.defaults.thinkingDefault` fills the gap when per-agent is unset.
- Model-centric fallback still produces a concrete ThinkLevel string (never `undefined`).
- `sessions.list` and `loadGatewaySessionRow` stay consistent on `thinkingLevel` (covers both TUI-feeding paths).
- Canonical webchat `sessionKey: "agent:main:main"` resolves via the normalized agent lookup.

## Test plan

- [x] `pnpm test src/gateway/session-utils.thinking-fallback.test.ts` — 6/6 PASS
- [x] Regression: `pnpm test src/gateway/session-utils.test.ts src/gateway/session-utils.fs.test.ts src/gateway/session-utils.search.test.ts src/gateway/session-utils.subagent.test.ts` — 139/139 PASS
- [x] `pnpm check` (tsgo core + core:test + extensions + extensions:test, oxlint, import-cycle + madge checks all green; ran via `scripts/committer`)

## Related

- #70259 — companion fix for the same drift in the `chat.history` RPC handler (catalog-aware sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)