### PR TITLE
fix(memory-core): keep Dream Diary to one entry per sweep

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -76,7 +76,7 @@ before ingestion.
 ## Dream Diary
 
 Dreaming also keeps a narrative **Dream Diary** in `DREAMS.md`.
-After each phase has enough material, `memory-core` runs a best-effort background
+After a full sweep has enough material, `memory-core` runs a best-effort background
 subagent turn (using the default runtime model) and appends a short diary entry.
 
 This diary is for human reading in the Dreams UI, not a promotion source.

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1,7 +1,5 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { RequestScopedSubagentRuntimeError } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core";
 import {
@@ -189,7 +187,7 @@ async function readCandidateSnippets(workspaceDir: string, nowIso: string): Prom
 }
 
 describe("memory-core dreaming phases", () => {
-  it("uses the hashed narrative session key for sweep-level fallback cleanup", async () => {
+  it("does not append Dream Diary entries during light-only sweep phases", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [
       `# ${DREAMING_TEST_DAY}`,
@@ -237,8 +235,6 @@ describe("memory-core dreaming phases", () => {
       error: vi.fn(),
     };
     const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
 
     await runDreamingSweepPhases({
       workspaceDir,
@@ -249,79 +245,12 @@ describe("memory-core dreaming phases", () => {
       nowMs,
     });
 
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
-    expect(subagent.deleteSession).toHaveBeenNthCalledWith(1, { sessionKey: expectedSessionKey });
-    expect(subagent.deleteSession).toHaveBeenNthCalledWith(2, { sessionKey: expectedSessionKey });
-  });
-
-  it("swallows synchronous request-scoped cleanup failures after narrative fallback", async () => {
-    const workspaceDir = await createDreamingWorkspace();
-    await writeDailyNote(workspaceDir, [
-      `# ${DREAMING_TEST_DAY}`,
-      "",
-      "- Move backups to S3 Glacier.",
-      "- Keep retention at 365 days.",
-    ]);
-    const testConfig: OpenClawConfig = {
-      ...LIGHT_DREAMING_TEST_CONFIG,
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-          userTimezone: "UTC",
-        },
-      },
-      plugins: {
-        entries: {
-          "memory-core": {
-            config: {
-              dreaming: {
-                enabled: true,
-                timezone: "UTC",
-                phases: {
-                  light: {
-                    enabled: true,
-                    limit: 20,
-                    lookbackDays: 2,
-                  },
-                  rem: {
-                    enabled: false,
-                    limit: 0,
-                    lookbackDays: 2,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    };
-    const subagent = createMockNarrativeSubagent();
-    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
-    subagent.deleteSession.mockImplementation(() => {
-      throw new RequestScopedSubagentRuntimeError();
+    expect(subagent.run).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
     });
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
-
-    await expect(
-      runDreamingSweepPhases({
-        workspaceDir,
-        cfg: testConfig,
-        pluginConfig: resolveMemoryCorePluginConfig(testConfig),
-        logger,
-        subagent,
-        nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
-      }),
-    ).resolves.toBeUndefined();
-
-    const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(dreams).toContain("Move backups to S3 Glacier.");
-    expect(logger.error).not.toHaveBeenCalled();
   });
-
   it("does not re-ingest managed light dreaming blocks from daily notes", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await withDreamingTestClock(async () => {
@@ -1827,7 +1756,7 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
-  it("passes staged light-dreaming snippets into the narrative pipeline", async () => {
+  it("does not append Dream Diary entries during standalone light dreaming", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const subagent = createMockNarrativeSubagent("The backup plan glowed like cold storage.");
     const { beforeAgentReply } = createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir, subagent);
@@ -1843,16 +1772,13 @@ describe("memory-core dreaming phases", () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
     });
 
-    expect(subagent.run).toHaveBeenCalledTimes(1);
-    const firstRun = subagent.run.mock.calls[0]?.[0];
-    expect(firstRun?.message).toContain("Move backups to S3 Glacier.");
-    expect(firstRun?.message).toContain("Keep retention at 365 days.");
-    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).resolves.toContain(
-      "The backup plan glowed like cold storage.",
-    );
+    expect(subagent.run).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
-  it("passes rem-dreaming snippets into the narrative pipeline", async () => {
+  it("does not append Dream Diary entries during standalone rem dreaming", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const subagent = createMockNarrativeSubagent("The traces braided themselves into a map.");
     const { beforeAgentReply } = createHarness(
@@ -1897,13 +1823,10 @@ describe("memory-core dreaming phases", () => {
       );
     });
 
-    expect(subagent.run).toHaveBeenCalledTimes(1);
-    const firstRun = subagent.run.mock.calls[0]?.[0];
-    expect(firstRun?.message).toContain("Move backups to S3 Glacier.");
-    expect(firstRun?.message).toContain("Keep retention at 365 days.");
-    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).resolves.toContain(
-      "The traces braided themselves into a map.",
-    );
+    expect(subagent.run).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("increments dailyCount when the same daily file is re-ingested on a later day", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -19,11 +19,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
-import {
-  buildNarrativeSessionKey,
-  generateAndAppendDreamNarrative,
-  type NarrativePhaseData,
-} from "./dreaming-narrative.js";
+import { generateAndAppendDreamNarrative } from "./dreaming-narrative.js";
 import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
 import {
   readShortTermRecallEntries,
@@ -1545,23 +1541,6 @@ async function runLightDreaming(params: {
       `memory-core: light dreaming staged ${Math.min(entries.length, params.config.limit)} candidate(s) [workspace=${params.workspaceDir}].`,
     );
   }
-  // Generate dream diary narrative from the staged entries.
-  if (params.subagent && capped.length > 0) {
-    const themes = [...new Set(capped.flatMap((e) => e.conceptTags).filter(Boolean))];
-    const data: NarrativePhaseData = {
-      phase: "light",
-      snippets: capped.map((e) => e.snippet).filter(Boolean),
-      ...(themes.length > 0 ? { themes } : {}),
-    };
-    await generateAndAppendDreamNarrative({
-      subagent: params.subagent,
-      workspaceDir: params.workspaceDir,
-      data,
-      nowMs,
-      timezone: params.config.timezone,
-      logger: params.logger,
-    });
-  }
 }
 
 async function runRemDreaming(params: {
@@ -1615,43 +1594,6 @@ async function runRemDreaming(params: {
       `memory-core: REM dreaming wrote reflections from ${entries.length} recent memory trace(s) [workspace=${params.workspaceDir}].`,
     );
   }
-  // Generate dream diary narrative from REM reflections.
-  if (params.subagent && entries.length > 0) {
-    const snippets = preview.candidateTruths.map((t) => t.snippet).filter(Boolean);
-    const themes = preview.reflections.filter(
-      (r) => !r.startsWith("- No strong") && !r.startsWith("  -"),
-    );
-    const data: NarrativePhaseData = {
-      phase: "rem",
-      snippets:
-        snippets.length > 0
-          ? snippets
-          : entries
-              .slice(0, 8)
-              .map((e) => e.snippet)
-              .filter(Boolean),
-      ...(themes.length > 0 ? { themes } : {}),
-    };
-    await generateAndAppendDreamNarrative({
-      subagent: params.subagent,
-      workspaceDir: params.workspaceDir,
-      data,
-      nowMs,
-      timezone: params.config.timezone,
-      logger: params.logger,
-    });
-  }
-}
-
-async function deleteNarrativeSessionBestEffort(
-  subagent: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"],
-  sessionKey: string,
-): Promise<void> {
-  try {
-    await subagent.deleteSession({ sessionKey });
-  } catch {
-    // Cleanup is best-effort; request-scoped runtimes can throw synchronously.
-  }
 }
 
 export async function runDreamingSweepPhases(params: {
@@ -1678,16 +1620,6 @@ export async function runDreamingSweepPhases(params: {
       subagent: params.subagent,
       nowMs: sweepNowMs,
     });
-    // Defensive cleanup: ensure the light-phase narrative session is deleted even if
-    // generateAndAppendDreamNarrative's primary cleanup was skipped due to an error.
-    if (params.subagent) {
-      const lightSessionKey = buildNarrativeSessionKey({
-        workspaceDir: params.workspaceDir,
-        phase: "light",
-        nowMs: sweepNowMs,
-      });
-      await deleteNarrativeSessionBestEffort(params.subagent, lightSessionKey);
-    }
   }
 
   const rem = resolveMemoryRemDreamingConfig({
@@ -1703,15 +1635,6 @@ export async function runDreamingSweepPhases(params: {
       subagent: params.subagent,
       nowMs: sweepNowMs,
     });
-    // Defensive cleanup: ensure the REM-phase narrative session is deleted.
-    if (params.subagent) {
-      const remSessionKey = buildNarrativeSessionKey({
-        workspaceDir: params.workspaceDir,
-        phase: "rem",
-        nowMs: sweepNowMs,
-      });
-      await deleteNarrativeSessionBestEffort(params.subagent, remSessionKey);
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- keep Dream Diary generation to one entry per nightly sweep
- stop light and REM phases from appending their own `DREAMS.md` diary entries
- update dreaming tests and docs to match deep-only diary generation

## Why
A single sweep was appending multiple diary entries with the same displayed timestamp because light, REM, and deep all used the same sweep time when calling the narrative append path. This keeps the diary readable without changing phase reporting or promotion behavior.

## Validation
- `pnpm test extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/dreaming-narrative.test.ts`
- `pnpm exec tsc -p extensions/memory-core/tsconfig.json --noEmit`

## Notes
- This follows the existing dreaming-bloat cleanup work, but had to be opened from a separate fork branch because the older PR branch is owned by another fork and is not writable from this account.

Follow-up to #68774.
Also builds on the earlier dreaming-bloat cleanup in #68445.
