### PR TITLE
Fix multi-agent OAuth profile drift

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -125,6 +125,17 @@ describe("openai codex provider", () => {
     );
   });
 
+  it("declares the legacy default OAuth profile repair", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    expect(provider.oauthProfileIdRepairs).toEqual([
+      {
+        legacyProfileId: "openai-codex:default",
+        promptLabel: "OpenAI Codex",
+      },
+    ]);
+  });
+
   it("offers OpenAI menu auth methods for browser login and device pairing", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -374,6 +374,12 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
     id: PROVIDER_ID,
     label: "OpenAI Codex",
     docsPath: "/providers/models",
+    oauthProfileIdRepairs: [
+      {
+        legacyProfileId: "openai-codex:default",
+        promptLabel: "OpenAI Codex",
+      },
+    ],
     auth: [
       {
         id: "oauth",

--- a/extensions/openai/provider-contract-api.ts
+++ b/extensions/openai/provider-contract-api.ts
@@ -12,6 +12,12 @@ export function createOpenAICodexProvider(): ProviderPlugin {
     id: "openai-codex",
     label: "OpenAI Codex",
     docsPath: "/providers/models",
+    oauthProfileIdRepairs: [
+      {
+        legacyProfileId: "openai-codex:default",
+        promptLabel: "OpenAI Codex",
+      },
+    ],
     auth: [
       {
         id: "oauth",

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -322,6 +322,95 @@ describe("ensureAuthProfileStore", () => {
     }
   });
 
+  it("preserves a valid main default OAuth profile while replacing a stale agent override", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-drift-base-default-"));
+    const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    try {
+      const mainDir = path.join(root, "main-agent");
+      const agentDir = path.join(root, "agent-x");
+      fs.mkdirSync(mainDir, { recursive: true });
+      fs.mkdirSync(agentDir, { recursive: true });
+
+      process.env.OPENCLAW_AGENT_DIR = mainDir;
+      process.env.PI_CODING_AGENT_DIR = mainDir;
+
+      const freshProfileId = "openai-codex:user@example.com";
+      const defaultProfileId = "openai-codex:default";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [freshProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "main-access",
+              refresh: "main-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+              email: "user@example.com",
+            },
+            [defaultProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "main-default-access",
+              refresh: "main-default-refresh",
+              expires: Date.now() + 45 * 60 * 1000,
+            },
+          },
+          order: {
+            "openai-codex": [freshProfileId, defaultProfileId],
+          },
+          usageStats: {
+            [defaultProfileId]: {
+              lastUsed: 123,
+            },
+          },
+        },
+        mainDir,
+      );
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [defaultProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "stale-agent-default-access",
+              refresh: "stale-agent-default-refresh",
+              expires: Date.now() - 60 * 60 * 1000,
+            },
+          },
+          order: {
+            "openai-codex": [defaultProfileId],
+          },
+          usageStats: {
+            [defaultProfileId]: {
+              lastUsed: 999,
+              errorCount: 2,
+            },
+          },
+        },
+        agentDir,
+      );
+      clearRuntimeAuthProfileStoreSnapshots();
+
+      const store = loadAuthProfileStoreForRuntime(agentDir, { readOnly: true });
+
+      expect(store.order?.["openai-codex"]).toEqual([freshProfileId]);
+      expect(store.profiles[defaultProfileId]).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: "main-default-access",
+      });
+      expect(store.usageStats?.[defaultProfileId]).toMatchObject({
+        lastUsed: 123,
+      });
+    } finally {
+      restoreAgentDirEnv({ previousAgentDir, previousPiAgentDir });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a stale default OAuth profile when the main profile belongs to a different identity", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-drift-mismatch-"));
     const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -7,6 +7,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
   loadAuthProfileStoreForRuntime,
+  saveAuthProfileStore,
 } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION, log } from "./auth-profiles/constants.js";
 import type { AuthProfileCredential } from "./auth-profiles/types.js";
@@ -57,6 +58,7 @@ vi.mock("./cli-credentials.js", () => ({
 
 describe("ensureAuthProfileStore", () => {
   afterEach(() => {
+    clearRuntimeAuthProfileStoreSnapshots();
     resolveExternalAuthProfilesWithPluginsMock.mockReset();
     resolveExternalAuthProfilesWithPluginsMock.mockReturnValue([]);
   });
@@ -224,6 +226,167 @@ describe("ensureAuthProfileStore", () => {
         provider: "openai",
         key: "agent-key",
       });
+    } finally {
+      restoreAgentDirEnv({ previousAgentDir, previousPiAgentDir });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the main agent's newer OAuth profile when an agent still has a stale default profile", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-drift-"));
+    const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    try {
+      const mainDir = path.join(root, "main-agent");
+      const agentDir = path.join(root, "agent-x");
+      fs.mkdirSync(mainDir, { recursive: true });
+      fs.mkdirSync(agentDir, { recursive: true });
+
+      process.env.OPENCLAW_AGENT_DIR = mainDir;
+      process.env.PI_CODING_AGENT_DIR = mainDir;
+
+      const freshProfileId = "openai-codex:user@example.com";
+      const staleProfileId = "openai-codex:default";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [freshProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "main-access",
+              refresh: "main-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+              email: "user@example.com",
+            },
+          },
+          order: {
+            "openai-codex": [freshProfileId],
+          },
+          lastGood: {
+            "openai-codex": freshProfileId,
+          },
+        },
+        mainDir,
+      );
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [staleProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "stale-access",
+              refresh: "stale-refresh",
+              expires: Date.now() - 60 * 60 * 1000,
+              accountId: "acct-from-old-codex-auth",
+            },
+          },
+          order: {
+            "openai-codex": [staleProfileId],
+          },
+          lastGood: {
+            "openai-codex": staleProfileId,
+          },
+          usageStats: {
+            [staleProfileId]: {
+              lastUsed: Date.now() - 30_000,
+              errorCount: 3,
+            },
+          },
+        },
+        agentDir,
+      );
+      clearRuntimeAuthProfileStoreSnapshots();
+
+      const store = loadAuthProfileStoreForRuntime(agentDir, { readOnly: true });
+
+      expect(store.profiles[freshProfileId]).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: "main-access",
+        refresh: "main-refresh",
+      });
+      expect(store.profiles[staleProfileId]).toBeUndefined();
+      expect(store.order?.["openai-codex"]).toEqual([freshProfileId]);
+      expect(store.lastGood?.["openai-codex"]).toBe(freshProfileId);
+      expect(store.usageStats?.[staleProfileId]).toBeUndefined();
+
+      const persistedAgentStore = JSON.parse(
+        fs.readFileSync(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as { profiles: Record<string, unknown> };
+      expect(persistedAgentStore.profiles[staleProfileId]).toBeDefined();
+    } finally {
+      restoreAgentDirEnv({ previousAgentDir, previousPiAgentDir });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a stale default OAuth profile when the main profile belongs to a different identity", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-drift-mismatch-"));
+    const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    try {
+      const mainDir = path.join(root, "main-agent");
+      const agentDir = path.join(root, "agent-x");
+      fs.mkdirSync(mainDir, { recursive: true });
+      fs.mkdirSync(agentDir, { recursive: true });
+
+      process.env.OPENCLAW_AGENT_DIR = mainDir;
+      process.env.PI_CODING_AGENT_DIR = mainDir;
+
+      const freshProfileId = "openai-codex:user@example.com";
+      const staleProfileId = "openai-codex:default";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [freshProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "main-access",
+              refresh: "main-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+              email: "user@example.com",
+            },
+          },
+        },
+        mainDir,
+      );
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [staleProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "other-access",
+              refresh: "other-refresh",
+              expires: Date.now() - 60 * 60 * 1000,
+              email: "other@example.com",
+            },
+          },
+          order: {
+            "openai-codex": [staleProfileId],
+          },
+          lastGood: {
+            "openai-codex": staleProfileId,
+          },
+        },
+        agentDir,
+      );
+      clearRuntimeAuthProfileStoreSnapshots();
+
+      const store = loadAuthProfileStoreForRuntime(agentDir, { readOnly: true });
+
+      expect(store.profiles[freshProfileId]).toBeDefined();
+      expect(store.profiles[staleProfileId]).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: "other-access",
+      });
+      expect(store.order?.["openai-codex"]).toEqual([staleProfileId]);
+      expect(store.lastGood?.["openai-codex"]).toBe(staleProfileId);
     } finally {
       restoreAgentDirEnv({ previousAgentDir, previousPiAgentDir });
       fs.rmSync(root, { recursive: true, force: true });

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -273,6 +273,14 @@ describe("ensureAuthProfileStore", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
+            [freshProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "stale-identity-access",
+              refresh: "stale-identity-refresh",
+              expires: Date.now() - 30 * 60 * 1000,
+              email: "user@example.com",
+            },
             [staleProfileId]: {
               type: "oauth",
               provider: "openai-codex",

--- a/src/agents/auth-profiles/oauth-shared.ts
+++ b/src/agents/auth-profiles/oauth-shared.ts
@@ -59,16 +59,18 @@ export function hasUsableOAuthCredential(
   return hasUsableStoredOAuthCredential(credential, { now });
 }
 
-function normalizeAuthIdentityToken(value: string | undefined): string | undefined {
+export function normalizeAuthIdentityToken(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
 }
 
-function normalizeAuthEmailToken(value: string | undefined): string | undefined {
+export function normalizeAuthEmailToken(value: string | undefined): string | undefined {
   return normalizeAuthIdentityToken(value)?.toLowerCase();
 }
 
-function hasOAuthIdentity(credential: Pick<OAuthCredential, "accountId" | "email">): boolean {
+export function hasOAuthIdentity(
+  credential: Pick<OAuthCredential, "accountId" | "email">,
+): boolean {
   return (
     normalizeAuthIdentityToken(credential.accountId) !== undefined ||
     normalizeAuthEmailToken(credential.email) !== undefined

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,7 +1,9 @@
 import { resolveOAuthPath } from "../../config/paths.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
+import { normalizeProviderId } from "../provider-id.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
+import { hasUsableOAuthCredential, isSafeToAdoptMainStoreOAuthIdentity } from "./oauth-shared.js";
 import { resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
 import {
   coerceAuthProfileState,
@@ -12,6 +14,7 @@ import type {
   AuthProfileCredential,
   AuthProfileSecretsStore,
   AuthProfileStore,
+  OAuthCredential,
   OAuthCredentials,
 } from "./types.js";
 
@@ -159,6 +162,187 @@ function mergeRecord<T>(
   return { ...base, ...override };
 }
 
+function dedupeMergedProfileOrder(profileIds: string[]): string[] {
+  return Array.from(new Set(profileIds));
+}
+
+function normalizeOAuthIdentityToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeOAuthEmailToken(value: string | undefined): string | undefined {
+  return normalizeOAuthIdentityToken(value)?.toLowerCase();
+}
+
+function hasOAuthIdentity(credential: OAuthCredential): boolean {
+  return Boolean(
+    normalizeOAuthIdentityToken(credential.accountId) ?? normalizeOAuthEmailToken(credential.email),
+  );
+}
+
+function hasComparableOAuthIdentityConflict(
+  existing: OAuthCredential,
+  candidate: OAuthCredential,
+): boolean {
+  const existingAccountId = normalizeOAuthIdentityToken(existing.accountId);
+  const candidateAccountId = normalizeOAuthIdentityToken(candidate.accountId);
+  if (
+    existingAccountId !== undefined &&
+    candidateAccountId !== undefined &&
+    existingAccountId !== candidateAccountId
+  ) {
+    return true;
+  }
+
+  const existingEmail = normalizeOAuthEmailToken(existing.email);
+  const candidateEmail = normalizeOAuthEmailToken(candidate.email);
+  return (
+    existingEmail !== undefined && candidateEmail !== undefined && existingEmail !== candidateEmail
+  );
+}
+
+function isLegacyDefaultOAuthProfile(profileId: string, credential: OAuthCredential): boolean {
+  return profileId === `${normalizeProviderId(credential.provider)}:default`;
+}
+
+function isNewerUsableOAuthCredential(
+  existing: OAuthCredential,
+  candidate: OAuthCredential,
+): boolean {
+  if (!hasUsableOAuthCredential(candidate)) {
+    return false;
+  }
+  if (!hasUsableOAuthCredential(existing)) {
+    return true;
+  }
+  return (
+    Number.isFinite(candidate.expires) &&
+    (!Number.isFinite(existing.expires) || candidate.expires > existing.expires)
+  );
+}
+
+function findMainStoreOAuthReplacement(params: {
+  base: AuthProfileStore;
+  legacyProfileId: string;
+  legacyCredential: OAuthCredential;
+}): string | undefined {
+  const providerKey = normalizeProviderId(params.legacyCredential.provider);
+  const candidates = Object.entries(params.base.profiles)
+    .flatMap(([profileId, credential]): Array<[string, OAuthCredential]> => {
+      if (
+        profileId === params.legacyProfileId ||
+        credential.type !== "oauth" ||
+        normalizeProviderId(credential.provider) !== providerKey
+      ) {
+        return [];
+      }
+      return [[profileId, credential]];
+    })
+    .filter(([, credential]) => isNewerUsableOAuthCredential(params.legacyCredential, credential))
+    .toSorted(([leftId, leftCredential], [rightId, rightCredential]) => {
+      const leftExpires = Number.isFinite(leftCredential.expires) ? leftCredential.expires : 0;
+      const rightExpires = Number.isFinite(rightCredential.expires) ? rightCredential.expires : 0;
+      if (rightExpires !== leftExpires) {
+        return rightExpires - leftExpires;
+      }
+      return leftId.localeCompare(rightId);
+    });
+
+  const exactIdentityCandidates = candidates.filter(([, credential]) =>
+    isSafeToAdoptMainStoreOAuthIdentity(params.legacyCredential, credential),
+  );
+  if (exactIdentityCandidates.length > 0) {
+    if (!hasOAuthIdentity(params.legacyCredential) && exactIdentityCandidates.length > 1) {
+      return undefined;
+    }
+    return exactIdentityCandidates[0]?.[0];
+  }
+
+  if (hasUsableOAuthCredential(params.legacyCredential)) {
+    return undefined;
+  }
+  const fallbackCandidates = candidates.filter(
+    ([, credential]) => !hasComparableOAuthIdentityConflict(params.legacyCredential, credential),
+  );
+  if (fallbackCandidates.length !== 1) {
+    return undefined;
+  }
+  return fallbackCandidates[0]?.[0];
+}
+
+function replaceMergedProfileReferences(
+  store: AuthProfileStore,
+  replacements: Map<string, string>,
+): AuthProfileStore {
+  if (replacements.size === 0) {
+    return store;
+  }
+
+  const profiles = { ...store.profiles };
+  for (const legacyProfileId of replacements.keys()) {
+    delete profiles[legacyProfileId];
+  }
+
+  const order = store.order
+    ? Object.fromEntries(
+        Object.entries(store.order).map(([provider, profileIds]) => [
+          provider,
+          dedupeMergedProfileOrder(
+            profileIds.map((profileId) => replacements.get(profileId) ?? profileId),
+          ),
+        ]),
+      )
+    : undefined;
+
+  const lastGood = store.lastGood
+    ? Object.fromEntries(
+        Object.entries(store.lastGood).map(([provider, profileId]) => [
+          provider,
+          replacements.get(profileId) ?? profileId,
+        ]),
+      )
+    : undefined;
+
+  const usageStats = store.usageStats
+    ? Object.fromEntries(
+        Object.entries(store.usageStats).filter(([profileId]) => !replacements.has(profileId)),
+      )
+    : undefined;
+
+  return {
+    ...store,
+    profiles,
+    ...(order && Object.keys(order).length > 0 ? { order } : { order: undefined }),
+    ...(lastGood && Object.keys(lastGood).length > 0 ? { lastGood } : { lastGood: undefined }),
+    ...(usageStats && Object.keys(usageStats).length > 0
+      ? { usageStats }
+      : { usageStats: undefined }),
+  };
+}
+
+function reconcileMainStoreOAuthProfileDrift(params: {
+  base: AuthProfileStore;
+  override: AuthProfileStore;
+  merged: AuthProfileStore;
+}): AuthProfileStore {
+  const replacements = new Map<string, string>();
+  for (const [profileId, credential] of Object.entries(params.override.profiles)) {
+    if (credential.type !== "oauth" || !isLegacyDefaultOAuthProfile(profileId, credential)) {
+      continue;
+    }
+    const replacementProfileId = findMainStoreOAuthReplacement({
+      base: params.base,
+      legacyProfileId: profileId,
+      legacyCredential: credential,
+    });
+    if (replacementProfileId) {
+      replacements.set(profileId, replacementProfileId);
+    }
+  }
+  return replaceMergedProfileReferences(params.merged, replacements);
+}
+
 export function mergeAuthProfileStores(
   base: AuthProfileStore,
   override: AuthProfileStore,
@@ -171,13 +355,14 @@ export function mergeAuthProfileStores(
   ) {
     return base;
   }
-  return {
+  const merged = {
     version: Math.max(base.version, override.version ?? base.version),
     profiles: { ...base.profiles, ...override.profiles },
     order: mergeRecord(base.order, override.order),
     lastGood: mergeRecord(base.lastGood, override.lastGood),
     usageStats: mergeRecord(base.usageStats, override.usageStats),
   };
+  return reconcileMainStoreOAuthProfileDrift({ base, override, merged });
 }
 
 export function buildPersistedAuthProfileSecretsStore(

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -3,7 +3,13 @@ import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
 import { normalizeProviderId } from "../provider-id.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
-import { hasUsableOAuthCredential, isSafeToAdoptMainStoreOAuthIdentity } from "./oauth-shared.js";
+import {
+  hasOAuthIdentity,
+  hasUsableOAuthCredential,
+  isSafeToAdoptMainStoreOAuthIdentity,
+  normalizeAuthEmailToken,
+  normalizeAuthIdentityToken,
+} from "./oauth-shared.js";
 import { resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
 import {
   coerceAuthProfileState,
@@ -166,27 +172,12 @@ function dedupeMergedProfileOrder(profileIds: string[]): string[] {
   return Array.from(new Set(profileIds));
 }
 
-function normalizeOAuthIdentityToken(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function normalizeOAuthEmailToken(value: string | undefined): string | undefined {
-  return normalizeOAuthIdentityToken(value)?.toLowerCase();
-}
-
-function hasOAuthIdentity(credential: OAuthCredential): boolean {
-  return Boolean(
-    normalizeOAuthIdentityToken(credential.accountId) ?? normalizeOAuthEmailToken(credential.email),
-  );
-}
-
 function hasComparableOAuthIdentityConflict(
   existing: OAuthCredential,
   candidate: OAuthCredential,
 ): boolean {
-  const existingAccountId = normalizeOAuthIdentityToken(existing.accountId);
-  const candidateAccountId = normalizeOAuthIdentityToken(candidate.accountId);
+  const existingAccountId = normalizeAuthIdentityToken(existing.accountId);
+  const candidateAccountId = normalizeAuthIdentityToken(candidate.accountId);
   if (
     existingAccountId !== undefined &&
     candidateAccountId !== undefined &&
@@ -195,8 +186,8 @@ function hasComparableOAuthIdentityConflict(
     return true;
   }
 
-  const existingEmail = normalizeOAuthEmailToken(existing.email);
-  const candidateEmail = normalizeOAuthEmailToken(candidate.email);
+  const existingEmail = normalizeAuthEmailToken(existing.email);
+  const candidateEmail = normalizeAuthEmailToken(candidate.email);
   return (
     existingEmail !== undefined && candidateEmail !== undefined && existingEmail !== candidateEmail
   );
@@ -271,17 +262,24 @@ function findMainStoreOAuthReplacement(params: {
   return fallbackCandidates[0]?.[0];
 }
 
-function replaceMergedProfileReferences(
-  store: AuthProfileStore,
-  replacements: Map<string, string>,
-): AuthProfileStore {
+function replaceMergedProfileReferences(params: {
+  store: AuthProfileStore;
+  base: AuthProfileStore;
+  replacements: Map<string, string>;
+}): AuthProfileStore {
+  const { store, base, replacements } = params;
   if (replacements.size === 0) {
     return store;
   }
 
   const profiles = { ...store.profiles };
   for (const legacyProfileId of replacements.keys()) {
-    delete profiles[legacyProfileId];
+    const baseCredential = base.profiles[legacyProfileId];
+    if (baseCredential) {
+      profiles[legacyProfileId] = baseCredential;
+    } else {
+      delete profiles[legacyProfileId];
+    }
   }
 
   const order = store.order
@@ -304,11 +302,17 @@ function replaceMergedProfileReferences(
       )
     : undefined;
 
-  const usageStats = store.usageStats
-    ? Object.fromEntries(
-        Object.entries(store.usageStats).filter(([profileId]) => !replacements.has(profileId)),
-      )
-    : undefined;
+  const usageStats = store.usageStats ? { ...store.usageStats } : undefined;
+  if (usageStats) {
+    for (const legacyProfileId of replacements.keys()) {
+      const baseStats = base.usageStats?.[legacyProfileId];
+      if (baseStats) {
+        usageStats[legacyProfileId] = baseStats;
+      } else {
+        delete usageStats[legacyProfileId];
+      }
+    }
+  }
 
   return {
     ...store,
@@ -340,7 +344,11 @@ function reconcileMainStoreOAuthProfileDrift(params: {
       replacements.set(profileId, replacementProfileId);
     }
   }
-  return replaceMergedProfileReferences(params.merged, replacements);
+  return replaceMergedProfileReferences({
+    store: params.merged,
+    base: params.base,
+    replacements,
+  });
 }
 
 export function mergeAuthProfileStores(

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -273,12 +273,16 @@ function replaceMergedProfileReferences(params: {
   }
 
   const profiles = { ...store.profiles };
-  for (const legacyProfileId of replacements.keys()) {
+  for (const [legacyProfileId, replacementProfileId] of replacements) {
     const baseCredential = base.profiles[legacyProfileId];
     if (baseCredential) {
       profiles[legacyProfileId] = baseCredential;
     } else {
       delete profiles[legacyProfileId];
+    }
+    const replacementBaseCredential = base.profiles[replacementProfileId];
+    if (replacementBaseCredential) {
+      profiles[replacementProfileId] = replacementBaseCredential;
     }
   }
 


### PR DESCRIPTION
This is stacked on #70390.

The first PR stops onboarding from importing Codex CLI auth into OpenClaw. This follow-up handles the existing drift that can be left behind in agent-specific auth stores: the main agent may have the current identity-scoped OAuth profile while another agent still has stale `openai-codex:default` state and order metadata pointing at it.

Before this, `mergeAuthProfileStores` treated the per-agent store as an unconditional override. That meant a sibling agent could keep selecting the stale default profile even though the main store had a fresher usable profile for the same provider.

This changes the merge so stale OAuth `:default` profiles stop shadowing a newer main-agent profile when adoption is safe. The runtime merged store now rewrites order and `lastGood` references to the main profile and drops stale usage stats for the old profile. It refuses clear different-account or different-email matches, and only falls back across non-comparable Codex identity shapes when there is a single fresh main candidate.

It also declares the OpenAI Codex legacy default profile repair so `openclaw doctor` can offer the same cleanup path as other OAuth providers.

Related to #59272.
