### PR TITLE
fix(codex): rotate shared app-server clients on auth changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex harness: rotate the shared app-server websocket client when the configured bearer token changes, so auth-token refreshes reconnect with the new `Authorization` header instead of reusing a stale socket. (#70328) Thanks @Lucenx9.
 - Config/models: merge provider-scoped model allowlist updates and protect model/provider map writes from accidental full replacement, adding `config set --merge` for additive updates and `--replace` for intentional clobbers. Fixes #65920, #68392, and #68653.
 - Agents/Pi auth: preserve AWS SDK-authenticated Bedrock runs for IMDS and task-role setups, clear stale refresh timers on sentinel fallback, and log unexpected runtime-auth prep failures instead of silently leaving the provider unauthenticated. Thanks @wirjo.
 - Config/gateway: recover configs accidentally prefixed with non-JSON output during gateway startup or `openclaw doctor --fix`, preserving the clobbered file as a backup while leaving normal config reads read-only.

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
+  codexAppServerStartOptionsKey,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
 } from "./config.js";
@@ -73,6 +74,29 @@ describe("Codex app-server config", () => {
         approvalsReviewer: "user",
       }),
     );
+  });
+
+  it("derives distinct shared-client keys for distinct auth tokens without exposing them", () => {
+    const first = codexAppServerStartOptionsKey({
+      transport: "websocket",
+      command: "codex",
+      args: [],
+      url: "ws://127.0.0.1:39175",
+      authToken: "tok_first",
+      headers: {},
+    });
+    const second = codexAppServerStartOptionsKey({
+      transport: "websocket",
+      command: "codex",
+      args: [],
+      url: "ws://127.0.0.1:39175",
+      authToken: "tok_second",
+      headers: {},
+    });
+
+    expect(first).not.toEqual(second);
+    expect(first).not.toContain("tok_first");
+    expect(second).not.toContain("tok_second");
   });
 
   it("keeps runtime config keys aligned with manifest schema and UI hints", async () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 
 export type CodexAppServerTransportMode = "stdio" | "websocket";
@@ -156,7 +157,7 @@ export function codexAppServerStartOptionsKey(options: CodexAppServerStartOption
     command: options.command,
     args: options.args,
     url: options.url ?? null,
-    authToken: options.authToken ? "<set>" : null,
+    authToken: hashSecretForKey(options.authToken),
     headers: Object.entries(options.headers).toSorted(([left], [right]) =>
       left.localeCompare(right),
     ),
@@ -221,6 +222,13 @@ function readNonEmptyString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed || undefined;
+}
+
+function hashSecretForKey(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function splitShellWords(value: string): string[] {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -102,4 +102,46 @@ describe("shared Codex app-server client", () => {
       }),
     );
   });
+
+  it("restarts the shared client when the bridged auth token changes", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "websocket",
+        command: "codex",
+        args: [],
+        url: "ws://127.0.0.1:39175",
+        authToken: "tok-first",
+        headers: {},
+      },
+    });
+    await sendInitializeResult(first, "openclaw/0.118.0 (macOS; test)");
+    await sendEmptyModelList(first);
+    await expect(firstList).resolves.toEqual({ models: [] });
+
+    const secondList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "websocket",
+        command: "codex",
+        args: [],
+        url: "ws://127.0.0.1:39175",
+        authToken: "tok-second",
+        headers: {},
+      },
+    });
+    await sendInitializeResult(second, "openclaw/0.118.0 (macOS; test)");
+    await sendEmptyModelList(second);
+    await expect(secondList).resolves.toEqual({ models: [] });
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
 });

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { WebSocketServer, type RawData } from "ws";
 import { CodexAppServerClient, MIN_CODEX_APP_SERVER_VERSION } from "./client.js";
 import { createClientHarness } from "./test-support.js";
 
@@ -16,6 +17,7 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
 }));
 
 let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
+let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 
 async function sendInitializeResult(
@@ -36,7 +38,8 @@ async function sendEmptyModelList(harness: ReturnType<typeof createClientHarness
 describe("shared Codex app-server client", () => {
   beforeAll(async () => {
     ({ listCodexAppServerModels } = await import("./models.js"));
-    ({ resetSharedCodexAppServerClientForTests } = await import("./shared-client.js"));
+    ({ clearSharedCodexAppServerClient, resetSharedCodexAppServerClientForTests } =
+      await import("./shared-client.js"));
   });
 
   afterEach(() => {
@@ -187,4 +190,77 @@ describe("shared Codex app-server client", () => {
 
     expect(second.process.kill).not.toHaveBeenCalled();
   });
+
+  it("uses a fresh websocket Authorization header after shared-client token rotation", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    const authHeaders: Array<string | undefined> = [];
+    server.on("connection", (socket, request) => {
+      authHeaders.push(request.headers.authorization);
+      socket.on("message", (data) => {
+        const message = JSON.parse(rawDataToText(data)) as { id?: number; method?: string };
+        if (message.method === "initialize") {
+          socket.send(
+            JSON.stringify({ id: message.id, result: { userAgent: "openclaw/0.118.0" } }),
+          );
+          return;
+        }
+        if (message.method === "model/list") {
+          socket.send(JSON.stringify({ id: message.id, result: { data: [] } }));
+        }
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.once("listening", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected websocket test server port");
+      }
+      const url = `ws://127.0.0.1:${address.port}`;
+
+      await expect(
+        listCodexAppServerModels({
+          timeoutMs: 1000,
+          startOptions: {
+            transport: "websocket",
+            command: "codex",
+            args: [],
+            url,
+            authToken: "tok-first",
+            headers: {},
+          },
+        }),
+      ).resolves.toEqual({ models: [] });
+      await expect(
+        listCodexAppServerModels({
+          timeoutMs: 1000,
+          startOptions: {
+            transport: "websocket",
+            command: "codex",
+            args: [],
+            url,
+            authToken: "tok-second",
+            headers: {},
+          },
+        }),
+      ).resolves.toEqual({ models: [] });
+
+      expect(authHeaders).toEqual(["Bearer tok-first", "Bearer tok-second"]);
+    } finally {
+      clearSharedCodexAppServerClient();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
 });
+
+function rawDataToText(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(new Uint8Array(data)).toString("utf8");
+  }
+  return Buffer.from(data).toString("utf8");
+}

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -144,4 +144,47 @@ describe("shared Codex app-server client", () => {
     expect(startSpy).toHaveBeenCalledTimes(2);
     expect(first.process.kill).toHaveBeenCalledWith("SIGTERM");
   });
+
+  it("does not let a superseded shared-client failure tear down the newer client", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "websocket",
+        command: "codex",
+        args: [],
+        url: "ws://127.0.0.1:39175",
+        authToken: "tok-first",
+        headers: {},
+      },
+    });
+    const firstFailure = firstList.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(first.writes.length).toBeGreaterThanOrEqual(1));
+
+    const secondList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      startOptions: {
+        transport: "websocket",
+        command: "codex",
+        args: [],
+        url: "ws://127.0.0.1:39175",
+        authToken: "tok-second",
+        headers: {},
+      },
+    });
+    await vi.waitFor(() => expect(second.writes.length).toBeGreaterThanOrEqual(1));
+
+    await expect(firstFailure).resolves.toBeInstanceOf(Error);
+
+    await sendInitializeResult(second, "openclaw/0.118.0 (macOS; test)");
+    await sendEmptyModelList(second);
+    await expect(secondList).resolves.toEqual({ models: [] });
+
+    expect(second.process.kill).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -40,28 +40,32 @@ export async function getSharedCodexAppServerClient(options?: {
     clearSharedCodexAppServerClient();
   }
   state.key = key;
-  state.promise ??= (async () => {
-    const client = CodexAppServerClient.start(startOptions);
-    state.client = client;
-    client.addCloseHandler(clearSharedClientIfCurrent);
-    try {
-      await client.initialize();
+  const sharedPromise =
+    state.promise ??
+    (state.promise = (async () => {
+      const client = CodexAppServerClient.start(startOptions);
+      state.client = client;
+      client.addCloseHandler(clearSharedClientIfCurrent);
+      try {
+        await client.initialize();
       return client;
     } catch (error) {
       // Startup failures happen before callers own the shared client, so close
       // the child here instead of leaving a rejected daemon attached to stdio.
-      client.close();
-      throw error;
-    }
-  })();
+        client.close();
+        throw error;
+      }
+    })());
   try {
     return await withTimeout(
-      state.promise,
+      sharedPromise,
       options?.timeoutMs ?? 0,
       "codex app-server initialize timed out",
     );
   } catch (error) {
-    clearSharedCodexAppServerClient();
+    if (state.promise === sharedPromise && state.key === key) {
+      clearSharedCodexAppServerClient();
+    }
     throw error;
   }
 }

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -48,10 +48,10 @@ export async function getSharedCodexAppServerClient(options?: {
       client.addCloseHandler(clearSharedClientIfCurrent);
       try {
         await client.initialize();
-      return client;
-    } catch (error) {
-      // Startup failures happen before callers own the shared client, so close
-      // the child here instead of leaving a rejected daemon attached to stdio.
+        return client;
+      } catch (error) {
+        // Startup failures happen before callers own the shared client, so close
+        // the child here instead of leaving a rejected daemon attached to stdio.
         client.close();
         throw error;
       }


### PR DESCRIPTION
## Summary

- Problem: the shared Codex app-server client key treated any non-empty `authToken` as the same value, so websocket sessions were reused across bearer-token rotations.
- Why it matters: the websocket `Authorization: Bearer ...` header is fixed when the socket is created, so a rotated or revoked token would not take effect until the shared client was torn down for some other reason.
- What changed: the shared-client key now includes a SHA-256 digest of `authToken`, and regression tests now lock in both distinct keying and shared-client restart on token changes.
- What did NOT change (scope boundary): this does not change approval policy, sandbox defaults, request routing, or websocket header construction itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `codexAppServerStartOptionsKey()` collapsed any configured `authToken` to `"<set>"`, so the shared-client cache key could not distinguish token A from token B.
- Missing detection / guardrail: there was no regression test asserting that auth-token rotation must invalidate the shared websocket client.
- Contributing context (if known): the websocket transport applies the bearer token only during socket creation, which made shared-client reuse especially sticky across rotations.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/config.test.ts`, `extensions/codex/src/app-server/shared-client.test.ts`
- Scenario the test should lock in: changing the bridged `authToken` produces a different shared-client key and forces a fresh shared app-server client.
- Why this is the smallest reliable guardrail: the bug lives in cache key derivation and shared-client lifecycle, so direct config/shared-client tests catch it without involving a live Codex server.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Rotating `plugins.entries.codex.config.appServer.authToken` now forces the shared websocket client to reconnect with the new bearer token instead of silently reusing the old connection.

## Diagram (if applicable)

```text
Before:
[token A configured] -> [shared client key = "<set>"] -> [socket reused after token B]

After:
[token A configured] -> [shared client key = sha256(token A)]
[token B configured] -> [shared client key = sha256(token B)] -> [fresh socket with new bearer]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - The shared-client cache key now uses a SHA-256 digest of `authToken` instead of a generic placeholder. This avoids leaking the raw token in the key while still invalidating cached websocket clients on token rotation.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (local dev container/host)
- Runtime/container: Node.js + pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): Codex app-server websocket/shared client
- Relevant config (redacted): `plugins.entries.codex.config.appServer.{transport:"websocket",url:"ws://127.0.0.1:39175",authToken:"<redacted>"}`

### Steps

1. Start a shared Codex app-server websocket client with `authToken=A`.
2. Request models again with the same websocket start options except `authToken=B`.
3. Observe whether the shared client is reused or restarted.

### Expected

- The second request tears down the old shared client and creates a new one keyed to token B.

### Actual

- Before this fix, both requests used the same shared-client key (`"<set>"`) and reused the original websocket.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: distinct `authToken` values now produce distinct start-option keys; shared model-list client restarts when the bridged token changes.
- Edge cases checked: raw bearer tokens are not embedded in the serialized shared-client key.
- What you did **not** verify: I did not run a live remote Codex websocket server; verification stayed at config/shared-client seam tests.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: token digesting changes the shared-client cache invalidation behavior and could restart websocket clients more often when auth config changes.
  - Mitigation: restart only happens when the effective bearer token actually changes, and tests lock in the intended lifecycle.
