### PR TITLE
Agents/model fallback: retry-and-stop on session write-lock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Pi: honor explicit `strict-agentic` execution contracts for incomplete-turn retry guards across providers, so manually opted-in local or compatible models get the same retry behavior without relying on OpenAI model inference. (#66750) Thanks @ziomancer.
 - OpenShell/sandbox: pin verified file reads to an already-opened descriptor, walk the ancestor chain for symlinked parents on platforms without fd-path readlink, and re-check file identity so parent symlink swaps cannot redirect in-sandbox reads to host files outside the allowed mount root. (#69798) Thanks @drobison00.
 - Gateway/Control UI: require authenticated Control UI read access before serving `/__openclaw/control-ui-config.json` when `gateway.auth` is enabled, so unauthenticated callers can no longer read bootstrap metadata. (#70247) Thanks @drobison00.
+- Agents/model fallback: treat session write-lock timeouts as per-session contention and retry the same candidate once before stopping the fan-out, instead of cascading through every fallback model. Previously one 10s lock (typically held by an in-flight compaction) was multiplied by the candidate count — a 6-model chain turned a brief stall into a ~60s wall time per blocked turn.
 
 ## 2026.4.21
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -355,6 +355,62 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledWith("openai", "gpt-5.4");
   });
 
+  it("retries the same model once on session lock timeout, then stops fan-out", async () => {
+    const cfg = makeCfg();
+    const lockError = new Error(
+      "session file locked (timeout 10000ms): pid=42 /tmp/session.jsonl.lock",
+    );
+    const run = vi.fn().mockRejectedValue(lockError);
+    vi.useFakeTimers();
+    try {
+      const promise = runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      });
+      const assertion = expect(promise).rejects.toThrow(/session file locked/);
+      await vi.runAllTimersAsync();
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+    // Same candidate twice, then break — do not fan out to other models.
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini"],
+    ]);
+  });
+
+  it("recovers on session-lock retry without using fallback models", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("session file locked (timeout 10000ms): pid=42 /tmp/session.jsonl.lock"),
+      )
+      .mockResolvedValueOnce("ok");
+    vi.useFakeTimers();
+    let result!: Awaited<ReturnType<typeof runWithModelFallback<string>>>;
+    try {
+      const promise = runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      });
+      await vi.runAllTimersAsync();
+      result = await promise;
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini"],
+    ]);
+  });
+
   it("falls back on unrecognized errors when candidates remain", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockRejectedValueOnce(new Error("bad request")).mockResolvedValueOnce("ok");

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -37,6 +37,36 @@ import type { FailoverReason } from "./pi-embedded-helpers/types.js";
 
 const log = createSubsystemLogger("model-fallback");
 
+// Detect `acquireSessionWriteLock` timeout escapes so we can retry the same
+// candidate once and then stop the fan-out. A per-session contention is not a
+// per-model problem; cycling through every candidate amplifies one 10s stall
+// into a 6×-long blackhole.
+const SESSION_LOCK_TIMEOUT_RE = /session file locked \(timeout (\d+)ms\)/i;
+const SESSION_LOCK_RETRY_LIMIT = 1;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseSessionLockTimeoutMs(err: unknown): number | null {
+  const message = formatErrorMessage(err);
+  const match = SESSION_LOCK_TIMEOUT_RE.exec(message);
+  if (!match) {
+    return null;
+  }
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function resolveSessionLockRetryBackoffMs(params: {
+  lockTimeoutMs: number | null;
+  retryAttempt: number;
+}): number {
+  const timeoutMs = params.lockTimeoutMs ?? 10_000;
+  const base = Math.min(2_000, Math.max(250, Math.floor(timeoutMs / 20)));
+  return Math.min(3_000, base * Math.max(1, params.retryAttempt));
+}
+
 /**
  * Structured error thrown when all model fallback candidates have been
  * exhausted. Carries per-attempt details so callers can build informative
@@ -676,6 +706,7 @@ export async function runWithModelFallback<T>(params: {
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
   const cooldownProbeUsedProviders = new Set<string>();
+  const sessionLockRetriesByCandidate = new Map<string, number>();
 
   const hasFallbackCandidates = candidates.length > 1;
 
@@ -850,6 +881,52 @@ export async function runWithModelFallback<T>(params: {
           provider: candidate.provider,
           model: candidate.model,
         }) ?? err;
+
+      // Session write-lock contention is per-session, not per-model. Retry the
+      // same candidate once so a brief hold (compaction, sibling flush) can
+      // clear, then break — do not cascade through every fallback model.
+      const sessionLockTimeoutMs = parseSessionLockTimeoutMs(normalized);
+      if (sessionLockTimeoutMs !== null) {
+        const candidateKey = `${candidate.provider}/${candidate.model}`;
+        const retriesUsed = sessionLockRetriesByCandidate.get(candidateKey) ?? 0;
+        if (retriesUsed < SESSION_LOCK_RETRY_LIMIT) {
+          const nextRetryAttempt = retriesUsed + 1;
+          sessionLockRetriesByCandidate.set(candidateKey, nextRetryAttempt);
+          const retryBackoffMs = resolveSessionLockRetryBackoffMs({
+            lockTimeoutMs: sessionLockTimeoutMs,
+            retryAttempt: nextRetryAttempt,
+          });
+          log.warn(
+            `session lock timeout on ${sanitizeForLog(candidate.provider)}/${sanitizeForLog(candidate.model)}; retrying same candidate in ${retryBackoffMs}ms`,
+          );
+          await sleep(retryBackoffMs);
+          i -= 1;
+          continue;
+        }
+        lastError = normalized;
+        recordFailedCandidateAttempt({
+          attempts,
+          candidate,
+          error: normalized,
+          runId: params.runId,
+          requestedProvider: params.provider,
+          requestedModel: params.model,
+          attempt: i + 1,
+          total: candidates.length,
+          nextCandidate: undefined,
+          isPrimary,
+          requestedModelMatched: requestedModel,
+          fallbackConfigured: hasFallbackCandidates,
+        });
+        await params.onError?.({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: normalized,
+          attempt: i + 1,
+          total: candidates.length,
+        });
+        break;
+      }
 
       // LiveSessionModelSwitchError during fallback means the session's
       // persisted model conflicts with this fallback candidate.  Treat it


### PR DESCRIPTION
## Summary

- Problem: A `session file locked (timeout Nms)` error from `acquireSessionWriteLock` propagates into the fallback loop as a generic failure, so every candidate model gets tried for the same contended session — a brief lock (usually an in-flight compaction) multiplies into `candidates.length × timeoutMs` of wasted wall time and a `FallbackSummaryError` that misblames the models.
- Why it matters: With a 6-candidate chain and the default 10s lock timeout, one legitimate ~1s compaction turned every queued turn into a ~60s blackhole ending in `All models failed (6)`. We observed p50=50.5s / p95=70.0s for contended turns in the field. Client-visible failure mode looks like "all models down" when actually the session is just momentarily locked.
- What changed: In `runWithModelFallback`, detect `session file locked (timeout Nms)` in the normalized error, retry the same candidate once with bounded backoff (250ms–3s), and if the lock is still held on retry, `break` out of the fallback loop instead of cycling through unrelated models. Other candidates can't resolve a session-scoped lock.
- What did NOT change (scope boundary): `session-write-lock.ts` behavior, staleness detection, watchdog, or timeout defaults. No changes to the per-candidate runner, auth-profile cooldowns, context-overflow handling, or the `LiveSessionModelSwitchError` path.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `session file locked` errors had no special-case in the fallback loop. They flowed through `coerceToFailoverError` → treated like any other failover reason → next candidate attempted. Since every candidate contends on the same session file, each attempt pays another full `timeoutMs` before moving on.
- Missing detection / guardrail: no parsing of the lock-timeout error shape; no per-session retry counter; no fast-path out of the fan-out when the failure is session-scoped rather than model-scoped.
- Contributing context: session locks are typically held briefly by legitimate compactions (<5 min watchdog window). Under that window, the lock clears on its own — we just need to wait, not fall back. The default fallback chain (~6 models) amplifies a ~1s stall into a ~60s user-facing failure.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/model-fallback.test.ts`
- Scenario the test should lock in:
  - `retries the same model once on session lock timeout, then stops fan-out` — with a `run` mock that always rejects `session file locked`, assert `run` is called exactly twice on the primary candidate and the promise rejects with `/session file locked/` (not `FallbackSummaryError: All models failed (N)`).
  - `recovers on session-lock retry without using fallback models` — with a `run` mock that rejects once then resolves `"ok"`, assert the result is `"ok"` and `run` was called exactly twice, both on the primary candidate (no fallback candidate invoked).
- Why this is the smallest reliable guardrail: the bug is a control-flow misroute inside the fallback loop; a targeted unit test with a fake `run` proves both the retry and the break-after-retry cleanly without needing a real session file or lock file.
- Existing test that already covers this (if any): `falls back on timeout abort errors` exercises the timeout path but not the session-lock message pattern.
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes

When a session write-lock is held (e.g., during compaction), a contended turn now takes at most one retry + one timeout + bounded backoff (~21s cap at default `timeoutMs=10000`) and either succeeds or fails fast with the real `session file locked` error. Previously it cycled through every fallback candidate and emitted `FallbackSummaryError: All models failed (N)` after `N × timeoutMs`. No config change required; no defaults altered.

## Diagram

```text
Before (6-candidate chain, 10s lock timeout):
  turn -> primary:10s lock -> claw-8b:10s lock -> qwen3:8b:10s lock
       -> claw-32b:10s lock -> qwen3-32b-orch:10s lock -> qwen3:32b:10s lock
       -> FallbackSummaryError: All models failed (6)   [~60s wall, user-visible failure]

After:
  turn -> primary:10s lock -> [sleep ~500ms] -> primary retry
       -> (a) success if lock released, OR (b) break -> surface "session file locked"
                                                          [~21s cap on (b)]
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Node 22.22.1, pnpm 10.33.0, macOS (Apple Silicon). Reproducible on Linux/x64 — the bug is in control flow, not platform-specific.

### Repro (before fix)

1. Start the gateway with any 2+ candidate fallback chain for a session.
2. From a separate process, grab the session write-lock by opening the `.jsonl.lock` file for longer than `timeoutMs` (the natural trigger is an in-flight compaction; for a synthetic repro, hold the file descriptor for ~15s).
3. While the lock is held, issue any `agent` call to that session.
4. Observe `gateway.err.log`: one `lane task error: ... session file locked` per candidate, followed by a `FallbackSummaryError: All models failed (N)` totaling ~`N × timeoutMs`.

### Verify (after fix)

- `pnpm test src/agents/model-fallback.test.ts` — 52/52 pass locally, including the two new cases.
- In live logs, the decision record for session-lock failures now reads `reason=timeout next=none detail=session file locked` (single log line, no cascade).
- Contended-turn wall time drops from p50=50.5s / p95=70.0s to p95≤~21s (bounded: one `timeoutMs` + one retry backoff + one `timeoutMs`).

### Tests run locally

- `pnpm test src/agents/model-fallback.test.ts` — pass
- `pnpm tsgo` — clean
- `pnpm build` — clean
- Staged, built, packed, `npm i -g`-installed on a real gateway; observed `next=none` log line on a real session-lock event (prior to patch: `next=ollama/claw-8b` etc. cascading).

## Notes for reviewers

- The backoff is intentionally bounded (`min(3s, base × retryAttempt)` with `base = clamp(250, 2000, timeoutMs/20)`) so the retry isn't just another long wait. At default `timeoutMs=10000`, retry-backoff is ~500ms.
- `SESSION_LOCK_RETRY_LIMIT=1` was deliberate: one retry catches the common compaction-clearing case; beyond that the caller should see the real error rather than stack more waits. Open to making it a config knob if reviewers prefer, but the default 1 matches the observed pattern.
- Reentrant session locks within the same process are handled upstream in `session-write-lock.ts`; this change only affects cross-process / sibling-flow contention as seen from the fallback consumer.
