### PR TITLE
fix(telegram): keep message.action target writeback admin-scoped

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -709,12 +709,17 @@ describe("handleTelegramAction", () => {
         delivery: { pin: { enabled: true } },
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
     );
 
     expect(pinMessageTelegram).toHaveBeenCalledWith(
       "123456",
       "789",
-      expect.objectContaining({ accountId: undefined, verbose: false }),
+      expect.objectContaining({
+        accountId: undefined,
+        verbose: false,
+        gatewayClientScopes: ["operator.write"],
+      }),
     );
   });
 

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -345,11 +345,16 @@ describe("handleTelegramAction", () => {
         content: "Hello, Telegram!",
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
     );
     expect(sendMessageTelegram).toHaveBeenCalledWith(
       "@testchannel",
       "Hello, Telegram!",
-      expect.objectContaining({ token: "tok", mediaUrl: undefined }),
+      expect.objectContaining({
+        token: "tok",
+        mediaUrl: undefined,
+        gatewayClientScopes: ["operator.write"],
+      }),
     );
     expect(result.content).toContainEqual({
       type: "text",
@@ -390,6 +395,7 @@ describe("handleTelegramAction", () => {
         silent: true,
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.admin"] },
     );
     expect(sendPollTelegram).toHaveBeenCalledWith(
       "@testchannel",
@@ -404,6 +410,7 @@ describe("handleTelegramAction", () => {
         token: "tok",
         isAnonymous: false,
         silent: true,
+        gatewayClientScopes: ["operator.admin"],
       }),
     );
     expect(result.details).toMatchObject({

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -182,6 +182,7 @@ async function maybePinTelegramActionSend(params: {
   accountId?: string;
   to: string;
   messageId?: string;
+  gatewayClientScopes?: readonly string[];
 }) {
   const pin = normalizeTelegramDeliveryPin(params.args);
   if (!pin) {
@@ -197,6 +198,7 @@ async function maybePinTelegramActionSend(params: {
     await telegramActionRuntime.pinMessageTelegram(params.to, params.messageId, {
       cfg: params.cfg,
       accountId: params.accountId,
+      gatewayClientScopes: params.gatewayClientScopes,
       notify: pin.notify,
       verbose: false,
     });
@@ -386,6 +388,7 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
       to,
       messageId: result.messageId,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     return jsonResult({
       ok: true,

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -213,6 +213,7 @@ export async function handleTelegramAction(
   options?: {
     mediaLocalRoots?: readonly string[];
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
+    gatewayClientScopes?: readonly string[];
   },
 ): Promise<AgentToolResult<unknown>> {
   const { action, accountId } = {
@@ -364,6 +365,7 @@ export async function handleTelegramAction(
       cfg,
       token,
       accountId: accountId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
       mediaUrl: mediaUrl || undefined,
       mediaLocalRoots: options?.mediaLocalRoots,
       mediaReadFile: options?.mediaReadFile,
@@ -449,6 +451,7 @@ export async function handleTelegramAction(
         cfg,
         token,
         accountId: accountId ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
         replyToMessageId: replyToMessageId ?? undefined,
         messageThreadId: messageThreadId ?? undefined,
         isAnonymous: isAnonymous ?? undefined,
@@ -482,6 +485,7 @@ export async function handleTelegramAction(
       cfg,
       token,
       accountId: accountId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     return jsonResult({ ok: true, deleted: true });
   }
@@ -524,6 +528,7 @@ export async function handleTelegramAction(
         cfg,
         token,
         accountId: accountId ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
         buttons,
       },
     );
@@ -559,6 +564,7 @@ export async function handleTelegramAction(
       cfg,
       token,
       accountId: accountId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
     });
@@ -613,6 +619,7 @@ export async function handleTelegramAction(
       cfg,
       token,
       accountId: accountId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
       iconColor,
       iconCustomEmojiId: iconCustomEmojiId ?? undefined,
     });
@@ -648,6 +655,7 @@ export async function handleTelegramAction(
         cfg,
         token,
         accountId: accountId ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
         name: name ?? undefined,
         iconCustomEmojiId: iconCustomEmojiId ?? undefined,
       },

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -60,6 +60,33 @@ describe("telegramMessageActions", () => {
     );
   });
 
+  it("forwards gateway client scopes into the Telegram action runtime", async () => {
+    await telegramMessageActions.handleAction!({
+      action: "send",
+      params: {
+        to: "@legacy-target",
+        message: "hi",
+      },
+      cfg: {} as never,
+      accountId: "default",
+      mediaLocalRoots: [],
+      gatewayClientScopes: ["operator.write"],
+    } as never);
+
+    expect(handleTelegramActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "@legacy-target",
+        accountId: "default",
+      }),
+      expect.anything(),
+      expect.objectContaining({
+        mediaLocalRoots: [],
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+  });
+
   it("computes poll/topic action availability from config gates", () => {
     const cases = [
       {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -176,7 +176,15 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
   extractToolSend: ({ args }) => {
     return extractToolSend(args, "sendMessage");
   },
-  handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, toolContext }) => {
+  handleAction: async ({
+    action,
+    params,
+    cfg,
+    accountId,
+    mediaLocalRoots,
+    gatewayClientScopes,
+    toolContext,
+  }) => {
     const telegramAction = resolveTelegramMessageActionName(action);
     if (!telegramAction) {
       throw new Error(`Unsupported Telegram action: ${action}`);
@@ -193,7 +201,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           : {}),
       },
       cfg,
-      { mediaLocalRoots },
+      { mediaLocalRoots, gatewayClientScopes },
     );
   },
 };

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1098,6 +1098,7 @@ type TelegramDeleteOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
 };
 
 export async function deleteMessageTelegram(
@@ -1113,6 +1114,7 @@ export async function deleteMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1140,6 +1142,7 @@ export async function pinMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1172,6 +1175,7 @@ export async function unpinMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = messageIdInput === undefined ? undefined : normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1233,6 +1237,7 @@ export async function editForumTopicTelegram(
     lookupTarget: target.chatId,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageThreadId = normalizeMessageId(messageThreadIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1283,6 +1288,7 @@ type TelegramEditOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   textMode?: "markdown" | "html";
   /** Controls whether link previews are shown in the edited message. */
   linkPreview?: boolean;
@@ -1298,6 +1304,7 @@ type TelegramEditReplyMarkupOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
   buttons?: TelegramInlineButtons;
   /** Resolved runtime config from the command or gateway boundary. */
@@ -1321,6 +1328,7 @@ export async function editMessageReplyMarkupTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1364,6 +1372,7 @@ export async function editMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1466,6 +1475,7 @@ type TelegramStickerOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Message ID to reply to (for threading) */
   replyToMessageId?: number;
   /** Forum topic thread ID (for forum supergroups) */
@@ -1495,6 +1505,7 @@ export async function sendStickerTelegram(
     lookupTarget: target.chatId,
     persistTarget: to,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
 
   const threadParams = buildTelegramThreadReplyParams({
@@ -1661,6 +1672,7 @@ type TelegramCreateForumTopicOpts = {
   api?: TelegramApiOverride;
   verbose?: boolean;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Icon color for the topic (must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, 0xFB6F5F). */
   iconColor?: TelegramCreateForumTopicParams["icon_color"];
   /** Custom emoji ID for the topic icon. */
@@ -1704,6 +1716,7 @@ export async function createForumTopicTelegram(
     lookupTarget: target.chatId,
     persistTarget: chatId,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
 
   const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -634,6 +634,7 @@ export type ChannelMessageActionContext = {
   sessionKey?: string | null;
   sessionId?: string | null;
   agentId?: string | null;
+  gatewayClientScopes?: readonly string[];
   gateway?: {
     url?: string;
     token?: string;

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1087,6 +1087,60 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("forwards gateway client scopes into plugin-owned message actions", async () => {
+    const capture = { gatewayClientScopes: undefined as readonly string[] | undefined };
+    const reactPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram message action scope forwarding test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async ({ gatewayClientScopes }) => {
+          capture.gatewayClientScopes = gatewayClientScopes;
+          return jsonResult({ ok: true });
+        },
+      },
+    };
+    mocks.getChannelPlugin.mockReturnValue(reactPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: reactPlugin,
+        },
+      ]),
+      "send-test-message-action-scopes",
+    );
+
+    await runMessageActionRequest(
+      {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "@legacy-target",
+          message: "hi",
+        },
+        idempotencyKey: "idem-message-action-scopes",
+      },
+      { connect: { scopes: ["operator.write"] } },
+    );
+
+    expect(capture.gatewayClientScopes).toEqual(["operator.write"]);
+  });
+
   it("forces senderIsOwner=false for narrowly-scoped callers but honors it for full operators", async () => {
     const capture = { senderIsOwner: undefined as boolean | undefined };
     const reactPlugin: ChannelPlugin = {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -351,6 +351,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           sessionKey: normalizeOptionalString(request.sessionKey) ?? undefined,
           sessionId: normalizeOptionalString(request.sessionId) ?? undefined,
           agentId: normalizeOptionalString(request.agentId) ?? undefined,
+          gatewayClientScopes: callerScopes,
           toolContext: request.toolContext,
           dryRun: false,
         });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `message.action` callers on the gateway only need `operator.write`, but the Telegram plugin action path dropped `gatewayClientScopes` before it reached the legacy target writeback guard.
- Why it matters: Telegram actions that resolve legacy `@channel` / `t.me/...` targets could still persist numeric chat ID rewrites into config/cron state even when the caller was not admin-scoped.
- What changed: `message.action` now forwards caller scopes into plugin action contexts, and the Telegram action adapter/runtime forwards those scopes into all target-resolving send/edit/delete/sticker/topic paths.
- What did NOT change (scope boundary): WhatsApp behavior is unchanged, and direct `send` / `poll` delivery paths were already carrying gateway scopes before this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the gateway `message.action` handler and `ChannelMessageActionContext` did not carry `gatewayClientScopes`, so Telegram plugin actions could not enforce the same admin-only writeback policy already used by outbound `send` / `poll` paths.
- Missing detection / guardrail: there was no regression test asserting scope propagation for `message.action`, and no Telegram action test checking that target-resolving action calls preserve gateway scopes.
- Contributing context (if known): the Telegram target writeback hardening was added around outbound send/poll delivery, but plugin-owned action dispatch remained on a separate context path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/send.test.ts`, `extensions/telegram/src/channel-actions.test.ts`, `extensions/telegram/src/action-runtime.test.ts`
- Scenario the test should lock in: a `message.action` request with only `operator.write` must propagate scopes into the Telegram action path, and Telegram target-resolving actions must forward those scopes to the writeback guard.
- Why this is the smallest reliable guardrail: the bug is a scope-propagation seam between gateway dispatch and the Telegram integration; these tests hit that seam directly without needing live Telegram I/O.
- Existing test that already covers this (if any): `send.test.ts` already covered scope propagation for outbound `send` / `poll`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Admin-scoped Telegram target writeback behavior is unchanged.
- Non-admin `message.action` callers can still execute Telegram actions, but they no longer trigger legacy target persistence side effects.

## Diagram (if applicable)

```text
Before:
[operator.write caller] -> [gateway message.action] -> [telegram action]
                                    -> [no scopes in ctx] -> [legacy target writeback allowed]

After:
[operator.write caller] -> [gateway message.action] -> [telegram action + scopes]
                                    -> [writeback guard sees no operator.admin] -> [no config/cron rewrite]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: this narrows config/cron write side effects for non-admin callers by preserving the existing `operator.admin` check through the Telegram plugin action path.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram enabled with a legacy `defaultTo` target such as `@channel` / `t.me/...`

### Steps

1. Call gateway `message.action` for channel `telegram` using a client scoped only to `operator.write`.
2. Use a target-resolving Telegram action such as `send` with a legacy `@channel` or `t.me/...` target.
3. Observe whether the action path forwards scopes into Telegram target writeback.

### Expected

- The action may run, but config/cron writeback is skipped unless the caller has `operator.admin`.

### Actual

- Before this change, `message.action` dropped scopes before the Telegram action path, so the writeback guard did not activate.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for gateway `message.action` scope forwarding, Telegram action adapter forwarding, and Telegram runtime send/poll propagation all pass.
- Edge cases checked: both `operator.write` and `operator.admin` scope propagation; no change to the already-covered outbound send/poll paths.
- What you did **not** verify: live Telegram API behavior; full repo-wide extension typecheck is still blocked in this checkout by unrelated missing modules (`@tencent-connect/qqbot-connector`, `tokenjuice/openclaw`).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: scope propagation could be missed on a Telegram action that resolves targets.
  - Mitigation: the runtime now threads `gatewayClientScopes` through all target-resolving Telegram action helpers touched by the message action surface, with regression tests at both the gateway and Telegram layers.
