### PR TITLE
fix(auth-profiles): broadcast refreshed OAuth credential to peer agents (#59272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/auth profiles: after an OAuth refresh, broadcast the fresh credential to every peer agent that already holds the same profile id, not just the main agent store. Previously, rotating-refresh-token providers (notably `openai-codex`) would silently invalidate idle peers whose stale refresh token was rotated out server-side; the expiry check then flagged those peers as EXPIRED until the next use hit the main-store adoption fallback. Closes #59272.
 - Docs/Codex harness: narrow native compaction docs to the current start/completion signals, without promising a readable summary or kept-entry audit list yet. (#69612) Thanks @91wan.
 - Providers/Amazon Bedrock: use known context-window metadata for discovered models while keeping the unknown-model fallback conservative, so compaction and overflow handling improve for newer Bedrock models without overstating unlisted model limits. Thanks @wirjo.
 - Providers/Amazon Bedrock Mantle: refresh IAM-backed bearer tokens at runtime instead of baking discovery-time tokens into provider config, so long-lived Mantle sessions keep working after the initial token ages out. Thanks @wirjo.

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE, withFileLock } from "../../infra/file-lock.js";
 import {
@@ -19,7 +20,12 @@ import {
   shouldReplaceStoredOAuthCredential,
   type RuntimeExternalOAuthProfile,
 } from "./oauth-shared.js";
-import { ensureAuthStoreFile, resolveAuthStorePath, resolveOAuthRefreshLockPath } from "./paths.js";
+import {
+  ensureAuthStoreFile,
+  listPeerAuthStorePaths,
+  resolveAuthStorePath,
+  resolveOAuthRefreshLockPath,
+} from "./paths.js";
 import {
   ensureAuthProfileStore,
   loadAuthProfileStoreForSecretsRuntime,
@@ -294,17 +300,27 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     }
   }
 
-  async function mirrorRefreshedCredentialIntoMainStore(params: {
+  async function mirrorRefreshedCredentialIntoStore(params: {
+    storePath: string;
+    agentDir: string | undefined;
     profileId: string;
     refreshed: OAuthCredential;
+    /**
+     * When true, do not write the credential unless the store already has a
+     * profile with this id. Used for peer agent stores, which should never
+     * have new profiles created implicitly — only refreshed in place.
+     */
+    requireExistingProfile: boolean;
   }): Promise<void> {
     try {
-      const mainPath = resolveAuthStorePath(undefined);
-      ensureAuthStoreFile(mainPath);
+      ensureAuthStoreFile(params.storePath);
       await updateAuthProfileStoreWithLock({
-        agentDir: undefined,
+        agentDir: params.agentDir,
         updater: (store) => {
           const existing = store.profiles[params.profileId];
+          if (params.requireExistingProfile && !existing) {
+            return false;
+          }
           const decision = shouldMirrorRefreshedOAuthCredential({
             existing,
             refreshed: params.refreshed,
@@ -313,13 +329,15 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             if (decision.reason === "identity-mismatch-or-regression") {
               log.warn("refused to mirror OAuth credential: identity mismatch or regression", {
                 profileId: params.profileId,
+                storePath: params.storePath,
               });
             }
             return false;
           }
           store.profiles[params.profileId] = { ...params.refreshed };
-          log.debug("mirrored refreshed OAuth credential to main agent store", {
+          log.debug("mirrored refreshed OAuth credential", {
             profileId: params.profileId,
+            storePath: params.storePath,
             expires: Number.isFinite(params.refreshed.expires)
               ? new Date(params.refreshed.expires).toISOString()
               : undefined,
@@ -328,9 +346,60 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         },
       });
     } catch (err) {
-      log.debug("mirrorRefreshedCredentialIntoMainStore failed", {
+      log.debug("mirrorRefreshedCredentialIntoStore failed", {
         profileId: params.profileId,
+        storePath: params.storePath,
         error: formatErrorMessage(err),
+      });
+    }
+  }
+
+  /**
+   * After a successful OAuth refresh, propagate the fresh credential to the
+   * main agent store (existing #26322 behavior) and to every peer agent that
+   * already holds the same profile id (closes #59272).
+   *
+   * Peers with a profile whose identity regresses (different accountId/email)
+   * are skipped with a warning — the existing `shouldMirrorRefreshedOAuthCredential`
+   * guard prevents a refresh from one account clobbering another account's
+   * tokens. Peers without the profile are left untouched — we never create
+   * new profiles implicitly.
+   *
+   * The `sourceAuthPath` is the store the refresh was written to; we skip
+   * mirroring back into it to avoid redundant work and any lock-ordering
+   * surprises. Opt out of the peer broadcast with
+   * `OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1`.
+   */
+  async function mirrorRefreshedCredentialToPeers(params: {
+    profileId: string;
+    refreshed: OAuthCredential;
+    sourceAuthPath: string;
+  }): Promise<void> {
+    const mainPath = resolveAuthStorePath(undefined);
+    if (path.resolve(mainPath) !== path.resolve(params.sourceAuthPath)) {
+      await mirrorRefreshedCredentialIntoStore({
+        storePath: mainPath,
+        agentDir: undefined,
+        profileId: params.profileId,
+        refreshed: params.refreshed,
+        // Preserve pre-fix behavior: main-store mirror may create the profile
+        // if absent. Main is the documented source of truth (see #26322).
+        requireExistingProfile: false,
+      });
+    }
+    const peerPaths = listPeerAuthStorePaths({
+      exclude: [params.sourceAuthPath, mainPath],
+    });
+    for (const peerPath of peerPaths) {
+      // peerPath = <stateDir>/agents/<id>/agent/auth-profiles.json
+      // agentDir = <stateDir>/agents/<id>/agent   (i.e. the file's directory)
+      const peerAgentDir = path.dirname(peerPath);
+      await mirrorRefreshedCredentialIntoStore({
+        storePath: peerPath,
+        agentDir: peerAgentDir,
+        profileId: params.profileId,
+        refreshed: params.refreshed,
+        requireExistingProfile: true,
       });
     }
   }
@@ -456,15 +525,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
           store.profiles[params.profileId] = refreshedCredentials;
           saveAuthProfileStore(store, params.agentDir);
-          if (params.agentDir) {
-            const mainPath = resolveAuthStorePath(undefined);
-            if (mainPath !== authPath) {
-              await mirrorRefreshedCredentialIntoMainStore({
-                profileId: params.profileId,
-                refreshed: refreshedCredentials,
-              });
-            }
-          }
+          await mirrorRefreshedCredentialToPeers({
+            profileId: params.profileId,
+            refreshed: refreshedCredentials,
+            sourceAuthPath: authPath,
+          });
           return {
             apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials),
             credential: refreshedCredentials,

--- a/src/agents/auth-profiles/oauth.peer-mirror-broadcast.test.ts
+++ b/src/agents/auth-profiles/oauth.peer-mirror-broadcast.test.ts
@@ -1,0 +1,353 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { captureEnv } from "../../test-utils/env.js";
+import { __testing as externalAuthTesting } from "./external-auth.js";
+import "./oauth-file-lock-passthrough.test-support.js";
+import { getOAuthProviderRuntimeMocks } from "./oauth-common-mocks.test-support.js";
+import {
+  OAUTH_AGENT_ENV_KEYS,
+  createOAuthMainAgentDir,
+  createOAuthTestTempRoot,
+  createExpiredOauthStore,
+  removeOAuthTestTempRoot,
+  resolveApiKeyForProfileInTest,
+  resetOAuthProviderRuntimeMocks,
+} from "./oauth-test-utils.js";
+import { resolveApiKeyForProfile, resetOAuthRefreshQueuesForTest } from "./oauth.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
+
+const {
+  refreshProviderOAuthCredentialWithPluginMock,
+  formatProviderAuthProfileApiKeyWithPluginMock,
+} = getOAuthProviderRuntimeMocks();
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthProviders: () => [{ id: "anthropic" }, { id: "openai-codex" }],
+  getOAuthApiKey: vi.fn(async (provider: string, credentials: Record<string, OAuthCredential>) => {
+    const credential = credentials[provider];
+    return credential
+      ? {
+          apiKey: credential.access,
+          newCredentials: credential,
+        }
+      : null;
+  }),
+}));
+
+async function readProfile(agentDir: string, profileId: string) {
+  const raw = JSON.parse(
+    await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+  ) as AuthProfileStore;
+  return raw.profiles[profileId];
+}
+
+describe("OAuth refresh peer-agent broadcast (#59272)", () => {
+  const envSnapshot = captureEnv([...OAUTH_AGENT_ENV_KEYS, "OPENCLAW_DISABLE_AUTH_PEER_MIRROR"]);
+  let tempRoot = "";
+  let caseIndex = 0;
+  let stateDir = "";
+  let mainAgentDir = "";
+
+  beforeAll(async () => {
+    tempRoot = await createOAuthTestTempRoot("openclaw-oauth-peer-mirror-");
+  });
+
+  beforeEach(async () => {
+    resetFileLockStateForTest();
+    resetOAuthProviderRuntimeMocks({
+      refreshProviderOAuthCredentialWithPluginMock,
+      formatProviderAuthProfileApiKeyWithPluginMock,
+    });
+    externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+    clearRuntimeAuthProfileStoreSnapshots();
+    caseIndex += 1;
+    stateDir = path.join(tempRoot, `case-${caseIndex}`);
+    mainAgentDir = await createOAuthMainAgentDir(stateDir);
+    resetOAuthRefreshQueuesForTest();
+    delete process.env.OPENCLAW_DISABLE_AUTH_PEER_MIRROR;
+  });
+
+  afterEach(async () => {
+    envSnapshot.restore();
+    resetFileLockStateForTest();
+    externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+    clearRuntimeAuthProfileStoreSnapshots();
+    resetOAuthRefreshQueuesForTest();
+  });
+
+  afterAll(async () => {
+    await removeOAuthTestTempRoot(tempRoot);
+  });
+
+  it("propagates refreshed credential to every peer agent that already holds the same profile", async () => {
+    const profileId = "openai-codex:omar@shahine.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const refreshingAgentDir = path.join(stateDir, "agents", "lobster-wa", "agent");
+    const peerAAgentDir = path.join(stateDir, "agents", "mail-router", "agent");
+    const peerBAgentDir = path.join(stateDir, "agents", "travel-hub", "agent");
+    await fs.mkdir(refreshingAgentDir, { recursive: true });
+    await fs.mkdir(peerAAgentDir, { recursive: true });
+    await fs.mkdir(peerBAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId }),
+      refreshingAgentDir,
+    );
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId }),
+      peerAAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId }),
+      peerBAgentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "peer-broadcast-access",
+          refresh: "peer-broadcast-refresh",
+          expires: freshExpiry,
+          accountId,
+        }) as never,
+    );
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(refreshingAgentDir),
+      profileId,
+      agentDir: refreshingAgentDir,
+    });
+
+    expect(result?.apiKey).toBe("peer-broadcast-access");
+
+    // Main always gets the mirror (existing #26322 behavior).
+    expect(await readProfile(mainAgentDir, profileId)).toMatchObject({
+      access: "peer-broadcast-access",
+      refresh: "peer-broadcast-refresh",
+      expires: freshExpiry,
+    });
+
+    // Each peer with a matching profile id adopts the fresh credential.
+    expect(await readProfile(peerAAgentDir, profileId)).toMatchObject({
+      access: "peer-broadcast-access",
+      refresh: "peer-broadcast-refresh",
+      expires: freshExpiry,
+    });
+    expect(await readProfile(peerBAgentDir, profileId)).toMatchObject({
+      access: "peer-broadcast-access",
+      refresh: "peer-broadcast-refresh",
+      expires: freshExpiry,
+    });
+  });
+
+  it("does not create a profile on peers that never had one", async () => {
+    const profileId = "openai-codex:omar@shahine.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const refreshingAgentDir = path.join(stateDir, "agents", "lobster-wa", "agent");
+    const bystanderAgentDir = path.join(stateDir, "agents", "unrelated", "agent");
+    await fs.mkdir(refreshingAgentDir, { recursive: true });
+    await fs.mkdir(bystanderAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId }),
+      refreshingAgentDir,
+    );
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
+    // Bystander has a DIFFERENT profile id — the broadcast must leave it alone.
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId: "anthropic:default",
+        provider: "anthropic",
+        accountId: "other",
+      }),
+      bystanderAgentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "bystander-safe-access",
+          refresh: "bystander-safe-refresh",
+          expires: freshExpiry,
+          accountId,
+        }) as never,
+    );
+
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(refreshingAgentDir),
+      profileId,
+      agentDir: refreshingAgentDir,
+    });
+
+    const bystanderRaw = JSON.parse(
+      await fs.readFile(path.join(bystanderAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(bystanderRaw.profiles[profileId]).toBeUndefined();
+    expect(bystanderRaw.profiles["anthropic:default"]).toBeDefined();
+  });
+
+  it("refuses to overwrite a peer whose profile identity regresses", async () => {
+    const profileId = "openai-codex:omar@shahine.com";
+    const provider = "openai-codex";
+    const refreshingAccountId = "acct-omar";
+    const otherAccountId = "acct-someone-else";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const refreshingAgentDir = path.join(stateDir, "agents", "lobster-wa", "agent");
+    const otherIdentityAgentDir = path.join(stateDir, "agents", "other-login", "agent");
+    await fs.mkdir(refreshingAgentDir, { recursive: true });
+    await fs.mkdir(otherIdentityAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId: refreshingAccountId }),
+      refreshingAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId: refreshingAccountId }),
+      mainAgentDir,
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
+            provider,
+            access: "other-account-access",
+            refresh: "other-account-refresh",
+            expires: Date.now() - 60_000,
+            accountId: otherAccountId,
+          },
+        },
+      },
+      otherIdentityAgentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "refreshed-for-omar",
+          refresh: "refreshed-for-omar-refresh",
+          expires: freshExpiry,
+          accountId: refreshingAccountId,
+        }) as never,
+    );
+
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(refreshingAgentDir),
+      profileId,
+      agentDir: refreshingAgentDir,
+    });
+
+    // Peer kept its distinct-identity credential — the identity guard
+    // stopped the broadcast from clobbering a different account's tokens.
+    expect(await readProfile(otherIdentityAgentDir, profileId)).toMatchObject({
+      access: "other-account-access",
+      accountId: otherAccountId,
+    });
+  });
+
+  it("skips the peer broadcast when OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1", async () => {
+    process.env.OPENCLAW_DISABLE_AUTH_PEER_MIRROR = "1";
+    const profileId = "openai-codex:omar@shahine.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const refreshingAgentDir = path.join(stateDir, "agents", "lobster-wa", "agent");
+    const peerAgentDir = path.join(stateDir, "agents", "mail-router", "agent");
+    await fs.mkdir(refreshingAgentDir, { recursive: true });
+    await fs.mkdir(peerAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId }),
+      refreshingAgentDir,
+    );
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), peerAgentDir);
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "opt-out-access",
+          refresh: "opt-out-refresh",
+          expires: freshExpiry,
+          accountId,
+        }) as never,
+    );
+
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(refreshingAgentDir),
+      profileId,
+      agentDir: refreshingAgentDir,
+    });
+
+    // Main still gets mirrored (pre-existing behavior), but the peer does NOT.
+    expect(await readProfile(mainAgentDir, profileId)).toMatchObject({ access: "opt-out-access" });
+    expect(await readProfile(peerAgentDir, profileId)).toMatchObject({
+      access: "cached-access-token",
+    });
+  });
+
+  it("broadcasts to peers when the refresh originates on the main agent", async () => {
+    const profileId = "openai-codex:omar@shahine.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const peerAgentDir = path.join(stateDir, "agents", "mail-router", "agent");
+    await fs.mkdir(peerAgentDir, { recursive: true });
+
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), peerAgentDir);
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "main-origin-access",
+          refresh: "main-origin-refresh",
+          expires: freshExpiry,
+          accountId,
+        }) as never,
+    );
+
+    const result = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(undefined),
+      profileId,
+      agentDir: undefined,
+    });
+    expect(result?.apiKey).toBe("main-origin-access");
+
+    // Previously this was the exact case that leaked — main refreshes,
+    // peers stay stale, and next refresh rotation invalidates the peers.
+    expect(await readProfile(peerAgentDir, profileId)).toMatchObject({
+      access: "main-origin-access",
+      refresh: "main-origin-refresh",
+      expires: freshExpiry,
+    });
+  });
+});

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
 import { saveJsonFile } from "../../infra/json-file.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
+import { AUTH_PROFILE_FILENAME } from "./path-constants.js";
 import { resolveAuthStatePath, resolveAuthStorePath } from "./path-resolve.js";
 import type { AuthProfileSecretsStore } from "./types.js";
 export {
@@ -21,4 +24,60 @@ export function ensureAuthStoreFile(pathname: string) {
     profiles: {},
   };
   saveJsonFile(pathname, payload);
+}
+
+/**
+ * Discover auth-profile store paths for every agent directory on disk, so
+ * OAuth refresh can broadcast fresh credentials to peer agents instead of
+ * only the invoking agent's store and the main store. This closes issue
+ * #59272 — without it, a refresh on agent A rotates the server-side refresh
+ * token and silently invalidates the stale copy held by every other agent
+ * that never entered the refresh path.
+ *
+ * The caller passes any store paths it wants to skip (usually the invoking
+ * agent's own path and the main path, which are handled elsewhere). Missing
+ * files are filtered out so a brand-new agent dir without an auth file is
+ * ignored rather than created — profiles only ever replace an existing
+ * entry on a peer; they never create a new one.
+ *
+ * Set `OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1` to opt out and restore the
+ * pre-fix behavior (mirror to main only).
+ */
+export function listPeerAuthStorePaths(
+  params: {
+    exclude?: readonly string[];
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string[] {
+  const env = params.env ?? process.env;
+  if (env.OPENCLAW_DISABLE_AUTH_PEER_MIRROR === "1") {
+    return [];
+  }
+  const agentsRoot = path.join(resolveStateDir(env), "agents");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(agentsRoot, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  const excluded = new Set((params.exclude ?? []).map((p) => path.resolve(p)));
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const candidate = path.join(agentsRoot, entry.name, "agent", AUTH_PROFILE_FILENAME);
+    if (excluded.has(path.resolve(candidate))) {
+      continue;
+    }
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    results.push(candidate);
+  }
+  return results.toSorted();
 }


### PR DESCRIPTION
## Summary

- Mirror a successful OAuth refresh into every peer agent store that already holds the same profile id, not just `main`. Closes #59272.
- Preserves single-agent behavior — no peers → no-op. Opt-out via `OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1`.
- Keeps the existing identity-regression guard so peers with a different account's profile are skipped with a warning rather than clobbered; peers without the profile are left untouched (we never create new profiles implicitly).

## Why

Rotating-refresh-token providers (notably `openai-codex`) rotate the refresh token server-side on every refresh. Under the prior behavior (`mirrorRefreshedCredentialIntoMainStore`), only the refreshing agent and the main agent got the new token. Idle peers kept the rotated-out refresh token and got flagged EXPIRED by expiry checks until their next use fell back to the inside-lock main-store adoption path.

The original reporter's workaround (see #59272) was to write a sync skill that treats `main` as source of truth and propagates to siblings — this PR makes that behavior first-class inside the gateway.

Hit this in production on a 12-agent setup: 7 of 12 agents silently diverged onto an old refresh token on Apr 22; the auth-health cron raised an EXPIRED alert on all 7 simultaneously. The 5 fresh agents all shared a single new refresh token pair, so only 5 files had been touched by the most recent refresh.

## Changes

- `src/agents/auth-profiles/paths.ts`: new `listPeerAuthStorePaths({ exclude, env })` that enumerates `<stateDir>/agents/*/agent/auth-profiles.json`, filters out missing files (no implicit creation) and any caller-excluded paths, and honors `OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1` as an opt-out.
- `src/agents/auth-profiles/oauth-manager.ts`:
  - Split the previous inlined helper into `mirrorRefreshedCredentialIntoStore` (per-store, reuses `shouldMirrorRefreshedOAuthCredential`; new `requireExistingProfile` flag so peers only refresh existing profiles while main keeps its create-if-missing behavior).
  - New `mirrorRefreshedCredentialToPeers` broadcasts to main (unchanged behavior) and every peer store, skipping the source path.
  - Single call site at the end of `doRefreshOAuthTokenWithLock` now uses the broadcaster; the `if (params.agentDir)` wrapper is gone — main-originated refreshes also broadcast to peers now, which is the key fix.
- `src/agents/auth-profiles/oauth.peer-mirror-broadcast.test.ts`: five new vitest cases covering the happy path, no-create-on-bystander, identity-regression refusal, the `OPENCLAW_DISABLE_AUTH_PEER_MIRROR=1` opt-out, and refresh originating on the main agent (previously the exact leaked case). All pass.

## Test plan

- [x] `pnpm check:test-types` — clean
- [x] `pnpm lint:core --fix` — 0 warnings, 0 errors
- [x] `pnpm check:import-cycles` + `pnpm check:madge-import-cycles` — no new cycles
- [x] `src/agents/auth-profiles/` vitest suite — 162/162 pass (18 files, includes the 5 new cases and the 5 existing mirror-to-main cases which still pass unchanged)
- [x] Pre-commit hooks (`lint:auth:pairing-account-scope`, `check:changed`) — clean

CHANGELOG entry added to `## Unreleased` > `### Fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)