### PR TITLE
fix(whatsapp): setting systemPrompt to "" suppresses the wildcard prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/restart: default session-scoped restart sentinels to a one-shot agent continuation, so chat-initiated Gateway restarts acknowledge successful boot automatically. (#70269) Thanks @obviyus.
 - Build/npm publish: fail postpublish verification when root `dist/*` files import bundled plugin runtime dependencies without mirroring them in the root package manifest, so Slack-style plugin deps cannot silently ship on the wrong module-resolution path again. (#60112) thanks @medns.
 - Gateway/sessions: extend the webchat session-mutation guard to `sessions.compact` and `sessions.compaction.restore`, so `WEBCHAT_UI` clients are rejected from compaction-side session mutations consistently with the existing patch/delete guards. (#70716) Thanks @drobison00.
+- WhatsApp/groups+direct: setting `systemPrompt: ""` on a specific `groups.<id>` or `direct.<peerId>` entry now suppresses the wildcard system prompt instead of falling through to it, so users can silence the global prompt for a specific group or peer. (#70381) Thanks @Bluetegu.
 
 ## 2026.4.21
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -500,15 +500,15 @@ Resolution hierarchy for group messages:
 
 The effective `groups` map is determined first: if the account defines its own `groups`, it fully replaces the root `groups` map (no deep merge). Prompt lookup then runs on the resulting single map:
 
-1. **Group-specific system prompt** (`groups["<groupId>"].systemPrompt`): used if the specific group entry defines a `systemPrompt`.
-2. **Group wildcard system prompt** (`groups["*"].systemPrompt`): used when the specific group entry is absent or defines no `systemPrompt`.
+1. **Group-specific system prompt** (`groups["<groupId>"].systemPrompt`): used when the specific group entry exists in the map **and** its `systemPrompt` key is defined. If `systemPrompt` is an empty string (`""`), the wildcard is suppressed and no system prompt is applied.
+2. **Group wildcard system prompt** (`groups["*"].systemPrompt`): used when the specific group entry is absent from the map entirely, or when it exists but defines no `systemPrompt` key.
 
 Resolution hierarchy for direct messages:
 
 The effective `direct` map is determined first: if the account defines its own `direct`, it fully replaces the root `direct` map (no deep merge). Prompt lookup then runs on the resulting single map:
 
-1. **Direct-specific system prompt** (`direct["<peerId>"].systemPrompt`): used if the specific peer entry defines a `systemPrompt`.
-2. **Direct wildcard system prompt** (`direct["*"].systemPrompt`): used when the specific peer entry is absent or defines no `systemPrompt`.
+1. **Direct-specific system prompt** (`direct["<peerId>"].systemPrompt`): used when the specific peer entry exists in the map **and** its `systemPrompt` key is defined. If `systemPrompt` is an empty string (`""`), the wildcard is suppressed and no system prompt is applied.
+2. **Direct wildcard system prompt** (`direct["*"].systemPrompt`): used when the specific peer entry is absent from the map entirely, or when it exists but defines no `systemPrompt` key.
 
 Note: `dms` remains the lightweight per-DM history override bucket (`dms.<id>.historyLimit`); prompt overrides live under `direct`.
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mocks used across tests so vi.mock factories can reference them.
+const { resolvePolicyMock, buildContextMock } = vi.hoisted(() => ({
+  resolvePolicyMock: vi.fn(),
+  buildContextMock: vi.fn(),
+}));
+
+vi.mock("../../inbound-policy.js", () => ({
+  resolveWhatsAppCommandAuthorized: async () => true,
+  resolveWhatsAppInboundPolicy: resolvePolicyMock,
+}));
+
+vi.mock("./inbound-dispatch.js", () => ({
+  buildWhatsAppInboundContext: buildContextMock,
+  dispatchWhatsAppBufferedReply: async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  }),
+  resolveWhatsAppDmRouteTarget: () => null,
+  resolveWhatsAppResponsePrefix: () => undefined,
+  updateWhatsAppMainLastRoute: () => {},
+}));
+
+vi.mock("../../identity.js", () => ({
+  getPrimaryIdentityId: () => null,
+  getSelfIdentity: () => ({ e164: "+15550001111" }),
+  getSenderIdentity: () => ({ name: "Alice", e164: "+15550002222" }),
+}));
+
+vi.mock("../../reconnect.js", () => ({ newConnectionId: () => "test-conn-id" }));
+vi.mock("../../session.js", () => ({ formatError: (e: unknown) => String(e) }));
+vi.mock("../deliver-reply.js", () => ({ deliverWebReply: async () => {} }));
+vi.mock("../loggers.js", () => ({
+  whatsappInboundLog: { info: () => {}, debug: () => {} },
+}));
+vi.mock("./ack-reaction.js", () => ({ maybeSendAckReaction: async () => {} }));
+vi.mock("./inbound-context.js", () => ({
+  resolveVisibleWhatsAppGroupHistory: () => [],
+  resolveVisibleWhatsAppReplyContext: () => null,
+}));
+vi.mock("./last-route.js", () => ({
+  trackBackgroundTask: () => {},
+  updateLastRouteInBackground: () => {},
+}));
+vi.mock("./message-line.js", () => ({ buildInboundLine: () => "hi" }));
+vi.mock("./runtime-api.js", () => ({
+  buildHistoryContextFromEntries: () => "hi",
+  createChannelReplyPipeline: () => ({ onModelSelected: () => {}, responsePrefix: undefined }),
+  formatInboundEnvelope: () => "hi",
+  logVerbose: () => {},
+  normalizeE164: (v: string) => v,
+  recordSessionMetaFromInbound: async () => {},
+  resolveChannelContextVisibilityMode: () => "off",
+  resolveInboundSessionEnvelopeContext: () => ({
+    storePath: "/tmp",
+    envelopeOptions: {},
+    previousTimestamp: undefined,
+  }),
+  resolvePinnedMainDmOwnerFromAllowlist: () => null,
+  shouldComputeCommandAuthorized: () => false,
+  shouldLogVerbose: () => false,
+}));
+
+import { processMessage } from "./process-message.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAccount(groups: Record<string, { systemPrompt?: string }> = {}): {
+  accountId: string;
+  authDir: string;
+  groups: Record<string, { systemPrompt?: string }>;
+} {
+  return { accountId: "default", authDir: "/tmp/wa-test-auth", groups };
+}
+
+function makePolicy(account: ReturnType<typeof makeAccount>) {
+  return {
+    account,
+    dmPolicy: "pairing",
+    groupPolicy: "allowlist",
+    configuredAllowFrom: [],
+    dmAllowFrom: [],
+    groupAllowFrom: [],
+    isSelfChat: false,
+    providerMissingFallbackApplied: false,
+    shouldReadStorePairingApprovals: true,
+    isSamePhone: () => false,
+    isDmSenderAllowed: () => false,
+    isGroupSenderAllowed: () => false,
+    resolveConversationGroupPolicy: () => "allowlist",
+    resolveConversationRequireMention: () => false,
+  };
+}
+
+const GROUP_JID = "123@g.us";
+
+const baseMsg = {
+  id: "msg1",
+  from: GROUP_JID,
+  to: "+15550001111",
+  conversationId: GROUP_JID,
+  accountId: "default",
+  chatId: GROUP_JID,
+  chatType: "group" as const,
+  body: "hi",
+  sendComposing: async () => {},
+  reply: async () => {},
+  sendMedia: async () => {},
+};
+
+const baseRoute = {
+  agentId: "main",
+  channel: "whatsapp",
+  accountId: "default",
+  sessionKey: "agent:main:whatsapp:group:123@g.us",
+  mainSessionKey: "agent:main:whatsapp:group:123@g.us",
+  lastRoutePolicy: "main",
+  matchedBy: "default",
+};
+
+function callProcessMessage() {
+  return processMessage({
+    cfg: {} as never,
+    msg: baseMsg as never,
+    route: baseRoute as never,
+    groupHistoryKey: "whatsapp:default:group:123@g.us",
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    connectionId: "conn-1",
+    verbose: false,
+    maxMediaBytes: 1024,
+    replyResolver: (async () => undefined) as never,
+    replyLogger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as never,
+    backgroundTasks: new Set(),
+    rememberSentText: () => {},
+    echoHas: () => false,
+    echoForget: () => {},
+    buildCombinedEchoKey: ({ sessionKey }) => sessionKey,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("processMessage group system prompt wiring", () => {
+  beforeEach(() => {
+    buildContextMock.mockClear();
+    resolvePolicyMock.mockClear();
+    buildContextMock.mockImplementation(
+      (params: { groupSystemPrompt?: string; combinedBody?: string }) => ({
+        GroupSystemPrompt: params.groupSystemPrompt,
+        Body: params.combinedBody ?? "",
+      }),
+    );
+  });
+
+  it("resolves group systemPrompt from account config and passes it into buildWhatsAppInboundContext", async () => {
+    resolvePolicyMock.mockReturnValue(
+      makePolicy(makeAccount({ [GROUP_JID]: { systemPrompt: "from config" } })),
+    );
+
+    await callProcessMessage();
+
+    expect(buildContextMock.mock.calls[0][0].groupSystemPrompt).toBe("from config");
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -6,61 +6,112 @@ const { resolvePolicyMock, buildContextMock } = vi.hoisted(() => ({
   buildContextMock: vi.fn(),
 }));
 
-vi.mock("../../inbound-policy.js", () => ({
-  resolveWhatsAppCommandAuthorized: async () => true,
-  resolveWhatsAppInboundPolicy: resolvePolicyMock,
-}));
+vi.mock("../../inbound-policy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../inbound-policy.js")>();
+  return {
+    ...actual,
+    resolveWhatsAppCommandAuthorized: async () => true,
+    resolveWhatsAppInboundPolicy: resolvePolicyMock,
+  };
+});
 
-vi.mock("./inbound-dispatch.js", () => ({
-  buildWhatsAppInboundContext: buildContextMock,
-  dispatchWhatsAppBufferedReply: async () => ({
-    queuedFinal: false,
-    counts: { tool: 0, block: 0, final: 0 },
-  }),
-  resolveWhatsAppDmRouteTarget: () => null,
-  resolveWhatsAppResponsePrefix: () => undefined,
-  updateWhatsAppMainLastRoute: () => {},
-}));
+vi.mock("./inbound-dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./inbound-dispatch.js")>();
+  return {
+    ...actual,
+    buildWhatsAppInboundContext: buildContextMock,
+    dispatchWhatsAppBufferedReply: async () => ({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    }),
+    resolveWhatsAppDmRouteTarget: () => null,
+    resolveWhatsAppResponsePrefix: () => undefined,
+    updateWhatsAppMainLastRoute: () => {},
+  };
+});
 
-vi.mock("../../identity.js", () => ({
-  getPrimaryIdentityId: () => null,
-  getSelfIdentity: () => ({ e164: "+15550001111" }),
-  getSenderIdentity: () => ({ name: "Alice", e164: "+15550002222" }),
-}));
+vi.mock("../../identity.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../identity.js")>();
+  return {
+    ...actual,
+    getPrimaryIdentityId: () => null,
+    getSelfIdentity: () => ({ e164: "+15550001111" }),
+    getSenderIdentity: () => ({ name: "Alice", e164: "+15550002222" }),
+  };
+});
 
-vi.mock("../../reconnect.js", () => ({ newConnectionId: () => "test-conn-id" }));
-vi.mock("../../session.js", () => ({ formatError: (e: unknown) => String(e) }));
-vi.mock("../deliver-reply.js", () => ({ deliverWebReply: async () => {} }));
-vi.mock("../loggers.js", () => ({
-  whatsappInboundLog: { info: () => {}, debug: () => {} },
-}));
-vi.mock("./ack-reaction.js", () => ({ maybeSendAckReaction: async () => {} }));
-vi.mock("./inbound-context.js", () => ({
-  resolveVisibleWhatsAppGroupHistory: () => [],
-  resolveVisibleWhatsAppReplyContext: () => null,
-}));
-vi.mock("./last-route.js", () => ({
-  trackBackgroundTask: () => {},
-  updateLastRouteInBackground: () => {},
-}));
-vi.mock("./message-line.js", () => ({ buildInboundLine: () => "hi" }));
-vi.mock("./runtime-api.js", () => ({
-  buildHistoryContextFromEntries: () => "hi",
-  createChannelReplyPipeline: () => ({ onModelSelected: () => {}, responsePrefix: undefined }),
-  formatInboundEnvelope: () => "hi",
-  logVerbose: () => {},
-  normalizeE164: (v: string) => v,
-  recordSessionMetaFromInbound: async () => {},
-  resolveChannelContextVisibilityMode: () => "off",
-  resolveInboundSessionEnvelopeContext: () => ({
-    storePath: "/tmp",
-    envelopeOptions: {},
-    previousTimestamp: undefined,
-  }),
-  resolvePinnedMainDmOwnerFromAllowlist: () => null,
-  shouldComputeCommandAuthorized: () => false,
-  shouldLogVerbose: () => false,
-}));
+vi.mock("../../reconnect.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../reconnect.js")>();
+  return { ...actual, newConnectionId: () => "test-conn-id" };
+});
+
+vi.mock("../../session.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../session.js")>();
+  return { ...actual, formatError: (e: unknown) => String(e) };
+});
+
+vi.mock("../deliver-reply.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../deliver-reply.js")>();
+  return { ...actual, deliverWebReply: async () => {} };
+});
+
+vi.mock("../loggers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../loggers.js")>();
+  return {
+    ...actual,
+    whatsappInboundLog: { info: () => {}, debug: () => {} },
+  };
+});
+
+vi.mock("./ack-reaction.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ack-reaction.js")>();
+  return { ...actual, maybeSendAckReaction: async () => {} };
+});
+
+vi.mock("./inbound-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./inbound-context.js")>();
+  return {
+    ...actual,
+    resolveVisibleWhatsAppGroupHistory: () => [],
+    resolveVisibleWhatsAppReplyContext: () => null,
+  };
+});
+
+vi.mock("./last-route.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./last-route.js")>();
+  return {
+    ...actual,
+    trackBackgroundTask: () => {},
+    updateLastRouteInBackground: () => {},
+  };
+});
+
+vi.mock("./message-line.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./message-line.js")>();
+  return { ...actual, buildInboundLine: () => "hi" };
+});
+
+vi.mock("./runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime-api.js")>();
+  return {
+    ...actual,
+    buildHistoryContextFromEntries: () => "hi",
+    createChannelReplyPipeline: () => ({ onModelSelected: () => {}, responsePrefix: undefined }),
+    formatInboundEnvelope: () => "hi",
+    logVerbose: () => {},
+    normalizeE164: (v: string) => v,
+    recordSessionMetaFromInbound: async () => {},
+    resolveChannelContextVisibilityMode: () => "off",
+    resolveInboundSessionEnvelopeContext: () => ({
+      storePath: "/tmp",
+      envelopeOptions: {},
+      previousTimestamp: undefined,
+    }),
+    resolvePinnedMainDmOwnerFromAllowlist: () => null,
+    shouldComputeCommandAuthorized: () => false,
+    shouldLogVerbose: () => false,
+  };
+});
 
 import { processMessage } from "./process-message.js";
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -148,8 +148,8 @@ function callProcessMessage() {
 
 describe("processMessage group system prompt wiring", () => {
   beforeEach(() => {
-    buildContextMock.mockClear();
-    resolvePolicyMock.mockClear();
+    buildContextMock.mockReset();
+    resolvePolicyMock.mockReset();
     buildContextMock.mockImplementation(
       (params: { groupSystemPrompt?: string; combinedBody?: string }) => ({
         GroupSystemPrompt: params.groupSystemPrompt,

--- a/extensions/whatsapp/src/system-prompt.test.ts
+++ b/extensions/whatsapp/src/system-prompt.test.ts
@@ -54,6 +54,20 @@ describe("resolveWhatsAppGroupSystemPrompt", () => {
     ).toBeUndefined();
   });
 
+  it("suppresses wildcard when specific group entry sets systemPrompt to whitespace-only string", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: {
+          groups: {
+            g1: { systemPrompt: "   " },
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("trims whitespace from specific group systemPrompt", () => {
     expect(
       resolveWhatsAppGroupSystemPrompt({
@@ -130,6 +144,20 @@ describe("resolveWhatsAppDirectSystemPrompt", () => {
         accountConfig: {
           direct: {
             p1: { systemPrompt: "" },
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("suppresses wildcard when specific peer entry sets systemPrompt to whitespace-only string", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: {
+          direct: {
+            p1: { systemPrompt: "   " },
             "*": { systemPrompt: "wildcard prompt" },
           },
         },

--- a/extensions/whatsapp/src/system-prompt.test.ts
+++ b/extensions/whatsapp/src/system-prompt.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveWhatsAppDirectSystemPrompt,
+  resolveWhatsAppGroupSystemPrompt,
+} from "./system-prompt.js";
+
+describe("resolveWhatsAppGroupSystemPrompt", () => {
+  it("returns undefined when groupId is absent", () => {
+    expect(resolveWhatsAppGroupSystemPrompt({ groupId: null })).toBeUndefined();
+    expect(resolveWhatsAppGroupSystemPrompt({ groupId: undefined })).toBeUndefined();
+    expect(resolveWhatsAppGroupSystemPrompt({})).toBeUndefined();
+  });
+
+  it("returns undefined when accountConfig is absent", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({ groupId: "g1", accountConfig: null }),
+    ).toBeUndefined();
+    expect(
+      resolveWhatsAppGroupSystemPrompt({ groupId: "g1", accountConfig: undefined }),
+    ).toBeUndefined();
+  });
+
+  it("returns the group-specific systemPrompt when defined", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: { groups: { g1: { systemPrompt: "group prompt" } } },
+      }),
+    ).toBe("group prompt");
+  });
+
+  it("falls back to wildcard when specific group entry is absent", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: {
+          groups: { "*": { systemPrompt: "wildcard prompt" } },
+        },
+      }),
+    ).toBe("wildcard prompt");
+  });
+
+  it("suppresses wildcard when specific group entry sets systemPrompt to empty string", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: {
+          groups: {
+            g1: { systemPrompt: "" },
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims whitespace from specific group systemPrompt", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: { groups: { g1: { systemPrompt: "  trimmed  " } } },
+      }),
+    ).toBe("trimmed");
+  });
+
+  it("returns undefined when specific group entry has no systemPrompt key and no wildcard", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: { groups: { g1: {} } },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to wildcard when specific group entry has no systemPrompt key", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        groupId: "g1",
+        accountConfig: {
+          groups: {
+            g1: {},
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBe("wildcard prompt");
+  });
+});
+
+describe("resolveWhatsAppDirectSystemPrompt", () => {
+  it("returns undefined when peerId is absent", () => {
+    expect(resolveWhatsAppDirectSystemPrompt({ peerId: null })).toBeUndefined();
+    expect(resolveWhatsAppDirectSystemPrompt({ peerId: undefined })).toBeUndefined();
+    expect(resolveWhatsAppDirectSystemPrompt({})).toBeUndefined();
+  });
+
+  it("returns undefined when accountConfig is absent", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({ peerId: "p1", accountConfig: null }),
+    ).toBeUndefined();
+    expect(
+      resolveWhatsAppDirectSystemPrompt({ peerId: "p1", accountConfig: undefined }),
+    ).toBeUndefined();
+  });
+
+  it("returns the peer-specific systemPrompt when defined", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: { direct: { p1: { systemPrompt: "direct prompt" } } },
+      }),
+    ).toBe("direct prompt");
+  });
+
+  it("falls back to wildcard when specific peer entry is absent", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: {
+          direct: { "*": { systemPrompt: "wildcard prompt" } },
+        },
+      }),
+    ).toBe("wildcard prompt");
+  });
+
+  it("suppresses wildcard when specific peer entry sets systemPrompt to empty string", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: {
+          direct: {
+            p1: { systemPrompt: "" },
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims whitespace from specific peer systemPrompt", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: { direct: { p1: { systemPrompt: "  trimmed  " } } },
+      }),
+    ).toBe("trimmed");
+  });
+
+  it("returns undefined when specific peer entry has no systemPrompt key and no wildcard", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: { direct: { p1: {} } },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to wildcard when specific peer entry has no systemPrompt key", () => {
+    expect(
+      resolveWhatsAppDirectSystemPrompt({
+        peerId: "p1",
+        accountConfig: {
+          direct: {
+            p1: {},
+            "*": { systemPrompt: "wildcard prompt" },
+          },
+        },
+      }),
+    ).toBe("wildcard prompt");
+  });
+});

--- a/extensions/whatsapp/src/system-prompt.ts
+++ b/extensions/whatsapp/src/system-prompt.ts
@@ -1,29 +1,31 @@
 export function resolveWhatsAppGroupSystemPrompt(params: {
-  accountConfig?: { groups?: Record<string, { systemPrompt?: string }> } | null;
+  accountConfig?: { groups?: Record<string, { systemPrompt?: string | null }> } | null;
   groupId?: string | null;
 }): string | undefined {
   if (!params.groupId) {
     return undefined;
   }
   const groups = params.accountConfig?.groups;
-  return (
-    groups?.[params.groupId]?.systemPrompt?.trim() ||
-    groups?.["*"]?.systemPrompt?.trim() ||
-    undefined
-  );
+  const specific = groups?.[params.groupId];
+  if (specific != null && specific.systemPrompt != null) {
+    return specific.systemPrompt.trim() || undefined;
+  }
+  const wildcard = groups?.["*"]?.systemPrompt;
+  return wildcard != null ? wildcard.trim() || undefined : undefined;
 }
 
 export function resolveWhatsAppDirectSystemPrompt(params: {
-  accountConfig?: { direct?: Record<string, { systemPrompt?: string }> } | null;
+  accountConfig?: { direct?: Record<string, { systemPrompt?: string | null }> } | null;
   peerId?: string | null;
 }): string | undefined {
   if (!params.peerId) {
     return undefined;
   }
   const direct = params.accountConfig?.direct;
-  return (
-    direct?.[params.peerId]?.systemPrompt?.trim() ||
-    direct?.["*"]?.systemPrompt?.trim() ||
-    undefined
-  );
+  const specific = direct?.[params.peerId];
+  if (specific != null && specific.systemPrompt != null) {
+    return specific.systemPrompt.trim() || undefined;
+  }
+  const wildcard = direct?.["*"]?.systemPrompt;
+  return wildcard != null ? wildcard.trim() || undefined : undefined;
 }


### PR DESCRIPTION
Developed with github copilot using claude sonnet 4.6

## Summary

- **Problem:** Setting `systemPrompt: ""` for a specific WhatsApp group or DM peer fell through to the wildcard system prompt instead of suppressing it. The old `||` short-circuit treated an empty string as falsy, so the wildcard was always applied whenever the specific entry was blank.
- **Why it matters:** Users who deliberately set an empty `systemPrompt` on a specific group/peer to silence the global wildcard got the wildcard applied anyway — the opposite of the intended behavior.
- **What changed:** `resolveWhatsAppGroupSystemPrompt` and `resolveWhatsAppDirectSystemPrompt` now use an explicit presence check (`!= null`) before reading `systemPrompt`. An empty string on a specific entry suppresses the wildcard and returns `undefined` (no system prompt). Docs updated to match. Unit tests for `system-prompt.ts` added in a new `system-prompt.test.ts`. Integration-level `processMessage` tests for the systemPrompt path (lost in commit `2514bb5b4d`) restored in `process-message.test.ts`. Manually verified end-to-end on the `direct` surface: all three cases (absent entry → wildcard, empty string → suppressed, non-empty → specific) confirmed.
- **What did NOT change:** The wildcard fallback behavior for entries that are absent or that have no `systemPrompt` key is unchanged. No other WhatsApp resolution paths touched.
- **Note:** Telegram already supports an analogous suppression — `resolveTelegramGroupConfig` uses `??`, so a specific group/direct entry wins entirely over the wildcard. Setting `systemPrompt: ""` on a Telegram-specific entry therefore also suppresses the wildcard system prompt (the empty string collapses to `undefined` in `resolveTelegramGroupPromptSettings`). The mechanism differs (object-level `??` vs. WhatsApp's new per-field presence check), but the user-visible effect is the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolveWhatsAppGroupSystemPrompt` and `resolveWhatsAppDirectSystemPrompt` used `||` to chain the specific-entry lookup with the wildcard fallback. Because `""` is falsy in JavaScript, an explicitly empty `systemPrompt` was indistinguishable from an absent one, so the wildcard was always applied.
- **Missing detection / guardrail:** No unit tests existed for the empty-string suppression case; the only tests for this function were deleted in the `refactor(commands): keep resolved auth seam core-only` refactor (`2514bb5b4d`), leaving the regression undetected.
- **Contributing context:** The `||`-based pattern is a common JS idiom that works correctly for "no value" but silently breaks "intentional empty value" semantics.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target tests:**
  - `extensions/whatsapp/src/system-prompt.test.ts` — new file; directly unit-tests both resolver functions across all cases (absent entry, absent key, non-empty value, empty-string suppression, wildcard fallback).
  - `extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts` — restored from `2514bb5b4d`; integration smoke through `processMessage` verifying the systemPrompt is resolved from account config and forwarded to `buildWhatsAppInboundContext`.
- **Scenario locked in:** `groups["g1"].systemPrompt = ""` with a wildcard present → resolver returns `undefined` (wildcard suppressed).
- **Why this is the smallest reliable guardrail:** The unit test targets the exact two exported functions; no network, no process launch. The `process-message` test mocks all runtime seams and tests only the dispatch path.
- **Existing test that already covers this:** None — the previous `process-message.test.ts` tests were removed in the refactor and no replacement existed.

## User-visible / Behavior Changes

Setting `systemPrompt: ""` under a specific `groups.<id>` or `direct.<peerId>` entry now correctly suppresses the wildcard system prompt. Previously, the wildcard was always applied when the specific entry's `systemPrompt` was blank. All other cases (absent entry, absent key, non-empty value) are unchanged.

Note: Telegram already supported the equivalent suppression — a specific group/direct config entry wins entirely over `"*"` via `??`, so an empty `systemPrompt` on a Telegram-specific entry also prevents the wildcard prompt from being used. No Telegram behavior changes.

## Diagram (if applicable)

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Model/provider: `google/gemini-3.1-pro-preview` (agent: C3-PO)
- Integration/channel: WhatsApp (`direct` surface, account `test`)
- Trigger: `/new` command from a whitelisted peer

### Steps

1. Start openclaw with only a wildcard `direct` entry — confirm wildcard prompt appears.
2. Restart; add a non-empty peer-specific `direct` entry alongside the wildcard — confirm specific prompt appears.
3. Restart; change the peer-specific `systemPrompt` to `""` — confirm no prompt marker appears (wildcard suppressed).

### Expected

- Step 1: wildcard marker present in response.
- Step 2: specific marker present; wildcard marker absent.
- Step 3: no marker present.

### Actual

Matched expected in all three steps. See Human Verification for full details.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

Manually tested all three cases on the `direct` surface. A full openclaw restart was performed between each step (automatic reconfiguration was not relied upon).

<img width="1275" height="321" alt="Screenshot 2026-04-23 at 1 22 53" src="https://github.com/user-attachments/assets/27abe94c-294e-4ba2-8130-ad4c600342d3" />

**Step 1 — Specific entry absent; wildcard applies (baseline)**

Config:
```json
"direct": {
  "*": { "systemPrompt": "Add DIRECT-ACCOUNT-WILDCARD at the middle of every direct response." }
}
```
Response: *"Hello! I'm ready DIRECT-ACCOUNT-WILDCARD to help you with whatever you need. What would you like to work on today?"*
✅ Wildcard applied.

**Step 2 — Non-empty peer-specific entry; specific prompt applies**

Config:
```json
"direct": {
  "+97289402586": { "systemPrompt": "Add DIRECT-SPECIFIC before the end of every response" },
  "*": { "systemPrompt": "Add DIRECT-ACCOUNT-WILDCARD at the middle of every direct response." }
}
```
Response: *"Hello! I'm ready to assist you. What would you like to work on today? DIRECT-SPECIFIC."*
✅ Specific prompt applied; wildcard not used.

**Step 3 — Peer-specific `systemPrompt: ""`; wildcard suppressed (fix verification)**

Config:
```json
"direct": {
  "+97289402586": { "systemPrompt": "" },
  "*": { "systemPrompt": "Add DIRECT-ACCOUNT-WILDCARD at the middle of every direct response." }
}
```
Response: *"Hello! I'm online and ready to go. What would you like to work on today?"*
✅ No marker — wildcard correctly suppressed.

- **Edge cases checked:** whitespace-only entry (trims to empty → same suppression), absent `systemPrompt` key with wildcard present (falls through to wildcard correctly).
- **What I did not verify:** group surface end-to-end (covered by unit tests); Telegram behavior (unchanged, no code touched).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

None
