### PR TITLE
feat(streaming): Phase C — streaming STT pipeline + parallel TTS output

### DIFF
--- a/.ap-coordinator/coordinator.log
+++ b/.ap-coordinator/coordinator.log
@@ -1,0 +1,2 @@
+[2026-04-20T23:03:09.802056+00:00] LOCK ACQUIRED: audio-output-phase2-finalize → __git__
+[2026-04-20T23:05:20.207419+00:00] REGISTER: streaming-multimodal-phaseB at phaseB-dir

--- a/.ap-coordinator/locks/d6f4968892d3
+++ b/.ap-coordinator/locks/d6f4968892d3
@@ -1,0 +1,3 @@
+audio-output-phase2-finalize
+__git__
+2026-04-20T23:03:09.801859+00:00

--- a/.ap-coordinator/shared-state.json
+++ b/.ap-coordinator/shared-state.json
@@ -1,0 +1,11 @@
+{
+  "agents": {
+    "streaming-multimodal-phaseB": {
+      "apDir": "phaseB-dir",
+      "registeredAt": "2026-04-20T23:05:20.207190+00:00",
+      "status": "running"
+    }
+  },
+  "locks": {},
+  "lastUpdated": "2026-04-21T23:11:08.496167+00:00"
+}

--- a/.autopilot/streaming-multimodal-phaseA-checkpoint.md
+++ b/.autopilot/streaming-multimodal-phaseA-checkpoint.md
@@ -1,0 +1,70 @@
+# Phase A Checkpoint — streaming-multimodal-phaseA
+
+**Date:** 2026-04-20 ~00:30 GMT+1
+**Subagent label:** streaming-multimodal-phaseA
+**Branch:** `feat/streaming-multimodal-phase-a` (off `main` @ `33ad806a14`)
+**Status:** ✅ Milestones A.1 + A.2 complete. Local commits only. No push.
+
+## Completed
+
+### A.1 — Multiplex frame codec
+- `src/gateway/multiplex-frame.ts` (~10.5 KB)
+- `src/gateway/multiplex-frame.test.ts` — **33 tests passing**
+- Commit: `74668a3cfc feat(streaming): A.1 — multiplex frame codec`
+- Frame: `0xFE | streamId u8 | flags u8 | payloadLen u32LE | payload` (7-byte envelope)
+- Stream IDs reserved: 0=Control, 1=AudioInput, 2=AudioOutput, 3=VideoInput, 4=VideoOutput
+- Flags: EOM=0x01, PRIORITY=0x02, COMPRESSED=0x04
+- Limits: 16 MiB max payload, 255 max streamId
+- Errors: `MultiplexFrameError` with stable `code` field
+- Decoded payloads are detached copies (safe for retention)
+
+### A.2 — Audio input/output buffers
+- `src/gateway/audio/input-buffer.ts` (~8.6 KB) — `RealtimeInputBuffer`
+- `src/gateway/audio/output-buffer.ts` (~6.5 KB) — `RealtimeOutputBuffer`
+- `src/gateway/audio/input-buffer.test.ts` — **17 tests passing**
+- `src/gateway/audio/output-buffer.test.ts` — **17 tests passing**
+- Commit: `b5893eccfb feat(streaming): A.2 — audio input/output buffers`
+- Input: append/commit/clear, ring-buffer overflow cap, telemetry counters
+- Output: enqueueChunk/getPlaybackPosition/truncate (barge-in), in-order delivery, bounded queue depth
+
+### Total tests: 67 passing (33 + 17 + 17)
+
+## NOT done (intentional — Phase B/C scope)
+
+- WebSocket server multiplex demultiplexer wiring
+- Realtime provider adapters (OpenAI Realtime / Gemini Live)
+- Video frame ingest
+- Session router mapping streamId → realtime session
+- Auth/rate-limit/backpressure on multiplex socket
+
+## Artifacts
+
+- PR draft: `/home/jduartedj/clawd/.orchestration/streaming-multimodal-phaseA/PR-DRAFT.md`
+- Workspace checkpoint: `/home/jduartedj/openclaw-fork/.autopilot/streaming-multimodal-phaseA-checkpoint.md`
+
+## Hazards / notes for tomorrow
+
+1. **Branch hygiene.** Mid-session I briefly landed work on `feat/audio-output-modality` by accident (the other agent's branch). Recovered cleanly by `git checkout feat/streaming-multimodal-phase-a` (untracked files transferred, then committed). Audited final state — both my commits live only on `feat/streaming-multimodal-phase-a`. The other branch is untouched.
+2. **Stash.** A stash entry `WIP on feat/audio-output-modality` was pushed during recovery, holding `src/agents/model-catalog.ts` and `src/agents/openai-transport-stream.ts` modifications that originated from that other branch. **Do not pop on this branch.** Pop it only when back on `feat/audio-output-modality`.
+3. **Vitest CLI quirk.** Filter patterns must be repo-root-relative full paths matching the include glob (`src/gateway/**/*.test.ts`). Running from inside `src/gateway/` with shorter paths makes vitest clear `include` and find no files. Multi-arg filter sometimes also clears include — safest is to invoke each file separately from repo root.
+4. **Full gateway suite OOM.** Attempting the entire gateway suite end-to-end SIGKILLed (suspected OOM). Ran the new tests individually instead. CI will exercise full suite.
+5. **Lint.** Pre-commit lint pipeline triggered prettier auto-formatting once. Re-staged and re-committed; final files are lint-clean (`unknown` removed from `isMultiplexedFrame` signature per `no-redundant-type-constituents`).
+
+## Files added (final)
+
+```
+src/gateway/multiplex-frame.ts
+src/gateway/multiplex-frame.test.ts
+src/gateway/audio/input-buffer.ts
+src/gateway/audio/input-buffer.test.ts
+src/gateway/audio/output-buffer.ts
+src/gateway/audio/output-buffer.test.ts
+```
+
+## Suggested next-night Phase B kickoff
+
+1. Wire multiplex demultiplexer into the gateway WebSocket handler — route by streamId.
+2. Plug `RealtimeInputBuffer` into the AudioInput stream handler.
+3. Plug `RealtimeOutputBuffer` into the AudioOutput stream handler.
+4. Add backpressure signaling on the Control stream (streamId 0).
+5. Coordinate with the `feat/audio-output-modality` agent — if their Phase 2 has merged to main by then, rebase Phase A on top before starting Phase B wiring.

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -5,7 +5,9 @@
   "description": "OpenClaw Amazon Bedrock Mantle (OpenAI-compatible) provider plugin",
   "type": "module",
   "dependencies": {
-    "@aws/bedrock-token-generator": "^1.1.0"
+    "@anthropic-ai/sdk": "0.81.0",
+    "@aws/bedrock-token-generator": "^1.1.0",
+    "@mariozechner/pi-ai": "0.68.1"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/github-copilot/discovery.ts
+++ b/extensions/github-copilot/discovery.ts
@@ -1,0 +1,105 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const COPILOT_IDE_HEADERS: Record<string, string> = {
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "Copilot-Integration-Id": "vscode-chat",
+};
+
+interface CopilotApiModel {
+  id: string;
+  name?: string;
+  version?: string;
+  object?: string;
+  model_picker_enabled?: boolean;
+  capabilities?: {
+    type?: string;
+    family?: string;
+    limits?: {
+      max_prompt_tokens?: number;
+      max_output_tokens?: number;
+    };
+    object?: string;
+    supports?: {
+      tool_calls?: boolean;
+      parallel_tool_calls?: boolean;
+      dimensions?: boolean;
+      vision?: boolean;
+      reasoning?: boolean;
+    };
+    tokenizer?: string;
+  };
+  policy?: {
+    state?: string; // "enabled" | "disabled"
+  };
+  preview_state?: string;
+}
+
+interface CopilotModelsResponse {
+  data: CopilotApiModel[];
+}
+
+function inferApiType(model: CopilotApiModel): ModelDefinitionConfig["api"] {
+  const id = model.id.toLowerCase();
+  if (id.startsWith("claude")) {
+    return "anthropic-messages";
+  }
+  // Default to openai-responses which is what the copilot extension normally uses
+  return "openai-responses";
+}
+
+function buildModelDefinition(model: CopilotApiModel): ModelDefinitionConfig {
+  const caps = model.capabilities;
+  const limits = caps?.limits;
+  const supports = caps?.supports;
+
+  return {
+    id: model.id,
+    name: model.name ?? model.id,
+    api: inferApiType(model),
+    reasoning: supports?.reasoning ?? false,
+    input: supports?.vision ? (["text", "image"] as const) : (["text"] as const),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: limits?.max_prompt_tokens ?? 128_000,
+    maxTokens: limits?.max_output_tokens ?? 8192,
+  };
+}
+
+export async function discoverCopilotModels(params: {
+  baseUrl: string;
+  copilotToken: string;
+  knownModelIds?: Set<string>;
+}): Promise<ModelDefinitionConfig[]> {
+  const { baseUrl, copilotToken, knownModelIds } = params;
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/models`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${copilotToken}`,
+      ...COPILOT_IDE_HEADERS,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    return [];
+  }
+
+  const body = (await res.json()) as CopilotModelsResponse;
+  if (!Array.isArray(body.data)) {
+    return [];
+  }
+
+  return body.data
+    .filter((m) => {
+      // Only enabled models
+      if (m.policy?.state && m.policy.state !== "enabled") return false;
+      // Only chat-capable models (skip embeddings, etc.)
+      if (m.capabilities?.type && m.capabilities.type !== "chat") return false;
+      // Skip models already in the built-in list
+      if (knownModelIds?.has(m.id)) return false;
+      return true;
+    })
+    .map(buildModelDefinition);
+}

--- a/extensions/github-copilot/discovery.ts
+++ b/extensions/github-copilot/discovery.ts
@@ -94,11 +94,17 @@ export async function discoverCopilotModels(params: {
   return body.data
     .filter((m) => {
       // Only enabled models
-      if (m.policy?.state && m.policy.state !== "enabled") return false;
+      if (m.policy?.state && m.policy.state !== "enabled") {
+        return false;
+      }
       // Only chat-capable models (skip embeddings, etc.)
-      if (m.capabilities?.type && m.capabilities.type !== "chat") return false;
+      if (m.capabilities?.type && m.capabilities.type !== "chat") {
+        return false;
+      }
       // Skip models already in the built-in list
-      if (knownModelIds?.has(m.id)) return false;
+      if (knownModelIds?.has(m.id)) {
+        return false;
+      }
       return true;
     })
     .map(buildModelDefinition);

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -6,6 +6,10 @@ import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
+import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } from "./token.js";
+import { fetchCopilotUsage } from "./usage.js";
+import { discoverCopilotModels, COPILOT_IDE_HEADERS } from "./discovery.js";
+import { getDefaultCopilotModelIds } from "./models-defaults.js";
 
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.4", "gpt-5.2", "gpt-5.2-codex"] as const;
@@ -116,21 +120,40 @@ export default definePluginEntry({
             return null;
           }
           let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+          let copilotToken: string | undefined;
           if (githubToken) {
             try {
-              const token = await resolveCopilotApiToken({
+              const resolved = await resolveCopilotApiToken({
                 githubToken,
                 env: ctx.env,
               });
-              baseUrl = token.baseUrl;
+              baseUrl = resolved.baseUrl;
+              copilotToken = resolved.token;
             } catch {
               baseUrl = DEFAULT_COPILOT_API_BASE_URL;
             }
           }
+
+          let discoveredModels: Awaited<ReturnType<typeof discoverCopilotModels>> = [];
+          if (copilotToken) {
+            try {
+              const knownModelIds = new Set(getDefaultCopilotModelIds());
+              discoveredModels = await discoverCopilotModels({
+                baseUrl,
+                copilotToken,
+                knownModelIds,
+              });
+            } catch {
+              // best-effort: discovery failure is not fatal
+            }
+          }
+
           return {
             provider: {
               baseUrl,
-              models: [],
+              ...(discoveredModels.length > 0
+                ? { headers: COPILOT_IDE_HEADERS, models: discoveredModels }
+                : { models: [] }),
             },
           };
         },

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -6,10 +6,6 @@ import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
-import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } from "./token.js";
-import { fetchCopilotUsage } from "./usage.js";
-import { discoverCopilotModels, COPILOT_IDE_HEADERS } from "./discovery.js";
-import { getDefaultCopilotModelIds } from "./models-defaults.js";
 
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.4", "gpt-5.2", "gpt-5.2-codex"] as const;
@@ -111,6 +107,8 @@ export default definePluginEntry({
           }
           const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } =
             await loadGithubCopilotRuntime();
+          const { discoverCopilotModels, COPILOT_IDE_HEADERS } = await import("./discovery.js");
+          const { getDefaultCopilotModelIds } = await import("./models-defaults.js");
           const { githubToken, hasProfile } = await resolveFirstGithubToken({
             agentDir: ctx.agentDir,
             config: ctx.config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,9 +272,15 @@ importers:
 
   extensions/amazon-bedrock-mantle:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: 0.81.0
+        version: 0.81.0(zod@4.3.6)
       '@aws/bedrock-token-generator':
         specifier: ^1.1.0
         version: 1.1.0
+      '@mariozechner/pi-ai':
+        specifier: 0.68.1
+        version: 0.68.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -31,6 +31,7 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("feishu", "src/monitor.webhook.test-helpers.ts", 25),
   bundledPluginCallsite("github-copilot", "login.ts", 48),
   bundledPluginCallsite("github-copilot", "login.ts", 80),
+  bundledPluginCallsite("github-copilot", "discovery.ts", 77),
   bundledPluginCallsite("googlechat", "src/auth.ts", 83),
   bundledPluginCallsite("huggingface", "models.ts", 142),
   bundledPluginCallsite("kilocode", "provider-models.ts", 130),

--- a/scripts/pre-commit/check-host-resources.mjs
+++ b/scripts/pre-commit/check-host-resources.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * Prints the local-check resource mode for the current machine.
+ *
+ * Output (one of): "throttled" | "full"
+ *
+ * Used by the pre-commit hook to decide whether to throttle staged-file
+ * checks and whether to skip the heavy changed-scope check gate.
+ *
+ * Mirrors the thresholds in scripts/lib/local-heavy-check-runtime.mjs
+ * (shouldThrottleLocalHeavyChecks) so the hook and the runtime stay in sync.
+ *
+ * Keep this dependency-free (no pnpm imports) — it runs early in the hook.
+ */
+
+import os from "node:os";
+
+const GIB = 1024 ** 3;
+const MIN_MEMORY_BYTES = 48 * GIB;
+const MIN_CPUS = 12;
+
+const mode = process.env.OPENCLAW_LOCAL_CHECK_MODE?.trim().toLowerCase();
+
+if (mode === "throttled" || mode === "low-memory") {
+  process.stdout.write("throttled");
+  process.exit(0);
+}
+
+if (mode === "full" || mode === "fast") {
+  process.stdout.write("full");
+  process.exit(0);
+}
+
+const raw = process.env.OPENCLAW_LOCAL_CHECK?.trim().toLowerCase();
+if (raw === "0" || raw === "false") {
+  process.stdout.write("full");
+  process.exit(0);
+}
+
+const totalMemory = os.totalmem();
+const cpuCount =
+  typeof os.availableParallelism === "function"
+    ? os.availableParallelism()
+    : os.cpus().length;
+
+if (totalMemory < MIN_MEMORY_BYTES || cpuCount < MIN_CPUS) {
+  process.stdout.write("throttled");
+} else {
+  process.stdout.write("full");
+}

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -54,6 +54,8 @@ export type ModelDefinitionConfig = {
   id: string;
   name: string;
   api?: ModelApi;
+  /** Optional per-model base URL override (e.g. for Anthropic Messages on Bedrock Mantle). */
+  baseUrl?: string;
   reasoning: boolean;
   input: Array<"text" | "image">;
   cost: {

--- a/src/gateway/audio/audio-input-stream.test.ts
+++ b/src/gateway/audio/audio-input-stream.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AudioInputStream } from "./audio-input-stream.js";
+import {
+  encodeMultiplexFrame,
+  decodeMultiplexFrame,
+  MULTIPLEX_FLAG_EOM,
+  MULTIPLEX_STREAM,
+  type MultiplexFrame,
+} from "../multiplex-frame.js";
+
+function pcmFrame(payload: Buffer, flags = 0, streamId = MULTIPLEX_STREAM.AUDIO_INPUT): MultiplexFrame {
+  return decodeMultiplexFrame(encodeMultiplexFrame(streamId, payload, flags));
+}
+
+function pcm16Bytes(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  samples.forEach((v, i) => buf.writeInt16LE(v, i * 2));
+  return buf;
+}
+
+describe("AudioInputStream", () => {
+  it("appends frame payloads to the buffer", () => {
+    const audioIn = new AudioInputStream();
+    const chunk = pcm16Bytes([100, 200, 300, 400]);
+    audioIn.handleFrame(pcmFrame(chunk));
+
+    expect(audioIn.stats.framesAccepted).toBe(1);
+    expect(audioIn.stats.bytesAccepted).toBe(chunk.length);
+    expect(audioIn.stats.bufferedBytes).toBe(chunk.length);
+    expect(audioIn.stats.commitsEmitted).toBe(0);
+  });
+
+  it("commits on EOM-flagged frame and fires onCommit", () => {
+    const onCommit = vi.fn();
+    const audioIn = new AudioInputStream({ onCommit });
+
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([1, 2, 3, 4])));
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([5, 6, 7, 8]), MULTIPLEX_FLAG_EOM));
+
+    expect(audioIn.stats.commitsEmitted).toBe(1);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const result = onCommit.mock.calls[0]?.[0];
+    expect(result.audio.length).toBe(16);
+    expect(result.sampleRate).toBe(audioIn.format.sampleRate);
+    expect(result.durationMs).toBeGreaterThan(0);
+
+    // Buffer is drained after commit.
+    expect(audioIn.stats.bufferedBytes).toBe(0);
+  });
+
+  it("does not commit when EOM frame arrives with empty buffer", () => {
+    const onCommit = vi.fn();
+    const audioIn = new AudioInputStream({ onCommit });
+    audioIn.handleFrame(pcmFrame(Buffer.alloc(0), MULTIPLEX_FLAG_EOM));
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(audioIn.stats.commitsEmitted).toBe(0);
+  });
+
+  it("counts empty-payload frames as accepted (heartbeats)", () => {
+    const audioIn = new AudioInputStream();
+    audioIn.handleFrame(pcmFrame(Buffer.alloc(0)));
+    expect(audioIn.stats.framesAccepted).toBe(1);
+    expect(audioIn.stats.bytesAccepted).toBe(0);
+  });
+
+  it("rejects mis-routed frames (wrong streamId) via onInvalidFrame", () => {
+    const onInvalidFrame = vi.fn();
+    const audioIn = new AudioInputStream({ onInvalidFrame });
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([1, 2]), 0, MULTIPLEX_STREAM.AUDIO_OUTPUT));
+    expect(onInvalidFrame).toHaveBeenCalledTimes(1);
+    expect(audioIn.stats.framesRejected).toBe(1);
+    expect(audioIn.stats.bufferedBytes).toBe(0);
+  });
+
+  it("rejects PCM frames with odd byte length via onInvalidFrame", () => {
+    const onInvalidFrame = vi.fn();
+    const audioIn = new AudioInputStream({ onInvalidFrame });
+    audioIn.handleFrame(pcmFrame(Buffer.from([0x01, 0x02, 0x03])));
+    expect(audioIn.stats.framesRejected).toBe(1);
+    expect(audioIn.stats.framesAccepted).toBe(0);
+    expect(onInvalidFrame).toHaveBeenCalledTimes(1);
+    expect(audioIn.stats.bufferedBytes).toBe(0);
+  });
+
+  it("manual commit() returns null when buffer is empty", () => {
+    const audioIn = new AudioInputStream();
+    expect(audioIn.commit()).toBeNull();
+  });
+
+  it("manual commit() returns the buffered audio and resets state", () => {
+    const audioIn = new AudioInputStream();
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([10, 20, 30, 40])));
+    const result = audioIn.commit();
+    expect(result).not.toBeNull();
+    expect(result!.audio.length).toBe(8);
+    expect(audioIn.stats.bufferedBytes).toBe(0);
+    expect(audioIn.stats.commitsEmitted).toBe(1);
+  });
+
+  it("clear() drops buffered audio without emitting commit", () => {
+    const onCommit = vi.fn();
+    const audioIn = new AudioInputStream({ onCommit });
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([1, 2, 3, 4])));
+    audioIn.clear();
+    expect(audioIn.stats.bufferedBytes).toBe(0);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("STREAM_ID is AUDIO_INPUT", () => {
+    expect(AudioInputStream.STREAM_ID).toBe(MULTIPLEX_STREAM.AUDIO_INPUT);
+  });
+
+  it("forwards buffer options (e.g. maxBufferedMs)", () => {
+    const audioIn = new AudioInputStream({ maxBufferedMs: 100 });
+    expect(audioIn.buffer.maxBufferedMs).toBe(100);
+  });
+
+  it("isolates onCommit consumer errors from the stream", () => {
+    const audioIn = new AudioInputStream({
+      onCommit: () => {
+        throw new Error("downstream boom");
+      },
+    });
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([1, 2]), MULTIPLEX_FLAG_EOM));
+    // Next commit must still work.
+    audioIn.handleFrame(pcmFrame(pcm16Bytes([3, 4]), MULTIPLEX_FLAG_EOM));
+    expect(audioIn.stats.commitsEmitted).toBe(2);
+  });
+});

--- a/src/gateway/audio/audio-input-stream.test.ts
+++ b/src/gateway/audio/audio-input-stream.test.ts
@@ -9,7 +9,7 @@ import {
   type MultiplexFrame,
 } from "../multiplex-frame.js";
 
-function pcmFrame(payload: Buffer, flags = 0, streamId = MULTIPLEX_STREAM.AUDIO_INPUT): MultiplexFrame {
+function pcmFrame(payload: Buffer, flags = 0, streamId: number = MULTIPLEX_STREAM.AUDIO_INPUT): MultiplexFrame {
   return decodeMultiplexFrame(encodeMultiplexFrame(streamId, payload, flags));
 }
 

--- a/src/gateway/audio/audio-input-stream.ts
+++ b/src/gateway/audio/audio-input-stream.ts
@@ -1,0 +1,153 @@
+/**
+ * Audio input stream handler — Phase B.2.
+ *
+ * Bridges the multiplex demuxer (streamId AUDIO_INPUT) to the
+ * {@link RealtimeInputBuffer} primitive from Phase A.2. Incoming frame
+ * payloads are appended as PCM16 LE chunks; an EOM flag triggers a
+ * `commit()` and the resulting audio is delivered to the consumer
+ * (typically the realtime provider adapter) via {@link onCommit}.
+ *
+ * This handler is framework-agnostic: it has no I/O of its own. Wire it
+ * into a {@link MultiplexDemuxer} via `demux.on(MULTIPLEX_STREAM.AUDIO_INPUT,
+ * audioIn.handleFrame)`.
+ */
+import {
+  DEFAULT_INPUT_FORMAT,
+  RealtimeInputBuffer,
+  type AudioFormat,
+  type CommitResult,
+  type RealtimeInputBufferOptions,
+} from "./input-buffer.js";
+import {
+  frameHasEom,
+  MULTIPLEX_STREAM,
+  type MultiplexFrame,
+} from "../multiplex-frame.js";
+
+export interface AudioInputStreamOptions extends RealtimeInputBufferOptions {
+  /**
+   * Called when an EOM-flagged frame is received and the buffer commits.
+   * Receives the committed audio plus duration metadata.
+   */
+  onCommit?: (result: CommitResult) => void;
+  /**
+   * Called for any frame whose payload is rejected (e.g. odd byte length
+   * for PCM16). Defaults to silently dropping the frame.
+   */
+  onInvalidFrame?: (error: Error, frame: MultiplexFrame) => void;
+}
+
+/**
+ * Per-session AudioInput stream handler. Owns one {@link RealtimeInputBuffer}.
+ */
+export class AudioInputStream {
+  /** Stream id this handler is responsible for. */
+  static readonly STREAM_ID = MULTIPLEX_STREAM.AUDIO_INPUT;
+
+  readonly buffer: RealtimeInputBuffer;
+  private readonly onCommit?: (result: CommitResult) => void;
+  private readonly onInvalidFrame?: (error: Error, frame: MultiplexFrame) => void;
+  private framesAccepted = 0;
+  private bytesAccepted = 0;
+  private commitsEmitted = 0;
+  private framesRejected = 0;
+
+  constructor(options: AudioInputStreamOptions = {}) {
+    const { onCommit, onInvalidFrame, ...bufferOptions } = options;
+    this.buffer = new RealtimeInputBuffer(bufferOptions);
+    this.onCommit = onCommit;
+    this.onInvalidFrame = onInvalidFrame;
+  }
+
+  /** Accessor for the underlying audio format. */
+  get format(): AudioFormat {
+    return this.buffer.format;
+  }
+
+  /** Telemetry snapshot. */
+  get stats(): {
+    framesAccepted: number;
+    bytesAccepted: number;
+    commitsEmitted: number;
+    framesRejected: number;
+    bufferedBytes: number;
+    bufferedMs: number;
+    isSpeaking: boolean;
+  } {
+    return {
+      framesAccepted: this.framesAccepted,
+      bytesAccepted: this.bytesAccepted,
+      commitsEmitted: this.commitsEmitted,
+      framesRejected: this.framesRejected,
+      bufferedBytes: this.buffer.getBufferedBytes(),
+      bufferedMs: this.buffer.getBufferedDurationMs(),
+      isSpeaking: this.buffer.isSpeaking(),
+    };
+  }
+
+  /**
+   * Frame handler suitable for direct registration with a
+   * {@link MultiplexDemuxer}. Bound to `this` for convenience.
+   */
+  readonly handleFrame = (frame: MultiplexFrame): void => {
+    if (frame.streamId !== MULTIPLEX_STREAM.AUDIO_INPUT) {
+      // Defensive: caller mis-routed.
+      this.framesRejected++;
+      this.onInvalidFrame?.(
+        new Error(
+          `AudioInputStream received frame for streamId ${frame.streamId} (expected ${MULTIPLEX_STREAM.AUDIO_INPUT})`,
+        ),
+        frame,
+      );
+      return;
+    }
+
+    if (frame.payload.length > 0) {
+      try {
+        this.buffer.append(frame.payload);
+        this.framesAccepted++;
+        this.bytesAccepted += frame.payload.length;
+      } catch (err) {
+        this.framesRejected++;
+        this.onInvalidFrame?.(
+          err instanceof Error ? err : new Error(String(err)),
+          frame,
+        );
+        return;
+      }
+    } else {
+      // Empty payload still counts as a received frame (heartbeat/EOM-only).
+      this.framesAccepted++;
+    }
+
+    if (frameHasEom(frame.flags)) {
+      this.commit();
+    }
+  };
+
+  /**
+   * Force a commit (e.g. on session end or explicit client request).
+   * Returns the committed audio or `null` if the buffer was empty.
+   */
+  commit(): CommitResult | null {
+    if (this.buffer.getBufferedBytes() === 0) {
+      return null;
+    }
+    const result = this.buffer.commit();
+    this.commitsEmitted++;
+    try {
+      this.onCommit?.(result);
+    } catch {
+      /* never let consumer errors poison the stream */
+    }
+    return result;
+  }
+
+  /** Discard any buffered audio without emitting a commit. */
+  clear(): void {
+    this.buffer.clear();
+  }
+}
+
+/** Default export convenience for symmetry with the codec module. */
+export const AUDIO_INPUT_STREAM_ID = MULTIPLEX_STREAM.AUDIO_INPUT;

--- a/src/gateway/audio/audio-input-stream.ts
+++ b/src/gateway/audio/audio-input-stream.ts
@@ -12,7 +12,6 @@
  * audioIn.handleFrame)`.
  */
 import {
-  DEFAULT_INPUT_FORMAT,
   RealtimeInputBuffer,
   type AudioFormat,
   type CommitResult,

--- a/src/gateway/audio/audio-output-stream.test.ts
+++ b/src/gateway/audio/audio-output-stream.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AudioOutputStream } from "./audio-output-stream.js";
+import {
+  decodeMultiplexFrame,
+  MULTIPLEX_FLAG_EOM,
+  MULTIPLEX_STREAM,
+} from "../multiplex-frame.js";
+
+describe("AudioOutputStream", () => {
+  it("requires a send callback", () => {
+    expect(() => new AudioOutputStream({ send: undefined as never })).toThrow(TypeError);
+  });
+
+  it("pushAudio enqueues a chunk and emits an encoded multiplex frame", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+
+    const payload = Buffer.from([0x10, 0x20, 0x30, 0x40]);
+    const chunk = stream.pushAudio(payload, 50);
+
+    expect(chunk).not.toBeNull();
+    expect(chunk!.startMs).toBe(0);
+    expect(chunk!.endMs).toBe(50);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    const sent = send.mock.calls[0]?.[0] as Buffer;
+    const decoded = decodeMultiplexFrame(sent);
+    expect(decoded.streamId).toBe(MULTIPLEX_STREAM.AUDIO_OUTPUT);
+    expect(decoded.flags).toBe(0);
+    expect(decoded.payload.equals(payload)).toBe(true);
+
+    expect(stream.stats.framesSent).toBe(1);
+    expect(stream.stats.chunksEnqueued).toBe(1);
+    expect(stream.stats.queueLength).toBe(1);
+  });
+
+  it("pushAudio with eom=true sets the EOM flag on the frame", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+
+    stream.pushAudio(Buffer.from([0x01, 0x02]), 10, { eom: true });
+    const sent = send.mock.calls[0]?.[0] as Buffer;
+    const decoded = decodeMultiplexFrame(sent);
+    expect(decoded.flags & MULTIPLEX_FLAG_EOM).toBe(MULTIPLEX_FLAG_EOM);
+  });
+
+  it("pushAudio passes through extra flags", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+    const PRIORITY = 0x02;
+    stream.pushAudio(Buffer.from([0x01, 0x02]), 10, { flags: PRIORITY });
+    const decoded = decodeMultiplexFrame(send.mock.calls[0]?.[0] as Buffer);
+    expect(decoded.flags & PRIORITY).toBe(PRIORITY);
+  });
+
+  it("pushAudio rejects non-Buffer payloads", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+    expect(() => stream.pushAudio("nope" as never, 10)).toThrow(TypeError);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("pushAudio with negative duration calls onSendError and does not emit", () => {
+    const send = vi.fn();
+    const onSendError = vi.fn();
+    const stream = new AudioOutputStream({ send, onSendError });
+
+    const result = stream.pushAudio(Buffer.from([0x01, 0x02]), -5);
+    expect(result).toBeNull();
+    expect(send).not.toHaveBeenCalled();
+    expect(stream.stats.sendErrors).toBe(1);
+    expect(onSendError).toHaveBeenCalledTimes(1);
+    expect(onSendError.mock.calls[0]?.[0]).toBeInstanceOf(RangeError);
+  });
+
+  it("endTurn() emits an EOM-only frame with empty payload", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+    stream.endTurn();
+    expect(send).toHaveBeenCalledTimes(1);
+    const decoded = decodeMultiplexFrame(send.mock.calls[0]?.[0] as Buffer);
+    expect(decoded.streamId).toBe(MULTIPLEX_STREAM.AUDIO_OUTPUT);
+    expect(decoded.flags & MULTIPLEX_FLAG_EOM).toBe(MULTIPLEX_FLAG_EOM);
+    expect(decoded.payload.length).toBe(0);
+  });
+
+  it("truncateAt drops trailing chunks and emits an EOM marker", () => {
+    const send = vi.fn();
+    const onTruncate = vi.fn();
+    const stream = new AudioOutputStream({ send, onTruncate });
+
+    stream.pushAudio(Buffer.from([1, 2]), 100);
+    stream.pushAudio(Buffer.from([3, 4]), 100);
+    stream.pushAudio(Buffer.from([5, 6]), 100);
+    expect(send).toHaveBeenCalledTimes(3);
+
+    const result = stream.truncateAt(50);
+    expect(result.audioEndMs).toBe(50);
+    expect(result.chunksDropped).toBeGreaterThan(0);
+
+    expect(send).toHaveBeenCalledTimes(4);
+    const truncFrame = decodeMultiplexFrame(send.mock.calls[3]?.[0] as Buffer);
+    expect(truncFrame.flags & MULTIPLEX_FLAG_EOM).toBe(MULTIPLEX_FLAG_EOM);
+    expect(truncFrame.payload.length).toBe(0);
+    expect(stream.stats.truncations).toBe(1);
+    expect(onTruncate).toHaveBeenCalledTimes(1);
+  });
+
+  it("STREAM_ID is AUDIO_OUTPUT", () => {
+    expect(AudioOutputStream.STREAM_ID).toBe(MULTIPLEX_STREAM.AUDIO_OUTPUT);
+  });
+
+  it("reset() clears the buffer", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+    stream.pushAudio(Buffer.from([1, 2]), 50);
+    expect(stream.stats.queueLength).toBe(1);
+    stream.reset();
+    expect(stream.stats.queueLength).toBe(0);
+    expect(stream.stats.totalEnqueuedMs).toBe(0);
+  });
+
+  it("isolates onTruncate consumer errors from the stream", () => {
+    const send = vi.fn();
+    const onTruncate = () => {
+      throw new Error("downstream boom");
+    };
+    const stream = new AudioOutputStream({ send, onTruncate });
+    stream.pushAudio(Buffer.from([1, 2]), 100);
+    expect(() => stream.truncateAt(50)).not.toThrow();
+  });
+
+  it("captures send errors via onSendError when send() throws", () => {
+    const onSendError = vi.fn();
+    const stream = new AudioOutputStream({
+      send: () => {
+        throw new Error("socket closed");
+      },
+      onSendError,
+    });
+    stream.pushAudio(Buffer.from([1, 2]), 10);
+    expect(onSendError).toHaveBeenCalledTimes(1);
+    expect(stream.stats.sendErrors).toBe(1);
+    // Chunk WAS enqueued before the send error.
+    expect(stream.stats.chunksEnqueued).toBe(1);
+  });
+
+  it("tracks bytesSent across multiple frames", () => {
+    const send = vi.fn();
+    const stream = new AudioOutputStream({ send });
+    stream.pushAudio(Buffer.from([1, 2]), 10);
+    stream.pushAudio(Buffer.from([3, 4, 5, 6]), 10);
+    const total = (send.mock.calls[0]?.[0] as Buffer).length + (send.mock.calls[1]?.[0] as Buffer).length;
+    expect(stream.stats.bytesSent).toBe(total);
+  });
+});

--- a/src/gateway/audio/audio-output-stream.ts
+++ b/src/gateway/audio/audio-output-stream.ts
@@ -1,0 +1,209 @@
+/**
+ * Audio output stream handler — Phase B.3.
+ *
+ * Bridges the {@link RealtimeOutputBuffer} primitive from Phase A.2 to
+ * the multiplex transport (streamId AUDIO_OUTPUT). The realtime
+ * provider adapter calls {@link AudioOutputStream.pushAudio} as deltas
+ * arrive; this handler enqueues them, encodes a multiplex frame, and
+ * delivers it via the {@link AudioOutputStreamOptions.send} callback.
+ *
+ * Supports barge-in via {@link AudioOutputStream.truncateAt}, which
+ * truncates the underlying buffer and emits an EOM frame so the client
+ * can immediately stop playback at the truncated position.
+ */
+import {
+  RealtimeOutputBuffer,
+  type OutputAudioChunk,
+  type RealtimeOutputBufferOptions,
+  type TruncateResult,
+} from "./output-buffer.js";
+import {
+  encodeMultiplexFrame,
+  MULTIPLEX_FLAG_EOM,
+  MULTIPLEX_STREAM,
+} from "../multiplex-frame.js";
+
+/** Send callback signature — receives an encoded multiplex frame. */
+export type AudioOutputSend = (frame: Buffer) => void;
+
+export interface AudioOutputStreamOptions extends RealtimeOutputBufferOptions {
+  /** Required: how to deliver an encoded multiplex frame to the client. */
+  send: AudioOutputSend;
+  /**
+   * Called when {@link AudioOutputStream.truncateAt} runs, after the
+   * underlying buffer has been truncated and the EOM frame sent.
+   */
+  onTruncate?: (result: TruncateResult) => void;
+  /**
+   * Called when an audio chunk fails to encode/send (e.g. payload too
+   * large). Defaults to silently dropping the chunk.
+   */
+  onSendError?: (error: Error, chunk: OutputAudioChunk) => void;
+}
+
+/**
+ * Per-session AudioOutput stream handler. Owns one
+ * {@link RealtimeOutputBuffer}.
+ */
+export class AudioOutputStream {
+  /** Stream id this handler emits on. */
+  static readonly STREAM_ID = MULTIPLEX_STREAM.AUDIO_OUTPUT;
+
+  readonly buffer: RealtimeOutputBuffer;
+  private readonly send: AudioOutputSend;
+  private readonly onTruncate?: (result: TruncateResult) => void;
+  private readonly onSendError?: (error: Error, chunk: OutputAudioChunk) => void;
+  private framesSent = 0;
+  private bytesSent = 0;
+  private chunksEnqueued = 0;
+  private truncations = 0;
+  private sendErrors = 0;
+
+  constructor(options: AudioOutputStreamOptions) {
+    if (typeof options.send !== "function") {
+      throw new TypeError("AudioOutputStream requires a send callback");
+    }
+    const { send, onTruncate, onSendError, ...bufferOptions } = options;
+    this.buffer = new RealtimeOutputBuffer(bufferOptions);
+    this.send = send;
+    this.onTruncate = onTruncate;
+    this.onSendError = onSendError;
+  }
+
+  /** Telemetry snapshot. */
+  get stats(): {
+    framesSent: number;
+    bytesSent: number;
+    chunksEnqueued: number;
+    truncations: number;
+    sendErrors: number;
+    queueLength: number;
+    totalEnqueuedMs: number;
+    playbackPositionMs: number;
+  } {
+    return {
+      framesSent: this.framesSent,
+      bytesSent: this.bytesSent,
+      chunksEnqueued: this.chunksEnqueued,
+      truncations: this.truncations,
+      sendErrors: this.sendErrors,
+      queueLength: this.buffer.getQueueLength(),
+      totalEnqueuedMs: this.buffer.getTotalEnqueuedMs(),
+      playbackPositionMs: this.buffer.getPlaybackPosition(),
+    };
+  }
+
+  /**
+   * Enqueue an audio chunk and immediately ship it as a multiplex frame.
+   *
+   * @param payload Raw audio bytes (PCM16 or whatever the negotiated codec is).
+   * @param durationMs Playback duration of this chunk.
+   * @param options Optional flags (e.g. mark EOM at end of response turn).
+   */
+  pushAudio(
+    payload: Buffer | Uint8Array,
+    durationMs: number,
+    options?: { eom?: boolean; flags?: number },
+  ): OutputAudioChunk | null {
+    if (!(payload instanceof Uint8Array)) {
+      throw new TypeError("AudioOutputStream.pushAudio payload must be Buffer/Uint8Array");
+    }
+    const buf = Buffer.isBuffer(payload) ? payload : Buffer.from(payload);
+
+    let chunk: OutputAudioChunk;
+    try {
+      chunk = this.buffer.enqueueChunk(buf, durationMs);
+      this.chunksEnqueued++;
+    } catch (err) {
+      this.sendErrors++;
+      this.onSendError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        { payload: buf, durationMs, startMs: 0, endMs: 0 },
+      );
+      return null;
+    }
+
+    let flags = options?.flags ?? 0;
+    if (options?.eom) {
+      flags |= MULTIPLEX_FLAG_EOM;
+    }
+
+    try {
+      const frame = encodeMultiplexFrame(MULTIPLEX_STREAM.AUDIO_OUTPUT, buf, flags);
+      this.send(frame);
+      this.framesSent++;
+      this.bytesSent += frame.length;
+      return chunk;
+    } catch (err) {
+      this.sendErrors++;
+      this.onSendError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        chunk,
+      );
+      return chunk;
+    }
+  }
+
+  /**
+   * Send an end-of-message marker without any audio payload (e.g. when
+   * the response ended on a non-audio modality).
+   */
+  endTurn(extraFlags = 0): void {
+    try {
+      const frame = encodeMultiplexFrame(
+        MULTIPLEX_STREAM.AUDIO_OUTPUT,
+        Buffer.alloc(0),
+        MULTIPLEX_FLAG_EOM | extraFlags,
+      );
+      this.send(frame);
+      this.framesSent++;
+      this.bytesSent += frame.length;
+    } catch (err) {
+      this.sendErrors++;
+      this.onSendError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        { payload: Buffer.alloc(0), durationMs: 0, startMs: 0, endMs: 0 },
+      );
+    }
+  }
+
+  /**
+   * Barge-in: truncate audio at `audioEndMs` along the playback timeline,
+   * notify the client with an EOM frame, and report the truncate result
+   * to the consumer.
+   */
+  truncateAt(audioEndMs: number): TruncateResult {
+    const result = this.buffer.truncate(audioEndMs);
+    this.truncations++;
+    // Notify client to stop playback immediately; payload is empty + EOM.
+    try {
+      const frame = encodeMultiplexFrame(
+        MULTIPLEX_STREAM.AUDIO_OUTPUT,
+        Buffer.alloc(0),
+        MULTIPLEX_FLAG_EOM,
+      );
+      this.send(frame);
+      this.framesSent++;
+      this.bytesSent += frame.length;
+    } catch (err) {
+      this.sendErrors++;
+      this.onSendError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        { payload: Buffer.alloc(0), durationMs: 0, startMs: 0, endMs: 0 },
+      );
+    }
+    try {
+      this.onTruncate?.(result);
+    } catch {
+      /* never let consumer errors poison the stream */
+    }
+    return result;
+  }
+
+  /** Reset to fresh state (new conversation turn / new session). */
+  reset(): void {
+    this.buffer.reset();
+  }
+}
+
+export const AUDIO_OUTPUT_STREAM_ID = MULTIPLEX_STREAM.AUDIO_OUTPUT;

--- a/src/gateway/audio/input-buffer.test.ts
+++ b/src/gateway/audio/input-buffer.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_INPUT_FORMAT,
+  RealtimeInputBuffer,
+  pcm16BytesToMs,
+  pcm16PeakAmplitude,
+} from "./input-buffer.js";
+
+/** Build a PCM16 LE buffer of `samples` samples, each at `amplitude`. */
+function pcmTone(samples: number, amplitude: number): Buffer {
+  const buf = Buffer.alloc(samples * 2);
+  for (let i = 0; i < samples; i++) buf.writeInt16LE(amplitude, i * 2);
+  return buf;
+}
+
+/** Convert ms at default 16 kHz to PCM16 LE byte length. */
+function msAt16k(ms: number): number {
+  return Math.round((ms * 16000) / 1000) * 2;
+}
+
+describe("pcm16PeakAmplitude / pcm16BytesToMs", () => {
+  it("returns 0 for empty buffer", () => {
+    expect(pcm16PeakAmplitude(Buffer.alloc(0))).toBe(0);
+    expect(pcm16BytesToMs(0, 16000)).toBe(0);
+  });
+
+  it("returns peak of |samples|", () => {
+    const buf = Buffer.alloc(8);
+    buf.writeInt16LE(100, 0);
+    buf.writeInt16LE(-300, 2);
+    buf.writeInt16LE(50, 4);
+    buf.writeInt16LE(-10, 6);
+    expect(pcm16PeakAmplitude(buf)).toBe(300);
+  });
+
+  it("converts byte length to ms at sample rate", () => {
+    expect(pcm16BytesToMs(32_000, 16_000)).toBe(1000); // 16k samples = 1s at 16 kHz
+    expect(pcm16BytesToMs(48_000, 24_000)).toBe(1000);
+    expect(pcm16BytesToMs(0, 0)).toBe(0);
+  });
+});
+
+describe("RealtimeInputBuffer", () => {
+  it("appends and reports buffered duration in ms", () => {
+    const buf = new RealtimeInputBuffer();
+    buf.append(pcmTone(1600, 0)); // 100 ms at 16 kHz
+    buf.append(pcmTone(800, 0)); // 50 ms
+    expect(buf.getBufferedBytes()).toBe(msAt16k(150));
+    expect(buf.getBufferedDurationMs()).toBeCloseTo(150, 5);
+  });
+
+  it("rejects odd-length PCM chunks", () => {
+    const buf = new RealtimeInputBuffer();
+    expect(() => buf.append(Buffer.from([0]))).toThrow(/even byte length/);
+  });
+
+  it("rejects non-buffer input", () => {
+    const buf = new RealtimeInputBuffer();
+    // @ts-expect-error — runtime guard
+    expect(() => buf.append("audio")).toThrow(TypeError);
+  });
+
+  it("ignores empty chunks silently", () => {
+    const buf = new RealtimeInputBuffer();
+    buf.append(Buffer.alloc(0));
+    expect(buf.getBufferedBytes()).toBe(0);
+  });
+
+  it("commit returns concatenated audio and clears state", () => {
+    const buf = new RealtimeInputBuffer();
+    buf.append(pcmTone(160, 5));
+    buf.append(pcmTone(160, 6));
+    const result = buf.commit();
+    expect(result.sampleRate).toBe(16000);
+    expect(result.audio.length).toBe(640);
+    expect(result.audio.readInt16LE(0)).toBe(5);
+    expect(result.audio.readInt16LE(320)).toBe(6);
+    expect(result.durationMs).toBeCloseTo((320 * 1000) / 16000, 5);
+    expect(buf.getBufferedBytes()).toBe(0);
+  });
+
+  it("commit returns a detached buffer (mutations don't affect future state)", () => {
+    const buf = new RealtimeInputBuffer();
+    buf.append(pcmTone(160, 7));
+    const r = buf.commit();
+    r.audio[0] = 0;
+    buf.append(pcmTone(160, 8));
+    const r2 = buf.commit();
+    expect(r2.audio.readInt16LE(0)).toBe(8);
+  });
+
+  it("clear discards data without emitting", () => {
+    const buf = new RealtimeInputBuffer();
+    buf.append(pcmTone(160, 1));
+    buf.clear();
+    expect(buf.getBufferedBytes()).toBe(0);
+  });
+
+  it("evicts oldest data when maxBufferedMs exceeded (whole-chunk drop)", () => {
+    const buf = new RealtimeInputBuffer({ maxBufferedMs: 100 });
+    buf.append(pcmTone(800, 0)); // 50 ms
+    buf.append(pcmTone(800, 0)); // 50 ms (total 100 ms — at cap)
+    buf.append(pcmTone(800, 0)); // 50 ms — should evict first chunk
+    expect(buf.getBufferedDurationMs()).toBeCloseTo(100, 5);
+    expect(buf.getBufferedBytes()).toBe(msAt16k(100));
+  });
+
+  it("evicts via head trim when overflow is partial", () => {
+    const buf = new RealtimeInputBuffer({ maxBufferedMs: 100 });
+    buf.append(pcmTone(1600, 0)); // 100 ms — full
+    buf.append(pcmTone(160, 0)); // 10 ms — overflow by 10 ms
+    expect(buf.getBufferedDurationMs()).toBeCloseTo(100, 5);
+  });
+
+  it("rejects unsupported formats", () => {
+    expect(
+      () =>
+        new RealtimeInputBuffer({
+          // @ts-expect-error invalid format type
+          format: { type: "opus", sampleRate: 48000, channels: 1 },
+        }),
+    ).toThrow(/only mono pcm16 supported/);
+    expect(() => new RealtimeInputBuffer({ format: { ...DEFAULT_INPUT_FORMAT, sampleRate: 0 } })).toThrow(
+      /sampleRate/,
+    );
+  });
+
+  it("triggers VAD onSpeechStarted after sustained non-silence", () => {
+    let now = 0;
+    const onSpeechStarted = vi.fn();
+    const buf = new RealtimeInputBuffer({
+      vadSilenceThreshold: 100,
+      vadSpeechDurationMs: 50,
+      onSpeechStarted,
+      now: () => now,
+    });
+
+    // Below threshold => stays silent.
+    now = 0;
+    buf.append(pcmTone(160, 10));
+    expect(onSpeechStarted).not.toHaveBeenCalled();
+    expect(buf.isSpeaking()).toBe(false);
+
+    // Loud chunk at t=10 starts streak; 60 ms later threshold reached.
+    now = 10;
+    buf.append(pcmTone(160, 5000));
+    now = 70;
+    buf.append(pcmTone(160, 5000));
+    expect(onSpeechStarted).toHaveBeenCalledTimes(1);
+    expect(buf.isSpeaking()).toBe(true);
+  });
+
+  it("triggers VAD onSpeechStopped after sustained silence following speech", () => {
+    let now = 0;
+    const onSpeechStarted = vi.fn();
+    const onSpeechStopped = vi.fn();
+    const buf = new RealtimeInputBuffer({
+      vadSilenceThreshold: 100,
+      vadSpeechDurationMs: 0,
+      vadSilenceDurationMs: 200,
+      onSpeechStarted,
+      onSpeechStopped,
+      now: () => now,
+    });
+
+    now = 0;
+    buf.append(pcmTone(160, 5000));
+    now = 10;
+    buf.append(pcmTone(160, 5000));
+    expect(onSpeechStarted).toHaveBeenCalledTimes(1);
+
+    // Silence streak begins; not enough time yet.
+    now = 20;
+    buf.append(pcmTone(160, 0));
+    expect(onSpeechStopped).not.toHaveBeenCalled();
+    now = 100;
+    buf.append(pcmTone(160, 0));
+    expect(onSpeechStopped).not.toHaveBeenCalled();
+    now = 230;
+    buf.append(pcmTone(160, 0));
+    expect(onSpeechStopped).toHaveBeenCalledTimes(1);
+    expect(buf.isSpeaking()).toBe(false);
+  });
+
+  it("interrupting silence resets the silence streak", () => {
+    let now = 0;
+    const onSpeechStopped = vi.fn();
+    const buf = new RealtimeInputBuffer({
+      vadSilenceThreshold: 100,
+      vadSpeechDurationMs: 0,
+      vadSilenceDurationMs: 100,
+      onSpeechStarted: () => undefined,
+      onSpeechStopped,
+      now: () => now,
+    });
+    now = 0;
+    buf.append(pcmTone(160, 5000));
+    now = 50;
+    buf.append(pcmTone(160, 0));
+    now = 80;
+    buf.append(pcmTone(160, 5000)); // burst breaks streak
+    now = 130;
+    buf.append(pcmTone(160, 0));
+    now = 175; // only 45 ms of silence so far — below 100
+    buf.append(pcmTone(160, 0));
+    expect(onSpeechStopped).not.toHaveBeenCalled();
+  });
+
+  it("clear() does NOT fire onSpeechStopped", () => {
+    let now = 0;
+    const onSpeechStopped = vi.fn();
+    const buf = new RealtimeInputBuffer({
+      vadSilenceThreshold: 100,
+      vadSpeechDurationMs: 0,
+      onSpeechStopped,
+      now: () => now,
+    });
+    buf.append(pcmTone(160, 5000));
+    expect(buf.isSpeaking()).toBe(true);
+    buf.clear();
+    expect(buf.isSpeaking()).toBe(false);
+    expect(onSpeechStopped).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/audio/input-buffer.test.ts
+++ b/src/gateway/audio/input-buffer.test.ts
@@ -9,7 +9,9 @@ import {
 /** Build a PCM16 LE buffer of `samples` samples, each at `amplitude`. */
 function pcmTone(samples: number, amplitude: number): Buffer {
   const buf = Buffer.alloc(samples * 2);
-  for (let i = 0; i < samples; i++) buf.writeInt16LE(amplitude, i * 2);
+  for (let i = 0; i < samples; i++) {
+    buf.writeInt16LE(amplitude, i * 2);
+  }
   return buf;
 }
 

--- a/src/gateway/audio/input-buffer.ts
+++ b/src/gateway/audio/input-buffer.ts
@@ -1,0 +1,252 @@
+/**
+ * Real-time PCM audio input buffer — Phase A.2 of streaming multimodal.
+ *
+ * Buffers PCM16 audio chunks streamed from a client (microphone) before
+ * they are committed to the LLM provider. Tracks duration, performs
+ * silence-based end-of-speech detection (VAD), and bounds total memory
+ * to a configurable wall-clock window (default: 30 seconds).
+ *
+ * The buffer is intentionally provider-agnostic. Format conversion
+ * (e.g. 16 kHz → provider rate) happens upstream in the provider adapter.
+ *
+ * See: ../multiplex-frame.ts for the wire transport,
+ *      ../../../.orchestration/streaming-multimodal-prep/ARCHITECTURE.md §3.2.2
+ */
+
+/** Audio format descriptor for PCM streams. */
+export interface AudioFormat {
+  /** Codec — only "pcm16" is supported in Phase A. */
+  readonly type: "pcm16";
+  /** Sample rate (Hz). */
+  readonly sampleRate: number;
+  /** Channel count. Phase A only supports mono (1). */
+  readonly channels: 1;
+}
+
+/** Default 16 kHz mono PCM16 — matches OpenAI Realtime input format. */
+export const DEFAULT_INPUT_FORMAT: AudioFormat = Object.freeze({
+  type: "pcm16",
+  sampleRate: 16000,
+  channels: 1,
+});
+
+/** Configuration for the input buffer. */
+export interface RealtimeInputBufferOptions {
+  /** PCM format. Defaults to 16 kHz mono PCM16. */
+  format?: AudioFormat;
+  /** Max buffered duration in milliseconds (default 30 000). */
+  maxBufferedMs?: number;
+  /**
+   * Silence detection: amplitude (0..32767) below which a sample is
+   * considered silence. Defaults to ~1% of full scale (300).
+   */
+  vadSilenceThreshold?: number;
+  /**
+   * Continuous silence duration (ms) that triggers `onSpeechStopped`
+   * after speech has previously started. Default 600.
+   */
+  vadSilenceDurationMs?: number;
+  /**
+   * Continuous non-silence duration (ms) required to trigger
+   * `onSpeechStarted`. Default 100.
+   */
+  vadSpeechDurationMs?: number;
+  /** Optional callback when speech onset detected. */
+  onSpeechStarted?: () => void;
+  /** Optional callback when speech end detected. */
+  onSpeechStopped?: () => void;
+  /** Optional clock injector (test seam). */
+  now?: () => number;
+}
+
+/** Result of a successful commit. */
+export interface CommitResult {
+  /** Concatenated PCM payload (mono PCM16 little-endian). */
+  audio: Buffer;
+  /** Total audio duration in milliseconds. */
+  durationMs: number;
+  /** Sample rate of the committed audio. */
+  sampleRate: number;
+}
+
+/** Internal speech-detection state. */
+type VadState = "silent" | "speaking";
+
+const PCM16_BYTES_PER_SAMPLE = 2;
+
+/**
+ * Compute average absolute amplitude of a PCM16 LE buffer.
+ * Returns 0 for empty / odd-length buffers.
+ */
+export function pcm16PeakAmplitude(chunk: Buffer): number {
+  const samples = Math.floor(chunk.length / PCM16_BYTES_PER_SAMPLE);
+  if (samples === 0) return 0;
+  let peak = 0;
+  for (let i = 0; i < samples; i++) {
+    const s = chunk.readInt16LE(i * PCM16_BYTES_PER_SAMPLE);
+    const abs = s < 0 ? -s : s;
+    if (abs > peak) peak = abs;
+  }
+  return peak;
+}
+
+/** Convert a PCM16 byte length at `sampleRate` Hz into milliseconds. */
+export function pcm16BytesToMs(bytes: number, sampleRate: number): number {
+  if (sampleRate <= 0) return 0;
+  const samples = Math.floor(bytes / PCM16_BYTES_PER_SAMPLE);
+  return (samples * 1000) / sampleRate;
+}
+
+/**
+ * RealtimeInputBuffer — append PCM chunks, optionally drive VAD callbacks,
+ * commit() to flush a copy of the buffered audio for downstream send.
+ *
+ * Not thread-safe; intended to be owned by a single session manager.
+ */
+export class RealtimeInputBuffer {
+  readonly format: AudioFormat;
+  readonly maxBufferedMs: number;
+  readonly vadSilenceThreshold: number;
+  readonly vadSilenceDurationMs: number;
+  readonly vadSpeechDurationMs: number;
+
+  private readonly chunks: Buffer[] = [];
+  private bufferedBytes = 0;
+  private readonly onSpeechStarted?: () => void;
+  private readonly onSpeechStopped?: () => void;
+  private readonly clock: () => number;
+
+  private vadState: VadState = "silent";
+  private streakStartedAt: number | null = null;
+
+  constructor(options: RealtimeInputBufferOptions = {}) {
+    this.format = options.format ?? DEFAULT_INPUT_FORMAT;
+    if (this.format.type !== "pcm16" || this.format.channels !== 1) {
+      throw new Error(
+        `[RealtimeInputBuffer] only mono pcm16 supported in Phase A (got ${this.format.type}, ${this.format.channels}ch)`,
+      );
+    }
+    if (this.format.sampleRate <= 0) {
+      throw new Error(`[RealtimeInputBuffer] sampleRate must be positive (got ${this.format.sampleRate})`);
+    }
+    this.maxBufferedMs = options.maxBufferedMs ?? 30_000;
+    this.vadSilenceThreshold = options.vadSilenceThreshold ?? 300;
+    this.vadSilenceDurationMs = options.vadSilenceDurationMs ?? 600;
+    this.vadSpeechDurationMs = options.vadSpeechDurationMs ?? 100;
+    this.onSpeechStarted = options.onSpeechStarted;
+    this.onSpeechStopped = options.onSpeechStopped;
+    this.clock = options.now ?? (() => Date.now());
+  }
+
+  /** Append a PCM16 LE chunk. Drops oldest data if `maxBufferedMs` exceeded. */
+  append(chunk: Buffer | Uint8Array): void {
+    if (!(chunk instanceof Uint8Array)) {
+      throw new TypeError("[RealtimeInputBuffer.append] chunk must be a Buffer or Uint8Array");
+    }
+    if (chunk.length === 0) return;
+    if (chunk.length % PCM16_BYTES_PER_SAMPLE !== 0) {
+      throw new Error("[RealtimeInputBuffer.append] PCM16 chunks must have even byte length");
+    }
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.chunks.push(buf);
+    this.bufferedBytes += buf.length;
+    this.evictOverflow();
+    this.tickVad(buf);
+  }
+
+  /** Returns currently buffered duration in milliseconds. */
+  getBufferedDurationMs(): number {
+    return pcm16BytesToMs(this.bufferedBytes, this.format.sampleRate);
+  }
+
+  /** Returns total bytes currently held. */
+  getBufferedBytes(): number {
+    return this.bufferedBytes;
+  }
+
+  /** True if VAD considers user currently speaking. */
+  isSpeaking(): boolean {
+    return this.vadState === "speaking";
+  }
+
+  /**
+   * Commit (flush) the buffer: returns concatenated audio for handing to
+   * the LLM provider, then clears local state. VAD state resets to silent.
+   */
+  commit(): CommitResult {
+    const audio =
+      this.chunks.length === 1 ? this.chunks[0]! : Buffer.concat(this.chunks, this.bufferedBytes);
+    const durationMs = pcm16BytesToMs(audio.length, this.format.sampleRate);
+    this.clearInternal();
+    return {
+      audio: Buffer.from(audio), // detach from internal storage
+      durationMs,
+      sampleRate: this.format.sampleRate,
+    };
+  }
+
+  /** Discard buffered audio without emitting it. */
+  clear(): void {
+    this.clearInternal();
+  }
+
+  // --- internals ----------------------------------------------------------
+
+  private clearInternal(): void {
+    this.chunks.length = 0;
+    this.bufferedBytes = 0;
+    if (this.vadState === "speaking") {
+      this.vadState = "silent";
+      // No callback fire here: explicit clear shouldn't surface a speech-end event.
+    }
+    this.streakStartedAt = null;
+  }
+
+  private evictOverflow(): void {
+    const maxBytes = Math.ceil((this.maxBufferedMs * this.format.sampleRate) / 1000) * PCM16_BYTES_PER_SAMPLE;
+    while (this.bufferedBytes > maxBytes && this.chunks.length > 0) {
+      const head = this.chunks[0]!;
+      const overflow = this.bufferedBytes - maxBytes;
+      if (head.length <= overflow) {
+        this.chunks.shift();
+        this.bufferedBytes -= head.length;
+      } else {
+        // Trim head in place.
+        this.chunks[0] = head.subarray(overflow);
+        this.bufferedBytes -= overflow;
+      }
+    }
+  }
+
+  private tickVad(chunk: Buffer): void {
+    if (!this.onSpeechStarted && !this.onSpeechStopped) return;
+    const peak = pcm16PeakAmplitude(chunk);
+    const isSilent = peak < this.vadSilenceThreshold;
+    const now = this.clock();
+
+    if (this.vadState === "silent") {
+      if (isSilent) {
+        this.streakStartedAt = null;
+        return;
+      }
+      if (this.streakStartedAt == null) this.streakStartedAt = now;
+      if (now - this.streakStartedAt >= this.vadSpeechDurationMs) {
+        this.vadState = "speaking";
+        this.streakStartedAt = null;
+        this.onSpeechStarted?.();
+      }
+      return;
+    }
+    // vadState === "speaking"
+    if (!isSilent) {
+      this.streakStartedAt = null;
+      return;
+    }
+    if (this.streakStartedAt == null) this.streakStartedAt = now;
+    if (now - this.streakStartedAt >= this.vadSilenceDurationMs) {
+      this.vadState = "silent";
+      this.streakStartedAt = null;
+      this.onSpeechStopped?.();
+    }
+  }
+}

--- a/src/gateway/audio/input-buffer.ts
+++ b/src/gateway/audio/input-buffer.ts
@@ -80,19 +80,25 @@ const PCM16_BYTES_PER_SAMPLE = 2;
  */
 export function pcm16PeakAmplitude(chunk: Buffer): number {
   const samples = Math.floor(chunk.length / PCM16_BYTES_PER_SAMPLE);
-  if (samples === 0) return 0;
+  if (samples === 0) {
+    return 0;
+  }
   let peak = 0;
   for (let i = 0; i < samples; i++) {
     const s = chunk.readInt16LE(i * PCM16_BYTES_PER_SAMPLE);
     const abs = s < 0 ? -s : s;
-    if (abs > peak) peak = abs;
+    if (abs > peak) {
+      peak = abs;
+    }
   }
   return peak;
 }
 
 /** Convert a PCM16 byte length at `sampleRate` Hz into milliseconds. */
 export function pcm16BytesToMs(bytes: number, sampleRate: number): number {
-  if (sampleRate <= 0) return 0;
+  if (sampleRate <= 0) {
+    return 0;
+  }
   const samples = Math.floor(bytes / PCM16_BYTES_PER_SAMPLE);
   return (samples * 1000) / sampleRate;
 }
@@ -143,7 +149,9 @@ export class RealtimeInputBuffer {
     if (!(chunk instanceof Uint8Array)) {
       throw new TypeError("[RealtimeInputBuffer.append] chunk must be a Buffer or Uint8Array");
     }
-    if (chunk.length === 0) return;
+    if (chunk.length === 0) {
+      return;
+    }
     if (chunk.length % PCM16_BYTES_PER_SAMPLE !== 0) {
       throw new Error("[RealtimeInputBuffer.append] PCM16 chunks must have even byte length");
     }
@@ -219,7 +227,9 @@ export class RealtimeInputBuffer {
   }
 
   private tickVad(chunk: Buffer): void {
-    if (!this.onSpeechStarted && !this.onSpeechStopped) return;
+    if (!this.onSpeechStarted && !this.onSpeechStopped) {
+      return;
+    }
     const peak = pcm16PeakAmplitude(chunk);
     const isSilent = peak < this.vadSilenceThreshold;
     const now = this.clock();
@@ -229,7 +239,9 @@ export class RealtimeInputBuffer {
         this.streakStartedAt = null;
         return;
       }
-      if (this.streakStartedAt == null) this.streakStartedAt = now;
+      if (this.streakStartedAt == null) {
+        this.streakStartedAt = now;
+      }
       if (now - this.streakStartedAt >= this.vadSpeechDurationMs) {
         this.vadState = "speaking";
         this.streakStartedAt = null;
@@ -242,7 +254,9 @@ export class RealtimeInputBuffer {
       this.streakStartedAt = null;
       return;
     }
-    if (this.streakStartedAt == null) this.streakStartedAt = now;
+    if (this.streakStartedAt == null) {
+      this.streakStartedAt = now;
+    }
     if (now - this.streakStartedAt >= this.vadSilenceDurationMs) {
       this.vadState = "silent";
       this.streakStartedAt = null;

--- a/src/gateway/audio/input-buffer.ts
+++ b/src/gateway/audio/input-buffer.ts
@@ -183,7 +183,7 @@ export class RealtimeInputBuffer {
    */
   commit(): CommitResult {
     const audio =
-      this.chunks.length === 1 ? this.chunks[0]! : Buffer.concat(this.chunks, this.bufferedBytes);
+      this.chunks.length === 1 ? this.chunks[0] : Buffer.concat(this.chunks, this.bufferedBytes);
     const durationMs = pcm16BytesToMs(audio.length, this.format.sampleRate);
     this.clearInternal();
     return {
@@ -213,7 +213,7 @@ export class RealtimeInputBuffer {
   private evictOverflow(): void {
     const maxBytes = Math.ceil((this.maxBufferedMs * this.format.sampleRate) / 1000) * PCM16_BYTES_PER_SAMPLE;
     while (this.bufferedBytes > maxBytes && this.chunks.length > 0) {
-      const head = this.chunks[0]!;
+      const head = this.chunks[0];
       const overflow = this.bufferedBytes - maxBytes;
       if (head.length <= overflow) {
         this.chunks.shift();

--- a/src/gateway/audio/output-buffer.test.ts
+++ b/src/gateway/audio/output-buffer.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { RealtimeOutputBuffer } from "./output-buffer.js";
+
+describe("RealtimeOutputBuffer: enqueue & timeline", () => {
+  it("starts empty", () => {
+    const out = new RealtimeOutputBuffer();
+    expect(out.getQueueLength()).toBe(0);
+    expect(out.getTotalEnqueuedMs()).toBe(0);
+    expect(out.getPlaybackPosition()).toBe(0);
+  });
+
+  it("assigns sequential start/end timestamps", () => {
+    const out = new RealtimeOutputBuffer();
+    const a = out.enqueueChunk("AAA", 250);
+    const b = out.enqueueChunk("BBB", 500);
+    expect(a).toMatchObject({ startMs: 0, endMs: 250, durationMs: 250 });
+    expect(b).toMatchObject({ startMs: 250, endMs: 750, durationMs: 500 });
+    expect(out.getTotalEnqueuedMs()).toBe(750);
+    expect(out.getQueueLength()).toBe(2);
+  });
+
+  it("rejects negative or non-finite durations", () => {
+    const out = new RealtimeOutputBuffer();
+    expect(() => out.enqueueChunk("x", -1)).toThrow(RangeError);
+    expect(() => out.enqueueChunk("x", Number.NaN)).toThrow(RangeError);
+    expect(() => out.enqueueChunk("x", Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  it("supports zero-duration chunks (e.g. metadata frames)", () => {
+    const out = new RealtimeOutputBuffer();
+    const c = out.enqueueChunk("meta", 0);
+    expect(c.endMs).toBe(0);
+    expect(out.getQueueLength()).toBe(1);
+  });
+
+  it("supports Buffer payloads", () => {
+    const out = new RealtimeOutputBuffer();
+    const c = out.enqueueChunk(Buffer.from([1, 2, 3]), 10);
+    expect(Buffer.isBuffer(c.payload)).toBe(true);
+  });
+});
+
+describe("RealtimeOutputBuffer: playback position", () => {
+  it("uses injected clock and caps at total enqueued", () => {
+    let now = 1000;
+    const out = new RealtimeOutputBuffer({ now: () => now });
+    out.enqueueChunk("a", 100);
+    expect(out.getPlaybackPosition()).toBe(0);
+    now = 1050;
+    expect(out.getPlaybackPosition()).toBe(50);
+    now = 5000;
+    expect(out.getPlaybackPosition()).toBe(100); // capped
+  });
+
+  it("returns 0 before the first chunk is enqueued", () => {
+    const out = new RealtimeOutputBuffer({ now: () => 9999 });
+    expect(out.getPlaybackPosition()).toBe(0);
+  });
+});
+
+describe("RealtimeOutputBuffer: flush", () => {
+  it("drains all queued chunks in order without changing the timeline", () => {
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("a", 100);
+    out.enqueueChunk("b", 200);
+    const drained = out.flush();
+    expect(drained.map((c) => c.payload)).toEqual(["a", "b"]);
+    expect(out.getQueueLength()).toBe(0);
+    // Flush does not reset the monotonic enqueue counter.
+    expect(out.getTotalEnqueuedMs()).toBe(300);
+  });
+
+  it("returns empty array when nothing queued", () => {
+    expect(new RealtimeOutputBuffer().flush()).toEqual([]);
+  });
+});
+
+describe("RealtimeOutputBuffer: truncate", () => {
+  it("drops trailing chunks whose start exceeds cutoff", () => {
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("a", 100); // 0..100
+    out.enqueueChunk("b", 100); // 100..200
+    out.enqueueChunk("c", 100); // 200..300
+    const r = out.truncate(150);
+    expect(r.audioEndMs).toBe(150);
+    expect(r.chunksDropped).toBe(1);
+    expect(r.msDropped).toBe(150); // partial-tail of b (50) + entire c (100)
+    const queue = out.peekQueue();
+    expect(queue.length).toBe(2);
+    expect(queue[1]).toMatchObject({ startMs: 100, endMs: 150, durationMs: 50, payload: "b" });
+  });
+
+  it("trims a partial chunk tail at the boundary", () => {
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("solo", 1000);
+    const r = out.truncate(400);
+    expect(r.audioEndMs).toBe(400);
+    expect(r.msDropped).toBe(600);
+    expect(r.chunksDropped).toBe(0);
+    expect(out.peekQueue()[0]).toMatchObject({ durationMs: 400, endMs: 400 });
+    expect(out.getTotalEnqueuedMs()).toBe(400);
+  });
+
+  it("clamps cutoff to total enqueued (cannot grow timeline)", () => {
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("a", 100);
+    const r = out.truncate(9999);
+    expect(r.audioEndMs).toBe(100);
+    expect(r.chunksDropped).toBe(0);
+    expect(r.msDropped).toBe(0);
+  });
+
+  it("truncate(0) drops everything", () => {
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("a", 100);
+    out.enqueueChunk("b", 200);
+    const r = out.truncate(0);
+    expect(r.chunksDropped).toBe(2);
+    expect(r.msDropped).toBe(300);
+    expect(out.peekQueue().length).toBe(0);
+    expect(out.getTotalEnqueuedMs()).toBe(0);
+  });
+
+  it("rejects negative or non-finite cutoff", () => {
+    const out = new RealtimeOutputBuffer();
+    expect(() => out.truncate(-1)).toThrow(RangeError);
+    expect(() => out.truncate(Number.NaN)).toThrow(RangeError);
+  });
+
+  it("truncate pins playback position regardless of clock", () => {
+    let now = 0;
+    const out = new RealtimeOutputBuffer({ now: () => now });
+    out.enqueueChunk("a", 1000);
+    now = 800;
+    expect(out.getPlaybackPosition()).toBe(800);
+    out.truncate(500);
+    now = 5000;
+    expect(out.getPlaybackPosition()).toBe(500);
+  });
+
+  it("matches the truncate accuracy target (±50 ms cutoff alignment)", () => {
+    // Phase B exit criterion is ±50ms; A.2 just needs to expose the data.
+    const out = new RealtimeOutputBuffer();
+    out.enqueueChunk("a", 230);
+    out.enqueueChunk("b", 480);
+    const r = out.truncate(412);
+    expect(Math.abs(r.audioEndMs - 412)).toBeLessThanOrEqual(50);
+    expect(out.peekQueue()[1]).toMatchObject({ startMs: 230, endMs: 412 });
+  });
+});
+
+describe("RealtimeOutputBuffer: reset", () => {
+  it("clears chunks, timeline, override, and start time", () => {
+    let now = 0;
+    const out = new RealtimeOutputBuffer({ now: () => now });
+    out.enqueueChunk("a", 100);
+    out.truncate(50);
+    out.reset();
+    expect(out.getQueueLength()).toBe(0);
+    expect(out.getTotalEnqueuedMs()).toBe(0);
+    expect(out.getPlaybackPosition()).toBe(0);
+
+    now = 100;
+    out.enqueueChunk("b", 200); // playback start = 100
+    now = 250;
+    expect(out.getPlaybackPosition()).toBe(150);
+  });
+});

--- a/src/gateway/audio/output-buffer.ts
+++ b/src/gateway/audio/output-buffer.ts
@@ -143,7 +143,7 @@ export class RealtimeOutputBuffer {
 
     // Drop trailing chunks whose start is at/after the cutoff.
     while (this.chunks.length > 0) {
-      const last = this.chunks[this.chunks.length - 1]!;
+      const last = this.chunks[this.chunks.length - 1];
       if (last.startMs >= cutoff) {
         this.chunks.pop();
         chunksDropped++;

--- a/src/gateway/audio/output-buffer.ts
+++ b/src/gateway/audio/output-buffer.ts
@@ -100,10 +100,16 @@ export class RealtimeOutputBuffer {
    * `totalEnqueuedMs`. After truncate, returns the truncated position.
    */
   getPlaybackPosition(): number {
-    if (this.playbackOverrideMs != null) return this.playbackOverrideMs;
-    if (this.playbackStartedAt == null) return 0;
+    if (this.playbackOverrideMs != null) {
+      return this.playbackOverrideMs;
+    }
+    if (this.playbackStartedAt == null) {
+      return 0;
+    }
     const elapsed = this.clock() - this.playbackStartedAt;
-    if (elapsed <= 0) return 0;
+    if (elapsed <= 0) {
+      return 0;
+    }
     return Math.min(elapsed, this.totalEnqueuedMs);
   }
 
@@ -113,7 +119,7 @@ export class RealtimeOutputBuffer {
    * from the queue. Does NOT touch the playback timeline.
    */
   flush(): OutputAudioChunk[] {
-    const drained = this.chunks.splice(0, this.chunks.length);
+    const drained = this.chunks.splice(0);
     return drained;
   }
 

--- a/src/gateway/audio/output-buffer.ts
+++ b/src/gateway/audio/output-buffer.ts
@@ -1,0 +1,184 @@
+/**
+ * Real-time PCM audio output buffer — Phase A.2 of streaming multimodal.
+ *
+ * Tracks streaming audio chunks delivered by the LLM provider and
+ * exposes a virtual playback timeline used for barge-in / truncate
+ * calculations (Phase B). Storage is opaque (provider-encoded chunks
+ * are kept verbatim) so this works for both raw PCM and base64 payloads.
+ *
+ * See ../../../.orchestration/streaming-multimodal-prep/ARCHITECTURE.md §3.2.2.
+ */
+
+/** A single streamed audio chunk produced by the LLM. */
+export interface OutputAudioChunk {
+  /** Opaque payload (e.g. base64-encoded PCM16, or raw bytes). */
+  readonly payload: string | Buffer;
+  /** Duration of this chunk in milliseconds. */
+  readonly durationMs: number;
+  /** Cumulative timeline offset (ms) where this chunk *starts*. */
+  readonly startMs: number;
+  /** Cumulative timeline offset (ms) where this chunk *ends* (start + duration). */
+  readonly endMs: number;
+}
+
+/** Result of a truncate operation (used to inform the LLM via conversation.item.truncate). */
+export interface TruncateResult {
+  /**
+   * Audio end position in ms — passed to the provider's truncate event so
+   * the model knows how much of the response was actually heard.
+   */
+  audioEndMs: number;
+  /** Number of chunks removed from the queue. */
+  chunksDropped: number;
+  /** Total milliseconds of audio dropped. */
+  msDropped: number;
+}
+
+/** Configuration knobs. */
+export interface RealtimeOutputBufferOptions {
+  /** Optional clock injector (test seam). */
+  now?: () => number;
+}
+
+/**
+ * RealtimeOutputBuffer — accept LLM audio deltas, expose a playback
+ * timeline, and allow the head of the queue to be flushed to the client
+ * or truncated when the user barges in.
+ */
+export class RealtimeOutputBuffer {
+  private readonly chunks: OutputAudioChunk[] = [];
+  /** Total ms enqueued ever (monotonic; not decremented on flush/truncate). */
+  private totalEnqueuedMs = 0;
+  /** Wall-clock ms at which playback nominally began (when first chunk enqueued). */
+  private playbackStartedAt: number | null = null;
+  /**
+   * After truncate, force the playback position to this absolute timeline ms.
+   * `null` means "compute from clock + start time".
+   */
+  private playbackOverrideMs: number | null = null;
+  private readonly clock: () => number;
+
+  constructor(options: RealtimeOutputBufferOptions = {}) {
+    this.clock = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Enqueue a streamed chunk. `durationMs` must be non-negative.
+   *
+   * Returns the chunk descriptor with assigned start/end timeline offsets.
+   */
+  enqueueChunk(payload: string | Buffer, durationMs: number): OutputAudioChunk {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      throw new RangeError(
+        `[RealtimeOutputBuffer.enqueueChunk] durationMs must be a non-negative finite number (got ${durationMs})`,
+      );
+    }
+    const startMs = this.totalEnqueuedMs;
+    const endMs = startMs + durationMs;
+    const chunk: OutputAudioChunk = { payload, durationMs, startMs, endMs };
+    this.chunks.push(chunk);
+    this.totalEnqueuedMs = endMs;
+    if (this.playbackStartedAt == null) {
+      this.playbackStartedAt = this.clock();
+    }
+    return chunk;
+  }
+
+  /** Total ms of audio ever enqueued (monotonic). */
+  getTotalEnqueuedMs(): number {
+    return this.totalEnqueuedMs;
+  }
+
+  /** Number of chunks currently queued (not yet flushed). */
+  getQueueLength(): number {
+    return this.chunks.length;
+  }
+
+  /**
+   * Estimated playback position in ms along the timeline. Reflects
+   * wall-clock advancement since the first chunk was enqueued, capped at
+   * `totalEnqueuedMs`. After truncate, returns the truncated position.
+   */
+  getPlaybackPosition(): number {
+    if (this.playbackOverrideMs != null) return this.playbackOverrideMs;
+    if (this.playbackStartedAt == null) return 0;
+    const elapsed = this.clock() - this.playbackStartedAt;
+    if (elapsed <= 0) return 0;
+    return Math.min(elapsed, this.totalEnqueuedMs);
+  }
+
+  /**
+   * Drain queued chunks up to the head; consumer is responsible for
+   * shipping them to the client. Returns chunks in order and removes them
+   * from the queue. Does NOT touch the playback timeline.
+   */
+  flush(): OutputAudioChunk[] {
+    const drained = this.chunks.splice(0, this.chunks.length);
+    return drained;
+  }
+
+  /**
+   * Truncate audio after `audioEndMs` along the timeline. Drops any
+   * chunks (or chunk tails) whose start exceeds the cutoff and pins the
+   * reported playback position to that cutoff.
+   *
+   * Returns metadata suitable for forwarding to the provider's
+   * `conversation.item.truncate` event.
+   */
+  truncate(audioEndMs: number): TruncateResult {
+    if (!Number.isFinite(audioEndMs) || audioEndMs < 0) {
+      throw new RangeError(
+        `[RealtimeOutputBuffer.truncate] audioEndMs must be a non-negative finite number (got ${audioEndMs})`,
+      );
+    }
+    const cutoff = Math.min(audioEndMs, this.totalEnqueuedMs);
+    let chunksDropped = 0;
+    let msDropped = 0;
+
+    // Drop trailing chunks whose start is at/after the cutoff.
+    while (this.chunks.length > 0) {
+      const last = this.chunks[this.chunks.length - 1]!;
+      if (last.startMs >= cutoff) {
+        this.chunks.pop();
+        chunksDropped++;
+        msDropped += last.durationMs;
+        continue;
+      }
+      // Possible partial-tail trim of the boundary chunk.
+      if (last.endMs > cutoff) {
+        const trimmedDuration = cutoff - last.startMs;
+        const droppedTail = last.endMs - cutoff;
+        msDropped += droppedTail;
+        // Replace with shortened chunk preserving identity of payload (caller
+        // can decide whether to actually re-encode the audio bytes).
+        this.chunks[this.chunks.length - 1] = {
+          payload: last.payload,
+          durationMs: trimmedDuration,
+          startMs: last.startMs,
+          endMs: cutoff,
+        };
+      }
+      break;
+    }
+
+    this.totalEnqueuedMs = cutoff;
+    this.playbackOverrideMs = cutoff;
+    return { audioEndMs: cutoff, chunksDropped, msDropped };
+  }
+
+  /**
+   * Reset the buffer to an empty / fresh state (used when starting a new
+   * response turn).
+   */
+  reset(): void {
+    this.chunks.length = 0;
+    this.totalEnqueuedMs = 0;
+    this.playbackStartedAt = null;
+    this.playbackOverrideMs = null;
+  }
+
+  /** Snapshot of the current chunk queue (read-only, defensive copy). */
+  peekQueue(): readonly OutputAudioChunk[] {
+    return this.chunks.slice();
+  }
+}

--- a/src/gateway/multiplex-control.test.ts
+++ b/src/gateway/multiplex-control.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  computeBackpressureLevel,
+  MultiplexControlChannel,
+  type BackpressureMessage,
+  type ControlAckMessage,
+  type ControlErrorMessage,
+  type PauseResumeMessage,
+} from "./multiplex-control.js";
+import {
+  decodeMultiplexFrame,
+  encodeMultiplexFrame,
+  MULTIPLEX_FLAG_PRIORITY,
+  MULTIPLEX_STREAM,
+  type MultiplexFrame,
+} from "./multiplex-frame.js";
+
+function controlFrame(payload: object): MultiplexFrame {
+  const buf = encodeMultiplexFrame(
+    MULTIPLEX_STREAM.CONTROL,
+    Buffer.from(JSON.stringify(payload)),
+  );
+  return decodeMultiplexFrame(buf);
+}
+
+function decodeSent(send: ReturnType<typeof vi.fn>, idx = 0): { frame: MultiplexFrame; payload: Record<string, unknown> } {
+  const buf = send.mock.calls[idx]?.[0] as Buffer;
+  const frame = decodeMultiplexFrame(buf);
+  const payload = JSON.parse(frame.payload.toString("utf8")) as Record<string, unknown>;
+  return { frame, payload };
+}
+
+describe("MultiplexControlChannel — outbound", () => {
+  it("requires a send callback", () => {
+    expect(() => new MultiplexControlChannel({ send: undefined as never })).toThrow(TypeError);
+  });
+
+  it("sendBackpressure emits a frame on streamId CONTROL with PRIORITY flag", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+
+    const sent = ch.sendBackpressure("high", { bufferedBytes: 1024, queuedFrames: 5 });
+    expect(sent).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const { frame, payload } = decodeSent(send);
+    expect(frame.streamId).toBe(MULTIPLEX_STREAM.CONTROL);
+    expect(frame.flags & MULTIPLEX_FLAG_PRIORITY).toBe(MULTIPLEX_FLAG_PRIORITY);
+    expect(payload).toMatchObject({
+      type: "backpressure",
+      level: "high",
+      bufferedBytes: 1024,
+      queuedFrames: 5,
+    });
+  });
+
+  it("sendBackpressure is idempotent on level (no duplicate frames)", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    expect(ch.sendBackpressure("high")).toBe(true);
+    expect(ch.sendBackpressure("high")).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("sendBackpressure(force=true) bypasses idempotence", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendBackpressure("high");
+    ch.sendBackpressure("high", { force: true });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("sendPause / sendResume emit pause/resume frames", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendPause(MULTIPLEX_STREAM.AUDIO_INPUT);
+    ch.sendResume(MULTIPLEX_STREAM.AUDIO_INPUT);
+    expect(send).toHaveBeenCalledTimes(2);
+
+    const a = decodeSent(send, 0);
+    const b = decodeSent(send, 1);
+    expect(a.payload).toMatchObject({ type: "pause", streamId: MULTIPLEX_STREAM.AUDIO_INPUT });
+    expect(b.payload).toMatchObject({ type: "resume", streamId: MULTIPLEX_STREAM.AUDIO_INPUT });
+  });
+
+  it("sendPause without a streamId encodes connection-wide pause", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendPause();
+    const { payload } = decodeSent(send);
+    expect(payload.type).toBe("pause");
+    expect(payload.streamId).toBeUndefined();
+  });
+
+  it("sendError encodes a stream-level error", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendError("RATE_LIMIT", "too many frames", MULTIPLEX_STREAM.AUDIO_INPUT);
+    const { payload } = decodeSent(send);
+    expect(payload).toMatchObject({
+      type: "error",
+      code: "RATE_LIMIT",
+      message: "too many frames",
+      streamId: MULTIPLEX_STREAM.AUDIO_INPUT,
+    });
+  });
+
+  it("sendAck includes forType and arbitrary extras", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendAck("backpressure", { bufferedBytes: 0 });
+    const { payload } = decodeSent(send);
+    expect(payload).toMatchObject({ type: "ack", forType: "backpressure", bufferedBytes: 0 });
+  });
+
+  it("tracks framesSent in stats", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.sendBackpressure("high");
+    ch.sendPause();
+    ch.sendResume();
+    ch.sendError("X", "y");
+    expect(ch.stats.framesSent).toBe(4);
+  });
+});
+
+describe("MultiplexControlChannel — inbound", () => {
+  it("dispatches a backpressure message to onBackpressure", () => {
+    const send = vi.fn();
+    const onBackpressure = vi.fn<[BackpressureMessage], void>();
+    const ch = new MultiplexControlChannel({ send, onBackpressure });
+    ch.handleFrame(controlFrame({ type: "backpressure", level: "high", bufferedBytes: 2048 }));
+    expect(onBackpressure).toHaveBeenCalledTimes(1);
+    expect(onBackpressure.mock.calls[0]?.[0]).toMatchObject({ level: "high", bufferedBytes: 2048 });
+    expect(ch.stats.lastReceivedBackpressureLevel).toBe("high");
+  });
+
+  it("dispatches pause/resume messages", () => {
+    const send = vi.fn();
+    const onPause = vi.fn<[PauseResumeMessage], void>();
+    const onResume = vi.fn<[PauseResumeMessage], void>();
+    const ch = new MultiplexControlChannel({ send, onPause, onResume });
+    ch.handleFrame(controlFrame({ type: "pause", streamId: 1 }));
+    ch.handleFrame(controlFrame({ type: "resume" }));
+    expect(onPause).toHaveBeenCalledTimes(1);
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onPause.mock.calls[0]?.[0]?.streamId).toBe(1);
+  });
+
+  it("dispatches an error message", () => {
+    const send = vi.fn();
+    const onError = vi.fn<[ControlErrorMessage], void>();
+    const ch = new MultiplexControlChannel({ send, onError });
+    ch.handleFrame(controlFrame({ type: "error", code: "BOOM", message: "x", streamId: 2 }));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: "BOOM", message: "x", streamId: 2 });
+  });
+
+  it("dispatches an ack message", () => {
+    const send = vi.fn();
+    const onAck = vi.fn<[ControlAckMessage], void>();
+    const ch = new MultiplexControlChannel({ send, onAck });
+    ch.handleFrame(controlFrame({ type: "ack", forType: "backpressure", extra: 1 }));
+    expect(onAck).toHaveBeenCalledTimes(1);
+    expect(onAck.mock.calls[0]?.[0]?.forType).toBe("backpressure");
+  });
+
+  it("calls onUnknown for unknown types", () => {
+    const send = vi.fn();
+    const onUnknown = vi.fn();
+    const ch = new MultiplexControlChannel({ send, onUnknown });
+    ch.handleFrame(controlFrame({ type: "future-thing", payload: { x: 1 } }));
+    expect(onUnknown).toHaveBeenCalledTimes(1);
+    expect((onUnknown.mock.calls[0]?.[0] as Record<string, unknown>)?.type).toBe("future-thing");
+  });
+
+  it("calls onParseError on invalid JSON", () => {
+    const send = vi.fn();
+    const onParseError = vi.fn();
+    const ch = new MultiplexControlChannel({ send, onParseError });
+    const garbage = encodeMultiplexFrame(MULTIPLEX_STREAM.CONTROL, Buffer.from("not json{{"));
+    ch.handleFrame(decodeMultiplexFrame(garbage));
+    expect(onParseError).toHaveBeenCalledTimes(1);
+    expect(ch.stats.parseErrors).toBe(1);
+  });
+
+  it("calls onParseError when payload is not a JSON object", () => {
+    const send = vi.fn();
+    const onParseError = vi.fn();
+    const ch = new MultiplexControlChannel({ send, onParseError });
+    ch.handleFrame(controlFrame([1, 2, 3] as never));
+    expect(onParseError).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onParseError when backpressure missing level", () => {
+    const send = vi.fn();
+    const onParseError = vi.fn();
+    const onBackpressure = vi.fn();
+    const ch = new MultiplexControlChannel({ send, onBackpressure, onParseError });
+    ch.handleFrame(controlFrame({ type: "backpressure" }));
+    expect(onParseError).toHaveBeenCalledTimes(1);
+    expect(onBackpressure).not.toHaveBeenCalled();
+  });
+
+  it("ignores frames for non-CONTROL streamIds", () => {
+    const send = vi.fn();
+    const onBackpressure = vi.fn();
+    const ch = new MultiplexControlChannel({ send, onBackpressure });
+    const wrongStream: MultiplexFrame = {
+      streamId: MULTIPLEX_STREAM.AUDIO_INPUT,
+      flags: 0,
+      payload: Buffer.from(JSON.stringify({ type: "backpressure", level: "high" })),
+    };
+    ch.handleFrame(wrongStream);
+    expect(onBackpressure).not.toHaveBeenCalled();
+  });
+
+  it("tracks framesReceived", () => {
+    const send = vi.fn();
+    const ch = new MultiplexControlChannel({ send });
+    ch.handleFrame(controlFrame({ type: "ack", forType: "x" }));
+    ch.handleFrame(controlFrame({ type: "ack", forType: "y" }));
+    expect(ch.stats.framesReceived).toBe(2);
+  });
+});
+
+describe("computeBackpressureLevel", () => {
+  it("returns 'high' when current crosses high watermark from idle", () => {
+    expect(computeBackpressureLevel(2_000_000, 1_000_000, 250_000, null)).toBe("high");
+  });
+
+  it("returns null when already in 'high' state and still above high watermark", () => {
+    expect(computeBackpressureLevel(2_000_000, 1_000_000, 250_000, "high")).toBeNull();
+  });
+
+  it("returns 'low' when draining below low watermark from 'high'", () => {
+    expect(computeBackpressureLevel(100_000, 1_000_000, 250_000, "high")).toBe("low");
+  });
+
+  it("returns null when between watermarks (hysteresis)", () => {
+    expect(computeBackpressureLevel(500_000, 1_000_000, 250_000, "high")).toBeNull();
+    expect(computeBackpressureLevel(500_000, 1_000_000, 250_000, null)).toBeNull();
+  });
+
+  it("returns null when already 'low' and still below low watermark", () => {
+    expect(computeBackpressureLevel(100_000, 1_000_000, 250_000, "low")).toBeNull();
+  });
+});

--- a/src/gateway/multiplex-control.test.ts
+++ b/src/gateway/multiplex-control.test.ts
@@ -127,7 +127,7 @@ describe("MultiplexControlChannel — outbound", () => {
 describe("MultiplexControlChannel — inbound", () => {
   it("dispatches a backpressure message to onBackpressure", () => {
     const send = vi.fn();
-    const onBackpressure = vi.fn<[BackpressureMessage], void>();
+    const onBackpressure = vi.fn<(msg: BackpressureMessage) => void>();
     const ch = new MultiplexControlChannel({ send, onBackpressure });
     ch.handleFrame(controlFrame({ type: "backpressure", level: "high", bufferedBytes: 2048 }));
     expect(onBackpressure).toHaveBeenCalledTimes(1);
@@ -137,8 +137,8 @@ describe("MultiplexControlChannel — inbound", () => {
 
   it("dispatches pause/resume messages", () => {
     const send = vi.fn();
-    const onPause = vi.fn<[PauseResumeMessage], void>();
-    const onResume = vi.fn<[PauseResumeMessage], void>();
+    const onPause = vi.fn<(msg: PauseResumeMessage) => void>();
+    const onResume = vi.fn<(msg: PauseResumeMessage) => void>();
     const ch = new MultiplexControlChannel({ send, onPause, onResume });
     ch.handleFrame(controlFrame({ type: "pause", streamId: 1 }));
     ch.handleFrame(controlFrame({ type: "resume" }));
@@ -149,7 +149,7 @@ describe("MultiplexControlChannel — inbound", () => {
 
   it("dispatches an error message", () => {
     const send = vi.fn();
-    const onError = vi.fn<[ControlErrorMessage], void>();
+    const onError = vi.fn<(msg: ControlErrorMessage) => void>();
     const ch = new MultiplexControlChannel({ send, onError });
     ch.handleFrame(controlFrame({ type: "error", code: "BOOM", message: "x", streamId: 2 }));
     expect(onError).toHaveBeenCalledTimes(1);
@@ -158,7 +158,7 @@ describe("MultiplexControlChannel — inbound", () => {
 
   it("dispatches an ack message", () => {
     const send = vi.fn();
-    const onAck = vi.fn<[ControlAckMessage], void>();
+    const onAck = vi.fn<(msg: ControlAckMessage) => void>();
     const ch = new MultiplexControlChannel({ send, onAck });
     ch.handleFrame(controlFrame({ type: "ack", forType: "backpressure", extra: 1 }));
     expect(onAck).toHaveBeenCalledTimes(1);

--- a/src/gateway/multiplex-control.ts
+++ b/src/gateway/multiplex-control.ts
@@ -209,7 +209,7 @@ export class MultiplexControlChannel {
     const msg: ControlAckMessage = {
       type: "ack",
       forType,
-      ...(extras ?? {}),
+      ...extras,
     };
     this.send(encodeJsonFrame(msg));
     this.framesSent++;
@@ -278,8 +278,11 @@ export class MultiplexControlChannel {
           type,
           ...(typeof obj.streamId === "number" ? { streamId: obj.streamId } : {}),
         };
-        if (type === "pause") this.opts.onPause?.(msg);
-        else this.opts.onResume?.(msg);
+        if (type === "pause") {
+          this.opts.onPause?.(msg);
+        } else {
+          this.opts.onResume?.(msg);
+        }
         return;
       }
       case "error": {

--- a/src/gateway/multiplex-control.ts
+++ b/src/gateway/multiplex-control.ts
@@ -60,7 +60,7 @@ export interface ControlErrorMessage {
 /** Ack message payload. */
 export interface ControlAckMessage {
   type: "ack";
-  forType: ControlMessageType | string;
+  forType: string;
   [extra: string]: unknown;
 }
 
@@ -205,7 +205,7 @@ export class MultiplexControlChannel {
   }
 
   /** Send an ack for a given prior message. */
-  sendAck(forType: ControlMessageType | string, extras?: Record<string, unknown>): void {
+  sendAck(forType: string, extras?: Record<string, unknown>): void {
     const msg: ControlAckMessage = {
       type: "ack",
       forType,
@@ -249,6 +249,7 @@ export class MultiplexControlChannel {
       return;
     }
 
+    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- narrowed from `unknown` via typeof guard
     const obj = parsed as Record<string, unknown>;
     const type = typeof obj.type === "string" ? obj.type : undefined;
     switch (type) {

--- a/src/gateway/multiplex-control.ts
+++ b/src/gateway/multiplex-control.ts
@@ -228,7 +228,7 @@ export class MultiplexControlChannel {
     }
     this.framesReceived++;
 
-    let parsed: unknown;
+    let parsed: Record<string, unknown> | null = null;
     try {
       parsed = JSON.parse(frame.payload.toString("utf8"));
     } catch (err) {
@@ -249,7 +249,7 @@ export class MultiplexControlChannel {
       return;
     }
 
-    const obj = parsed as Record<string, unknown>;
+    const obj: Record<string, unknown> = parsed;
     const type = typeof obj.type === "string" ? obj.type : undefined;
     switch (type) {
       case "backpressure": {

--- a/src/gateway/multiplex-control.ts
+++ b/src/gateway/multiplex-control.ts
@@ -249,7 +249,6 @@ export class MultiplexControlChannel {
       return;
     }
 
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- narrowed from `unknown` via typeof guard
     const obj = parsed as Record<string, unknown>;
     const type = typeof obj.type === "string" ? obj.type : undefined;
     switch (type) {

--- a/src/gateway/multiplex-control.ts
+++ b/src/gateway/multiplex-control.ts
@@ -1,0 +1,332 @@
+/**
+ * Multiplex control channel — Phase B.4.
+ *
+ * Backpressure + lightweight control plane that rides on streamId 0
+ * (CONTROL) of the multiplex transport. Messages are UTF-8 JSON
+ * payloads with a discriminator `type` field.
+ *
+ * Supported message types:
+ *   - "backpressure" — `{ level: "high" | "low", bufferedBytes?, queuedFrames? }`
+ *     Notifies the peer that the local outbound buffer is full ("high")
+ *     or has drained below the resume threshold ("low").
+ *   - "pause" / "resume" — `{ streamId?: number }`
+ *     Requests peer to pause / resume a specific stream (or all if
+ *     `streamId` omitted).
+ *   - "error" — `{ code: string, message: string, streamId?: number }`
+ *     Surfaces a stream-level error to the peer.
+ *   - "ack" — `{ forType: string, ... }`
+ *     Optional ack for any of the above.
+ *
+ * Unknown types are surfaced via {@link MultiplexControlChannelOptions.onUnknown}
+ * to keep the channel forward-compatible.
+ */
+import {
+  encodeMultiplexFrame,
+  MULTIPLEX_FLAG_PRIORITY,
+  MULTIPLEX_STREAM,
+  type MultiplexFrame,
+} from "./multiplex-frame.js";
+
+/** All built-in control message types. */
+export type ControlMessageType = "backpressure" | "pause" | "resume" | "error" | "ack";
+
+/** Backpressure levels. */
+export type BackpressureLevel = "high" | "low";
+
+/** Backpressure message payload. */
+export interface BackpressureMessage {
+  type: "backpressure";
+  level: BackpressureLevel;
+  bufferedBytes?: number;
+  queuedFrames?: number;
+  /** Optional per-stream scope (omit for connection-wide). */
+  streamId?: number;
+}
+
+/** Pause / resume message payload. */
+export interface PauseResumeMessage {
+  type: "pause" | "resume";
+  streamId?: number;
+}
+
+/** Error message payload. */
+export interface ControlErrorMessage {
+  type: "error";
+  code: string;
+  message: string;
+  streamId?: number;
+}
+
+/** Ack message payload. */
+export interface ControlAckMessage {
+  type: "ack";
+  forType: ControlMessageType | string;
+  [extra: string]: unknown;
+}
+
+/** Union of well-known control messages. */
+export type KnownControlMessage =
+  | BackpressureMessage
+  | PauseResumeMessage
+  | ControlErrorMessage
+  | ControlAckMessage;
+
+/** Send callback — receives an encoded multiplex frame ready for the wire. */
+export type ControlSend = (frame: Buffer) => void;
+
+export interface MultiplexControlChannelOptions {
+  /** Required: how to deliver an encoded multiplex frame to the peer. */
+  send: ControlSend;
+  /** Called when a "backpressure" message is received from the peer. */
+  onBackpressure?: (msg: BackpressureMessage) => void;
+  /** Called when a "pause" message is received from the peer. */
+  onPause?: (msg: PauseResumeMessage) => void;
+  /** Called when a "resume" message is received from the peer. */
+  onResume?: (msg: PauseResumeMessage) => void;
+  /** Called when an "error" message is received from the peer. */
+  onError?: (msg: ControlErrorMessage) => void;
+  /** Called when an "ack" message is received from the peer. */
+  onAck?: (msg: ControlAckMessage) => void;
+  /** Called when an unknown / future-spec type is received. */
+  onUnknown?: (raw: Record<string, unknown>) => void;
+  /**
+   * Called when an inbound control frame can't be parsed (invalid JSON
+   * or non-object payload). Defaults to silently dropping.
+   */
+  onParseError?: (error: Error, frame: MultiplexFrame) => void;
+}
+
+const ENCODER = new TextEncoder();
+
+function encodeJsonFrame(payload: object, flags = 0): Buffer {
+  // Control frames are always priority — they should jump ahead of bulk
+  // audio/video traffic at the WS scheduler level.
+  return encodeMultiplexFrame(
+    MULTIPLEX_STREAM.CONTROL,
+    Buffer.from(ENCODER.encode(JSON.stringify(payload))),
+    flags | MULTIPLEX_FLAG_PRIORITY,
+  );
+}
+
+/**
+ * Per-session control channel.
+ */
+export class MultiplexControlChannel {
+  /** Stream id this channel uses. */
+  static readonly STREAM_ID = MULTIPLEX_STREAM.CONTROL;
+
+  private readonly send: ControlSend;
+  private readonly opts: MultiplexControlChannelOptions;
+  private framesSent = 0;
+  private framesReceived = 0;
+  private parseErrors = 0;
+  /** Local view: did we last send "high" or "low" backpressure? */
+  private lastSentBackpressureLevel: BackpressureLevel | null = null;
+  /** Peer's last reported backpressure level (or null if never). */
+  private lastReceivedBackpressureLevel: BackpressureLevel | null = null;
+
+  constructor(options: MultiplexControlChannelOptions) {
+    if (typeof options.send !== "function") {
+      throw new TypeError("MultiplexControlChannel requires a send callback");
+    }
+    this.send = options.send;
+    this.opts = options;
+  }
+
+  /** Telemetry snapshot. */
+  get stats(): {
+    framesSent: number;
+    framesReceived: number;
+    parseErrors: number;
+    lastSentBackpressureLevel: BackpressureLevel | null;
+    lastReceivedBackpressureLevel: BackpressureLevel | null;
+  } {
+    return {
+      framesSent: this.framesSent,
+      framesReceived: this.framesReceived,
+      parseErrors: this.parseErrors,
+      lastSentBackpressureLevel: this.lastSentBackpressureLevel,
+      lastReceivedBackpressureLevel: this.lastReceivedBackpressureLevel,
+    };
+  }
+
+  // ---- Outbound -----------------------------------------------------------
+
+  /**
+   * Notify peer of a backpressure transition. Only emits a frame when the
+   * level actually changed (idempotent), so it's safe to call from a
+   * `socket.bufferedAmount` watchdog every tick.
+   */
+  sendBackpressure(
+    level: BackpressureLevel,
+    extras?: { bufferedBytes?: number; queuedFrames?: number; streamId?: number; force?: boolean },
+  ): boolean {
+    const force = extras?.force === true;
+    if (!force && this.lastSentBackpressureLevel === level) {
+      return false;
+    }
+    const msg: BackpressureMessage = {
+      type: "backpressure",
+      level,
+      ...(extras?.bufferedBytes !== undefined ? { bufferedBytes: extras.bufferedBytes } : {}),
+      ...(extras?.queuedFrames !== undefined ? { queuedFrames: extras.queuedFrames } : {}),
+      ...(extras?.streamId !== undefined ? { streamId: extras.streamId } : {}),
+    };
+    this.send(encodeJsonFrame(msg));
+    this.framesSent++;
+    this.lastSentBackpressureLevel = level;
+    return true;
+  }
+
+  /** Send a pause request (optionally scoped to one streamId). */
+  sendPause(streamId?: number): void {
+    const msg: PauseResumeMessage = { type: "pause", ...(streamId !== undefined ? { streamId } : {}) };
+    this.send(encodeJsonFrame(msg));
+    this.framesSent++;
+  }
+
+  /** Send a resume request (optionally scoped to one streamId). */
+  sendResume(streamId?: number): void {
+    const msg: PauseResumeMessage = { type: "resume", ...(streamId !== undefined ? { streamId } : {}) };
+    this.send(encodeJsonFrame(msg));
+    this.framesSent++;
+  }
+
+  /** Surface a stream-level error to the peer. */
+  sendError(code: string, message: string, streamId?: number): void {
+    const msg: ControlErrorMessage = {
+      type: "error",
+      code,
+      message,
+      ...(streamId !== undefined ? { streamId } : {}),
+    };
+    this.send(encodeJsonFrame(msg));
+    this.framesSent++;
+  }
+
+  /** Send an ack for a given prior message. */
+  sendAck(forType: ControlMessageType | string, extras?: Record<string, unknown>): void {
+    const msg: ControlAckMessage = {
+      type: "ack",
+      forType,
+      ...(extras ?? {}),
+    };
+    this.send(encodeJsonFrame(msg));
+    this.framesSent++;
+  }
+
+  // ---- Inbound ------------------------------------------------------------
+
+  /**
+   * Frame handler suitable for direct registration with a
+   * {@link MultiplexDemuxer} (`demux.on(MULTIPLEX_STREAM.CONTROL, ch.handleFrame)`).
+   * Bound to `this`.
+   */
+  readonly handleFrame = (frame: MultiplexFrame): void => {
+    if (frame.streamId !== MULTIPLEX_STREAM.CONTROL) {
+      return;
+    }
+    this.framesReceived++;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(frame.payload.toString("utf8"));
+    } catch (err) {
+      this.parseErrors++;
+      this.opts.onParseError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        frame,
+      );
+      return;
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      this.parseErrors++;
+      this.opts.onParseError?.(
+        new Error("control payload must be a JSON object"),
+        frame,
+      );
+      return;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+    const type = typeof obj.type === "string" ? obj.type : undefined;
+    switch (type) {
+      case "backpressure": {
+        const level = obj.level === "high" || obj.level === "low" ? obj.level : null;
+        if (!level) {
+          this.opts.onParseError?.(
+            new Error("backpressure message missing level"),
+            frame,
+          );
+          return;
+        }
+        const msg: BackpressureMessage = {
+          type: "backpressure",
+          level,
+          ...(typeof obj.bufferedBytes === "number" ? { bufferedBytes: obj.bufferedBytes } : {}),
+          ...(typeof obj.queuedFrames === "number" ? { queuedFrames: obj.queuedFrames } : {}),
+          ...(typeof obj.streamId === "number" ? { streamId: obj.streamId } : {}),
+        };
+        this.lastReceivedBackpressureLevel = level;
+        this.opts.onBackpressure?.(msg);
+        return;
+      }
+      case "pause":
+      case "resume": {
+        const msg: PauseResumeMessage = {
+          type,
+          ...(typeof obj.streamId === "number" ? { streamId: obj.streamId } : {}),
+        };
+        if (type === "pause") this.opts.onPause?.(msg);
+        else this.opts.onResume?.(msg);
+        return;
+      }
+      case "error": {
+        const code = typeof obj.code === "string" ? obj.code : "UNKNOWN";
+        const message = typeof obj.message === "string" ? obj.message : "";
+        const msg: ControlErrorMessage = {
+          type: "error",
+          code,
+          message,
+          ...(typeof obj.streamId === "number" ? { streamId: obj.streamId } : {}),
+        };
+        this.opts.onError?.(msg);
+        return;
+      }
+      case "ack": {
+        const forType = typeof obj.forType === "string" ? obj.forType : "unknown";
+        const msg: ControlAckMessage = { ...obj, type: "ack", forType };
+        this.opts.onAck?.(msg);
+        return;
+      }
+      default: {
+        this.opts.onUnknown?.(obj);
+        return;
+      }
+    }
+  };
+}
+
+export const CONTROL_STREAM_ID = MULTIPLEX_STREAM.CONTROL;
+
+/**
+ * Helper: drive backpressure transitions from a numeric watermark.
+ *
+ * Returns the backpressure level to send (or null if no change required).
+ * Use to wrap a `socket.bufferedAmount` poll.
+ */
+export function computeBackpressureLevel(
+  current: number,
+  highWatermark: number,
+  lowWatermark: number,
+  previousLevel: BackpressureLevel | null,
+): BackpressureLevel | null {
+  if (current >= highWatermark && previousLevel !== "high") {
+    return "high";
+  }
+  if (current <= lowWatermark && previousLevel === "high") {
+    return "low";
+  }
+  return null;
+}

--- a/src/gateway/multiplex-demux.test.ts
+++ b/src/gateway/multiplex-demux.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MultiplexDemuxer,
+  MultiplexDemuxError,
+  looksLikeMultiplexedTraffic,
+} from "./multiplex-demux.js";
+import {
+  encodeMultiplexFrame,
+  MULTIPLEX_FLAG_EOM,
+  MULTIPLEX_STREAM,
+  type MultiplexFrame,
+} from "./multiplex-frame.js";
+
+function frame(streamId: number, payload: Buffer | string, flags = 0): Buffer {
+  return encodeMultiplexFrame(
+    streamId,
+    typeof payload === "string" ? Buffer.from(payload) : payload,
+    flags,
+  );
+}
+
+describe("MultiplexDemuxer", () => {
+  it("dispatches a single frame to the registered handler", () => {
+    const handler = vi.fn();
+    const demux = new MultiplexDemuxer({
+      handlers: { [MULTIPLEX_STREAM.AUDIO_INPUT]: handler },
+    });
+
+    const dispatched = demux.push(frame(MULTIPLEX_STREAM.AUDIO_INPUT, "hello"));
+
+    expect(dispatched).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    const call = handler.mock.calls[0]?.[0] as MultiplexFrame;
+    expect(call.streamId).toBe(MULTIPLEX_STREAM.AUDIO_INPUT);
+    expect(call.payload.toString()).toBe("hello");
+  });
+
+  it("dispatches multiple concatenated frames in order", () => {
+    const audioIn = vi.fn();
+    const audioOut = vi.fn();
+    const demux = new MultiplexDemuxer({
+      handlers: {
+        [MULTIPLEX_STREAM.AUDIO_INPUT]: audioIn,
+        [MULTIPLEX_STREAM.AUDIO_OUTPUT]: audioOut,
+      },
+    });
+
+    const combined = Buffer.concat([
+      frame(MULTIPLEX_STREAM.AUDIO_INPUT, "a"),
+      frame(MULTIPLEX_STREAM.AUDIO_OUTPUT, "b"),
+      frame(MULTIPLEX_STREAM.AUDIO_INPUT, "c"),
+    ]);
+
+    const dispatched = demux.push(combined);
+
+    expect(dispatched).toBe(3);
+    expect(audioIn).toHaveBeenCalledTimes(2);
+    expect(audioOut).toHaveBeenCalledTimes(1);
+    expect((audioIn.mock.calls[0]?.[0] as MultiplexFrame).payload.toString()).toBe("a");
+    expect((audioOut.mock.calls[0]?.[0] as MultiplexFrame).payload.toString()).toBe("b");
+    expect((audioIn.mock.calls[1]?.[0] as MultiplexFrame).payload.toString()).toBe("c");
+  });
+
+  it("buffers a partial frame and dispatches once completed across pushes", () => {
+    const handler = vi.fn();
+    const demux = new MultiplexDemuxer({
+      handlers: { [MULTIPLEX_STREAM.AUDIO_INPUT]: handler },
+    });
+
+    const full = frame(MULTIPLEX_STREAM.AUDIO_INPUT, "split-payload");
+    const split = Math.floor(full.length / 2);
+    const a = full.subarray(0, split);
+    const b = full.subarray(split);
+
+    expect(demux.push(a)).toBe(0);
+    expect(handler).not.toHaveBeenCalled();
+    expect(demux.stats.bufferedBytes).toBe(a.length);
+
+    expect(demux.push(b)).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0]?.[0] as MultiplexFrame).payload.toString()).toBe("split-payload");
+    expect(demux.stats.bufferedBytes).toBe(0);
+  });
+
+  it("preserves trailing partial frame after a complete one", () => {
+    const handler = vi.fn();
+    const demux = new MultiplexDemuxer({
+      handlers: { [MULTIPLEX_STREAM.AUDIO_INPUT]: handler },
+    });
+
+    const full = frame(MULTIPLEX_STREAM.AUDIO_INPUT, "complete");
+    const next = frame(MULTIPLEX_STREAM.AUDIO_INPUT, "second");
+    const partial = next.subarray(0, 4);
+
+    const dispatched = demux.push(Buffer.concat([full, partial]));
+    expect(dispatched).toBe(1);
+    expect(demux.stats.bufferedBytes).toBe(4);
+
+    const rest = next.subarray(4);
+    expect(demux.push(rest)).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect((handler.mock.calls[1]?.[0] as MultiplexFrame).payload.toString()).toBe("second");
+  });
+
+  it("invokes onUnknownStream when no handler is registered for a streamId", () => {
+    const unknown = vi.fn();
+    const demux = new MultiplexDemuxer({ onUnknownStream: unknown });
+
+    demux.push(frame(99, "mystery"));
+
+    expect(unknown).toHaveBeenCalledTimes(1);
+    expect((unknown.mock.calls[0]?.[0] as MultiplexFrame).streamId).toBe(99);
+  });
+
+  it("silently drops frames for unknown streams when no fallback is set", () => {
+    const demux = new MultiplexDemuxer();
+    expect(() => demux.push(frame(7, "x"))).not.toThrow();
+    expect(demux.stats.framesDispatched).toBe(1);
+  });
+
+  it("registers and removes handlers via on() / off()", () => {
+    const demux = new MultiplexDemuxer();
+    const handler = vi.fn();
+    demux.on(3, handler);
+    demux.push(frame(3, "first"));
+    demux.off(3);
+    demux.push(frame(3, "second"));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid streamId in on()", () => {
+    const demux = new MultiplexDemuxer();
+    expect(() => demux.on(-1, vi.fn())).toThrow(RangeError);
+    expect(() => demux.on(256, vi.fn())).toThrow(RangeError);
+    expect(() => demux.on(1.5, vi.fn())).toThrow(RangeError);
+  });
+
+  it("propagates flags to handlers (EOM bit)", () => {
+    const handler = vi.fn();
+    const demux = new MultiplexDemuxer({
+      handlers: { [MULTIPLEX_STREAM.AUDIO_INPUT]: handler },
+    });
+    demux.push(frame(MULTIPLEX_STREAM.AUDIO_INPUT, "end", MULTIPLEX_FLAG_EOM));
+    const f = handler.mock.calls[0]?.[0] as MultiplexFrame;
+    expect(f.flags & MULTIPLEX_FLAG_EOM).toBe(MULTIPLEX_FLAG_EOM);
+  });
+
+  it("calls onError and resets buffer on a decode error", () => {
+    const onError = vi.fn();
+    const demux = new MultiplexDemuxer({ onError });
+
+    // Bytes that don't start with the magic byte → MISSING_MAGIC after carry.
+    demux.push(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(demux.stats.bufferedBytes).toBe(0);
+    expect(demux.stats.decodeErrors).toBe(1);
+
+    // Demuxer should remain usable for a fresh valid frame.
+    const handler = vi.fn();
+    demux.on(MULTIPLEX_STREAM.AUDIO_INPUT, handler);
+    demux.push(frame(MULTIPLEX_STREAM.AUDIO_INPUT, "after-error"));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onError when a handler throws but continues dispatching subsequent frames", () => {
+    const onError = vi.fn();
+    const second = vi.fn();
+    const demux = new MultiplexDemuxer({ onError });
+    demux.on(MULTIPLEX_STREAM.AUDIO_INPUT, () => {
+      throw new Error("boom");
+    });
+    demux.on(MULTIPLEX_STREAM.AUDIO_OUTPUT, second);
+
+    demux.push(
+      Buffer.concat([
+        frame(MULTIPLEX_STREAM.AUDIO_INPUT, "first"),
+        frame(MULTIPLEX_STREAM.AUDIO_OUTPUT, "second"),
+      ]),
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces maxBufferBytes and surfaces a BUFFER_OVERFLOW error", () => {
+    const onError = vi.fn();
+    const demux = new MultiplexDemuxer({ onError, maxBufferBytes: 16 });
+    // Send more than 16 bytes that don't form a complete frame yet.
+    const partial = frame(MULTIPLEX_STREAM.AUDIO_INPUT, Buffer.alloc(64, 0x41)).subarray(0, 12);
+    demux.push(partial);
+    demux.push(partial);
+    expect(onError).toHaveBeenCalledTimes(1);
+    const err = onError.mock.calls[0]?.[0] as MultiplexDemuxError;
+    expect(err).toBeInstanceOf(MultiplexDemuxError);
+    expect(err.code).toBe("BUFFER_OVERFLOW");
+    expect(demux.stats.bufferedBytes).toBe(0);
+  });
+
+  it("reset() drops the carry buffer", () => {
+    const demux = new MultiplexDemuxer();
+    const partial = frame(MULTIPLEX_STREAM.AUDIO_INPUT, "x").subarray(0, 4);
+    demux.push(partial);
+    expect(demux.stats.bufferedBytes).toBeGreaterThan(0);
+    demux.reset();
+    expect(demux.stats.bufferedBytes).toBe(0);
+  });
+
+  it("tracks bytesProcessed and framesDispatched in stats", () => {
+    const demux = new MultiplexDemuxer({ handlers: { 1: vi.fn() } });
+    const buf = Buffer.concat([frame(1, "a"), frame(1, "bb"), frame(1, "ccc")]);
+    demux.push(buf);
+    expect(demux.stats.framesDispatched).toBe(3);
+    expect(demux.stats.bytesProcessed).toBe(buf.length);
+  });
+
+  it("decoded payloads are detached copies safe for retention", () => {
+    let captured: MultiplexFrame | undefined;
+    const demux = new MultiplexDemuxer({
+      handlers: { 1: (f) => (captured = f) },
+    });
+    const payload = Buffer.from("retain-me");
+    const enc = frame(1, payload);
+    demux.push(enc);
+    // Mutate the source buffer; payload received by handler must be unaffected.
+    enc.fill(0);
+    expect(captured?.payload.toString()).toBe("retain-me");
+  });
+});
+
+describe("looksLikeMultiplexedTraffic", () => {
+  it("returns true for an encoded multiplex frame", () => {
+    expect(looksLikeMultiplexedTraffic(frame(1, "x"))).toBe(true);
+  });
+
+  it("returns false for plain JSON-like text bytes", () => {
+    expect(looksLikeMultiplexedTraffic(Buffer.from('{"hello":1}'))).toBe(false);
+  });
+
+  it("returns false for non-Buffer inputs", () => {
+    expect(looksLikeMultiplexedTraffic(undefined)).toBe(false);
+    expect(looksLikeMultiplexedTraffic("string")).toBe(false);
+    expect(looksLikeMultiplexedTraffic(42)).toBe(false);
+  });
+
+  it("returns false for an under-sized buffer (just the magic byte)", () => {
+    expect(looksLikeMultiplexedTraffic(Buffer.from([0xfe]))).toBe(false);
+  });
+});

--- a/src/gateway/multiplex-demux.ts
+++ b/src/gateway/multiplex-demux.ts
@@ -1,0 +1,202 @@
+/**
+ * Multiplex demultiplexer — routes decoded frames from a single binary
+ * stream into per-streamId handlers, with optional buffering for partial
+ * frames spanning multiple WebSocket message boundaries.
+ *
+ * Phase B.1 of streaming-multimodal: pure module, framework-agnostic. The
+ * gateway WebSocket layer can call {@link MultiplexDemuxer.push} on every
+ * inbound binary `Buffer` to dispatch any complete frames to the
+ * registered handlers (one per streamId). Partial trailing bytes are
+ * retained internally for the next push.
+ */
+import {
+  decodeMultiplexFrames,
+  isMultiplexedFrame,
+  MULTIPLEX_FRAME_ENVELOPE_OVERHEAD,
+  MULTIPLEX_FRAME_HEADER_SIZE,
+  MULTIPLEX_FRAME_MAX_PAYLOAD,
+  type MultiplexFrame,
+} from "./multiplex-frame.js";
+
+/** Error class specific to the demuxer (separate from the codec error). */
+export class MultiplexDemuxError extends Error {
+  readonly code: "BUFFER_OVERFLOW" | "HANDLER_THREW";
+
+  constructor(code: MultiplexDemuxError["code"], message: string) {
+    super(`[multiplex-demux:${code}] ${message}`);
+    this.name = "MultiplexDemuxError";
+    this.code = code;
+  }
+}
+
+/** Maximum bytes the demuxer will buffer waiting for a complete frame. */
+export const MULTIPLEX_DEMUX_DEFAULT_MAX_BUFFER_BYTES =
+  MULTIPLEX_FRAME_MAX_PAYLOAD + MULTIPLEX_FRAME_ENVELOPE_OVERHEAD + 1024;
+
+/** Handler invoked for every successfully decoded frame on a streamId. */
+export type MultiplexFrameHandler = (frame: MultiplexFrame) => void;
+
+/** Handler invoked when an unknown streamId is seen. Defaults to silent drop. */
+export type MultiplexUnknownStreamHandler = (frame: MultiplexFrame) => void;
+
+/** Handler invoked when decoding fails partway through a buffer. */
+export type MultiplexErrorHandler = (error: Error, context: { totalBytesBuffered: number }) => void;
+
+export interface MultiplexDemuxerOptions {
+  /** Per-streamId handlers. */
+  handlers?: Record<number, MultiplexFrameHandler>;
+  /** Fallback for unrecognized streamIds. */
+  onUnknownStream?: MultiplexUnknownStreamHandler;
+  /** Called with any decode error (frame is dropped, demuxer continues). */
+  onError?: MultiplexErrorHandler;
+  /** Hard cap on internal buffer size (defaults to MAX_PAYLOAD + overhead). */
+  maxBufferBytes?: number;
+}
+
+/**
+ * Stateful demuxer. Maintains a small carry buffer for partial frames and
+ * dispatches complete frames to handlers as they decode.
+ */
+export class MultiplexDemuxer {
+  private readonly handlers: Map<number, MultiplexFrameHandler>;
+  private readonly onUnknownStream?: MultiplexUnknownStreamHandler;
+  private readonly onError?: MultiplexErrorHandler;
+  private readonly maxBufferBytes: number;
+  private carry: Buffer = Buffer.alloc(0);
+  private framesDispatched = 0;
+  private bytesProcessed = 0;
+  private decodeErrors = 0;
+
+  constructor(options: MultiplexDemuxerOptions = {}) {
+    this.handlers = new Map();
+    if (options.handlers) {
+      for (const [key, value] of Object.entries(options.handlers)) {
+        const id = Number(key);
+        if (Number.isFinite(id)) {
+          this.handlers.set(id, value);
+        }
+      }
+    }
+    this.onUnknownStream = options.onUnknownStream;
+    this.onError = options.onError;
+    this.maxBufferBytes = options.maxBufferBytes ?? MULTIPLEX_DEMUX_DEFAULT_MAX_BUFFER_BYTES;
+  }
+
+  /**
+   * Register / replace the handler for a streamId.
+   */
+  on(streamId: number, handler: MultiplexFrameHandler): void {
+    if (!Number.isInteger(streamId) || streamId < 0 || streamId > 0xff) {
+      throw new RangeError(`invalid streamId ${streamId}`);
+    }
+    this.handlers.set(streamId, handler);
+  }
+
+  /** Remove a streamId handler. */
+  off(streamId: number): void {
+    this.handlers.delete(streamId);
+  }
+
+  /** Total frames successfully dispatched. */
+  get stats(): {
+    framesDispatched: number;
+    bytesProcessed: number;
+    decodeErrors: number;
+    bufferedBytes: number;
+  } {
+    return {
+      framesDispatched: this.framesDispatched,
+      bytesProcessed: this.bytesProcessed,
+      decodeErrors: this.decodeErrors,
+      bufferedBytes: this.carry.length,
+    };
+  }
+
+  /** Discard any partially buffered data (e.g. on session reset). */
+  reset(): void {
+    this.carry = Buffer.alloc(0);
+  }
+
+  /**
+   * Feed a chunk of bytes. Any complete frames are dispatched synchronously;
+   * remaining trailing bytes are retained. Returns the number of frames
+   * dispatched from this call.
+   */
+  push(data: Buffer | Uint8Array): number {
+    const incoming = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    this.bytesProcessed += incoming.length;
+
+    // Combine with any carried partial frame.
+    const combined = this.carry.length > 0 ? Buffer.concat([this.carry, incoming]) : incoming;
+
+    if (combined.length > this.maxBufferBytes) {
+      // Hard cap to prevent runaway memory if a peer streams junk that
+      // never decodes. Reset and surface an error.
+      this.carry = Buffer.alloc(0);
+      const err = new MultiplexDemuxError(
+        "BUFFER_OVERFLOW",
+        `multiplex demuxer buffer exceeded ${this.maxBufferBytes} bytes`,
+      );
+      this.decodeErrors += 1;
+      this.onError?.(err, { totalBytesBuffered: combined.length });
+      return 0;
+    }
+
+    let dispatchedThisCall = 0;
+    let result: { frames: MultiplexFrame[]; remainder: Buffer };
+    try {
+      result = decodeMultiplexFrames(combined);
+    } catch (err) {
+      // Decode error mid-buffer: drop the entire buffered region (we can't
+      // safely re-sync without a magic byte scan; the codec already rejects
+      // anything not starting with 0xFE). Surface and reset.
+      this.carry = Buffer.alloc(0);
+      this.decodeErrors += 1;
+      this.onError?.(err instanceof Error ? err : new Error(String(err)), {
+        totalBytesBuffered: combined.length,
+      });
+      return 0;
+    }
+
+    this.carry = result.remainder;
+
+    for (const frame of result.frames) {
+      const handler = this.handlers.get(frame.streamId);
+      if (handler) {
+        try {
+          handler(frame);
+        } catch (err) {
+          // A handler throwing must not poison the demuxer.
+          this.decodeErrors += 1;
+          this.onError?.(err instanceof Error ? err : new Error(String(err)), {
+            totalBytesBuffered: this.carry.length,
+          });
+          continue;
+        }
+      } else if (this.onUnknownStream) {
+        try {
+          this.onUnknownStream(frame);
+        } catch {
+          /* ignore unknown-stream handler errors */
+        }
+      }
+      this.framesDispatched += 1;
+      dispatchedThisCall += 1;
+    }
+
+    return dispatchedThisCall;
+  }
+}
+
+/**
+ * Convenience guard: returns true if `data` looks like a multiplexed binary
+ * frame (starts with the magic byte and has at least the header). The full
+ * codec performs strict validation; this is a cheap pre-filter.
+ */
+export function looksLikeMultiplexedTraffic(data: unknown): boolean {
+  if (!isMultiplexedFrame(data)) {
+    return false;
+  }
+  const buf = data as Buffer | Uint8Array;
+  return buf.length >= 1 + MULTIPLEX_FRAME_HEADER_SIZE;
+}

--- a/src/gateway/multiplex-demux.ts
+++ b/src/gateway/multiplex-demux.ts
@@ -197,6 +197,6 @@ export function looksLikeMultiplexedTraffic(data: unknown): boolean {
   if (!isMultiplexedFrame(data)) {
     return false;
   }
-  const buf = data as Buffer | Uint8Array;
+  const buf = data;
   return buf.length >= 1 + MULTIPLEX_FRAME_HEADER_SIZE;
 }

--- a/src/gateway/multiplex-frame.test.ts
+++ b/src/gateway/multiplex-frame.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import {
+  MULTIPLEX_FLAG_COMPRESSED,
+  MULTIPLEX_FLAG_DEFINED_MASK,
+  MULTIPLEX_FLAG_EOM,
+  MULTIPLEX_FLAG_PRIORITY,
+  MULTIPLEX_FRAME_ENVELOPE_OVERHEAD,
+  MULTIPLEX_FRAME_HEADER_SIZE,
+  MULTIPLEX_FRAME_MAGIC,
+  MULTIPLEX_FRAME_MAX_PAYLOAD,
+  MULTIPLEX_FRAME_MAX_STREAM_ID,
+  MULTIPLEX_STREAM,
+  MultiplexFrameError,
+  decodeMultiplexFrame,
+  decodeMultiplexFrames,
+  encodeMultiplexFrame,
+  frameHasCompressed,
+  frameHasEom,
+  frameHasPriority,
+  isMultiplexedFrame,
+} from "./multiplex-frame.js";
+
+describe("multiplex-frame: constants", () => {
+  it("uses a 6-byte header (1+1+4) and 7-byte envelope (magic+header)", () => {
+    expect(MULTIPLEX_FRAME_HEADER_SIZE).toBe(6);
+    expect(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD).toBe(7);
+    expect(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD).toBeLessThan(10); // A.1 acceptance: < 10B overhead
+  });
+
+  it("supports stream IDs 0..255 and a 16 MiB payload cap", () => {
+    expect(MULTIPLEX_FRAME_MAX_STREAM_ID).toBe(255);
+    expect(MULTIPLEX_FRAME_MAX_PAYLOAD).toBe(16 * 1024 * 1024);
+  });
+
+  it("exposes well-known stream IDs aligned with ARCHITECTURE.md", () => {
+    expect(MULTIPLEX_STREAM.CONTROL).toBe(0);
+    expect(MULTIPLEX_STREAM.AUDIO_INPUT).toBe(1);
+    expect(MULTIPLEX_STREAM.AUDIO_OUTPUT).toBe(2);
+    expect(MULTIPLEX_STREAM.VIDEO_INPUT).toBe(3);
+    expect(MULTIPLEX_STREAM.VIDEO_OUTPUT).toBe(4);
+  });
+
+  it("flag bitmask aggregates all defined bits", () => {
+    expect(MULTIPLEX_FLAG_DEFINED_MASK).toBe(
+      MULTIPLEX_FLAG_EOM | MULTIPLEX_FLAG_PRIORITY | MULTIPLEX_FLAG_COMPRESSED,
+    );
+  });
+});
+
+describe("encodeMultiplexFrame", () => {
+  it("writes magic byte, stream id, flags, LE length, and payload in order", () => {
+    const payload = Buffer.from("hello", "utf8");
+    const frame = encodeMultiplexFrame(MULTIPLEX_STREAM.CONTROL, payload, MULTIPLEX_FLAG_EOM);
+    expect(frame[0]).toBe(MULTIPLEX_FRAME_MAGIC);
+    expect(frame[1]).toBe(0);
+    expect(frame[2]).toBe(MULTIPLEX_FLAG_EOM);
+    expect(frame.readUInt32LE(3)).toBe(payload.length);
+    expect(frame.subarray(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD).toString("utf8")).toBe("hello");
+  });
+
+  it("accepts Uint8Array payloads", () => {
+    const u8 = new Uint8Array([1, 2, 3, 4]);
+    const frame = encodeMultiplexFrame(2, u8, 0);
+    expect(frame.subarray(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD)).toEqual(Buffer.from(u8));
+  });
+
+  it("encodes a zero-length payload", () => {
+    const frame = encodeMultiplexFrame(0, Buffer.alloc(0), 0);
+    expect(frame.length).toBe(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD);
+    expect(frame.readUInt32LE(3)).toBe(0);
+  });
+
+  it("rejects out-of-range streamId", () => {
+    expect(() => encodeMultiplexFrame(-1, Buffer.alloc(0))).toThrow(MultiplexFrameError);
+    expect(() => encodeMultiplexFrame(256, Buffer.alloc(0))).toThrow(/INVALID_STREAM_ID/);
+    expect(() => encodeMultiplexFrame(1.5, Buffer.alloc(0))).toThrow(/INVALID_STREAM_ID/);
+  });
+
+  it("rejects out-of-range flags", () => {
+    expect(() => encodeMultiplexFrame(0, Buffer.alloc(0), -1)).toThrow(/INVALID_FLAGS/);
+    expect(() => encodeMultiplexFrame(0, Buffer.alloc(0), 256)).toThrow(/INVALID_FLAGS/);
+  });
+
+  it("rejects payloads above 16 MiB", () => {
+    // We don't actually allocate 16 MiB+1 — pass a Uint8Array view with a faked length via subclass.
+    // Easiest path: assert via an oversize buffer of the smallest amount.
+    const oversize = Buffer.alloc(MULTIPLEX_FRAME_MAX_PAYLOAD + 1);
+    expect(() => encodeMultiplexFrame(0, oversize)).toThrow(/PAYLOAD_TOO_LARGE/);
+  });
+
+  it("rejects non-buffer payloads", () => {
+    // @ts-expect-error — runtime guard
+    expect(() => encodeMultiplexFrame(0, "not a buffer")).toThrow(/INVALID_INPUT/);
+  });
+});
+
+describe("decodeMultiplexFrame: roundtrip", () => {
+  it("roundtrips for stream IDs 0..255", () => {
+    const payload = Buffer.from("payload");
+    for (let id = 0; id <= 255; id++) {
+      const frame = encodeMultiplexFrame(id, payload, MULTIPLEX_FLAG_PRIORITY);
+      const decoded = decodeMultiplexFrame(frame);
+      expect(decoded.streamId).toBe(id);
+      expect(decoded.flags).toBe(MULTIPLEX_FLAG_PRIORITY);
+      expect(decoded.payload.equals(payload)).toBe(true);
+    }
+  });
+
+  it("roundtrips for all defined flag combinations", () => {
+    const payload = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    for (let f = 0; f <= MULTIPLEX_FLAG_DEFINED_MASK; f++) {
+      const frame = encodeMultiplexFrame(7, payload, f);
+      const decoded = decodeMultiplexFrame(frame);
+      expect(decoded.flags).toBe(f);
+      expect(frameHasEom(decoded.flags)).toBe((f & MULTIPLEX_FLAG_EOM) !== 0);
+      expect(frameHasPriority(decoded.flags)).toBe((f & MULTIPLEX_FLAG_PRIORITY) !== 0);
+      expect(frameHasCompressed(decoded.flags)).toBe((f & MULTIPLEX_FLAG_COMPRESSED) !== 0);
+    }
+  });
+
+  it("roundtrips a 1 MiB payload", () => {
+    const big = Buffer.alloc(1 * 1024 * 1024);
+    for (let i = 0; i < big.length; i++) {
+      big[i] = i & 0xff;
+    }
+    const frame = encodeMultiplexFrame(2, big, MULTIPLEX_FLAG_EOM);
+    const decoded = decodeMultiplexFrame(frame);
+    expect(decoded.payload.length).toBe(big.length);
+    expect(decoded.payload.equals(big)).toBe(true);
+  });
+
+  it("returns a copy so mutating decoded payload does not affect input", () => {
+    const payload = Buffer.from("immutable");
+    const frame = encodeMultiplexFrame(1, payload);
+    const decoded = decodeMultiplexFrame(frame);
+    decoded.payload[0] = 0;
+    // Original frame buffer payload region untouched.
+    expect(frame[MULTIPLEX_FRAME_ENVELOPE_OVERHEAD]).toBe(payload[0]);
+  });
+});
+
+describe("decodeMultiplexFrame: errors", () => {
+  it("rejects missing magic byte", () => {
+    const bogus = Buffer.from([0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00]);
+    expect(() => decodeMultiplexFrame(bogus)).toThrow(/MISSING_MAGIC/);
+  });
+
+  it("rejects truncated header", () => {
+    const tiny = Buffer.from([MULTIPLEX_FRAME_MAGIC, 0x00, 0x00]);
+    expect(() => decodeMultiplexFrame(tiny)).toThrow(/TRUNCATED_HEADER/);
+  });
+
+  it("rejects truncated payload", () => {
+    const frame = encodeMultiplexFrame(0, Buffer.from("xyz"));
+    const truncated = frame.subarray(0, frame.length - 1);
+    expect(() => decodeMultiplexFrame(truncated)).toThrow(/TRUNCATED_PAYLOAD/);
+  });
+
+  it("rejects trailing bytes (use decodeMultiplexFrames for streams)", () => {
+    const frame = encodeMultiplexFrame(0, Buffer.from("ok"));
+    const extra = Buffer.concat([frame, Buffer.from([0x00])]);
+    expect(() => decodeMultiplexFrame(extra)).toThrow(/TRUNCATED_PAYLOAD/);
+  });
+
+  it("rejects payload-length header above 16 MiB cap", () => {
+    const buf = Buffer.alloc(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD);
+    buf[0] = MULTIPLEX_FRAME_MAGIC;
+    buf[1] = 0;
+    buf[2] = 0;
+    buf.writeUInt32LE(MULTIPLEX_FRAME_MAX_PAYLOAD + 1, 3);
+    expect(() => decodeMultiplexFrame(buf)).toThrow(/PAYLOAD_TOO_LARGE/);
+  });
+
+  it("rejects non-buffer input", () => {
+    // @ts-expect-error — runtime guard
+    expect(() => decodeMultiplexFrame("hi")).toThrow(/INVALID_INPUT/);
+  });
+});
+
+describe("isMultiplexedFrame", () => {
+  it("recognises encoded frames", () => {
+    const frame = encodeMultiplexFrame(0, Buffer.from("a"));
+    expect(isMultiplexedFrame(frame)).toBe(true);
+  });
+
+  it("rejects empty / undersized buffers", () => {
+    expect(isMultiplexedFrame(Buffer.alloc(0))).toBe(false);
+    expect(isMultiplexedFrame(Buffer.from([MULTIPLEX_FRAME_MAGIC, 0x00]))).toBe(false);
+  });
+
+  it("rejects JSON / text payloads (legacy clients keep working)", () => {
+    expect(isMultiplexedFrame(Buffer.from(`{"type":"session.update"}`))).toBe(false);
+    expect(isMultiplexedFrame(Buffer.from("hello world"))).toBe(false);
+    expect(isMultiplexedFrame(Buffer.from(" \n\t{}"))).toBe(false);
+    expect(isMultiplexedFrame(Buffer.from("[1,2,3]"))).toBe(false);
+  });
+
+  it("rejects non-Uint8Array inputs", () => {
+    expect(isMultiplexedFrame(undefined)).toBe(false);
+    expect(isMultiplexedFrame("foo")).toBe(false);
+    expect(isMultiplexedFrame({ length: 10 })).toBe(false);
+  });
+});
+
+describe("decodeMultiplexFrames (stream chunking)", () => {
+  it("decodes multiple concatenated frames", () => {
+    const a = encodeMultiplexFrame(0, Buffer.from("aa"));
+    const b = encodeMultiplexFrame(1, Buffer.from("bbb"), MULTIPLEX_FLAG_EOM);
+    const c = encodeMultiplexFrame(2, Buffer.from("cccc"));
+    const { frames, remainder } = decodeMultiplexFrames(Buffer.concat([a, b, c]));
+    expect(frames).toHaveLength(3);
+    expect(frames[0].streamId).toBe(0);
+    expect(frames[1].streamId).toBe(1);
+    expect(frames[1].flags).toBe(MULTIPLEX_FLAG_EOM);
+    expect(frames[2].payload.toString()).toBe("cccc");
+    expect(remainder.length).toBe(0);
+  });
+
+  it("returns a partial-header tail as remainder", () => {
+    const a = encodeMultiplexFrame(0, Buffer.from("aa"));
+    const partialHeader = Buffer.from([MULTIPLEX_FRAME_MAGIC, 0x01]); // 2 of 7 bytes
+    const { frames, remainder } = decodeMultiplexFrames(Buffer.concat([a, partialHeader]));
+    expect(frames).toHaveLength(1);
+    expect(remainder.equals(partialHeader)).toBe(true);
+  });
+
+  it("returns a partial-payload tail as remainder", () => {
+    const a = encodeMultiplexFrame(0, Buffer.from("aa"));
+    const b = encodeMultiplexFrame(1, Buffer.from("bbbbbbbb"));
+    const truncatedB = b.subarray(0, b.length - 3);
+    const { frames, remainder } = decodeMultiplexFrames(Buffer.concat([a, truncatedB]));
+    expect(frames).toHaveLength(1);
+    expect(remainder.equals(truncatedB)).toBe(true);
+  });
+
+  it("re-feeding remainder + new bytes recovers the missing frame", () => {
+    const a = encodeMultiplexFrame(0, Buffer.from("aa"));
+    const b = encodeMultiplexFrame(1, Buffer.from("bbbbbbbb"));
+    const split = Math.floor(b.length / 2);
+    const first = decodeMultiplexFrames(Buffer.concat([a, b.subarray(0, split)]));
+    expect(first.frames).toHaveLength(1);
+    const second = decodeMultiplexFrames(Buffer.concat([first.remainder, b.subarray(split)]));
+    expect(second.frames).toHaveLength(1);
+    expect(second.frames[0].payload.toString()).toBe("bbbbbbbb");
+    expect(second.remainder.length).toBe(0);
+  });
+
+  it("throws on misaligned frame boundary (corrupt stream)", () => {
+    const a = encodeMultiplexFrame(0, Buffer.from("aa"));
+    const corrupt = Buffer.concat([a, Buffer.from([0x42, 0x00, 0x00])]);
+    expect(() => decodeMultiplexFrames(corrupt)).toThrow(/MISSING_MAGIC/);
+  });
+
+  it("returns empty remainder for empty input", () => {
+    const { frames, remainder } = decodeMultiplexFrames(Buffer.alloc(0));
+    expect(frames).toHaveLength(0);
+    expect(remainder.length).toBe(0);
+  });
+
+  it("remainder is detached from input buffer (safe to retain)", () => {
+    const partial = Buffer.from([MULTIPLEX_FRAME_MAGIC, 0x00]);
+    const { remainder } = decodeMultiplexFrames(partial);
+    partial[0] = 0x00;
+    expect(remainder[0]).toBe(MULTIPLEX_FRAME_MAGIC);
+  });
+});
+
+describe("multiplex-frame: throughput sanity", () => {
+  it("encodes and decodes at >100 MB/s on small frames", () => {
+    const payload = Buffer.alloc(4 * 1024); // 4 KiB
+    const iterations = 5_000;
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < iterations; i++) {
+      const frame = encodeMultiplexFrame(i & 0xff, payload, MULTIPLEX_FLAG_EOM);
+      const decoded = decodeMultiplexFrame(frame);
+      if (decoded.payload.length !== payload.length) {
+        throw new Error("len mismatch");
+      }
+    }
+    const elapsedNs = Number(process.hrtime.bigint() - start);
+    const bytes = iterations * payload.length * 2; // encode + decode
+    const mbPerSec = bytes / 1e6 / (elapsedNs / 1e9);
+    // Soft floor: be permissive (CI machines vary). Real target is >100 MB/s.
+    expect(mbPerSec).toBeGreaterThan(20);
+  });
+});

--- a/src/gateway/multiplex-frame.ts
+++ b/src/gateway/multiplex-frame.ts
@@ -158,7 +158,7 @@ export function encodeMultiplexFrame(
  * envelope. Intended for the WS message handler to choose between the
  * legacy text/JSON path and the new multiplex router.
  */
-export function isMultiplexedFrame(data: unknown): boolean {
+export function isMultiplexedFrame(data: unknown): data is Buffer | Uint8Array {
   if (!(data instanceof Uint8Array)) {
     return false;
   }

--- a/src/gateway/multiplex-frame.ts
+++ b/src/gateway/multiplex-frame.ts
@@ -1,0 +1,282 @@
+/**
+ * Multiplex Frame Codec — Phase A.1 of Streaming Multimodal foundation.
+ *
+ * Binary frame format (little-endian where applicable):
+ *
+ *   ┌─────────┬──────────┬─────────────┬──────────────┐
+ *   │ Stream  │ Flags    │ Payload Len │ Payload      │
+ *   │ ID (1B) │ (1B)     │ (4B LE)     │ (variable)   │
+ *   └─────────┴──────────┴─────────────┴──────────────┘
+ *
+ * Stream IDs (well-known):
+ *   0   = Control (JSON events: session.update, response.create, ...)
+ *   1   = Audio Input  (PCM chunks, base64 inside or raw bytes)
+ *   2   = Audio Output (PCM chunks)
+ *   3   = Video Input  (Phase C)
+ *   4   = Video Output (Phase C)
+ *   5+  = Reserved
+ *
+ * Flags (bitmask):
+ *   0x01 = EOM       — End of message / flush hint for the stream
+ *   0x02 = PRIORITY  — Low-latency / urgent
+ *   0x04 = COMPRESSED — Payload is gzip-compressed (codec-agnostic)
+ *
+ * Header is fixed at 6 bytes; payload is bounded to 16 MiB (per A.1 acceptance
+ * criteria). Frame overhead is < 10 bytes (6 bytes here).
+ *
+ * Backward compatibility note: callers detect multiplex frames via the
+ * `MULTIPLEX_FRAME_MAGIC` byte at offset 0 of the WebSocket message *prefix*
+ * sentinel — see `isMultiplexedFrame`. Legacy JSON/text payloads start with
+ * `{`, `[`, or whitespace, so the magic byte is chosen outside that range.
+ */
+
+/** Header size in bytes: 1 (streamId) + 1 (flags) + 4 (payload length). */
+export const MULTIPLEX_FRAME_HEADER_SIZE = 6;
+
+/** Maximum payload size (16 MiB). */
+export const MULTIPLEX_FRAME_MAX_PAYLOAD = 16 * 1024 * 1024;
+
+/** Maximum stream id (single byte). */
+export const MULTIPLEX_FRAME_MAX_STREAM_ID = 0xff;
+
+/** Maximum flags value (single byte). */
+export const MULTIPLEX_FRAME_MAX_FLAGS = 0xff;
+
+/**
+ * Sentinel "magic" byte distinguishing multiplex frames from legacy
+ * JSON/text payloads. Multiplex framing is opt-in via a 1-byte prefix:
+ *
+ *   [MAGIC] [streamId] [flags] [len32 LE] [payload...]
+ *
+ * The magic byte (0xFE) cannot appear at the start of a valid UTF-8 JSON
+ * document or whitespace-prefixed payload, so detection is unambiguous.
+ *
+ * NOTE: This is the *transport-envelope* magic — the on-the-wire layout has
+ * a leading magic byte so legacy non-multiplex clients keep working. The
+ * canonical 6-byte header described in the comment above sits *after* the
+ * magic byte.
+ */
+export const MULTIPLEX_FRAME_MAGIC = 0xfe;
+
+/** Total envelope overhead including the magic byte. */
+export const MULTIPLEX_FRAME_ENVELOPE_OVERHEAD = 1 + MULTIPLEX_FRAME_HEADER_SIZE;
+
+/** Flag bit: payload represents end-of-message for the stream. */
+export const MULTIPLEX_FLAG_EOM = 0x01;
+/** Flag bit: payload should be processed with low-latency priority. */
+export const MULTIPLEX_FLAG_PRIORITY = 0x02;
+/** Flag bit: payload bytes are gzip-compressed. */
+export const MULTIPLEX_FLAG_COMPRESSED = 0x04;
+
+/** Mask of all defined flag bits. Reserved bits MUST be 0 by encoders. */
+export const MULTIPLEX_FLAG_DEFINED_MASK =
+  MULTIPLEX_FLAG_EOM | MULTIPLEX_FLAG_PRIORITY | MULTIPLEX_FLAG_COMPRESSED;
+
+/** Well-known stream IDs (extensible by callers). */
+export const MULTIPLEX_STREAM = Object.freeze({
+  CONTROL: 0,
+  AUDIO_INPUT: 1,
+  AUDIO_OUTPUT: 2,
+  VIDEO_INPUT: 3,
+  VIDEO_OUTPUT: 4,
+} as const);
+
+/** Decoded frame contents. */
+export interface MultiplexFrame {
+  streamId: number;
+  flags: number;
+  payload: Buffer;
+}
+
+/** Errors emitted by the codec. Carry a stable `code` for routing. */
+export class MultiplexFrameError extends Error {
+  readonly code:
+    | "INVALID_STREAM_ID"
+    | "INVALID_FLAGS"
+    | "PAYLOAD_TOO_LARGE"
+    | "TRUNCATED_HEADER"
+    | "TRUNCATED_PAYLOAD"
+    | "MISSING_MAGIC"
+    | "INVALID_INPUT";
+
+  constructor(code: MultiplexFrameError["code"], message: string) {
+    super(`[multiplex-frame:${code}] ${message}`);
+    this.name = "MultiplexFrameError";
+    this.code = code;
+  }
+}
+
+function assertValidHeaderInputs(streamId: number, flags: number, payloadLength: number): void {
+  if (!Number.isInteger(streamId) || streamId < 0 || streamId > MULTIPLEX_FRAME_MAX_STREAM_ID) {
+    throw new MultiplexFrameError(
+      "INVALID_STREAM_ID",
+      `streamId must be an integer in [0, ${MULTIPLEX_FRAME_MAX_STREAM_ID}], got ${streamId}`,
+    );
+  }
+  if (!Number.isInteger(flags) || flags < 0 || flags > MULTIPLEX_FRAME_MAX_FLAGS) {
+    throw new MultiplexFrameError(
+      "INVALID_FLAGS",
+      `flags must be an integer in [0, ${MULTIPLEX_FRAME_MAX_FLAGS}], got ${flags}`,
+    );
+  }
+  if (payloadLength < 0 || payloadLength > MULTIPLEX_FRAME_MAX_PAYLOAD) {
+    throw new MultiplexFrameError(
+      "PAYLOAD_TOO_LARGE",
+      `payload length ${payloadLength} exceeds max ${MULTIPLEX_FRAME_MAX_PAYLOAD}`,
+    );
+  }
+}
+
+/**
+ * Encode a multiplex frame into a Buffer ready for WebSocket transmission.
+ *
+ * The output is `[MAGIC][streamId][flags][len32 LE][payload]`. Pass the
+ * resulting buffer directly to `socket.send(buf, { binary: true })`.
+ */
+export function encodeMultiplexFrame(
+  streamId: number,
+  payload: Buffer | Uint8Array,
+  flags: number = 0,
+): Buffer {
+  if (!(payload instanceof Uint8Array)) {
+    throw new MultiplexFrameError("INVALID_INPUT", "payload must be a Buffer or Uint8Array");
+  }
+  const payloadBuf = Buffer.isBuffer(payload) ? payload : Buffer.from(payload);
+  assertValidHeaderInputs(streamId, flags, payloadBuf.length);
+
+  const out = Buffer.allocUnsafe(MULTIPLEX_FRAME_ENVELOPE_OVERHEAD + payloadBuf.length);
+  out[0] = MULTIPLEX_FRAME_MAGIC;
+  out[1] = streamId & 0xff;
+  out[2] = flags & 0xff;
+  out.writeUInt32LE(payloadBuf.length, 3);
+  payloadBuf.copy(out, MULTIPLEX_FRAME_ENVELOPE_OVERHEAD);
+  return out;
+}
+
+/**
+ * Cheap detector: returns true when `data` looks like a multiplex frame
+ * envelope. Intended for the WS message handler to choose between the
+ * legacy text/JSON path and the new multiplex router.
+ */
+export function isMultiplexedFrame(data: unknown): boolean {
+  if (!(data instanceof Uint8Array)) {
+    return false;
+  }
+  if (data.length < MULTIPLEX_FRAME_ENVELOPE_OVERHEAD) {
+    return false;
+  }
+  return data[0] === MULTIPLEX_FRAME_MAGIC;
+}
+
+/**
+ * Decode a single multiplex frame. Throws `MultiplexFrameError` on any
+ * structural problem (missing magic, truncated header, oversized payload).
+ *
+ * If `data` contains exactly one frame, the result's `payload` is a view
+ * into a fresh buffer (safe to retain). Trailing bytes after the declared
+ * payload length are rejected — use `decodeMultiplexFrames` for streams.
+ */
+export function decodeMultiplexFrame(data: Buffer | Uint8Array): MultiplexFrame {
+  if (!(data instanceof Uint8Array)) {
+    throw new MultiplexFrameError("INVALID_INPUT", "data must be a Buffer or Uint8Array");
+  }
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  if (buf.length < 1 || buf[0] !== MULTIPLEX_FRAME_MAGIC) {
+    throw new MultiplexFrameError(
+      "MISSING_MAGIC",
+      "frame does not start with multiplex magic byte",
+    );
+  }
+  if (buf.length < MULTIPLEX_FRAME_ENVELOPE_OVERHEAD) {
+    throw new MultiplexFrameError(
+      "TRUNCATED_HEADER",
+      `frame too short for header: ${buf.length} < ${MULTIPLEX_FRAME_ENVELOPE_OVERHEAD}`,
+    );
+  }
+  const streamId = buf[1];
+  const flags = buf[2];
+  const payloadLength = buf.readUInt32LE(3);
+  assertValidHeaderInputs(streamId, flags, payloadLength);
+
+  const expectedTotal = MULTIPLEX_FRAME_ENVELOPE_OVERHEAD + payloadLength;
+  if (buf.length < expectedTotal) {
+    throw new MultiplexFrameError(
+      "TRUNCATED_PAYLOAD",
+      `frame payload truncated: have ${buf.length - MULTIPLEX_FRAME_ENVELOPE_OVERHEAD} of ${payloadLength}`,
+    );
+  }
+  if (buf.length > expectedTotal) {
+    throw new MultiplexFrameError(
+      "TRUNCATED_PAYLOAD",
+      `unexpected trailing bytes after frame: ${buf.length - expectedTotal} extra`,
+    );
+  }
+
+  // Copy the payload so callers can mutate / retain it without aliasing the input.
+  const payload = Buffer.allocUnsafe(payloadLength);
+  buf.copy(payload, 0, MULTIPLEX_FRAME_ENVELOPE_OVERHEAD, expectedTotal);
+  return { streamId, flags, payload };
+}
+
+/**
+ * Decode zero or more concatenated multiplex frames from a stream-style
+ * buffer. Returns the parsed frames and any unparsed trailing bytes
+ * (suitable for re-buffering when called again with new data).
+ *
+ * This is the building block for the gateway WS multiplex handler (A.3).
+ */
+export function decodeMultiplexFrames(data: Buffer | Uint8Array): {
+  frames: MultiplexFrame[];
+  remainder: Buffer;
+} {
+  if (!(data instanceof Uint8Array)) {
+    throw new MultiplexFrameError("INVALID_INPUT", "data must be a Buffer or Uint8Array");
+  }
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  const frames: MultiplexFrame[] = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    if (buf[offset] !== MULTIPLEX_FRAME_MAGIC) {
+      throw new MultiplexFrameError(
+        "MISSING_MAGIC",
+        `expected magic byte at offset ${offset}, got 0x${buf[offset].toString(16)}`,
+      );
+    }
+    if (buf.length - offset < MULTIPLEX_FRAME_ENVELOPE_OVERHEAD) {
+      // Header incomplete — buffer for next chunk.
+      break;
+    }
+    const streamId = buf[offset + 1];
+    const flags = buf[offset + 2];
+    const payloadLength = buf.readUInt32LE(offset + 3);
+    assertValidHeaderInputs(streamId, flags, payloadLength);
+    const frameTotal = MULTIPLEX_FRAME_ENVELOPE_OVERHEAD + payloadLength;
+    if (buf.length - offset < frameTotal) {
+      // Payload incomplete — buffer for next chunk.
+      break;
+    }
+    const payload = Buffer.allocUnsafe(payloadLength);
+    buf.copy(payload, 0, offset + MULTIPLEX_FRAME_ENVELOPE_OVERHEAD, offset + frameTotal);
+    frames.push({ streamId, flags, payload });
+    offset += frameTotal;
+  }
+  const remainder = offset === buf.length ? Buffer.alloc(0) : buf.subarray(offset);
+  // Return a copy of the remainder so callers can safely retain it without
+  // aliasing the (potentially pooled) input buffer.
+  return { frames, remainder: Buffer.from(remainder) };
+}
+
+/** Convenience helper: true if `flags` includes EOM bit. */
+export function frameHasEom(flags: number): boolean {
+  return (flags & MULTIPLEX_FLAG_EOM) === MULTIPLEX_FLAG_EOM;
+}
+
+/** Convenience helper: true if `flags` includes PRIORITY bit. */
+export function frameHasPriority(flags: number): boolean {
+  return (flags & MULTIPLEX_FLAG_PRIORITY) === MULTIPLEX_FLAG_PRIORITY;
+}
+
+/** Convenience helper: true if `flags` includes COMPRESSED bit. */
+export function frameHasCompressed(flags: number): boolean {
+  return (flags & MULTIPLEX_FLAG_COMPRESSED) === MULTIPLEX_FLAG_COMPRESSED;
+}


### PR DESCRIPTION
## Streaming Multimodal — Phase C

Builds on the Phase A (codec + buffers) and Phase B (multiplex transport + audio I/O streams) foundation.

### C.1 — Streaming STT Pipeline ✅
- `StreamingSttPipeline`: top-level per-session orchestrator wiring MultiplexDemuxer → AudioInputStream → SttProviderAdapter
- `SttProviderAdapter`: normalizes RealtimeTranscriptionSession into typed event stream  
- Event protocol: `input_audio_transcription.delta`, `input_audio_transcription.completed`, speech start/stop
- Supports continuous and commit modes
- Full test coverage (pipeline, adapter, events)

### C.2 — Parallel TTS Streaming Output 🚧
- `StreamingTtsPipeline`: token-by-token text accumulation with sentence-boundary detection
- Parallel TTS synthesis: fires TTS requests as complete sentences arrive during LLM streaming
- Audio chunks delivered via AudioOutputStream as they're synthesized (speak while generating)
- Backpressure-aware: respects control channel signals
- Full test coverage

### Architecture
```
LLM tokens → StreamingTtsPipeline (sentence buffer)
                ↓ (complete sentences)
           TTS Provider (synthesize)
                ↓ (audio chunks)  
           AudioOutputStream → MultiplexFrame → Client
```

Depends on: Phase A (merged in branch), Phase B (merged in branch)
