### PR TITLE
fix: load logging config in flattened builds

### DIFF
--- a/src/logging/config-loader.test.ts
+++ b/src/logging/config-loader.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LoggingConfig } from "../config/types.base.js";
+
+function buildConfigModule(logging: unknown) {
+  return {
+    loadConfig: () => ({ logging }) as { logging?: LoggingConfig },
+    readBestEffortConfig: () => ({ logging }) as { logging?: LoggingConfig },
+  };
+}
+
+describe("readBestEffortLoggingConfig", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("./node-require.js");
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:url");
+  });
+
+  it("loads config from the source-tree path when available", async () => {
+    const requireConfigMock = vi.fn((id: string) => {
+      if (id === "../config/config.js") {
+        return buildConfigModule({ level: "debug" });
+      }
+      throw new Error(`unexpected module id: ${id}`);
+    });
+
+    const { readBestEffortLoggingConfig } = await import("./config-loader.js");
+
+    expect(readBestEffortLoggingConfig(requireConfigMock)).toEqual({ level: "debug" });
+    expect(requireConfigMock).toHaveBeenCalledWith("../config/config.js");
+  });
+
+  it("falls back to the flattened build path when source-layout config is absent", async () => {
+    const requireConfigMock = vi.fn((id: string) => {
+      if (id === "../config/config.js") {
+        throw new Error("module not found");
+      }
+      if (id === "./config.js") {
+        return buildConfigModule({ consoleStyle: "json" });
+      }
+      throw new Error(`unexpected module id: ${id}`);
+    });
+
+    const { readBestEffortLoggingConfig } = await import("./config-loader.js");
+
+    expect(readBestEffortLoggingConfig(requireConfigMock)).toEqual({ consoleStyle: "json" });
+    expect(requireConfigMock).toHaveBeenCalledWith("../config/config.js");
+    expect(requireConfigMock).toHaveBeenCalledWith("./config.js");
+  });
+
+  it("falls back to a hashed flattened config chunk when config.js is not the config module", async () => {
+    const requireConfigMock = vi.fn((id: string) => {
+      if (id === "../config/config.js") {
+        throw new Error("module not found");
+      }
+      if (id === "./config.js") {
+        return {
+          loadConfig: () => ({ logging: { level: "error" } }) as { logging?: LoggingConfig },
+        };
+      }
+      if (id === "./config-Ck9ngs9g.js") {
+        return buildConfigModule({ consoleStyle: "json" });
+      }
+      throw new Error(`unexpected module id: ${id}`);
+    });
+    const readdirSyncMock = vi.fn(() => [
+      { name: "config-Ck9ngs9g.js", isFile: () => true },
+      { name: "config-loader-Dqw-HP5B.js", isFile: () => true },
+      { name: "nested", isFile: () => false },
+    ]);
+    vi.doMock("./node-require.js", () => ({
+      resolveNodeRequireFromMeta: () => requireConfigMock,
+    }));
+    vi.doMock("node:fs", () => ({
+      default: {
+        readdirSync: readdirSyncMock,
+      },
+    }));
+    vi.doMock("node:url", async () => {
+      const actual = await vi.importActual<typeof import("node:url")>("node:url");
+      return {
+        ...actual,
+        fileURLToPath: () => "/tmp/dist/config-loader.js",
+      };
+    });
+
+    const { readBestEffortLoggingConfig } = await import("./config-loader.js");
+
+    expect(readBestEffortLoggingConfig()).toEqual({ consoleStyle: "json" });
+    expect(readdirSyncMock).toHaveBeenCalledWith("/tmp/dist", { withFileTypes: true });
+    expect(requireConfigMock).toHaveBeenCalledWith("../config/config.js");
+    expect(requireConfigMock).toHaveBeenCalledWith("./config.js");
+    expect(requireConfigMock).toHaveBeenCalledWith("./config-Ck9ngs9g.js");
+    expect(requireConfigMock).not.toHaveBeenCalledWith("./config-loader-Dqw-HP5B.js");
+  });
+
+  it("ignores candidates that do not export loadConfig", async () => {
+    const requireConfigMock = vi.fn(() => ({}));
+    vi.doMock("node:fs", () => ({
+      default: {
+        readdirSync: () => [],
+      },
+    }));
+
+    const { readBestEffortLoggingConfig } = await import("./config-loader.js");
+
+    expect(readBestEffortLoggingConfig(requireConfigMock)).toBeUndefined();
+    expect(requireConfigMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined when the logging section is not an object", async () => {
+    const requireConfigMock = vi.fn(() => buildConfigModule("debug"));
+
+    const { readBestEffortLoggingConfig } = await import("./config-loader.js");
+
+    expect(readBestEffortLoggingConfig(requireConfigMock)).toBeUndefined();
+  });
+});

--- a/src/logging/config-loader.ts
+++ b/src/logging/config-loader.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { LoggingConfig } from "../config/types.base.js";
+import { resolveNodeRequireFromMeta } from "./node-require.js";
+
+type ConfigModule = {
+  loadConfig?: () => {
+    logging?: unknown;
+  };
+  readBestEffortConfig?: () => unknown;
+};
+type ConfigModuleResolver = (id: string) => unknown;
+
+const defaultResolveModule = resolveNodeRequireFromMeta(import.meta.url);
+const MODULE_DIR_PATH = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_TREE_CONFIG_MODULE_SPECIFIER = "../config/config.js";
+// Some flattened builds keep a stable config.js alias beside config-loader.js.
+// When that alias is absent or points at the wrong chunk, fall back to hashed
+// sibling discovery below.
+const FLATTENED_DIST_CONFIG_MODULE_SPECIFIER = "./config.js";
+const KNOWN_CONFIG_MODULE_SPECIFIERS = [
+  SOURCE_TREE_CONFIG_MODULE_SPECIFIER,
+  FLATTENED_DIST_CONFIG_MODULE_SPECIFIER,
+] as const;
+const HASHED_FLATTENED_CONFIG_MODULE_BASENAME_RE = /^config-[A-Za-z0-9_-]+\.js$/u;
+let cachedDefaultConfigModule: ConfigModule | null | undefined;
+
+function isConfigModule(value: unknown): value is ConfigModule {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as ConfigModule).loadConfig === "function" &&
+    typeof (value as ConfigModule).readBestEffortConfig === "function"
+  );
+}
+
+function isLoggingConfig(value: unknown): value is LoggingConfig {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCandidateConfigChunk(fileName: string): boolean {
+  return (
+    HASHED_FLATTENED_CONFIG_MODULE_BASENAME_RE.test(fileName) &&
+    !fileName.startsWith("config-loader-")
+  );
+}
+
+function listFlattenedConfigModuleSpecifiers(): string[] {
+  try {
+    return fs
+      .readdirSync(MODULE_DIR_PATH, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && isCandidateConfigChunk(entry.name))
+      .map((entry) => `./${entry.name}`)
+      .toSorted((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+function resolveConfigModule(
+  resolveModule: ConfigModuleResolver | null = defaultResolveModule,
+): ConfigModule | undefined {
+  const canUseCache = resolveModule === defaultResolveModule;
+  if (canUseCache && cachedDefaultConfigModule !== undefined) {
+    return cachedDefaultConfigModule ?? undefined;
+  }
+  if (!resolveModule) {
+    if (canUseCache) {
+      cachedDefaultConfigModule = null;
+    }
+    return undefined;
+  }
+  for (const specifier of [
+    ...KNOWN_CONFIG_MODULE_SPECIFIERS,
+    ...listFlattenedConfigModuleSpecifiers(),
+  ]) {
+    try {
+      const loaded = resolveModule(specifier) as ConfigModule | undefined;
+      if (isConfigModule(loaded)) {
+        if (canUseCache) {
+          cachedDefaultConfigModule = loaded;
+        }
+        return loaded;
+      }
+    } catch {
+      // Try the next known package layout.
+    }
+  }
+  if (canUseCache) {
+    cachedDefaultConfigModule = null;
+  }
+  return undefined;
+}
+
+export function readBestEffortLoggingConfig(
+  resolveModule?: ConfigModuleResolver | null,
+): LoggingConfig | undefined {
+  try {
+    const logging = resolveConfigModule(resolveModule)?.loadConfig?.().logging;
+    return isLoggingConfig(logging) ? logging : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -1,31 +1,33 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const readBestEffortLoggingConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./config-loader.js", () => ({
+  readBestEffortLoggingConfig: readBestEffortLoggingConfigMock,
+}));
+
 import { readLoggingConfig } from "./config.js";
-
-const loadConfigMock = vi.hoisted(() => vi.fn());
-
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  return {
-    ...actual,
-    loadConfig: () => loadConfigMock(),
-  };
-});
 
 const originalArgv = process.argv;
 
 describe("readLoggingConfig", () => {
   afterEach(() => {
     process.argv = originalArgv;
-    loadConfigMock.mockReset();
+    readBestEffortLoggingConfigMock.mockReset();
   });
 
   it("skips mutating config loads for config schema", async () => {
     process.argv = ["node", "openclaw", "config", "schema"];
-    loadConfigMock.mockImplementation(() => {
-      throw new Error("loadConfig should not be called");
-    });
 
     expect(readLoggingConfig()).toBeUndefined();
-    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(readBestEffortLoggingConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the best-effort loader for regular commands", async () => {
+    process.argv = ["node", "openclaw", "gateway", "run"];
+    readBestEffortLoggingConfigMock.mockReturnValue({ level: "debug" });
+
+    expect(readLoggingConfig()).toEqual({ level: "debug" });
+    expect(readBestEffortLoggingConfigMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,10 +1,6 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
-
-type LoggingConfig = OpenClawConfig["logging"];
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
+import type { LoggingConfig } from "../config/types.base.js";
+import { readBestEffortLoggingConfig } from "./config-loader.js";
 
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
@@ -12,22 +8,5 @@ export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.arg
 }
 
 export function readLoggingConfig(): LoggingConfig | undefined {
-  if (shouldSkipMutatingLoggingConfigRead()) {
-    return undefined;
-  }
-  try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    const parsed = loaded?.loadConfig?.();
-    const logging = parsed?.logging;
-    if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
-      return undefined;
-    }
-    return logging as LoggingConfig;
-  } catch {
-    return undefined;
-  }
+  return shouldSkipMutatingLoggingConfigRead() ? undefined : readBestEffortLoggingConfig();
 }

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -1,12 +1,12 @@
 import util from "node:util";
-import type { OpenClawConfig } from "../config/types.js";
+import type { LoggingConfig } from "../config/types.base.js";
 import { isVerbose } from "../global-state.js";
 import { stripAnsi } from "../terminal/ansi.js";
+import { readBestEffortLoggingConfig } from "./config-loader.js";
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger } from "./logger.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatLocalIsoWithOffset, formatTimestamp } from "./timestamps.js";
 import type { ConsoleStyle, LoggerSettings } from "./types.js";
@@ -17,21 +17,8 @@ type ConsoleSettings = {
   style: ConsoleStyle;
 };
 export type ConsoleLoggerSettings = ConsoleSettings;
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
-type ConsoleConfigLoader = () => OpenClawConfig["logging"] | undefined;
-const loadConfigFallbackDefault: ConsoleConfigLoader = () => {
-  try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    return loaded?.loadConfig?.().logging;
-  } catch {
-    return undefined;
-  }
-};
+type ConsoleConfigLoader = () => LoggingConfig | undefined;
+const loadConfigFallbackDefault: ConsoleConfigLoader = () => readBestEffortLoggingConfig();
 let loadConfigFallback: ConsoleConfigLoader = loadConfigFallbackDefault;
 
 export function setConsoleConfigLoaderForTests(loader?: ConsoleConfigLoader): void {
@@ -72,7 +59,7 @@ function resolveConsoleSettings(): ConsoleSettings {
     return { level: "silent", style: normalizeConsoleStyle(undefined) };
   }
 
-  let cfg: OpenClawConfig["logging"] | undefined =
+  let cfg: LoggingConfig | undefined =
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
     if (loggingState.resolvingConsoleSettings) {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,15 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
-import type { OpenClawConfig } from "../config/types.js";
+import type { LoggingConfig } from "../config/types.base.js";
 import {
   POSIX_OPENCLAW_TMP_DIR,
   resolvePreferredOpenClawTmpDir,
 } from "../infra/tmp-openclaw-dir.js";
+import { readBestEffortLoggingConfig } from "./config-loader.js";
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
 import type { LoggerSettings } from "./types.js";
@@ -48,8 +48,6 @@ const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 500 * 1024 * 1024; // 500 MB
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 type LogObj = { date?: Date } & Record<string, unknown>;
 
@@ -106,19 +104,10 @@ function resolveSettings(): ResolvedSettings {
     };
   }
 
-  let cfg: OpenClawConfig["logging"] | undefined =
+  let cfg: LoggingConfig | undefined =
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
-    try {
-      const loaded = requireConfig?.("../config/config.js") as
-        | {
-            loadConfig?: () => OpenClawConfig;
-          }
-        | undefined;
-      cfg = loaded?.loadConfig?.().logging;
-    } catch {
-      cfg = undefined;
-    }
+    cfg = readBestEffortLoggingConfig();
   }
   const defaultLevel =
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,9 +1,6 @@
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compileConfigRegex } from "../security/config-regex.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
+import { readBestEffortLoggingConfig } from "./config-loader.js";
 import { replacePatternBounded } from "./redact-bounded.js";
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type RedactSensitiveMode = "off" | "tools";
 type RedactPattern = string | RegExp;
@@ -117,17 +114,7 @@ function redactText(text: string, patterns: RegExp[]): string {
 }
 
 function resolveConfigRedaction(): RedactOptions {
-  let cfg: OpenClawConfig["logging"] | undefined;
-  try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    cfg = loaded?.loadConfig?.().logging;
-  } catch {
-    cfg = undefined;
-  }
+  const cfg = readBestEffortLoggingConfig();
   return {
     mode: normalizeMode(cfg?.redactSensitive),
     patterns: cfg?.redactPatterns,


### PR DESCRIPTION
## Summary

- Problem: logging config fallback only had stable relative imports, so flattened builds could miss the real config module when `dist/` contained hashed `config-*.js` chunks instead of a usable `config.js`.
- Why it matters: when that lookup misses, user `logging` settings are ignored and logging falls back to defaults (issue originally introduced with https://github.com/openclaw/openclaw/commit/1086acf3c24ee5d83481ac121b554a9dc33fdebf)
- What changed: added a shared logging config loader that keeps the source-tree path, tries the flattened `./config.js` path when present, and then scans sibling hashed `config-*.js` chunks until it finds the real config module surface.
- What did NOT change (scope boundary): no config schema changes, no published root alias changes, no CLI behavior changes, and no logging default changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the lazy logging config path assumed a stable flattened module name, but flattened builds can emit multiple hashed `config-*.js` root chunks and only one of them is the actual config module.
- Missing detection / guardrail: there was no regression coverage for the case where `./config.js` is absent or points somewhere other than the real config module.
- Contributing context (if known): several logging entry points had duplicated best-effort config loading behavior, which made the bad assumption easy to repeat.
- https://github.com/openclaw/openclaw/commit/1086acf3c24ee5d83481ac121b554a9dc33fdebf - caused logging settings no longer being read from config

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: [x] Unit test
- Coverage level that should have caught this: [x] Seam / integration test
- Coverage level that should have caught this: [ ] End-to-end test
- Coverage level that should have caught this: [ ] Existing coverage already sufficient
- Target test or file: `src/logging/config-loader.test.ts`
- Scenario the test should lock in: source-tree lookup still works, flattened `./config.js` still works when valid, and hashed sibling `config-*.js` fallback wins when `./config.js` is not the real config module.
- Why this is the smallest reliable guardrail: the failure happens at the lazy module-resolution seam, so mocking the loader boundary catches the regression without needing a publish/install cycle.
- Existing test that already covers this (if any): `src/logging/config.test.ts` covers the `config schema` / `config validate` skip path, and `test/scripts/runtime-postbuild.test.ts` now asserts that root alias coverage does not create `config.js`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Logging config works again in flattened builds.
- User-configured logging settings such as `level`, `consoleLevel`, `consoleStyle`, `redactSensitive`, and `redactPatterns` are applied instead of silently falling back to defaults.
- No migration required.

## Diagram (if applicable)

```text
Before:
[logging code] -> try "../config/config.js" or "./config.js" -> miss real config chunk -> logging config undefined -> defaults used

After:
[logging code] -> try "../config/config.js" -> try "./config.js" -> scan sibling "config-*.js" chunks -> find real config module -> configured logging applied
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): any config with a `logging` block

### Steps

1. Build OpenClaw so logging code is emitted into flattened `dist/` output.
2. Run a code path that resolves logging settings from config.
3. Use a non-default logging setting such as `logging.consoleStyle = "json"`.

### Expected

- Logging resolves the real config module and applies the configured logging settings.

### Actual

- Before this fix, flattened output could contain multiple hashed `config-*.js` chunks, and the logging fallback could miss the real config module and use defaults instead.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test -- src/logging/config-loader.test.ts src/logging/config.test.ts src/logging/logger-settings.test.ts src/logging/console-settings.test.ts test/scripts/runtime-postbuild.test.ts`
- Edge cases checked: source-tree config load, flattened `./config.js` load, wrong `./config.js` with correct hashed `config-*.js` sibling, invalid candidate modules, invalid logging shape, and `config schema` skip behavior
- What you did **not** verify: full `pnpm build` wrapper did not return cleanly in this sandbox, but `node scripts/tsdown-build.mjs` passed and emitted `dist/config-loader-*.js` with the hashed-chunk fallback logic

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the hashed fallback could pick the wrong sibling chunk if another `config-*.js` file exported the same config surface.
- Mitigation: the loader only accepts modules that expose the expected config API surface, prefers stable paths first, and has regression coverage for the ambiguous flattened-build case.