### PR TITLE
fix(codex): fail closed on unscoped turn events

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -234,6 +234,25 @@ describe("Codex app-server approval bridge", () => {
     expect(description).toContain("High-risk targets:");
   });
 
+  it("ignores approval requests that are missing explicit thread or turn ids", async () => {
+    const params = createParams();
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        itemId: "cmd-2",
+        command: "pnpm test",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(params.onAgentEvent).not.toHaveBeenCalled();
+  });
+
   it("maps app-server approval response families separately", () => {
     expect(
       buildApprovalResponse(

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -176,18 +176,12 @@ function matchesCurrentTurn(
   turnId: string,
 ): boolean {
   if (!requestParams) {
-    return true;
+    return false;
   }
   const requestThreadId =
     readString(requestParams, "threadId") ?? readString(requestParams, "conversationId");
   const requestTurnId = readString(requestParams, "turnId");
-  if (requestThreadId && requestThreadId !== threadId) {
-    return false;
-  }
-  if (requestTurnId && requestTurnId !== turnId) {
-    return false;
-  }
-  return true;
+  return requestThreadId === threadId && requestTurnId === turnId;
 }
 
 function buildApprovalContext(params: {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -292,6 +292,25 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual([]);
   });
 
+  it("ignores notifications that omit top-level thread and turn ids", async () => {
+    const projector = createProjector();
+
+    await projector.handleNotification({
+      method: "turn/completed",
+      params: {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-1", text: "wrong turn" }],
+        },
+      },
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+  });
+
   it("preserves sessions_yield detection in attempt results", () => {
     const projector = new CodexAppServerEventProjector(
       {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -293,7 +293,7 @@ describe("CodexAppServerEventProjector", () => {
   });
 
   it("ignores notifications that omit top-level thread and turn ids", async () => {
-    const projector = createProjector();
+    const projector = await createProjector();
 
     await projector.handleNotification({
       method: "turn/completed",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -577,7 +577,7 @@ export class CodexAppServerEventProjector {
   private isNotificationForTurn(params: JsonObject): boolean {
     const threadId = readString(params, "threadId");
     const turnId = readString(params, "turnId");
-    return (!threadId || threadId === this.threadId) && (!turnId || turnId === this.turnId);
+    return threadId === this.threadId && turnId === this.turnId;
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -117,9 +117,6 @@ function createAppServerHarness(
         },
       });
     },
-    async notify(notification: CodexServerNotification) {
-      await notify(notification);
-    },
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -104,6 +104,9 @@ function createAppServerHarness(
         interval: 1,
       });
     },
+    async notify(notification: CodexServerNotification) {
+      await notify(notification);
+    },
     async completeTurn(params: { threadId: string; turnId: string }) {
       await notify({
         method: "turn/completed",
@@ -616,6 +619,50 @@ describe("runCodexAppServerAttempt", () => {
         createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
       ),
     ).resolves.toMatchObject({
+      aborted: false,
+      timedOut: false,
+    });
+  });
+
+  it("does not complete on unscoped turn/completed notifications", async () => {
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+    );
+    let resolved = false;
+    void run.then(() => {
+      resolved = true;
+    });
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-wrong", text: "wrong completion" }],
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(resolved).toBe(false);
+
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-right", text: "final completion" }],
+        },
+      },
+    });
+
+    await expect(run).resolves.toMatchObject({
+      assistantTexts: ["final completion"],
       aborted: false,
       timedOut: false,
     });

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -175,7 +175,8 @@ export async function runCodexAppServerAttempt(
     // inside projector.handleNotification still releases the session lane.
     // See openclaw/openclaw#67996.
     const isTurnCompletion =
-      notification.method === "turn/completed" && isTurnNotification(notification.params, turnId);
+      notification.method === "turn/completed" &&
+      isTurnNotification(notification.params, thread.threadId, turnId);
     try {
       await projector.handleNotification(notification);
     } catch (error) {
@@ -562,16 +563,15 @@ function readDynamicToolCallParams(
   };
 }
 
-function isTurnNotification(value: JsonValue | undefined, turnId: string): boolean {
+function isTurnNotification(
+  value: JsonValue | undefined,
+  threadId: string,
+  turnId: string,
+): boolean {
   if (!isJsonObject(value)) {
     return false;
   }
-  const directTurnId = readString(value, "turnId");
-  if (directTurnId === turnId) {
-    return true;
-  }
-  const turn = isJsonObject(value.turn) ? value.turn : undefined;
-  return readString(turn ?? {}, "id") === turnId;
+  return readString(value, "threadId") === threadId && readString(value, "turnId") === turnId;
 }
 
 function readString(record: JsonObject, key: string): string | undefined {


### PR DESCRIPTION
## Summary

- Problem: the Codex app-server bridge treated approval requests and notifications without top-level `threadId` / `turnId` as implicitly belonging to the active run.
- Why it matters: a missing-scope event could be misattributed to the current turn instead of being ignored, which weakens turn isolation and can route the wrong approval/completion signal into chat state.
- What changed: `approval-bridge` and `event-projector` now require exact top-level `threadId` + `turnId` matches before handling these events, and regression tests lock in the fail-closed behavior.
- What did NOT change (scope boundary): no protocol expansion, no new approval surface, and no changes to model/provider selection or tool behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex bridge helpers used fail-open matching for top-level `threadId` / `turnId`, so missing IDs were treated as a match for the current run.
- Missing detection / guardrail: there was no regression test asserting that unscoped approval requests or notifications must be ignored.
- Contributing context (if known): the current turn still had nested IDs in some payloads, which made the fail-open behavior easy to miss during normal happy-path tests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/approval-bridge.test.ts`, `extensions/codex/src/app-server/event-projector.test.ts`
- Scenario the test should lock in: approval requests and raw notifications missing top-level turn scoping are ignored instead of being attributed to the active turn.
- Why this is the smallest reliable guardrail: the bug is local to the Codex bridge/projector matching helpers, so focused unit coverage catches it without needing a full app-server harness.
- Existing test that already covers this (if any): existing tests already covered mismatched IDs, but not omitted IDs.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Codex now ignores app-server approval requests and notifications that do not carry explicit top-level `threadId` and `turnId` for the active run.

## Diagram (if applicable)

```text
Before:
[unscoped Codex approval/notification] -> [fail-open match] -> [active turn handles it]

After:
[unscoped Codex approval/notification] -> [exact top-level ID check fails] -> [event ignored]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm repo checkout
- Model/provider: Codex app-server bridge tests
- Integration/channel (if any): Codex app-server
- Relevant config (redacted): default local test config

### Steps

1. Send an app-server approval request without top-level `threadId` / `turnId` into `handleCodexAppServerApprovalRequest`.
2. Send a `turn/completed` notification without top-level `threadId` / `turnId` into `CodexAppServerEventProjector`.
3. Observe whether the current run consumes those events.

### Expected

- Unscoped requests/notifications are ignored and do not affect the active turn.

### Actual

- Before this patch, missing IDs were treated as a match and the active turn could consume them.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for ignored unscoped approval requests and ignored unscoped `turn/completed` notifications; existing `run-attempt` tests still pass.
- Edge cases checked: mismatched IDs still ignore events; exact current-turn IDs still pass existing tests.
- What you did **not** verify: live Codex app-server traffic against a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a future Codex app-server event type could legitimately omit top-level IDs and now be ignored.
  - Mitigation: the strict check is limited to the current approval bridge and event projector paths, and the new tests make that contract explicit so any protocol expansion can update the matcher intentionally.
