### PR TITLE
feat(codex): add llm lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Tokenjuice: add bundled native OpenClaw support for tokenjuice as an opt-in plugin that compacts noisy `exec` and `bash` tool results in Pi embedded runs. (#69946) Thanks @vincentkoc.
 - Codex harness/hooks: route native Codex app-server turns through `before_prompt_build` and emit `before_compaction` / `after_compaction` for native compaction items so prompt and compaction hooks stop drifting from Pi. Thanks @vincentkoc.
 - Codex harness/plugins: add a bundled-plugin Codex app-server extension seam for async `tool_result` middleware, fire `after_tool_call` for Codex tool runs, and route mirrored Codex transcript writes through `before_message_write` so tool integrations stop diverging from Pi. Thanks @vincentkoc.
+- Codex harness/hooks: fire `llm_input`, `llm_output`, and `agent_end` for native Codex app-server turns so lifecycle hooks stop drifting from Pi. Thanks @vincentkoc.
 - Providers/Tencent: add the bundled Tencent Cloud provider plugin with TokenHub and Token Plan onboarding, docs, `hy3-preview` model catalog entries, and tiered Hy3 pricing metadata. (#68460) Thanks @JuniperSling.
 - TUI: add local embedded mode for running terminal chats without a Gateway while keeping plugin approval gates enforced. (#66767) Thanks @fuller-stack-dev.
 - CLI/Claude: default `claude-cli` runs to warm stdio sessions, including custom configs that omit transport fields, and resume from the stored Claude session after Gateway restarts or idle exits. (#69679) Thanks @obviyus.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -20,6 +20,10 @@ approvals, media delivery, and the visible transcript mirror.
 Native Codex turns also respect the shared `before_prompt_build`,
 `before_compaction`, and `after_compaction` plugin hooks, so prompt shims and
 compaction-aware automation can stay aligned with the PI harness.
+Native Codex turns also respect the shared `before_prompt_build`,
+`before_compaction`, `after_compaction`, `llm_input`, `llm_output`, and
+`agent_end` plugin hooks, so prompt shims, compaction-aware automation, and
+lifecycle observers can stay aligned with the PI harness.
 
 The harness is off by default. It is selected only when the `codex` plugin is
 enabled and the resolved model is a `codex/*` model, or when you explicitly

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -378,6 +378,11 @@ describe("runCodexAppServerAttempt", () => {
         { hookName: "agent_end", handler: agentEnd },
       ]),
     );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("existing context", Date.now()),
+    );
     createStartedThreadHarness(async (method) => {
       if (method === "turn/start") {
         throw new Error("turn start exploded");
@@ -385,11 +390,9 @@ describe("runCodexAppServerAttempt", () => {
       return undefined;
     });
 
-    await expect(
-      runCodexAppServerAttempt(
-        createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
-      ),
-    ).rejects.toThrow("turn start exploded");
+    await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
+      "turn start exploded",
+    );
 
     await vi.waitFor(() => expect(llmInput).toHaveBeenCalledTimes(1), { interval: 1 });
     await vi.waitFor(() => expect(llmOutput).toHaveBeenCalledTimes(1), { interval: 1 });
@@ -408,7 +411,34 @@ describe("runCodexAppServerAttempt", () => {
       expect.objectContaining({
         success: false,
         error: "turn start exploded",
-        messages: [],
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "assistant" }),
+          expect.objectContaining({ role: "user" }),
+        ]),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("fires agent_end with success false when the codex turn is aborted", async () => {
+    const agentEnd = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
+    );
+    const { waitForMethod } = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+    );
+
+    await waitForMethod("turn/start");
+    expect(abortAgentHarnessRun("session-1")).toBe(true);
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), { interval: 1 });
+    expect(agentEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
       }),
       expect.any(Object),
     );

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -368,54 +368,49 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("fires llm_output and agent_end when turn/start fails", async () => {
+    const llmInput = vi.fn();
     const llmOutput = vi.fn();
     const agentEnd = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([
+        { hookName: "llm_input", handler: llmInput },
         { hookName: "llm_output", handler: llmOutput },
         { hookName: "agent_end", handler: agentEnd },
       ]),
     );
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    createAppServerHarness(async (method) => {
-      if (method === "thread/start") {
-        return threadStartResult();
-      }
+    createStartedThreadHarness(async (method) => {
       if (method === "turn/start") {
-        throw new Error("codex turn start failed");
+        throw new Error("turn start exploded");
       }
-      return {};
+      return undefined;
     });
 
-    await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
-      "codex turn start failed",
-    );
+    await expect(
+      runCodexAppServerAttempt(
+        createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      ),
+    ).rejects.toThrow("turn start exploded");
 
+    await vi.waitFor(() => expect(llmInput).toHaveBeenCalledTimes(1), { interval: 1 });
     await vi.waitFor(() => expect(llmOutput).toHaveBeenCalledTimes(1), { interval: 1 });
     await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), { interval: 1 });
-
     expect(llmOutput).toHaveBeenCalledWith(
       expect.objectContaining({
-        runId: "run-1",
-        sessionId: "session-1",
         assistantTexts: [],
-      }),
-      expect.objectContaining({
+        model: "gpt-5.4-codex",
+        provider: "codex",
         runId: "run-1",
         sessionId: "session-1",
       }),
+      expect.any(Object),
     );
     expect(agentEnd).toHaveBeenCalledWith(
       expect.objectContaining({
         success: false,
-        error: "codex turn start failed",
+        error: "turn start exploded",
         messages: [],
       }),
-      expect.objectContaining({
-        runId: "run-1",
-        sessionId: "session-1",
-      }),
+      expect.any(Object),
     );
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -114,6 +114,9 @@ function createAppServerHarness(
         },
       });
     },
+    async notify(notification: CodexServerNotification) {
+      await notify(notification);
+    },
   };
 }
 
@@ -235,6 +238,184 @@ describe("runCodexAppServerAttempt", () => {
           }),
         },
       ]),
+    );
+  });
+
+  it("fires llm_input, llm_output, and agent_end hooks for codex turns", async () => {
+    const llmInput = vi.fn();
+    const llmOutput = vi.fn();
+    const agentEnd = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "llm_input", handler: llmInput },
+        { hookName: "llm_output", handler: llmOutput },
+        { hookName: "agent_end", handler: agentEnd },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(assistantMessage("existing context", Date.now()));
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+    await vi.waitFor(() => expect(llmInput).toHaveBeenCalledTimes(1), { interval: 1 });
+
+    expect(llmInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "codex",
+        model: "gpt-5.4-codex",
+        prompt: "hello",
+        imagesCount: 0,
+        historyMessages: [expect.objectContaining({ role: "assistant" })],
+        systemPrompt: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+      }),
+    );
+
+    await harness.notify({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "msg-1",
+        delta: "hello back",
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(result.assistantTexts).toEqual(["hello back"]);
+    await vi.waitFor(() => expect(llmOutput).toHaveBeenCalledTimes(1), { interval: 1 });
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), { interval: 1 });
+
+    expect(llmOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "codex",
+        model: "gpt-5.4-codex",
+        assistantTexts: ["hello back"],
+        lastAssistant: expect.objectContaining({
+          role: "assistant",
+        }),
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+      }),
+    );
+    expect(agentEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "user" }),
+          expect.objectContaining({ role: "assistant" }),
+        ]),
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+      }),
+    );
+  });
+
+  it("fires agent_end with failure metadata when the codex turn fails", async () => {
+    const agentEnd = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "failed",
+          error: { message: "codex exploded" },
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.promptError).toBe("codex exploded");
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), { interval: 1 });
+    expect(agentEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "codex exploded",
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+      }),
+    );
+  });
+
+  it("fires llm_output and agent_end when turn/start fails", async () => {
+    const llmOutput = vi.fn();
+    const agentEnd = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "llm_output", handler: llmOutput },
+        { hookName: "agent_end", handler: agentEnd },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    createAppServerHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      if (method === "turn/start") {
+        throw new Error("codex turn start failed");
+      }
+      return {};
+    });
+
+    await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
+      "codex turn start failed",
+    );
+
+    await vi.waitFor(() => expect(llmOutput).toHaveBeenCalledTimes(1), { interval: 1 });
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), { interval: 1 });
+
+    expect(llmOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+        assistantTexts: [],
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+      }),
+    );
+    expect(agentEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "codex turn start failed",
+        messages: [],
+      }),
+      expect.objectContaining({
+        runId: "run-1",
+        sessionId: "session-1",
+      }),
     );
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -116,7 +116,7 @@ export async function runCodexAppServerAttempt(
   const hookContext = {
     runId: params.runId,
     agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
+    sessionKey: sandboxSessionKey,
     sessionId: params.sessionId,
     workspaceDir: params.workspaceDir,
     messageProvider: params.messageProvider ?? undefined,
@@ -233,6 +233,13 @@ export async function runCodexAppServerAttempt(
     historyMessages,
     imagesCount: params.images?.length ?? 0,
   };
+  const turnStartFailureMessages = [
+    ...historyMessages,
+    {
+      role: "user",
+      content: [{ type: "text", text: promptBuild.prompt }],
+    },
+  ];
 
   let turn: CodexTurnStartResponse;
   try {
@@ -263,7 +270,7 @@ export async function runCodexAppServerAttempt(
     });
     runAgentHarnessAgentEndHook({
       event: {
-        messages: [],
+        messages: turnStartFailureMessages,
         success: false,
         error: formatErrorMessage(error),
         durationMs: Date.now() - attemptStartedAt,
@@ -323,6 +330,9 @@ export async function runCodexAppServerAttempt(
   try {
     await completion;
     const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
+    const finalAborted = result.aborted || runAbortController.signal.aborted;
+    const finalPromptError = timedOut ? "codex app-server attempt timed out" : result.promptError;
+    const finalPromptErrorSource = timedOut ? "prompt" : result.promptErrorSource;
     await mirrorTranscriptBestEffort({
       params,
       agentId: sessionAgentId,
@@ -346,8 +356,8 @@ export async function runCodexAppServerAttempt(
     runAgentHarnessAgentEndHook({
       event: {
         messages: result.messagesSnapshot,
-        success: !result.aborted && !result.promptError,
-        ...(result.promptError ? { error: formatErrorMessage(result.promptError) } : {}),
+        success: !finalAborted && !finalPromptError,
+        ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
         durationMs: Date.now() - attemptStartedAt,
       },
       ctx: hookContext,
@@ -355,9 +365,9 @@ export async function runCodexAppServerAttempt(
     return {
       ...result,
       timedOut,
-      aborted: result.aborted || runAbortController.signal.aborted,
-      promptError: timedOut ? "codex app-server attempt timed out" : result.promptError,
-      promptErrorSource: timedOut ? "prompt" : result.promptErrorSource,
+      aborted: finalAborted,
+      promptError: finalPromptError,
+      promptErrorSource: finalPromptErrorSource,
     };
   } finally {
     clearTimeout(timeout);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -223,16 +223,6 @@ export async function runCodexAppServerAttempt(
     return toolBridge.handleToolCall(call) as Promise<JsonValue>;
   });
 
-  const hookContext = {
-    runId: params.runId,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-    workspaceDir: params.workspaceDir,
-    messageProvider: params.messageProvider ?? undefined,
-    trigger: params.trigger,
-    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-  };
   const llmInputEvent = {
     runId: params.runId,
     sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -5,6 +5,7 @@ import {
   clearActiveEmbeddedRun,
   createOpenClawCodingTools,
   embeddedAgentLog,
+  formatErrorMessage,
   isSubagentSessionKey,
   normalizeProviderToolSchemas,
   resolveAttemptSpawnWorkspaceDir,
@@ -14,6 +15,9 @@ import {
   resolveSessionAgentIds,
   resolveUserPath,
   resolveAgentHarnessBeforePromptBuildResult,
+  runAgentHarnessAgentEndHook,
+  runAgentHarnessLlmInputHook,
+  runAgentHarnessLlmOutputHook,
   setActiveEmbeddedRun,
   supportsModelTools,
   type EmbeddedRunAttemptParams,
@@ -51,6 +55,7 @@ export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
   options: { pluginConfig?: unknown; startupTimeoutFloorMs?: number } = {},
 ): Promise<EmbeddedRunAttemptResult> {
+  const attemptStartedAt = Date.now();
   const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: options.pluginConfig });
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   await fs.mkdir(resolvedWorkspace, { recursive: true });
@@ -108,20 +113,21 @@ export async function runCodexAppServerAttempt(
     },
   });
   const historyMessages = readMirroredSessionHistoryMessages(params.sessionFile);
+  const hookContext = {
+    runId: params.runId,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir: params.workspaceDir,
+    messageProvider: params.messageProvider ?? undefined,
+    trigger: params.trigger,
+    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+  };
   const promptBuild = await resolveAgentHarnessBeforePromptBuildResult({
     prompt: params.prompt,
     developerInstructions: buildDeveloperInstructions(params),
     messages: historyMessages,
-    ctx: {
-      runId: params.runId,
-      agentId: sessionAgentId,
-      sessionKey: params.sessionKey,
-      sessionId: params.sessionId,
-      workspaceDir: params.workspaceDir,
-      messageProvider: params.messageProvider ?? undefined,
-      trigger: params.trigger,
-      channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-    },
+    ctx: hookContext,
   });
   let client: CodexAppServerClient;
   let thread: CodexAppServerThreadBinding;
@@ -219,6 +225,19 @@ export async function runCodexAppServerAttempt(
 
   let turn: CodexTurnStartResponse;
   try {
+    runAgentHarnessLlmInputHook({
+      event: {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: params.provider,
+        model: params.modelId,
+        systemPrompt: promptBuild.developerInstructions,
+        prompt: promptBuild.prompt,
+        historyMessages,
+        imagesCount: params.images?.length ?? 0,
+      },
+      ctx: hookContext,
+    });
     turn = await client.request<CodexTurnStartResponse>(
       "turn/start",
       buildTurnStartParams(params, {
@@ -230,6 +249,25 @@ export async function runCodexAppServerAttempt(
       { timeoutMs: params.timeoutMs, signal: runAbortController.signal },
     );
   } catch (error) {
+    runAgentHarnessLlmOutputHook({
+      event: {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: params.provider,
+        model: params.modelId,
+        assistantTexts: [],
+      },
+      ctx: hookContext,
+    });
+    runAgentHarnessAgentEndHook({
+      event: {
+        messages: [],
+        success: false,
+        error: formatErrorMessage(error),
+        durationMs: Date.now() - attemptStartedAt,
+      },
+      ctx: hookContext,
+    });
     notificationCleanup();
     requestCleanup();
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
@@ -290,6 +328,27 @@ export async function runCodexAppServerAttempt(
       sessionKey: sandboxSessionKey,
       threadId: thread.threadId,
       turnId: activeTurnId,
+    });
+    runAgentHarnessLlmOutputHook({
+      event: {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: params.provider,
+        model: params.modelId,
+        assistantTexts: result.assistantTexts,
+        ...(result.lastAssistant ? { lastAssistant: result.lastAssistant } : {}),
+        ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
+      },
+      ctx: hookContext,
+    });
+    runAgentHarnessAgentEndHook({
+      event: {
+        messages: result.messagesSnapshot,
+        success: !result.aborted && !result.promptError,
+        ...(result.promptError ? { error: formatErrorMessage(result.promptError) } : {}),
+        durationMs: Date.now() - attemptStartedAt,
+      },
+      ctx: hookContext,
     });
     return {
       ...result,
@@ -512,7 +571,7 @@ function readMirroredSessionHistoryMessages(sessionFile: string): unknown[] {
   try {
     return SessionManager.open(sessionFile).buildSessionContext().messages;
   } catch (error) {
-    embeddedAgentLog.warn("failed to read mirrored session history for codex prompt hooks", {
+    embeddedAgentLog.warn("failed to read mirrored session history for codex harness hooks", {
       error,
       sessionFile,
     });

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -223,19 +223,31 @@ export async function runCodexAppServerAttempt(
     return toolBridge.handleToolCall(call) as Promise<JsonValue>;
   });
 
+  const hookContext = {
+    runId: params.runId,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir: params.workspaceDir,
+    messageProvider: params.messageProvider ?? undefined,
+    trigger: params.trigger,
+    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+  };
+  const llmInputEvent = {
+    runId: params.runId,
+    sessionId: params.sessionId,
+    provider: params.provider,
+    model: params.modelId,
+    systemPrompt: promptBuild.developerInstructions,
+    prompt: promptBuild.prompt,
+    historyMessages,
+    imagesCount: params.images?.length ?? 0,
+  };
+
   let turn: CodexTurnStartResponse;
   try {
     runAgentHarnessLlmInputHook({
-      event: {
-        runId: params.runId,
-        sessionId: params.sessionId,
-        provider: params.provider,
-        model: params.modelId,
-        systemPrompt: promptBuild.developerInstructions,
-        prompt: promptBuild.prompt,
-        historyMessages,
-        imagesCount: params.images?.length ?? 0,
-      },
+      event: llmInputEvent,
       ctx: hookContext,
     });
     turn = await client.request<CodexTurnStartResponse>(

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -1,0 +1,73 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type {
+  PluginHookAgentEndEvent,
+  PluginHookAgentContext,
+  PluginHookLlmInputEvent,
+  PluginHookLlmOutputEvent,
+} from "../../plugins/hook-types.js";
+
+const log = createSubsystemLogger("agents/harness");
+
+type AgentHarnessHookContext = {
+  runId: string;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  messageProvider?: string;
+  trigger?: string;
+  channelId?: string;
+};
+
+function buildAgentHookContext(params: AgentHarnessHookContext): PluginHookAgentContext {
+  return {
+    runId: params.runId,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    ...(params.messageProvider ? { messageProvider: params.messageProvider } : {}),
+    ...(params.trigger ? { trigger: params.trigger } : {}),
+    ...(params.channelId ? { channelId: params.channelId } : {}),
+  };
+}
+
+export function runAgentHarnessLlmInputHook(params: {
+  event: PluginHookLlmInputEvent;
+  ctx: AgentHarnessHookContext;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("llm_input")) {
+    return;
+  }
+  void hookRunner.runLlmInput(params.event, buildAgentHookContext(params.ctx)).catch((error) => {
+    log.warn(`llm_input hook failed: ${String(error)}`);
+  });
+}
+
+export function runAgentHarnessLlmOutputHook(params: {
+  event: PluginHookLlmOutputEvent;
+  ctx: AgentHarnessHookContext;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("llm_output")) {
+    return;
+  }
+  void hookRunner.runLlmOutput(params.event, buildAgentHookContext(params.ctx)).catch((error) => {
+    log.warn(`llm_output hook failed: ${String(error)}`);
+  });
+}
+
+export function runAgentHarnessAgentEndHook(params: {
+  event: PluginHookAgentEndEvent;
+  ctx: AgentHarnessHookContext;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("agent_end")) {
+    return;
+  }
+  void hookRunner.runAgentEnd(params.event, buildAgentHookContext(params.ctx)).catch((error) => {
+    log.warn(`agent_end hook failed: ${String(error)}`);
+  });
+}

--- a/src/plugin-sdk/agent-harness.ts
+++ b/src/plugin-sdk/agent-harness.ts
@@ -71,3 +71,8 @@ export {
   runAgentHarnessAfterToolCallHook,
   runAgentHarnessBeforeMessageWriteHook,
 } from "../agents/harness/hook-helpers.js";
+export {
+  runAgentHarnessAgentEndHook,
+  runAgentHarnessLlmInputHook,
+  runAgentHarnessLlmOutputHook,
+} from "../agents/harness/lifecycle-hook-helpers.js";


### PR DESCRIPTION
## Summary

- Problem: native Codex app-server turns did not emit the shared `llm_input`, `llm_output`, or `agent_end` plugin hooks.
- Why it matters: lifecycle automation and diagnostics that work on PI runs silently miss Codex harness turns, so hook behavior drifts by runtime.
- What changed: add shared harness helpers for those lifecycle hooks, fire `llm_input` before Codex `turn/start`, and fire `llm_output` plus `agent_end` after Codex turn completion using mirrored session history and the projected attempt result.
- What did NOT change (scope boundary): this does not cover `before_prompt_build`, compaction hooks, or Codex tool-result middleware.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69946
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex harness owns its own turn-start and turn-complete flow, but those lifecycle points never forwarded into the shared plugin hook runner.
- Missing detection / guardrail: we had no Codex harness tests asserting LLM lifecycle hook parity, so the gap sat there until the parity audit.
- Contributing context (if known): the same hook families already run on PI, so native Codex runs looked healthy while still skipping automation that depended on those hooks.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: a Codex run fires `llm_input`, `llm_output`, and `agent_end` with the expected payloads, including failure metadata.
- Why this is the smallest reliable guardrail: the bug is in the Codex harness attempt lifecycle, not inside isolated hook-runner helpers.
- Existing test that already covers this (if any): `plugin-sdk-subpaths` keeps the new helper exports honest.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Native Codex app-server turns now emit `llm_input`, `llm_output`, and `agent_end` plugin hooks.
- Codex `llm_input` uses the mirrored OpenClaw session transcript as its history snapshot.

## Diagram (if applicable)

```text
Before:
[codex turn/start] -> [native Codex turn] -> [result]
                 x llm_input
[result]         x llm_output / agent_end

After:
[codex turn/start] -> [llm_input] -> [native Codex turn]
[result] -> [llm_output] -> [agent_end]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm workspace
- Model/provider: Codex app-server harness
- Integration/channel (if any): N/A
- Relevant config (redacted): default local repo setup

### Steps

1. Initialize the global hook runner with `llm_input`, `llm_output`, or `agent_end` handlers.
2. Start a Codex app-server attempt and drive a turn to completion or failure in the test harness.
3. Verify the handlers receive the projected Codex lifecycle payloads.

### Expected

- Codex turns trigger the same LLM lifecycle hooks that PI already emits.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran Codex run-attempt tests for success and failure hook payloads, plugin-sdk subpath contract tests, and plugin-sdk API baseline checks locally.
- Edge cases checked: mirrored transcript history inclusion, failure-path `agent_end`, public helper export drift.
- What you did **not** verify: full repo `pnpm check` / `pnpm build`, and a live Codex app-server session outside the test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Codex hook payloads use the mirrored OpenClaw transcript, which can still differ slightly from the native Codex thread state.
  - Mitigation: that mirror is the same local transcript OpenClaw already persists and exposes elsewhere, and the remaining prompt-build/compaction parity work stays split into follow-up PRs.
