### PR TITLE
fix(agents): route /btw through provider stream fn for correct URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/BTW: route `/btw` side questions through provider stream registration with the session workspace, so Ollama provider URL construction and workspace-scoped hooks apply correctly. Fixes #68336. (#70413) Thanks @suboss87.
 - Codex harness: route Codex-tagged MCP tool approval elicitations through OpenClaw plugin approvals, including current empty-schema app-server requests, while leaving generic user-input prompts fail-closed. (#68807) Thanks @kesslerio.
 - WhatsApp/outbound: hold an in-memory active-delivery claim while a live outbound send is in flight, so a concurrent reconnect drain no longer re-drives the same pending queue entry and duplicates cron sends 7-12x after the 30-minute inbound-silence watchdog fires mid-delivery. Crash-replay of fresh queue entries left behind by a dead process is preserved because the claim is intentionally process-local. Fixes #70386. (#70428) Thanks @neeravmakwana.
 - Providers/SDK retry: cap long `Retry-After` sleeps in Stainless-based Anthropic/OpenAI model SDKs so 60s+ retry windows surface immediately for OpenClaw failover instead of blocking the run. (#68474) Thanks @jetd1.

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -17,6 +17,7 @@ const getActiveEmbeddedRunSnapshotMock = vi.fn();
 const resolveSessionAgentIdMock = vi.fn();
 const resolveAgentWorkspaceDirMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
+const registerProviderStreamForModelMock = vi.fn();
 const diagDebugMock = vi.fn();
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -69,6 +70,11 @@ vi.mock("./agent-scope.js", () => ({
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: (...args: unknown[]) => prepareProviderRuntimeAuthMock(...args),
+}));
+
+vi.mock("./provider-stream.js", () => ({
+  registerProviderStreamForModel: (...args: unknown[]) =>
+    registerProviderStreamForModelMock(...args),
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({
@@ -275,6 +281,7 @@ describe("runBtwSideQuestion", () => {
     resolveSessionAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
+    registerProviderStreamForModelMock.mockReset();
     diagDebugMock.mockReset();
 
     buildSessionContextMock.mockReturnValue({
@@ -293,6 +300,7 @@ describe("runBtwSideQuestion", () => {
     resolveSessionAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
+    registerProviderStreamForModelMock.mockReturnValue(undefined);
   });
 
   it("streams blocks without persisting BTW data to disk", async () => {
@@ -430,6 +438,48 @@ describe("runBtwSideQuestion", () => {
       expect.anything(),
       expect.objectContaining({ apiKey: "copilot-runtime-token" }),
     );
+  });
+
+  it("uses the provider's stream fn when registered so provider URL construction runs (#68336)", async () => {
+    // Regression: before this fix, /btw called streamSimple directly and
+    // bypassed the provider's createStreamFn/wrapStreamFn hooks. That caused
+    // Ollama Cloud (api: "openai-completions", baseUrl: "https://ollama.com/")
+    // to hit the marketing site instead of /v1/chat/completions.
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "ollama",
+      id: "glm-5.1",
+      api: "openai-completions",
+      baseUrl: "https://ollama.com/",
+    });
+    const providerStreamFn = vi
+      .fn()
+      .mockReturnValue(makeAsyncEvents([createDoneEvent("Ollama Cloud answer.")]));
+    registerProviderStreamForModelMock.mockReturnValue(providerStreamFn);
+
+    const result = await runSideQuestion({ provider: "ollama", model: "glm-5.1" });
+
+    expect(result).toEqual({ text: "Ollama Cloud answer." });
+    expect(registerProviderStreamForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "ollama",
+          api: "openai-completions",
+          baseUrl: "https://ollama.com/",
+        }),
+      }),
+    );
+    expect(providerStreamFn).toHaveBeenCalledTimes(1);
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to streamSimple when no provider stream fn is registered", async () => {
+    registerProviderStreamForModelMock.mockReturnValue(undefined);
+    mockDoneAnswer("Fallback answer.");
+
+    const result = await runSideQuestion();
+
+    expect(result).toEqual({ text: "Fallback answer." });
+    expect(streamSimpleMock).toHaveBeenCalledTimes(1);
   });
 
   it("strips injected empty tools arrays from BTW payloads before sending", async () => {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -466,6 +466,7 @@ describe("runBtwSideQuestion", () => {
           api: "openai-completions",
           baseUrl: "https://ollama.com/",
         }),
+        workspaceDir: "/tmp/workspace",
       }),
     );
     expect(providerStreamFn).toHaveBeenCalledTimes(1);

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -33,6 +33,7 @@ import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
 import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
 import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
+import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
 
@@ -432,6 +433,17 @@ export async function runBtwSideQuestion(
     }
   }
 
+  // Use the provider's own stream fn so providers like Ollama (which build
+  // `/api/chat` or `/v1/chat/completions` paths based on api mode) construct
+  // URLs correctly. Without this, streamSimple hits the provider's baseUrl
+  // directly and 404s on endpoints like Ollama Cloud (#68336).
+  const providerStreamFn = registerProviderStreamForModel({
+    model: runtimeModel,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    env: process.env,
+  });
+
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking
       ? new EmbeddedBlockChunker(params.blockReplyChunking)
@@ -459,7 +471,7 @@ export async function runBtwSideQuestion(
   };
 
   const stream = await streamWithPayloadPatch(
-    streamSimple,
+    providerStreamFn ?? streamSimple,
     runtimeModel,
     {
       systemPrompt: buildBtwSystemPrompt(),

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -398,12 +398,12 @@ export async function runBtwSideQuestion(
     apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
       ? undefined
       : requireApiKey(apiKeyInfo, model.provider);
+  const sessionAgentId = resolveSessionAgentId({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+  });
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, sessionAgentId);
   if (apiKey) {
-    const sessionAgentId = resolveSessionAgentId({
-      sessionKey: params.sessionKey,
-      config: params.cfg,
-    });
-    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, sessionAgentId);
     const preparedAuth = await prepareProviderRuntimeAuth({
       provider: model.provider,
       config: params.cfg,
@@ -441,6 +441,7 @@ export async function runBtwSideQuestion(
     model: runtimeModel,
     cfg: params.cfg,
     agentDir: params.agentDir,
+    workspaceDir,
     env: process.env,
   });
 


### PR DESCRIPTION
## Summary

Fixes #68336. `/btw` was calling `streamSimple` directly and bypassing the provider's `createStreamFn` / `wrapStreamFn` hooks. For Ollama Cloud with `api: "openai-completions"`, that meant requests went to `https://ollama.com/` (marketing site, 404 HTML) instead of `https://ollama.com/v1/chat/completions`.

## Root cause

`src/agents/btw.ts` built a `runtimeModel` from config and auth prep, then handed it straight to `streamSimple`. The regular (non-/btw) streaming path goes through `registerProviderStreamForModel` which resolves the provider-specific stream fn and registers it with the custom API registry. That registration is what the Ollama plugin uses to build `/v1/chat/completions` (openai-compat) or `/api/chat` (native) paths for each model. `/btw` skipped this step entirely.

## Fix

Call `registerProviderStreamForModel` after the runtime model is finalized and pass the returned stream fn into `streamWithPayloadPatch`, falling back to `streamSimple` when the provider doesn't register one. Matches the pattern already used in `src/agents/simple-completion-transport.ts`.

## Evidence

- **Symptom:** reporter's log in #68336 shows `404` with marketing-site HTML response when hitting `https://ollama.com` directly.
- **Root cause in code:** `src/agents/btw.ts:462` called `streamSimple` with the runtime model; no call to `registerProviderStreamForModel`.
- **Fix touches the implicated path:** change is at the same call site (`src/agents/btw.ts`), adding the provider stream fn resolution before the `streamWithPayloadPatch` call.
- **Regression test:** `src/agents/btw.test.ts` now asserts that for a model with `provider: "ollama"`, `api: "openai-completions"`, `baseUrl: "https://ollama.com/"`, `/btw` uses the provider's stream fn and never falls through to `streamSimple`.

## Test plan

- [x] New regression test covering the exact Ollama Cloud config shape from #68336
- [x] New fallback test verifying `streamSimple` is still used when no provider stream fn registers
- [x] All 25 existing `/btw` tests pass unchanged

Closes #68336.