### PR TITLE
fix(slack): treat Slack Connect finalize errors as benign in stopSlackStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
   `tools.deny: ["bundle-mcp"]` opt-out behavior. Fixes #68875 and #68818.
 - Plugins/startup: tolerate transient bundled-channel catalog/metadata drift while auto-enabling configured plugins, so CLI and gateway startup no longer crash when a channel id is known but its display metadata is unavailable.
 - CLI/Claude: report CLI-backed reply runs as streaming while Claude/Codex CLI turns are still in flight, so WebChat keeps visible response state until the backend finishes. Fixes #70125.
+- Slack/streaming: fall back to normal Slack replies for Slack Connect streams rejected before the SDK flushes its local buffer, so short replies no longer disappear or report success before Slack acknowledges delivery. Fixes #70295. (#70370) Thanks @mvanhorn.
 - Codex harness: rotate the shared app-server websocket client when the configured bearer token changes, so auth-token refreshes reconnect with the new `Authorization` header instead of reusing a stale socket. (#70328) Thanks @Lucenx9.
 - Channels/sandbox: derive runtime policy keys for external direct messages that share the main conversation, so sandbox/tool policy no longer treats channel-originated DMs as local main-session runs.
 - Config/models: merge provider-scoped model allowlist updates and protect model/provider map writes from accidental full replacement, adding `config set --merge` for additive updates and `--replace` for intentional clobbers. Fixes #65920, #68392, and #68653.

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -7,6 +7,27 @@ const SAME_TEXT = "same reply";
 const createSlackDraftStreamMock = vi.fn();
 const deliverRepliesMock = vi.fn(async () => {});
 const finalizeSlackPreviewEditMock = vi.fn(async () => {});
+const postMessageMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
+const appendSlackStreamMock = vi.fn(async () => {});
+const startSlackStreamMock = vi.fn(async () => ({
+  channel: "C123",
+  threadTs: THREAD_TS,
+  stopped: false,
+  delivered: true,
+  pendingText: "",
+}));
+const stopSlackStreamMock = vi.fn(async () => {});
+class TestSlackStreamNotDeliveredError extends Error {
+  readonly pendingText: string;
+  readonly slackCode: string;
+  constructor(pendingText: string, slackCode: string) {
+    super(`slack-stream not delivered: ${slackCode}`);
+    this.name = "SlackStreamNotDeliveredError";
+    this.pendingText = pendingText;
+    this.slackCode = slackCode;
+  }
+}
+let mockedNativeStreaming = false;
 let mockedDispatchSequence: Array<{
   kind: "tool" | "block" | "final";
   payload: { text: string; isError?: boolean; mediaUrl?: string; mediaUrls?: string[] };
@@ -35,7 +56,7 @@ function createPreparedSlackMessage() {
       cfg: {},
       runtime: {},
       botToken: "xoxb-test",
-      app: { client: {} },
+      app: { client: { chat: { postMessage: postMessageMock } } },
       teamId: "T1",
       textLimit: 4000,
       typingReaction: "",
@@ -109,7 +130,7 @@ vi.mock("openclaw/plugin-sdk/channel-reply-pipeline", () => ({
 
 vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
   resolveChannelStreamingBlockEnabled: () => false,
-  resolveChannelStreamingNativeTransport: () => false,
+  resolveChannelStreamingNativeTransport: () => mockedNativeStreaming,
   resolveChannelStreamingPreviewToolProgress: () => true,
 }));
 
@@ -183,18 +204,28 @@ vi.mock("../../stream-mode.js", () => ({
   buildStatusFinalPreviewText: () => "status",
   resolveSlackStreamingConfig: () => ({
     mode: "partial",
-    nativeStreaming: false,
+    nativeStreaming: mockedNativeStreaming,
     draftMode: "append",
   }),
 }));
 
 vi.mock("../../streaming.js", () => ({
-  appendSlackStream: async () => {},
-  startSlackStream: async () => ({
-    threadTs: THREAD_TS,
-    stopped: false,
-  }),
-  stopSlackStream: async () => {},
+  appendSlackStream: appendSlackStreamMock,
+  markSlackStreamFallbackDelivered: (session: {
+    delivered: boolean;
+    pendingText: string;
+    stopped: boolean;
+  }) => {
+    const hadNativeDelivery = session.delivered;
+    session.delivered = true;
+    session.pendingText = "";
+    if (!hadNativeDelivery) {
+      session.stopped = true;
+    }
+  },
+  SlackStreamNotDeliveredError: TestSlackStreamNotDeliveredError,
+  startSlackStream: startSlackStreamMock,
+  stopSlackStream: stopSlackStreamMock,
 }));
 
 vi.mock("../../threading.js", () => ({
@@ -269,10 +300,24 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     createSlackDraftStreamMock.mockReset();
     deliverRepliesMock.mockReset();
     finalizeSlackPreviewEditMock.mockReset();
+    postMessageMock.mockClear();
+    appendSlackStreamMock.mockReset();
+    startSlackStreamMock.mockReset();
+    stopSlackStreamMock.mockReset();
+    mockedNativeStreaming = false;
     mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
 
     createSlackDraftStreamMock.mockReturnValue(createDraftStreamStub());
     finalizeSlackPreviewEditMock.mockRejectedValue(new Error("socket closed"));
+    startSlackStreamMock.mockResolvedValue({
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    });
+    appendSlackStreamMock.mockResolvedValue(undefined);
+    stopSlackStreamMock.mockResolvedValue(undefined);
   });
 
   it("falls back to normal delivery when preview finalize fails", async () => {
@@ -362,5 +407,62 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
     expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("posts pending native stream text when finalize fails before the SDK buffer flushes", async () => {
+    mockedNativeStreaming = true;
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: FINAL_REPLY_TEXT,
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, "user_not_found"),
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledTimes(1);
+    expect(postMessageMock).toHaveBeenCalledWith({
+      channel: "C123",
+      thread_ts: THREAD_TS,
+      text: FINAL_REPLY_TEXT,
+    });
+    expect(session.stopped).toBe(true);
+  });
+
+  it("posts all pending native stream text when an append flush fails", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "first buffered" } },
+      { kind: "final", payload: { text: "second flushes" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "first buffered",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText += "\nsecond flushes";
+      throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledTimes(1);
+    expect(postMessageMock).toHaveBeenCalledWith({
+      channel: "C123",
+      thread_ts: THREAD_TS,
+      text: "first buffered\nsecond flushes",
+    });
+    expect(stopSlackStreamMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -37,7 +37,12 @@ import {
   resolveSlackStreamingConfig,
 } from "../../stream-mode.js";
 import type { SlackStreamSession } from "../../streaming.js";
-import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
+import {
+  appendSlackStream,
+  SlackStreamNotDeliveredError,
+  startSlackStream,
+  stopSlackStream,
+} from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { resolveStorePath, updateLastRoute } from "../config.runtime.js";
@@ -862,17 +867,50 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   // -----------------------------------------------------------------------
   // Finalize the stream if one was started
   // -----------------------------------------------------------------------
+  let streamFallbackDelivered = false;
   const finalStream = streamSession as SlackStreamSession | null;
   if (finalStream && !finalStream.stopped) {
     try {
       await stopSlackStream({ session: finalStream });
     } catch (err) {
-      runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatErrorMessage(err)}`));
+      if (err instanceof SlackStreamNotDeliveredError) {
+        // Slack rejected the stream before any text reached the recipient
+        // (common for short replies to Slack Connect users - the SDK buffers
+        // under 256 chars and the internal chat.startStream inside stop()
+        // is the first call to Slack). Fall back to a plain chat.postMessage
+        // so the reply is not lost.
+        try {
+          // Rename-bind to dodge eslint-plugin-unicorn/require-post-message-target-origin
+          // which cannot distinguish Slack chat.postMessage from window.postMessage.
+          const postChatMessage = ctx.app.client.chat.postMessage.bind(ctx.app.client.chat);
+          await postChatMessage({
+            channel: finalStream.channel,
+            thread_ts: finalStream.threadTs,
+            text: err.pendingText,
+          });
+          streamFallbackDelivered = true;
+          logVerbose(
+            `slack-stream: streamed finalize failed (${err.slackCode}); delivered ${err.pendingText.length} chars via chat.postMessage fallback`,
+          );
+        } catch (postErr) {
+          runtime.error?.(
+            danger(
+              `slack-stream: fallback chat.postMessage failed after ${err.slackCode}: ${formatErrorMessage(postErr)}`,
+            ),
+          );
+        }
+      } else {
+        runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatErrorMessage(err)}`));
+      }
     }
   }
 
   const anyReplyDelivered =
-    observedReplyDelivery || queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+    observedReplyDelivery ||
+    queuedFinal ||
+    streamFallbackDelivered ||
+    (counts.block ?? 0) > 0 ||
+    (counts.final ?? 0) > 0;
 
   if (statusReactionsEnabled) {
     if (dispatchError) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -39,6 +39,7 @@ import {
 import type { SlackStreamSession } from "../../streaming.js";
 import {
   appendSlackStream,
+  markSlackStreamFallbackDelivered,
   SlackStreamNotDeliveredError,
   startSlackStream,
   stopSlackStream,
@@ -430,6 +431,41 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
   const deliveryTracker = createSlackTurnDeliveryTracker();
+  const deliverPendingStreamFallback = async (
+    session: SlackStreamSession,
+    err: SlackStreamNotDeliveredError,
+  ): Promise<boolean> => {
+    // The Slack SDK still owns this text in-memory; no streaming API call has
+    // acknowledged it. Send it once through normal chat.postMessage.
+    const fallbackText = err.pendingText.trim();
+    if (!fallbackText) {
+      return false;
+    }
+    try {
+      // Rename-bind to dodge eslint-plugin-unicorn/require-post-message-target-origin
+      // which cannot distinguish Slack chat.postMessage from window.postMessage.
+      const postChatMessage = ctx.app.client.chat.postMessage.bind(ctx.app.client.chat);
+      await postChatMessage({
+        channel: session.channel,
+        thread_ts: session.threadTs,
+        text: fallbackText,
+      });
+      markSlackStreamFallbackDelivered(session);
+      observedReplyDelivery = true;
+      usedReplyThreadTs ??= session.threadTs;
+      logVerbose(
+        `slack-stream: streamed delivery failed (${err.slackCode}); delivered ${fallbackText.length} chars via chat.postMessage fallback`,
+      );
+      return true;
+    } catch (postErr) {
+      runtime.error?.(
+        danger(
+          `slack-stream: fallback chat.postMessage failed after ${err.slackCode}: ${formatErrorMessage(postErr)}`,
+        ),
+      );
+      return false;
+    }
+  };
 
   const deliverNormally = async (params: {
     payload: ReplyPayload;
@@ -530,7 +566,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           }),
           userId: message.user,
         });
-        observedReplyDelivery = true;
+        // startSlackStream may only buffer locally. Count delivery only after
+        // the SDK reports a real Slack response.
+        if (streamSession.delivered) {
+          observedReplyDelivery = true;
+        }
         usedReplyThreadTs ??= streamThreadTs;
         replyPlan.markSent();
         deliveryTracker.markDelivered({
@@ -557,6 +597,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         session: streamSession,
         text: "\n" + text,
       });
+      // appendSlackStream also buffers locally below the SDK threshold; avoid
+      // optimistic "done" status until Slack acknowledges a flush.
+      if (streamSession.delivered) {
+        observedReplyDelivery = true;
+      }
       deliveryTracker.markDelivered({
         kind: params.kind,
         payload: params.payload,
@@ -564,6 +609,29 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         textOverride: text,
       });
     } catch (err) {
+      if (err instanceof SlackStreamNotDeliveredError) {
+        streamFailed = true;
+        if (streamSession) {
+          const delivered = await deliverPendingStreamFallback(streamSession, err);
+          if (delivered) {
+            replyPlan.markSent();
+            deliveryTracker.markDelivered({
+              kind: params.kind,
+              payload: params.payload,
+              threadTs: streamSession.threadTs,
+              textOverride: text,
+            });
+            return;
+          }
+          throw err;
+        }
+        await deliverNormally({
+          payload: params.payload,
+          kind: params.kind,
+          forcedThreadTs: plannedThreadTs,
+        });
+        return;
+      }
       runtime.error?.(
         danger(`slack-stream: streaming API call failed: ${formatErrorMessage(err)}, falling back`),
       );
@@ -874,31 +942,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       await stopSlackStream({ session: finalStream });
     } catch (err) {
       if (err instanceof SlackStreamNotDeliveredError) {
-        // Slack rejected the stream before any text reached the recipient
-        // (common for short replies to Slack Connect users - the SDK buffers
-        // under 256 chars and the internal chat.startStream inside stop()
-        // is the first call to Slack). Fall back to a plain chat.postMessage
-        // so the reply is not lost.
-        try {
-          // Rename-bind to dodge eslint-plugin-unicorn/require-post-message-target-origin
-          // which cannot distinguish Slack chat.postMessage from window.postMessage.
-          const postChatMessage = ctx.app.client.chat.postMessage.bind(ctx.app.client.chat);
-          await postChatMessage({
-            channel: finalStream.channel,
-            thread_ts: finalStream.threadTs,
-            text: err.pendingText,
-          });
-          streamFallbackDelivered = true;
-          logVerbose(
-            `slack-stream: streamed finalize failed (${err.slackCode}); delivered ${err.pendingText.length} chars via chat.postMessage fallback`,
-          );
-        } catch (postErr) {
-          runtime.error?.(
-            danger(
-              `slack-stream: fallback chat.postMessage failed after ${err.slackCode}: ${formatErrorMessage(postErr)}`,
-            ),
-          );
-        }
+        streamFallbackDelivered = await deliverPendingStreamFallback(finalStream, err);
       } else {
         runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatErrorMessage(err)}`));
       }

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -4,7 +4,9 @@ import {
   appendSlackStream,
   extractSlackErrorCode,
   isBenignSlackFinalizeError,
+  markSlackStreamFallbackDelivered,
   SlackStreamNotDeliveredError,
+  startSlackStream,
   stopSlackStream,
   type SlackStreamSession,
 } from "./streaming.js";
@@ -81,6 +83,55 @@ describe("stopSlackStream finalize error handling", () => {
     expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe("hello world");
   });
 
+  it("clears pendingText after an append flush is acknowledged by Slack", async () => {
+    const session = makeSession({
+      appendImpl: async () => ({ ts: "1700000000.100203" }),
+    });
+
+    await appendSlackStream({ session, text: "flushed text" });
+
+    expect(session.delivered).toBe(true);
+    expect(session.pendingText).toBe("");
+  });
+
+  it("throws SlackStreamNotDeliveredError with buffered text when append flush fails", async () => {
+    const session = makeSession({
+      appendImpl: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockRejectedValueOnce(slackApiError("user_not_found")),
+    });
+
+    await appendSlackStream({ session, text: "first buffered" });
+    const thrown = await appendSlackStream({ session, text: "\nsecond flushes" }).catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(SlackStreamNotDeliveredError);
+    expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe(
+      "first buffered\nsecond flushes",
+    );
+  });
+
+  it("falls back only still-pending tail text after a prior flush succeeded", async () => {
+    const session = makeSession({
+      appendImpl: vi
+        .fn()
+        .mockResolvedValueOnce({ ts: "1700000000.100204" })
+        .mockResolvedValue(null),
+      stopImpl: async () => {
+        throw slackApiError("team_not_found");
+      },
+    });
+
+    await appendSlackStream({ session, text: "already visible" });
+    await appendSlackStream({ session, text: "\npending tail" });
+    const thrown = await stopSlackStream({ session }).catch((err: unknown) => err);
+
+    expect(thrown).toBeInstanceOf(SlackStreamNotDeliveredError);
+    expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe("\npending tail");
+  });
+
   it("swallows missing_recipient_user_id when delivered", async () => {
     const session = makeSession({
       appendImpl: async () => ({ ts: "1700000000.100201" }),
@@ -139,6 +190,45 @@ describe("stopSlackStream finalize error handling", () => {
     expect(session.delivered).toBe(false);
     await stopSlackStream({ session });
     expect(session.delivered).toBe(true);
+    expect(session.pendingText).toBe("");
+  });
+
+  it("converts a start-time flush rejection into a pending-text fallback error", async () => {
+    const client = {
+      chatStream: () => ({
+        append: async () => {
+          throw slackApiError("user_not_found");
+        },
+        stop: async () => {},
+      }),
+    };
+
+    const thrown = await startSlackStream({
+      client: client as never,
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      text: "initial chunk that flushes immediately",
+    }).catch((err: unknown) => err);
+
+    expect(thrown).toBeInstanceOf(SlackStreamNotDeliveredError);
+    expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe(
+      "initial chunk that flushes immediately",
+    );
+  });
+
+  it("marks fallback-delivered sessions stopped only when no native stream exists", () => {
+    const neverDelivered = makeSession({});
+    markSlackStreamFallbackDelivered(neverDelivered);
+    expect(neverDelivered.delivered).toBe(true);
+    expect(neverDelivered.pendingText).toBe("");
+    expect(neverDelivered.stopped).toBe(true);
+
+    const alreadyDelivered = makeSession({});
+    alreadyDelivered.delivered = true;
+    markSlackStreamFallbackDelivered(alreadyDelivered);
+    expect(alreadyDelivered.delivered).toBe(true);
+    expect(alreadyDelivered.pendingText).toBe("");
+    expect(alreadyDelivered.stopped).toBe(false);
   });
 });
 

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -1,0 +1,76 @@
+import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
+import { describe, expect, it, vi } from "vitest";
+import { stopSlackStream, type SlackStreamSession } from "./streaming.js";
+
+function makeSession(stopImpl: () => Promise<void>): SlackStreamSession {
+  return {
+    streamer: {
+      append: vi.fn(async () => {}),
+      stop: vi.fn(stopImpl),
+    } as unknown as ChatStreamer,
+    channel: "C123",
+    threadTs: "1700000000.000100",
+    stopped: false,
+  };
+}
+
+function slackApiError(code: string): Error {
+  const err = new Error(`An API error occurred: ${code}`);
+  (err as unknown as { data: { error: string } }).data = { error: code };
+  return err;
+}
+
+describe("stopSlackStream finalize error handling", () => {
+  it("swallows user_not_found (Slack Connect DMs) and marks the session stopped", async () => {
+    const session = makeSession(async () => {
+      throw slackApiError("user_not_found");
+    });
+    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    expect(session.stopped).toBe(true);
+  });
+
+  it("swallows team_not_found (Slack Connect cross-workspace) and marks stopped", async () => {
+    const session = makeSession(async () => {
+      throw slackApiError("team_not_found");
+    });
+    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    expect(session.stopped).toBe(true);
+  });
+
+  it("swallows missing_recipient_user_id (DM closed mid-stream) and marks stopped", async () => {
+    const session = makeSession(async () => {
+      throw slackApiError("missing_recipient_user_id");
+    });
+    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    expect(session.stopped).toBe(true);
+  });
+
+  it("re-throws unexpected Slack API errors so callers can log them", async () => {
+    const session = makeSession(async () => {
+      throw slackApiError("not_authed");
+    });
+    await expect(stopSlackStream({ session })).rejects.toThrow(/not_authed/);
+    // Session is still marked stopped so retries do not re-enter streamer.stop.
+    expect(session.stopped).toBe(true);
+  });
+
+  it("re-throws non-Slack-shaped errors unchanged", async () => {
+    const session = makeSession(async () => {
+      throw new Error("socket reset");
+    });
+    await expect(stopSlackStream({ session })).rejects.toThrow(/socket reset/);
+    expect(session.stopped).toBe(true);
+  });
+
+  it("returns a no-op on an already-stopped session", async () => {
+    const stop = vi.fn(async () => {});
+    const session: SlackStreamSession = {
+      streamer: { append: vi.fn(async () => {}), stop } as unknown as ChatStreamer,
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      stopped: true,
+    };
+    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    expect(stop).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -1,16 +1,28 @@
 import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { describe, expect, it, vi } from "vitest";
-import { stopSlackStream, type SlackStreamSession } from "./streaming.js";
+import {
+  appendSlackStream,
+  extractSlackErrorCode,
+  isBenignSlackFinalizeError,
+  SlackStreamNotDeliveredError,
+  stopSlackStream,
+  type SlackStreamSession,
+} from "./streaming.js";
 
-function makeSession(stopImpl: () => Promise<void>): SlackStreamSession {
+type AppendImpl = () => Promise<unknown>;
+type StopImpl = () => Promise<void>;
+
+function makeSession(params: { appendImpl?: AppendImpl; stopImpl?: StopImpl }): SlackStreamSession {
   return {
     streamer: {
-      append: vi.fn(async () => {}),
-      stop: vi.fn(stopImpl),
+      append: vi.fn(params.appendImpl ?? (async () => null)),
+      stop: vi.fn(params.stopImpl ?? (async () => {})),
     } as unknown as ChatStreamer,
     channel: "C123",
     threadTs: "1700000000.000100",
     stopped: false,
+    delivered: false,
+    pendingText: "",
   };
 }
 
@@ -21,42 +33,84 @@ function slackApiError(code: string): Error {
 }
 
 describe("stopSlackStream finalize error handling", () => {
-  it("swallows user_not_found (Slack Connect DMs) and marks the session stopped", async () => {
-    const session = makeSession(async () => {
-      throw slackApiError("user_not_found");
+  it("swallows user_not_found after prior append flushed (delivered=true)", async () => {
+    const session = makeSession({
+      appendImpl: async () => ({ ts: "1700000000.100200" }), // non-null => flushed
+      stopImpl: async () => {
+        throw slackApiError("user_not_found");
+      },
     });
+    await appendSlackStream({ session, text: "some text that Slack saw" });
+    expect(session.delivered).toBe(true);
+
     await expect(stopSlackStream({ session })).resolves.toBeUndefined();
     expect(session.stopped).toBe(true);
   });
 
-  it("swallows team_not_found (Slack Connect cross-workspace) and marks stopped", async () => {
-    const session = makeSession(async () => {
-      throw slackApiError("team_not_found");
+  it("throws SlackStreamNotDeliveredError when user_not_found fires before any flush", async () => {
+    const session = makeSession({
+      appendImpl: async () => null, // null => buffered, never hit Slack
+      stopImpl: async () => {
+        throw slackApiError("user_not_found");
+      },
     });
+    await appendSlackStream({ session, text: "short reply under buffer size" });
+    expect(session.delivered).toBe(false);
+
+    const thrown = await stopSlackStream({ session }).catch((err: unknown) => err);
+    expect(thrown).toBeInstanceOf(SlackStreamNotDeliveredError);
+    expect((thrown as SlackStreamNotDeliveredError).slackCode).toBe("user_not_found");
+    expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe(
+      "short reply under buffer size",
+    );
+    expect(session.stopped).toBe(true);
+  });
+
+  it("throws SlackStreamNotDeliveredError carrying stop()'s final text too", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => {
+        throw slackApiError("team_not_found");
+      },
+    });
+    await appendSlackStream({ session, text: "hello " });
+
+    const thrown = await stopSlackStream({ session, text: "world" }).catch((err: unknown) => err);
+    expect(thrown).toBeInstanceOf(SlackStreamNotDeliveredError);
+    expect((thrown as SlackStreamNotDeliveredError).slackCode).toBe("team_not_found");
+    expect((thrown as SlackStreamNotDeliveredError).pendingText).toBe("hello world");
+  });
+
+  it("swallows missing_recipient_user_id when delivered", async () => {
+    const session = makeSession({
+      appendImpl: async () => ({ ts: "1700000000.100201" }),
+      stopImpl: async () => {
+        throw slackApiError("missing_recipient_user_id");
+      },
+    });
+    await appendSlackStream({ session, text: "chars" });
     await expect(stopSlackStream({ session })).resolves.toBeUndefined();
     expect(session.stopped).toBe(true);
   });
 
-  it("swallows missing_recipient_user_id (DM closed mid-stream) and marks stopped", async () => {
-    const session = makeSession(async () => {
-      throw slackApiError("missing_recipient_user_id");
+  it("re-throws unexpected Slack API errors even when delivered", async () => {
+    const session = makeSession({
+      appendImpl: async () => ({ ts: "1700000000.100202" }),
+      stopImpl: async () => {
+        throw slackApiError("not_authed");
+      },
     });
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
-    expect(session.stopped).toBe(true);
-  });
-
-  it("re-throws unexpected Slack API errors so callers can log them", async () => {
-    const session = makeSession(async () => {
-      throw slackApiError("not_authed");
-    });
+    await appendSlackStream({ session, text: "some text" });
     await expect(stopSlackStream({ session })).rejects.toThrow(/not_authed/);
     // Session is still marked stopped so retries do not re-enter streamer.stop.
     expect(session.stopped).toBe(true);
   });
 
   it("re-throws non-Slack-shaped errors unchanged", async () => {
-    const session = makeSession(async () => {
-      throw new Error("socket reset");
+    const session = makeSession({
+      stopImpl: async () => {
+        throw new Error("socket reset");
+      },
     });
     await expect(stopSlackStream({ session })).rejects.toThrow(/socket reset/);
     expect(session.stopped).toBe(true);
@@ -65,12 +119,59 @@ describe("stopSlackStream finalize error handling", () => {
   it("returns a no-op on an already-stopped session", async () => {
     const stop = vi.fn(async () => {});
     const session: SlackStreamSession = {
-      streamer: { append: vi.fn(async () => {}), stop } as unknown as ChatStreamer,
+      streamer: { append: vi.fn(async () => null), stop } as unknown as ChatStreamer,
       channel: "C123",
       threadTs: "1700000000.000100",
       stopped: true,
+      delivered: false,
+      pendingText: "",
     };
     await expect(stopSlackStream({ session })).resolves.toBeUndefined();
     expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("marks delivered=true on successful stop() without prior flush", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => {},
+    });
+    await appendSlackStream({ session, text: "short" });
+    expect(session.delivered).toBe(false);
+    await stopSlackStream({ session });
+    expect(session.delivered).toBe(true);
+  });
+});
+
+describe("error classification", () => {
+  it("isBenignSlackFinalizeError matches each allowlisted code", () => {
+    for (const code of ["user_not_found", "team_not_found", "missing_recipient_user_id"]) {
+      expect(isBenignSlackFinalizeError(slackApiError(code))).toBe(true);
+    }
+  });
+
+  it("isBenignSlackFinalizeError rejects non-listed codes", () => {
+    for (const code of ["not_authed", "ratelimited", "channel_not_found"]) {
+      expect(isBenignSlackFinalizeError(slackApiError(code))).toBe(false);
+    }
+  });
+
+  it("extractSlackErrorCode handles data.error, message fallback, and junk shapes", () => {
+    // Canonical SDK shape
+    expect(extractSlackErrorCode(slackApiError("user_not_found"))).toBe("user_not_found");
+    // message-regex fallback when data is absent
+    expect(extractSlackErrorCode(new Error("An API error occurred: rate_limited"))).toBe(
+      "rate_limited",
+    );
+    // data.error not a string - falls through to message parse
+    const wrongShape = new Error("plain message");
+    (wrongShape as unknown as { data: unknown }).data = { error: 42 };
+    expect(extractSlackErrorCode(wrongShape)).toBeUndefined();
+    // data.error null - falls through
+    (wrongShape as unknown as { data: unknown }).data = null;
+    expect(extractSlackErrorCode(wrongShape)).toBeUndefined();
+    // Non-object error
+    expect(extractSlackErrorCode("raw string")).toBeUndefined();
+    expect(extractSlackErrorCode(null)).toBeUndefined();
+    expect(extractSlackErrorCode(undefined)).toBeUndefined();
   });
 });

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -28,6 +28,19 @@ export type SlackStreamSession = {
   threadTs: string;
   /** True once stop() has been called. */
   stopped: boolean;
+  /**
+   * True once any Slack API call (startStream / appendStream) has succeeded.
+   * The SDK buffers appended text locally until the buffer exceeds
+   * `buffer_size` (default 256 chars); only then does it issue a network
+   * call. Until `delivered` flips, nothing has actually reached Slack.
+   */
+  delivered: boolean;
+  /**
+   * Concatenation of every `text` passed to the session. Used by the
+   * caller to fall back to a normal `chat.postMessage` when finalize fails
+   * before any append flushed the buffer.
+   */
+  pendingText: string;
 };
 
 export type StartSlackStreamParams = {
@@ -60,6 +73,27 @@ export type StopSlackStreamParams = {
   /** Optional final markdown text to append before stopping. */
   text?: string;
 };
+
+/**
+ * Thrown by {@link stopSlackStream} when Slack's `chat.stopStream` rejects
+ * with a recipient-resolution error (see
+ * {@link BENIGN_SLACK_FINALIZE_ERROR_CODES}) and no prior `append` had
+ * flushed the buffer, so no text ever reached Slack. Carries the pending
+ * text so the caller can deliver it via a normal `chat.postMessage`.
+ */
+export class SlackStreamNotDeliveredError extends Error {
+  readonly pendingText: string;
+  readonly slackCode: string;
+  constructor(pendingText: string, slackCode: string) {
+    super(
+      `slack-stream: finalize failed with ${slackCode} before any text reached Slack ` +
+        `(${pendingText.length} chars pending)`,
+    );
+    this.name = "SlackStreamNotDeliveredError";
+    this.pendingText = pendingText;
+    this.slackCode = slackCode;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Stream lifecycle
@@ -94,13 +128,22 @@ export async function startSlackStream(
     channel,
     threadTs,
     stopped: false,
+    delivered: false,
+    pendingText: "",
   };
 
-  // If initial text is provided, send it as the first append which will
-  // trigger the ChatStreamer to call chat.startStream under the hood.
   if (text) {
-    await streamer.append({ markdown_text: text });
-    logVerbose(`slack-stream: appended initial text (${text.length} chars)`);
+    session.pendingText += text;
+    // `append` returns the Slack response when it actually hits the network,
+    // null when the buffer is still under `buffer_size` (see chat-stream.js).
+    // Flip `delivered` only when Slack acknowledged.
+    const result = await streamer.append({ markdown_text: text });
+    if (result) {
+      session.delivered = true;
+    }
+    logVerbose(
+      `slack-stream: appended initial text (${text.length} chars, ${result ? "flushed" : "buffered"})`,
+    );
   }
 
   return session;
@@ -121,8 +164,12 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
     return;
   }
 
-  await session.streamer.append({ markdown_text: text });
-  logVerbose(`slack-stream: appended ${text.length} chars`);
+  session.pendingText += text;
+  const result = await session.streamer.append({ markdown_text: text });
+  if (result) {
+    session.delivered = true;
+  }
+  logVerbose(`slack-stream: appended ${text.length} chars (${result ? "flushed" : "buffered"})`);
 }
 
 /**
@@ -132,10 +179,16 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  * Optionally include final text to append before stopping.
  *
  * If Slack's `chat.stopStream` responds with a known benign finalize error
- * (e.g. `user_not_found` for Slack Connect recipients - see issue #70295),
- * any text already delivered via `append()` stays visible and the session
- * is marked stopped. Other Slack API errors still propagate so the caller
- * can record them.
+ * (see {@link BENIGN_SLACK_FINALIZE_ERROR_CODES}) AND any prior `append`
+ * has already landed on Slack, the error is swallowed and the session is
+ * marked stopped - the already-delivered text stays visible.
+ *
+ * If the same benign error fires before any append flushed (e.g. short
+ * replies that never exceeded the SDK's buffer_size), this function throws
+ * a {@link SlackStreamNotDeliveredError} carrying the pending text so the
+ * caller can deliver it via `chat.postMessage`.
+ *
+ * All other errors propagate unchanged.
  */
 export async function stopSlackStream(params: StopSlackStreamParams): Promise<void> {
   const { session, text } = params;
@@ -146,6 +199,9 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   }
 
   session.stopped = true;
+  if (text) {
+    session.pendingText += text;
+  }
 
   logVerbose(
     `slack-stream: stopping stream in ${session.channel} thread=${session.threadTs}${
@@ -155,13 +211,20 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
 
   try {
     await session.streamer.stop(text ? { markdown_text: text } : undefined);
+    session.delivered = true;
   } catch (err) {
     if (isBenignSlackFinalizeError(err)) {
-      logVerbose(
-        `slack-stream: finalize rejected by Slack (${formatSlackError(err)}); ` +
-          "appended text remains visible, treating stream as stopped",
-      );
-      return;
+      const code = extractSlackErrorCode(err) ?? "unknown";
+      if (session.delivered) {
+        logVerbose(
+          `slack-stream: finalize rejected by Slack (${code}); prior appends delivered, treating stream as stopped`,
+        );
+        return;
+      }
+      // No append ever flushed; the ChatStreamer's stop() runs chat.startStream
+      // internally and that call failed. Surface the pending text so the
+      // caller can post a normal message via chat.postMessage.
+      throw new SlackStreamNotDeliveredError(session.pendingText, code);
     }
     throw err;
   }
@@ -174,11 +237,12 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
 // ---------------------------------------------------------------------------
 
 /**
- * Slack API error codes that indicate `chat.stopStream` cannot finalize the
- * stream for the current recipient/team, but any `chat.appendStream` calls
- * that already landed are still visible to the user. Treat these as benign
- * at the dispatch layer so the reply is not reported as an error when text
- * did get through.
+ * Slack API error codes that indicate `chat.stopStream` (or the
+ * `chat.startStream` call the SDK issues inside `stop()` when the buffer
+ * never flushed) cannot finalize the stream for the current recipient or
+ * team. Either the caller falls back to a normal message (see
+ * {@link SlackStreamNotDeliveredError}) or, if prior appends already
+ * delivered text, the error is logged verbosely and swallowed.
  */
 const BENIGN_SLACK_FINALIZE_ERROR_CODES = new Set<string>([
   // Slack Connect recipients: finalize fails because the external user id
@@ -190,12 +254,12 @@ const BENIGN_SLACK_FINALIZE_ERROR_CODES = new Set<string>([
   "missing_recipient_user_id",
 ]);
 
-function isBenignSlackFinalizeError(err: unknown): boolean {
+export function isBenignSlackFinalizeError(err: unknown): boolean {
   const code = extractSlackErrorCode(err);
   return code !== undefined && BENIGN_SLACK_FINALIZE_ERROR_CODES.has(code);
 }
 
-function extractSlackErrorCode(err: unknown): string | undefined {
+export function extractSlackErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
   }
@@ -211,15 +275,4 @@ function extractSlackErrorCode(err: unknown): string | undefined {
   const message = typeof record.message === "string" ? record.message : "";
   const match = message.match(/An API error occurred:\s*([a-z_][a-z0-9_]*)/i);
   return match?.[1];
-}
-
-function formatSlackError(err: unknown): string {
-  const code = extractSlackErrorCode(err);
-  if (code) {
-    return code;
-  }
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
 }

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -35,11 +35,7 @@ export type SlackStreamSession = {
    * call. Until `delivered` flips, nothing has actually reached Slack.
    */
   delivered: boolean;
-  /**
-   * Concatenation of every `text` passed to the session. Used by the
-   * caller to fall back to a normal `chat.postMessage` when finalize fails
-   * before any append flushed the buffer.
-   */
+  /** Text accepted by the SDK but not yet acknowledged by Slack. */
   pendingText: string;
 };
 
@@ -75,11 +71,10 @@ export type StopSlackStreamParams = {
 };
 
 /**
- * Thrown by {@link stopSlackStream} when Slack's `chat.stopStream` rejects
- * with a recipient-resolution error (see
- * {@link BENIGN_SLACK_FINALIZE_ERROR_CODES}) and no prior `append` had
- * flushed the buffer, so no text ever reached Slack. Carries the pending
- * text so the caller can deliver it via a normal `chat.postMessage`.
+ * Thrown when Slack rejects a stream flush/finalize with a recipient-resolution
+ * error (see {@link BENIGN_SLACK_FINALIZE_ERROR_CODES}) while text is still
+ * only buffered locally by the Slack SDK. Carries the pending text so the
+ * caller can deliver it via a normal `chat.postMessage`.
  */
 export class SlackStreamNotDeliveredError extends Error {
   readonly pendingText: string;
@@ -134,16 +129,27 @@ export async function startSlackStream(
 
   if (text) {
     session.pendingText += text;
-    // `append` returns the Slack response when it actually hits the network,
-    // null when the buffer is still under `buffer_size` (see chat-stream.js).
-    // Flip `delivered` only when Slack acknowledged.
-    const result = await streamer.append({ markdown_text: text });
-    if (result) {
-      session.delivered = true;
+    // Slack SDK ChatStreamer keeps short markdown_text chunks in a local buffer
+    // and returns null until buffer_size is reached. Only a non-null response
+    // means Slack acknowledged startStream/appendStream.
+    try {
+      const result = await streamer.append({ markdown_text: text });
+      if (result) {
+        session.delivered = true;
+        session.pendingText = "";
+      }
+      logVerbose(
+        `slack-stream: appended initial text (${text.length} chars, ${result ? "flushed" : "buffered"})`,
+      );
+    } catch (err) {
+      if (isBenignSlackFinalizeError(err) && session.pendingText) {
+        throw new SlackStreamNotDeliveredError(
+          session.pendingText,
+          extractSlackErrorCode(err) ?? "unknown",
+        );
+      }
+      throw err;
     }
-    logVerbose(
-      `slack-stream: appended initial text (${text.length} chars, ${result ? "flushed" : "buffered"})`,
-    );
   }
 
   return session;
@@ -165,11 +171,24 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
   }
 
   session.pendingText += text;
-  const result = await session.streamer.append({ markdown_text: text });
-  if (result) {
-    session.delivered = true;
+  try {
+    // Same SDK contract as startSlackStream: null means local-only buffer,
+    // non-null means Slack accepted the pending buffer and it is visible.
+    const result = await session.streamer.append({ markdown_text: text });
+    if (result) {
+      session.delivered = true;
+      session.pendingText = "";
+    }
+    logVerbose(`slack-stream: appended ${text.length} chars (${result ? "flushed" : "buffered"})`);
+  } catch (err) {
+    if (isBenignSlackFinalizeError(err) && session.pendingText) {
+      throw new SlackStreamNotDeliveredError(
+        session.pendingText,
+        extractSlackErrorCode(err) ?? "unknown",
+      );
+    }
+    throw err;
   }
-  logVerbose(`slack-stream: appended ${text.length} chars (${result ? "flushed" : "buffered"})`);
 }
 
 /**
@@ -183,10 +202,10 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  * has already landed on Slack, the error is swallowed and the session is
  * marked stopped - the already-delivered text stays visible.
  *
- * If the same benign error fires before any append flushed (e.g. short
- * replies that never exceeded the SDK's buffer_size), this function throws
- * a {@link SlackStreamNotDeliveredError} carrying the pending text so the
- * caller can deliver it via `chat.postMessage`.
+ * If the same benign error fires while text is still only buffered locally
+ * (e.g. short replies that never exceeded the SDK's buffer_size), this
+ * function throws a {@link SlackStreamNotDeliveredError} carrying that pending
+ * text so the caller can deliver it via `chat.postMessage`.
  *
  * All other errors propagate unchanged.
  */
@@ -212,19 +231,21 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   try {
     await session.streamer.stop(text ? { markdown_text: text } : undefined);
     session.delivered = true;
+    session.pendingText = "";
   } catch (err) {
     if (isBenignSlackFinalizeError(err)) {
       const code = extractSlackErrorCode(err) ?? "unknown";
+      if (session.pendingText) {
+        // stop() can be the first network call for short replies. If Slack
+        // Connect rejects it, the user has not seen the SDK-buffered text yet.
+        throw new SlackStreamNotDeliveredError(session.pendingText, code);
+      }
       if (session.delivered) {
         logVerbose(
           `slack-stream: finalize rejected by Slack (${code}); prior appends delivered, treating stream as stopped`,
         );
         return;
       }
-      // No append ever flushed; the ChatStreamer's stop() runs chat.startStream
-      // internally and that call failed. Surface the pending text so the
-      // caller can post a normal message via chat.postMessage.
-      throw new SlackStreamNotDeliveredError(session.pendingText, code);
     }
     throw err;
   }
@@ -275,4 +296,13 @@ export function extractSlackErrorCode(err: unknown): string | undefined {
   const message = typeof record.message === "string" ? record.message : "";
   const match = message.match(/An API error occurred:\s*([a-z_][a-z0-9_]*)/i);
   return match?.[1];
+}
+
+export function markSlackStreamFallbackDelivered(session: SlackStreamSession): void {
+  const hadNativeDelivery = session.delivered;
+  session.pendingText = "";
+  session.delivered = true;
+  if (!hadNativeDelivery) {
+    session.stopped = true;
+  }
 }

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -130,6 +130,12 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  *
  * After calling this the stream message becomes a normal Slack message.
  * Optionally include final text to append before stopping.
+ *
+ * If Slack's `chat.stopStream` responds with a known benign finalize error
+ * (e.g. `user_not_found` for Slack Connect recipients - see issue #70295),
+ * any text already delivered via `append()` stays visible and the session
+ * is marked stopped. Other Slack API errors still propagate so the caller
+ * can record them.
  */
 export async function stopSlackStream(params: StopSlackStreamParams): Promise<void> {
   const { session, text } = params;
@@ -147,7 +153,73 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
     }`,
   );
 
-  await session.streamer.stop(text ? { markdown_text: text } : undefined);
+  try {
+    await session.streamer.stop(text ? { markdown_text: text } : undefined);
+  } catch (err) {
+    if (isBenignSlackFinalizeError(err)) {
+      logVerbose(
+        `slack-stream: finalize rejected by Slack (${formatSlackError(err)}); ` +
+          "appended text remains visible, treating stream as stopped",
+      );
+      return;
+    }
+    throw err;
+  }
 
   logVerbose("slack-stream: stream stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Finalize error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Slack API error codes that indicate `chat.stopStream` cannot finalize the
+ * stream for the current recipient/team, but any `chat.appendStream` calls
+ * that already landed are still visible to the user. Treat these as benign
+ * at the dispatch layer so the reply is not reported as an error when text
+ * did get through.
+ */
+const BENIGN_SLACK_FINALIZE_ERROR_CODES = new Set<string>([
+  // Slack Connect recipients: finalize fails because the external user id
+  // is not resolvable in the host workspace (#70295).
+  "user_not_found",
+  // Slack Connect team mismatch in shared channels.
+  "team_not_found",
+  // DMs that closed between stream start and stop.
+  "missing_recipient_user_id",
+]);
+
+function isBenignSlackFinalizeError(err: unknown): boolean {
+  const code = extractSlackErrorCode(err);
+  return code !== undefined && BENIGN_SLACK_FINALIZE_ERROR_CODES.has(code);
+}
+
+function extractSlackErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const record = err as Record<string, unknown>;
+  // @slack/web-api errors expose `data.error` with the Slack error code.
+  if (record.data && typeof record.data === "object") {
+    const inner = (record.data as Record<string, unknown>).error;
+    if (typeof inner === "string") {
+      return inner;
+    }
+  }
+  // Fallback: parse from message string ("An API error occurred: user_not_found").
+  const message = typeof record.message === "string" ? record.message : "";
+  const match = message.match(/An API error occurred:\s*([a-z_][a-z0-9_]*)/i);
+  return match?.[1];
+}
+
+function formatSlackError(err: unknown): string {
+  const code = extractSlackErrorCode(err);
+  if (code) {
+    return code;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
 }


### PR DESCRIPTION
## Summary

- Problem: When Slack native streaming is enabled and the recipient is a Slack Connect user, `chat.stopStream` fails with `An API error occurred: user_not_found`. OpenClaw logs `slack-stream: failed to stop stream: ...` via `runtime.error` in dispatch, which makes every Slack Connect reply look like an error even though the text delivered via `chat.appendStream` is already visible to the user.
- Why it matters: On any workspace that uses Slack Connect / shared channels, native streaming silently looks broken at the dispatch layer. Operators see a stream of red in the gateway log that is caused by the Slack Connect recipient shape, not a dropped reply.
- What changed: `stopSlackStream` in `extensions/slack/src/streaming.ts` now catches `session.streamer.stop(...)` errors. When the Slack error code is one of `user_not_found`, `team_not_found`, or `missing_recipient_user_id` (all Slack Connect / recipient-resolution cases), swallow the error, keep the session marked as `stopped`, and log through the existing `logVerbose` path explaining that appended text is still visible. Any other Slack error still propagates so the caller's existing `runtime.error(...)` log is preserved.
- What did NOT change (scope boundary): No behavior change for DMs in the host workspace, thread replies to non-Connect users, or non-streaming delivery paths. The dispatch call site in `extensions/slack/src/monitor/message-handler/dispatch.ts` is unchanged; this PR stays inside the `streaming.ts` boundary. No other plugin, core, or SDK changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70295
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `stopSlackStream` in `extensions/slack/src/streaming.ts` awaited `session.streamer.stop(...)` without any error handling. The Slack Connect recipient_user_id / team_id path is not resolvable at finalize time, so Slack returns `user_not_found` (or sibling codes) on `chat.stopStream`. The error bubbled up through the outer try/catch in `dispatch.ts` and was logged via `runtime.error` as if the reply itself had failed.
- Missing detection / guardrail: no classification of finalize errors that are "visible text already delivered" vs "stream actually failed". The caller cannot distinguish the two.
- Contributing context (if known): the issue triage (@rafiki270 on #70295) identified `extensions/slack/src/streaming.ts` `stopSlackStream()` as the missing-error-handling site and the finalize failure mode as Slack-Connect-specific.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/streaming.test.ts` (new)
- Scenario the test should lock in: `session.streamer.stop()` throwing each of the three benign Slack Connect error shapes -> `stopSlackStream` resolves without throwing and marks the session stopped. An unexpected Slack error code (`not_authed`) AND a non-Slack-shaped error (`new Error("socket reset")`) still re-throw so the caller's log path stays intact. Duplicate-stop on an already-stopped session remains a no-op.
- Why this is the smallest reliable guardrail: `stopSlackStream` is the seam; the dispatch call site is unchanged.
- Existing test that already covers this (if any): none - `streaming.ts` had no direct unit coverage.
- If no new test is added, why not: N/A (added).

## User-visible / Behavior Changes

- Slack Connect replies with native streaming enabled no longer surface a `runtime.error("slack-stream: failed to stop stream: user_not_found")` line when the stream text was actually delivered.
- Log output shifts these finalize failures to `logVerbose` with a clear note that appended text remains visible and the stream is treated as stopped.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (we do not issue follow-on calls on finalize failure; the `append()` call's text is already at Slack).
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22, pnpm
- Model/provider: any (reply is generated upstream; this is the delivery path)
- Integration/channel (if any): Slack, native streaming enabled
- Relevant config (redacted):
  ```
  channels.slack.streaming.mode = "partial"
  channels.slack.streaming.nativeTransport = true
  channels.slack.replyToMode = "first"
  ```

### Steps

1. Configure OpenClaw Slack with native streaming as above.
2. Trigger a reply in a shared channel/thread that includes a Slack Connect user.

### Expected

Reply appears in thread (as it already does via `append()`) and no `slack-stream: failed to stop stream` error line appears at the dispatch layer for the `user_not_found` / `team_not_found` / `missing_recipient_user_id` cases.

### Actual (before this PR)

`[slack] slack-stream: failed to stop stream: Error: An API error occurred: user_not_found` at `runtime.error` level, even when the reply text is visible.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local checks before push:

- `pnpm test extensions/slack/src/streaming.test.ts`: 1 file, 6 tests pass.
- `pnpm test extensions/slack`: 90 files, 736 tests pass.
- `pnpm check:changed --staged` (pre-commit): extension lane ran 89 files, 734 tests, all pass.
- `pnpm format:check`, `pnpm lint` on touched files: clean.

## Human Verification (required)

- Verified scenarios (via unit tests mocking `ChatStreamer.stop`):
  - `user_not_found` throw -> `stopSlackStream` resolves, session marked stopped.
  - `team_not_found` throw -> same.
  - `missing_recipient_user_id` throw -> same.
  - Unexpected Slack code (`not_authed`) -> re-thrown with the original message; session still marked stopped to prevent retry loops.
  - Non-Slack error (`socket reset`) -> re-thrown unchanged.
  - Duplicate stop on an already-stopped session -> no-op, `streamer.stop` not called.
  - Full Slack extension lane still green (736 tests).
- Edge cases checked: preserving `session.stopped = true` on both throw paths so a retry would not re-enter `streamer.stop`. The error classification reads from `err.data.error` (shape used by `@slack/web-api` errors) with a message-string fallback for custom Error subclasses.
- What I did not verify: I do not have a live Slack Connect workspace to reproduce against. The classification is based on the error strings reported in #70295 and the Slack API docs. If Slack adds / renames finalize error codes for Connect in the future the allowlist needs to follow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The allowlist of benign finalize codes hides a real delivery failure if Slack later reuses one of these codes for a case where appended text did NOT reach the user.
  - Mitigation: the three allowlisted codes are recipient-resolution failures that occur at finalize time. `chat.appendStream` uses the same recipient context, so a `user_not_found` at stop generally means start/append also hit the same validation path and either already failed (caller sees that as a throw) or succeeded (text is visible). If Slack changes the semantics, the allowlist is a single file and easy to adjust.
- Risk: Non-streaming delivery is accidentally affected.
  - Mitigation: the change is scoped to `stopSlackStream` inside `extensions/slack/src/streaming.ts`. Non-streaming delivery paths do not call it.
