### PR TITLE
fix(gateway,ui): restore managed media transcript persistence in webchat

### DIFF
--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -288,6 +288,18 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.statusCode).toBe(405);
   });
 
+  it("rejects malformed encoded session keys", async () => {
+    const { attachmentId } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/%E0%A4%A/${attachmentId}/full`,
+      authResponse: { authMethod: "device-token" },
+    });
+
+    expect(result.statusCode).toBe(404);
+  });
+
   it("reuses the session attachment index across requests until the transcript changes", async () => {
     const { attachmentId, sessionKey } = await createFixture(stateDir);
     const sessionFile = path.join(stateDir, "sessions", "sess-main.jsonl");
@@ -593,7 +605,6 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(blocks[0]?.type).toBe("image");
     expect(blocks[1]).toMatchObject({ type: "text" });
   });
-
 
   it("skips broken attachments when continueOnPrepareError is enabled", async () => {
     const onPrepareError = vi.fn();

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1,0 +1,960 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinnedLookup } from "../infra/net/ssrf.js";
+import { setMediaStoreNetworkDepsForTest } from "../media/store.js";
+
+const authorizeGatewayHttpRequestOrReplyMock = vi.fn();
+const resolveOpenAiCompatibleHttpOperatorScopesMock = vi.fn();
+const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
+const loadSessionEntryMock = vi.fn();
+const readSessionMessagesMock = vi.fn();
+
+vi.mock("./http-utils.js", () => ({
+  authorizeGatewayHttpRequestOrReply: authorizeGatewayHttpRequestOrReplyMock,
+  resolveOpenAiCompatibleHttpOperatorScopes: resolveOpenAiCompatibleHttpOperatorScopesMock,
+}));
+
+vi.mock("./session-utils.js", () => ({
+  loadSessionEntry: loadSessionEntryMock,
+  readSessionMessages: readSessionMessagesMock,
+}));
+
+vi.mock("../agents/subagent-registry.js", () => ({
+  getLatestSubagentRunByChildSessionKey: getLatestSubagentRunByChildSessionKeyMock,
+}));
+
+const {
+  DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS,
+  attachManagedOutgoingImagesToMessage,
+  cleanupManagedOutgoingImageRecords,
+  createManagedOutgoingImageBlocks,
+  handleManagedOutgoingImageHttpRequest,
+  resolveManagedImageAttachmentLimits,
+} = await import("./managed-image-attachments.js");
+
+type RequestResult = {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+};
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnXcZ0AAAAASUVORK5CYII=";
+
+async function createPngDataUrl(width: number, height: number): Promise<string> {
+  const sharp = (await import("sharp")).default;
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 24, g: 64, b: 128, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return `data:image/png;base64,${buffer.toString("base64")}`;
+}
+
+async function createNoisyPngBuffer(width: number, height: number): Promise<Buffer> {
+  const sharp = (await import("sharp")).default;
+  const pixels = Buffer.alloc(width * height * 4);
+  for (let i = 0; i < pixels.length; i += 4) {
+    const seed = i / 4;
+    pixels[i] = seed % 251;
+    pixels[i + 1] = (seed * 17) % 253;
+    pixels[i + 2] = (seed * 29) % 255;
+    pixels[i + 3] = 255;
+  }
+  return sharp(pixels, { raw: { width, height, channels: 4 } })
+    .png({ compressionLevel: 0 })
+    .toBuffer();
+}
+
+async function createFixture(
+  stateDir: string,
+  options?: { sessionKey?: string; attachmentId?: string; filename?: string },
+) {
+  const attachmentId = options?.attachmentId ?? "att-123";
+  const sessionKey = options?.sessionKey ?? "agent:main:main";
+  const filename = options?.filename ?? `${attachmentId}-cat-full.png`;
+  const originalPath = path.join(stateDir, "files", filename);
+  await fs.mkdir(path.dirname(originalPath), { recursive: true });
+  await fs.writeFile(originalPath, Buffer.from("original-image"));
+  const record: Record<string, unknown> = {
+    attachmentId,
+    sessionKey,
+    messageId: "msg-1",
+    createdAt: new Date().toISOString(),
+    alt: "Cat",
+    original: {
+      path: originalPath,
+      contentType: "image/png",
+      width: 1024,
+      height: 768,
+      sizeBytes: 14,
+      filename: "cat.png",
+    },
+  };
+  const recordsDir = path.join(stateDir, "media", "outgoing", "records");
+  await fs.mkdir(recordsDir, { recursive: true });
+  await fs.writeFile(
+    path.join(recordsDir, `${attachmentId}.json`),
+    JSON.stringify(record, null, 2),
+    "utf-8",
+  );
+  return { attachmentId, sessionKey, originalPath };
+}
+
+async function requestManagedImage(params: {
+  stateDir: string;
+  pathName: string;
+  method?: string;
+  scopes?: string[];
+  denyAuth?: boolean;
+  authResponse?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  transcriptMessages?: Record<string, unknown>[];
+  subagentRun?: Record<string, unknown> | null;
+  sessionEntry?: { sessionId: string; sessionFile?: string };
+}) {
+  authorizeGatewayHttpRequestOrReplyMock.mockImplementation(async ({ res }) => {
+    if (params.denyAuth) {
+      res.statusCode = 401;
+      res.end();
+      return null;
+    }
+    return { ok: true, ...params.authResponse };
+  });
+  resolveOpenAiCompatibleHttpOperatorScopesMock.mockReturnValue(params.scopes ?? ["operator.read"]);
+  getLatestSubagentRunByChildSessionKeyMock.mockReturnValue(params.subagentRun ?? null);
+  loadSessionEntryMock.mockReturnValue({
+    storePath: path.join(params.stateDir, "gateway-sessions.json"),
+    entry: params.sessionEntry ?? { sessionId: "sess-1", sessionFile: "session.jsonl" },
+  });
+  readSessionMessagesMock.mockReturnValue(
+    params.transcriptMessages ?? [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            url: params.pathName,
+            openUrl: params.pathName,
+          },
+        ],
+        __openclaw: { id: "msg-1" },
+      },
+    ],
+  );
+
+  const auth = { mode: "test" } as never;
+  const server = http.createServer(async (req, res) => {
+    const handled = await handleManagedOutgoingImageHttpRequest(req, res, {
+      auth,
+      trustedProxies: ["127.0.0.1/32"],
+      allowRealIpFallback: false,
+      stateDir: params.stateDir,
+    });
+    if (!handled) {
+      res.statusCode = 404;
+      res.end("unhandled");
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+
+  try {
+    const result = await new Promise<RequestResult>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port: address.port,
+          path: params.pathName,
+          method: params.method ?? "GET",
+          headers: params.headers,
+        },
+        async (res) => {
+          const chunks: Buffer[] = [];
+          for await (const chunk of res) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          }
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks),
+          });
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+    return { result, auth };
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+describe("resolveManagedImageAttachmentLimits", () => {
+  it("keeps the existing public limit shape", () => {
+    expect(resolveManagedImageAttachmentLimits()).toEqual(DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS);
+  });
+});
+
+describe("handleManagedOutgoingImageHttpRequest", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-images-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    setMediaStoreNetworkDepsForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("serves full images for authorized chat-history readers", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      headers: { "x-openclaw-requester-session-key": sessionKey },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["content-type"]).toBe("image/png");
+    expect(result.headers["content-disposition"]).toContain("inline");
+    expect(result.body.toString("utf-8")).toBe("original-image");
+  });
+
+  it("rejects unauthenticated requests before serving bytes", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      denyAuth: true,
+    });
+
+    expect(result.statusCode).toBe(401);
+    expect(result.body.byteLength).toBe(0);
+  });
+
+  it("rejects requests from unrelated sessions", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      headers: { "x-openclaw-requester-session-key": "agent:main:other" },
+    });
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("allows device-token access without requester session ownership", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      authResponse: { authMethod: "device-token" },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body.toString("utf-8")).toBe("original-image");
+  });
+
+  it("rejects non-GET methods", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+
+    const { result } = await requestManagedImage({
+      stateDir,
+      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+      method: "POST",
+      headers: { "x-openclaw-requester-session-key": sessionKey },
+    });
+
+    expect(result.statusCode).toBe(405);
+  });
+
+  it("reuses the session attachment index across requests until the transcript changes", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const sessionFile = path.join(stateDir, "sessions", "sess-main.jsonl");
+    await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+    await fs.writeFile(sessionFile, '{"message":{}}\n', "utf-8");
+
+    const transcriptMessages = [
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+          },
+        ],
+      },
+    ];
+
+    const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
+    const first = await requestManagedImage({
+      stateDir,
+      pathName,
+      headers: { "x-openclaw-requester-session-key": sessionKey },
+      sessionEntry: { sessionId: "sess-main", sessionFile },
+      transcriptMessages,
+    });
+    const second = await requestManagedImage({
+      stateDir,
+      pathName,
+      headers: { "x-openclaw-requester-session-key": sessionKey },
+      sessionEntry: { sessionId: "sess-main", sessionFile },
+      transcriptMessages,
+    });
+
+    expect(first.result.statusCode).toBe(200);
+    expect(second.result.statusCode).toBe(200);
+    expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await fs.writeFile(sessionFile, '{"message":{}}\n{"message":{"content":"updated"}}\n', "utf-8");
+
+    const third = await requestManagedImage({
+      stateDir,
+      pathName,
+      headers: { "x-openclaw-requester-session-key": sessionKey },
+      sessionEntry: { sessionId: "sess-main", sessionFile },
+      transcriptMessages,
+    });
+
+    expect(third.result.statusCode).toBe(200);
+    expect(readSessionMessagesMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createManagedOutgoingImageBlocks", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-image-blocks-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    setMediaStoreNetworkDepsForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("creates inline/open blocks that both point at the full image", async () => {
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+      stateDir,
+      messageId: "msg-1",
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "image",
+      alt: "Generated image 1",
+      mimeType: "image/png",
+    });
+    expect(blocks[0]?.url).toBe(blocks[0]?.openUrl);
+    expect(String(blocks[0]?.url)).toMatch(/\/full$/);
+
+    const recordsDir = path.join(stateDir, "media", "outgoing", "records");
+    const [recordName] = await fs.readdir(recordsDir);
+    const record = JSON.parse(await fs.readFile(path.join(recordsDir, recordName), "utf-8")) as {
+      original: { path: string };
+    };
+    expect(record.original.path).toContain(
+      `${path.sep}media${path.sep}outgoing${path.sep}originals${path.sep}`,
+    );
+  });
+
+  it("rejects oversized image data urls before decoding the payload", async () => {
+    const oversizedDataUrl = "data:image/png;base64,AAAAAA==";
+
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [oversizedDataUrl],
+        stateDir,
+        limits: {
+          ...DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS,
+          maxBytes: 3,
+        },
+      }),
+    ).rejects.toThrow(/Generated image 1.*byte limit/);
+
+    await expect(fs.readdir(path.join(stateDir, "media", "outgoing", "records"))).rejects.toThrow();
+  });
+
+  it("rewrites local image sources into managed display blocks without leaking the source path", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const sourcePath = path.join(stateDir, "workspace", "fixtures", "dot.png");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    try {
+      const blocks = await createManagedOutgoingImageBlocks({
+        stateDir,
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        localRoots: [path.join(stateDir, "workspace")],
+      });
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toMatchObject({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/agent%3Amain%3Amain/"),
+        openUrl: expect.stringContaining("/full"),
+      });
+      expect(blocks[0]?.url).toBe(blocks[0]?.openUrl);
+      expect(JSON.stringify(blocks[0])).not.toContain(sourcePath);
+
+      const attachmentId = String(blocks[0]?.url).split("/").at(-2);
+      expect(attachmentId).toBeTruthy();
+      const record = JSON.parse(
+        await fs.readFile(
+          path.join(stateDir, "media", "outgoing", "records", `${attachmentId}.json`),
+          "utf-8",
+        ),
+      ) as { original: { filename: string; path: string } };
+      expect(record.original.filename).toMatch(/\.png$/);
+      expect(record.original.path).not.toBe(sourcePath);
+      expect(record.original.path).toContain(path.join(stateDir, "media", "outgoing", "originals"));
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("ingests external image URLs into managed storage instead of hotlinking them", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const imageBuffer = Buffer.from(TINY_PNG_BASE64, "base64");
+    const upstream = http.createServer((req, res) => {
+      expect(req.url).toBe("/remote-cat.png?sig=secret");
+      res.statusCode = 200;
+      res.setHeader("content-type", "image/png");
+      res.end(imageBuffer);
+    });
+
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    const address = upstream.address() as AddressInfo;
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+
+    try {
+      const sourceUrl = `http://127.0.0.1:${address.port}/remote-cat.png?sig=secret`;
+      const blocks = await createManagedOutgoingImageBlocks({
+        stateDir,
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourceUrl],
+      });
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]?.alt).toBe("remote-cat.png");
+      expect(blocks[0]).toMatchObject({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/agent%3Amain%3Amain/"),
+        openUrl: expect.stringContaining("/full"),
+      });
+      expect(blocks[0]?.url).toBe(blocks[0]?.openUrl);
+      expect(JSON.stringify(blocks[0])).not.toContain("127.0.0.1");
+      expect(JSON.stringify(blocks[0])).not.toContain("sig=secret");
+
+      const attachmentId = String(blocks[0]?.url).split("/").at(-2);
+      expect(attachmentId).toBeTruthy();
+      const record = JSON.parse(
+        await fs.readFile(
+          path.join(stateDir, "media", "outgoing", "records", `${attachmentId}.json`),
+          "utf-8",
+        ),
+      ) as { original: { path: string } };
+      expect(record.original.path).toContain(path.join(stateDir, "media", "outgoing", "originals"));
+      expect(JSON.stringify(record)).not.toContain("127.0.0.1");
+      expect(JSON.stringify(record)).not.toContain("sig=secret");
+      expect(await fs.readFile(record.original.path)).toEqual(imageBuffer);
+    } finally {
+      setMediaStoreNetworkDepsForTest();
+      await new Promise<void>((resolve, reject) =>
+        upstream.close((error) => (error ? reject(error) : resolve())),
+      );
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("keeps managed originals under the state-dir media root when config path differs", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    const externalConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-image-config-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = path.join(externalConfigDir, "config.json");
+    const sourcePath = path.join(stateDir, "workspace", "fixtures", "dot.png");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    try {
+      const blocks = await createManagedOutgoingImageBlocks({
+        stateDir,
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        localRoots: [path.join(stateDir, "workspace")],
+      });
+
+      const attachmentId = String(blocks[0]?.url).split("/").at(-2);
+      expect(attachmentId).toBeTruthy();
+
+      const record = JSON.parse(
+        await fs.readFile(
+          path.join(stateDir, "media", "outgoing", "records", `${attachmentId}.json`),
+          "utf-8",
+        ),
+      ) as { original: { path: string } };
+
+      expect(record.original.path).toContain(path.join(stateDir, "media", "outgoing", "originals"));
+      expect(record.original.path).not.toContain(externalConfigDir);
+      await expect(fs.access(record.original.path)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(externalConfigDir, { recursive: true, force: true });
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousConfigPath == null) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+      }
+    }
+  });
+
+  it("merges configured managed image limits with defaults", () => {
+    expect(resolveManagedImageAttachmentLimits()).toEqual(DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS);
+    expect(
+      resolveManagedImageAttachmentLimits({
+        maxWidth: 8192,
+        maxHeight: 2048,
+      }),
+    ).toEqual({
+      ...DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS,
+      maxWidth: 8192,
+      maxHeight: 2048,
+    });
+  });
+
+  it("rejects managed outgoing images that exceed configured byte limits", async () => {
+    await expect(
+      createManagedOutgoingImageBlocks({
+        stateDir,
+        sessionKey: "agent:main:main",
+        mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+        limits: { maxBytes: 32 },
+      }),
+    ).rejects.toThrow(/0MB limit|32 bytes|byte limit/i);
+  });
+
+  it("adds a warning block when an image is resized to fit limits", async () => {
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [await createPngDataUrl(200, 120)],
+      stateDir,
+      limits: { maxWidth: 64, maxHeight: 64, maxPixels: 4096 },
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.type).toBe("image");
+    expect(blocks[1]).toMatchObject({ type: "text" });
+  });
+
+  it("accepts URL images up to the configured managed-image byte limit", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const imageBuffer = await createNoisyPngBuffer(1600, 1200);
+    expect(imageBuffer.byteLength).toBeGreaterThan(5 * 1024 * 1024);
+    expect(imageBuffer.byteLength).toBeLessThan(DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS.maxBytes);
+
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "image/png");
+      res.end(imageBuffer);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+
+    try {
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [`http://127.0.0.1:${address.port}/large-image.png`],
+        stateDir,
+      });
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toMatchObject({ type: "image" });
+    } finally {
+      setMediaStoreNetworkDepsForTest();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("rejects local image paths outside allowed roots", async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-image-outside-"));
+    const outsidePath = path.join(outsideDir, "outside.png");
+    await fs.writeFile(outsidePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    try {
+      await expect(
+        createManagedOutgoingImageBlocks({
+          sessionKey: "agent:main:main",
+          mediaUrls: [outsidePath],
+          stateDir,
+          localRoots: [path.join(stateDir, "workspace")],
+        }),
+      ).rejects.toThrow(/could not be prepared/i);
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts local image paths inside allowed roots", async () => {
+    const allowedDir = path.join(stateDir, "workspace", "uploads");
+    const allowedPath = path.join(allowedDir, "inside.png");
+    await fs.mkdir(allowedDir, { recursive: true });
+    await fs.writeFile(allowedPath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [allowedPath],
+      stateDir,
+      localRoots: [path.join(stateDir, "workspace")],
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: "image" });
+  });
+
+  it("rejects relative local image paths that resolve outside allowed roots", async () => {
+    const allowedWorkspaceDir = path.join(stateDir, "workspace");
+    const outsidePath = path.join(stateDir, "outside.png");
+    await fs.mkdir(allowedWorkspaceDir, { recursive: true });
+    await fs.writeFile(outsidePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(allowedWorkspaceDir);
+    try {
+      await expect(
+        createManagedOutgoingImageBlocks({
+          sessionKey: "agent:main:main",
+          mediaUrls: ["../outside.png"],
+          stateDir,
+          localRoots: [allowedWorkspaceDir],
+        }),
+      ).rejects.toThrow(/could not be prepared/i);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it("drops downloaded non-image sources without leaving orphaned originals", async () => {
+    const pdfPath = path.join(stateDir, "not-an-image.pdf");
+    await fs.writeFile(pdfPath, Buffer.from("%PDF-1.4\n% test\n"));
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [pdfPath],
+      stateDir,
+      localRoots: [stateDir],
+    });
+    expect(blocks).toEqual([]);
+    const originalsDir = path.join(stateDir, "media", "outgoing", "originals");
+    let originals: string[] | null = null;
+    try {
+      originals = await fs.readdir(originalsDir);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "ENOENT" });
+    }
+    expect(originals ?? []).toEqual([]);
+  });
+
+  it("skips oversized downloaded non-image sources instead of failing finalization", async () => {
+    const audioPath = path.join(stateDir, "large-audio.mp3");
+    await fs.writeFile(audioPath, Buffer.alloc(2048, 1));
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [audioPath],
+      stateDir,
+      localRoots: [stateDir],
+      limits: { maxBytes: 1024 },
+    });
+    expect(blocks).toEqual([]);
+    const originalsDir = path.join(stateDir, "media", "outgoing", "originals");
+    let originals: string[] | null = null;
+    try {
+      originals = await fs.readdir(originalsDir);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "ENOENT" });
+    }
+    expect(originals ?? []).toEqual([]);
+  });
+
+  it("does not reap older transient records while creating a new managed image", async () => {
+    const staleOriginalPath = path.join(stateDir, "files", "stale-cat.png");
+    const staleAttachmentId = "stale-att";
+    const staleRecordPath = path.join(
+      stateDir,
+      "media",
+      "outgoing",
+      "records",
+      `${staleAttachmentId}.json`,
+    );
+    await fs.mkdir(path.dirname(staleOriginalPath), { recursive: true });
+    await fs.mkdir(path.dirname(staleRecordPath), { recursive: true });
+    await fs.writeFile(staleOriginalPath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    await fs.writeFile(
+      staleRecordPath,
+      JSON.stringify(
+        {
+          attachmentId: staleAttachmentId,
+          sessionKey: "agent:main:main",
+          messageId: null,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          retentionClass: "transient",
+          alt: "Stale cat",
+          original: {
+            path: staleOriginalPath,
+            contentType: "image/png",
+            width: 1,
+            height: 1,
+            sizeBytes: Buffer.from(TINY_PNG_BASE64, "base64").byteLength,
+            filename: "stale-cat.png",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+      stateDir,
+    });
+
+    await expect(fs.access(staleRecordPath)).resolves.toBeUndefined();
+    await expect(fs.access(staleOriginalPath)).resolves.toBeUndefined();
+  });
+});
+
+describe("attachManagedOutgoingImagesToMessage", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-image-attach-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("upgrades transient image records to history when the message is committed", async () => {
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+      stateDir,
+    });
+
+    await attachManagedOutgoingImagesToMessage({
+      messageId: "msg-committed",
+      blocks: blocks as Record<string, unknown>[],
+      stateDir,
+    });
+
+    const recordsDir = path.join(stateDir, "media", "outgoing", "records");
+    const [recordName] = await fs.readdir(recordsDir);
+    const record = JSON.parse(await fs.readFile(path.join(recordsDir, recordName), "utf-8")) as {
+      messageId: string | null;
+      retentionClass?: string;
+      updatedAt?: string;
+    };
+    expect(record.messageId).toBe("msg-committed");
+    expect(record.retentionClass).toBe("history");
+    expect(typeof record.updatedAt).toBe("string");
+  });
+});
+
+describe("cleanupManagedOutgoingImageRecords", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-image-cleanup-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("cleans up dereferenced records and original files", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readSessionMessagesMock.mockReturnValue([]);
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toMatchObject({
+      deletedRecordCount: 1,
+      deletedFileCount: 1,
+      retainedCount: 0,
+    });
+    await expect(fs.access(fixture.originalPath)).rejects.toThrow();
+  });
+
+  it("retains committed records that are still referenced by a full-image block", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readSessionMessagesMock.mockReturnValue([
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(fixture.sessionKey)}/${fixture.attachmentId}/full`,
+          },
+        ],
+      },
+    ]);
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toMatchObject({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 1,
+    });
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+  });
+
+  it("reads each session transcript once while evaluating committed records", async () => {
+    const firstFixture = await createFixture(stateDir, {
+      attachmentId: "att-1",
+      filename: "att-1.png",
+    });
+    const secondFixture = await createFixture(stateDir, {
+      attachmentId: "att-2",
+      filename: "att-2.png",
+    });
+    loadSessionEntryMock.mockReturnValue({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: { sessionId: "sess-main", sessionFile: "/tmp/sess-main.jsonl" },
+    });
+    readSessionMessagesMock.mockReturnValue([
+      {
+        __openclaw: { id: "msg-1" },
+        content: [
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
+            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(firstFixture.sessionKey)}/${firstFixture.attachmentId}/full`,
+          },
+          {
+            type: "image",
+            url: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
+            openUrl: `/api/chat/media/outgoing/${encodeURIComponent(secondFixture.sessionKey)}/${secondFixture.attachmentId}/full`,
+          },
+        ],
+      },
+    ]);
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toMatchObject({
+      deletedRecordCount: 0,
+      deletedFileCount: 0,
+      retainedCount: 2,
+    });
+    expect(readSessionMessagesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not delete files still referenced by other sessions during session-scoped cleanup", async () => {
+    const retainedFixture = await createFixture(stateDir, {
+      sessionKey: "agent:other:session",
+      attachmentId: "att-keep",
+    });
+    const deletedFixture = await createFixture(stateDir, {
+      sessionKey: "agent:main:main",
+      attachmentId: "att-delete",
+    });
+
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      storePath: path.join(stateDir, "gateway-sessions.json"),
+      entry: {
+        sessionId: sessionKey === retainedFixture.sessionKey ? "sess-other" : "sess-main",
+        sessionFile: "/tmp/session.jsonl",
+      },
+    }));
+    readSessionMessagesMock.mockReturnValue([]);
+
+    const result = await cleanupManagedOutgoingImageRecords({
+      stateDir,
+      sessionKey: deletedFixture.sessionKey,
+      forceDeleteSessionRecords: true,
+    });
+
+    expect(result).toMatchObject({
+      deletedRecordCount: 1,
+      retainedCount: 1,
+    });
+    await expect(fs.access(retainedFixture.originalPath)).resolves.toBeUndefined();
+  });
+});

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -594,6 +594,27 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(blocks[1]).toMatchObject({ type: "text" });
   });
 
+
+  it("skips broken attachments when continueOnPrepareError is enabled", async () => {
+    const onPrepareError = vi.fn();
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [await createPngDataUrl(32, 32), path.join(stateDir, "missing.png")],
+      stateDir,
+      localRoots: [stateDir],
+      continueOnPrepareError: true,
+      onPrepareError,
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: "image" });
+    expect(onPrepareError).toHaveBeenCalledTimes(1);
+    expect(onPrepareError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(onPrepareError.mock.calls[0]?.[0]?.message).toMatch(
+      /Managed image attachment .* could not be prepared/i,
+    );
+  });
+
   it("accepts URL images up to the configured managed-image byte limit", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = stateDir;

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -79,7 +79,7 @@ async function createFixture(
   stateDir: string,
   options?: { sessionKey?: string; attachmentId?: string; filename?: string },
 ) {
-  const attachmentId = options?.attachmentId ?? "att-123";
+  const attachmentId = options?.attachmentId ?? "11111111-1111-4111-8111-111111111111";
   const sessionKey = options?.sessionKey ?? "agent:main:main";
   const filename = options?.filename ?? `${attachmentId}-cat-full.png`;
   const originalPath = path.join(stateDir, "files", filename);
@@ -887,11 +887,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
 
   it("reads each session transcript once while evaluating committed records", async () => {
     const firstFixture = await createFixture(stateDir, {
-      attachmentId: "att-1",
+      attachmentId: "11111111-1111-4111-8111-111111111111",
       filename: "att-1.png",
     });
     const secondFixture = await createFixture(stateDir, {
-      attachmentId: "att-2",
+      attachmentId: "22222222-2222-4222-8222-222222222222",
       filename: "att-2.png",
     });
     loadSessionEntryMock.mockReturnValue({
@@ -929,11 +929,11 @@ describe("cleanupManagedOutgoingImageRecords", () => {
   it("does not delete files still referenced by other sessions during session-scoped cleanup", async () => {
     const retainedFixture = await createFixture(stateDir, {
       sessionKey: "agent:other:session",
-      attachmentId: "att-keep",
+      attachmentId: "33333333-3333-4333-8333-333333333333",
     });
     const deletedFixture = await createFixture(stateDir, {
       sessionKey: "agent:main:main",
-      attachmentId: "att-delete",
+      attachmentId: "44444444-4444-4444-8444-444444444444",
     });
 
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -25,6 +25,8 @@ import { loadSessionEntry, readSessionMessages } from "./session-utils.js";
 
 const OUTGOING_IMAGE_ROUTE_PREFIX = "/api/chat/media/outgoing";
 const DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS = 15 * 60 * 1000;
+const MANAGED_OUTGOING_ATTACHMENT_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS = {
   maxBytes: 12 * 1024 * 1024,
@@ -216,6 +218,7 @@ function computeManagedImageResizeTarget(
 
 async function resizeManagedImageBufferToLimits(params: {
   buffer: Buffer;
+  contentType: string;
   metadata: { width: number; height: number };
   limits: ManagedImageAttachmentLimits;
 }): Promise<{ buffer: Buffer; contentType: string; width: number; height: number }> {
@@ -223,7 +226,7 @@ async function resizeManagedImageBufferToLimits(params: {
   if (!target) {
     return {
       buffer: params.buffer,
-      contentType: "image/jpeg",
+      contentType: params.contentType,
       width: params.metadata.width,
       height: params.metadata.height,
     };
@@ -569,6 +572,9 @@ function parseManagedOutgoingRoute(value: string) {
     if (!match) {
       return null;
     }
+    if (!MANAGED_OUTGOING_ATTACHMENT_ID_RE.test(match[2])) {
+      return null;
+    }
     return {
       sessionKey: decodeURIComponent(match[1]),
       attachmentId: match[2],
@@ -820,7 +826,8 @@ export async function createManagedOutgoingImageBlocks(params: {
               );
             })();
       savedOriginalPath = savedOriginal.path;
-      if (!savedOriginal.contentType?.startsWith("image/")) {
+      let savedOriginalContentType = savedOriginal.contentType;
+      if (!savedOriginalContentType?.startsWith("image/")) {
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginalPath = null;
         continue;
@@ -859,6 +866,7 @@ export async function createManagedOutgoingImageBlocks(params: {
         }
         const resized = await resizeManagedImageBufferToLimits({
           buffer: originalBuffer,
+          contentType: savedOriginalContentType,
           metadata: effectiveMetadata,
           limits,
         });
@@ -873,6 +881,7 @@ export async function createManagedOutgoingImageBlocks(params: {
         );
         await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
         savedOriginal = replacement;
+        savedOriginalContentType = replacement.contentType ?? resized.contentType;
         savedOriginalPath = savedOriginal.path;
         originalBuffer = resized.buffer;
         originalStats = await getVariantStats(savedOriginal.path);
@@ -901,7 +910,7 @@ export async function createManagedOutgoingImageBlocks(params: {
         alt,
         original: {
           path: savedOriginal.path,
-          contentType: savedOriginal.contentType ?? "application/octet-stream",
+          contentType: savedOriginalContentType,
           width: originalStats.width,
           height: originalStats.height,
           sizeBytes: originalStats.sizeBytes,
@@ -992,6 +1001,10 @@ export async function handleManagedOutgoingImageHttpRequest(
   const attachmentId = match[2];
   if (!encodedSessionKey || !attachmentId) {
     return false;
+  }
+  if (!MANAGED_OUTGOING_ATTACHMENT_ID_RE.test(attachmentId)) {
+    sendStatus(res, 404, "not found");
+    return true;
   }
   const sessionKey = decodeURIComponent(encodedSessionKey);
   const record = await readManagedImageRecord(attachmentId, opts.stateDir);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1013,7 +1013,13 @@ export async function handleManagedOutgoingImageHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  const sessionKey = decodeURIComponent(encodedSessionKey);
+  let sessionKey: string;
+  try {
+    sessionKey = decodeURIComponent(encodedSessionKey);
+  } catch {
+    sendStatus(res, 404, "not found");
+    return true;
+  }
   const record = await readManagedImageRecord(attachmentId, opts.stateDir);
   if (!record || record.sessionKey !== sessionKey) {
     sendStatus(res, 404, "not found");

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1,0 +1,1052 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
+import { getLatestSubagentRunByChildSessionKey } from "../agents/subagent-registry.js";
+import { resolveStateDir } from "../config/paths.js";
+import {
+  getImageMetadata,
+  hasAlphaChannel,
+  resizeToJpeg,
+  resizeToPng,
+} from "../media/image-ops.js";
+import { assertLocalMediaAllowed } from "../media/local-media-access.js";
+import { resolveLocalMediaPath } from "../media/local-roots.js";
+import { MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../media/store.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  authorizeGatewayHttpRequestOrReply,
+  resolveOpenAiCompatibleHttpOperatorScopes,
+} from "./http-utils.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { loadSessionEntry, readSessionMessages } from "./session-utils.js";
+
+const OUTGOING_IMAGE_ROUTE_PREFIX = "/api/chat/media/outgoing";
+const DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS = 15 * 60 * 1000;
+
+export const DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS = {
+  maxBytes: 12 * 1024 * 1024,
+  maxWidth: 4096,
+  maxHeight: 4096,
+  maxPixels: 20_000_000,
+} as const;
+
+export type ManagedImageAttachmentLimits = {
+  maxBytes: number;
+  maxWidth: number;
+  maxHeight: number;
+  maxPixels: number;
+};
+
+type ManagedImageAttachmentLimitsConfig = Partial<
+  Pick<ManagedImageAttachmentLimits, "maxBytes" | "maxWidth" | "maxHeight" | "maxPixels">
+>;
+
+type ManagedImageRecordVariant = {
+  path: string;
+  contentType: string;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  filename: string | null;
+};
+
+type ManagedImageRetentionClass = "transient" | "history";
+
+type ManagedImageRecord = {
+  attachmentId: string;
+  sessionKey: string;
+  messageId: string | null;
+  createdAt: string;
+  updatedAt?: string;
+  retentionClass?: ManagedImageRetentionClass;
+  alt: string;
+  original: ManagedImageRecordVariant;
+};
+
+type ParsedImageDataUrl =
+  | { kind: "not-data-url" }
+  | { kind: "non-image-data-url" }
+  | { kind: "image-data-url"; buffer: Buffer; contentType: string };
+
+type ManagedImageBlock = Record<string, unknown>;
+
+type CleanupManagedOutgoingImageRecordsResult = {
+  deletedRecordCount: number;
+  deletedFileCount: number;
+  retainedCount: number;
+};
+
+type SessionManagedOutgoingAttachmentIndex = Set<string>;
+
+type SessionManagedOutgoingAttachmentIndexCacheEntry = {
+  transcriptPath: string;
+  mtimeMs: number;
+  size: number;
+  index: SessionManagedOutgoingAttachmentIndex;
+};
+
+const sessionManagedOutgoingAttachmentIndexCache = new Map<
+  string,
+  SessionManagedOutgoingAttachmentIndexCacheEntry
+>();
+const MAX_SESSION_MANAGED_OUTGOING_ATTACHMENT_INDEX_CACHE_ENTRIES = 500;
+
+export function resolveManagedImageAttachmentLimits(
+  config?: ManagedImageAttachmentLimitsConfig | null,
+): ManagedImageAttachmentLimits {
+  return {
+    maxBytes: config?.maxBytes ?? DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS.maxBytes,
+    maxWidth: config?.maxWidth ?? DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS.maxWidth,
+    maxHeight: config?.maxHeight ?? DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS.maxHeight,
+    maxPixels: config?.maxPixels ?? DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS.maxPixels,
+  };
+}
+
+function formatLimitMiB(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${bytes} bytes`;
+  }
+  return Number.isInteger(bytes / (1024 * 1024))
+    ? `${bytes / (1024 * 1024)} MiB`
+    : `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function createManagedImageAttachmentError(message: string) {
+  const error = new Error(message);
+  error.name = "ManagedImageAttachmentError";
+  return error;
+}
+
+function isManagedImageAttachmentSafeError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.name === "ManagedImageAttachmentError") {
+    return true;
+  }
+  return (
+    error.message.startsWith("Managed image attachment ") ||
+    error.message.startsWith("Invalid image data URL")
+  );
+}
+
+function throwSanitizedManagedImageAttachmentError(error: unknown, alt: string): never {
+  if (isManagedImageAttachmentSafeError(error)) {
+    throw error;
+  }
+  throw createManagedImageAttachmentError(
+    `Managed image attachment ${JSON.stringify(alt)} could not be prepared`,
+  );
+}
+
+function validateManagedImageBuffer(
+  buffer: Buffer,
+  alt: string,
+  limits: ManagedImageAttachmentLimits,
+): void {
+  if (buffer.byteLength > limits.maxBytes) {
+    throw createManagedImageAttachmentError(
+      `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
+    );
+  }
+}
+
+function estimateBase64DecodedByteLength(base64: string): number {
+  const normalized = base64.replace(/\s+/g, "");
+  const paddingMatch = /=+$/u.exec(normalized);
+  const padding = Math.min(paddingMatch?.[0].length ?? 0, 2);
+  return Math.floor((normalized.length * 3) / 4) - padding;
+}
+
+function getManagedImageMetadataLimitError(
+  metadata: { width: number; height: number } | null,
+  alt: string,
+  limits: ManagedImageAttachmentLimits,
+): string | null {
+  if (!metadata) {
+    return `Managed image attachment ${JSON.stringify(alt)} is missing readable dimensions`;
+  }
+
+  if (metadata.width > limits.maxWidth) {
+    return `Managed image attachment ${JSON.stringify(alt)} exceeds the ${limits.maxWidth}px width limit`;
+  }
+  if (metadata.height > limits.maxHeight) {
+    return `Managed image attachment ${JSON.stringify(alt)} exceeds the ${limits.maxHeight}px height limit`;
+  }
+  if (metadata.width * metadata.height > limits.maxPixels) {
+    return `Managed image attachment ${JSON.stringify(alt)} exceeds the ${limits.maxPixels.toLocaleString("en-US")} pixel limit`;
+  }
+  return null;
+}
+
+function computeManagedImageResizeTarget(
+  metadata: { width: number; height: number },
+  limits: ManagedImageAttachmentLimits,
+): { width: number; height: number } | null {
+  const scale = Math.min(
+    1,
+    limits.maxWidth / metadata.width,
+    limits.maxHeight / metadata.height,
+    Math.sqrt(limits.maxPixels / (metadata.width * metadata.height)),
+  );
+  if (!Number.isFinite(scale) || scale >= 1) {
+    return null;
+  }
+
+  let width = Math.max(1, Math.floor(metadata.width * scale));
+  let height = Math.max(1, Math.floor(metadata.height * scale));
+  while (
+    width > limits.maxWidth ||
+    height > limits.maxHeight ||
+    width * height > limits.maxPixels
+  ) {
+    if (width >= height && width > 1) {
+      width -= 1;
+    } else if (height > 1) {
+      height -= 1;
+    } else {
+      break;
+    }
+  }
+  return { width, height };
+}
+
+async function resizeManagedImageBufferToLimits(params: {
+  buffer: Buffer;
+  metadata: { width: number; height: number };
+  limits: ManagedImageAttachmentLimits;
+}): Promise<{ buffer: Buffer; contentType: string; width: number; height: number }> {
+  const target = computeManagedImageResizeTarget(params.metadata, params.limits);
+  if (!target) {
+    return {
+      buffer: params.buffer,
+      contentType: "image/jpeg",
+      width: params.metadata.width,
+      height: params.metadata.height,
+    };
+  }
+
+  const preserveAlpha = await hasAlphaChannel(params.buffer).catch(() => false);
+  const resizedBuffer = preserveAlpha
+    ? await resizeToPng({
+        buffer: params.buffer,
+        maxWidth: target.width,
+        maxHeight: target.height,
+        compressionLevel: 9,
+        withoutEnlargement: true,
+      })
+    : await resizeToJpeg({
+        buffer: params.buffer,
+        maxWidth: target.width,
+        maxHeight: target.height,
+        quality: 92,
+        withoutEnlargement: true,
+      });
+
+  return {
+    buffer: resizedBuffer,
+    contentType: preserveAlpha ? "image/png" : "image/jpeg",
+    width: target.width,
+    height: target.height,
+  };
+}
+
+function resolveOutgoingRecordsDir(stateDir = resolveStateDir()) {
+  return path.join(stateDir, "media", "outgoing", "records");
+}
+
+function resolveOutgoingOriginalsDir(stateDir = resolveStateDir()) {
+  return path.join(stateDir, "media", "outgoing", "originals");
+}
+
+function resolveOutgoingRecordPath(attachmentId: string, stateDir = resolveStateDir()) {
+  return path.join(resolveOutgoingRecordsDir(stateDir), `${attachmentId}.json`);
+}
+
+function buildOutgoingVariantUrl(sessionKey: string, attachmentId: string, variant: "full") {
+  return `${OUTGOING_IMAGE_ROUTE_PREFIX}/${encodeURIComponent(sessionKey)}/${attachmentId}/${variant}`;
+}
+
+function resolveRequesterSessionKey(req: IncomingMessage) {
+  const raw = req.headers["x-openclaw-requester-session-key"];
+  if (Array.isArray(raw)) {
+    return raw[0]?.trim() || null;
+  }
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+}
+
+async function requesterOwnsManagedImageSession(params: {
+  requesterSessionKey: string;
+  targetSessionKey: string;
+}) {
+  if (params.requesterSessionKey === params.targetSessionKey) {
+    return true;
+  }
+  const subagentRun = getLatestSubagentRunByChildSessionKey(params.targetSessionKey);
+  if (!subagentRun) {
+    return false;
+  }
+  return (
+    subagentRun.requesterSessionKey === params.requesterSessionKey ||
+    subagentRun.controllerSessionKey === params.requesterSessionKey
+  );
+}
+
+function deriveAltText(source: string, index: number) {
+  const fallback = `Generated image ${index + 1}`;
+  try {
+    if (/^https?:\/\//i.test(source)) {
+      const parsed = new URL(source);
+      const name = path.basename(parsed.pathname || "").trim();
+      return name || fallback;
+    }
+  } catch {
+    // Fall through to local path handling.
+  }
+  const localName = path.basename(source).trim();
+  return localName || fallback;
+}
+
+function parseImageDataUrl(
+  source: string,
+  alt: string,
+  limits: ManagedImageAttachmentLimits,
+): ParsedImageDataUrl {
+  const trimmed = source.trim();
+  if (!trimmed.startsWith("data:")) {
+    return { kind: "not-data-url" };
+  }
+  const match = /^data:([^;,]+)(?:;[^,]*)*;base64,([A-Za-z0-9+/=\s]+)$/i.exec(trimmed);
+  if (!match) {
+    throw new Error("Invalid image data URL");
+  }
+  const contentType = match[1]?.trim().toLowerCase() ?? "";
+  if (!contentType.startsWith("image/")) {
+    return { kind: "non-image-data-url" };
+  }
+  if (estimateBase64DecodedByteLength(match[2]) > limits.maxBytes) {
+    throw createManagedImageAttachmentError(
+      `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
+    );
+  }
+  return {
+    kind: "image-data-url",
+    buffer: Buffer.from(match[2].replace(/\s+/g, ""), "base64"),
+    contentType,
+  };
+}
+
+async function getVariantStats(filePath: string) {
+  const [stats, metadataBuffer] = await Promise.all([fs.stat(filePath), fs.readFile(filePath)]);
+  const metadata = (await getImageMetadata(metadataBuffer).catch(() => null)) ?? {
+    width: null,
+    height: null,
+  };
+  return {
+    width: metadata.width ?? null,
+    height: metadata.height ?? null,
+    sizeBytes: Number.isFinite(stats.size) ? stats.size : null,
+  };
+}
+
+async function writeManagedImageRecord(record: ManagedImageRecord, stateDir = resolveStateDir()) {
+  const recordPath = resolveOutgoingRecordPath(record.attachmentId, stateDir);
+  await fs.mkdir(path.dirname(recordPath), { recursive: true });
+  await fs.writeFile(recordPath, JSON.stringify(record, null, 2), "utf-8");
+}
+
+async function deleteManagedImageRecordArtifacts(
+  record: ManagedImageRecord,
+  stateDir = resolveStateDir(),
+) {
+  const files = new Set<string>();
+  if (record.original?.path) {
+    files.add(record.original.path);
+  }
+  let deletedFileCount = 0;
+  for (const filePath of files) {
+    try {
+      await fs.rm(filePath, { force: true });
+      deletedFileCount += 1;
+    } catch {
+      // Ignore cleanup races or already-missing files.
+    }
+  }
+  try {
+    await fs.rm(resolveOutgoingRecordPath(record.attachmentId, stateDir), { force: true });
+  } catch {
+    // Ignore cleanup races or already-missing records.
+  }
+  return deletedFileCount;
+}
+
+async function deleteOrphanManagedImageFiles(params: {
+  stateDir: string;
+  referencedPaths: ReadonlySet<string>;
+}) {
+  let deletedFileCount = 0;
+  for (const dir of [resolveOutgoingOriginalsDir(params.stateDir)]) {
+    let names: string[] = [];
+    try {
+      names = await fs.readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const filePath = path.join(dir, name);
+      if (params.referencedPaths.has(filePath)) {
+        continue;
+      }
+      try {
+        const stats = await fs.stat(filePath);
+        if (!stats.isFile()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      try {
+        await fs.rm(filePath, { force: true });
+        deletedFileCount += 1;
+      } catch {
+        // Ignore cleanup races or already-missing files.
+      }
+    }
+  }
+  return deletedFileCount;
+}
+
+export async function cleanupManagedOutgoingImageRecords(params?: {
+  stateDir?: string;
+  nowMs?: number;
+  transientMaxAgeMs?: number;
+  sessionKey?: string;
+  forceDeleteSessionRecords?: boolean;
+}): Promise<CleanupManagedOutgoingImageRecordsResult> {
+  const stateDir = params?.stateDir ?? resolveStateDir();
+  const nowMs = params?.nowMs ?? Date.now();
+  const transientMaxAgeMs = params?.transientMaxAgeMs ?? DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS;
+  const sessionKeyFilter = params?.sessionKey ?? null;
+  const forceDeleteSessionRecords = params?.forceDeleteSessionRecords === true;
+  const recordsDir = resolveOutgoingRecordsDir(stateDir);
+  let names: string[] = [];
+  try {
+    names = await fs.readdir(recordsDir);
+  } catch {
+    names = [];
+  }
+
+  let deletedRecordCount = 0;
+  let deletedFileCount = 0;
+  let retainedCount = 0;
+  const retainedReferencedPaths = new Set<string>();
+  const transcriptAttachmentIndexCache = new Map<
+    string,
+    SessionManagedOutgoingAttachmentIndex | null
+  >();
+  for (const name of names) {
+    if (!name.endsWith(".json")) {
+      continue;
+    }
+    const recordPath = path.join(recordsDir, name);
+    let record: ManagedImageRecord;
+    try {
+      record = JSON.parse(await fs.readFile(recordPath, "utf-8")) as ManagedImageRecord;
+    } catch {
+      try {
+        await fs.rm(recordPath, { force: true });
+      } catch {
+        // Ignore cleanup races or already-missing records.
+      }
+      deletedRecordCount += 1;
+      continue;
+    }
+    if (sessionKeyFilter && record.sessionKey !== sessionKeyFilter) {
+      if (record.original?.path) {
+        retainedReferencedPaths.add(record.original.path);
+      }
+      retainedCount += 1;
+      continue;
+    }
+
+    let shouldDelete = false;
+    if (
+      forceDeleteSessionRecords &&
+      (!sessionKeyFilter || record.sessionKey === sessionKeyFilter)
+    ) {
+      shouldDelete = true;
+    } else if (record.messageId) {
+      shouldDelete = !(await recordMatchesTranscriptMessage(
+        record,
+        transcriptAttachmentIndexCache,
+      ));
+    } else {
+      const createdAtMs = Date.parse(record.createdAt);
+      shouldDelete = Number.isFinite(createdAtMs) && nowMs - createdAtMs >= transientMaxAgeMs;
+    }
+
+    if (shouldDelete) {
+      deletedRecordCount += 1;
+      deletedFileCount += await deleteManagedImageRecordArtifacts(record, stateDir);
+    } else {
+      if (record.original?.path) {
+        retainedReferencedPaths.add(record.original.path);
+      }
+      retainedCount += 1;
+    }
+  }
+
+  deletedFileCount += await deleteOrphanManagedImageFiles({
+    stateDir,
+    referencedPaths: retainedReferencedPaths,
+  });
+
+  return { deletedRecordCount, deletedFileCount, retainedCount };
+}
+
+async function readManagedImageRecord(
+  attachmentId: string,
+  stateDir = resolveStateDir(),
+): Promise<ManagedImageRecord | null> {
+  try {
+    const raw = await fs.readFile(resolveOutgoingRecordPath(attachmentId, stateDir), "utf-8");
+    return JSON.parse(raw) as ManagedImageRecord;
+  } catch {
+    return null;
+  }
+}
+
+function buildManagedImageBlock(record: ManagedImageRecord): ManagedImageBlock {
+  const fullUrl = buildOutgoingVariantUrl(record.sessionKey, record.attachmentId, "full");
+  return {
+    type: "image",
+    url: fullUrl,
+    openUrl: fullUrl,
+    alt: record.alt,
+    mimeType: record.original.contentType,
+    width: record.original.width,
+    height: record.original.height,
+  };
+}
+
+function buildManagedOutgoingAttachmentRefKey(messageId: string, attachmentId: string) {
+  return `${messageId}::${attachmentId}`;
+}
+
+function buildManagedImageResizeWarningBlock(params: {
+  alt: string;
+  originalWidth: number;
+  originalHeight: number;
+  resizedWidth: number;
+  resizedHeight: number;
+}): ManagedImageBlock {
+  return {
+    type: "text",
+    text:
+      `[Image warning] ${params.alt} exceeded gateway dimension/pixel limits and was resized from ` +
+      `${params.originalWidth}×${params.originalHeight} to ${params.resizedWidth}×${params.resizedHeight}.`,
+  };
+}
+
+function toRecordFilename(filePath: string) {
+  const name = path.basename(filePath).trim();
+  return name || null;
+}
+
+function asArray(value: string[] | undefined | null) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === "string" && item.trim())
+    : [];
+}
+
+function parseManagedOutgoingRoute(value: string) {
+  try {
+    const parsed = new URL(value, "http://localhost");
+    const match = parsed.pathname.match(/^\/api\/chat\/media\/outgoing\/([^/]+)\/([^/]+)\/full$/);
+    if (!match) {
+      return null;
+    }
+    return {
+      sessionKey: decodeURIComponent(match[1]),
+      attachmentId: match[2],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function collectManagedOutgoingAttachmentRefs(
+  blocks: readonly Record<string, unknown>[] | undefined,
+  expectedSessionKey?: string,
+) {
+  const refs = new Map<string, { attachmentId: string; sessionKey: string }>();
+  for (const block of blocks ?? []) {
+    if (block?.type !== "image") {
+      continue;
+    }
+    for (const candidate of [block.url, block.openUrl]) {
+      if (typeof candidate !== "string") {
+        continue;
+      }
+      const parsed = parseManagedOutgoingRoute(candidate);
+      if (!parsed) {
+        continue;
+      }
+      if (expectedSessionKey && parsed.sessionKey !== expectedSessionKey) {
+        continue;
+      }
+      refs.set(parsed.attachmentId, {
+        attachmentId: parsed.attachmentId,
+        sessionKey: parsed.sessionKey,
+      });
+    }
+  }
+  return [...refs.values()];
+}
+
+function getCachedSessionManagedOutgoingAttachmentIndex(
+  sessionKey: string,
+  stat: { transcriptPath: string; mtimeMs: number; size: number },
+) {
+  const cached = sessionManagedOutgoingAttachmentIndexCache.get(sessionKey);
+  if (!cached) {
+    return null;
+  }
+  if (
+    cached.transcriptPath !== stat.transcriptPath ||
+    cached.mtimeMs !== stat.mtimeMs ||
+    cached.size !== stat.size
+  ) {
+    sessionManagedOutgoingAttachmentIndexCache.delete(sessionKey);
+    return null;
+  }
+  sessionManagedOutgoingAttachmentIndexCache.delete(sessionKey);
+  sessionManagedOutgoingAttachmentIndexCache.set(sessionKey, cached);
+  return cached.index;
+}
+
+function setCachedSessionManagedOutgoingAttachmentIndex(
+  sessionKey: string,
+  stat: { transcriptPath: string; mtimeMs: number; size: number },
+  index: SessionManagedOutgoingAttachmentIndex,
+) {
+  sessionManagedOutgoingAttachmentIndexCache.set(sessionKey, {
+    transcriptPath: stat.transcriptPath,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+    index,
+  });
+  while (
+    sessionManagedOutgoingAttachmentIndexCache.size >
+    MAX_SESSION_MANAGED_OUTGOING_ATTACHMENT_INDEX_CACHE_ENTRIES
+  ) {
+    const oldestKey = sessionManagedOutgoingAttachmentIndexCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    sessionManagedOutgoingAttachmentIndexCache.delete(oldestKey);
+  }
+}
+
+async function getSessionManagedOutgoingAttachmentIndex(
+  sessionKey: string,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
+) {
+  if (cache?.has(sessionKey)) {
+    return cache.get(sessionKey) ?? null;
+  }
+  const { storePath, entry } = loadSessionEntry(sessionKey);
+  const sessionId = entry?.sessionId;
+  if (!sessionId) {
+    cache?.set(sessionKey, null);
+    return null;
+  }
+
+  let transcriptStat: { transcriptPath: string; mtimeMs: number; size: number } | null = null;
+  const transcriptPath = typeof entry?.sessionFile === "string" ? entry.sessionFile.trim() : "";
+  if (transcriptPath) {
+    try {
+      const stat = await fs.stat(transcriptPath);
+      transcriptStat = {
+        transcriptPath,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      };
+      const cachedIndex = getCachedSessionManagedOutgoingAttachmentIndex(
+        sessionKey,
+        transcriptStat,
+      );
+      if (cachedIndex) {
+        cache?.set(sessionKey, cachedIndex);
+        return cachedIndex;
+      }
+    } catch {
+      sessionManagedOutgoingAttachmentIndexCache.delete(sessionKey);
+    }
+  }
+
+  const messages = readSessionMessages(sessionId, storePath, entry.sessionFile);
+  const index: SessionManagedOutgoingAttachmentIndex = new Set();
+  for (const message of messages) {
+    const meta = (message as { __openclaw?: { id?: string } } | null)?.__openclaw;
+    const messageId = meta?.id;
+    if (typeof messageId !== "string" || !messageId) {
+      continue;
+    }
+    for (const ref of collectManagedOutgoingAttachmentRefs(
+      Array.isArray((message as { content?: unknown[] } | null)?.content)
+        ? ((message as { content: unknown[] }).content as Record<string, unknown>[])
+        : [],
+      sessionKey,
+    )) {
+      index.add(buildManagedOutgoingAttachmentRefKey(messageId, ref.attachmentId));
+    }
+  }
+
+  if (transcriptStat) {
+    setCachedSessionManagedOutgoingAttachmentIndex(sessionKey, transcriptStat, index);
+  }
+  cache?.set(sessionKey, index);
+  return index;
+}
+
+async function recordMatchesTranscriptMessage(
+  record: ManagedImageRecord,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
+) {
+  if (!record.messageId) {
+    return false;
+  }
+  const index = await getSessionManagedOutgoingAttachmentIndex(record.sessionKey, cache);
+  return (
+    index?.has(buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId)) ?? false
+  );
+}
+
+export async function attachManagedOutgoingImagesToMessage(params: {
+  messageId: string;
+  blocks?: readonly Record<string, unknown>[];
+  stateDir?: string;
+}) {
+  const messageId = params.messageId.trim();
+  if (!messageId) {
+    return;
+  }
+  const refs = collectManagedOutgoingAttachmentRefs(params.blocks);
+  if (refs.length === 0) {
+    return;
+  }
+  await Promise.all(
+    refs.map(async ({ attachmentId, sessionKey }) => {
+      const record = await readManagedImageRecord(attachmentId, params.stateDir);
+      if (!record || record.sessionKey !== sessionKey) {
+        return;
+      }
+      if (record.messageId === messageId && record.retentionClass === "history") {
+        return;
+      }
+      await writeManagedImageRecord(
+        {
+          ...record,
+          messageId,
+          retentionClass: "history",
+          updatedAt: new Date().toISOString(),
+        },
+        params.stateDir,
+      );
+    }),
+  );
+}
+
+export async function createManagedOutgoingImageBlocks(params: {
+  sessionKey: string;
+  mediaUrls?: string[] | null;
+  stateDir?: string;
+  messageId?: string | null;
+  limits?: ManagedImageAttachmentLimitsConfig | null;
+  localRoots?: readonly string[] | "any";
+}): Promise<ManagedImageBlock[]> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return [];
+  }
+  const mediaUrls = asArray(params.mediaUrls);
+  if (mediaUrls.length === 0) {
+    return [];
+  }
+  const stateDir = params.stateDir ?? resolveStateDir();
+  const mediaDir = path.join(stateDir, "media");
+  const limits = resolveManagedImageAttachmentLimits(params.limits);
+  const blocks: ManagedImageBlock[] = [];
+  for (const [index, mediaUrl] of mediaUrls.entries()) {
+    const fallbackAlt = `Generated image ${index + 1}`;
+    const parsedDataUrl = parseImageDataUrl(mediaUrl, fallbackAlt, limits);
+    const alt =
+      parsedDataUrl.kind === "image-data-url" ? fallbackAlt : deriveAltText(mediaUrl, index);
+    if (parsedDataUrl.kind === "non-image-data-url") {
+      continue;
+    }
+
+    let savedOriginalPath: string | null = null;
+    try {
+      let resizeWarning: ManagedImageBlock | null = null;
+      if (parsedDataUrl.kind === "image-data-url") {
+        validateManagedImageBuffer(parsedDataUrl.buffer, alt, limits);
+      }
+      let savedOriginal =
+        parsedDataUrl.kind === "image-data-url"
+          ? await saveMediaBuffer(
+              parsedDataUrl.buffer,
+              parsedDataUrl.contentType,
+              "outgoing/originals",
+              limits.maxBytes,
+              `generated-image-${index + 1}`,
+              mediaDir,
+            )
+          : await (async () => {
+              const localMediaPath = resolveLocalMediaPath(mediaUrl);
+              if (localMediaPath) {
+                await assertLocalMediaAllowed(localMediaPath, params.localRoots);
+              }
+              return await saveMediaSource(
+                mediaUrl,
+                undefined,
+                "outgoing/originals",
+                Math.max(limits.maxBytes, MEDIA_MAX_BYTES),
+                mediaDir,
+              );
+            })();
+      savedOriginalPath = savedOriginal.path;
+      if (!savedOriginal.contentType?.startsWith("image/")) {
+        await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
+        savedOriginalPath = null;
+        continue;
+      }
+      if (savedOriginal.size > limits.maxBytes) {
+        throw createManagedImageAttachmentError(
+          `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
+        );
+      }
+
+      let originalBuffer =
+        parsedDataUrl.kind === "image-data-url"
+          ? parsedDataUrl.buffer
+          : await fs.readFile(savedOriginal.path);
+      validateManagedImageBuffer(originalBuffer, alt, limits);
+
+      let originalStats = await getVariantStats(savedOriginal.path);
+      if (originalStats.sizeBytes != null && originalStats.sizeBytes > limits.maxBytes) {
+        throw createManagedImageAttachmentError(
+          `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
+        );
+      }
+
+      const originalMetadata =
+        originalStats.width != null && originalStats.height != null
+          ? { width: originalStats.width, height: originalStats.height }
+          : await getImageMetadata(originalBuffer);
+      let effectiveMetadata = originalMetadata;
+      let metadataLimitError = getManagedImageMetadataLimitError(effectiveMetadata, alt, limits);
+      for (let resizeAttempt = 0; metadataLimitError; resizeAttempt += 1) {
+        if (!effectiveMetadata) {
+          throw createManagedImageAttachmentError(metadataLimitError);
+        }
+        if (resizeAttempt >= 3) {
+          throw createManagedImageAttachmentError(metadataLimitError);
+        }
+        const resized = await resizeManagedImageBufferToLimits({
+          buffer: originalBuffer,
+          metadata: effectiveMetadata,
+          limits,
+        });
+        validateManagedImageBuffer(resized.buffer, alt, limits);
+        const replacement = await saveMediaBuffer(
+          resized.buffer,
+          resized.contentType,
+          "outgoing/originals",
+          limits.maxBytes,
+          toRecordFilename(savedOriginal.path) ?? `generated-image-${index + 1}`,
+          mediaDir,
+        );
+        await fs.rm(savedOriginal.path, { force: true }).catch(() => {});
+        savedOriginal = replacement;
+        savedOriginalPath = savedOriginal.path;
+        originalBuffer = resized.buffer;
+        originalStats = await getVariantStats(savedOriginal.path);
+        effectiveMetadata =
+          originalStats.width != null && originalStats.height != null
+            ? { width: originalStats.width, height: originalStats.height }
+            : await getImageMetadata(originalBuffer);
+        metadataLimitError = getManagedImageMetadataLimitError(effectiveMetadata, alt, limits);
+        if (!metadataLimitError) {
+          resizeWarning = buildManagedImageResizeWarningBlock({
+            alt,
+            originalWidth: originalMetadata?.width ?? effectiveMetadata?.width ?? resized.width,
+            originalHeight: originalMetadata?.height ?? effectiveMetadata?.height ?? resized.height,
+            resizedWidth: effectiveMetadata?.width ?? resized.width,
+            resizedHeight: effectiveMetadata?.height ?? resized.height,
+          });
+        }
+      }
+
+      const record: ManagedImageRecord = {
+        attachmentId: randomUUID(),
+        sessionKey,
+        messageId: params.messageId ?? null,
+        createdAt: new Date().toISOString(),
+        retentionClass: params.messageId ? "history" : "transient",
+        alt,
+        original: {
+          path: savedOriginal.path,
+          contentType: savedOriginal.contentType ?? "application/octet-stream",
+          width: originalStats.width,
+          height: originalStats.height,
+          sizeBytes: originalStats.sizeBytes,
+          filename: toRecordFilename(savedOriginal.path),
+        },
+      };
+      await writeManagedImageRecord(record, stateDir);
+      blocks.push(buildManagedImageBlock(record));
+      if (resizeWarning) {
+        blocks.push(resizeWarning);
+      }
+    } catch (error) {
+      if (savedOriginalPath) {
+        await fs.rm(savedOriginalPath, { force: true }).catch(() => {});
+      }
+      throwSanitizedManagedImageAttachmentError(error, alt);
+    }
+  }
+  return blocks;
+}
+
+function sendStatus(res: ServerResponse, statusCode: number, body: string) {
+  if (res.writableEnded) {
+    return;
+  }
+  res.statusCode = statusCode;
+  res.setHeader("content-type", "text/plain; charset=utf-8");
+  res.end(body);
+}
+
+function safeAttachmentFilename(value: string | null) {
+  const fallback = "generated-image";
+  const base = (value ?? fallback).replace(/[\r\n"\\]/g, "_").trim();
+  return base || fallback;
+}
+
+export async function handleManagedOutgoingImageHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+    stateDir?: string;
+  },
+): Promise<boolean> {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+  const match = requestUrl.pathname.match(/^\/api\/chat\/media\/outgoing\/([^/]+)\/([^/]+)\/full$/);
+  if (!match) {
+    return false;
+  }
+
+  if (req.method !== "GET") {
+    sendMethodNotAllowed(res, "GET");
+    return true;
+  }
+
+  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+    req,
+    res,
+    auth: opts.auth,
+    trustedProxies: opts.trustedProxies,
+    allowRealIpFallback: opts.allowRealIpFallback,
+    rateLimiter: opts.rateLimiter,
+  });
+  if (!requestAuth) {
+    return true;
+  }
+
+  const privilegedAccess =
+    requestAuth.trustDeclaredOperatorScopes || requestAuth.authMethod === "device-token";
+
+  const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth);
+  const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
+  if (!scopeAuth.allowed) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: `missing scope: ${scopeAuth.missingScope}`,
+      },
+    });
+    return true;
+  }
+
+  const encodedSessionKey = match[1];
+  const attachmentId = match[2];
+  if (!encodedSessionKey || !attachmentId) {
+    return false;
+  }
+  const sessionKey = decodeURIComponent(encodedSessionKey);
+  const record = await readManagedImageRecord(attachmentId, opts.stateDir);
+  if (!record || record.sessionKey !== sessionKey) {
+    sendStatus(res, 404, "not found");
+    return true;
+  }
+  if (!privilegedAccess) {
+    const requesterSessionKey = resolveRequesterSessionKey(req);
+    if (!requesterSessionKey) {
+      sendJson(res, 403, {
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: "requester session ownership required",
+        },
+      });
+      return true;
+    }
+    const ownsSession = await requesterOwnsManagedImageSession({
+      requesterSessionKey,
+      targetSessionKey: record.sessionKey,
+    });
+    if (!ownsSession) {
+      sendJson(res, 403, {
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: "requester session does not own attachment session",
+        },
+      });
+      return true;
+    }
+  }
+  if (!(await recordMatchesTranscriptMessage(record))) {
+    sendStatus(res, 404, "not found");
+    return true;
+  }
+
+  let body: Buffer;
+  try {
+    body = await fs.readFile(record.original.path);
+  } catch {
+    sendStatus(res, 404, "not found");
+    return true;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("content-type", record.original.contentType || "application/octet-stream");
+  res.setHeader("content-length", String(body.byteLength));
+  res.setHeader("cache-control", "private, max-age=31536000, immutable");
+  res.setHeader(
+    "content-disposition",
+    `inline; filename="${safeAttachmentFilename(record.original.filename)}"`,
+  );
+  res.end(body);
+  return true;
+}

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -136,10 +136,14 @@ function isManagedImageAttachmentSafeError(error: unknown): error is Error {
 }
 
 function throwSanitizedManagedImageAttachmentError(error: unknown, alt: string): never {
+  throw getSanitizedManagedImageAttachmentError(error, alt);
+}
+
+function getSanitizedManagedImageAttachmentError(error: unknown, alt: string): Error {
   if (isManagedImageAttachmentSafeError(error)) {
-    throw error;
+    return error;
   }
-  throw createManagedImageAttachmentError(
+  return createManagedImageAttachmentError(
     `Managed image attachment ${JSON.stringify(alt)} could not be prepared`,
   );
 }
@@ -774,6 +778,8 @@ export async function createManagedOutgoingImageBlocks(params: {
   messageId?: string | null;
   limits?: ManagedImageAttachmentLimitsConfig | null;
   localRoots?: readonly string[] | "any";
+  continueOnPrepareError?: boolean;
+  onPrepareError?: (error: Error) => void;
 }): Promise<ManagedImageBlock[]> {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
@@ -926,7 +932,12 @@ export async function createManagedOutgoingImageBlocks(params: {
       if (savedOriginalPath) {
         await fs.rm(savedOriginalPath, { force: true }).catch(() => {});
       }
-      throwSanitizedManagedImageAttachmentError(error, alt);
+      const sanitizedError = getSanitizedManagedImageAttachmentError(error, alt);
+      if (params.continueOnPrepareError) {
+        params.onPrepareError?.(sanitizedError);
+        continue;
+      }
+      throw sanitizedError;
     }
   }
   return blocks;

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -135,10 +135,6 @@ function isManagedImageAttachmentSafeError(error: unknown): error is Error {
   );
 }
 
-function throwSanitizedManagedImageAttachmentError(error: unknown, alt: string): never {
-  throw getSanitizedManagedImageAttachmentError(error, alt);
-}
-
 function getSanitizedManagedImageAttachmentError(error: unknown, alt: string): Error {
   if (isManagedImageAttachmentSafeError(error)) {
     return error;

--- a/src/gateway/server-http.control-ui-route.test.ts
+++ b/src/gateway/server-http.control-ui-route.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { handleControlUiAvatarRequestMock, handleControlUiHttpRequestMock } = vi.hoisted(() => ({
+  handleControlUiAvatarRequestMock: vi.fn(async () => false),
+  handleControlUiHttpRequestMock: vi.fn(),
+}));
+
+vi.mock("./control-ui.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./control-ui.js")>();
+  return {
+    ...actual,
+    handleControlUiAvatarRequest: handleControlUiAvatarRequestMock,
+    handleControlUiHttpRequest: handleControlUiHttpRequestMock,
+  };
+});
+
+import {
+  AUTH_TOKEN,
+  createRequest,
+  createResponse,
+  dispatchRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
+
+describe("gateway control-ui route", () => {
+  beforeEach(() => {
+    handleControlUiAvatarRequestMock.mockClear();
+    handleControlUiHttpRequestMock.mockReset();
+  });
+
+  it("forwards auth context to the control-ui HTTP handler", async () => {
+    handleControlUiHttpRequestMock.mockImplementation(async (_req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+      return true;
+    });
+
+    await withGatewayServer({
+      prefix: "control-ui-route-auth",
+      resolvedAuth: AUTH_TOKEN,
+      overrides: {
+        controlUiEnabled: true,
+      },
+      run: async (server) => {
+        const req = createRequest({
+          path: "/__control__/bootstrap-config",
+          authorization: "Bearer test-token",
+        });
+        const { res, getBody } = createResponse();
+        await dispatchRequest(server, req, res);
+
+        expect(handleControlUiHttpRequestMock).toHaveBeenCalledTimes(1);
+        expect(handleControlUiHttpRequestMock).toHaveBeenCalledWith(
+          req,
+          res,
+          expect.objectContaining({
+            auth: AUTH_TOKEN,
+            trustedProxies: [],
+            allowRealIpFallback: false,
+          }),
+        );
+        expect(res.statusCode).toBe(200);
+        expect(getBody()).toBe("ok");
+      },
+    });
+  });
+});

--- a/src/gateway/server-http.managed-image-route.test.ts
+++ b/src/gateway/server-http.managed-image-route.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { handleManagedOutgoingImageHttpRequestMock } = vi.hoisted(() => ({
+  handleManagedOutgoingImageHttpRequestMock: vi.fn(),
+}));
+
+vi.mock("./managed-image-attachments.js", () => ({
+  handleManagedOutgoingImageHttpRequest: handleManagedOutgoingImageHttpRequestMock,
+}));
+
+import {
+  AUTH_NONE,
+  createRequest,
+  createResponse,
+  dispatchRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
+
+describe("gateway managed outgoing image route", () => {
+  beforeEach(() => {
+    handleManagedOutgoingImageHttpRequestMock.mockReset();
+  });
+
+  it("dispatches matching paths to the managed image handler", async () => {
+    handleManagedOutgoingImageHttpRequestMock.mockImplementation(async (_req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+      return true;
+    });
+
+    await withGatewayServer({
+      prefix: "managed-outgoing-image-route",
+      resolvedAuth: AUTH_NONE,
+      run: async (server) => {
+        const req = createRequest({
+          path: "/api/chat/media/outgoing/agent%3Amain%3Amain/att-123/full",
+        });
+        const { res, getBody } = createResponse();
+        await dispatchRequest(server, req, res);
+
+        expect(handleManagedOutgoingImageHttpRequestMock).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBe(200);
+        expect(getBody()).toBe("ok");
+      },
+    });
+  });
+});

--- a/src/gateway/server-http.sessions-history-route.test.ts
+++ b/src/gateway/server-http.sessions-history-route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import type { handleSessionHistoryHttpRequest } from "./sessions-history-http.js";
+
+const { handleSessionHistoryHttpRequestMock } = vi.hoisted(() => ({
+  handleSessionHistoryHttpRequestMock: vi.fn(),
+}));
+
+vi.mock("./sessions-history-http.js", () => ({
+  handleSessionHistoryHttpRequest: handleSessionHistoryHttpRequestMock,
+}));
+
+import {
+  AUTH_TOKEN,
+  createRequest,
+  createResponse,
+  dispatchRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
+
+type SessionHistoryRouteOptions = Parameters<typeof handleSessionHistoryHttpRequest>[2];
+
+describe("gateway sessions history route", () => {
+  beforeEach(() => {
+    handleSessionHistoryHttpRequestMock.mockReset();
+  });
+
+  it("passes getResolvedAuth through so session history can re-check rotated auth", async () => {
+    let captured:
+      | {
+          auth?: ResolvedGatewayAuth;
+          getResolvedAuth?: SessionHistoryRouteOptions["getResolvedAuth"];
+        }
+      | undefined;
+    let currentAuth = AUTH_TOKEN;
+
+    handleSessionHistoryHttpRequestMock.mockImplementation(
+      async (
+        _req: unknown,
+        res: { statusCode: number; end: (body?: string) => void },
+        opts: SessionHistoryRouteOptions,
+      ) => {
+        captured = opts;
+        res.statusCode = 200;
+        res.end("ok");
+        return true;
+      },
+    );
+
+    await withGatewayServer({
+      prefix: "sessions-history-route",
+      resolvedAuth: AUTH_TOKEN,
+      overrides: {
+        getResolvedAuth: () => currentAuth,
+      },
+      run: async (server) => {
+        const req = createRequest({
+          path: "/sessions/agent%3Amain/history",
+          authorization: "Bearer test-token",
+          remoteAddress: "10.0.0.8",
+          host: "gateway.test",
+        });
+        const { res } = createResponse();
+        await dispatchRequest(server, req, res);
+      },
+    });
+
+    expect(handleSessionHistoryHttpRequestMock).toHaveBeenCalledTimes(1);
+    expect(captured?.auth?.token).toBe("test-token");
+    expect(captured?.getResolvedAuth).toBeTypeOf("function");
+
+    currentAuth = {
+      ...AUTH_TOKEN,
+      token: "rotated-token",
+    };
+
+    expect(captured?.getResolvedAuth?.().token).toBe("rotated-token");
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -988,6 +988,7 @@ export function createGatewayHttpServer(opts: {
           run: async () =>
             (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
               auth: resolvedAuth,
+              getResolvedAuth,
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -81,6 +81,9 @@ const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
 let identityAvatarModulePromise: Promise<typeof import("../agents/identity-avatar.js")> | undefined;
 let controlUiModulePromise: Promise<typeof import("./control-ui.js")> | undefined;
 let embeddingsHttpModulePromise: Promise<typeof import("./embeddings-http.js")> | undefined;
+let managedImageAttachmentsModulePromise:
+  | Promise<typeof import("./managed-image-attachments.js")>
+  | undefined;
 let modelsHttpModulePromise: Promise<typeof import("./models-http.js")> | undefined;
 let openAiHttpModulePromise: Promise<typeof import("./openai-http.js")> | undefined;
 let openResponsesHttpModulePromise: Promise<typeof import("./openresponses-http.js")> | undefined;
@@ -103,6 +106,11 @@ function getControlUiModule() {
 function getEmbeddingsHttpModule() {
   embeddingsHttpModulePromise ??= import("./embeddings-http.js");
   return embeddingsHttpModulePromise;
+}
+
+function getManagedImageAttachmentsModule() {
+  managedImageAttachmentsModulePromise ??= import("./managed-image-attachments.js");
+  return managedImageAttachmentsModulePromise;
 }
 
 function getModelsHttpModule() {
@@ -247,6 +255,10 @@ function isSessionKillPath(pathname: string): boolean {
 
 function isSessionHistoryPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/history$/.test(pathname);
+}
+
+function isManagedOutgoingImagePath(pathname: string): boolean {
+  return /^\/api\/chat\/media\/outgoing\/[^/]+\/[^/]+\/full$/.test(pathname);
 }
 
 function isA2uiPath(pathname: string): boolean {
@@ -976,11 +988,26 @@ export function createGatewayHttpServer(opts: {
           run: async () =>
             (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
               auth: resolvedAuth,
-              getResolvedAuth,
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,
             }),
+        });
+      }
+      if (isManagedOutgoingImagePath(requestPath)) {
+        requestStages.push({
+          name: "managed-outgoing-image",
+          run: async () =>
+            (await getManagedImageAttachmentsModule()).handleManagedOutgoingImageHttpRequest(
+              req,
+              res,
+              {
+                auth: resolvedAuth,
+                trustedProxies,
+                allowRealIpFallback,
+                rateLimiter,
+              },
+            ),
         });
       }
       if (openResponsesEnabled && isOpenResponsesPath(requestPath)) {
@@ -1099,10 +1126,6 @@ export function createGatewayHttpServer(opts: {
               config: configSnapshot,
               agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
               root: controlUiRoot,
-              auth: resolvedAuth,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
             }),
         });
       }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1126,6 +1126,10 @@ export function createGatewayHttpServer(opts: {
               config: configSnapshot,
               agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
               root: controlUiRoot,
+              auth: resolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
             }),
         });
       }

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -41,12 +41,32 @@ function resolveInjectedAssistantContent(params: {
   return [{ type: "text", text: `${labelPrefix}${params.message}` }];
 }
 
+function sanitizeInjectedAssistantTranscriptText(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const sanitized = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        Boolean(line) &&
+        !line.startsWith("MEDIA:") &&
+        line !== "[[reply_to_current]]" &&
+        !/^\[\[reply_to:.+\]\]$/.test(line) &&
+        line !== "[[audio_as_voice]]",
+    )
+    .join("\n")
+    .trim();
+  return sanitized || undefined;
+}
+
 export function appendInjectedAssistantMessageToTranscript(params: {
   transcriptPath: string;
-  message: string;
-  label?: string;
+  message?: string;
   /** When set, used as the assistant `content` array (e.g. text + embedded audio blocks). */
   content?: Array<Record<string, unknown>>;
+  label?: string;
   idempotencyKey?: string;
   abortMeta?: GatewayInjectedAbortMeta;
   now?: number;
@@ -67,10 +87,23 @@ export function appendInjectedAssistantMessageToTranscript(params: {
     },
   };
   const resolvedContent = resolveInjectedAssistantContent({
-    message: params.message,
+    message: params.message ?? "",
     label: params.label,
     content: params.content,
   });
+  const text =
+    sanitizeInjectedAssistantTranscriptText(params.message) ||
+    sanitizeInjectedAssistantTranscriptText(
+      resolvedContent
+        .map((block) =>
+          block?.type === "text" && typeof block.text === "string" ? block.text.trim() : "",
+        )
+        .filter(Boolean)
+        .join("\n\n"),
+    );
+  if (resolvedContent.length === 0 && !text) {
+    return { ok: false, error: "assistant message was empty" };
+  }
   const messageBody: AppendMessageArg & Record<string, unknown> = {
     role: "assistant",
     // Gateway-injected assistant messages can include non-model content blocks (e.g. embedded TTS audio).
@@ -78,6 +111,7 @@ export function appendInjectedAssistantMessageToTranscript(params: {
       AppendMessageArg,
       { role: "assistant" }
     >["content"],
+    ...(text ? { text } : {}),
     timestamp: now,
     // Pi stopReason is a strict enum; this is not model output, but we still store it as a
     // normal assistant message so it participates in the session parentId chain.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2116,50 +2116,80 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("does not persist sensitive image media into transcript updates", async () => {
     createTranscriptFixture("openclaw-chat-send-sensitive-media-final-");
-    mockState.finalPayload = {
-      text: "Scan this QR code with the OpenClaw iOS app:",
-      mediaUrl: TEST_PNG_DATA_URL,
-      sensitiveMedia: true,
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sensitive-image-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      mockState.finalPayload = {
+        text: "Scan this QR code with the OpenClaw iOS app:",
+        mediaUrl: TEST_PNG_DATA_URL,
+        sensitiveMedia: true,
+      };
+      const respond = vi.fn();
+      const context = createChatContext();
 
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-sensitive-media-final",
-    });
+      const payload = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-sensitive-media-final",
+      });
 
-    const content = extractContentBlocks(payload);
-    expect(content[0]).toEqual({
-      type: "text",
-      text: "Scan this QR code with the OpenClaw iOS app:",
-    });
-    expect(content[1]).toEqual(
-      expect.objectContaining({
-        type: "image",
-        url: expect.stringContaining("/api/chat/media/outgoing/"),
-        openUrl: expect.stringContaining("/full"),
-        alt: "Generated image 1",
-        mimeType: "image/png",
-        width: 1,
-        height: 1,
-      }),
-    );
-    const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
-      (update) =>
-        typeof update.message === "object" &&
-        update.message !== null &&
-        (update.message as { role?: unknown }).role === "assistant",
-    );
-    expect(transcriptUpdate).toMatchObject({
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Scan this QR code with the OpenClaw iOS app:" }],
-      },
-    });
-    expect(JSON.stringify(transcriptUpdate)).not.toContain("/api/chat/media/outgoing/");
-    expect(JSON.stringify(transcriptUpdate)).not.toContain(TEST_PNG_DATA_URL);
+      const content = extractContentBlocks(payload);
+      expect(content[0]).toEqual({
+        type: "text",
+        text: "Scan this QR code with the OpenClaw iOS app:",
+      });
+      expect(content[1]).toEqual(
+        expect.objectContaining({
+          type: "image",
+          url: expect.stringContaining("/api/chat/media/outgoing/"),
+          openUrl: expect.stringContaining("/full"),
+          alt: "Generated image 1",
+          mimeType: "image/png",
+          width: 1,
+          height: 1,
+        }),
+      );
+      const imageUrl = typeof content[1]?.url === "string" ? content[1].url : "";
+      const attachmentId = imageUrl.match(
+        /\/api\/chat\/media\/outgoing\/[^/]+\/([0-9a-f-]{36})\/full$/i,
+      )?.[1];
+      expect(attachmentId).toBeTruthy();
+      const recordPath = path.join(
+        stateDir,
+        "media",
+        "outgoing",
+        "records",
+        `${attachmentId}.json`,
+      );
+      const record = JSON.parse(fs.readFileSync(recordPath, "utf-8")) as {
+        messageId: string | null;
+        retentionClass?: string;
+      };
+      expect(record.messageId).toBeTruthy();
+      expect(record.retentionClass).toBe("history");
+      const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
+        (update) =>
+          typeof update.message === "object" &&
+          update.message !== null &&
+          (update.message as { role?: unknown }).role === "assistant",
+      );
+      expect(transcriptUpdate).toMatchObject({
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Scan this QR code with the OpenClaw iOS app:" }],
+        },
+      });
+      expect(JSON.stringify(transcriptUpdate)).not.toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(transcriptUpdate)).not.toContain(TEST_PNG_DATA_URL);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("does not persist sensitive audio media into transcript updates", async () => {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -23,6 +23,8 @@ const mockState = vi.hoisted(() => ({
   finalPayload: null as {
     text?: string;
     mediaUrl?: string;
+    mediaUrls?: string[];
+    trustedLocalMedia?: boolean;
     sensitiveMedia?: boolean;
     replyToId?: string;
     replyToCurrent?: boolean;
@@ -33,6 +35,7 @@ const mockState = vi.hoisted(() => ({
       text?: string;
       mediaUrl?: string;
       mediaUrls?: string[];
+      sensitiveMedia?: boolean;
       trustedLocalMedia?: boolean;
       replyToId?: string;
       replyToCurrent?: boolean;
@@ -110,6 +113,8 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
         sendFinalReply: (payload: {
           text?: string;
           mediaUrl?: string;
+          mediaUrls?: string[];
+          trustedLocalMedia?: boolean;
           sensitiveMedia?: boolean;
           replyToId?: string;
           replyToCurrent?: boolean;
@@ -118,6 +123,7 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
           text?: string;
           mediaUrl?: string;
           mediaUrls?: string[];
+          sensitiveMedia?: boolean;
           trustedLocalMedia?: boolean;
           replyToId?: string;
           replyToCurrent?: boolean;
@@ -126,6 +132,7 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
           text?: string;
           mediaUrl?: string;
           mediaUrls?: string[];
+          sensitiveMedia?: boolean;
           trustedLocalMedia?: boolean;
           replyToId?: string;
           replyToCurrent?: boolean;
@@ -2153,6 +2160,57 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
     expect(JSON.stringify(transcriptUpdate)).not.toContain("/api/chat/media/outgoing/");
     expect(JSON.stringify(transcriptUpdate)).not.toContain(TEST_PNG_DATA_URL);
+  });
+
+  it("does not persist sensitive audio media into transcript updates", async () => {
+    createTranscriptFixture("openclaw-chat-send-sensitive-audio-final-");
+    const transcriptDir = path.dirname(mockState.transcriptPath);
+    const audioPath = path.join(transcriptDir, "reply.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    mockState.finalPayload = {
+      text: "Here is the secure voice reply.",
+      mediaUrl: audioPath,
+      mediaUrls: [audioPath],
+      sensitiveMedia: true,
+      trustedLocalMedia: true,
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-sensitive-audio-final",
+    });
+
+    const content = extractContentBlocks(payload);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "Here is the secure voice reply.",
+    });
+    expect(content[1]).toEqual(
+      expect.objectContaining({
+        type: "audio",
+        source: expect.objectContaining({
+          type: "base64",
+          media_type: "audio/mpeg",
+        }),
+      }),
+    );
+    const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant",
+    );
+    expect(transcriptUpdate).toMatchObject({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the secure voice reply." }],
+      },
+    });
+    expect(JSON.stringify(transcriptUpdate)).not.toContain('"type":"audio"');
+    expect(JSON.stringify(transcriptUpdate)).not.toContain("audio/mpeg");
   });
 
   it("sanitizes malformed replyToId values so control tags do not leak into transcript or broadcast", async () => {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -69,6 +69,9 @@ Sender labels:
 example
 <<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeefdeadbeef">>>`;
 
+const TEST_PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
 vi.mock("../session-utils.js", async () => {
   const original =
     await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
@@ -200,10 +203,13 @@ vi.mock("../../media/store.js", async () => {
       }
       mockState.savedMediaCalls.push({ contentType, subdir, size: buffer.byteLength });
       const next = mockState.savedMediaResults.shift();
+      const savedPath = next?.path ?? `/tmp/${mockState.savedMediaCalls.length}.png`;
       try {
+        fs.mkdirSync(path.dirname(savedPath), { recursive: true });
+        fs.writeFileSync(savedPath, buffer);
         return {
           id: "saved-media",
-          path: next?.path ?? `/tmp/${mockState.savedMediaCalls.length}.png`,
+          path: savedPath,
           size: buffer.byteLength,
           contentType: next?.contentType ?? contentType,
         };
@@ -271,6 +277,39 @@ function extractFirstTextBlock(payload: unknown): string | undefined {
   }
   const firstText = (first as { text?: unknown }).text;
   return typeof firstText === "string" ? firstText : undefined;
+}
+
+function extractFirstContentBlock(payload: unknown): Record<string, unknown> | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const message = (payload as { message?: unknown }).message;
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const first = content[0];
+  return first && typeof first === "object" ? (first as Record<string, unknown>) : undefined;
+}
+
+function extractContentBlocks(payload: unknown): Array<Record<string, unknown>> {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const message = (payload as { message?: unknown }).message;
+  if (!message || typeof message !== "object") {
+    return [];
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.filter(
+    (block): block is Record<string, unknown> => Boolean(block) && typeof block === "object",
+  );
 }
 
 function createScopedCliClient(
@@ -509,13 +548,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const transcriptDir = path.dirname(mockState.transcriptPath);
     const audioPath = path.join(transcriptDir, "reply.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
     mockState.triggerAgentRunStart = true;
     mockState.dispatchedReplies = [
       {
@@ -573,7 +605,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     createTranscriptFixture("openclaw-chat-send-agent-image-");
     mockState.finalPayload = {
       text: "Scan this QR code with the OpenClaw iOS app:",
-      mediaUrl: "data:image/png;base64,cG5n",
+      mediaUrl: TEST_PNG_DATA_URL,
     };
     const respond = vi.fn();
     const context = createChatContext();
@@ -584,14 +616,64 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-agent-image",
     });
 
-    expect(payload?.message).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "text", text: "Scan this QR code with the OpenClaw iOS app:" },
-        { type: "input_image", image_url: "data:image/png;base64,cG5n" },
-      ],
+    const content = extractContentBlocks(payload);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "Scan this QR code with the OpenClaw iOS app:",
     });
-    expect(JSON.stringify(payload?.message)).not.toContain("MEDIA:data:image/png;base64,cG5n");
+    expect(content[1]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/"),
+        openUrl: expect.stringContaining("/full"),
+        alt: "Generated image 1",
+        mimeType: "image/png",
+        width: 1,
+        height: 1,
+      }),
+    );
+    expect(JSON.stringify(payload?.message)).not.toContain(`MEDIA:${TEST_PNG_DATA_URL}`);
+  });
+
+  it("does not embed agent audio from arbitrary local paths outside the agent media roots", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-audio-outside-roots-");
+    const rogueDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-chat-rogue-audio-"));
+    const audioPath = path.join(rogueDir, "reply.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "block",
+        payload: {
+          mediaUrl: audioPath,
+          mediaUrls: [audioPath],
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-audio-outside-roots",
+        expectBroadcast: false,
+      });
+
+      await waitForAssertion(() => {
+        const assistantMediaUpdate = mockState.emittedTranscriptUpdates.find(
+          (update) =>
+            typeof update.message === "object" &&
+            update.message !== null &&
+            (update.message as { idempotencyKey?: unknown }).idempotencyKey ===
+              "idem-agent-audio-outside-roots:assistant-media",
+        );
+        expect(assistantMediaUpdate).toBeUndefined();
+      });
+    } finally {
+      fs.rmSync(rogueDir, { recursive: true, force: true });
+    }
   });
 
   it("chat.inject keeps message defined when directive tag is the only content", async () => {
@@ -1917,7 +1999,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("preserves media-only final replies in the final broadcast message", async () => {
     createTranscriptFixture("openclaw-chat-send-media-only-final-");
-    mockState.finalPayload = { mediaUrl: "data:image/png;base64,cG5n" };
+    mockState.finalPayload = {
+      mediaUrl: TEST_PNG_DATA_URL,
+    };
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -1927,20 +2011,25 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-media-only-final",
     });
 
-    expect(payload?.message).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "text", text: "Image reply" },
-        { type: "input_image", image_url: "data:image/png;base64,cG5n" },
-      ],
-    });
+    expect(extractFirstTextBlock(payload)).toBeUndefined();
+    expect(extractFirstContentBlock(payload)).toEqual(
+      expect.objectContaining({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/"),
+        openUrl: expect.stringContaining("/full"),
+        alt: "Generated image 1",
+        mimeType: "image/png",
+        width: 1,
+        height: 1,
+      }),
+    );
   });
 
   it("strips NO_REPLY from transcript text when final replies only carry media", async () => {
     createTranscriptFixture("openclaw-chat-send-media-only-silent-final-");
     mockState.finalPayload = {
       text: "NO_REPLY",
-      mediaUrl: "data:image/png;base64,cG5n",
+      mediaUrl: TEST_PNG_DATA_URL,
     };
     const respond = vi.fn();
     const context = createChatContext();
@@ -1951,20 +2040,25 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-media-only-silent-final",
     });
 
-    expect(payload?.message).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "text", text: "Image reply" },
-        { type: "input_image", image_url: "data:image/png;base64,cG5n" },
-      ],
-    });
+    expect(extractFirstTextBlock(payload)).toBeUndefined();
+    expect(extractFirstContentBlock(payload)).toEqual(
+      expect.objectContaining({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/"),
+        openUrl: expect.stringContaining("/full"),
+        alt: "Generated image 1",
+        mimeType: "image/png",
+        width: 1,
+        height: 1,
+      }),
+    );
   });
 
   it("preserves reply tags in transcript updates for media replies while stripping them from the broadcast", async () => {
     createTranscriptFixture("openclaw-chat-send-media-reply-tags-");
     mockState.finalPayload = {
       replyToCurrent: true,
-      mediaUrl: "data:image/png;base64,cG5n",
+      mediaUrl: TEST_PNG_DATA_URL,
     };
     const respond = vi.fn();
     const context = createChatContext();
@@ -1975,13 +2069,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-media-reply-tags",
     });
 
-    expect(payload?.message).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "text", text: "Image reply" },
-        { type: "input_image", image_url: "data:image/png;base64,cG5n" },
-      ],
-    });
+    expect(extractFirstTextBlock(payload)).toBeUndefined();
+    expect(extractFirstContentBlock(payload)).toEqual(
+      expect.objectContaining({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/"),
+        openUrl: expect.stringContaining("/full"),
+        alt: "Generated image 1",
+        mimeType: "image/png",
+        width: 1,
+        height: 1,
+      }),
+    );
     const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
       (update) =>
         typeof update.message === "object" &&
@@ -1998,7 +2097,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         role: "assistant",
         content: [
           { type: "text", text: "[[reply_to_current]]Image reply" },
-          { type: "input_image", image_url: "data:image/png;base64,cG5n" },
+          {
+            type: "image",
+            url: expect.stringContaining("/api/chat/media/outgoing/"),
+            openUrl: expect.stringContaining("/full"),
+          },
         ],
       },
     });
@@ -2008,7 +2111,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     createTranscriptFixture("openclaw-chat-send-sensitive-media-final-");
     mockState.finalPayload = {
       text: "Scan this QR code with the OpenClaw iOS app:",
-      mediaUrl: "data:image/png;base64,cG5n",
+      mediaUrl: TEST_PNG_DATA_URL,
       sensitiveMedia: true,
     };
     const respond = vi.fn();
@@ -2020,13 +2123,22 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-sensitive-media-final",
     });
 
-    expect(payload?.message).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "text", text: "Scan this QR code with the OpenClaw iOS app:" },
-        { type: "input_image", image_url: "data:image/png;base64,cG5n" },
-      ],
+    const content = extractContentBlocks(payload);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "Scan this QR code with the OpenClaw iOS app:",
     });
+    expect(content[1]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        url: expect.stringContaining("/api/chat/media/outgoing/"),
+        openUrl: expect.stringContaining("/full"),
+        alt: "Generated image 1",
+        mimeType: "image/png",
+        width: 1,
+        height: 1,
+      }),
+    );
     const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
       (update) =>
         typeof update.message === "object" &&
@@ -2039,11 +2151,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         content: [{ type: "text", text: "Scan this QR code with the OpenClaw iOS app:" }],
       },
     });
-    expect(JSON.stringify(transcriptUpdate)).not.toContain("input_image");
-    expect(JSON.stringify(transcriptUpdate)).not.toContain("data:image/png;base64,cG5n");
+    expect(JSON.stringify(transcriptUpdate)).not.toContain("/api/chat/media/outgoing/");
+    expect(JSON.stringify(transcriptUpdate)).not.toContain(TEST_PNG_DATA_URL);
   });
 
-  it("sanitizes replyToId before emitting inline reply directives", async () => {
+  it("sanitizes malformed replyToId values so control tags do not leak into transcript or broadcast", async () => {
     createTranscriptFixture("openclaw-chat-send-sanitized-reply-id-");
     mockState.finalPayload = {
       text: "hello",
@@ -2059,13 +2171,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     expect(extractFirstTextBlock(payload)?.trim()).toBe("hello");
+    expect(JSON.stringify(payload)).not.toContain("[[reply_to:");
+    expect(JSON.stringify(payload)).not.toContain("[[audio_as_voice]]");
     const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
       (update) =>
         typeof update.message === "object" &&
         update.message !== null &&
         (update.message as { role?: unknown }).role === "assistant",
     );
-    expect(JSON.stringify(transcriptUpdate)).toContain("[[reply_to:abcaudio_as_voice]]");
+    expect(JSON.stringify(transcriptUpdate)).not.toContain("[[reply_to:");
     expect(JSON.stringify(transcriptUpdate)).not.toContain("[[audio_as_voice]]");
   });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1476,6 +1476,9 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
     } else if (typeof payload.text === "string" && payload.text.trim().length > 0) {
       strippedTextPayloadCount += 1;
     }
+    if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
+      continue;
+    }
     const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([payload], {
       localRoots: Array.isArray(params.managedImageLocalRoots)
         ? params.managedImageLocalRoots
@@ -1486,9 +1489,6 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
     });
     if (audioBlocks.length > 0) {
       content.push(...audioBlocks);
-    }
-    if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
-      continue;
     }
     const mediaUrls = Array.from(
       new Set([

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -157,7 +157,9 @@ type AssistantDisplayContentBlock = Record<string, unknown>;
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
 let chatHistoryPlaceholderEmitCount = 0;
+const chatHistoryManagedImageCleanupState = new Map<string, Promise<void>>();
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
   "direct",
@@ -1496,6 +1498,7 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
         ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
       ]),
     );
+    let managedImagePrepareError: Error | undefined;
     const imageBlocks = await createManagedOutgoingImageBlocks({
       sessionKey: params.sessionKey,
       mediaUrls,
@@ -1503,11 +1506,19 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
       localRoots: params.managedImageLocalRoots,
       continueOnPrepareError: true,
       onPrepareError: (error) => {
+        managedImagePrepareError ??= error;
         params.onManagedImagePrepareError?.(error.message);
       },
     });
     if (imageBlocks.length > 0) {
       content.push(...imageBlocks);
+    } else if (
+      managedImagePrepareError &&
+      !text &&
+      audioBlocks.length === 0 &&
+      mediaUrls.length > 0
+    ) {
+      throw managedImagePrepareError;
     }
   }
 
@@ -1560,6 +1571,71 @@ function replaceAssistantContentTextBlocks(
     return [...transcriptTextBlocks.slice(transcriptTextIndex), ...merged];
   }
   return merged;
+}
+
+function isManagedOutgoingImageUrl(value: unknown): boolean {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value, "http://localhost");
+    return parsed.pathname.startsWith(MANAGED_OUTGOING_IMAGE_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
+function stripManagedOutgoingAssistantContentBlocks(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): AssistantDisplayContentBlock[] | undefined {
+  if (!content || content.length === 0) {
+    return undefined;
+  }
+  const filtered = content.filter((block) => {
+    if (block?.type !== "image") {
+      return true;
+    }
+    return !(isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl));
+  });
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function extractAssistantDisplayText(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): string | undefined {
+  if (!content || content.length === 0) {
+    return undefined;
+  }
+  const text = content
+    .map((block) => (block?.type === "text" && typeof block.text === "string" ? block.text : ""))
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  return text || undefined;
+}
+
+function scheduleChatHistoryManagedImageCleanup(params: {
+  sessionKey: string;
+  context: Pick<GatewayRequestContext, "logGateway">;
+}) {
+  if (chatHistoryManagedImageCleanupState.has(params.sessionKey)) {
+    return;
+  }
+  const pending: Promise<void> = cleanupManagedOutgoingImageRecords({
+    sessionKey: params.sessionKey,
+  })
+    .then(() => undefined)
+    .catch((error) => {
+      params.context.logGateway.debug(
+        `chat.history managed image cleanup skipped sessionKey=${JSON.stringify(params.sessionKey)} error=${formatForLog(error)}`,
+      );
+    })
+    .finally(() => {
+      if (chatHistoryManagedImageCleanupState.get(params.sessionKey) === pending) {
+        chatHistoryManagedImageCleanupState.delete(params.sessionKey);
+      }
+    });
+  chatHistoryManagedImageCleanupState.set(params.sessionKey, pending);
 }
 
 function normalizeExplicitChatSendOrigin(
@@ -1796,13 +1872,10 @@ export const chatHandlers: GatewayRequestHandlers = {
     };
     const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
     const cleanupSessionKey = canonicalKey || sessionKey;
-    try {
-      await cleanupManagedOutgoingImageRecords({ sessionKey: cleanupSessionKey });
-    } catch (error) {
-      context.logGateway.debug(
-        `chat.history managed image cleanup skipped sessionKey=${JSON.stringify(cleanupSessionKey)} error=${formatForLog(error)}`,
-      );
-    }
+    scheduleChatHistoryManagedImageCleanup({
+      sessionKey: cleanupSessionKey,
+      context,
+    });
 
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
@@ -2533,15 +2606,20 @@ export const chatHandlers: GatewayRequestHandlers = {
                   context.logGateway.warn(
                     `webchat transcript append failed: ${appended.error ?? "unknown error"}`,
                   );
+                  const fallbackAssistantContent =
+                    stripManagedOutgoingAssistantContentBlocks(persistedAssistantContent) ??
+                    stripManagedOutgoingAssistantContentBlocks(assistantContent);
+                  const fallbackText =
+                    extractAssistantDisplayText(fallbackAssistantContent) ?? combinedReply;
                   const now = Date.now();
                   message = {
                     role: "assistant",
-                    ...(assistantContent?.length
-                      ? { content: assistantContent }
-                      : combinedReply
-                        ? { content: [{ type: "text", text: combinedReply }] }
+                    ...(fallbackAssistantContent?.length
+                      ? { content: fallbackAssistantContent }
+                      : fallbackText
+                        ? { content: [{ type: "text", text: fallbackText }] }
                         : {}),
-                    ...(combinedReply ? { text: combinedReply } : {}),
+                    ...(fallbackText ? { text: fallbackText } : {}),
                     timestamp: now,
                     // Keep this compatible with Pi stopReason enums even though this message isn't
                     // persisted to the transcript due to the append failure.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,8 +13,12 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { logLargePayload } from "../../logging/diagnostic-payload.js";
-import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { isAudioFileName } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
@@ -54,6 +58,11 @@ import { MediaOffloadError } from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { isSuppressedControlReplyText } from "../control-reply-text.js";
+import {
+  attachManagedOutgoingImagesToMessage,
+  cleanupManagedOutgoingImageRecords,
+  createManagedOutgoingImageBlocks,
+} from "../managed-image-attachments.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -75,8 +84,8 @@ import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
 import {
   capArrayByJsonBytes,
   loadSessionEntry,
-  resolveGatewayModelSupportsImages,
   resolveDeletedAgentIdFromSessionKey,
+  resolveGatewayModelSupportsImages,
   readSessionMessages,
   resolveSessionModelRef,
 } from "../session-utils.js";
@@ -85,7 +94,10 @@ import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
-import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import {
+  buildWebchatAssistantMessageFromReplyPayloads,
+  buildWebchatAudioContentBlocksFromReplyPayloads,
+} from "./chat-webchat-media.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -139,6 +151,8 @@ async function buildWebchatAssistantMediaMessage(
     },
   });
 }
+
+type AssistantDisplayContentBlock = Record<string, unknown>;
 
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
@@ -1278,9 +1292,9 @@ function transcriptHasIdempotencyKey(transcriptPath: string, idempotencyKey: str
 }
 
 function appendAssistantTranscriptMessage(params: {
-  message: string;
+  message?: string;
+  content?: readonly AssistantDisplayContentBlock[];
   label?: string;
-  content?: Array<Record<string, unknown>>;
   sessionId: string;
   storePath: string | undefined;
   sessionFile?: string;
@@ -1323,8 +1337,8 @@ function appendAssistantTranscriptMessage(params: {
   return appendInjectedAssistantMessageToTranscript({
     transcriptPath,
     message: params.message,
+    content: params.content ? [...params.content] : undefined,
     label: params.label,
-    content: params.content,
     idempotencyKey: params.idempotencyKey,
     abortMeta: params.abortMeta,
   });
@@ -1404,6 +1418,143 @@ function createChatAbortOps(context: GatewayRequestContext): ChatAbortOps {
 function normalizeOptionalText(value?: string | null): string | undefined {
   const trimmed = value?.trim();
   return trimmed || undefined;
+}
+
+function sanitizeAssistantDisplayText(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const withoutEnvelope = stripEnvelopeFromMessage(value);
+  const normalized = typeof withoutEnvelope === "string" ? withoutEnvelope : value;
+  const stripped = stripInlineDirectiveTagsForDisplay(normalized).text.trim();
+  return stripped || undefined;
+}
+
+function extractAssistantDisplayTextFromContent(
+  content?: readonly AssistantDisplayContentBlock[] | null,
+): string | undefined {
+  if (!Array.isArray(content) || content.length === 0) {
+    return undefined;
+  }
+  const parts = content
+    .map((block) => {
+      if (block?.type !== "text" || typeof block.text !== "string") {
+        return "";
+      }
+      return block.text.trim();
+    })
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return parts.join("\n\n");
+}
+
+async function buildAssistantDisplayContentFromReplyPayloads(params: {
+  sessionKey: string;
+  payloads: ReplyPayload[];
+  managedImageAttachmentsLimits?: Parameters<typeof createManagedOutgoingImageBlocks>[0]["limits"];
+  managedImageLocalRoots?: Parameters<typeof createManagedOutgoingImageBlocks>[0]["localRoots"];
+  includeSensitiveMedia?: boolean;
+  onLocalAudioAccessDenied?: (message: string) => void;
+}): Promise<AssistantDisplayContentBlock[] | undefined> {
+  const rawTextPayloadCount = params.payloads.filter(
+    (payload) => typeof payload.text === "string" && payload.text.trim().length > 0,
+  ).length;
+  const normalized = normalizeReplyPayloadsForDelivery(params.payloads);
+  if (normalized.length === 0) {
+    return rawTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
+  }
+
+  const content: AssistantDisplayContentBlock[] = [];
+  let strippedTextPayloadCount = 0;
+  for (const payload of normalized) {
+    const text = sanitizeAssistantDisplayText(payload.text);
+    if (text) {
+      content.push({ type: "text", text });
+    } else if (typeof payload.text === "string" && payload.text.trim().length > 0) {
+      strippedTextPayloadCount += 1;
+    }
+    const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([payload], {
+      localRoots: Array.isArray(params.managedImageLocalRoots)
+        ? params.managedImageLocalRoots
+        : undefined,
+      onLocalAudioAccessDenied: (err) => {
+        params.onLocalAudioAccessDenied?.(formatForLog(err));
+      },
+    });
+    if (audioBlocks.length > 0) {
+      content.push(...audioBlocks);
+    }
+    if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
+      continue;
+    }
+    const mediaUrls = Array.from(
+      new Set([
+        ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
+        ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
+      ]),
+    );
+    const imageBlocks = await createManagedOutgoingImageBlocks({
+      sessionKey: params.sessionKey,
+      mediaUrls,
+      limits: params.managedImageAttachmentsLimits,
+      localRoots: params.managedImageLocalRoots,
+    });
+    if (imageBlocks.length > 0) {
+      content.push(...imageBlocks);
+    }
+  }
+
+  if (content.length > 0) {
+    return content;
+  }
+  if (strippedTextPayloadCount > 0) {
+    return [{ type: "text", text: "" }];
+  }
+  return undefined;
+}
+
+function replaceAssistantContentTextBlocks(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+  transcriptMediaMessage: { content: Array<Record<string, unknown>> } | null,
+): AssistantDisplayContentBlock[] | undefined {
+  const transcriptTextBlocks = (transcriptMediaMessage?.content ?? []).filter(
+    (block): block is AssistantDisplayContentBlock =>
+      Boolean(block) &&
+      typeof block === "object" &&
+      block.type === "text" &&
+      typeof block.text === "string",
+  );
+  if (transcriptTextBlocks.length === 0) {
+    return content ? [...content] : undefined;
+  }
+  if (!content || content.length === 0) {
+    return [...transcriptTextBlocks];
+  }
+  const textBlockCount = content.filter(
+    (block) => block?.type === "text" && typeof block.text === "string",
+  ).length;
+  if (textBlockCount === 0) {
+    return [...transcriptTextBlocks, ...content];
+  }
+  const merged: AssistantDisplayContentBlock[] = [];
+  let transcriptTextIndex = 0;
+  for (const block of content) {
+    if (
+      block?.type === "text" &&
+      typeof block.text === "string" &&
+      transcriptTextIndex < transcriptTextBlocks.length
+    ) {
+      merged.push(transcriptTextBlocks[transcriptTextIndex++]);
+      continue;
+    }
+    merged.push(block);
+  }
+  if (transcriptTextIndex < transcriptTextBlocks.length) {
+    return [...transcriptTextBlocks.slice(transcriptTextIndex), ...merged];
+  }
+  return merged;
 }
 
 function normalizeExplicitChatSendOrigin(
@@ -1638,7 +1789,16 @@ export const chatHandlers: GatewayRequestHandlers = {
       limit?: number;
       maxChars?: number;
     };
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+    const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+    const cleanupSessionKey = canonicalKey || sessionKey;
+    try {
+      await cleanupManagedOutgoingImageRecords({ sessionKey: cleanupSessionKey });
+    } catch (error) {
+      context.logGateway.debug(
+        `chat.history managed image cleanup skipped sessionKey=${JSON.stringify(cleanupSessionKey)} error=${formatForLog(error)}`,
+      );
+    }
+
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
@@ -2126,8 +2286,19 @@ export const chatHandlers: GatewayRequestHandlers = {
         if (!agentRunStarted || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {
           return;
         }
+        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(sessionKey);
+        const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
+        const resolvedTranscriptPath = resolveTranscriptPath({
+          sessionId,
+          storePath: latestStorePath,
+          sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+          agentId,
+        });
         const mediaMessage = await buildWebchatAssistantMediaMessage([payload], {
-          localRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
+          localRoots: appendLocalMediaParentRoots(
+            getAgentScopedMediaLocalRoots(cfg, agentId),
+            resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+          ),
           onLocalAudioAccessDenied: (message) => {
             context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
           },
@@ -2135,8 +2306,6 @@ export const chatHandlers: GatewayRequestHandlers = {
         if (!mediaMessage) {
           return;
         }
-        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(sessionKey);
-        const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
         const appended = appendAssistantTranscriptMessage({
           message: mediaMessage.transcriptText,
           ...(payload.sensitiveMedia === true ? {} : { content: mediaMessage.content }),
@@ -2257,23 +2426,78 @@ export const chatHandlers: GatewayRequestHandlers = {
             } else {
               const finalPayloads = deliveredReplies
                 .filter((entry) => entry.kind === "final")
-                .map((entry) => entry.payload);
-              const combinedReply = buildTranscriptReplyText(finalPayloads);
-              const mediaMessage = await buildWebchatAssistantMediaMessage(finalPayloads, {
-                localRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
+                .map((entry) => entry.payload)
+                .filter(
+                  (payload) =>
+                    typeof payload.text === "string" ||
+                    typeof payload.mediaUrl === "string" ||
+                    payload.mediaUrls?.length,
+                );
+              const { storePath: latestStorePath, entry: latestEntry } =
+                loadSessionEntry(sessionKey);
+              const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
+              const resolvedTranscriptPath = resolveTranscriptPath({
+                sessionId,
+                storePath: latestStorePath,
+                sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+                agentId,
+              });
+              const mediaLocalRoots = appendLocalMediaParentRoots(
+                getAgentScopedMediaLocalRoots(cfg, agentId),
+                resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+              );
+              const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+                sessionKey,
+                payloads: finalPayloads,
+                managedImageAttachmentsLimits: undefined,
+                managedImageLocalRoots: mediaLocalRoots,
                 onLocalAudioAccessDenied: (message) => {
                   context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
                 },
               });
-              const hasSensitiveMedia = hasSensitiveMediaPayload(finalPayloads);
+              const transcriptMediaMessage = await buildWebchatAssistantMediaMessage(
+                finalPayloads,
+                {
+                  localRoots: mediaLocalRoots,
+                  onLocalAudioAccessDenied: (message) => {
+                    context.logGateway.warn(
+                      `webchat audio embedding denied local path: ${message}`,
+                    );
+                  },
+                },
+              );
+              const persistedAssistantContent = replaceAssistantContentTextBlocks(
+                hasSensitiveMediaPayload(finalPayloads)
+                  ? await buildAssistantDisplayContentFromReplyPayloads({
+                      sessionKey,
+                      payloads: finalPayloads,
+                      managedImageAttachmentsLimits: undefined,
+                      managedImageLocalRoots: mediaLocalRoots,
+                      includeSensitiveMedia: false,
+                      onLocalAudioAccessDenied: (message) => {
+                        context.logGateway.warn(
+                          `webchat audio embedding denied local path: ${message}`,
+                        );
+                      },
+                    })
+                  : assistantContent,
+                transcriptMediaMessage,
+              );
+              const combinedReply =
+                extractAssistantDisplayTextFromContent(assistantContent) ??
+                buildTranscriptReplyText(finalPayloads);
+              const transcriptReply = transcriptMediaMessage?.transcriptText ?? combinedReply;
               let message: Record<string, unknown> | undefined;
-              if (mediaMessage || combinedReply) {
-                const { storePath: latestStorePath, entry: latestEntry } =
-                  loadSessionEntry(sessionKey);
-                const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
+              if (
+                transcriptReply ||
+                persistedAssistantContent?.length ||
+                assistantContent?.length
+              ) {
                 const appended = appendAssistantTranscriptMessage({
-                  message: mediaMessage?.transcriptText ?? combinedReply,
-                  ...(mediaMessage && !hasSensitiveMedia ? { content: mediaMessage.content } : {}),
+                  ...(transcriptReply ? { message: transcriptReply } : {}),
+                  ...(persistedAssistantContent?.length
+                    ? { content: persistedAssistantContent }
+                    : {}),
                   sessionId,
                   storePath: latestStorePath,
                   sessionFile: latestEntry?.sessionFile,
@@ -2281,13 +2505,16 @@ export const chatHandlers: GatewayRequestHandlers = {
                   createIfMissing: true,
                 });
                 if (appended.ok) {
-                  if (hasSensitiveMedia && mediaMessage) {
-                    message = {
-                      ...appended.message,
-                      content: mediaMessage.content,
-                    };
-                  } else {
-                    message = appended.message;
+                  if (appended.messageId && persistedAssistantContent?.length) {
+                    await attachManagedOutgoingImagesToMessage({
+                      messageId: appended.messageId,
+                      blocks: persistedAssistantContent,
+                    });
+                  }
+                  if (appended.message) {
+                    message = assistantContent?.length
+                      ? { ...appended.message, content: assistantContent }
+                      : appended.message;
                   }
                 } else {
                   context.logGateway.warn(
@@ -2296,7 +2523,12 @@ export const chatHandlers: GatewayRequestHandlers = {
                   const now = Date.now();
                   message = {
                     role: "assistant",
-                    content: mediaMessage?.content ?? [{ type: "text", text: combinedReply }],
+                    ...(assistantContent?.length
+                      ? { content: assistantContent }
+                      : combinedReply
+                        ? { content: [{ type: "text", text: combinedReply }] }
+                        : {}),
+                    ...(combinedReply ? { text: combinedReply } : {}),
                     timestamp: now,
                     // Keep this compatible with Pi stopReason enums even though this message isn't
                     // persisted to the transcript due to the append failure.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2518,10 +2518,10 @@ export const chatHandlers: GatewayRequestHandlers = {
                   createIfMissing: true,
                 });
                 if (appended.ok) {
-                  if (appended.messageId && persistedAssistantContent?.length) {
+                  if (appended.messageId && assistantContent?.length) {
                     await attachManagedOutgoingImagesToMessage({
                       messageId: appended.messageId,
-                      blocks: persistedAssistantContent,
+                      blocks: assistantContent,
                     });
                   }
                   if (appended.message) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1457,6 +1457,7 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
   managedImageLocalRoots?: Parameters<typeof createManagedOutgoingImageBlocks>[0]["localRoots"];
   includeSensitiveMedia?: boolean;
   onLocalAudioAccessDenied?: (message: string) => void;
+  onManagedImagePrepareError?: (message: string) => void;
 }): Promise<AssistantDisplayContentBlock[] | undefined> {
   const rawTextPayloadCount = params.payloads.filter(
     (payload) => typeof payload.text === "string" && payload.text.trim().length > 0,
@@ -1500,6 +1501,10 @@ async function buildAssistantDisplayContentFromReplyPayloads(params: {
       mediaUrls,
       limits: params.managedImageAttachmentsLimits,
       localRoots: params.managedImageLocalRoots,
+      continueOnPrepareError: true,
+      onPrepareError: (error) => {
+        params.onManagedImagePrepareError?.(error.message);
+      },
     });
     if (imageBlocks.length > 0) {
       content.push(...imageBlocks);
@@ -2454,6 +2459,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                 onLocalAudioAccessDenied: (message) => {
                   context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
                 },
+                onManagedImagePrepareError: (message) => {
+                  context.logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
+                },
               });
               const transcriptMediaMessage = await buildWebchatAssistantMediaMessage(
                 finalPayloads,
@@ -2477,6 +2485,11 @@ export const chatHandlers: GatewayRequestHandlers = {
                       onLocalAudioAccessDenied: (message) => {
                         context.logGateway.warn(
                           `webchat audio embedding denied local path: ${message}`,
+                        );
+                      },
+                      onManagedImagePrepareError: (message) => {
+                        context.logGateway.warn(
+                          `webchat image embedding skipped attachment: ${message}`,
                         );
                       },
                     })

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
@@ -975,8 +976,105 @@ describe("gateway server chat", () => {
         });
         expect(historyRes.ok).toBe(true);
 
-        await expect(fs.access(recordPath)).rejects.toThrow();
+        let recordDeleted = false;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          try {
+            await fs.access(recordPath);
+          } catch {
+            recordDeleted = true;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        expect(recordDeleted).toBe(true);
       } finally {
+        if (previousStateDir == null) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
+  test("chat.send fallback final payload omits managed image URLs when transcript append fails", async () => {
+    await withMainSessionStore(async (dir) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = dir;
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+      const originalOpen = SessionManager.open.bind(SessionManager);
+      let failAssistantAppend = true;
+      const openSpy = vi.spyOn(SessionManager, "open").mockImplementation((...args) => {
+        const manager = originalOpen(...args);
+        const originalAppendMessage = manager.appendMessage.bind(manager);
+        const wrappedManager = Object.assign(
+          Object.create(Object.getPrototypeOf(manager)) as SessionManager,
+          manager,
+        );
+        wrappedManager.appendMessage = (message: Parameters<typeof manager.appendMessage>[0]) => {
+          if (
+            failAssistantAppend &&
+            message &&
+            typeof message === "object" &&
+            (message as { role?: unknown }).role === "assistant"
+          ) {
+            failAssistantAppend = false;
+            throw new Error("simulated transcript append failure");
+          }
+          return originalAppendMessage(message);
+        };
+        return wrappedManager;
+      });
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            dispatcher: {
+              sendFinalReply: (payload: { text?: string; mediaUrls?: string[] }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+              getQueuedCounts: () => { final: number; block: number; tool: number };
+            };
+          },
+        ];
+        params.dispatcher.sendFinalReply({
+          mediaUrls: [`data:image/png;base64,${pngB64}`],
+        });
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: params.dispatcher.getQueuedCounts(),
+        };
+      });
+
+      try {
+        const finalEventPromise = onceMessage(
+          ws,
+          (o) =>
+            o.type === "event" &&
+            o.event === "chat" &&
+            o.payload?.state === "final" &&
+            o.payload?.runId === "idem-managed-image-append-fallback",
+          8000,
+        );
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "show me an image",
+          idempotencyKey: "idem-managed-image-append-fallback",
+        });
+
+        expect(res.ok).toBe(true);
+
+        const finalEvent = await finalEventPromise;
+        const finalMessage = finalEvent.payload?.message as
+          | { content?: Array<Record<string, unknown>>; text?: string }
+          | undefined;
+        expect(finalMessage?.text).toBe("Image reply");
+        expect(finalMessage?.content).toEqual([{ type: "text", text: "Image reply" }]);
+        expect(JSON.stringify(finalMessage ?? {})).not.toContain("/api/chat/media/outgoing/");
+      } finally {
+        openSpy.mockRestore();
         if (previousStateDir == null) {
           delete process.env.OPENCLAW_STATE_DIR;
         } else {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -721,6 +721,334 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history deduplicates assistant image sources across mediaUrl and mediaUrls", async () => {
+    await withMainSessionStore(async (dir) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = dir;
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+      const dataUrl = `data:image/png;base64,${pngB64}`;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            dispatcher: {
+              sendFinalReply: (payload: {
+                text?: string;
+                mediaUrl?: string;
+                mediaUrls?: string[];
+              }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+              getQueuedCounts: () => { final: number; block: number; tool: number };
+            };
+          },
+        ];
+        params.dispatcher.sendFinalReply({
+          mediaUrl: dataUrl,
+          mediaUrls: [dataUrl],
+        });
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: params.dispatcher.getQueuedCounts(),
+        };
+      });
+
+      try {
+        const finalPromise = onceMessage(
+          ws,
+          (o) =>
+            o.type === "event" &&
+            o.event === "chat" &&
+            o.payload?.state === "final" &&
+            o.payload?.runId === "idem-managed-image-dedupe",
+          8000,
+        );
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "show me one image",
+          idempotencyKey: "idem-managed-image-dedupe",
+        });
+
+        expect(res.ok).toBe(true);
+        await finalPromise;
+
+        let assistantMessage: Record<string, unknown> | undefined;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+            sessionKey: "main",
+          });
+          expect(historyRes.ok).toBe(true);
+          const messages = historyRes.payload?.messages ?? [];
+          assistantMessage = messages.find(
+            (message): message is Record<string, unknown> =>
+              typeof message === "object" &&
+              message !== null &&
+              (message as { role?: unknown }).role === "assistant",
+          );
+          if (assistantMessage) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        expect(assistantMessage).toBeTruthy();
+        const assistantContent = (assistantMessage as { content?: unknown[] }).content ?? [];
+        expect(assistantContent).toEqual([
+          { type: "text", text: "Image reply" },
+          expect.objectContaining({
+            type: "image",
+            url: expect.stringContaining("/api/chat/media/outgoing/"),
+          }),
+        ]);
+      } finally {
+        if (previousStateDir == null) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
+  test("chat.history rewrites assistant image data URLs into managed image blocks", async () => {
+    await withMainSessionStore(async (dir) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = dir;
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            dispatcher: {
+              sendFinalReply: (payload: { text?: string; mediaUrls?: string[] }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+              getQueuedCounts: () => { final: number; block: number; tool: number };
+            };
+          },
+        ];
+        params.dispatcher.sendFinalReply({
+          mediaUrls: [`data:image/png;base64,${pngB64}`],
+        });
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: params.dispatcher.getQueuedCounts(),
+        };
+      });
+
+      try {
+        const finalPromise = onceMessage(
+          ws,
+          (o) =>
+            o.type === "event" &&
+            o.event === "chat" &&
+            o.payload?.state === "final" &&
+            o.payload?.runId === "idem-managed-image-1",
+          8000,
+        );
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "show me an image",
+          idempotencyKey: "idem-managed-image-1",
+        });
+
+        expect(res.ok).toBe(true);
+        expect(res.payload?.runId).toBe("idem-managed-image-1");
+        await finalPromise;
+
+        let assistantMessage: Record<string, unknown> | undefined;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+            sessionKey: "main",
+          });
+          expect(historyRes.ok).toBe(true);
+          const messages = historyRes.payload?.messages ?? [];
+          assistantMessage = messages.find(
+            (message): message is Record<string, unknown> =>
+              typeof message === "object" &&
+              message !== null &&
+              (message as { role?: unknown }).role === "assistant",
+          );
+          if (assistantMessage) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        expect(assistantMessage).toBeTruthy();
+        const assistantContent = (assistantMessage as { content?: unknown[] }).content ?? [];
+        expect(assistantContent).toEqual([
+          { type: "text", text: "Image reply" },
+          expect.objectContaining({
+            type: "image",
+            url: expect.stringContaining("/api/chat/media/outgoing/"),
+            openUrl: expect.stringContaining("/full"),
+            alt: "Generated image 1",
+            mimeType: "image/png",
+            width: 1,
+            height: 1,
+          }),
+        ]);
+        const serializedAssistant = JSON.stringify(assistantMessage);
+        expect(serializedAssistant).not.toContain("data:image/png;base64");
+        expect(serializedAssistant).not.toContain(pngB64);
+      } finally {
+        if (previousStateDir == null) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
+  test("chat.history cleans up stale managed image records", async () => {
+    await withMainSessionStore(async (dir) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = dir;
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            dispatcher: {
+              sendFinalReply: (payload: { text?: string; mediaUrls?: string[] }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+              getQueuedCounts: () => { final: number; block: number; tool: number };
+            };
+          },
+        ];
+        params.dispatcher.sendFinalReply({
+          mediaUrls: [`data:image/png;base64,${pngB64}`],
+        });
+        params.dispatcher.markComplete();
+        await params.dispatcher.waitForIdle();
+        return {
+          queuedFinal: true,
+          counts: params.dispatcher.getQueuedCounts(),
+        };
+      });
+
+      try {
+        const finalPromise = onceMessage(
+          ws,
+          (o) =>
+            o.type === "event" &&
+            o.event === "chat" &&
+            o.payload?.state === "final" &&
+            o.payload?.runId === "idem-managed-image-cleanup",
+          8000,
+        );
+        const sendRes = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "show me an image",
+          idempotencyKey: "idem-managed-image-cleanup",
+        });
+
+        expect(sendRes.ok).toBe(true);
+        await finalPromise;
+
+        const recordsDir = path.join(dir, "media", "outgoing", "records");
+        let recordName: string | undefined;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          const names = await fs.readdir(recordsDir).catch(() => []);
+          recordName = names[0];
+          if (recordName) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        expect(recordName).toBeTruthy();
+
+        const recordPath = path.join(recordsDir, recordName!);
+        const record = JSON.parse(await fs.readFile(recordPath, "utf-8"));
+        record.messageId = "missing-message";
+        await fs.writeFile(recordPath, `${JSON.stringify(record)}\n`, "utf-8");
+
+        const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+          sessionKey: "main",
+        });
+        expect(historyRes.ok).toBe(true);
+
+        await expect(fs.access(recordPath)).rejects.toThrow();
+      } finally {
+        if (previousStateDir == null) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
+  test("chat.send does not leak local file paths when managed image preparation fails", async () => {
+    await withMainSessionStore(async (dir) => {
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = dir;
+
+      try {
+        const missingPath = path.join(dir, "secret-subdir", "missing-image.png");
+        dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+          const [params] = args as [
+            {
+              dispatcher: {
+                sendFinalReply: (payload: { text?: string; mediaUrls?: string[] }) => boolean;
+                markComplete: () => void;
+                waitForIdle: () => Promise<void>;
+                getQueuedCounts: () => { final: number; block: number; tool: number };
+              };
+            },
+          ];
+          params.dispatcher.sendFinalReply({
+            mediaUrls: [missingPath],
+          });
+          params.dispatcher.markComplete();
+          await params.dispatcher.waitForIdle();
+          return {
+            queuedFinal: true,
+            counts: params.dispatcher.getQueuedCounts(),
+          };
+        });
+
+        const errorEventPromise = onceMessage(
+          ws,
+          (o) =>
+            o.type === "event" &&
+            o.event === "chat" &&
+            o.payload?.runId === "idem-managed-image-error" &&
+            o.payload?.state === "error",
+          8000,
+        );
+
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "attach it",
+          idempotencyKey: "idem-managed-image-error",
+        });
+
+        expect(res.ok).toBe(true);
+
+        const errorEvent = await errorEventPromise;
+        expect(errorEvent.payload?.errorMessage).toMatch(
+          /managed image attachment|unable to read local media file/i,
+        );
+        expect(errorEvent.payload?.errorMessage).not.toContain(missingPath);
+        expect(errorEvent.payload?.errorMessage).not.toContain(dir);
+      } finally {
+        if (previousStateDir == null) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
   test("routes block-streamed /btw replies through side-result events", async () => {
     await withMainSessionStore(async (dir) => {
       await fs.writeFile(

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -4,7 +4,6 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 
 type Sharp = typeof import("sharp");
-type SharpFactory = (buffer: Buffer) => ReturnType<Sharp>;
 
 export type ImageMetadata = {
   width: number;
@@ -32,18 +31,14 @@ function prefersSips(): boolean {
   );
 }
 
-let sharpFactoryPromise: Promise<SharpFactory> | null = null;
-
-async function loadSharp(): Promise<SharpFactory> {
-  sharpFactoryPromise ??= import("sharp").then((mod) => {
-    const sharp = (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp);
-    return (buffer: Buffer) =>
-      sharp(buffer, {
-        failOnError: false,
-        limitInputPixels: MAX_IMAGE_INPUT_PIXELS,
-      });
-  });
-  return sharpFactoryPromise;
+async function loadSharp(): Promise<(buffer: Buffer) => ReturnType<Sharp>> {
+  const mod = (await import("sharp")) as unknown as { default?: Sharp };
+  const sharp = mod.default ?? (mod as unknown as Sharp);
+  return (buffer) =>
+    sharp(buffer, {
+      failOnError: false,
+      limitInputPixels: MAX_IMAGE_INPUT_PIXELS,
+    });
 }
 
 function isPositiveImageDimension(value: number): boolean {
@@ -503,11 +498,17 @@ export async function normalizeExifOrientation(buffer: Buffer): Promise<Buffer> 
 
 export async function resizeToJpeg(params: {
   buffer: Buffer;
-  maxSide: number;
+  maxSide?: number;
+  maxWidth?: number;
+  maxHeight?: number;
   quality: number;
   withoutEnlargement?: boolean;
 }): Promise<Buffer> {
   await assertImagePixelLimit(params.buffer);
+
+  const maxWidth = params.maxWidth ?? params.maxSide;
+  const maxHeight = params.maxHeight ?? params.maxSide;
+  const maxSide = params.maxSide ?? Math.max(maxWidth ?? 0, maxHeight ?? 0);
 
   if (prefersSips()) {
     // Normalize EXIF orientation BEFORE resizing (sips resize doesn't auto-rotate)
@@ -518,7 +519,7 @@ export async function resizeToJpeg(params: {
       const meta = await getImageMetadata(normalized);
       if (meta) {
         const maxDim = Math.max(meta.width, meta.height);
-        if (maxDim > 0 && maxDim <= params.maxSide) {
+        if (maxDim > 0 && maxDim <= maxSide) {
           return await sipsResizeToJpeg({
             buffer: normalized,
             maxSide: maxDim,
@@ -529,7 +530,7 @@ export async function resizeToJpeg(params: {
     }
     return await sipsResizeToJpeg({
       buffer: normalized,
-      maxSide: params.maxSide,
+      maxSide,
       quality: params.quality,
     });
   }
@@ -539,8 +540,8 @@ export async function resizeToJpeg(params: {
   return await sharp(params.buffer)
     .rotate() // Auto-rotate based on EXIF before resizing
     .resize({
-      width: params.maxSide,
-      height: params.maxSide,
+      width: maxWidth,
+      height: maxHeight,
       fit: "inside",
       withoutEnlargement: params.withoutEnlargement !== false,
     })
@@ -583,21 +584,25 @@ export async function hasAlphaChannel(buffer: Buffer): Promise<boolean> {
  */
 export async function resizeToPng(params: {
   buffer: Buffer;
-  maxSide: number;
+  maxSide?: number;
+  maxWidth?: number;
+  maxHeight?: number;
   compressionLevel?: number;
   withoutEnlargement?: boolean;
 }): Promise<Buffer> {
   await assertImagePixelLimit(params.buffer);
 
   const sharp = await loadSharp();
+  const maxWidth = params.maxWidth ?? params.maxSide;
+  const maxHeight = params.maxHeight ?? params.maxSide;
   // Compression level 6 is a good balance (0=fastest, 9=smallest)
   const compressionLevel = params.compressionLevel ?? 6;
 
   return await sharp(params.buffer)
     .rotate() // Auto-rotate based on EXIF if present
     .resize({
-      width: params.maxSide,
-      height: params.maxSide,
+      width: maxWidth,
+      height: maxHeight,
       fit: "inside",
       withoutEnlargement: params.withoutEnlargement !== false,
     })

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -134,6 +134,19 @@ describe("local media roots", () => {
     expect(roots.map(normalizeHostPath)).toEqual([normalizeHostPath("/tmp/base")]);
   });
 
+  it("resolves relative local media sources to absolute filesystem paths", () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/tmp");
+    try {
+      const roots = appendLocalMediaParentRoots(["/tmp/base"], ["nested/photo.png"]);
+
+      expect(roots.map(normalizeHostPath)).toEqual(
+        expect.arrayContaining([normalizeHostPath("/tmp/base"), normalizeHostPath("/tmp/nested")]),
+      );
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
   it.each([
     {
       name: "widens agent media roots for concrete local sources when workspaceOnly is disabled",

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -71,7 +71,7 @@ export function getAgentScopedMediaLocalRoots(
   return roots;
 }
 
-function resolveLocalMediaPath(source: string): string | undefined {
+export function resolveLocalMediaPath(source: string): string | undefined {
   const trimmed = source.trim();
   if (!trimmed || isPassThroughRemoteMediaSource(trimmed) || DATA_URL_RE.test(trimmed)) {
     return undefined;
@@ -89,7 +89,7 @@ function resolveLocalMediaPath(source: string): string | undefined {
   if (path.isAbsolute(trimmed) || WINDOWS_DRIVE_RE.test(trimmed)) {
     return path.resolve(trimmed);
   }
-  return undefined;
+  return path.resolve(trimmed);
 }
 
 export function appendLocalMediaParentRoots(

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -367,8 +367,9 @@ export async function saveMediaSource(
   headers?: Record<string, string>,
   subdir = "",
   maxBytes = MAX_BYTES,
+  mediaDirOverride?: string,
 ): Promise<SavedMedia> {
-  const baseDir = resolveMediaDir();
+  const baseDir = mediaDirOverride ?? resolveMediaDir();
   const dir = subdir ? path.join(baseDir, subdir) : baseDir;
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   await cleanOldMedia(DEFAULT_TTL_MS, { recursive: false });
@@ -410,11 +411,12 @@ export async function saveMediaBuffer(
   subdir = "inbound",
   maxBytes = MAX_BYTES,
   originalFilename?: string,
+  mediaDirOverride?: string,
 ): Promise<SavedMedia> {
   if (buffer.byteLength > maxBytes) {
     throw new Error(`Media exceeds ${formatMediaLimitMb(maxBytes)} limit`);
   }
-  const dir = path.join(resolveMediaDir(), subdir);
+  const dir = path.join(mediaDirOverride ?? resolveMediaDir(), subdir);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const uuid = crypto.randomUUID();
   const headerExt = extensionForMime(normalizeOptionalString(contentType?.split(";")[0]));

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -208,6 +208,16 @@ describe("resolveAssistantAttachmentAuthToken", () => {
     ).toBe("shared-password");
   });
 
+  it("falls back to the paired device token when shared auth is unavailable", () => {
+    expect(
+      resolveAssistantAttachmentAuthToken({
+        settings: { token: "" } as AppViewState["settings"],
+        password: "   ",
+        hello: { auth: { deviceToken: "paired-device-token" } } as AppViewState["hello"],
+      }),
+    ).toBe("paired-device-token");
+  });
+
   it("returns null when neither auth secret is available", () => {
     expect(
       resolveAssistantAttachmentAuthToken({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -119,6 +119,7 @@ import {
   updateSkillEnabled,
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
+import { resolveGatewayHttpAuthHeader } from "./gateway-http-auth.ts";
 import { icons } from "./icons.ts";
 import "./components/dashboard-header.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
@@ -1011,10 +1012,6 @@ export function renderApp(state: AppViewState) {
             setTheme: (theme, context) => state.setTheme(theme, context),
             setThemeMode: (mode, context) => state.setThemeMode(mode, context),
             setBorderRadius: (value) => state.setBorderRadius(value),
-            userName: state.userName ?? null,
-            userAvatar: state.userAvatar ?? null,
-            onUserNameChange: (name) => state.applyLocalUserIdentity?.({ name }),
-            onUserAvatarChange: (avatar) => state.applyLocalUserIdentity?.({ avatar }),
             configObject: configObj,
             onApplyPreset: (presetId) => {
               void applyQuickSettingsPreset(state, presetId).then(() => requestHostUpdate?.());
@@ -2246,6 +2243,7 @@ export function renderApp(state: AppViewState) {
                 });
               },
               onChatScroll: (event) => state.handleChatScroll(event),
+              onMediaLoad: () => requestHostUpdate?.(),
               getDraft: () => state.chatMessage,
               onDraftChange: (next) => (state.chatMessage = next),
               onRequestUpdate: requestHostUpdate,
@@ -2299,13 +2297,17 @@ export function renderApp(state: AppViewState) {
               onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
               assistantName: state.assistantName,
               assistantAvatar: state.assistantAvatar,
-              userName: state.userName ?? null,
-              userAvatar: state.userAvatar ?? null,
               localMediaPreviewRoots: state.localMediaPreviewRoots,
               embedSandboxMode: state.embedSandboxMode,
               allowExternalEmbedUrls: state.allowExternalEmbedUrls,
               assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
               basePath: state.basePath ?? "",
+              authHeader:
+                resolveGatewayHttpAuthHeader({
+                  password: state.password,
+                  settings: state.settings,
+                  hello: state.hello,
+                }) ?? undefined,
             })
           : nothing}
         ${renderConfigTabForActiveTab()}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2307,6 +2307,7 @@ export function renderApp(state: AppViewState) {
               onCloseSidebar: () => state.handleCloseSidebar(),
               onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
               assistantName: state.assistantName,
+              userName: state.userName ?? null,
               assistantAvatar: state.assistantAvatar,
               localMediaPreviewRoots: state.localMediaPreviewRoots,
               embedSandboxMode: state.embedSandboxMode,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -119,7 +119,10 @@ import {
   updateSkillEnabled,
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
-import { resolveGatewayHttpAuthHeader } from "./gateway-http-auth.ts";
+import {
+  resolveGatewayHttpAuthHeader,
+  resolveGatewayHttpAuthHeaders,
+} from "./gateway-http-auth.ts";
 import { icons } from "./icons.ts";
 import "./components/dashboard-header.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
@@ -1158,6 +1161,10 @@ export function renderApp(state: AppViewState) {
       case "tools":
         void loadToolsCatalog(state, agentId);
         void refreshVisibleToolsEffectiveForCurrentSession(state);
+        return;
+      case "overview":
+      case "channels":
+      case "cron":
         return;
     }
   };
@@ -2312,6 +2319,11 @@ export function renderApp(state: AppViewState) {
                   settings: state.settings,
                   hello: state.hello,
                 }) ?? undefined,
+              authHeaders: resolveGatewayHttpAuthHeaders({
+                password: state.password,
+                settings: state.settings,
+                hello: state.hello,
+              }),
             })
           : nothing}
         ${renderConfigTabForActiveTab()}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1012,6 +1012,10 @@ export function renderApp(state: AppViewState) {
             setTheme: (theme, context) => state.setTheme(theme, context),
             setThemeMode: (mode, context) => state.setThemeMode(mode, context),
             setBorderRadius: (value) => state.setBorderRadius(value),
+            userName: state.userName ?? null,
+            userAvatar: state.userAvatar ?? null,
+            onUserNameChange: (name) => state.applyLocalUserIdentity?.({ name }),
+            onUserAvatarChange: (avatar) => state.applyLocalUserIdentity?.({ avatar }),
             configObject: configObj,
             onApplyPreset: (presetId) => {
               void applyQuickSettingsPreset(state, presetId).then(() => requestHostUpdate?.());

--- a/ui/src/ui/chat/gateway-http-auth.test.ts
+++ b/ui/src/ui/chat/gateway-http-auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildGatewayHttpHeaders, resolveGatewayHttpAuthHeader } from "../gateway-http-auth.js";
+
+describe("resolveGatewayHttpAuthHeader", () => {
+  it("prefers the configured gateway token over the paired device token for HTTP requests", () => {
+    expect(
+      resolveGatewayHttpAuthHeader({
+        settings: { token: "gateway-token" },
+        hello: { auth: { deviceToken: "paired-device-token" } },
+      }),
+    ).toBe("Bearer gateway-token");
+  });
+
+  it("falls back to the gateway password when no token is configured", () => {
+    expect(
+      resolveGatewayHttpAuthHeader({
+        password: "gateway-password",
+        hello: { auth: { deviceToken: "paired-device-token" } },
+      }),
+    ).toBe("Bearer gateway-password");
+  });
+
+  it("uses the device token only when no gateway token or password is available", () => {
+    expect(
+      resolveGatewayHttpAuthHeader({
+        hello: { auth: { deviceToken: "paired-device-token" } },
+      }),
+    ).toBe("Bearer paired-device-token");
+  });
+
+  it("trims whitespace and omits auth headers when nothing usable is present", () => {
+    expect(
+      resolveGatewayHttpAuthHeader({
+        settings: { token: "   " },
+        password: " ",
+        hello: { auth: { deviceToken: "   " } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildGatewayHttpHeaders", () => {
+  it("includes the resolved authorization header alongside extra headers", () => {
+    expect(
+      buildGatewayHttpHeaders(
+        {
+          settings: { token: "gateway-token" },
+          hello: { auth: { deviceToken: "paired-device-token" } },
+        },
+        { "X-Test": "1" },
+      ),
+    ).toEqual({
+      "X-Test": "1",
+      Authorization: "Bearer gateway-token",
+    });
+  });
+});

--- a/ui/src/ui/chat/gateway-http-auth.test.ts
+++ b/ui/src/ui/chat/gateway-http-auth.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildGatewayHttpHeaders, resolveGatewayHttpAuthHeader } from "../gateway-http-auth.js";
+import {
+  buildGatewayHttpHeaders,
+  resolveGatewayHttpAuthHeader,
+  resolveGatewayHttpAuthHeaders,
+} from "../gateway-http-auth.js";
 
 describe("resolveGatewayHttpAuthHeader", () => {
   it("prefers the configured gateway token over the paired device token for HTTP requests", () => {
@@ -36,6 +40,28 @@ describe("resolveGatewayHttpAuthHeader", () => {
         hello: { auth: { deviceToken: "   " } },
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveGatewayHttpAuthHeaders", () => {
+  it("returns all usable credentials in fallback order without duplicates", () => {
+    expect(
+      resolveGatewayHttpAuthHeaders({
+        settings: { token: " gateway-token " },
+        password: "gateway-password",
+        hello: { auth: { deviceToken: "gateway-password" } },
+      }),
+    ).toEqual(["Bearer gateway-token", "Bearer gateway-password"]);
+  });
+
+  it("returns an empty list when no credentials are available", () => {
+    expect(
+      resolveGatewayHttpAuthHeaders({
+        settings: { token: "   " },
+        password: " ",
+        hello: { auth: { deviceToken: "   " } },
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -19,23 +19,6 @@ vi.mock("../views/agents-utils.ts", () => ({
   agentLogoUrl: () => "/openclaw-logo.svg",
   isRenderableControlUiAvatarUrl: (value: string) =>
     /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//")),
-  resolveChatAvatarRenderUrl: (
-    candidate: string | null | undefined,
-    agent: { identity?: { avatar?: string; avatarUrl?: string } },
-  ) => {
-    if (typeof candidate === "string" && candidate.startsWith("blob:")) {
-      return candidate;
-    }
-    for (const value of [candidate, agent.identity?.avatarUrl, agent.identity?.avatar]) {
-      if (
-        typeof value === "string" &&
-        (/^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//")))
-      ) {
-        return value;
-      }
-    }
-    return null;
-  },
 }));
 
 vi.mock("./speech.ts", () => ({
@@ -239,84 +222,6 @@ describe("grouped chat rendering", () => {
     const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.assistant");
     expect(avatar).not.toBeNull();
     expect(avatar?.getAttribute("src")).toBe("/openclaw-logo.svg");
-  });
-
-  it("renders the configured local user name in user message footers", () => {
-    const container = document.createElement("div");
-
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "hello",
-        timestamp: 1000,
-      },
-      "user",
-      { userName: "Buns" },
-    );
-
-    const sender = container.querySelector<HTMLElement>(".chat-group.user .chat-sender-name");
-    expect(sender?.textContent).toBe("Buns");
-  });
-
-  it("renders a local user image avatar when provided", () => {
-    const container = document.createElement("div");
-
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "hello",
-        timestamp: 1000,
-      },
-      "user",
-      { userName: "Buns", userAvatar: "data:image/png;base64,AAA" },
-    );
-
-    const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.user");
-    expect(avatar).not.toBeNull();
-    expect(avatar?.getAttribute("src")).toBe("data:image/png;base64,AAA");
-    expect(avatar?.getAttribute("alt")).toBe("Buns");
-  });
-
-  it("renders a local user avatar route when provided", () => {
-    const container = document.createElement("div");
-
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "hello",
-        timestamp: 1000,
-      },
-      "user",
-      { userName: "Buns", userAvatar: "/avatar/user" },
-    );
-
-    const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.user");
-    expect(avatar).not.toBeNull();
-    expect(avatar?.getAttribute("src")).toBe("/avatar/user");
-    expect(avatar?.getAttribute("alt")).toBe("Buns");
-  });
-
-  it("renders a local user text avatar when provided", () => {
-    const container = document.createElement("div");
-
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "hello",
-        timestamp: 1000,
-      },
-      "user",
-      { userAvatar: "🦞" },
-    );
-
-    const avatar = container.querySelector<HTMLElement>(".chat-avatar.user");
-    expect(avatar).not.toBeNull();
-    expect(avatar?.tagName).toBe("DIV");
-    expect(avatar?.textContent).toContain("🦞");
   });
 
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {
@@ -599,6 +504,31 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-message-image")).toBeNull();
   });
 
+  it("deduplicates repeated legacy MediaPath and MediaPaths image entries", () => {
+    const container = document.createElement("div");
+
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-legacy-media-paths-dedupe",
+        role: "assistant",
+        content: [{ type: "text", text: "duplicate legacy paths" }],
+        MediaPath: "/media/legacy-shared.png",
+        MediaPaths: ["/media/legacy-shared.png", "/media/legacy-other.png"],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+
+    const images = Array.from(
+      container.querySelectorAll<HTMLImageElement>(".chat-message-images img"),
+    );
+    expect(images.map((image) => image.getAttribute("src"))).toEqual([
+      "http://localhost:3000/media/legacy-shared.png",
+      "http://localhost:3000/media/legacy-other.png",
+    ]);
+  });
+
   it("renders legacy input_image image_url blocks", () => {
     const container = document.createElement("div");
 
@@ -665,14 +595,14 @@ describe("grouped chat rendering", () => {
       openSpy.mockClear();
       renderAssistantImage("javascript:alert(1)");
       image = container.querySelector<HTMLImageElement>(".chat-message-image");
-      expect(image).not.toBeNull();
-      image?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(image).toBeNull();
+      expect(container.querySelector(".chat-message-image-unavailable")).not.toBeNull();
       expect(openSpy).not.toHaveBeenCalled();
 
       renderAssistantImage("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' />");
       image = container.querySelector<HTMLImageElement>(".chat-message-image");
-      expect(image).not.toBeNull();
-      image?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(image).toBeNull();
+      expect(container.querySelector(".chat-message-image-unavailable")).not.toBeNull();
       expect(openSpy).not.toHaveBeenCalled();
     } finally {
       openSpy.mockRestore();

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -226,6 +226,23 @@ describe("grouped chat rendering", () => {
     expect(avatar?.getAttribute("src")).toBe("/openclaw-logo.svg");
   });
 
+  it("uses the configured local user name when a user message has no sender label", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: "hello",
+        timestamp: 1000,
+      },
+      "user",
+      { userName: "Daein" },
+    );
+
+    expect(container.querySelector(".chat-sender-name")?.textContent).toBe("Daein");
+  });
+
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {
     const container = document.createElement("div");
     const message = {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -3,6 +3,7 @@
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getSafeLocalStorage } from "../../local-storage.ts";
+import * as openExternalUrlModule from "../open-external-url.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { buildChatItems, type BuildChatItemsProps } from "./build-chat-items.ts";
 import {
@@ -140,6 +141,7 @@ async function flushAssistantAttachmentAvailabilityChecks() {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -1157,5 +1159,155 @@ describe("grouped chat rendering", () => {
         kind: "markdown",
       }),
     );
+  });
+
+  it("retries managed image previews with fallback gateway auth headers", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const createObjectURLMock = vi.fn(() => "blob:preview-fallback");
+    const revokeObjectURLMock = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: createObjectURLMock,
+        revokeObjectURL: revokeObjectURLMock,
+      }),
+    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(["preview"], { type: "image/png" }),
+      } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full",
+            alt: "Fallback preview",
+          },
+        ],
+      },
+      {
+        authHeader: "Bearer stale-token",
+        authHeaders: ["Bearer stale-token", "Bearer device-token"],
+      },
+    );
+
+    await flushAssistantAttachmentAvailabilityChecks();
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer stale-token" }),
+      }),
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer device-token" }),
+      }),
+    );
+    expect(
+      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+    ).toBe("blob:preview-fallback");
+  });
+
+  it("retries managed image opens with fallback gateway auth headers", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const createObjectURLMock = vi
+      .fn<(blob: Blob) => string>()
+      .mockReturnValueOnce("blob:preview-open")
+      .mockReturnValueOnce("blob:open");
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: createObjectURLMock,
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    const openExternalUrlSafeSpy = vi
+      .spyOn(openExternalUrlModule, "openExternalUrlSafe")
+      .mockReturnValue(window);
+    const toRequestUrl = (input: RequestInfo | URL): string => {
+      if (typeof input === "string") {
+        return input;
+      }
+      if (input instanceof URL) {
+        return input.href;
+      }
+      return input.url;
+    };
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) => {
+      const url = toRequestUrl(input);
+      const auth = init?.headers as Record<string, string> | undefined;
+      if (url.endsWith("/preview")) {
+        return {
+          ok: true,
+          status: 200,
+          blob: async () => new Blob(["preview"], { type: "image/png" }),
+        } as Response;
+      }
+      if (auth?.Authorization === "Bearer stale-token") {
+        return {
+          ok: false,
+          status: 401,
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(["open"], { type: "image/png" }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            url: "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/preview",
+            openUrl:
+              "/api/chat/media/outgoing/agent%3Amain%3Amain/11111111-1111-4111-8111-111111111111/full",
+            alt: "Fallback open",
+          },
+        ],
+      },
+      {
+        authHeader: "Bearer stale-token",
+        authHeaders: ["Bearer stale-token", "Bearer device-token"],
+      },
+    );
+
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    const openButton = container.querySelector<HTMLButtonElement>(".chat-message-image-open");
+    expect(openButton).toBeTruthy();
+    openButton?.click();
+    await flushAssistantAttachmentAvailabilityChecks();
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    const authCalls = fetchMock.mock.calls
+      .filter(([input]) => toRequestUrl(input).endsWith("/full"))
+      .map(([, init]) => init?.headers as Record<string, string> | undefined);
+    expect(authCalls).toEqual([
+      expect.objectContaining({ Authorization: "Bearer stale-token" }),
+      expect.objectContaining({ Authorization: "Bearer device-token" }),
+    ]);
+    expect(openExternalUrlSafeSpy).toHaveBeenCalledWith("blob:open");
   });
 });

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -374,6 +374,7 @@ export function renderMessageGroup(
     onToggleToolExpanded?: (toolCardId: string) => void;
     onRequestUpdate?: () => void;
     assistantName?: string;
+    userName?: string | null;
     assistantAvatar?: string | null;
     basePath?: string;
     localMediaPreviewRoots?: readonly string[];
@@ -392,9 +393,10 @@ export function renderMessageGroup(
   const normalizedRole = normalizeRoleForGrouping(group.role);
   const assistantName = opts.assistantName ?? "Assistant";
   const userLabel = group.senderLabel?.trim();
+  const fallbackUserName = opts.userName?.trim() || "You";
   const who =
     normalizedRole === "user"
-      ? (userLabel ?? "You")
+      ? (userLabel ?? fallbackUserName)
       : normalizedRole === "assistant"
         ? assistantName
         : normalizedRole === "tool"

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1,11 +1,12 @@
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { until } from "lit/directives/until.js";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
-import { openExternalUrlSafe } from "../open-external-url.ts";
+import { openExternalUrlSafe, resolveSafeExternalUrl } from "../open-external-url.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type {
@@ -14,11 +15,6 @@ import type {
   NormalizedMessage,
   ToolCard,
 } from "../types/chat-types.ts";
-import {
-  resolveLocalUserAvatarText,
-  resolveLocalUserAvatarUrl,
-  resolveLocalUserName,
-} from "../user-identity.ts";
 import { agentLogoUrl, isRenderableControlUiAvatarUrl } from "../views/agents-utils.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
@@ -54,69 +50,138 @@ export function resetAssistantAttachmentAvailabilityCacheForTest() {
 
 type ImageBlock = {
   url: string;
+  openUrl?: string;
   alt?: string;
-};
-
-type ImageRenderOptions = {
-  localMediaPreviewRoots?: readonly string[];
-  basePath?: string;
-  authToken?: string | null;
+  width?: number;
+  height?: number;
 };
 
 type RenderableImageBlock = ImageBlock & {
-  displayUrl: string;
+  previewUrl: string;
 };
 
-function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
-  if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
-    images.push(block);
+const DEFAULT_INLINE_IMAGE_PREVIEW_MAX_WIDTH = 480;
+const DEFAULT_INLINE_IMAGE_PREVIEW_MAX_HEIGHT = 480;
+
+function normalizeMarkdownLinkTarget(target: string): string {
+  const trimmed = target.trim();
+  if (!trimmed) {
+    return "";
   }
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1).trim();
+  }
+  const whitespaceIndex = trimmed.search(/\s/);
+  return whitespaceIndex === -1 ? trimmed : trimmed.slice(0, whitespaceIndex).trim();
 }
 
-function buildBase64ImageUrl(params: { data: string; mediaType?: string }): string {
-  return params.data.startsWith("data:")
-    ? params.data
-    : `data:${params.mediaType ?? "image/png"};base64,${params.data}`;
-}
-
-function getFileExtension(url: string): string | undefined {
-  const source = (() => {
-    try {
-      const trimmed = url.trim();
-      if (/^https?:\/\//i.test(trimmed)) {
-        return new URL(trimmed).pathname;
-      }
-    } catch {
-      // Fall back to the raw path when URL parsing fails.
-    }
-    return url;
-  })();
-  const fileName = source.split(/[\\/]/).pop() ?? source;
-  const match = /\.([a-zA-Z0-9]+)$/.exec(fileName);
-  return match?.[1]?.toLowerCase();
-}
-
-function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
-  if (typeof mediaType === "string" && mediaType.trim()) {
-    const normalized = mediaType.trim().toLowerCase();
-    if (normalized.startsWith("image/")) {
+function isImageOnlyUrlToken(value: string, imageUrls: ReadonlySet<string>): boolean {
+  const normalized = value.trim().replace(/^<|>$/g, "");
+  if (!normalized) {
+    return false;
+  }
+  if (imageUrls.has(normalized)) {
+    return true;
+  }
+  if (/^data:image\//i.test(normalized)) {
+    return true;
+  }
+  try {
+    const parsed = new URL(normalized, "https://openclaw.invalid");
+    const href = parsed.href;
+    if (imageUrls.has(href)) {
       return true;
     }
-    if (normalized !== "application/octet-stream") {
-      return false;
+    const pathname = parsed.pathname.toLowerCase();
+    if (/\.(avif|bmp|gif|ico|jpe?g|png|svg|webp)$/i.test(pathname)) {
+      return true;
+    }
+    if (/\/api\/chat\/media\/outgoing\/.+\/full$/.test(pathname)) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function hasMeaningfulMarkdownText(markdown: string, images: readonly ImageBlock[]): boolean {
+  const imageUrls = new Set<string>();
+  for (const image of images) {
+    imageUrls.add(image.url);
+    if (image.openUrl) {
+      imageUrls.add(image.openUrl);
     }
   }
-  const ext = getFileExtension(path);
-  return (
-    ext !== undefined &&
-    ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "heic", "heif", "avif"].includes(ext)
+
+  let stripped = markdown;
+  stripped = stripped.replace(
+    /!\[[^\]]*\]\((<[^>]+>|[^)\s]+)(?:\s+["'][^"']*["'])?\)/g,
+    (match, rawTarget: string) =>
+      isImageOnlyUrlToken(normalizeMarkdownLinkTarget(rawTarget), imageUrls) ? " " : match,
   );
+  stripped = stripped.replace(/<img\b[^>]*\bsrc=(['"])(.*?)\1[^>]*>/gi, (match, _quote, src) =>
+    isImageOnlyUrlToken(src, imageUrls) ? " " : match,
+  );
+  stripped = stripped.replace(
+    /(^|\s)(<https?:[^>\s]+>|https?:\/\/\S+|data:image\/\S+)/gi,
+    (match, prefix: string, rawUrl: string) =>
+      isImageOnlyUrlToken(rawUrl, imageUrls) ? `${prefix} ` : match,
+  );
+
+  return stripped.trim().length > 0;
+}
+
+function normalizePositiveDimension(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.max(1, Math.round(value));
+}
+
+function imageDisplayStyle(img: ImageBlock): string {
+  const width = normalizePositiveDimension(img.width);
+  const height = normalizePositiveDimension(img.height);
+  const styles = [
+    `--chat-message-image-default-width: ${DEFAULT_INLINE_IMAGE_PREVIEW_MAX_WIDTH}`,
+    `--chat-message-image-default-height: ${DEFAULT_INLINE_IMAGE_PREVIEW_MAX_HEIGHT}`,
+  ];
+  if (width && height) {
+    styles.push(`--chat-message-image-width: ${width}`);
+    styles.push(`--chat-message-image-height: ${height}`);
+  }
+  return `${styles.join("; ")};`;
+}
+
+function isImageLikeLegacyMediaPath(value: string, mediaType?: unknown): boolean {
+  if (typeof mediaType === "string" && mediaType.toLowerCase().startsWith("image/")) {
+    return true;
+  }
+  if (/^data:image\//i.test(value)) {
+    return true;
+  }
+  try {
+    const parsed = new URL(value, "https://openclaw.invalid");
+    const pathname = parsed.pathname.toLowerCase();
+    return /\.(avif|bmp|gif|heic|heif|ico|jpe?g|png|svg|webp)$/i.test(pathname);
+  } catch {
+    return false;
+  }
 }
 
 function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
   const images: ImageBlock[] = [];
+  const seen = new Set<string>();
+  const pushImage = (image: ImageBlock) => {
+    const key = `${image.url}\u0000${image.openUrl ?? ""}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    images.push(image);
+  };
 
   if (Array.isArray(content)) {
     for (const block of content) {
@@ -129,64 +194,109 @@ function extractImages(message: unknown): ImageBlock[] {
         // Handle source object format (from sendChatMessage)
         const source = b.source as Record<string, unknown> | undefined;
         if (source?.type === "base64" && typeof source.data === "string") {
-          appendImageBlock(images, {
-            url: buildBase64ImageUrl({
-              data: source.data,
-              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
-            }),
-          });
+          const data = source.data;
+          const mediaType = (source.media_type as string) || "image/png";
+          // If data is already a data URL, use it directly
+          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+          pushImage({ url });
         } else if (typeof b.url === "string") {
-          appendImageBlock(images, { url: b.url });
+          pushImage({
+            url: b.url,
+            openUrl: typeof b.openUrl === "string" ? b.openUrl : undefined,
+            alt: typeof b.alt === "string" ? b.alt : undefined,
+            width: normalizePositiveDimension(b.width),
+            height: normalizePositiveDimension(b.height),
+          });
         }
       } else if (b.type === "image_url") {
         // OpenAI format
         const imageUrl = b.image_url as Record<string, unknown> | undefined;
         if (typeof imageUrl?.url === "string") {
-          appendImageBlock(images, { url: imageUrl.url });
+          pushImage({ url: imageUrl.url });
         }
       } else if (b.type === "input_image") {
         const imageUrl = b.image_url;
         if (typeof imageUrl === "string") {
-          appendImageBlock(images, { url: imageUrl });
+          pushImage({ url: imageUrl });
         } else if (imageUrl && typeof imageUrl === "object") {
           const url = (imageUrl as Record<string, unknown>).url;
           if (typeof url === "string") {
-            appendImageBlock(images, { url });
+            pushImage({ url });
           }
         }
         const source = b.source as Record<string, unknown> | undefined;
         if (typeof source?.url === "string") {
-          appendImageBlock(images, { url: source.url });
+          pushImage({ url: source.url });
         } else if (typeof source?.data === "string") {
-          appendImageBlock(images, {
-            url: buildBase64ImageUrl({
-              data: source.data,
-              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
-            }),
-          });
+          const data = source.data;
+          const mediaType = (source.media_type as string) || "image/png";
+          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+          pushImage({ url });
         }
       }
     }
   }
 
-  const transcriptMediaPaths = Array.isArray(m.MediaPaths)
-    ? m.MediaPaths.filter((value): value is string => typeof value === "string")
-    : typeof m.MediaPath === "string"
-      ? [m.MediaPath]
-      : [];
-  const transcriptMediaTypes = Array.isArray(m.MediaTypes)
-    ? m.MediaTypes
-    : typeof m.MediaType === "string"
-      ? [m.MediaType]
-      : [];
-  for (const [index, mediaPath] of transcriptMediaPaths.entries()) {
-    if (!isImageTranscriptMediaPath(mediaPath, transcriptMediaTypes[index])) {
-      continue;
+  const mediaPath = m.MediaPath;
+  if (
+    typeof mediaPath === "string" &&
+    mediaPath.trim() &&
+    isImageLikeLegacyMediaPath(mediaPath, m.MediaType)
+  ) {
+    pushImage({ url: mediaPath });
+  }
+  const mediaPaths = m.MediaPaths;
+  const mediaTypes = Array.isArray(m.MediaTypes) ? m.MediaTypes : [];
+  if (Array.isArray(mediaPaths)) {
+    for (const [index, candidate] of mediaPaths.entries()) {
+      if (
+        typeof candidate === "string" &&
+        candidate.trim() &&
+        isImageLikeLegacyMediaPath(candidate, mediaTypes[index])
+      ) {
+        pushImage({ url: candidate });
+      }
     }
-    appendImageBlock(images, { url: mediaPath });
   }
 
   return images;
+}
+
+function preferTextBeforeImages(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  let firstTextIndex = Number.POSITIVE_INFINITY;
+  let firstImageIndex = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const block = content[index];
+    if (typeof block !== "object" || block === null) {
+      continue;
+    }
+    const candidate = block as Record<string, unknown>;
+    if (
+      firstTextIndex === Number.POSITIVE_INFINITY &&
+      candidate.type === "text" &&
+      typeof candidate.text === "string" &&
+      candidate.text.trim()
+    ) {
+      firstTextIndex = index;
+    }
+    if (
+      firstImageIndex === Number.POSITIVE_INFINITY &&
+      (candidate.type === "image" || candidate.type === "image_url")
+    ) {
+      firstImageIndex = index;
+    }
+  }
+
+  return firstTextIndex < firstImageIndex;
 }
 
 export function renderReadingIndicatorGroup(
@@ -196,7 +306,7 @@ export function renderReadingIndicatorGroup(
 ) {
   return html`
     <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, undefined, basePath, authToken)}
+      ${renderAvatar("assistant", assistant, basePath, authToken)}
       <div class="chat-group-messages">
         <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
           <span class="chat-reading-indicator__dots">
@@ -224,7 +334,7 @@ export function renderStreamingGroup(
 
   return html`
     <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, undefined, basePath, authToken)}
+      ${renderAvatar("assistant", assistant, basePath, authToken)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
           {
@@ -233,7 +343,7 @@ export function renderStreamingGroup(
             timestamp: startedAt,
           },
           `stream:${startedAt}`,
-          { isStreaming: true, showReasoning: false },
+          { isStreaming: true, showReasoning: false, basePath },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">
@@ -259,28 +369,25 @@ export function renderMessageGroup(
     onRequestUpdate?: () => void;
     assistantName?: string;
     assistantAvatar?: string | null;
-    userName?: string | null;
-    userAvatar?: string | null;
     basePath?: string;
     localMediaPreviewRoots?: readonly string[];
     assistantAttachmentAuthToken?: string | null;
     canvasHostUrl?: string | null;
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    onMediaLoad?: () => void;
     contextWindow?: number | null;
     onDelete?: () => void;
   },
 ) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
   const assistantName = opts.assistantName ?? "Assistant";
-  const resolvedUserName = resolveLocalUserName({
-    name: opts.userName ?? null,
-    avatar: opts.userAvatar ?? null,
-  });
   const userLabel = group.senderLabel?.trim();
   const who =
     normalizedRole === "user"
-      ? (userLabel ?? resolvedUserName)
+      ? (userLabel ?? "You")
       : normalizedRole === "assistant"
         ? assistantName
         : normalizedRole === "tool"
@@ -310,10 +417,6 @@ export function renderMessageGroup(
           name: assistantName,
           avatar: opts.assistantAvatar ?? null,
         },
-        {
-          name: opts.userName ?? null,
-          avatar: opts.userAvatar ?? null,
-        },
         opts.basePath,
         opts.assistantAttachmentAuthToken,
       )}
@@ -337,6 +440,9 @@ export function renderMessageGroup(
               localMediaPreviewRoots: opts.localMediaPreviewRoots,
               assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
               embedSandboxMode: opts.embedSandboxMode,
+              authHeader: opts.authHeader,
+              requesterSessionKey: opts.requesterSessionKey,
+              onMediaLoad: opts.onMediaLoad,
             },
             opts.onOpenSidebar,
           ),
@@ -606,16 +712,12 @@ function renderTtsButton(group: MessageGroup) {
 function renderAvatar(
   role: string,
   assistant?: Pick<AssistantIdentity, "name" | "avatar">,
-  user?: { name?: string | null; avatar?: string | null },
   basePath?: string,
   authToken?: string | null,
 ) {
   const normalized = normalizeRoleForGrouping(role);
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
-  const userName = resolveLocalUserName(user);
-  const userAvatarUrl = resolveLocalUserAvatarUrl(user);
-  const userAvatarText = resolveLocalUserAvatarText(user);
   const initial =
     normalized === "user"
       ? html`
@@ -662,16 +764,6 @@ function renderAvatar(
           ? "tool"
           : "other";
 
-  if (normalized === "user" && userAvatarUrl) {
-    return html`<img class="chat-avatar ${className}" src="${userAvatarUrl}" alt="${userName}" />`;
-  }
-
-  if (normalized === "user" && userAvatarText) {
-    return html`<div class="chat-avatar ${className}" aria-label="${userName}">
-      ${userAvatarText}
-    </div>`;
-  }
-
   if (assistantAvatar && normalized === "assistant") {
     if (isAvatarUrl(assistantAvatar)) {
       if (authToken?.trim() && assistantAvatar.startsWith("/")) {
@@ -711,45 +803,619 @@ function isAvatarUrl(value: string): boolean {
   return isRenderableControlUiAvatarUrl(value);
 }
 
-function resolveRenderableMessageImages(
-  images: ImageBlock[],
-  opts?: ImageRenderOptions,
-): RenderableImageBlock[] {
-  return images.flatMap((img) => {
-    const isLocalImage = isLocalAssistantAttachmentSource(img.url);
-    const canProxyLocalImage =
-      isLocalImage && isLocalAttachmentPreviewAllowed(img.url, opts?.localMediaPreviewRoots ?? []);
-    if (isLocalImage && !canProxyLocalImage) {
-      return [];
-    }
-    const displayUrl = canProxyLocalImage
-      ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
-      : img.url;
-    return [{ ...img, displayUrl }];
+const managedImageBlobUrlCache = new Map<string, Promise<string | null>>();
+const managedImageBlobUrlResolvedCache = new Map<string, string>();
+const managedImageBlobUrlMissCache = new Map<string, number>();
+const MANAGED_IMAGE_FETCH_RETRY_DELAYS_MS = [0, 75, 200, 500] as const;
+const MANAGED_IMAGE_FETCH_MISS_TTL_MS = 10_000;
+const IMAGE_ACTION_COPIED_FEEDBACK_MS = 1_500;
+const imageActionFeedbackTimers = new WeakMap<HTMLButtonElement, number>();
+const MANAGED_IMAGE_PREVIEW_SELECTOR = ".chat-message-image";
+
+function buildManagedImageFetchCacheKey(
+  url: string,
+  authHeader?: string,
+  requesterSessionKey?: string,
+) {
+  return JSON.stringify([url, authHeader ?? null, requesterSessionKey ?? null]);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveBaseHref(basePath?: string): string {
+  return basePath
+    ? new URL(basePath.endsWith("/") ? basePath : `${basePath}/`, window.location.href).toString()
+    : window.location.href;
+}
+
+function resolveImageDisplayUrl(
+  rawUrl: string | null | undefined,
+  opts: { basePath?: string; assistantAttachmentAuthToken?: string | null },
+): string | null {
+  if (!rawUrl) {
+    return null;
+  }
+  if (isLocalAssistantAttachmentSource(rawUrl)) {
+    return buildAssistantAttachmentUrl(rawUrl, opts.basePath, opts.assistantAttachmentAuthToken);
+  }
+  return resolveSafeExternalUrl(rawUrl, resolveBaseHref(opts.basePath), {
+    allowDataImage: true,
   });
 }
 
-function renderMessageImages(images: RenderableImageBlock[]) {
+function resolveManagedImageUrl(
+  rawUrl: string | null | undefined,
+  opts: { basePath?: string; authHeader?: string; allowDataImage?: boolean },
+): string | null {
+  if (!rawUrl) {
+    return null;
+  }
+  const mountedBaseHref = opts.basePath ? resolveBaseHref(opts.basePath) : null;
+  const baseHref = mountedBaseHref ?? window.location.href;
+  const safeUrl = resolveSafeExternalUrl(rawUrl, baseHref, {
+    allowDataImage: opts.allowDataImage ?? true,
+  });
+  if (!safeUrl || safeUrl.startsWith("data:") || safeUrl.startsWith("blob:")) {
+    return null;
+  }
+  try {
+    const parsed = new URL(safeUrl, window.location.href);
+    if (parsed.origin !== window.location.origin) {
+      return null;
+    }
+    const allowedPathPrefixes = ["/api/chat/media/outgoing/"];
+    if (mountedBaseHref) {
+      const mountedBasePath = new URL(mountedBaseHref).pathname.replace(/\/+$/, "");
+      if (mountedBasePath) {
+        allowedPathPrefixes.push(`${mountedBasePath}/api/chat/media/outgoing/`);
+      }
+    }
+    if (!allowedPathPrefixes.some((prefix) => parsed.pathname.startsWith(prefix))) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchManagedImageBlob(
+  url: string,
+  authHeader?: string,
+  opts?: { bypassMissCache?: boolean; requesterSessionKey?: string },
+): Promise<Blob | null> {
+  const cacheKey = buildManagedImageFetchCacheKey(url, authHeader, opts?.requesterSessionKey);
+  const bypassMissCache = opts?.bypassMissCache === true;
+  if (!bypassMissCache) {
+    const missUntil = managedImageBlobUrlMissCache.get(cacheKey);
+    if (typeof missUntil === "number" && missUntil > Date.now()) {
+      return null;
+    }
+  }
+
+  for (let index = 0; index < MANAGED_IMAGE_FETCH_RETRY_DELAYS_MS.length; index += 1) {
+    const delayMs = MANAGED_IMAGE_FETCH_RETRY_DELAYS_MS[index];
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+    try {
+      const headers: Record<string, string> = {};
+      if (authHeader) {
+        headers.Authorization = authHeader;
+      }
+      if (opts?.requesterSessionKey) {
+        headers["x-openclaw-requester-session-key"] = opts.requesterSessionKey;
+      }
+      const response = await fetch(url, {
+        credentials: "same-origin",
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
+      });
+      if (response.ok) {
+        managedImageBlobUrlMissCache.delete(cacheKey);
+        return await response.blob();
+      }
+      if (response.status !== 404) {
+        managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
+        return null;
+      }
+    } catch {
+      managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
+      return null;
+    }
+  }
+  managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
+  return null;
+}
+
+async function fetchManagedImageBlobUrl(
+  url: string,
+  authHeader?: string,
+  opts?: { bypassMissCache?: boolean; requesterSessionKey?: string },
+): Promise<string | null> {
+  const cacheKey = buildManagedImageFetchCacheKey(url, authHeader, opts?.requesterSessionKey);
+  const resolved = managedImageBlobUrlResolvedCache.get(cacheKey);
+  if (typeof resolved === "string" && resolved.length > 0) {
+    return resolved;
+  }
+
+  const bypassMissCache = opts?.bypassMissCache === true;
+  if (!bypassMissCache) {
+    const missUntil = managedImageBlobUrlMissCache.get(cacheKey);
+    if (typeof missUntil === "number" && missUntil > Date.now()) {
+      return null;
+    }
+  }
+
+  let pending = managedImageBlobUrlCache.get(cacheKey);
+  if (!pending) {
+    pending = (async () => {
+      const blob = await fetchManagedImageBlob(url, authHeader, opts);
+      if (!blob) {
+        return null;
+      }
+      const blobUrl = URL.createObjectURL(blob);
+      managedImageBlobUrlResolvedCache.set(cacheKey, blobUrl);
+      return blobUrl;
+    })();
+    managedImageBlobUrlCache.set(cacheKey, pending);
+    void pending.then(
+      () => {
+        managedImageBlobUrlCache.delete(cacheKey);
+      },
+      () => {
+        managedImageBlobUrlCache.delete(cacheKey);
+      },
+    );
+  }
+  return pending;
+}
+
+async function fetchImageBlob(
+  rawUrl: string,
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    assistantAttachmentAuthToken?: string | null;
+  },
+): Promise<Blob | null> {
+  const managedUrl = resolveManagedImageUrl(rawUrl, {
+    basePath: opts.basePath,
+    authHeader: opts.authHeader,
+    allowDataImage: true,
+  });
+  if (managedUrl) {
+    return fetchManagedImageBlob(managedUrl, opts.authHeader, {
+      bypassMissCache: true,
+      requesterSessionKey: opts.requesterSessionKey,
+    });
+  }
+
+  const safeUrl = resolveImageDisplayUrl(rawUrl, {
+    basePath: opts.basePath,
+    assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+  });
+  if (!safeUrl) {
+    return null;
+  }
+  try {
+    const response = await fetch(safeUrl);
+    if (!response.ok) {
+      return null;
+    }
+    return await response.blob();
+  } catch {
+    return null;
+  }
+}
+
+function showCopiedImageActionFeedback(button: HTMLButtonElement): void {
+  button.dataset.state = "copied";
+  const priorTimer = imageActionFeedbackTimers.get(button);
+  if (typeof priorTimer === "number") {
+    window.clearTimeout(priorTimer);
+  }
+  const timer = window.setTimeout(() => {
+    delete button.dataset.state;
+    imageActionFeedbackTimers.delete(button);
+  }, IMAGE_ACTION_COPIED_FEEDBACK_MS);
+  imageActionFeedbackTimers.set(button, timer);
+}
+
+async function cloneBlobForClipboard(blob: Blob, mimeType: string): Promise<Blob> {
+  try {
+    const bytes = await blob.arrayBuffer();
+    return new Blob([bytes], { type: mimeType });
+  } catch {
+    return blob;
+  }
+}
+
+async function rasterizeBlobToPng(blob: Blob): Promise<Blob | null> {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image();
+      img.addEventListener("load", () => resolve(img), { once: true });
+      img.addEventListener("error", () => reject(new Error("image load failed")), { once: true });
+      img.src = objectUrl;
+    });
+    const canvas = document.createElement("canvas");
+    const width = Math.max(1, image.naturalWidth || image.width || 1);
+    const height = Math.max(1, image.naturalHeight || image.height || 1);
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return null;
+    }
+    context.drawImage(image, 0, 0, width, height);
+    return await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((pngBlob) => resolve(pngBlob), "image/png");
+    });
+  } catch {
+    return null;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+async function prepareClipboardImageBlob(blob: Blob): Promise<Blob> {
+  if (blob.type === "image/png") {
+    return cloneBlobForClipboard(blob, "image/png");
+  }
+  if (blob.type?.startsWith("image/")) {
+    const pngBlob = await rasterizeBlobToPng(blob);
+    if (pngBlob) {
+      return cloneBlobForClipboard(pngBlob, "image/png");
+    }
+  }
+  throw new Error("unsupported clipboard image type");
+}
+
+async function copyImageUrl(
+  rawUrl: string,
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    assistantAttachmentAuthToken?: string | null;
+  },
+): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    return false;
+  }
+
+  const ClipboardItemCtor = globalThis.ClipboardItem as
+    | (new (items: Record<string, Blob | Promise<Blob>>) => ClipboardItem)
+    | undefined;
+  if (typeof navigator.clipboard.write !== "function" || !ClipboardItemCtor) {
+    return false;
+  }
+
+  const clipboardBlobPromise = (async () => {
+    const blob = await fetchImageBlob(rawUrl, opts);
+    if (!blob) {
+      throw new Error("image fetch failed");
+    }
+    return prepareClipboardImageBlob(blob);
+  })();
+  try {
+    await navigator.clipboard.write([new ClipboardItemCtor({ "image/png": clipboardBlobPromise })]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function cleanupUnusedManagedImagePreviewBlobUrls(
+  root: ParentNode,
+  options?: { revokeActive?: boolean },
+): void {
+  const activeBlobUrls = new Set(
+    Array.from(root.querySelectorAll<HTMLImageElement>(MANAGED_IMAGE_PREVIEW_SELECTOR))
+      .map((image) => image.currentSrc || image.src || "")
+      .filter((src) => typeof src === "string" && src.startsWith("blob:")),
+  );
+  for (const [cacheKey, blobUrl] of managedImageBlobUrlResolvedCache.entries()) {
+    if (options?.revokeActive || !activeBlobUrls.has(blobUrl)) {
+      URL.revokeObjectURL(blobUrl);
+      managedImageBlobUrlResolvedCache.delete(cacheKey);
+    }
+  }
+}
+
+async function fetchManagedPreviewBlobUrl(
+  rawUrl: string | null | undefined,
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    fallbackRawUrl?: string;
+    assistantAttachmentAuthToken?: string | null;
+  },
+): Promise<string | null> {
+  if (!rawUrl) {
+    return null;
+  }
+  const managedUrl = resolveManagedImageUrl(rawUrl, {
+    basePath: opts.basePath,
+    authHeader: opts.authHeader,
+    allowDataImage: true,
+  });
+  if (managedUrl) {
+    const primary = await fetchManagedImageBlobUrl(managedUrl, opts.authHeader, {
+      requesterSessionKey: opts.requesterSessionKey,
+    });
+    if (primary) {
+      return primary;
+    }
+    if (opts.fallbackRawUrl) {
+      const fallbackManagedUrl = resolveManagedImageUrl(opts.fallbackRawUrl, {
+        basePath: opts.basePath,
+        authHeader: opts.authHeader,
+        allowDataImage: true,
+      });
+      if (fallbackManagedUrl && fallbackManagedUrl !== managedUrl) {
+        const fallback = await fetchManagedImageBlobUrl(fallbackManagedUrl, opts.authHeader, {
+          requesterSessionKey: opts.requesterSessionKey,
+        });
+        if (fallback) {
+          return fallback;
+        }
+      }
+    }
+    return null;
+  }
+  return resolveImageDisplayUrl(rawUrl, {
+    basePath: opts.basePath,
+    assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+  });
+}
+
+function resolveManagedPreviewSource(
+  rawUrl: string | null | undefined,
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    fallbackRawUrl?: string;
+    assistantAttachmentAuthToken?: string | null;
+  },
+): string | Promise<string | null> | null {
+  if (!rawUrl) {
+    return null;
+  }
+  const managedUrl = resolveManagedImageUrl(rawUrl, {
+    basePath: opts.basePath,
+    authHeader: opts.authHeader,
+    allowDataImage: true,
+  });
+  if (!managedUrl) {
+    return resolveImageDisplayUrl(rawUrl, {
+      basePath: opts.basePath,
+      assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+    });
+  }
+
+  const resolvedPrimary = managedImageBlobUrlResolvedCache.get(
+    buildManagedImageFetchCacheKey(managedUrl, opts.authHeader, opts.requesterSessionKey),
+  );
+  if (typeof resolvedPrimary === "string" && resolvedPrimary.length > 0) {
+    return resolvedPrimary;
+  }
+
+  if (opts.fallbackRawUrl) {
+    const fallbackManagedUrl = resolveManagedImageUrl(opts.fallbackRawUrl, {
+      basePath: opts.basePath,
+      authHeader: opts.authHeader,
+      allowDataImage: true,
+    });
+    if (fallbackManagedUrl && fallbackManagedUrl !== managedUrl) {
+      const resolvedFallback = managedImageBlobUrlResolvedCache.get(
+        buildManagedImageFetchCacheKey(
+          fallbackManagedUrl,
+          opts.authHeader,
+          opts.requesterSessionKey,
+        ),
+      );
+      if (typeof resolvedFallback === "string" && resolvedFallback.length > 0) {
+        return resolvedFallback;
+      }
+    }
+  }
+
+  return fetchManagedPreviewBlobUrl(rawUrl, opts);
+}
+
+async function openImageUrl(
+  rawUrl: string,
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    assistantAttachmentAuthToken?: string | null;
+  },
+): Promise<void> {
+  const managedUrl = resolveManagedImageUrl(rawUrl, {
+    basePath: opts.basePath,
+    authHeader: opts.authHeader,
+    allowDataImage: true,
+  });
+  if (managedUrl) {
+    const blobUrl = await fetchManagedImageBlobUrl(managedUrl, opts.authHeader, {
+      bypassMissCache: true,
+      requesterSessionKey: opts.requesterSessionKey,
+    });
+    if (blobUrl) {
+      const opened = openExternalUrlSafe(blobUrl);
+      if (!opened) {
+        const link = document.createElement("a");
+        link.href = blobUrl;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.click();
+      }
+      return;
+    }
+  }
+  const safeUrl = resolveImageDisplayUrl(rawUrl, {
+    basePath: opts.basePath,
+    assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+  });
+  if (!safeUrl) {
+    return;
+  }
+  openExternalUrlSafe(safeUrl, {
+    baseHref: resolveBaseHref(opts.basePath),
+    allowDataImage: true,
+  });
+}
+
+function resolveRenderableMessageImages(
+  images: ImageBlock[],
+  opts: {
+    basePath?: string;
+    localMediaPreviewRoots?: readonly string[];
+    assistantAttachmentAuthToken?: string | null;
+  },
+): RenderableImageBlock[] {
+  const renderable: RenderableImageBlock[] = [];
+  for (const image of images) {
+    if (isLocalAssistantAttachmentSource(image.url)) {
+      if (!isLocalAttachmentPreviewAllowed(image.url, opts.localMediaPreviewRoots ?? [])) {
+        continue;
+      }
+      renderable.push({
+        ...image,
+        previewUrl: image.url,
+      });
+      continue;
+    }
+    renderable.push({ ...image, previewUrl: image.url });
+  }
+  return renderable;
+}
+
+function renderMessageImages(
+  images: RenderableImageBlock[],
+  opts: {
+    basePath?: string;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    assistantAttachmentAuthToken?: string | null;
+    onMediaLoad?: () => void;
+  },
+) {
   if (images.length === 0) {
     return nothing;
   }
 
-  const openImage = (url: string) => {
-    openExternalUrlSafe(url, { allowDataImage: true });
+  const openImage = (img: ImageBlock) => {
+    void openImageUrl(img.openUrl ?? img.url, {
+      basePath: opts.basePath,
+      authHeader: opts.authHeader,
+      requesterSessionKey: opts.requesterSessionKey,
+      assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+    });
+  };
+  const copyImage = (img: ImageBlock, button: HTMLButtonElement | null) => {
+    if (!button) {
+      return;
+    }
+    const copySource = img.openUrl ?? img.url;
+    void copyImageUrl(copySource, {
+      basePath: opts.basePath,
+      authHeader: opts.authHeader,
+      requesterSessionKey: opts.requesterSessionKey,
+      assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+    })
+      .then((copied) => {
+        if (copied) {
+          showCopiedImageActionFeedback(button);
+        }
+      })
+      .catch(() => {});
+  };
+
+  const renderImageFrameContent = (img: ImageBlock, resolvedPreviewSrc: string | null) => {
+    if (!resolvedPreviewSrc) {
+      return html`<div class="chat-message-image-unavailable" role="status">
+        Image unavailable
+      </div>`;
+    }
+    return html`
+      <img
+        src=${resolvedPreviewSrc}
+        alt=${img.alt?.trim() || "Attached image"}
+        class="chat-message-image"
+        loading="lazy"
+        decoding="async"
+        @load=${() => opts.onMediaLoad?.()}
+        @click=${() => openImage(img)}
+      />
+      <div class="chat-message-image-overlay">
+        <button
+          type="button"
+          class="chat-message-image-action chat-message-image-copy"
+          title="copy image"
+          aria-label="copy image"
+          @click=${(event: Event) =>
+            copyImage(img, event.currentTarget as HTMLButtonElement | null)}
+        >
+          <span class="chat-message-image-action__icon chat-message-image-action__icon--copy"
+            >${icons.copy}</span
+          >
+          <span class="chat-message-image-action__icon chat-message-image-action__icon--check"
+            >${icons.check}</span
+          >
+        </button>
+        <button
+          type="button"
+          class="chat-message-image-action chat-message-image-open"
+          title="open"
+          aria-label="open"
+          @click=${() => openImage(img)}
+        >
+          ${icons.externalLink}
+        </button>
+      </div>
+    `;
   };
 
   return html`
     <div class="chat-message-images">
-      ${images.map(
-        (img) => html`
-          <img
-            src=${img.displayUrl}
-            alt=${img.alt ?? "Attached image"}
-            class="chat-message-image"
-            @click=${() => openImage(img.displayUrl)}
-          />
-        `,
-      )}
+      ${images.map((img) => {
+        const previewSrc = resolveManagedPreviewSource(img.previewUrl, {
+          basePath: opts.basePath,
+          authHeader: opts.authHeader,
+          requesterSessionKey: opts.requesterSessionKey,
+          fallbackRawUrl: img.openUrl ?? img.url,
+          assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+        });
+        const displayStyle = imageDisplayStyle(img);
+        return html`
+          <div class="chat-message-image-card" style=${displayStyle}>
+            <div class="chat-message-image-frame">
+              ${typeof previewSrc === "string"
+                ? renderImageFrameContent(img, previewSrc)
+                : previewSrc
+                  ? until(
+                      previewSrc.then((resolvedPreviewSrc) =>
+                        renderImageFrameContent(img, resolvedPreviewSrc),
+                      ),
+                      nothing,
+                    )
+                  : renderImageFrameContent(img, null)}
+            </div>
+          </div>
+        `;
+      })}
     </div>
   `;
 }
@@ -897,6 +1563,9 @@ function resolveAssistantAttachmentAvailability(
 ): AssistantAttachmentAvailability {
   if (!isLocalAssistantAttachmentSource(source)) {
     return { status: "available" };
+  }
+  if (localMediaPreviewRoots.length === 0) {
+    return { status: "checking" };
   }
   if (!isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)) {
     return { status: "unavailable", reason: "Outside allowed folders", checkedAt: Date.now() };
@@ -1201,6 +1870,9 @@ function renderGroupedMessage(
     assistantAttachmentAuthToken?: string | null;
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
+    authHeader?: string;
+    requesterSessionKey?: string;
+    onMediaLoad?: () => void;
   },
   onOpenSidebar?: (content: SidebarContent) => void,
 ) {
@@ -1216,13 +1888,13 @@ function renderGroupedMessage(
 
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCards(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
-  const imageRenderOptions = {
-    localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
+  const images = extractImages(message);
+  const renderableImages = resolveRenderableMessageImages(images, {
     basePath: opts.basePath,
-    authToken: opts.assistantAttachmentAuthToken,
-  };
-  const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
-  const hasImages = images.length > 0;
+    localMediaPreviewRoots: opts.localMediaPreviewRoots,
+    assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+  });
+  const hasImages = renderableImages.length > 0;
 
   const normalizedMessage = normalizeMessage(message);
   const extractedText = normalizedMessage.content
@@ -1246,13 +1918,25 @@ function renderGroupedMessage(
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
-  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
-  const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const textBeforeImages = hasImages && Boolean(markdown) && preferTextBeforeImages(message);
+  const hasActionableMarkdown = Boolean(
+    markdown?.trim() && (!hasImages || hasMeaningfulMarkdownText(markdown, renderableImages)),
+  );
+  const canCopyMarkdown = role === "assistant" && hasActionableMarkdown;
+  const canExpand = role === "assistant" && Boolean(onOpenSidebar && hasActionableMarkdown);
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
+  const hasActions = canCopyMarkdown || canExpand;
 
-  const bubbleClasses = ["chat-bubble", opts.isStreaming ? "streaming" : "", "fade-in"]
+  const bubbleClasses = [
+    "chat-bubble",
+    opts.isStreaming ? "streaming" : "",
+    "fade-in",
+    canCopyMarkdown ? "has-copy" : "",
+    hasActions ? "has-bubble-actions" : "",
+    hasImages ? "has-images" : "",
+  ]
     .filter(Boolean)
     .join(" ");
 
@@ -1286,8 +1970,37 @@ function renderGroupedMessage(
         ? "Tool output"
         : "Tool call"
       : "Tool output";
-
-  const hasActions = canCopyMarkdown || canExpand;
+  const renderedTextualContent = html`
+    ${reasoningMarkdown
+      ? html`<div class="chat-thinking">
+          ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+        </div>`
+      : nothing}
+    ${jsonResult
+      ? html`<details class="chat-json-collapse" ?open=${Boolean(opts.autoExpandToolCalls)}>
+          <summary class="chat-json-summary">
+            <span class="chat-json-badge">JSON</span>
+            <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
+          </summary>
+          <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+        </details>`
+      : markdown
+        ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+            ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+          </div>`
+        : nothing}
+  `;
+  const renderedImages = renderMessageImages(renderableImages, {
+    basePath: opts.basePath,
+    authHeader: opts.authHeader,
+    requesterSessionKey: opts.requesterSessionKey,
+    assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
+    onMediaLoad: opts.onMediaLoad,
+  });
+  const renderedOrderedContent = html`
+    ${textBeforeImages ? renderedTextualContent : renderedImages}
+    ${textBeforeImages ? renderedImages : renderedTextualContent}
+  `;
 
   return html`
     <div class="${bubbleClasses}">
@@ -1322,7 +2035,7 @@ function renderGroupedMessage(
               ${toolMessageExpanded
                 ? html`
                     <div class="chat-tool-msg-body">
-                      ${renderMessageImages(images)}
+                      ${renderedOrderedContent}
                       ${renderAssistantAttachments(
                         assistantAttachments,
                         opts.localMediaPreviewRoots ?? [],
@@ -1330,29 +2043,6 @@ function renderGroupedMessage(
                         opts.assistantAttachmentAuthToken,
                         opts.onRequestUpdate,
                       )}
-                      ${reasoningMarkdown
-                        ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                          </div>`
-                        : nothing}
-                      ${jsonResult
-                        ? html`<details
-                            class="chat-json-collapse"
-                            ?open=${Boolean(opts.autoExpandToolCalls)}
-                          >
-                            <summary class="chat-json-summary">
-                              <span class="chat-json-badge">JSON</span>
-                              <span class="chat-json-label"
-                                >${jsonSummaryLabel(jsonResult.parsed)}</span
-                              >
-                            </summary>
-                            <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                          </details>`
-                        : markdown
-                          ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                              ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
-                            </div>`
-                          : nothing}
                       ${hasToolCards
                         ? singleToolCard && !markdown && !hasImages
                           ? renderExpandedToolCardContent(
@@ -1378,7 +2068,7 @@ function renderGroupedMessage(
             </div>
           `
         : html`
-            ${renderMessageImages(images)}
+            ${renderedOrderedContent}
             ${renderAssistantAttachments(
               assistantAttachments,
               opts.localMediaPreviewRoots ?? [],
@@ -1386,11 +2076,6 @@ function renderGroupedMessage(
               opts.assistantAttachmentAuthToken,
               opts.onRequestUpdate,
             )}
-            ${reasoningMarkdown
-              ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                </div>`
-              : nothing}
             ${normalizedRole === "assistant" && assistantViewBlocks.length > 0
               ? html`${assistantViewBlocks.map(
                   (block) => html`${renderToolPreview(block.preview, "chat_message", {
@@ -1402,19 +2087,6 @@ function renderGroupedMessage(
                   ${block.rawText ? renderRawOutputToggle(block.rawText) : nothing}`,
                 )}`
               : nothing}
-            ${jsonResult
-              ? html`<details class="chat-json-collapse">
-                  <summary class="chat-json-summary">
-                    <span class="chat-json-badge">JSON</span>
-                    <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
-                  </summary>
-                  <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                </details>`
-              : markdown
-                ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
-                  </div>`
-                : nothing}
             ${hasToolCards
               ? renderInlineToolCards(toolCards, {
                   messageKey,

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -46,6 +46,12 @@ const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 
 export function resetAssistantAttachmentAvailabilityCacheForTest() {
   assistantAttachmentAvailabilityCache.clear();
+  for (const blobUrl of managedImageBlobUrlResolvedCache.values()) {
+    URL.revokeObjectURL(blobUrl);
+  }
+  managedImageBlobUrlCache.clear();
+  managedImageBlobUrlResolvedCache.clear();
+  managedImageBlobUrlMissCache.clear();
 }
 
 type ImageBlock = {
@@ -376,6 +382,7 @@ export function renderMessageGroup(
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     onMediaLoad?: () => void;
     contextWindow?: number | null;
@@ -441,6 +448,7 @@ export function renderMessageGroup(
               assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
               embedSandboxMode: opts.embedSandboxMode,
               authHeader: opts.authHeader,
+              authHeaders: opts.authHeaders,
               requesterSessionKey: opts.requesterSessionKey,
               onMediaLoad: opts.onMediaLoad,
             },
@@ -814,10 +822,25 @@ const MANAGED_IMAGE_PREVIEW_SELECTOR = ".chat-message-image";
 
 function buildManagedImageFetchCacheKey(
   url: string,
-  authHeader?: string,
+  authHeaderOrHeaders?: string | readonly string[],
   requesterSessionKey?: string,
 ) {
-  return JSON.stringify([url, authHeader ?? null, requesterSessionKey ?? null]);
+  const authHeaders = Array.isArray(authHeaderOrHeaders)
+    ? authHeaderOrHeaders
+    : authHeaderOrHeaders
+      ? [authHeaderOrHeaders]
+      : [];
+  return JSON.stringify([url, authHeaders, requesterSessionKey ?? null]);
+}
+
+function resolveManagedImageAuthHeaders(
+  authHeader?: string,
+  authHeaders?: readonly string[],
+): string[] {
+  const combined = [authHeader, ...(authHeaders ?? [])]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+  return [...new Set(combined)];
 }
 
 function sleep(ms: number): Promise<void> {
@@ -884,9 +907,14 @@ function resolveManagedImageUrl(
 async function fetchManagedImageBlob(
   url: string,
   authHeader?: string,
-  opts?: { bypassMissCache?: boolean; requesterSessionKey?: string },
+  opts?: {
+    authHeaders?: readonly string[];
+    bypassMissCache?: boolean;
+    requesterSessionKey?: string;
+  },
 ): Promise<Blob | null> {
-  const cacheKey = buildManagedImageFetchCacheKey(url, authHeader, opts?.requesterSessionKey);
+  const authCandidates = resolveManagedImageAuthHeaders(authHeader, opts?.authHeaders);
+  const cacheKey = buildManagedImageFetchCacheKey(url, authCandidates, opts?.requesterSessionKey);
   const bypassMissCache = opts?.bypassMissCache === true;
   if (!bypassMissCache) {
     const missUntil = managedImageBlobUrlMissCache.get(cacheKey);
@@ -900,29 +928,39 @@ async function fetchManagedImageBlob(
     if (delayMs > 0) {
       await sleep(delayMs);
     }
-    try {
-      const headers: Record<string, string> = {};
-      if (authHeader) {
-        headers.Authorization = authHeader;
-      }
-      if (opts?.requesterSessionKey) {
-        headers["x-openclaw-requester-session-key"] = opts.requesterSessionKey;
-      }
-      const response = await fetch(url, {
-        credentials: "same-origin",
-        ...(Object.keys(headers).length > 0 ? { headers } : {}),
-      });
-      if (response.ok) {
-        managedImageBlobUrlMissCache.delete(cacheKey);
-        return await response.blob();
-      }
-      if (response.status !== 404) {
+    for (let authIndex = 0; authIndex < Math.max(authCandidates.length, 1); authIndex += 1) {
+      const resolvedAuthHeader = authCandidates[authIndex];
+      try {
+        const headers: Record<string, string> = {};
+        if (resolvedAuthHeader) {
+          headers.Authorization = resolvedAuthHeader;
+        }
+        if (opts?.requesterSessionKey) {
+          headers["x-openclaw-requester-session-key"] = opts.requesterSessionKey;
+        }
+        const response = await fetch(url, {
+          credentials: "same-origin",
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
+        });
+        if (response.ok) {
+          managedImageBlobUrlMissCache.delete(cacheKey);
+          return await response.blob();
+        }
+        if (response.status === 404) {
+          break;
+        }
+        const canRetryAuth =
+          (response.status === 401 || response.status === 403) &&
+          authIndex < authCandidates.length - 1;
+        if (canRetryAuth) {
+          continue;
+        }
+        managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
+        return null;
+      } catch {
         managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
         return null;
       }
-    } catch {
-      managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
-      return null;
     }
   }
   managedImageBlobUrlMissCache.set(cacheKey, Date.now() + MANAGED_IMAGE_FETCH_MISS_TTL_MS);
@@ -932,9 +970,14 @@ async function fetchManagedImageBlob(
 async function fetchManagedImageBlobUrl(
   url: string,
   authHeader?: string,
-  opts?: { bypassMissCache?: boolean; requesterSessionKey?: string },
+  opts?: {
+    authHeaders?: readonly string[];
+    bypassMissCache?: boolean;
+    requesterSessionKey?: string;
+  },
 ): Promise<string | null> {
-  const cacheKey = buildManagedImageFetchCacheKey(url, authHeader, opts?.requesterSessionKey);
+  const authCandidates = resolveManagedImageAuthHeaders(authHeader, opts?.authHeaders);
+  const cacheKey = buildManagedImageFetchCacheKey(url, authCandidates, opts?.requesterSessionKey);
   const resolved = managedImageBlobUrlResolvedCache.get(cacheKey);
   if (typeof resolved === "string" && resolved.length > 0) {
     return resolved;
@@ -977,6 +1020,7 @@ async function fetchImageBlob(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     assistantAttachmentAuthToken?: string | null;
   },
@@ -988,6 +1032,7 @@ async function fetchImageBlob(
   });
   if (managedUrl) {
     return fetchManagedImageBlob(managedUrl, opts.authHeader, {
+      authHeaders: opts.authHeaders,
       bypassMissCache: true,
       requesterSessionKey: opts.requesterSessionKey,
     });
@@ -1083,6 +1128,7 @@ async function copyImageUrl(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     assistantAttachmentAuthToken?: string | null;
   },
@@ -1135,6 +1181,7 @@ async function fetchManagedPreviewBlobUrl(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     fallbackRawUrl?: string;
     assistantAttachmentAuthToken?: string | null;
@@ -1150,6 +1197,7 @@ async function fetchManagedPreviewBlobUrl(
   });
   if (managedUrl) {
     const primary = await fetchManagedImageBlobUrl(managedUrl, opts.authHeader, {
+      authHeaders: opts.authHeaders,
       requesterSessionKey: opts.requesterSessionKey,
     });
     if (primary) {
@@ -1163,6 +1211,7 @@ async function fetchManagedPreviewBlobUrl(
       });
       if (fallbackManagedUrl && fallbackManagedUrl !== managedUrl) {
         const fallback = await fetchManagedImageBlobUrl(fallbackManagedUrl, opts.authHeader, {
+          authHeaders: opts.authHeaders,
           requesterSessionKey: opts.requesterSessionKey,
         });
         if (fallback) {
@@ -1183,6 +1232,7 @@ function resolveManagedPreviewSource(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     fallbackRawUrl?: string;
     assistantAttachmentAuthToken?: string | null;
@@ -1203,8 +1253,9 @@ function resolveManagedPreviewSource(
     });
   }
 
+  const authCacheKey = resolveManagedImageAuthHeaders(opts.authHeader, opts.authHeaders);
   const resolvedPrimary = managedImageBlobUrlResolvedCache.get(
-    buildManagedImageFetchCacheKey(managedUrl, opts.authHeader, opts.requesterSessionKey),
+    buildManagedImageFetchCacheKey(managedUrl, authCacheKey, opts.requesterSessionKey),
   );
   if (typeof resolvedPrimary === "string" && resolvedPrimary.length > 0) {
     return resolvedPrimary;
@@ -1218,11 +1269,7 @@ function resolveManagedPreviewSource(
     });
     if (fallbackManagedUrl && fallbackManagedUrl !== managedUrl) {
       const resolvedFallback = managedImageBlobUrlResolvedCache.get(
-        buildManagedImageFetchCacheKey(
-          fallbackManagedUrl,
-          opts.authHeader,
-          opts.requesterSessionKey,
-        ),
+        buildManagedImageFetchCacheKey(fallbackManagedUrl, authCacheKey, opts.requesterSessionKey),
       );
       if (typeof resolvedFallback === "string" && resolvedFallback.length > 0) {
         return resolvedFallback;
@@ -1238,6 +1285,7 @@ async function openImageUrl(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     assistantAttachmentAuthToken?: string | null;
   },
@@ -1249,6 +1297,7 @@ async function openImageUrl(
   });
   if (managedUrl) {
     const blobUrl = await fetchManagedImageBlobUrl(managedUrl, opts.authHeader, {
+      authHeaders: opts.authHeaders,
       bypassMissCache: true,
       requesterSessionKey: opts.requesterSessionKey,
     });
@@ -1307,6 +1356,7 @@ function renderMessageImages(
   opts: {
     basePath?: string;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     assistantAttachmentAuthToken?: string | null;
     onMediaLoad?: () => void;
@@ -1320,6 +1370,7 @@ function renderMessageImages(
     void openImageUrl(img.openUrl ?? img.url, {
       basePath: opts.basePath,
       authHeader: opts.authHeader,
+      authHeaders: opts.authHeaders,
       requesterSessionKey: opts.requesterSessionKey,
       assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
     });
@@ -1332,6 +1383,7 @@ function renderMessageImages(
     void copyImageUrl(copySource, {
       basePath: opts.basePath,
       authHeader: opts.authHeader,
+      authHeaders: opts.authHeaders,
       requesterSessionKey: opts.requesterSessionKey,
       assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
     })
@@ -1394,6 +1446,7 @@ function renderMessageImages(
         const previewSrc = resolveManagedPreviewSource(img.previewUrl, {
           basePath: opts.basePath,
           authHeader: opts.authHeader,
+          authHeaders: opts.authHeaders,
           requesterSessionKey: opts.requesterSessionKey,
           fallbackRawUrl: img.openUrl ?? img.url,
           assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
@@ -1438,7 +1491,10 @@ function renderReplyPill(replyTarget: NormalizedMessage["replyTarget"]) {
 
 function isLocalAssistantAttachmentSource(source: string): boolean {
   const trimmed = source.trim();
-  if (/^\/(?:__openclaw__|media)\//.test(trimmed)) {
+  if (
+    /^\/(?:__openclaw__|media)\//.test(trimmed) ||
+    /(?:^|\/)api\/chat\/media\/outgoing\//.test(trimmed)
+  ) {
     return false;
   }
   return (
@@ -1871,6 +1927,7 @@ function renderGroupedMessage(
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
     authHeader?: string;
+    authHeaders?: readonly string[];
     requesterSessionKey?: string;
     onMediaLoad?: () => void;
   },
@@ -1993,6 +2050,7 @@ function renderGroupedMessage(
   const renderedImages = renderMessageImages(renderableImages, {
     basePath: opts.basePath,
     authHeader: opts.authHeader,
+    authHeaders: opts.authHeaders,
     requesterSessionKey: opts.requesterSessionKey,
     assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
     onMediaLoad: opts.onMediaLoad,

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -111,8 +111,57 @@ describe("loadControlUiBootstrapConfig", () => {
     vi.unstubAllGlobals();
   });
 
-  it("includes gateway auth header when a token is configured", async () => {
+  it("includes the configured auth token on bootstrap fetches", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "/openclaw",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+      settings: { token: "session-token" },
+      password: null,
+      hello: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: "Bearer session-token",
+        },
+      }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("retries with the alternate shared-secret credential when the first returns 401", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          basePath: "",
+          assistantName: "Ops",
+          assistantAvatar: null,
+          assistantAgentId: null,
+          serverVersion: "2026.4.22",
+          localMediaPreviewRoots: [],
+          embedSandbox: "scripts",
+          allowExternalEmbedUrls: false,
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const state = {
@@ -124,7 +173,68 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
-      settings: { token: "secret-token" },
+      settings: { token: "stale-token" },
+      password: "fresh-password",
+      hello: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, firstInit] = fetchMock.mock.calls[0] ?? [];
+    const [, secondInit] = fetchMock.mock.calls[1] ?? [];
+    expect((firstInit?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+      "Bearer stale-token",
+    );
+    expect((secondInit?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+      "Bearer fresh-password",
+    );
+    expect(state.assistantName).toBe("Ops");
+    expect(state.serverVersion).toBe("2026.4.22");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("stops retrying on non-auth errors", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+      settings: { token: "a" },
+      password: "b",
+      hello: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(state.assistantName).toBe("Assistant");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not attach auth headers to protocol-relative bootstrap URLs", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "//evil.example",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+      settings: { token: "session-token" },
       password: null,
       hello: null,
     };
@@ -132,15 +242,16 @@ describe("loadControlUiBootstrapConfig", () => {
     await loadControlUiBootstrapConfig(state);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+      `//evil.example${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
       expect.objectContaining({
         method: "GET",
-        headers: {
+        headers: expect.objectContaining({
           Accept: "application/json",
-          Authorization: "Bearer secret-token",
-        },
+        }),
       }),
     );
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -30,13 +30,16 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      settings: null,
+      password: null,
+      hello: null,
     };
 
     await loadControlUiBootstrapConfig(state);
 
     expect(fetchMock).toHaveBeenCalledWith(
       `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", headers: { Accept: "application/json" } }),
     );
     expect(state.assistantName).toBe("Ops");
     expect(state.assistantAvatar).toBe("O");
@@ -62,13 +65,16 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      settings: null,
+      password: null,
+      hello: null,
     };
 
     await loadControlUiBootstrapConfig(state);
 
     expect(fetchMock).toHaveBeenCalledWith(
       CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", headers: { Accept: "application/json" } }),
     );
     expect(state.assistantName).toBe("Assistant");
     expect(state.embedSandboxMode).toBe("scripts");
@@ -90,67 +96,23 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      settings: null,
+      password: null,
+      hello: null,
     };
 
     await loadControlUiBootstrapConfig(state);
 
     expect(fetchMock).toHaveBeenCalledWith(
       `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", headers: { Accept: "application/json" } }),
     );
 
     vi.unstubAllGlobals();
   });
 
-  it("includes the configured auth token on bootstrap fetches", async () => {
+  it("includes gateway auth header when a token is configured", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: false });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const state = {
-      basePath: "/openclaw",
-      assistantName: "Assistant",
-      assistantAvatar: null,
-      assistantAgentId: null,
-      localMediaPreviewRoots: [],
-      embedSandboxMode: "scripts" as const,
-      allowExternalEmbedUrls: false,
-      serverVersion: null,
-      settings: { token: "session-token" },
-    };
-
-    await loadControlUiBootstrapConfig(state);
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          Accept: "application/json",
-          Authorization: "Bearer session-token",
-        }),
-      }),
-    );
-
-    vi.unstubAllGlobals();
-  });
-
-  it("retries with the alternate shared-secret credential when the first returns 401", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({ ok: false, status: 401 })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          basePath: "",
-          assistantName: "Ops",
-          assistantAvatar: null,
-          assistantAgentId: null,
-          serverVersion: "2026.4.22",
-          localMediaPreviewRoots: [],
-          embedSandbox: "scripts",
-          allowExternalEmbedUrls: false,
-        }),
-      });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const state = {
@@ -162,81 +124,23 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
-      settings: { token: "stale-token" },
-      password: "fresh-password",
-    };
-
-    await loadControlUiBootstrapConfig(state);
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const [, firstInit] = fetchMock.mock.calls[0] ?? [];
-    const [, secondInit] = fetchMock.mock.calls[1] ?? [];
-    expect((firstInit?.headers as Record<string, string> | undefined)?.Authorization).toBe(
-      "Bearer stale-token",
-    );
-    expect((secondInit?.headers as Record<string, string> | undefined)?.Authorization).toBe(
-      "Bearer fresh-password",
-    );
-    expect(state.assistantName).toBe("Ops");
-    expect(state.serverVersion).toBe("2026.4.22");
-
-    vi.unstubAllGlobals();
-  });
-
-  it("stops retrying on non-auth errors", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const state = {
-      basePath: "",
-      assistantName: "Assistant",
-      assistantAvatar: null,
-      assistantAgentId: null,
-      localMediaPreviewRoots: [],
-      embedSandboxMode: "scripts" as const,
-      allowExternalEmbedUrls: false,
-      serverVersion: null,
-      settings: { token: "a" },
-      password: "b",
-    };
-
-    await loadControlUiBootstrapConfig(state);
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(state.assistantName).toBe("Assistant");
-
-    vi.unstubAllGlobals();
-  });
-
-  it("does not attach auth headers to protocol-relative bootstrap URLs", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const state = {
-      basePath: "//evil.example",
-      assistantName: "Assistant",
-      assistantAvatar: null,
-      assistantAgentId: null,
-      localMediaPreviewRoots: [],
-      embedSandboxMode: "scripts" as const,
-      allowExternalEmbedUrls: false,
-      serverVersion: null,
-      settings: { token: "session-token" },
+      settings: { token: "secret-token" },
+      password: null,
+      hello: null,
     };
 
     await loadControlUiBootstrapConfig(state);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `//evil.example${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
+      CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
       expect.objectContaining({
         method: "GET",
-        headers: expect.objectContaining({
+        headers: {
           Accept: "application/json",
-        }),
+          Authorization: "Bearer secret-token",
+        },
       }),
     );
-    const [, init] = fetchMock.mock.calls[0] ?? [];
-    expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -4,7 +4,7 @@ import {
   type ControlUiEmbedSandboxMode,
 } from "../../../../src/gateway/control-ui-contract.js";
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
-import { buildGatewayHttpHeaders } from "../gateway-http-auth.ts";
+import { resolveControlUiAuthCandidates } from "../control-ui-auth.ts";
 import { normalizeBasePath } from "../navigation.ts";
 
 export type ControlUiBootstrapState = {
@@ -16,15 +16,9 @@ export type ControlUiBootstrapState = {
   localMediaPreviewRoots: string[];
   embedSandboxMode: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
+  hello?: { auth?: { deviceToken?: string | null } | null } | null;
+  settings?: { token?: string | null } | null;
   password?: string | null;
-  settings?: {
-    token?: string | null;
-  } | null;
-  hello?: {
-    auth?: {
-      deviceToken?: string | null;
-    } | null;
-  } | null;
 };
 
 export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapState) {
@@ -41,12 +35,25 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     : CONTROL_UI_BOOTSTRAP_CONFIG_PATH;
 
   try {
-    const res = await fetch(url, {
-      method: "GET",
-      headers: buildGatewayHttpHeaders(state, { Accept: "application/json" }),
-      credentials: "same-origin",
-    });
-    if (!res.ok) {
+    const resolvedUrl = new URL(url, window.location.origin);
+    const sameOrigin = resolvedUrl.origin === window.location.origin;
+    const authCandidates = sameOrigin ? resolveControlUiAuthCandidates(state) : [];
+    const attempts: string[] = authCandidates.length > 0 ? authCandidates : [""];
+    let res: Response | null = null;
+    for (const candidate of attempts) {
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (candidate) {
+        headers.Authorization = `Bearer ${candidate}`;
+      }
+      res = await fetch(url, { method: "GET", headers, credentials: "same-origin" });
+      if (res.ok) {
+        break;
+      }
+      if (res.status !== 401 && res.status !== 403) {
+        return;
+      }
+    }
+    if (!res || !res.ok) {
       return;
     }
     const parsed = (await res.json()) as ControlUiBootstrapConfig;

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -4,7 +4,7 @@ import {
   type ControlUiEmbedSandboxMode,
 } from "../../../../src/gateway/control-ui-contract.js";
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
-import { resolveControlUiAuthCandidates } from "../control-ui-auth.ts";
+import { buildGatewayHttpHeaders } from "../gateway-http-auth.ts";
 import { normalizeBasePath } from "../navigation.ts";
 
 export type ControlUiBootstrapState = {
@@ -16,9 +16,15 @@ export type ControlUiBootstrapState = {
   localMediaPreviewRoots: string[];
   embedSandboxMode: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
-  hello?: { auth?: { deviceToken?: string | null } | null } | null;
-  settings?: { token?: string | null } | null;
   password?: string | null;
+  settings?: {
+    token?: string | null;
+  } | null;
+  hello?: {
+    auth?: {
+      deviceToken?: string | null;
+    } | null;
+  } | null;
 };
 
 export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapState) {
@@ -35,30 +41,12 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     : CONTROL_UI_BOOTSTRAP_CONFIG_PATH;
 
   try {
-    const resolvedUrl = new URL(url, window.location.origin);
-    const sameOrigin = resolvedUrl.origin === window.location.origin;
-    const authCandidates = sameOrigin ? resolveControlUiAuthCandidates(state) : [];
-    // If credentials are available, try them in priority order; on 401/403
-    // retry with the next candidate — recovers from a stale `settings.token`
-    // when the live session is authenticated via `password` (or vice versa).
-    // If no credentials are available, fall through with no Authorization
-    // header so bootstrap still works on auth-disabled deployments.
-    const attempts: string[] = authCandidates.length > 0 ? authCandidates : [""];
-    let res: Response | null = null;
-    for (const candidate of attempts) {
-      const headers: Record<string, string> = { Accept: "application/json" };
-      if (candidate) {
-        headers.Authorization = `Bearer ${candidate}`;
-      }
-      res = await fetch(url, { method: "GET", headers, credentials: "same-origin" });
-      if (res.ok) {
-        break;
-      }
-      if (res.status !== 401 && res.status !== 403) {
-        return;
-      }
-    }
-    if (!res || !res.ok) {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: buildGatewayHttpHeaders(state, { Accept: "application/json" }),
+      credentials: "same-origin",
+    });
+    if (!res.ok) {
       return;
     }
     const parsed = (await res.json()) as ControlUiBootstrapConfig;

--- a/ui/src/ui/gateway-http-auth.ts
+++ b/ui/src/ui/gateway-http-auth.ts
@@ -1,0 +1,41 @@
+export type GatewayHttpAuthSource = {
+  password?: string | null;
+  settings?: {
+    token?: string | null;
+  } | null;
+  hello?: {
+    auth?: {
+      deviceToken?: string | null;
+    } | null;
+  } | null;
+};
+
+export function resolveGatewayHttpAuthHeader(source: GatewayHttpAuthSource): string | null {
+  const token = source.settings?.token?.trim();
+  if (token) {
+    return `Bearer ${token}`;
+  }
+  const password = source.password?.trim();
+  if (password) {
+    return `Bearer ${password}`;
+  }
+  const deviceToken = source.hello?.auth?.deviceToken?.trim();
+  if (deviceToken) {
+    return `Bearer ${deviceToken}`;
+  }
+  return null;
+}
+
+export function buildGatewayHttpHeaders(
+  source: GatewayHttpAuthSource,
+  extraHeaders?: Record<string, string>,
+): HeadersInit {
+  const authHeader = resolveGatewayHttpAuthHeader(source);
+  if (!authHeader) {
+    return extraHeaders ?? {};
+  }
+  return {
+    ...extraHeaders,
+    Authorization: authHeader,
+  };
+}

--- a/ui/src/ui/gateway-http-auth.ts
+++ b/ui/src/ui/gateway-http-auth.ts
@@ -10,20 +10,16 @@ export type GatewayHttpAuthSource = {
   } | null;
 };
 
+export function resolveGatewayHttpAuthHeaders(source: GatewayHttpAuthSource): string[] {
+  const candidates = [source.settings?.token, source.password, source.hello?.auth?.deviceToken]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+    .map((value) => `Bearer ${value}`);
+  return [...new Set(candidates)];
+}
+
 export function resolveGatewayHttpAuthHeader(source: GatewayHttpAuthSource): string | null {
-  const token = source.settings?.token?.trim();
-  if (token) {
-    return `Bearer ${token}`;
-  }
-  const password = source.password?.trim();
-  if (password) {
-    return `Bearer ${password}`;
-  }
-  const deviceToken = source.hello?.auth?.deviceToken?.trim();
-  if (deviceToken) {
-    return `Bearer ${deviceToken}`;
-  }
-  return null;
+  return resolveGatewayHttpAuthHeaders(source)[0] ?? null;
 }
 
 export function buildGatewayHttpHeaders(

--- a/ui/src/ui/views/chat-image-open.browser.test.ts
+++ b/ui/src/ui/views/chat-image-open.browser.test.ts
@@ -1,0 +1,125 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "../../test-helpers/load-styles.ts";
+import { renderChat, type ChatProps } from "./chat.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
+  return {
+    sessionKey: "main",
+    onSessionKeyChange: () => undefined,
+    thinkingLevel: null,
+    showThinking: false,
+    showToolCalls: true,
+    loading: false,
+    sending: false,
+    canAbort: false,
+    compactionStatus: null,
+    fallbackStatus: null,
+    messages: [],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    assistantAvatarUrl: null,
+    draft: "",
+    queue: [],
+    connected: true,
+    canSend: true,
+    disabledReason: null,
+    error: null,
+    sessions: {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+          inputTokens: 3_800,
+          contextTokens: 4_000,
+        },
+      ],
+    },
+    focusMode: false,
+    assistantName: "OpenClaw",
+    assistantAvatar: null,
+    onRefresh: () => undefined,
+    onToggleFocusMode: () => undefined,
+    onDraftChange: () => undefined,
+    onSend: () => undefined,
+    onQueueRemove: () => undefined,
+    onNewSession: () => undefined,
+    agentsList: null,
+    currentAgentId: "",
+    onAgentChange: () => undefined,
+    ...overrides,
+  };
+}
+
+function renderAssistantImage(url: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "image_url", image_url: { url } }],
+    timestamp: Date.now(),
+  };
+}
+
+async function renderImageChat(url: string) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  render(
+    renderChat(
+      createProps({
+        messages: [renderAssistantImage(url)],
+      }),
+    ),
+    container,
+  );
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  return container;
+}
+
+describe("chat image open safety", () => {
+  it("opens safe image URLs in a hardened new tab", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const container = await renderImageChat("https://example.com/cat.png");
+
+    const image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image).not.toBeNull();
+    image?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/cat.png",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("does not open unsafe image URLs", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const container = await renderImageChat("javascript:alert(1)");
+
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+    expect(container.querySelector(".chat-message-image-unavailable")).not.toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not open SVG data image URLs", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const container = await renderImageChat(
+      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' />",
+    );
+
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+    expect(container.querySelector(".chat-message-image-unavailable")).not.toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -113,6 +113,7 @@ export type ChatProps = {
   onMediaLoad?: () => void;
   basePath?: string;
   authHeader?: string;
+  authHeaders?: string[];
 };
 
 // Persistent instances keyed by session
@@ -915,6 +916,7 @@ export function renderChat(props: ChatProps) {
                 embedSandboxMode: props.embedSandboxMode ?? "scripts",
                 allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
                 authHeader: props.authHeader,
+                authHeaders: props.authHeaders,
                 requesterSessionKey: activeSession?.key ?? undefined,
                 onMediaLoad: props.onMediaLoad,
                 contextWindow:

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -79,6 +79,7 @@ export type ChatProps = {
   embedSandboxMode?: EmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   assistantName: string;
+  userName?: string | null;
   assistantAvatar: string | null;
   localMediaPreviewRoots?: string[];
   assistantAttachmentAuthToken?: string | null;
@@ -908,6 +909,7 @@ export function renderChat(props: ChatProps) {
                 onToggleToolExpanded: toggleToolCardExpanded,
                 onRequestUpdate: requestUpdate,
                 assistantName: props.assistantName,
+                userName: props.userName,
                 assistantAvatar: assistantIdentity.avatar,
                 basePath: props.basePath,
                 localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -11,6 +11,7 @@ import { renderContextNotice } from "../chat/context-notice.ts";
 import { DeletedMessages } from "../chat/deleted-messages.ts";
 import { exportChatMarkdown } from "../chat/export.ts";
 import {
+  cleanupUnusedManagedImagePreviewBlobUrls,
   renderMessageGroup,
   renderReadingIndicatorGroup,
   renderStreamingGroup,
@@ -40,7 +41,6 @@ import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { SessionsListResult } from "../types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
-import { resolveLocalUserName } from "../user-identity.ts";
 import { agentLogoUrl, resolveChatAvatarRenderUrl } from "./agents-utils.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
@@ -80,8 +80,6 @@ export type ChatProps = {
   allowExternalEmbedUrls?: boolean;
   assistantName: string;
   assistantAvatar: string | null;
-  userName?: string | null;
-  userAvatar?: string | null;
   localMediaPreviewRoots?: string[];
   assistantAttachmentAuthToken?: string | null;
   autoExpandToolCalls?: boolean;
@@ -112,7 +110,9 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onMediaLoad?: () => void;
   basePath?: string;
+  authHeader?: string;
 };
 
 // Persistent instances keyed by session
@@ -550,10 +550,6 @@ function renderPinnedSection(
   pinned: PinnedMessages,
   requestUpdate: () => void,
 ): TemplateResult | typeof nothing {
-  const userRoleLabel = resolveLocalUserName({
-    name: props.userName ?? null,
-    avatar: props.userAvatar ?? null,
-  });
   const messages = Array.isArray(props.messages) ? props.messages : [];
   const entries: Array<{ index: number; text: string; role: string }> = [];
   for (const idx of pinned.indices) {
@@ -589,7 +585,7 @@ function renderPinnedSection(
                 ({ index, text, role }) => html`
                   <div class="agent-chat__pinned-item">
                     <span class="agent-chat__pinned-role"
-                      >${role === "user" ? userRoleLabel : "Assistant"}</span
+                      >${role === "user" ? "You" : "Assistant"}</span
                     >
                     <span class="agent-chat__pinned-text"
                       >${text.slice(0, 100)}${text.length > 100 ? "..." : ""}</span
@@ -739,6 +735,9 @@ function renderSlashMenu(
 }
 
 export function renderChat(props: ChatProps) {
+  if (typeof document !== "undefined") {
+    cleanupUnusedManagedImagePreviewBlobUrls(document);
+  }
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
@@ -909,14 +908,15 @@ export function renderChat(props: ChatProps) {
                 onRequestUpdate: requestUpdate,
                 assistantName: props.assistantName,
                 assistantAvatar: assistantIdentity.avatar,
-                userName: props.userName ?? null,
-                userAvatar: props.userAvatar ?? null,
                 basePath: props.basePath,
                 localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],
                 assistantAttachmentAuthToken: props.assistantAttachmentAuthToken ?? null,
                 canvasHostUrl: props.canvasHostUrl,
                 embedSandboxMode: props.embedSandboxMode ?? "scripts",
                 allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
+                authHeader: props.authHeader,
+                requesterSessionKey: activeSession?.key ?? undefined,
+                onMediaLoad: props.onMediaLoad,
                 contextWindow:
                   activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,
                 onDelete: () => {


### PR DESCRIPTION
## Summary

Recreates the managed-media persistence fix from a clean branch after #69500 was auto-closed as dirty.

This restores the webchat/control UI path so assistant-managed media replies, especially image replies, are durably persisted and re-render correctly after reload/history fetch.

## What changed

- restore gateway-side managed attachment persistence and serving for assistant replies
- preserve media-bearing reply metadata through transcript injection/history flows
- add UI-side auth-aware managed media resolution/open behavior
- harden grouped chat rendering and control-ui bootstrap handling for managed media
- add targeted gateway, media, and UI regression coverage for the persistence path

## Problem

Managed media could render live, then disappear or come back inconsistently after reload because the reply/transcript/UI path was not durably carrying the needed managed-media state.

## Expected

Assistant media replies render live and persist into transcript/history.

## Actual

Some replies rendered live but were not durably persisted, causing missing or inconsistent history on reload.

## Evidence

- `pnpm check:changed --staged`
- targeted/full changed-lane Vitest coverage passed for gateway, media, and UI paths
- browser image-open safety test passing in local Vitest browser run

## Human Verification (required)

- Verified scenarios:
  - targeted gateway chat tests for managed-image persistence paths
  - targeted UI chat tests
  - targeted managed-image attachment tests
  - browser image-open safety coverage
- Edge cases checked:
  - image-only assistant replies
  - follow-up preview behavior
  - managed media auth/open path from the UI
- What you did not verify:
  - broad end-to-end cross-channel coverage outside the targeted webchat/control UI path
  - live post-restart webchat smoke after merge

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: managed-media rendering and transcript persistence touch both gateway and UI seams.
- Mitigation: targeted gateway/UI/media regression coverage was added and hardened.
- Risk: media auth/reload behavior can regress in subtle ways.
- Mitigation: explicit UI auth-path coverage and browser validation for the image-open path.
