### PR TITLE
feat(diagnostics-otel): unify end-to-end tracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -174,6 +174,7 @@ COPY --from=runtime-assets --chown=node:node /app/dist ./dist
 COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
+COPY --from=runtime-assets --chown=node:node /app/otel-preload.mjs .
 COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -71,14 +71,15 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   return {
     id: "diagnostics-otel",
     async start(ctx) {
-      if (process.env.OPENCLAW_OTEL_PRELOADED === "1") {
-        ctx.logger.info("diagnostics-otel: skipping OTel SDK start (preloaded)");
-        return;
-      }
       const cfg = ctx.config.diagnostics;
       const otel = cfg?.otel;
       if (!cfg?.enabled || !otel?.enabled) {
         return;
+      }
+
+      const preloaded = process.env.OPENCLAW_OTEL_PRELOADED === "1";
+      if (preloaded) {
+        ctx.logger.info("diagnostics-otel: OTel SDK already started via preload");
       }
 
       const protocol = otel.protocol ?? process.env.OTEL_EXPORTER_OTLP_PROTOCOL ?? "http/protobuf";
@@ -130,7 +131,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           })
         : undefined;
 
-      if (tracesEnabled || metricsEnabled) {
+      if (!preloaded && (tracesEnabled || metricsEnabled)) {
         sdk = new NodeSDK({
           resource,
           ...(traceExporter ? { traceExporter } : {}),

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -71,6 +71,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   return {
     id: "diagnostics-otel",
     async start(ctx) {
+      if (process.env.OPENCLAW_OTEL_PRELOADED === "1") {
+        ctx.logger.info("diagnostics-otel: skipping OTel SDK start (preloaded)");
+        return;
+      }
       const cfg = ctx.config.diagnostics;
       const otel = cfg?.otel;
       if (!cfg?.enabled || !otel?.enabled) {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -97,6 +97,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const tracesEnabled = otel.traces !== false;
       const metricsEnabled = otel.metrics !== false;
       const logsEnabled = otel.logs === true;
+
+      if (preloaded && !tracesEnabled) {
+        trace.disable();
+        ctx.logger.info("diagnostics-otel: traces disabled by config, global tracer provider unregistered");
+      }
+
       if (!tracesEnabled && !metricsEnabled && !logsEnabled) {
         return;
       }

--- a/otel-preload.mjs
+++ b/otel-preload.mjs
@@ -1,0 +1,36 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { Resource } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from "@opentelemetry/core";
+
+const sdk = new NodeSDK({
+  resource: new Resource({
+    [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || "openclaw-gateway",
+  }),
+  textMapPropagator: new CompositePropagator({
+    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+  traceExporter: new OTLPTraceExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT 
+      ? (process.env.OTEL_EXPORTER_OTLP_ENDPOINT.endsWith("/v1/traces") 
+          ? process.env.OTEL_EXPORTER_OTLP_ENDPOINT 
+          : `${process.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`)
+      : "http://otel-collector:4318/v1/traces",
+  }),
+});
+
+sdk.start();
+
+process.on("SIGTERM", () => {
+  sdk.shutdown()
+    .then(() => console.log("OTel SDK shut down"))
+    .catch((err) => console.log("Error shutting down OTel SDK", err))
+    .finally(() => process.exit(0));
+});

--- a/otel-preload.mjs
+++ b/otel-preload.mjs
@@ -27,10 +27,14 @@ const sdk = new NodeSDK({
 });
 
 sdk.start();
+process.env.OPENCLAW_OTEL_PRELOADED = "1";
 
-process.on("SIGTERM", () => {
+const shutdown = () => {
   sdk.shutdown()
     .then(() => console.log("OTel SDK shut down"))
     .catch((err) => console.log("Error shutting down OTel SDK", err))
     .finally(() => process.exit(0));
-});
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/otel-preload.mjs
+++ b/otel-preload.mjs
@@ -32,9 +32,8 @@ process.env.OPENCLAW_OTEL_PRELOADED = "1";
 const shutdown = () => {
   sdk.shutdown()
     .then(() => console.log("OTel SDK shut down"))
-    .catch((err) => console.log("Error shutting down OTel SDK", err))
-    .finally(() => process.exit(0));
+    .catch((err) => console.log("Error shutting down OTel SDK", err));
 };
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);

--- a/package.json
+++ b/package.json
@@ -1529,6 +1529,13 @@
     "ui:install": "node scripts/ui.js install"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "^0.56.0",
+    "@opentelemetry/core": "^2.7.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.215.0",
+    "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-node": "^0.215.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@agentclientprotocol/sdk": "0.19.0",
     "@anthropic-ai/vertex-sdk": "^0.16.0",
     "@clack/prompts": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,27 @@ importers:
       '@napi-rs/canvas':
         specifier: ^0.1.89
         version: 0.1.92
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/auto-instrumentations-node':
+        specifier: ^0.56.0
+        version: 0.56.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.40.0
+        version: 1.40.0
       '@sinclair/typebox':
         specifier: 0.34.49
         version: 0.34.49
@@ -2997,9 +3018,19 @@ packages:
     resolution: {integrity: sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/auto-instrumentations-node@0.56.1':
+    resolution: {integrity: sha512-4cK0+unfkXRRbQQg2r9K3ki8JlE0j9Iw8+4DZEkChShAnmviiE+/JMgHGvK+VVcLrSlgV6BBHv4+ZTLukQwhkA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.1
 
   '@opentelemetry/configuration@0.215.0':
     resolution: {integrity: sha512-FSWvDryxjinHROfzEVbJGBw10FqGzLEm2C1LPX6Lot6hvxq3lFJzNLlue8vm64C5yIbqSQVjWsPhYu56ThQS4Q==}
@@ -3007,9 +3038,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/context-async-hooks@2.7.0':
     resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -3025,9 +3068,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-http@0.215.0':
     resolution: {integrity: sha512-U7Qb+TVX2GZH5RSC+Gx9aE5zChKP1kPg87X3PlI/41lWVPJdBIzmgMmuE28MmQlrK84nLHCIqUOOben8YkSzBw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2':
+    resolution: {integrity: sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3037,9 +3092,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-metrics-otlp-grpc@0.215.0':
     resolution: {integrity: sha512-1TAMliHQvzc+v1OtnLMHSk5sU8BSkJbxIKrWzuCWcQjajWrvem/r5ugLK6agI0PjPz/ADfZju5AVYedlNyeO9g==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3049,9 +3116,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2':
+    resolution: {integrity: sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-metrics-otlp-proto@0.215.0':
     resolution: {integrity: sha512-d8/Sys9MtxLbn0S+RE1pUNcuoI9ZyI4SPfOO+yskSEQiPFoKCTMwwthB8MTY4S8qxCBAWyM+P7QMX+vEIT7PZw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3061,9 +3140,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-prometheus@0.57.2':
+    resolution: {integrity: sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-grpc@0.215.0':
     resolution: {integrity: sha512-+SuWfPFVjPTvHJhlzTCBetLsPVu86xSFPR3fv8TN+H7lpe5aZzF96TUsfMHDR0lwpIwlJpG57CJnGalIfrpXkg==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3073,11 +3164,29 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-proto@0.215.0':
     resolution: {integrity: sha512-+QclHuJmlp/I3Z2fNn+j1dAajMjJqJ4Sgo8ajwiK6Tzmg5SNwBGmBX66AZvTLe/3/bc3L7bo90m9gsaJBrzEsA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@1.30.1':
+    resolution: {integrity: sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
 
   '@opentelemetry/exporter-zipkin@2.7.0':
     resolution: {integrity: sha512-tbzcYDmZWtX4hgJn15qP7/iYFVd1yzbUloBuSYsQtn0XQTxJsG7vgwkPKEBellriH0XJmlZJxYtWkHpwzHBhaQ==}
@@ -3085,9 +3194,249 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/instrumentation-amqplib@0.46.1':
+    resolution: {integrity: sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-lambda@0.50.3':
+    resolution: {integrity: sha512-kotm/mRvSWUauudxcylc5YCDei+G/r+jnOH6q5S99aPLQ/Ms8D2yonMIxEJUILIPlthEmwLYxkw3ualWzMjm/A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-sdk@0.49.1':
+    resolution: {integrity: sha512-Vbj4BYeV/1K4Pbbfk+gQ8gwYL0w+tBeUwG88cOxnF7CLPO1XnskGV8Q3Gzut2Ah/6Dg17dBtlzEqL3UiFP2Z6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-bunyan@0.45.1':
+    resolution: {integrity: sha512-T9POV9ccS41UjpsjLrJ4i0m8LfplBiN3dMeH9XZ2btiDrjoaWtDrst6tNb1avetBjkeshOuBp1EWKP22EVSr0g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.45.1':
+    resolution: {integrity: sha512-RqnP0rK2hcKK1AKcmYvedLiL6G5TvFGiSUt2vI9wN0cCBdTt9Y9+wxxY19KoGxq7e9T/aHow6P5SUhCVI1sHvQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.43.1':
+    resolution: {integrity: sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cucumber@0.14.1':
+    resolution: {integrity: sha512-ybO+tmH85pDO0ywTskmrMtZcccKyQr7Eb7wHy1keR2HFfx46SzZbjHo1AuGAX//Hook3gjM7+w211gJ2bwKe1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1':
+    resolution: {integrity: sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dns@0.43.1':
+    resolution: {integrity: sha512-e/tMZYU1nc+k+J3259CQtqVZIPsPRSLNoAQbGEmSKrjLEY/KJSbpBZ17lu4dFVBzqoF1cZYIZxn9WPQxy4V9ng==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.47.1':
+    resolution: {integrity: sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fastify@0.44.2':
+    resolution: {integrity: sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.19.1':
+    resolution: {integrity: sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1':
+    resolution: {integrity: sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.47.1':
+    resolution: {integrity: sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-grpc@0.57.2':
+    resolution: {integrity: sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.45.2':
+    resolution: {integrity: sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.57.2':
+    resolution: {integrity: sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1':
+    resolution: {integrity: sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1':
+    resolution: {integrity: sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.44.1':
+    resolution: {integrity: sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.47.1':
+    resolution: {integrity: sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1':
+    resolution: {integrity: sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-memcached@0.43.1':
+    resolution: {integrity: sha512-rK5YWC22gmsLp2aEbaPk5F+9r6BFFZuc9GTnW/ErrWpz2XNHUgeFInoPDg4t+Trs8OttIfn8XwkfFkSKqhxanw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0':
+    resolution: {integrity: sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1':
+    resolution: {integrity: sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2':
+    resolution: {integrity: sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.45.1':
+    resolution: {integrity: sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.1':
+    resolution: {integrity: sha512-4TXaqJK27QXoMqrt4+hcQ6rKFd8B6V4JfrTJKnqBmWR1cbaqd/uwyl9yxhNH1JEkyo8GaBfdpBC4ZE4FuUhPmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-net@0.43.1':
+    resolution: {integrity: sha512-TaMqP6tVx9/SxlY81dHlSyP5bWJIKq+K7vKfk4naB/LX4LBePPY3++1s0edpzH+RfwN+tEGVW9zTb9ci0up/lQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.51.1':
+    resolution: {integrity: sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pino@0.46.1':
+    resolution: {integrity: sha512-HB8gD/9CNAKlTV+mdZehnFC4tLUtQ7e+729oGq88e4WipxzZxmMYuRwZ2vzOA9/APtq+MRkERJ9PcoDqSIjZ+g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1':
+    resolution: {integrity: sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.46.1':
+    resolution: {integrity: sha512-AN7OvlGlXmlvsgbLHs6dS1bggp6Fcki+GxgYZdSrb/DB692TyfjR7sVILaCe0crnP66aJuXsg9cge3hptHs9UA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-restify@0.45.1':
+    resolution: {integrity: sha512-Zd6Go9iEa+0zcoA2vDka9r/plYKaT3BhD3ESIy4JNIzFWXeQBGbH3zZxQIsz0jbNTMEtonlymU7eTLeaGWiApA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-router@0.44.1':
+    resolution: {integrity: sha512-l4T/S7ByjpY5TCUPeDe1GPns02/5BpR0jroSMexyH3ZnXJt9PtYqx1IKAlOjaFEGEOQF2tGDsMi4PY5l+fSniQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-socket.io@0.46.1':
+    resolution: {integrity: sha512-9AsCVUAHOqvfe2RM/2I0DsDnx2ihw1d5jIN4+Bly1YPFTJIbk4+bXjAkr9+X6PUfhiV5urQHZkiYYPU1Q4yzPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.18.1':
+    resolution: {integrity: sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.10.1':
+    resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation-winston@0.44.1':
+    resolution: {integrity: sha512-iexblTsT3fP0hHUz/M1mWr+Ylg3bsYN2En/jvKXZtboW3Qkvt17HrQJYTF9leVIkXAfN97QxAcTE99YGbQW7vQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.215.0':
     resolution: {integrity: sha512-SyJONuqypQ2xWdYMy99vF7JhZ2kDTGx4oRmM/jZV+kRtZ96JTnJmEINbIJgHz7Gnhtw0bimHwbPy/pguA5wpPQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3097,9 +3446,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-grpc-exporter-base@0.215.0':
     resolution: {integrity: sha512-WkuHkUrhwNxTKrm7Xuf6S+HmLNbk2T8S2YiZhN606RfgetSQb9xLp4NizWLwXvw63uxGsBaK262dirFO2yht2g==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2':
+    resolution: {integrity: sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3109,15 +3470,79 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagation-utils@0.30.16':
+    resolution: {integrity: sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/propagator-b3@2.7.0':
     resolution: {integrity: sha512-HNm+tdXY5i8dzAo4YankchNWdZ4Z1Boop7lhbb3wltWT0MwEMo0QADRJwrF83pXEeDT+5Bmq4J8sStFaUywE3g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/propagator-jaeger@2.7.0':
     resolution: {integrity: sha512-lKMAjekRkFYWrjmPTaxUJt+V8Mr1iB94sP3HDZZCmdZ/LUV/wtqAGqXhgnkIbdlnWxxvEs9MGEIMdJC+xObMFg==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/redis-common@0.36.2':
+    resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.30.1':
+    resolution: {integrity: sha512-9l0FVP3F4+Z6ax27vMzkmhZdNtxAbDqEfy7rduzya3xFLaRiJSvOpw6cru6Edl5LwO+WvgNui+VzHa9ViE8wCg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-aws@1.12.0':
+    resolution: {integrity: sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-azure@0.6.1':
+    resolution: {integrity: sha512-Djr31QCExVfWViaf9cGJnH+bUInD72p0GEfgDGgjCAztyvyji6WJvKjs6qmkpPN+Ig6KLk0ho2VgzT5Kdl4L2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-container@0.6.1':
+    resolution: {integrity: sha512-o4sLzx149DQXDmVa8pgjBDEEKOj9SuQnkSLbjUVOpQNnn10v0WNR6wLwh30mFsK26xOJ6SpqZBGKZiT7i5MjlA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-gcp@0.33.1':
+    resolution: {integrity: sha512-/aZJXI1rU6Eus04ih2vU0hxXAibXXMzH1WlDZ8bXcTJmhwmTY8cP392+6l7cWeMnTQOibBUz8UKV3nhcCBAefw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -3133,6 +3558,18 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.7.0':
     resolution: {integrity: sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -3145,11 +3582,29 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/sdk-node@0.57.2':
+    resolution: {integrity: sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.7.0':
     resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-node@2.7.0':
     resolution: {integrity: sha512-RrFHOXw0IYp/OThew6QORdybnnLitUAUMCJKcQNBYS0hDkCYarO2vTkVxfrGxCIqd5XHSMvbCpBd/T8ZMw8oSg==}
@@ -3157,9 +3612,19 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.40.1':
+    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
@@ -4098,11 +4563,17 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aws-lambda@8.10.147':
+    resolution: {integrity: sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
   '@types/bun@1.3.11':
     resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
+  '@types/bunyan@1.8.11':
+    resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4155,11 +4626,17 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/memcached@2.2.10':
+    resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
+
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/mysql@2.15.26':
+    resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
@@ -4172,6 +4649,12 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/pg-pool@2.0.6':
+    resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.6.1':
+    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
@@ -4193,6 +4676,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -4694,6 +5183,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -5212,6 +5704,9 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -5451,6 +5946,9 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
@@ -6368,6 +6866,17 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -6418,6 +6927,22 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
@@ -6629,6 +7154,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -6775,6 +7304,9 @@ packages:
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -7441,6 +7973,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -9584,7 +10120,65 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-lambda': 0.50.3(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-sdk': 0.49.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-bunyan': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cucumber': 0.14.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dns': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fastify': 0.44.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-memcached': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-nestjs-core': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-net': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pino': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-restify': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-router': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-socket.io': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-winston': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-alibaba-cloud': 0.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-aws': 1.12.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-azure': 0.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-container': 0.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@opentelemetry/configuration@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9592,9 +10186,18 @@ snapshots:
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       yaml: 2.8.3
 
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9611,6 +10214,16 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-logs-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9619,6 +10232,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-logs-otlp-proto@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9630,6 +10252,17 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9643,6 +10276,18 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-metrics-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9651,6 +10296,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-proto@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9662,6 +10316,16 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-prometheus@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9669,6 +10333,13 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-prometheus@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9681,6 +10352,17 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9689,6 +10371,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9699,6 +10390,23 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
   '@opentelemetry/exporter-zipkin@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9706,6 +10414,341 @@ snapshots:
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-lambda@0.50.3(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/aws-lambda': 8.10.147
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-sdk@0.49.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagation-utils': 0.30.16(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-bunyan@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@types/bunyan': 1.8.11
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cucumber@0.14.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dns@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fastify@0.44.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+      forwarded-parse: 2.1.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-memcached@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/memcached': 2.2.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.26
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-net@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.6.1
+      '@types/pg-pool': 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pino@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-restify@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-router@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-socket.io@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-winston@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9716,11 +10759,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/otlp-exporter-base@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9729,6 +10790,14 @@ snapshots:
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9741,15 +10810,87 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       protobufjs: 7.5.5
 
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.5
+
+  '@opentelemetry/propagation-utils@0.30.16(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/propagator-b3@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/propagator-jaeger@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/redis-common@0.36.2': {}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resource-detector-aws@1.12.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resource-detector-azure@0.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resource-detector-container@0.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      gcp-metadata: 6.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9764,6 +10905,19 @@ snapshots:
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9802,12 +10956,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/sdk-node@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
   '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      semver: 7.7.4
 
   '@opentelemetry/sdk-trace-node@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9816,7 +11013,14 @@ snapshots:
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@oxc-project/types@0.126.0': {}
 
@@ -10713,6 +11917,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aws-lambda@8.10.147': {}
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -10722,6 +11928,10 @@ snapshots:
     dependencies:
       bun-types: 1.3.11
     optional: true
+
+  '@types/bunyan@1.8.11':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10781,9 +11991,17 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/memcached@2.2.10':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/mime-types@2.1.4': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/mysql@2.15.26':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/node@16.9.1': {}
 
@@ -10798,6 +12016,16 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/pg-pool@2.0.6':
+    dependencies:
+      '@types/pg': 8.6.1
+
+  '@types/pg@8.6.1':
+    dependencies:
+      '@types/node': 25.6.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/qrcode-terminal@0.12.2': {}
 
@@ -10816,6 +12044,12 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
+      '@types/node': 25.6.0
+
+  '@types/shimmer@1.2.0': {}
+
+  '@types/tedious@4.0.14':
+    dependencies:
       '@types/node': 25.6.0
 
   '@types/trusted-types@2.0.7': {}
@@ -11345,6 +12579,8 @@ snapshots:
   chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -11878,6 +13114,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -12199,6 +13437,13 @@ snapshots:
       '@types/node': 16.9.1
 
   immediate@3.0.6: {}
+
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
 
   import-in-the-middle@3.0.1:
     dependencies:
@@ -13238,6 +14483,18 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -13287,6 +14544,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   pretty-bytes@6.1.1: {}
 
@@ -13538,6 +14805,14 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -13736,6 +15011,8 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  shimmer@1.2.1: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -14350,6 +15627,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ minimumReleaseAgeExclude:
   - "rolldown"
   - "sqlite-vec"
   - "sqlite-vec-*"
+  - "tokenjuice"
 
 onlyBuiltDependencies:
   - "@lydell/node-pty"

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -1,3 +1,4 @@
+import { trace, SpanStatusCode, context } from "@opentelemetry/api";
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
@@ -517,6 +518,46 @@ export async function runExecProcess(opts: {
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
+  const tracer = trace.getTracer("openclaw");
+  return tracer.startActiveSpan("openclaw.exec", {}, context.active(), async (span) => {
+    try {
+      span.setAttributes({
+        "openclaw.exec.command": opts.command,
+        "openclaw.exec.workdir": opts.workdir,
+        "openclaw.exec.target": opts.sandbox ? "sandbox" : "host",
+      });
+      const result = await runExecProcessInternal(opts);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+async function runExecProcessInternal(opts: {
+  command: string;
+  execCommand?: string;
+  workdir: string;
+  env: Record<string, string>;
+  sandbox?: BashSandboxConfig;
+  containerWorkdir?: string | null;
+  usePty: boolean;
+  warnings: string[];
+  maxOutput: number;
+  pendingMaxOutput: number;
+  notifyOnExit: boolean;
+  notifyOnExitEmptySuccess?: boolean;
+  scopeKey?: string;
+  sessionKey?: string;
+  notifyDeliveryContext?: DeliveryContext;
+  timeoutSec: number | null;
+  onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
+}) {
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -519,22 +519,40 @@ export async function runExecProcess(opts: {
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
   const tracer = trace.getTracer("openclaw");
-  return tracer.startActiveSpan("openclaw.exec", {}, context.active(), async (span) => {
+  const span = tracer.startSpan("openclaw.exec", {
+    attributes: {
+      "openclaw.exec.command": opts.command,
+      "openclaw.exec.workdir": opts.workdir,
+      "openclaw.exec.target": opts.sandbox ? "sandbox" : "host",
+    },
+  }, context.active());
+
+  return context.with(trace.setSpan(context.active(), span), async () => {
     try {
-      span.setAttributes({
-        "openclaw.exec.command": opts.command,
-        "openclaw.exec.workdir": opts.workdir,
-        "openclaw.exec.target": opts.sandbox ? "sandbox" : "host",
-      });
       const result = await runExecProcessInternal(opts);
-      span.setStatus({ code: SpanStatusCode.OK });
+
+      result.promise
+        .then((outcome) => {
+          if (outcome.status === "failed") {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: outcome.reason });
+          } else {
+            span.setStatus({ code: SpanStatusCode.OK });
+          }
+        })
+        .catch((err) => {
+          span.recordException(err as Error);
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        })
+        .finally(() => {
+          span.end();
+        });
+
       return result;
     } catch (err) {
       span.recordException(err as Error);
       span.setStatus({ code: SpanStatusCode.ERROR });
-      throw err;
-    } finally {
       span.end();
+      throw err;
     }
   });
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -43,6 +43,7 @@ import {
 } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
+import { redactSensitiveText } from "../logging/redact.js";
 
 export { execSchema } from "./bash-tools.schemas.js";
 
@@ -521,7 +522,7 @@ export async function runExecProcess(opts: {
   const tracer = trace.getTracer("openclaw");
   const span = tracer.startSpan("openclaw.exec", {
     attributes: {
-      "openclaw.exec.command": opts.command,
+      "openclaw.exec.command": redactSensitiveText(opts.command, { mode: "tools" }),
       "openclaw.exec.workdir": opts.workdir,
       "openclaw.exec.target": opts.sandbox ? "sandbox" : "host",
     },

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
+import { trace, SpanStatusCode, context } from "@opentelemetry/api";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveContextEngine } from "../../context-engine/registry.js";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -249,1899 +249,1927 @@ export async function runEmbeddedPiAgent(
 
   throwIfAborted();
 
-  return enqueueSession(() => {
-    throwIfAborted();
-    return enqueueGlobal(async () => {
-      throwIfAborted();
-      const started = Date.now();
-      const workspaceResolution = resolveRunWorkspaceDir({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        config: params.config,
-      });
-      const resolvedWorkspace = workspaceResolution.workspaceDir;
-      const canonicalWorkspace = resolveUserPath(
-        resolveAgentWorkspaceDir(params.config ?? {}, workspaceResolution.agentId),
-      );
-      const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
-      const redactedSessionId = redactRunIdentifier(params.sessionId);
-      const redactedSessionKey = redactRunIdentifier(params.sessionKey);
-      const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
-      if (workspaceResolution.usedFallback) {
-        log.warn(
-          `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
-        );
-      }
-      ensureRuntimePluginsLoaded({
-        config: params.config,
-        workspaceDir: resolvedWorkspace,
-        allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-      });
-
-      let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const normalizedSessionKey = params.sessionKey?.trim();
-      const fallbackConfigured = hasConfiguredModelFallbacks({
-        cfg: params.config,
-        agentId: params.agentId,
-        sessionKey: normalizedSessionKey,
-      });
-      await ensureOpenClawModelsJson(params.config, agentDir);
-      const resolvedSessionKey = normalizedSessionKey;
-      const hookRunner = getGlobalHookRunner();
-      const hookCtx = {
-        runId: params.runId,
-        agentId: workspaceResolution.agentId,
-        sessionKey: resolvedSessionKey,
-        sessionId: params.sessionId,
-        workspaceDir: resolvedWorkspace,
-        modelProviderId: provider,
-        modelId,
-        messageProvider: params.messageProvider ?? undefined,
-        trigger: params.trigger,
-        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-      };
-
-      const hookSelection = await resolveHookModelSelection({
-        prompt: params.prompt,
-        attachments: buildBeforeModelResolveAttachments(params.images),
-        provider,
-        modelId,
-        hookRunner,
-        hookContext: hookCtx,
-      });
-      provider = hookSelection.provider;
-      modelId = hookSelection.modelId;
-      const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
-
-      const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
-        provider,
-        modelId,
-        agentDir,
-        params.config,
-      );
-      if (!model) {
-        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
-          reason: "model_not_found",
-          provider,
-          model: modelId,
-        });
-      }
-      let runtimeModel = model;
-
-      const resolvedRuntimeModel = resolveEffectiveRuntimeModel({
-        cfg: params.config,
-        provider,
-        modelId,
-        runtimeModel,
-      });
-      const ctxInfo = resolvedRuntimeModel.ctxInfo;
-      let effectiveModel = resolvedRuntimeModel.effectiveModel;
-
-      const authStore = ensureAuthProfileStore(agentDir, {
-        allowKeychainPrompt: false,
-      });
-      const preferredProfileId = params.authProfileId?.trim();
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      if (lockedProfileId) {
-        const lockedProfile = authStore.profiles[lockedProfileId];
-        if (
-          !lockedProfile ||
-          normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
-        ) {
-          lockedProfileId = undefined;
-        }
-      }
-      if (lockedProfileId) {
-        const eligibility = resolveAuthProfileEligibility({
-          cfg: params.config,
-          store: authStore,
-          provider,
-          profileId: lockedProfileId,
-        });
-        if (!eligibility.eligible) {
-          throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
-        }
-      }
-      const profileOrder = shouldPreferExplicitConfigApiKeyAuth(params.config, provider)
-        ? []
-        : resolveAuthProfileOrder({
-            cfg: params.config,
-            store: authStore,
-            provider,
-            preferredProfile: preferredProfileId,
-          });
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : profileOrder.length > 0
-          ? profileOrder
-          : [undefined];
-      let profileIndex = 0;
-      const traceAttempts: TraceAttempt[] = [];
-
-      const initialThinkLevel = params.thinkLevel ?? "off";
-      let thinkLevel = initialThinkLevel;
-      const attemptedThinking = new Set<ThinkLevel>();
-      let apiKeyInfo: ApiKeyInfo | null = null;
-      let lastProfileId: string | undefined;
-      let runtimeAuthState: RuntimeAuthState | null = null;
-      let runtimeAuthRefreshCancelled = false;
-      const {
-        advanceAuthProfile,
-        initializeAuthProfile,
-        maybeRefreshRuntimeAuthForAuthError,
-        stopRuntimeAuthRefreshTimer,
-      } = createEmbeddedRunAuthController({
-        config: params.config,
-        agentDir,
-        workspaceDir: resolvedWorkspace,
-        authStore,
-        authStorage,
-        profileCandidates,
-        lockedProfileId,
-        initialThinkLevel,
-        attemptedThinking,
-        fallbackConfigured,
-        allowTransientCooldownProbe: params.allowTransientCooldownProbe === true,
-        getProvider: () => provider,
-        getModelId: () => modelId,
-        getRuntimeModel: () => runtimeModel,
-        setRuntimeModel: (next) => {
-          runtimeModel = next;
-        },
-        getEffectiveModel: () => effectiveModel,
-        setEffectiveModel: (next) => {
-          effectiveModel = next;
-        },
-        getApiKeyInfo: () => apiKeyInfo,
-        setApiKeyInfo: (next) => {
-          apiKeyInfo = next;
-        },
-        getLastProfileId: () => lastProfileId,
-        setLastProfileId: (next) => {
-          lastProfileId = next;
-        },
-        getRuntimeAuthState: () => runtimeAuthState,
-        setRuntimeAuthState: (next) => {
-          runtimeAuthState = next;
-        },
-        getRuntimeAuthRefreshCancelled: () => runtimeAuthRefreshCancelled,
-        setRuntimeAuthRefreshCancelled: (next) => {
-          runtimeAuthRefreshCancelled = next;
-        },
-        getProfileIndex: () => profileIndex,
-        setProfileIndex: (next) => {
-          profileIndex = next;
-        },
-        setThinkLevel: (next) => {
-          thinkLevel = next;
-        },
-        log,
-      });
-
-      await initializeAuthProfile();
-      const { sessionAgentId } = resolveSessionAgentIds({
-        sessionKey: params.sessionKey,
-        config: params.config,
-        agentId: params.agentId,
-      });
-      const configuredExecutionContract =
-        resolveAgentExecutionContract(params.config, sessionAgentId) ?? "default";
-      const strictAgenticActive = isStrictAgenticExecutionContractActive({
-        config: params.config,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        provider,
-        modelId,
-      });
-      const executionContract = strictAgenticActive ? "strict-agentic" : "default";
-      const maxPlanningOnlyRetryAttempts = resolvePlanningOnlyRetryLimit(executionContract);
-      const maxReasoningOnlyRetryAttempts = DEFAULT_REASONING_ONLY_RETRY_LIMIT;
-      const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
-
-      const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
-      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
-      const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
-      let overflowCompactionAttempts = 0;
-      let toolResultTruncationAttempted = false;
-      let bootstrapPromptWarningSignaturesSeen =
-        params.bootstrapPromptWarningSignaturesSeen ??
-        (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
-      const usageAccumulator = createUsageAccumulator();
-      let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-      let autoCompactionCount = 0;
-      let runLoopIterations = 0;
-      let overloadProfileRotations = 0;
-      let planningOnlyRetryAttempts = 0;
-      let reasoningOnlyRetryAttempts = 0;
-      let emptyResponseRetryAttempts = 0;
-      let sameModelIdleTimeoutRetries = 0;
-      let lastRetryFailoverReason: FailoverReason | null = null;
-      let planningOnlyRetryInstruction: string | null = null;
-      let reasoningOnlyRetryInstruction: string | null = null;
-      let emptyResponseRetryInstruction: string | null = null;
-      const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
-        provider,
-        modelId,
-        prompt: params.prompt,
-      });
-      let rateLimitProfileRotations = 0;
-      let timeoutCompactionAttempts = 0;
-      // Silent-error retry: non-strict-agentic models (e.g. ollama/glm-5.1) can
-      // end a turn with stopReason="error" + zero output tokens, producing no
-      // user-visible text. The existing empty-response retry is gated on
-      // isStrictAgenticSupportedProviderModel (gpt-5 only). This is an
-      // orthogonal, model-agnostic resubmission.
-      const MAX_EMPTY_ERROR_RETRIES = 3;
-      let emptyErrorRetries = 0;
-      const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
-      const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
-      const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
-      const maybeEscalateRateLimitProfileFallback = (params: {
-        failoverProvider: string;
-        failoverModel: string;
-        logFallbackDecision: (decision: "fallback_model", extra?: { status?: number }) => void;
-      }) => {
-        rateLimitProfileRotations += 1;
-        if (rateLimitProfileRotations <= rateLimitProfileRotationLimit || !fallbackConfigured) {
-          return;
-        }
-        const status = resolveFailoverStatus("rate_limit");
-        log.warn(
-          `rate-limit profile rotation cap reached for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} after ${rateLimitProfileRotations} rotations; escalating to model fallback`,
-        );
-        params.logFallbackDecision("fallback_model", { status });
-        throw new FailoverError(
-          "The AI service is temporarily rate-limited. Please try again in a moment.",
-          {
-            reason: "rate_limit",
-            provider: params.failoverProvider,
-            model: params.failoverModel,
-            profileId: lastProfileId,
-            status,
-          },
-        );
-      };
-      const maybeMarkAuthProfileFailure = async (failure: {
-        profileId?: string;
-        reason?: AuthProfileFailureReason | null;
-        config?: RunEmbeddedPiAgentParams["config"];
-        agentDir?: RunEmbeddedPiAgentParams["agentDir"];
-        modelId?: string;
-      }) => {
-        const { profileId, reason } = failure;
-        if (!profileId || !reason || reason === "timeout") {
-          return;
-        }
-        await markAuthProfileFailure({
-          store: authStore,
-          profileId,
-          reason,
-          cfg: params.config,
-          agentDir,
-          runId: params.runId,
-          modelId: failure.modelId,
-        });
-      };
-      const resolveAuthProfileFailureReason = (
-        failoverReason: FailoverReason | null,
-      ): AuthProfileFailureReason | null => {
-        // Timeouts are transport/model-path failures, not auth health signals,
-        // so they should not persist auth-profile failure state.
-        if (!failoverReason || failoverReason === "timeout") {
-          return null;
-        }
-        return failoverReason;
-      };
-      const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
-        if (reason !== "overloaded" || overloadFailoverBackoffMs <= 0) {
-          return;
-        }
-        log.warn(
-          `overload backoff before failover for ${provider}/${modelId}: delayMs=${overloadFailoverBackoffMs}`,
-        );
-        try {
-          await sleepWithAbort(overloadFailoverBackoffMs, params.abortSignal);
-        } catch (err) {
-          if (params.abortSignal?.aborted) {
-            const abortErr = new Error("Operation aborted", { cause: err });
-            abortErr.name = "AbortError";
-            throw abortErr;
-          }
-          throw err;
-        }
-      };
-      // Resolve the context engine once and reuse across retries to avoid
-      // repeated initialization/connection overhead per attempt.
-      ensureContextEnginesInitialized();
-      const contextEngine = await resolveContextEngine(params.config);
-      try {
-        // When the engine owns compaction, compactEmbeddedPiSessionDirect is
-        // bypassed. Fire lifecycle hooks here so recovery paths still notify
-        // subscribers like memory extensions and usage trackers.
-        const runOwnsCompactionBeforeHook = async (reason: string) => {
-          if (
-            contextEngine.info.ownsCompaction !== true ||
-            !hookRunner?.hasHooks("before_compaction")
-          ) {
-            return;
-          }
-          try {
-            await hookRunner.runBeforeCompaction(
-              { messageCount: -1, sessionFile: params.sessionFile },
-              hookCtx,
-            );
-          } catch (hookErr) {
-            log.warn(`before_compaction hook failed during ${reason}: ${String(hookErr)}`);
-          }
-        };
-        const runOwnsCompactionAfterHook = async (
-          reason: string,
-          compactResult: Awaited<ReturnType<typeof contextEngine.compact>>,
-        ) => {
-          if (
-            contextEngine.info.ownsCompaction !== true ||
-            !compactResult.ok ||
-            !compactResult.compacted ||
-            !hookRunner?.hasHooks("after_compaction")
-          ) {
-            return;
-          }
-          try {
-            await hookRunner.runAfterCompaction(
-              {
-                messageCount: -1,
-                compactedCount: -1,
-                tokenCount: compactResult.result?.tokensAfter,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            );
-          } catch (hookErr) {
-            log.warn(`after_compaction hook failed during ${reason}: ${String(hookErr)}`);
-          }
-        };
-        let authRetryPending = false;
-        let accumulatedReplayState = createEmbeddedRunReplayState();
-        // Hoisted so the retry-limit error path can use the most recent API total.
-        let lastTurnTotal: number | undefined;
-        while (true) {
-          if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
-            const message =
-              `Exceeded retry limit after ${runLoopIterations} attempts ` +
-              `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
-            log.error(
-              `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
-                `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
-            );
-            const retryLimitDecision = resolveRunFailoverDecision({
-              stage: "retry_limit",
-              fallbackConfigured,
-              failoverReason: lastRetryFailoverReason,
-            });
-            return handleRetryLimitExhaustion({
-              message,
-              decision: retryLimitDecision,
-              provider,
-              model: modelId,
-              profileId: lastProfileId,
-              durationMs: Date.now() - started,
-              agentMeta: buildErrorAgentMeta({
-                sessionId: params.sessionId,
-                provider,
-                model: model.id,
-                usageAccumulator,
-                lastRunPromptUsage,
-                lastTurnTotal,
-              }),
-              replayInvalid: accumulatedReplayState.replayInvalid ? true : undefined,
-              livenessState: "blocked",
-            });
-          }
-          runLoopIterations += 1;
-          const runtimeAuthRetry = authRetryPending;
-          authRetryPending = false;
-          attemptedThinking.add(thinkLevel);
-          await fs.mkdir(resolvedWorkspace, { recursive: true });
-
-          const basePrompt =
-            provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
-          const promptAdditions = [
-            ackExecutionFastPathInstruction,
-            planningOnlyRetryInstruction,
-            reasoningOnlyRetryInstruction,
-            emptyResponseRetryInstruction,
-          ].filter(
-            (value): value is string => typeof value === "string" && value.trim().length > 0,
-          );
-          const prompt =
-            promptAdditions.length > 0
-              ? `${basePrompt}\n\n${promptAdditions.join("\n\n")}`
-              : basePrompt;
-          let resolvedStreamApiKey: string | undefined;
-          if (!runtimeAuthState && apiKeyInfo) {
-            resolvedStreamApiKey = (apiKeyInfo as ApiKeyInfo).apiKey;
-          }
-
-          const attempt = await runEmbeddedAttemptWithBackend({
-            sessionId: params.sessionId,
-            sessionKey: resolvedSessionKey,
-            sandboxSessionKey: params.sandboxSessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            memberRoleIds: params.memberRoleIds,
-            spawnedBy: params.spawnedBy,
-            isCanonicalWorkspace,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-            senderIsOwner: params.senderIsOwner,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: params.sessionFile,
-            workspaceDir: resolvedWorkspace,
-            agentDir,
+  const tracer = trace.getTracer("openclaw");
+  return tracer.startActiveSpan("openclaw.agent.run", {}, context.active(), async (span) => {
+    try {
+      return await enqueueSession(() => {
+        throwIfAborted();
+        return enqueueGlobal(async () => {
+          throwIfAborted();
+          const started = Date.now();
+          const workspaceResolution = resolveRunWorkspaceDir({
+            workspaceDir: params.workspaceDir,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
             config: params.config,
+          });
+          const resolvedWorkspace = workspaceResolution.workspaceDir;
+          const canonicalWorkspace = resolveUserPath(
+            resolveAgentWorkspaceDir(params.config ?? {}, workspaceResolution.agentId),
+          );
+          const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
+          const redactedSessionId = redactRunIdentifier(params.sessionId);
+          const redactedSessionKey = redactRunIdentifier(params.sessionKey);
+          const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
+          if (workspaceResolution.usedFallback) {
+            log.warn(
+              `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
+            );
+          }
+          ensureRuntimePluginsLoaded({
+            config: params.config,
+            workspaceDir: resolvedWorkspace,
             allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            images: params.images,
-            imageOrder: params.imageOrder,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
+          });
+
+          let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+          let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+          const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+          const normalizedSessionKey = params.sessionKey?.trim();
+          const fallbackConfigured = hasConfiguredModelFallbacks({
+            cfg: params.config,
+            agentId: params.agentId,
+            sessionKey: normalizedSessionKey,
+          });
+          await ensureOpenClawModelsJson(params.config, agentDir);
+          const resolvedSessionKey = normalizedSessionKey;
+          const hookRunner = getGlobalHookRunner();
+          const hookCtx = {
+            runId: params.runId,
+            agentId: workspaceResolution.agentId,
+            sessionKey: resolvedSessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: resolvedWorkspace,
+            modelProviderId: provider,
+            modelId,
+            messageProvider: params.messageProvider ?? undefined,
+            trigger: params.trigger,
+            channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+          };
+
+          const hookSelection = await resolveHookModelSelection({
+            prompt: params.prompt,
+            attachments: buildBeforeModelResolveAttachments(params.images),
             provider,
             modelId,
-            model: applyAuthHeaderOverride(
-              applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-              // When runtime auth exchange produced a different credential
-              // (runtimeAuthState is set), the exchanged token lives in
-              // authStorage and the SDK will pick it up automatically.
-              // Skip header injection to avoid leaking the pre-exchange key.
-              runtimeAuthState ? null : apiKeyInfo,
-              params.config,
-            ),
-            resolvedApiKey: resolvedStreamApiKey,
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
-            initialReplayState: accumulatedReplayState,
-            authStorage,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            legacyBeforeAgentStartResult,
-            thinkLevel,
-            fastMode: params.fastMode,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runId: params.runId,
-            abortSignal: params.abortSignal,
-            replyOperation: params.replyOperation,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentEvent: params.onAgentEvent,
-            extraSystemPrompt: params.extraSystemPrompt,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-            silentExpected: params.silentExpected,
-            bootstrapContextMode: params.bootstrapContextMode,
-            bootstrapContextRunKind: params.bootstrapContextRunKind,
-            toolsAllow: params.toolsAllow,
-            disableMessageTool: params.disableMessageTool,
-            forceMessageTool: params.forceMessageTool,
-            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
-            internalEvents: params.internalEvents,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
+            hookRunner,
+            hookContext: hookCtx,
           });
+          provider = hookSelection.provider;
+          modelId = hookSelection.modelId;
+          const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
 
-          const {
-            aborted,
-            externalAbort,
-            promptError,
-            promptErrorSource,
-            preflightRecovery,
-            timedOut,
-            idleTimedOut,
-            timedOutDuringCompaction,
-            sessionIdUsed,
-            lastAssistant: sessionLastAssistant,
-            currentAttemptAssistant,
-          } = attempt;
-          bootstrapPromptWarningSignaturesSeen =
-            attempt.bootstrapPromptWarningSignaturesSeen ??
-            (attempt.bootstrapPromptWarningSignature
-              ? Array.from(
-                  new Set([
-                    ...bootstrapPromptWarningSignaturesSeen,
-                    attempt.bootstrapPromptWarningSignature,
-                  ]),
-                )
-              : bootstrapPromptWarningSignaturesSeen);
-          const lastAssistantUsage = normalizeUsage(sessionLastAssistant?.usage as UsageLike);
-          const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
-          mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
-          // Keep prompt size from the latest model call so session totalTokens
-          // reflects current context usage, not accumulated tool-loop usage.
-          lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
-          lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
-          const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
-          autoCompactionCount += attemptCompactionCount;
-          const activeErrorContext = resolveActiveErrorContext({
+          const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
             provider,
-            model: modelId,
-            assistant: currentAttemptAssistant ?? sessionLastAssistant,
-          });
-          const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
-            accumulatedReplayState.replayInvalid ||
-            resolveReplayInvalidFlag({
-              attempt,
-              incompleteTurnText,
-            });
-          if (resolveReplayInvalidForAttempt(null)) {
-            accumulatedReplayState.replayInvalid = true;
-          }
-          accumulatedReplayState = observeReplayMetadata(
-            accumulatedReplayState,
-            attempt.replayMetadata,
+            modelId,
+            agentDir,
+            params.config,
           );
-          const formattedAssistantErrorText = sessionLastAssistant
-            ? formatAssistantErrorText(sessionLastAssistant, {
-                cfg: params.config,
-                sessionKey: resolvedSessionKey ?? params.sessionId,
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
-              })
-            : undefined;
-          const assistantErrorText =
-            sessionLastAssistant?.stopReason === "error"
-              ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
-              : undefined;
-          const canRestartForLiveSwitch =
-            !attempt.didSendViaMessagingTool &&
-            !attempt.didSendDeterministicApprovalPrompt &&
-            !attempt.lastToolError &&
-            attempt.toolMetas.length === 0 &&
-            attempt.assistantTexts.length === 0;
-          if (preflightRecovery?.handled) {
-            log.info(
-              `[context-overflow-precheck] early recovery route=${preflightRecovery.route} ` +
-                `completed for ${provider}/${modelId}; retrying prompt`,
-            );
-            continue;
-          }
-          const requestedSelection = shouldSwitchToLiveModel({
-            cfg: params.config,
-            sessionKey: resolvedSessionKey,
-            agentId: params.agentId,
-            defaultProvider: DEFAULT_PROVIDER,
-            defaultModel: DEFAULT_MODEL,
-            currentProvider: provider,
-            currentModel: modelId,
-            currentAuthProfileId: preferredProfileId,
-            currentAuthProfileIdSource: params.authProfileIdSource,
-          });
-          if (requestedSelection && canRestartForLiveSwitch) {
-            await clearLiveModelSwitchPending({
-              cfg: params.config,
-              sessionKey: resolvedSessionKey,
-              agentId: params.agentId,
-            });
-            log.info(
-              `live session model switch requested during active attempt for ${params.sessionId}: ${provider}/${modelId} -> ${requestedSelection.provider}/${requestedSelection.model}`,
-            );
-            throw new LiveSessionModelSwitchError(requestedSelection);
-          }
-          // ── Timeout-triggered compaction ──────────────────────────────────
-          // When the LLM times out with high context usage, compact before
-          // retrying to break the death spiral of repeated timeouts.
-          if (timedOut && !timedOutDuringCompaction) {
-            // Only consider prompt-side tokens here. API totals include output
-            // tokens, which can make a long generation look like high context
-            // pressure even when the prompt itself was small.
-            const lastTurnPromptTokens = derivePromptTokens(lastRunPromptUsage);
-            const tokenUsedRatio =
-              lastTurnPromptTokens != null && ctxInfo.tokens > 0
-                ? lastTurnPromptTokens / ctxInfo.tokens
-                : 0;
-            if (timeoutCompactionAttempts >= MAX_TIMEOUT_COMPACTION_ATTEMPTS) {
-              log.warn(
-                `[timeout-compaction] already attempted timeout compaction ${timeoutCompactionAttempts} time(s); falling through to failover rotation`,
-              );
-            } else if (tokenUsedRatio > 0.65) {
-              const timeoutDiagId = createCompactionDiagId();
-              timeoutCompactionAttempts++;
-              log.warn(
-                `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%); ` +
-                  `attempting compaction before retry (attempt ${timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
-              );
-              let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              await runOwnsCompactionBeforeHook("timeout recovery");
-              try {
-                const timeoutCompactionRuntimeContext = {
-                  ...buildEmbeddedCompactionRuntimeContext({
-                    sessionKey: params.sessionKey,
-                    messageChannel: params.messageChannel,
-                    messageProvider: params.messageProvider,
-                    agentAccountId: params.agentAccountId,
-                    currentChannelId: params.currentChannelId,
-                    currentThreadTs: params.currentThreadTs,
-                    currentMessageId: params.currentMessageId,
-                    authProfileId: lastProfileId,
-                    workspaceDir: resolvedWorkspace,
-                    agentDir,
-                    config: params.config,
-                    skillsSnapshot: params.skillsSnapshot,
-                    senderIsOwner: params.senderIsOwner,
-                    senderId: params.senderId,
-                    provider,
-                    modelId,
-                    thinkLevel,
-                    reasoningLevel: params.reasoningLevel,
-                    bashElevated: params.bashElevated,
-                    extraSystemPrompt: params.extraSystemPrompt,
-                    ownerNumbers: params.ownerNumbers,
-                  }),
-                  ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
-                  runId: params.runId,
-                  trigger: "timeout_recovery",
-                  diagId: timeoutDiagId,
-                  attempt: timeoutCompactionAttempts,
-                  maxAttempts: MAX_TIMEOUT_COMPACTION_ATTEMPTS,
-                };
-                timeoutCompactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: timeoutCompactionRuntimeContext,
-                });
-              } catch (compactErr) {
-                log.warn(
-                  `[timeout-compaction] contextEngine.compact() threw during timeout recovery for ${provider}/${modelId}: ${String(compactErr)}`,
-                );
-                timeoutCompactResult = {
-                  ok: false,
-                  compacted: false,
-                  reason: String(compactErr),
-                };
-              }
-              await runOwnsCompactionAfterHook("timeout recovery", timeoutCompactResult);
-              if (timeoutCompactResult.compacted) {
-                autoCompactionCount += 1;
-                if (contextEngine.info.ownsCompaction === true) {
-                  await runPostCompactionSideEffects({
-                    config: params.config,
-                    sessionKey: params.sessionKey,
-                    sessionFile: params.sessionFile,
-                  });
-                }
-                log.info(
-                  `[timeout-compaction] compaction succeeded for ${provider}/${modelId}; retrying prompt`,
-                );
-                continue;
-              } else {
-                log.warn(
-                  `[timeout-compaction] compaction did not reduce context for ${provider}/${modelId}; falling through to normal handling`,
-                );
-              }
-            }
-          }
-
-          const contextOverflowError = !aborted
-            ? (() => {
-                if (promptError) {
-                  const errorText = formatErrorMessage(promptError);
-                  if (isLikelyContextOverflowError(errorText)) {
-                    return { text: errorText, source: "promptError" as const };
-                  }
-                  // Prompt submission failed with a non-overflow error. Do not
-                  // inspect prior assistant errors from history for this attempt.
-                  return null;
-                }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
-                  return {
-                    text: assistantErrorText,
-                    source: "assistantError" as const,
-                  };
-                }
-                return null;
-              })()
-            : null;
-
-          if (contextOverflowError) {
-            const overflowDiagId = createCompactionDiagId();
-            const errorText = contextOverflowError.text;
-            const msgCount = attempt.messagesSnapshot?.length ?? 0;
-            const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
-            log.warn(
-              `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
-                `messages=${msgCount} sessionFile=${params.sessionFile} ` +
-                `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
-                `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
-                `error=${errorText.slice(0, 200)}`,
-            );
-            const isCompactionFailure = isCompactionFailureError(errorText);
-            const hadAttemptLevelCompaction = attemptCompactionCount > 0;
-            // If this attempt already compacted (SDK auto-compaction), avoid immediately
-            // running another explicit compaction for the same overflow trigger.
-            if (
-              !isCompactionFailure &&
-              hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
-              );
-              continue;
-            }
-            // Attempt explicit overflow compaction only when this attempt did not
-            // already auto-compact.
-            if (
-              !isCompactionFailure &&
-              !hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              if (log.isEnabled("debug")) {
-                log.debug(
-                  `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                    `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                );
-              }
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
-              );
-              let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              await runOwnsCompactionBeforeHook("overflow recovery");
-              try {
-                const overflowCompactionRuntimeContext = {
-                  ...buildEmbeddedCompactionRuntimeContext({
-                    sessionKey: params.sessionKey,
-                    messageChannel: params.messageChannel,
-                    messageProvider: params.messageProvider,
-                    agentAccountId: params.agentAccountId,
-                    currentChannelId: params.currentChannelId,
-                    currentThreadTs: params.currentThreadTs,
-                    currentMessageId: params.currentMessageId,
-                    authProfileId: lastProfileId,
-                    workspaceDir: resolvedWorkspace,
-                    agentDir,
-                    config: params.config,
-                    skillsSnapshot: params.skillsSnapshot,
-                    senderIsOwner: params.senderIsOwner,
-                    senderId: params.senderId,
-                    provider,
-                    modelId,
-                    thinkLevel,
-                    reasoningLevel: params.reasoningLevel,
-                    bashElevated: params.bashElevated,
-                    extraSystemPrompt: params.extraSystemPrompt,
-                    ownerNumbers: params.ownerNumbers,
-                  }),
-                  ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
-                  runId: params.runId,
-                  trigger: "overflow",
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  diagId: overflowDiagId,
-                  attempt: overflowCompactionAttempts,
-                  maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
-                };
-                compactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: overflowCompactionRuntimeContext,
-                });
-                if (compactResult.ok && compactResult.compacted) {
-                  await runContextEngineMaintenance({
-                    contextEngine,
-                    sessionId: params.sessionId,
-                    sessionKey: params.sessionKey,
-                    sessionFile: params.sessionFile,
-                    reason: "compaction",
-                    runtimeContext: overflowCompactionRuntimeContext,
-                  });
-                }
-              } catch (compactErr) {
-                log.warn(
-                  `contextEngine.compact() threw during overflow recovery for ${provider}/${modelId}: ${String(compactErr)}`,
-                );
-                compactResult = {
-                  ok: false,
-                  compacted: false,
-                  reason: String(compactErr),
-                };
-              }
-              await runOwnsCompactionAfterHook("overflow recovery", compactResult);
-              if (compactResult.compacted) {
-                if (preflightRecovery?.route === "compact_then_truncate") {
-                  const truncResult = await truncateOversizedToolResultsInSession({
-                    sessionFile: params.sessionFile,
-                    contextWindowTokens: ctxInfo.tokens,
-                    maxCharsOverride: resolveLiveToolResultMaxChars({
-                      contextWindowTokens: ctxInfo.tokens,
-                      cfg: params.config,
-                      agentId: sessionAgentId,
-                    }),
-                    sessionId: params.sessionId,
-                    sessionKey: params.sessionKey,
-                  });
-                  if (truncResult.truncated) {
-                    log.info(
-                      `[context-overflow-precheck] post-compaction tool-result truncation succeeded for ` +
-                        `${provider}/${modelId}; truncated ${truncResult.truncatedCount} tool result(s)`,
-                    );
-                  } else {
-                    log.warn(
-                      `[context-overflow-precheck] post-compaction tool-result truncation did not help for ` +
-                        `${provider}/${modelId}: ${truncResult.reason ?? "unknown"}`,
-                    );
-                  }
-                }
-                autoCompactionCount += 1;
-                log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
-                continue;
-              }
-              log.warn(
-                `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
-              );
-            }
-            if (!toolResultTruncationAttempted) {
-              const contextWindowTokens = ctxInfo.tokens;
-              const toolResultMaxChars = resolveLiveToolResultMaxChars({
-                contextWindowTokens,
-                cfg: params.config,
-                agentId: sessionAgentId,
-              });
-              const hasOversized = attempt.messagesSnapshot
-                ? sessionLikelyHasOversizedToolResults({
-                    messages: attempt.messagesSnapshot,
-                    contextWindowTokens,
-                    maxCharsOverride: toolResultMaxChars,
-                  })
-                : false;
-
-              if (hasOversized) {
-                toolResultTruncationAttempted = true;
-                log.warn(
-                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
-                    `(contextWindow=${contextWindowTokens} tokens)`,
-                );
-                const truncResult = await truncateOversizedToolResultsInSession({
-                  sessionFile: params.sessionFile,
-                  contextWindowTokens,
-                  maxCharsOverride: toolResultMaxChars,
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                });
-                if (truncResult.truncated) {
-                  log.info(
-                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
-                  );
-                  continue;
-                }
-                log.warn(
-                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
-                );
-              }
-            }
-            if (
-              (isCompactionFailure ||
-                overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&
-              log.isEnabled("debug")
-            ) {
-              log.debug(
-                `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                  `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                  `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-              );
-            }
-            const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid: resolveReplayInvalidForAttempt(),
-              livenessState: "blocked",
-            });
-            return {
-              payloads: [
-                {
-                  text:
-                    "Context overflow: prompt too large for the model. " +
-                    "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
-                  sessionId: sessionIdUsed,
-                  provider,
-                  model: model.id,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastAssistant: sessionLastAssistant,
-                  lastTurnTotal,
-                }),
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                replayInvalid: resolveReplayInvalidForAttempt(),
-                livenessState: "blocked",
-                error: { kind, message: errorText },
-              },
-            };
-          }
-
-          if (promptError && !aborted && promptErrorSource !== "compaction") {
-            // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
-            // FailoverError so rate-limit classification works even for nested shapes.
-            //
-            // promptErrorSource === "compaction" means the model call already completed and the
-            // abort happened only while waiting for compaction/retry cleanup. Retrying from here
-            // would replay that completed tool turn as a fresh prompt attempt.
-            const normalizedPromptFailover = coerceToFailoverError(promptError, {
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              profileId: lastProfileId,
-            });
-            const promptErrorDetails = normalizedPromptFailover
-              ? describeFailoverError(normalizedPromptFailover)
-              : describeFailoverError(promptError);
-            const errorText = promptErrorDetails.message || formatErrorMessage(promptError);
-            if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
-              authRetryPending = true;
-              continue;
-            }
-            // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
-              attempt.setTerminalLifecycleMeta?.({
-                replayInvalid: resolveReplayInvalidForAttempt(),
-                livenessState: "blocked",
-              });
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Message ordering conflict - please try again. " +
-                      "If this persists, use /new to start a fresh session.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant: sessionLastAssistant,
-                    lastTurnTotal,
-                  }),
-                  systemPromptReport: attempt.systemPromptReport,
-                  finalPromptText: attempt.finalPromptText,
-                  replayInvalid: resolveReplayInvalidForAttempt(),
-                  livenessState: "blocked",
-                  error: { kind: "role_ordering", message: errorText },
-                },
-              };
-            }
-            // Handle image size errors with a user-friendly message (no retry needed)
-            const imageSizeError = parseImageSizeError(errorText);
-            if (imageSizeError) {
-              const maxMb = imageSizeError.maxMb;
-              const maxMbLabel =
-                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
-              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
-              attempt.setTerminalLifecycleMeta?.({
-                replayInvalid: resolveReplayInvalidForAttempt(),
-                livenessState: "blocked",
-              });
-              return {
-                payloads: [
-                  {
-                    text:
-                      `Image too large for the model${maxBytesHint}. ` +
-                      "Please compress or resize the image and try again.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant: sessionLastAssistant,
-                    lastTurnTotal,
-                  }),
-                  systemPromptReport: attempt.systemPromptReport,
-                  finalPromptText: attempt.finalPromptText,
-                  replayInvalid: resolveReplayInvalidForAttempt(),
-                  livenessState: "blocked",
-                  error: { kind: "image_size", message: errorText },
-                },
-              };
-            }
-            const promptFailoverReason =
-              promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider });
-            const promptProfileFailureReason =
-              resolveAuthProfileFailureReason(promptFailoverReason);
-            await maybeMarkAuthProfileFailure({
-              profileId: lastProfileId,
-              reason: promptProfileFailureReason,
-              modelId,
-            });
-            const promptFailoverFailure =
-              promptFailoverReason !== null || isFailoverErrorMessage(errorText, { provider });
-            // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-            const failedPromptProfileId = lastProfileId;
-            const logPromptFailoverDecision = createFailoverDecisionLogger({
-              stage: "prompt",
-              runId: params.runId,
-              rawError: errorText,
-              failoverReason: promptFailoverReason,
-              profileFailureReason: promptProfileFailureReason,
+          if (!model) {
+            throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+              reason: "model_not_found",
               provider,
               model: modelId,
-              sourceProvider: provider,
-              sourceModel: modelId,
-              profileId: failedPromptProfileId,
-              fallbackConfigured,
-              aborted,
             });
-            if (promptFailoverReason === "rate_limit") {
-              maybeEscalateRateLimitProfileFallback({
-                failoverProvider: provider,
-                failoverModel: modelId,
-                logFallbackDecision: logPromptFailoverDecision,
-              });
-            }
-            let promptFailoverDecision = resolveRunFailoverDecision({
-              stage: "prompt",
-              aborted,
-              externalAbort,
-              fallbackConfigured,
-              failoverFailure: promptFailoverFailure,
-              failoverReason: promptFailoverReason,
-              profileRotated: false,
-            });
+          }
+          let runtimeModel = model;
+
+          const resolvedRuntimeModel = resolveEffectiveRuntimeModel({
+            cfg: params.config,
+            provider,
+            modelId,
+            runtimeModel,
+          });
+          const ctxInfo = resolvedRuntimeModel.ctxInfo;
+          let effectiveModel = resolvedRuntimeModel.effectiveModel;
+
+          const authStore = ensureAuthProfileStore(agentDir, {
+            allowKeychainPrompt: false,
+          });
+          const preferredProfileId = params.authProfileId?.trim();
+          let lockedProfileId =
+            params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+          if (lockedProfileId) {
+            const lockedProfile = authStore.profiles[lockedProfileId];
             if (
-              promptFailoverDecision.action === "rotate_profile" &&
-              (await advanceAuthProfile())
+              !lockedProfile ||
+              normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
             ) {
-              traceAttempts.push({
-                provider,
-                model: modelId,
-                result: promptFailoverReason === "timeout" ? "timeout" : "rotate_profile",
-                ...(promptFailoverReason ? { reason: promptFailoverReason } : {}),
-                stage: "prompt",
-              });
-              lastRetryFailoverReason = mergeRetryFailoverReason({
-                previous: lastRetryFailoverReason,
-                failoverReason: promptFailoverReason,
-              });
-              logPromptFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              continue;
+              lockedProfileId = undefined;
             }
-            if (promptFailoverDecision.action === "rotate_profile") {
-              promptFailoverDecision = resolveRunFailoverDecision({
-                stage: "prompt",
-                aborted,
-                externalAbort,
-                fallbackConfigured,
-                failoverFailure: promptFailoverFailure,
-                failoverReason: promptFailoverReason,
-                profileRotated: true,
-              });
-            }
-            const fallbackThinking = pickFallbackThinkingLevel({
-              message: errorText,
-              attempted: attemptedThinking,
+          }
+          if (lockedProfileId) {
+            const eligibility = resolveAuthProfileEligibility({
+              cfg: params.config,
+              store: authStore,
+              provider,
+              profileId: lockedProfileId,
             });
-            if (fallbackThinking) {
-              log.warn(
-                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+            if (!eligibility.eligible) {
+              throw new Error(
+                `Auth profile "${lockedProfileId}" is not configured for ${provider}.`,
               );
-              thinkLevel = fallbackThinking;
-              continue;
             }
-            // Throw FailoverError for prompt-side failover reasons when fallbacks
-            // are configured so outer model fallback can continue on overload,
-            // rate-limit, auth, or billing failures.
-            if (promptFailoverDecision.action === "fallback_model") {
-              const fallbackReason = promptFailoverDecision.reason ?? "unknown";
-              const status = resolveFailoverStatus(fallbackReason);
-              traceAttempts.push({
+          }
+          const profileOrder = shouldPreferExplicitConfigApiKeyAuth(params.config, provider)
+            ? []
+            : resolveAuthProfileOrder({
+                cfg: params.config,
+                store: authStore,
                 provider,
-                model: modelId,
-                result: promptFailoverReason === "timeout" ? "timeout" : "fallback_model",
-                reason: fallbackReason,
-                stage: "prompt",
-                ...(typeof status === "number" ? { status } : {}),
+                preferredProfile: preferredProfileId,
               });
-              logPromptFailoverDecision("fallback_model", { status });
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              throw (
-                normalizedPromptFailover ??
-                new FailoverError(errorText, {
-                  reason: fallbackReason,
+          const profileCandidates = lockedProfileId
+            ? [lockedProfileId]
+            : profileOrder.length > 0
+              ? profileOrder
+              : [undefined];
+          let profileIndex = 0;
+          const traceAttempts: TraceAttempt[] = [];
+
+          const initialThinkLevel = params.thinkLevel ?? "off";
+          let thinkLevel = initialThinkLevel;
+          const attemptedThinking = new Set<ThinkLevel>();
+          let apiKeyInfo: ApiKeyInfo | null = null;
+          let lastProfileId: string | undefined;
+          let runtimeAuthState: RuntimeAuthState | null = null;
+          let runtimeAuthRefreshCancelled = false;
+          const {
+            advanceAuthProfile,
+            initializeAuthProfile,
+            maybeRefreshRuntimeAuthForAuthError,
+            stopRuntimeAuthRefreshTimer,
+          } = createEmbeddedRunAuthController({
+            config: params.config,
+            agentDir,
+            workspaceDir: resolvedWorkspace,
+            authStore,
+            authStorage,
+            profileCandidates,
+            lockedProfileId,
+            initialThinkLevel,
+            attemptedThinking,
+            fallbackConfigured,
+            allowTransientCooldownProbe: params.allowTransientCooldownProbe === true,
+            getProvider: () => provider,
+            getModelId: () => modelId,
+            getRuntimeModel: () => runtimeModel,
+            setRuntimeModel: (next) => {
+              runtimeModel = next;
+            },
+            getEffectiveModel: () => effectiveModel,
+            setEffectiveModel: (next) => {
+              effectiveModel = next;
+            },
+            getApiKeyInfo: () => apiKeyInfo,
+            setApiKeyInfo: (next) => {
+              apiKeyInfo = next;
+            },
+            getLastProfileId: () => lastProfileId,
+            setLastProfileId: (next) => {
+              lastProfileId = next;
+            },
+            getRuntimeAuthState: () => runtimeAuthState,
+            setRuntimeAuthState: (next) => {
+              runtimeAuthState = next;
+            },
+            getRuntimeAuthRefreshCancelled: () => runtimeAuthRefreshCancelled,
+            setRuntimeAuthRefreshCancelled: (next) => {
+              runtimeAuthRefreshCancelled = next;
+            },
+            getProfileIndex: () => profileIndex,
+            setProfileIndex: (next) => {
+              profileIndex = next;
+            },
+            setThinkLevel: (next) => {
+              thinkLevel = next;
+            },
+            log,
+          });
+
+          await initializeAuthProfile();
+          const { sessionAgentId } = resolveSessionAgentIds({
+            sessionKey: params.sessionKey,
+            config: params.config,
+            agentId: params.agentId,
+          });
+          const configuredExecutionContract =
+            resolveAgentExecutionContract(params.config, sessionAgentId) ?? "default";
+          const strictAgenticActive = isStrictAgenticExecutionContractActive({
+            config: params.config,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            provider,
+            modelId,
+          });
+          const executionContract = strictAgenticActive ? "strict-agentic" : "default";
+          const maxPlanningOnlyRetryAttempts = resolvePlanningOnlyRetryLimit(executionContract);
+          const maxReasoningOnlyRetryAttempts = DEFAULT_REASONING_ONLY_RETRY_LIMIT;
+          const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
+
+          const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
+          const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+          const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
+          let overflowCompactionAttempts = 0;
+          let toolResultTruncationAttempted = false;
+          let bootstrapPromptWarningSignaturesSeen =
+            params.bootstrapPromptWarningSignaturesSeen ??
+            (params.bootstrapPromptWarningSignature
+              ? [params.bootstrapPromptWarningSignature]
+              : []);
+          const usageAccumulator = createUsageAccumulator();
+          let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
+          let autoCompactionCount = 0;
+          let runLoopIterations = 0;
+          let overloadProfileRotations = 0;
+          let planningOnlyRetryAttempts = 0;
+          let reasoningOnlyRetryAttempts = 0;
+          let emptyResponseRetryAttempts = 0;
+          let sameModelIdleTimeoutRetries = 0;
+          let lastRetryFailoverReason: FailoverReason | null = null;
+          let planningOnlyRetryInstruction: string | null = null;
+          let reasoningOnlyRetryInstruction: string | null = null;
+          let emptyResponseRetryInstruction: string | null = null;
+          const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
+            provider,
+            modelId,
+            prompt: params.prompt,
+          });
+          let rateLimitProfileRotations = 0;
+          let timeoutCompactionAttempts = 0;
+          // Silent-error retry: non-strict-agentic models (e.g. ollama/glm-5.1) can
+          // end a turn with stopReason="error" + zero output tokens, producing no
+          // user-visible text. The existing empty-response retry is gated on
+          // isStrictAgenticSupportedProviderModel (gpt-5 only). This is an
+          // orthogonal, model-agnostic resubmission.
+          const MAX_EMPTY_ERROR_RETRIES = 3;
+          let emptyErrorRetries = 0;
+          const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
+          const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
+          const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
+          const maybeEscalateRateLimitProfileFallback = (params: {
+            failoverProvider: string;
+            failoverModel: string;
+            logFallbackDecision: (decision: "fallback_model", extra?: { status?: number }) => void;
+          }) => {
+            rateLimitProfileRotations += 1;
+            if (rateLimitProfileRotations <= rateLimitProfileRotationLimit || !fallbackConfigured) {
+              return;
+            }
+            const status = resolveFailoverStatus("rate_limit");
+            log.warn(
+              `rate-limit profile rotation cap reached for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} after ${rateLimitProfileRotations} rotations; escalating to model fallback`,
+            );
+            params.logFallbackDecision("fallback_model", { status });
+            throw new FailoverError(
+              "The AI service is temporarily rate-limited. Please try again in a moment.",
+              {
+                reason: "rate_limit",
+                provider: params.failoverProvider,
+                model: params.failoverModel,
+                profileId: lastProfileId,
+                status,
+              },
+            );
+          };
+          const maybeMarkAuthProfileFailure = async (failure: {
+            profileId?: string;
+            reason?: AuthProfileFailureReason | null;
+            config?: RunEmbeddedPiAgentParams["config"];
+            agentDir?: RunEmbeddedPiAgentParams["agentDir"];
+            modelId?: string;
+          }) => {
+            const { profileId, reason } = failure;
+            if (!profileId || !reason || reason === "timeout") {
+              return;
+            }
+            await markAuthProfileFailure({
+              store: authStore,
+              profileId,
+              reason,
+              cfg: params.config,
+              agentDir,
+              runId: params.runId,
+              modelId: failure.modelId,
+            });
+          };
+          const resolveAuthProfileFailureReason = (
+            failoverReason: FailoverReason | null,
+          ): AuthProfileFailureReason | null => {
+            // Timeouts are transport/model-path failures, not auth health signals,
+            // so they should not persist auth-profile failure state.
+            if (!failoverReason || failoverReason === "timeout") {
+              return null;
+            }
+            return failoverReason;
+          };
+          const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
+            if (reason !== "overloaded" || overloadFailoverBackoffMs <= 0) {
+              return;
+            }
+            log.warn(
+              `overload backoff before failover for ${provider}/${modelId}: delayMs=${overloadFailoverBackoffMs}`,
+            );
+            try {
+              await sleepWithAbort(overloadFailoverBackoffMs, params.abortSignal);
+            } catch (err) {
+              if (params.abortSignal?.aborted) {
+                const abortErr = new Error("Operation aborted", { cause: err });
+                abortErr.name = "AbortError";
+                throw abortErr;
+              }
+              throw err;
+            }
+          };
+          // Resolve the context engine once and reuse across retries to avoid
+          // repeated initialization/connection overhead per attempt.
+          ensureContextEnginesInitialized();
+          const contextEngine = await resolveContextEngine(params.config);
+          try {
+            // When the engine owns compaction, compactEmbeddedPiSessionDirect is
+            // bypassed. Fire lifecycle hooks here so recovery paths still notify
+            // subscribers like memory extensions and usage trackers.
+            const runOwnsCompactionBeforeHook = async (reason: string) => {
+              if (
+                contextEngine.info.ownsCompaction !== true ||
+                !hookRunner?.hasHooks("before_compaction")
+              ) {
+                return;
+              }
+              try {
+                await hookRunner.runBeforeCompaction(
+                  { messageCount: -1, sessionFile: params.sessionFile },
+                  hookCtx,
+                );
+              } catch (hookErr) {
+                log.warn(`before_compaction hook failed during ${reason}: ${String(hookErr)}`);
+              }
+            };
+            const runOwnsCompactionAfterHook = async (
+              reason: string,
+              compactResult: Awaited<ReturnType<typeof contextEngine.compact>>,
+            ) => {
+              if (
+                contextEngine.info.ownsCompaction !== true ||
+                !compactResult.ok ||
+                !compactResult.compacted ||
+                !hookRunner?.hasHooks("after_compaction")
+              ) {
+                return;
+              }
+              try {
+                await hookRunner.runAfterCompaction(
+                  {
+                    messageCount: -1,
+                    compactedCount: -1,
+                    tokenCount: compactResult.result?.tokensAfter,
+                    sessionFile: params.sessionFile,
+                  },
+                  hookCtx,
+                );
+              } catch (hookErr) {
+                log.warn(`after_compaction hook failed during ${reason}: ${String(hookErr)}`);
+              }
+            };
+            let authRetryPending = false;
+            let accumulatedReplayState = createEmbeddedRunReplayState();
+            // Hoisted so the retry-limit error path can use the most recent API total.
+            let lastTurnTotal: number | undefined;
+            while (true) {
+              if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
+                const message =
+                  `Exceeded retry limit after ${runLoopIterations} attempts ` +
+                  `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
+                log.error(
+                  `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                    `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
+                    `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
+                );
+                const retryLimitDecision = resolveRunFailoverDecision({
+                  stage: "retry_limit",
+                  fallbackConfigured,
+                  failoverReason: lastRetryFailoverReason,
+                });
+                return handleRetryLimitExhaustion({
+                  message,
+                  decision: retryLimitDecision,
                   provider,
                   model: modelId,
                   profileId: lastProfileId,
-                  status,
-                })
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: params.sessionId,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastTurnTotal,
+                  }),
+                  replayInvalid: accumulatedReplayState.replayInvalid ? true : undefined,
+                  livenessState: "blocked",
+                });
+              }
+              runLoopIterations += 1;
+              const runtimeAuthRetry = authRetryPending;
+              authRetryPending = false;
+              attemptedThinking.add(thinkLevel);
+              await fs.mkdir(resolvedWorkspace, { recursive: true });
+
+              const basePrompt =
+                provider === "anthropic"
+                  ? scrubAnthropicRefusalMagic(params.prompt)
+                  : params.prompt;
+              const promptAdditions = [
+                ackExecutionFastPathInstruction,
+                planningOnlyRetryInstruction,
+                reasoningOnlyRetryInstruction,
+                emptyResponseRetryInstruction,
+              ].filter(
+                (value): value is string => typeof value === "string" && value.trim().length > 0,
               );
-            }
-            if (promptFailoverDecision.action === "surface_error") {
-              traceAttempts.push({
+              const prompt =
+                promptAdditions.length > 0
+                  ? `${basePrompt}\n\n${promptAdditions.join("\n\n")}`
+                  : basePrompt;
+              let resolvedStreamApiKey: string | undefined;
+              if (!runtimeAuthState && apiKeyInfo) {
+                resolvedStreamApiKey = (apiKeyInfo as ApiKeyInfo).apiKey;
+              }
+
+              const attempt = await runEmbeddedAttemptWithBackend({
+                sessionId: params.sessionId,
+                sessionKey: resolvedSessionKey,
+                sandboxSessionKey: params.sandboxSessionKey,
+                trigger: params.trigger,
+                memoryFlushWritePath: params.memoryFlushWritePath,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                messageTo: params.messageTo,
+                messageThreadId: params.messageThreadId,
+                groupId: params.groupId,
+                groupChannel: params.groupChannel,
+                groupSpace: params.groupSpace,
+                memberRoleIds: params.memberRoleIds,
+                spawnedBy: params.spawnedBy,
+                isCanonicalWorkspace,
+                senderId: params.senderId,
+                senderName: params.senderName,
+                senderUsername: params.senderUsername,
+                senderE164: params.senderE164,
+                senderIsOwner: params.senderIsOwner,
+                currentChannelId: params.currentChannelId,
+                currentThreadTs: params.currentThreadTs,
+                currentMessageId: params.currentMessageId,
+                replyToMode: params.replyToMode,
+                hasRepliedRef: params.hasRepliedRef,
+                sessionFile: params.sessionFile,
+                workspaceDir: resolvedWorkspace,
+                agentDir,
+                config: params.config,
+                allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+                contextEngine,
+                contextTokenBudget: ctxInfo.tokens,
+                skillsSnapshot: params.skillsSnapshot,
+                prompt,
+                images: params.images,
+                imageOrder: params.imageOrder,
+                clientTools: params.clientTools,
+                disableTools: params.disableTools,
+                provider,
+                modelId,
+                model: applyAuthHeaderOverride(
+                  applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+                  // When runtime auth exchange produced a different credential
+                  // (runtimeAuthState is set), the exchanged token lives in
+                  // authStorage and the SDK will pick it up automatically.
+                  // Skip header injection to avoid leaking the pre-exchange key.
+                  runtimeAuthState ? null : apiKeyInfo,
+                  params.config,
+                ),
+                resolvedApiKey: resolvedStreamApiKey,
+                authProfileId: lastProfileId,
+                authProfileIdSource: lockedProfileId ? "user" : "auto",
+                initialReplayState: accumulatedReplayState,
+                authStorage,
+                modelRegistry,
+                agentId: workspaceResolution.agentId,
+                legacyBeforeAgentStartResult,
+                thinkLevel,
+                fastMode: params.fastMode,
+                verboseLevel: params.verboseLevel,
+                reasoningLevel: params.reasoningLevel,
+                toolResultFormat: resolvedToolResultFormat,
+                execOverrides: params.execOverrides,
+                bashElevated: params.bashElevated,
+                timeoutMs: params.timeoutMs,
+                runId: params.runId,
+                abortSignal: params.abortSignal,
+                replyOperation: params.replyOperation,
+                shouldEmitToolResult: params.shouldEmitToolResult,
+                shouldEmitToolOutput: params.shouldEmitToolOutput,
+                onPartialReply: params.onPartialReply,
+                onAssistantMessageStart: params.onAssistantMessageStart,
+                onBlockReply: params.onBlockReply,
+                onBlockReplyFlush: params.onBlockReplyFlush,
+                blockReplyBreak: params.blockReplyBreak,
+                blockReplyChunking: params.blockReplyChunking,
+                onReasoningStream: params.onReasoningStream,
+                onReasoningEnd: params.onReasoningEnd,
+                onToolResult: params.onToolResult,
+                onAgentEvent: params.onAgentEvent,
+                extraSystemPrompt: params.extraSystemPrompt,
+                inputProvenance: params.inputProvenance,
+                streamParams: params.streamParams,
+                ownerNumbers: params.ownerNumbers,
+                enforceFinalTag: params.enforceFinalTag,
+                silentExpected: params.silentExpected,
+                bootstrapContextMode: params.bootstrapContextMode,
+                bootstrapContextRunKind: params.bootstrapContextRunKind,
+                toolsAllow: params.toolsAllow,
+                disableMessageTool: params.disableMessageTool,
+                forceMessageTool: params.forceMessageTool,
+                requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+                internalEvents: params.internalEvents,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature:
+                  bootstrapPromptWarningSignaturesSeen[
+                    bootstrapPromptWarningSignaturesSeen.length - 1
+                  ],
+              });
+
+              const {
+                aborted,
+                externalAbort,
+                promptError,
+                promptErrorSource,
+                preflightRecovery,
+                timedOut,
+                idleTimedOut,
+                timedOutDuringCompaction,
+                sessionIdUsed,
+                lastAssistant: sessionLastAssistant,
+                currentAttemptAssistant,
+              } = attempt;
+              bootstrapPromptWarningSignaturesSeen =
+                attempt.bootstrapPromptWarningSignaturesSeen ??
+                (attempt.bootstrapPromptWarningSignature
+                  ? Array.from(
+                      new Set([
+                        ...bootstrapPromptWarningSignaturesSeen,
+                        attempt.bootstrapPromptWarningSignature,
+                      ]),
+                    )
+                  : bootstrapPromptWarningSignaturesSeen);
+              const lastAssistantUsage = normalizeUsage(sessionLastAssistant?.usage as UsageLike);
+              const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
+              mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+              // Keep prompt size from the latest model call so session totalTokens
+              // reflects current context usage, not accumulated tool-loop usage.
+              lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
+              lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
+              const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
+              autoCompactionCount += attemptCompactionCount;
+              const activeErrorContext = resolveActiveErrorContext({
                 provider,
                 model: modelId,
-                result: promptFailoverReason === "timeout" ? "timeout" : "surface_error",
-                ...(promptFailoverReason ? { reason: promptFailoverReason } : {}),
-                stage: "prompt",
+                assistant: currentAttemptAssistant ?? sessionLastAssistant,
               });
-              logPromptFailoverDecision("surface_error");
-            }
-            throw promptError;
-          }
-
-          const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: assistantForFailover?.errorMessage,
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-            );
-            thinkLevel = fallbackThinking;
-            continue;
-          }
-
-          const authFailure = isAuthAssistantError(assistantForFailover);
-          const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
-          const billingFailure = isBillingAssistantError(assistantForFailover);
-          const failoverFailure = isFailoverAssistantError(assistantForFailover);
-          const assistantFailoverReason = classifyFailoverReason(
-            assistantForFailover?.errorMessage ?? "",
-            {
-              provider: assistantForFailover?.provider,
-            },
-          );
-          const assistantProfileFailureReason =
-            resolveAuthProfileFailureReason(assistantFailoverReason);
-          const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(
-            assistantForFailover?.errorMessage ?? "",
-          );
-          // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-          const failedAssistantProfileId = lastProfileId;
-          const logAssistantFailoverDecision = createFailoverDecisionLogger({
-            stage: "assistant",
-            runId: params.runId,
-            rawError: assistantForFailover?.errorMessage?.trim(),
-            failoverReason: assistantFailoverReason,
-            profileFailureReason: assistantProfileFailureReason,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            sourceProvider: assistantForFailover?.provider ?? provider,
-            sourceModel: assistantForFailover?.model ?? modelId,
-            profileId: failedAssistantProfileId,
-            fallbackConfigured,
-            timedOut,
-            aborted,
-          });
-
-          if (
-            authFailure &&
-            (await maybeRefreshRuntimeAuthForAuthError(
-              assistantForFailover?.errorMessage ?? "",
-              runtimeAuthRetry,
-            ))
-          ) {
-            authRetryPending = true;
-            continue;
-          }
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
-            );
-          }
-
-          const assistantFailoverDecision = resolveRunFailoverDecision({
-            stage: "assistant",
-            aborted,
-            externalAbort,
-            fallbackConfigured,
-            failoverFailure,
-            failoverReason: assistantFailoverReason,
-            timedOut,
-            timedOutDuringCompaction,
-            profileRotated: false,
-          });
-          const assistantFailoverOutcome = await handleAssistantFailover({
-            initialDecision: assistantFailoverDecision,
-            aborted,
-            externalAbort,
-            fallbackConfigured,
-            failoverFailure,
-            failoverReason: assistantFailoverReason,
-            timedOut,
-            idleTimedOut,
-            timedOutDuringCompaction,
-            allowSameModelIdleTimeoutRetry:
-              timedOut &&
-              idleTimedOut &&
-              !timedOutDuringCompaction &&
-              !fallbackConfigured &&
-              canRestartForLiveSwitch &&
-              sameModelIdleTimeoutRetries < MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES,
-            assistantProfileFailureReason,
-            lastProfileId,
-            modelId,
-            provider,
-            activeErrorContext,
-            lastAssistant: assistantForFailover,
-            config: params.config,
-            sessionKey: params.sessionKey ?? params.sessionId,
-            authFailure,
-            rateLimitFailure,
-            billingFailure,
-            cloudCodeAssistFormatError,
-            isProbeSession,
-            overloadProfileRotations,
-            overloadProfileRotationLimit,
-            previousRetryFailoverReason: lastRetryFailoverReason,
-            logAssistantFailoverDecision,
-            warn: (message) => log.warn(message),
-            maybeMarkAuthProfileFailure,
-            maybeEscalateRateLimitProfileFallback,
-            maybeBackoffBeforeOverloadFailover,
-            advanceAuthProfile,
-          });
-          overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
-          if (assistantFailoverOutcome.action === "retry") {
-            traceAttempts.push({
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              result:
-                assistantFailoverOutcome.retryKind === "same_model_idle_timeout" ||
-                assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : "rotate_profile",
-              ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
-              stage: "assistant",
-            });
-            if (assistantFailoverOutcome.retryKind === "same_model_idle_timeout") {
-              sameModelIdleTimeoutRetries += 1;
-            }
-            lastRetryFailoverReason = assistantFailoverOutcome.lastRetryFailoverReason;
-            continue;
-          }
-          if (assistantFailoverOutcome.action === "throw") {
-            traceAttempts.push({
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              result:
-                assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : assistantFailoverDecision.action === "fallback_model"
-                    ? "fallback_model"
-                    : "error",
-              ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
-              stage: "assistant",
-              ...(typeof assistantFailoverOutcome.error.status === "number"
-                ? { status: assistantFailoverOutcome.error.status }
-                : {}),
-            });
-            throw assistantFailoverOutcome.error;
-          }
-          const usageMeta = buildUsageAgentMetaFields({
-            usageAccumulator,
-            lastAssistantUsage: sessionLastAssistant?.usage as UsageLike | undefined,
-            lastRunPromptUsage,
-            lastTurnTotal,
-          });
-          const agentMeta: EmbeddedPiAgentMeta = {
-            sessionId: sessionIdUsed,
-            provider: sessionLastAssistant?.provider ?? provider,
-            model: sessionLastAssistant?.model ?? model.id,
-            usage: usageMeta.usage,
-            lastCallUsage: usageMeta.lastCallUsage,
-            promptTokens: usageMeta.promptTokens,
-            compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
-          };
-          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
-          const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
-
-          const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
-            toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
-            lastToolError: attempt.lastToolError,
-            config: params.config,
-            isCronTrigger: params.trigger === "cron",
-            sessionKey: params.sessionKey ?? params.sessionId,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            suppressToolErrorWarnings: params.suppressToolErrorWarnings,
-            inlineToolResultsAllowed: false,
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-          });
-          const payloadsWithToolMedia = mergeAttemptToolMediaPayloads({
-            payloads,
-            toolMediaUrls: attempt.toolMediaUrls,
-            toolAudioAsVoice: attempt.toolAudioAsVoice,
-          });
-
-          // Timeout aborts can leave the run without any assistant payloads.
-          // Emit an explicit timeout error instead of silently completing, so
-          // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
-            const timeoutText = idleTimedOut
-              ? "The model did not produce a response before the LLM idle timeout. " +
-                "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
-              : "Request timed out before a response was generated. " +
-                "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
-            const replayInvalid = resolveReplayInvalidForAttempt(null);
-            const livenessState = resolveRunLivenessState({
-              payloadCount: payloads.length,
-              aborted,
-              timedOut,
-              attempt,
-              incompleteTurnText: null,
-            });
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid,
-              livenessState,
-            });
-            return {
-              payloads: [
-                {
-                  text: timeoutText,
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
-
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
-          const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
-            provider,
-            modelId,
-            executionContract,
-            prompt: params.prompt,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          const nextReasoningOnlyRetryInstruction = resolveReasoningOnlyRetryInstruction({
-            provider: activeErrorContext.provider,
-            modelId: activeErrorContext.model,
-            executionContract,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          const nextEmptyResponseRetryInstruction = resolveEmptyResponseRetryInstruction({
-            provider: activeErrorContext.provider,
-            modelId: activeErrorContext.model,
-            executionContract,
-            payloadCount,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          if (
-            nextPlanningOnlyRetryInstruction &&
-            planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
-          ) {
-            const planningOnlyText = attempt.assistantTexts.join("\n\n").trim();
-            const planDetails = extractPlanningOnlyPlanDetails(planningOnlyText);
-            if (planDetails) {
-              emitAgentPlanEvent({
-                runId: params.runId,
-                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-                data: {
-                  phase: "update",
-                  title: "Assistant proposed a plan",
-                  explanation: planDetails.explanation,
-                  steps: planDetails.steps,
-                  source: "planning_only_retry",
-                },
+              const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
+                accumulatedReplayState.replayInvalid ||
+                resolveReplayInvalidFlag({
+                  attempt,
+                  incompleteTurnText,
+                });
+              if (resolveReplayInvalidForAttempt(null)) {
+                accumulatedReplayState.replayInvalid = true;
+              }
+              accumulatedReplayState = observeReplayMetadata(
+                accumulatedReplayState,
+                attempt.replayMetadata,
+              );
+              const formattedAssistantErrorText = sessionLastAssistant
+                ? formatAssistantErrorText(sessionLastAssistant, {
+                    cfg: params.config,
+                    sessionKey: resolvedSessionKey ?? params.sessionId,
+                    provider: activeErrorContext.provider,
+                    model: activeErrorContext.model,
+                  })
+                : undefined;
+              const assistantErrorText =
+                sessionLastAssistant?.stopReason === "error"
+                  ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+                  : undefined;
+              const canRestartForLiveSwitch =
+                !attempt.didSendViaMessagingTool &&
+                !attempt.didSendDeterministicApprovalPrompt &&
+                !attempt.lastToolError &&
+                attempt.toolMetas.length === 0 &&
+                attempt.assistantTexts.length === 0;
+              if (preflightRecovery?.handled) {
+                log.info(
+                  `[context-overflow-precheck] early recovery route=${preflightRecovery.route} ` +
+                    `completed for ${provider}/${modelId}; retrying prompt`,
+                );
+                continue;
+              }
+              const requestedSelection = shouldSwitchToLiveModel({
+                cfg: params.config,
+                sessionKey: resolvedSessionKey,
+                agentId: params.agentId,
+                defaultProvider: DEFAULT_PROVIDER,
+                defaultModel: DEFAULT_MODEL,
+                currentProvider: provider,
+                currentModel: modelId,
+                currentAuthProfileId: preferredProfileId,
+                currentAuthProfileIdSource: params.authProfileIdSource,
               });
-              params.onAgentEvent?.({
-                stream: "plan",
-                data: {
-                  phase: "update",
-                  title: "Assistant proposed a plan",
-                  explanation: planDetails.explanation,
-                  steps: planDetails.steps,
-                  source: "planning_only_retry",
-                },
-              });
-            }
-            planningOnlyRetryAttempts += 1;
-            planningOnlyRetryInstruction = nextPlanningOnlyRetryInstruction;
-            log.warn(
-              `planning-only turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${provider}/${modelId} contract=${executionContract} configured=${configuredExecutionContract} — retrying ` +
-                `${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} with act-now steer`,
-            );
-            continue;
-          }
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            nextReasoningOnlyRetryInstruction &&
-            reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
-          ) {
-            reasoningOnlyRetryAttempts += 1;
-            reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
-            log.warn(
-              `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
-                `with visible-answer continuation`,
-            );
-            continue;
-          }
-          const reasoningOnlyRetriesExhausted =
-            !nextPlanningOnlyRetryInstruction &&
-            nextReasoningOnlyRetryInstruction &&
-            reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            !nextReasoningOnlyRetryInstruction &&
-            nextEmptyResponseRetryInstruction &&
-            emptyResponseRetryAttempts < maxEmptyResponseRetryAttempts
-          ) {
-            emptyResponseRetryAttempts += 1;
-            emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
-            log.warn(
-              `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
-                `with visible-answer continuation`,
-            );
-            continue;
-          }
-          const incompleteTurnText = resolveIncompleteTurnPayloadText({
-            payloadCount,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            log.warn(
-              `reasoning-only retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
-            );
-          }
-          if (!incompleteTurnText && nextPlanningOnlyRetryInstruction && strictAgenticActive) {
-            log.warn(
-              `strict-agentic run exhausted planning-only retries: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${provider}/${modelId} configured=${configuredExecutionContract} — surfacing blocked state`,
-            );
-            // Criterion 4 of the GPT-5.4 parity gate requires every terminal
-            // exit path to emit an explicit livenessState + replayInvalid so
-            // downstream observers never see "silent disappearance". Every
-            // other hard-error terminal branch in this file uses "blocked"
-            // for its livenessState (role ordering, image size, schema
-            // error, compaction timeout, aborted-with-no-payloads). Match
-            // that convention here so lifecycle consumers treat an
-            // isError:true strict-agentic-blocked payload the same way they
-            // treat any other error-terminal payload. Replay validity is
-            // delegated to the shared resolver because the plan-only
-            // transcript itself is replay-safe even though the run is
-            // terminal.
-            const replayInvalid = resolveReplayInvalidForAttempt(null);
-            const livenessState: EmbeddedRunLivenessState = "blocked";
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid,
-              livenessState,
-            });
-            return {
-              payloads: [
-                {
-                  text: STRICT_AGENTIC_BLOCKED_TEXT,
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
-          if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(
-              "⚠️ Agent couldn't generate a response. Please try again.",
-            );
-            const livenessState = resolveRunLivenessState({
-              payloadCount: 0,
-              aborted,
-              timedOut,
-              attempt,
-              incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
-            });
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid,
-              livenessState,
-            });
-            if (lastProfileId) {
-              await maybeMarkAuthProfileFailure({
-                profileId: lastProfileId,
-                reason: resolveAuthProfileFailureReason(assistantFailoverReason),
-              });
-            }
-            return {
-              payloads: [
-                {
-                  text: "⚠️ Agent couldn't generate a response. Please try again.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            !nextReasoningOnlyRetryInstruction &&
-            nextEmptyResponseRetryInstruction &&
-            emptyResponseRetryAttempts >= maxEmptyResponseRetryAttempts
-          ) {
-            log.warn(
-              `empty response retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} — surfacing incomplete-turn error`,
-            );
-          }
-          // ── silent-error retry ────────────────────────────────────────────
-          // Observed with ollama/glm-5.1: a turn can end with stopReason="error"
-          // and zero output tokens AND empty content after a successful
-          // tool-call sequence, producing no user-visible text at all. The
-          // existing empty-response retry path (resolveEmptyResponseRetryInstruction)
-          // is gated on the strict-agentic contract (gpt-5 only), so non-frontier
-          // models fall through to "incomplete turn detected" → silent gap
-          // until the user nudges. This is a narrower, model-agnostic
-          // resubmission: same prompt, same session transcript (tool results
-          // already captured), no instruction injection. Placed before the
-          // incompleteTurnText return so it actually gets a chance to fire.
-          //
-          // Content-empty guard: a reasoning-only error (content has thinking
-          // blocks) is a distinct failure mode handled elsewhere; only retry
-          // when the assistant truly produced nothing.
-          //
-          // Side-effect guard: if the failed attempt already recorded potential
-          // side effects (messaging tool sent, cron add, mutating tool
-          // call that wasn't round-tripped as replay-safe), resubmission can
-          // duplicate those actions. Mirror the gate the other retry resolvers
-          // use (resolveEmptyResponseRetryInstruction, reasoning-only, planning-
-          // only), which short-circuit on attempt.replayMetadata.hadPotentialSideEffects.
-          const silentErrorContent = sessionLastAssistant?.content as Array<unknown> | undefined;
-          if (
-            incompleteTurnText &&
-            !aborted &&
-            !promptError &&
-            !timedOut &&
-            sessionLastAssistant?.stopReason === "error" &&
-            ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) === 0 &&
-            (silentErrorContent?.length ?? 0) === 0 &&
-            !attempt.replayMetadata.hadPotentialSideEffects &&
-            emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
-          ) {
-            emptyErrorRetries += 1;
-            log.warn(
-              `[empty-error-retry] stopReason=error output=0; resubmitting ` +
-                `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
-                `provider=${sessionLastAssistant?.provider ?? provider} ` +
-                `model=${sessionLastAssistant?.model ?? model.id} ` +
-                `sessionKey=${params.sessionKey ?? params.sessionId}`,
-            );
-            continue;
-          }
-          if (incompleteTurnText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);
-            const livenessState = resolveRunLivenessState({
-              payloadCount: payloads.length,
-              aborted,
-              timedOut,
-              attempt,
-              incompleteTurnText,
-            });
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid,
-              livenessState,
-            });
-            const incompleteStopReason = attempt.lastAssistant?.stopReason;
-            log.warn(
-              `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `stopReason=${incompleteStopReason} payloads=0 — surfacing error to user`,
-            );
+              if (requestedSelection && canRestartForLiveSwitch) {
+                await clearLiveModelSwitchPending({
+                  cfg: params.config,
+                  sessionKey: resolvedSessionKey,
+                  agentId: params.agentId,
+                });
+                log.info(
+                  `live session model switch requested during active attempt for ${params.sessionId}: ${provider}/${modelId} -> ${requestedSelection.provider}/${requestedSelection.model}`,
+                );
+                throw new LiveSessionModelSwitchError(requestedSelection);
+              }
+              // ── Timeout-triggered compaction ──────────────────────────────────
+              // When the LLM times out with high context usage, compact before
+              // retrying to break the death spiral of repeated timeouts.
+              if (timedOut && !timedOutDuringCompaction) {
+                // Only consider prompt-side tokens here. API totals include output
+                // tokens, which can make a long generation look like high context
+                // pressure even when the prompt itself was small.
+                const lastTurnPromptTokens = derivePromptTokens(lastRunPromptUsage);
+                const tokenUsedRatio =
+                  lastTurnPromptTokens != null && ctxInfo.tokens > 0
+                    ? lastTurnPromptTokens / ctxInfo.tokens
+                    : 0;
+                if (timeoutCompactionAttempts >= MAX_TIMEOUT_COMPACTION_ATTEMPTS) {
+                  log.warn(
+                    `[timeout-compaction] already attempted timeout compaction ${timeoutCompactionAttempts} time(s); falling through to failover rotation`,
+                  );
+                } else if (tokenUsedRatio > 0.65) {
+                  const timeoutDiagId = createCompactionDiagId();
+                  timeoutCompactionAttempts++;
+                  log.warn(
+                    `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%); ` +
+                      `attempting compaction before retry (attempt ${timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
+                  );
+                  let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
+                  await runOwnsCompactionBeforeHook("timeout recovery");
+                  try {
+                    const timeoutCompactionRuntimeContext = {
+                      ...buildEmbeddedCompactionRuntimeContext({
+                        sessionKey: params.sessionKey,
+                        messageChannel: params.messageChannel,
+                        messageProvider: params.messageProvider,
+                        agentAccountId: params.agentAccountId,
+                        currentChannelId: params.currentChannelId,
+                        currentThreadTs: params.currentThreadTs,
+                        currentMessageId: params.currentMessageId,
+                        authProfileId: lastProfileId,
+                        workspaceDir: resolvedWorkspace,
+                        agentDir,
+                        config: params.config,
+                        skillsSnapshot: params.skillsSnapshot,
+                        senderIsOwner: params.senderIsOwner,
+                        senderId: params.senderId,
+                        provider,
+                        modelId,
+                        thinkLevel,
+                        reasoningLevel: params.reasoningLevel,
+                        bashElevated: params.bashElevated,
+                        extraSystemPrompt: params.extraSystemPrompt,
+                        ownerNumbers: params.ownerNumbers,
+                      }),
+                      ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
+                      runId: params.runId,
+                      trigger: "timeout_recovery",
+                      diagId: timeoutDiagId,
+                      attempt: timeoutCompactionAttempts,
+                      maxAttempts: MAX_TIMEOUT_COMPACTION_ATTEMPTS,
+                    };
+                    timeoutCompactResult = await contextEngine.compact({
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                      sessionFile: params.sessionFile,
+                      tokenBudget: ctxInfo.tokens,
+                      force: true,
+                      compactionTarget: "budget",
+                      runtimeContext: timeoutCompactionRuntimeContext,
+                    });
+                  } catch (compactErr) {
+                    log.warn(
+                      `[timeout-compaction] contextEngine.compact() threw during timeout recovery for ${provider}/${modelId}: ${String(compactErr)}`,
+                    );
+                    timeoutCompactResult = {
+                      ok: false,
+                      compacted: false,
+                      reason: String(compactErr),
+                    };
+                  }
+                  await runOwnsCompactionAfterHook("timeout recovery", timeoutCompactResult);
+                  if (timeoutCompactResult.compacted) {
+                    autoCompactionCount += 1;
+                    if (contextEngine.info.ownsCompaction === true) {
+                      await runPostCompactionSideEffects({
+                        config: params.config,
+                        sessionKey: params.sessionKey,
+                        sessionFile: params.sessionFile,
+                      });
+                    }
+                    log.info(
+                      `[timeout-compaction] compaction succeeded for ${provider}/${modelId}; retrying prompt`,
+                    );
+                    continue;
+                  } else {
+                    log.warn(
+                      `[timeout-compaction] compaction did not reduce context for ${provider}/${modelId}; falling through to normal handling`,
+                    );
+                  }
+                }
+              }
 
-            // Mark the failing profile for cooldown so multi-profile setups
-            // rotate away from the exhausted credential on the next turn.
-            if (lastProfileId) {
-              await maybeMarkAuthProfileFailure({
-                profileId: lastProfileId,
-                reason: resolveAuthProfileFailureReason(assistantFailoverReason),
-              });
-            }
+              const contextOverflowError = !aborted
+                ? (() => {
+                    if (promptError) {
+                      const errorText = formatErrorMessage(promptError);
+                      if (isLikelyContextOverflowError(errorText)) {
+                        return { text: errorText, source: "promptError" as const };
+                      }
+                      // Prompt submission failed with a non-overflow error. Do not
+                      // inspect prior assistant errors from history for this attempt.
+                      return null;
+                    }
+                    if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                      return {
+                        text: assistantErrorText,
+                        source: "assistantError" as const,
+                      };
+                    }
+                    return null;
+                  })()
+                : null;
 
-            return {
-              payloads: [
-                {
-                  text: incompleteTurnText,
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
+              if (contextOverflowError) {
+                const overflowDiagId = createCompactionDiagId();
+                const errorText = contextOverflowError.text;
+                const msgCount = attempt.messagesSnapshot?.length ?? 0;
+                const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+                log.warn(
+                  `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                    `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
+                    `messages=${msgCount} sessionFile=${params.sessionFile} ` +
+                    `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
+                    `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
+                    `error=${errorText.slice(0, 200)}`,
+                );
+                const isCompactionFailure = isCompactionFailureError(errorText);
+                const hadAttemptLevelCompaction = attemptCompactionCount > 0;
+                // If this attempt already compacted (SDK auto-compaction), avoid immediately
+                // running another explicit compaction for the same overflow trigger.
+                if (
+                  !isCompactionFailure &&
+                  hadAttemptLevelCompaction &&
+                  overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+                ) {
+                  overflowCompactionAttempts++;
+                  log.warn(
+                    `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
+                  );
+                  continue;
+                }
+                // Attempt explicit overflow compaction only when this attempt did not
+                // already auto-compact.
+                if (
+                  !isCompactionFailure &&
+                  !hadAttemptLevelCompaction &&
+                  overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+                ) {
+                  if (log.isEnabled("debug")) {
+                    log.debug(
+                      `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
+                        `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
+                        `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                    );
+                  }
+                  overflowCompactionAttempts++;
+                  log.warn(
+                    `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+                  );
+                  let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
+                  await runOwnsCompactionBeforeHook("overflow recovery");
+                  try {
+                    const overflowCompactionRuntimeContext = {
+                      ...buildEmbeddedCompactionRuntimeContext({
+                        sessionKey: params.sessionKey,
+                        messageChannel: params.messageChannel,
+                        messageProvider: params.messageProvider,
+                        agentAccountId: params.agentAccountId,
+                        currentChannelId: params.currentChannelId,
+                        currentThreadTs: params.currentThreadTs,
+                        currentMessageId: params.currentMessageId,
+                        authProfileId: lastProfileId,
+                        workspaceDir: resolvedWorkspace,
+                        agentDir,
+                        config: params.config,
+                        skillsSnapshot: params.skillsSnapshot,
+                        senderIsOwner: params.senderIsOwner,
+                        senderId: params.senderId,
+                        provider,
+                        modelId,
+                        thinkLevel,
+                        reasoningLevel: params.reasoningLevel,
+                        bashElevated: params.bashElevated,
+                        extraSystemPrompt: params.extraSystemPrompt,
+                        ownerNumbers: params.ownerNumbers,
+                      }),
+                      ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
+                      runId: params.runId,
+                      trigger: "overflow",
+                      ...(observedOverflowTokens !== undefined
+                        ? { currentTokenCount: observedOverflowTokens }
+                        : {}),
+                      diagId: overflowDiagId,
+                      attempt: overflowCompactionAttempts,
+                      maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+                    };
+                    compactResult = await contextEngine.compact({
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                      sessionFile: params.sessionFile,
+                      tokenBudget: ctxInfo.tokens,
+                      ...(observedOverflowTokens !== undefined
+                        ? { currentTokenCount: observedOverflowTokens }
+                        : {}),
+                      force: true,
+                      compactionTarget: "budget",
+                      runtimeContext: overflowCompactionRuntimeContext,
+                    });
+                    if (compactResult.ok && compactResult.compacted) {
+                      await runContextEngineMaintenance({
+                        contextEngine,
+                        sessionId: params.sessionId,
+                        sessionKey: params.sessionKey,
+                        sessionFile: params.sessionFile,
+                        reason: "compaction",
+                        runtimeContext: overflowCompactionRuntimeContext,
+                      });
+                    }
+                  } catch (compactErr) {
+                    log.warn(
+                      `contextEngine.compact() threw during overflow recovery for ${provider}/${modelId}: ${String(compactErr)}`,
+                    );
+                    compactResult = {
+                      ok: false,
+                      compacted: false,
+                      reason: String(compactErr),
+                    };
+                  }
+                  await runOwnsCompactionAfterHook("overflow recovery", compactResult);
+                  if (compactResult.compacted) {
+                    if (preflightRecovery?.route === "compact_then_truncate") {
+                      const truncResult = await truncateOversizedToolResultsInSession({
+                        sessionFile: params.sessionFile,
+                        contextWindowTokens: ctxInfo.tokens,
+                        maxCharsOverride: resolveLiveToolResultMaxChars({
+                          contextWindowTokens: ctxInfo.tokens,
+                          cfg: params.config,
+                          agentId: sessionAgentId,
+                        }),
+                        sessionId: params.sessionId,
+                        sessionKey: params.sessionKey,
+                      });
+                      if (truncResult.truncated) {
+                        log.info(
+                          `[context-overflow-precheck] post-compaction tool-result truncation succeeded for ` +
+                            `${provider}/${modelId}; truncated ${truncResult.truncatedCount} tool result(s)`,
+                        );
+                      } else {
+                        log.warn(
+                          `[context-overflow-precheck] post-compaction tool-result truncation did not help for ` +
+                            `${provider}/${modelId}: ${truncResult.reason ?? "unknown"}`,
+                        );
+                      }
+                    }
+                    autoCompactionCount += 1;
+                    log.info(
+                      `auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`,
+                    );
+                    continue;
+                  }
+                  log.warn(
+                    `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+                  );
+                }
+                if (!toolResultTruncationAttempted) {
+                  const contextWindowTokens = ctxInfo.tokens;
+                  const toolResultMaxChars = resolveLiveToolResultMaxChars({
+                    contextWindowTokens,
+                    cfg: params.config,
+                    agentId: sessionAgentId,
+                  });
+                  const hasOversized = attempt.messagesSnapshot
+                    ? sessionLikelyHasOversizedToolResults({
+                        messages: attempt.messagesSnapshot,
+                        contextWindowTokens,
+                        maxCharsOverride: toolResultMaxChars,
+                      })
+                    : false;
 
-          log.debug(
-            `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
-          );
-          if (lastProfileId) {
-            await markAuthProfileGood({
-              store: authStore,
-              provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
-          const replayInvalid = resolveReplayInvalidForAttempt(null);
-          const livenessState = resolveRunLivenessState({
-            payloadCount: payloads.length,
-            aborted,
-            timedOut,
-            attempt,
-            incompleteTurnText: null,
-          });
-          const stopReason = attempt.clientToolCall
-            ? "tool_calls"
-            : attempt.yieldDetected
-              ? "end_turn"
-              : (sessionLastAssistant?.stopReason as string | undefined);
-          attempt.setTerminalLifecycleMeta?.({
-            replayInvalid,
-            livenessState,
-          });
-          return {
-            payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
-            meta: {
-              durationMs: Date.now() - started,
-              agentMeta,
-              aborted,
-              systemPromptReport: attempt.systemPromptReport,
-              finalPromptText: attempt.finalPromptText,
-              finalAssistantVisibleText,
-              finalAssistantRawText,
-              replayInvalid,
-              livenessState,
-              // Handle client tool calls (OpenResponses hosted tools)
-              // Propagate the LLM stop reason so callers (lifecycle events,
-              // ACP bridge) can distinguish end_turn from max_tokens.
-              stopReason,
-              pendingToolCalls: attempt.clientToolCall
-                ? [
+                  if (hasOversized) {
+                    toolResultTruncationAttempted = true;
+                    log.warn(
+                      `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
+                        `(contextWindow=${contextWindowTokens} tokens)`,
+                    );
+                    const truncResult = await truncateOversizedToolResultsInSession({
+                      sessionFile: params.sessionFile,
+                      contextWindowTokens,
+                      maxCharsOverride: toolResultMaxChars,
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                    });
+                    if (truncResult.truncated) {
+                      log.info(
+                        `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
+                      );
+                      continue;
+                    }
+                    log.warn(
+                      `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
+                    );
+                  }
+                }
+                if (
+                  (isCompactionFailure ||
+                    overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&
+                  log.isEnabled("debug")
+                ) {
+                  log.debug(
+                    `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
+                      `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
+                      `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                  );
+                }
+                const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid: resolveReplayInvalidForAttempt(),
+                  livenessState: "blocked",
+                });
+                return {
+                  payloads: [
                     {
-                      id: randomBytes(5).toString("hex").slice(0, 9),
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
+                      text:
+                        "Context overflow: prompt too large for the model. " +
+                        "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+                      isError: true,
                     },
-                  ]
-                : undefined,
-              executionTrace: {
-                winnerProvider: sessionLastAssistant?.provider ?? provider,
-                winnerModel: sessionLastAssistant?.model ?? model.id,
-                attempts:
-                  traceAttempts.length > 0 ||
-                  sessionLastAssistant?.provider ||
-                  sessionLastAssistant?.model
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: buildErrorAgentMeta({
+                      sessionId: sessionIdUsed,
+                      provider,
+                      model: model.id,
+                      usageAccumulator,
+                      lastRunPromptUsage,
+                      lastAssistant: sessionLastAssistant,
+                      lastTurnTotal,
+                    }),
+                    systemPromptReport: attempt.systemPromptReport,
+                    finalPromptText: attempt.finalPromptText,
+                    replayInvalid: resolveReplayInvalidForAttempt(),
+                    livenessState: "blocked",
+                    error: { kind, message: errorText },
+                  },
+                };
+              }
+
+              if (promptError && !aborted && promptErrorSource !== "compaction") {
+                // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
+                // FailoverError so rate-limit classification works even for nested shapes.
+                //
+                // promptErrorSource === "compaction" means the model call already completed and the
+                // abort happened only while waiting for compaction/retry cleanup. Retrying from here
+                // would replay that completed tool turn as a fresh prompt attempt.
+                const normalizedPromptFailover = coerceToFailoverError(promptError, {
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                  profileId: lastProfileId,
+                });
+                const promptErrorDetails = normalizedPromptFailover
+                  ? describeFailoverError(normalizedPromptFailover)
+                  : describeFailoverError(promptError);
+                const errorText = promptErrorDetails.message || formatErrorMessage(promptError);
+                if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
+                  authRetryPending = true;
+                  continue;
+                }
+                // Handle role ordering errors with a user-friendly message
+                if (/incorrect role information|roles must alternate/i.test(errorText)) {
+                  attempt.setTerminalLifecycleMeta?.({
+                    replayInvalid: resolveReplayInvalidForAttempt(),
+                    livenessState: "blocked",
+                  });
+                  return {
+                    payloads: [
+                      {
+                        text:
+                          "Message ordering conflict - please try again. " +
+                          "If this persists, use /new to start a fresh session.",
+                        isError: true,
+                      },
+                    ],
+                    meta: {
+                      durationMs: Date.now() - started,
+                      agentMeta: buildErrorAgentMeta({
+                        sessionId: sessionIdUsed,
+                        provider,
+                        model: model.id,
+                        usageAccumulator,
+                        lastRunPromptUsage,
+                        lastAssistant: sessionLastAssistant,
+                        lastTurnTotal,
+                      }),
+                      systemPromptReport: attempt.systemPromptReport,
+                      finalPromptText: attempt.finalPromptText,
+                      replayInvalid: resolveReplayInvalidForAttempt(),
+                      livenessState: "blocked",
+                      error: { kind: "role_ordering", message: errorText },
+                    },
+                  };
+                }
+                // Handle image size errors with a user-friendly message (no retry needed)
+                const imageSizeError = parseImageSizeError(errorText);
+                if (imageSizeError) {
+                  const maxMb = imageSizeError.maxMb;
+                  const maxMbLabel =
+                    typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+                  const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
+                  attempt.setTerminalLifecycleMeta?.({
+                    replayInvalid: resolveReplayInvalidForAttempt(),
+                    livenessState: "blocked",
+                  });
+                  return {
+                    payloads: [
+                      {
+                        text:
+                          `Image too large for the model${maxBytesHint}. ` +
+                          "Please compress or resize the image and try again.",
+                        isError: true,
+                      },
+                    ],
+                    meta: {
+                      durationMs: Date.now() - started,
+                      agentMeta: buildErrorAgentMeta({
+                        sessionId: sessionIdUsed,
+                        provider,
+                        model: model.id,
+                        usageAccumulator,
+                        lastRunPromptUsage,
+                        lastAssistant: sessionLastAssistant,
+                        lastTurnTotal,
+                      }),
+                      systemPromptReport: attempt.systemPromptReport,
+                      finalPromptText: attempt.finalPromptText,
+                      replayInvalid: resolveReplayInvalidForAttempt(),
+                      livenessState: "blocked",
+                      error: { kind: "image_size", message: errorText },
+                    },
+                  };
+                }
+                const promptFailoverReason =
+                  promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider });
+                const promptProfileFailureReason =
+                  resolveAuthProfileFailureReason(promptFailoverReason);
+                await maybeMarkAuthProfileFailure({
+                  profileId: lastProfileId,
+                  reason: promptProfileFailureReason,
+                  modelId,
+                });
+                const promptFailoverFailure =
+                  promptFailoverReason !== null || isFailoverErrorMessage(errorText, { provider });
+                // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
+                const failedPromptProfileId = lastProfileId;
+                const logPromptFailoverDecision = createFailoverDecisionLogger({
+                  stage: "prompt",
+                  runId: params.runId,
+                  rawError: errorText,
+                  failoverReason: promptFailoverReason,
+                  profileFailureReason: promptProfileFailureReason,
+                  provider,
+                  model: modelId,
+                  sourceProvider: provider,
+                  sourceModel: modelId,
+                  profileId: failedPromptProfileId,
+                  fallbackConfigured,
+                  aborted,
+                });
+                if (promptFailoverReason === "rate_limit") {
+                  maybeEscalateRateLimitProfileFallback({
+                    failoverProvider: provider,
+                    failoverModel: modelId,
+                    logFallbackDecision: logPromptFailoverDecision,
+                  });
+                }
+                let promptFailoverDecision = resolveRunFailoverDecision({
+                  stage: "prompt",
+                  aborted,
+                  externalAbort,
+                  fallbackConfigured,
+                  failoverFailure: promptFailoverFailure,
+                  failoverReason: promptFailoverReason,
+                  profileRotated: false,
+                });
+                if (
+                  promptFailoverDecision.action === "rotate_profile" &&
+                  (await advanceAuthProfile())
+                ) {
+                  traceAttempts.push({
+                    provider,
+                    model: modelId,
+                    result: promptFailoverReason === "timeout" ? "timeout" : "rotate_profile",
+                    ...(promptFailoverReason ? { reason: promptFailoverReason } : {}),
+                    stage: "prompt",
+                  });
+                  lastRetryFailoverReason = mergeRetryFailoverReason({
+                    previous: lastRetryFailoverReason,
+                    failoverReason: promptFailoverReason,
+                  });
+                  logPromptFailoverDecision("rotate_profile");
+                  await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+                  continue;
+                }
+                if (promptFailoverDecision.action === "rotate_profile") {
+                  promptFailoverDecision = resolveRunFailoverDecision({
+                    stage: "prompt",
+                    aborted,
+                    externalAbort,
+                    fallbackConfigured,
+                    failoverFailure: promptFailoverFailure,
+                    failoverReason: promptFailoverReason,
+                    profileRotated: true,
+                  });
+                }
+                const fallbackThinking = pickFallbackThinkingLevel({
+                  message: errorText,
+                  attempted: attemptedThinking,
+                });
+                if (fallbackThinking) {
+                  log.warn(
+                    `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                  );
+                  thinkLevel = fallbackThinking;
+                  continue;
+                }
+                // Throw FailoverError for prompt-side failover reasons when fallbacks
+                // are configured so outer model fallback can continue on overload,
+                // rate-limit, auth, or billing failures.
+                if (promptFailoverDecision.action === "fallback_model") {
+                  const fallbackReason = promptFailoverDecision.reason ?? "unknown";
+                  const status = resolveFailoverStatus(fallbackReason);
+                  traceAttempts.push({
+                    provider,
+                    model: modelId,
+                    result: promptFailoverReason === "timeout" ? "timeout" : "fallback_model",
+                    reason: fallbackReason,
+                    stage: "prompt",
+                    ...(typeof status === "number" ? { status } : {}),
+                  });
+                  logPromptFailoverDecision("fallback_model", { status });
+                  await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+                  throw (
+                    normalizedPromptFailover ??
+                    new FailoverError(errorText, {
+                      reason: fallbackReason,
+                      provider,
+                      model: modelId,
+                      profileId: lastProfileId,
+                      status,
+                    })
+                  );
+                }
+                if (promptFailoverDecision.action === "surface_error") {
+                  traceAttempts.push({
+                    provider,
+                    model: modelId,
+                    result: promptFailoverReason === "timeout" ? "timeout" : "surface_error",
+                    ...(promptFailoverReason ? { reason: promptFailoverReason } : {}),
+                    stage: "prompt",
+                  });
+                  logPromptFailoverDecision("surface_error");
+                }
+                throw promptError;
+              }
+
+              const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
+              const fallbackThinking = pickFallbackThinkingLevel({
+                message: assistantForFailover?.errorMessage,
+                attempted: attemptedThinking,
+              });
+              if (fallbackThinking && !aborted) {
+                log.warn(
+                  `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                );
+                thinkLevel = fallbackThinking;
+                continue;
+              }
+
+              const authFailure = isAuthAssistantError(assistantForFailover);
+              const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
+              const billingFailure = isBillingAssistantError(assistantForFailover);
+              const failoverFailure = isFailoverAssistantError(assistantForFailover);
+              const assistantFailoverReason = classifyFailoverReason(
+                assistantForFailover?.errorMessage ?? "",
+                {
+                  provider: assistantForFailover?.provider,
+                },
+              );
+              const assistantProfileFailureReason =
+                resolveAuthProfileFailureReason(assistantFailoverReason);
+              const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
+              const imageDimensionError = parseImageDimensionError(
+                assistantForFailover?.errorMessage ?? "",
+              );
+              // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
+              const failedAssistantProfileId = lastProfileId;
+              const logAssistantFailoverDecision = createFailoverDecisionLogger({
+                stage: "assistant",
+                runId: params.runId,
+                rawError: assistantForFailover?.errorMessage?.trim(),
+                failoverReason: assistantFailoverReason,
+                profileFailureReason: assistantProfileFailureReason,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
+                sourceProvider: assistantForFailover?.provider ?? provider,
+                sourceModel: assistantForFailover?.model ?? modelId,
+                profileId: failedAssistantProfileId,
+                fallbackConfigured,
+                timedOut,
+                aborted,
+              });
+
+              if (
+                authFailure &&
+                (await maybeRefreshRuntimeAuthForAuthError(
+                  assistantForFailover?.errorMessage ?? "",
+                  runtimeAuthRetry,
+                ))
+              ) {
+                authRetryPending = true;
+                continue;
+              }
+              if (imageDimensionError && lastProfileId) {
+                const details = [
+                  imageDimensionError.messageIndex !== undefined
+                    ? `message=${imageDimensionError.messageIndex}`
+                    : null,
+                  imageDimensionError.contentIndex !== undefined
+                    ? `content=${imageDimensionError.contentIndex}`
+                    : null,
+                  imageDimensionError.maxDimensionPx !== undefined
+                    ? `limit=${imageDimensionError.maxDimensionPx}px`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                log.warn(
+                  `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+                );
+              }
+
+              const assistantFailoverDecision = resolveRunFailoverDecision({
+                stage: "assistant",
+                aborted,
+                externalAbort,
+                fallbackConfigured,
+                failoverFailure,
+                failoverReason: assistantFailoverReason,
+                timedOut,
+                timedOutDuringCompaction,
+                profileRotated: false,
+              });
+              const assistantFailoverOutcome = await handleAssistantFailover({
+                initialDecision: assistantFailoverDecision,
+                aborted,
+                externalAbort,
+                fallbackConfigured,
+                failoverFailure,
+                failoverReason: assistantFailoverReason,
+                timedOut,
+                idleTimedOut,
+                timedOutDuringCompaction,
+                allowSameModelIdleTimeoutRetry:
+                  timedOut &&
+                  idleTimedOut &&
+                  !timedOutDuringCompaction &&
+                  !fallbackConfigured &&
+                  canRestartForLiveSwitch &&
+                  sameModelIdleTimeoutRetries < MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES,
+                assistantProfileFailureReason,
+                lastProfileId,
+                modelId,
+                provider,
+                activeErrorContext,
+                lastAssistant: assistantForFailover,
+                config: params.config,
+                sessionKey: params.sessionKey ?? params.sessionId,
+                authFailure,
+                rateLimitFailure,
+                billingFailure,
+                cloudCodeAssistFormatError,
+                isProbeSession,
+                overloadProfileRotations,
+                overloadProfileRotationLimit,
+                previousRetryFailoverReason: lastRetryFailoverReason,
+                logAssistantFailoverDecision,
+                warn: (message) => log.warn(message),
+                maybeMarkAuthProfileFailure,
+                maybeEscalateRateLimitProfileFallback,
+                maybeBackoffBeforeOverloadFailover,
+                advanceAuthProfile,
+              });
+              overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
+              if (assistantFailoverOutcome.action === "retry") {
+                traceAttempts.push({
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                  result:
+                    assistantFailoverOutcome.retryKind === "same_model_idle_timeout" ||
+                    assistantFailoverReason === "timeout"
+                      ? "timeout"
+                      : "rotate_profile",
+                  ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
+                  stage: "assistant",
+                });
+                if (assistantFailoverOutcome.retryKind === "same_model_idle_timeout") {
+                  sameModelIdleTimeoutRetries += 1;
+                }
+                lastRetryFailoverReason = assistantFailoverOutcome.lastRetryFailoverReason;
+                continue;
+              }
+              if (assistantFailoverOutcome.action === "throw") {
+                traceAttempts.push({
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                  result:
+                    assistantFailoverReason === "timeout"
+                      ? "timeout"
+                      : assistantFailoverDecision.action === "fallback_model"
+                        ? "fallback_model"
+                        : "error",
+                  ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
+                  stage: "assistant",
+                  ...(typeof assistantFailoverOutcome.error.status === "number"
+                    ? { status: assistantFailoverOutcome.error.status }
+                    : {}),
+                });
+                throw assistantFailoverOutcome.error;
+              }
+              const usageMeta = buildUsageAgentMetaFields({
+                usageAccumulator,
+                lastAssistantUsage: sessionLastAssistant?.usage as UsageLike | undefined,
+                lastRunPromptUsage,
+                lastTurnTotal,
+              });
+              const agentMeta: EmbeddedPiAgentMeta = {
+                sessionId: sessionIdUsed,
+                provider: sessionLastAssistant?.provider ?? provider,
+                model: sessionLastAssistant?.model ?? model.id,
+                usage: usageMeta.usage,
+                lastCallUsage: usageMeta.lastCallUsage,
+                promptTokens: usageMeta.promptTokens,
+                compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+              };
+              const finalAssistantVisibleText =
+                resolveFinalAssistantVisibleText(sessionLastAssistant);
+              const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+
+              const payloads = buildEmbeddedRunPayloads({
+                assistantTexts: attempt.assistantTexts,
+                toolMetas: attempt.toolMetas,
+                lastAssistant: attempt.lastAssistant,
+                lastToolError: attempt.lastToolError,
+                config: params.config,
+                isCronTrigger: params.trigger === "cron",
+                sessionKey: params.sessionKey ?? params.sessionId,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
+                verboseLevel: params.verboseLevel,
+                reasoningLevel: params.reasoningLevel,
+                toolResultFormat: resolvedToolResultFormat,
+                suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+                inlineToolResultsAllowed: false,
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              });
+              const payloadsWithToolMedia = mergeAttemptToolMediaPayloads({
+                payloads,
+                toolMediaUrls: attempt.toolMediaUrls,
+                toolAudioAsVoice: attempt.toolAudioAsVoice,
+              });
+
+              // Timeout aborts can leave the run without any assistant payloads.
+              // Emit an explicit timeout error instead of silently completing, so
+              // callers do not lose the turn as an orphaned user message.
+              if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
+                const timeoutText = idleTimedOut
+                  ? "The model did not produce a response before the LLM idle timeout. " +
+                    "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
+                  : "Request timed out before a response was generated. " +
+                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
+                const replayInvalid = resolveReplayInvalidForAttempt(null);
+                const livenessState = resolveRunLivenessState({
+                  payloadCount: payloads.length,
+                  aborted,
+                  timedOut,
+                  attempt,
+                  incompleteTurnText: null,
+                });
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid,
+                  livenessState,
+                });
+                return {
+                  payloads: [
+                    {
+                      text: timeoutText,
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta,
+                    aborted,
+                    systemPromptReport: attempt.systemPromptReport,
+                    finalPromptText: attempt.finalPromptText,
+                    finalAssistantVisibleText,
+                    finalAssistantRawText,
+                    replayInvalid,
+                    livenessState,
+                  },
+                  didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                  messagingToolSentTexts: attempt.messagingToolSentTexts,
+                  messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                  messagingToolSentTargets: attempt.messagingToolSentTargets,
+                  successfulCronAdds: attempt.successfulCronAdds,
+                };
+              }
+
+              const payloadCount = payloadsWithToolMedia?.length ?? 0;
+              const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
+                provider,
+                modelId,
+                executionContract,
+                prompt: params.prompt,
+                aborted,
+                timedOut,
+                attempt,
+              });
+              const nextReasoningOnlyRetryInstruction = resolveReasoningOnlyRetryInstruction({
+                provider: activeErrorContext.provider,
+                modelId: activeErrorContext.model,
+                executionContract,
+                aborted,
+                timedOut,
+                attempt,
+              });
+              const nextEmptyResponseRetryInstruction = resolveEmptyResponseRetryInstruction({
+                provider: activeErrorContext.provider,
+                modelId: activeErrorContext.model,
+                executionContract,
+                payloadCount,
+                aborted,
+                timedOut,
+                attempt,
+              });
+              if (
+                nextPlanningOnlyRetryInstruction &&
+                planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
+              ) {
+                const planningOnlyText = attempt.assistantTexts.join("\n\n").trim();
+                const planDetails = extractPlanningOnlyPlanDetails(planningOnlyText);
+                if (planDetails) {
+                  emitAgentPlanEvent({
+                    runId: params.runId,
+                    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                    data: {
+                      phase: "update",
+                      title: "Assistant proposed a plan",
+                      explanation: planDetails.explanation,
+                      steps: planDetails.steps,
+                      source: "planning_only_retry",
+                    },
+                  });
+                  params.onAgentEvent?.({
+                    stream: "plan",
+                    data: {
+                      phase: "update",
+                      title: "Assistant proposed a plan",
+                      explanation: planDetails.explanation,
+                      steps: planDetails.steps,
+                      source: "planning_only_retry",
+                    },
+                  });
+                }
+                planningOnlyRetryAttempts += 1;
+                planningOnlyRetryInstruction = nextPlanningOnlyRetryInstruction;
+                log.warn(
+                  `planning-only turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${provider}/${modelId} contract=${executionContract} configured=${configuredExecutionContract} — retrying ` +
+                    `${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} with act-now steer`,
+                );
+                continue;
+              }
+              if (
+                !nextPlanningOnlyRetryInstruction &&
+                nextReasoningOnlyRetryInstruction &&
+                reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
+              ) {
+                reasoningOnlyRetryAttempts += 1;
+                reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
+                log.warn(
+                  `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
+                    `with visible-answer continuation`,
+                );
+                continue;
+              }
+              const reasoningOnlyRetriesExhausted =
+                !nextPlanningOnlyRetryInstruction &&
+                nextReasoningOnlyRetryInstruction &&
+                reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
+              if (
+                !nextPlanningOnlyRetryInstruction &&
+                !nextReasoningOnlyRetryInstruction &&
+                nextEmptyResponseRetryInstruction &&
+                emptyResponseRetryAttempts < maxEmptyResponseRetryAttempts
+              ) {
+                emptyResponseRetryAttempts += 1;
+                emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
+                log.warn(
+                  `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
+                    `with visible-answer continuation`,
+                );
+                continue;
+              }
+              const incompleteTurnText = resolveIncompleteTurnPayloadText({
+                payloadCount,
+                aborted,
+                timedOut,
+                attempt,
+              });
+              if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
+                log.warn(
+                  `reasoning-only retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
+                );
+              }
+              if (!incompleteTurnText && nextPlanningOnlyRetryInstruction && strictAgenticActive) {
+                log.warn(
+                  `strict-agentic run exhausted planning-only retries: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${provider}/${modelId} configured=${configuredExecutionContract} — surfacing blocked state`,
+                );
+                // Criterion 4 of the GPT-5.4 parity gate requires every terminal
+                // exit path to emit an explicit livenessState + replayInvalid so
+                // downstream observers never see "silent disappearance". Every
+                // other hard-error terminal branch in this file uses "blocked"
+                // for its livenessState (role ordering, image size, schema
+                // error, compaction timeout, aborted-with-no-payloads). Match
+                // that convention here so lifecycle consumers treat an
+                // isError:true strict-agentic-blocked payload the same way they
+                // treat any other error-terminal payload. Replay validity is
+                // delegated to the shared resolver because the plan-only
+                // transcript itself is replay-safe even though the run is
+                // terminal.
+                const replayInvalid = resolveReplayInvalidForAttempt(null);
+                const livenessState: EmbeddedRunLivenessState = "blocked";
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid,
+                  livenessState,
+                });
+                return {
+                  payloads: [
+                    {
+                      text: STRICT_AGENTIC_BLOCKED_TEXT,
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta,
+                    aborted,
+                    systemPromptReport: attempt.systemPromptReport,
+                    finalPromptText: attempt.finalPromptText,
+                    finalAssistantVisibleText,
+                    finalAssistantRawText,
+                    replayInvalid,
+                    livenessState,
+                  },
+                  didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                  messagingToolSentTexts: attempt.messagingToolSentTexts,
+                  messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                  messagingToolSentTargets: attempt.messagingToolSentTargets,
+                  successfulCronAdds: attempt.successfulCronAdds,
+                };
+              }
+              if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
+                const replayInvalid = resolveReplayInvalidForAttempt(
+                  "⚠️ Agent couldn't generate a response. Please try again.",
+                );
+                const livenessState = resolveRunLivenessState({
+                  payloadCount: 0,
+                  aborted,
+                  timedOut,
+                  attempt,
+                  incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
+                });
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid,
+                  livenessState,
+                });
+                if (lastProfileId) {
+                  await maybeMarkAuthProfileFailure({
+                    profileId: lastProfileId,
+                    reason: resolveAuthProfileFailureReason(assistantFailoverReason),
+                  });
+                }
+                return {
+                  payloads: [
+                    {
+                      text: "⚠️ Agent couldn't generate a response. Please try again.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta,
+                    aborted,
+                    systemPromptReport: attempt.systemPromptReport,
+                    finalPromptText: attempt.finalPromptText,
+                    finalAssistantVisibleText,
+                    finalAssistantRawText,
+                    replayInvalid,
+                    livenessState,
+                  },
+                  didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                  messagingToolSentTexts: attempt.messagingToolSentTexts,
+                  messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                  messagingToolSentTargets: attempt.messagingToolSentTargets,
+                  successfulCronAdds: attempt.successfulCronAdds,
+                };
+              }
+              if (
+                !nextPlanningOnlyRetryInstruction &&
+                !nextReasoningOnlyRetryInstruction &&
+                nextEmptyResponseRetryInstruction &&
+                emptyResponseRetryAttempts >= maxEmptyResponseRetryAttempts
+              ) {
+                log.warn(
+                  `empty response retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} — surfacing incomplete-turn error`,
+                );
+              }
+              // ── silent-error retry ────────────────────────────────────────────
+              // Observed with ollama/glm-5.1: a turn can end with stopReason="error"
+              // and zero output tokens AND empty content after a successful
+              // tool-call sequence, producing no user-visible text at all. The
+              // existing empty-response retry path (resolveEmptyResponseRetryInstruction)
+              // is gated on the strict-agentic contract (gpt-5 only), so non-frontier
+              // models fall through to "incomplete turn detected" → silent gap
+              // until the user nudges. This is a narrower, model-agnostic
+              // resubmission: same prompt, same session transcript (tool results
+              // already captured), no instruction injection. Placed before the
+              // incompleteTurnText return so it actually gets a chance to fire.
+              //
+              // Content-empty guard: a reasoning-only error (content has thinking
+              // blocks) is a distinct failure mode handled elsewhere; only retry
+              // when the assistant truly produced nothing.
+              //
+              // Side-effect guard: if the failed attempt already recorded potential
+              // side effects (messaging tool sent, cron add, mutating tool
+              // call that wasn't round-tripped as replay-safe), resubmission can
+              // duplicate those actions. Mirror the gate the other retry resolvers
+              // use (resolveEmptyResponseRetryInstruction, reasoning-only, planning-
+              // only), which short-circuit on attempt.replayMetadata.hadPotentialSideEffects.
+              const silentErrorContent = sessionLastAssistant?.content as
+                | Array<unknown>
+                | undefined;
+              if (
+                incompleteTurnText &&
+                !aborted &&
+                !promptError &&
+                !timedOut &&
+                sessionLastAssistant?.stopReason === "error" &&
+                ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) ===
+                  0 &&
+                (silentErrorContent?.length ?? 0) === 0 &&
+                !attempt.replayMetadata.hadPotentialSideEffects &&
+                emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
+              ) {
+                emptyErrorRetries += 1;
+                log.warn(
+                  `[empty-error-retry] stopReason=error output=0; resubmitting ` +
+                    `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
+                    `provider=${sessionLastAssistant?.provider ?? provider} ` +
+                    `model=${sessionLastAssistant?.model ?? model.id} ` +
+                    `sessionKey=${params.sessionKey ?? params.sessionId}`,
+                );
+                continue;
+              }
+              if (incompleteTurnText) {
+                const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);
+                const livenessState = resolveRunLivenessState({
+                  payloadCount: payloads.length,
+                  aborted,
+                  timedOut,
+                  attempt,
+                  incompleteTurnText,
+                });
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid,
+                  livenessState,
+                });
+                const incompleteStopReason = attempt.lastAssistant?.stopReason;
+                log.warn(
+                  `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `stopReason=${incompleteStopReason} payloads=0 — surfacing error to user`,
+                );
+
+                // Mark the failing profile for cooldown so multi-profile setups
+                // rotate away from the exhausted credential on the next turn.
+                if (lastProfileId) {
+                  await maybeMarkAuthProfileFailure({
+                    profileId: lastProfileId,
+                    reason: resolveAuthProfileFailureReason(assistantFailoverReason),
+                  });
+                }
+
+                return {
+                  payloads: [
+                    {
+                      text: incompleteTurnText,
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta,
+                    aborted,
+                    systemPromptReport: attempt.systemPromptReport,
+                    finalPromptText: attempt.finalPromptText,
+                    finalAssistantVisibleText,
+                    finalAssistantRawText,
+                    replayInvalid,
+                    livenessState,
+                  },
+                  didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                  messagingToolSentTexts: attempt.messagingToolSentTexts,
+                  messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                  messagingToolSentTargets: attempt.messagingToolSentTargets,
+                  successfulCronAdds: attempt.successfulCronAdds,
+                };
+              }
+
+              log.debug(
+                `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
+              );
+              if (lastProfileId) {
+                await markAuthProfileGood({
+                  store: authStore,
+                  provider,
+                  profileId: lastProfileId,
+                  agentDir: params.agentDir,
+                });
+                await markAuthProfileUsed({
+                  store: authStore,
+                  profileId: lastProfileId,
+                  agentDir: params.agentDir,
+                });
+              }
+              const replayInvalid = resolveReplayInvalidForAttempt(null);
+              const livenessState = resolveRunLivenessState({
+                payloadCount: payloads.length,
+                aborted,
+                timedOut,
+                attempt,
+                incompleteTurnText: null,
+              });
+              const stopReason = attempt.clientToolCall
+                ? "tool_calls"
+                : attempt.yieldDetected
+                  ? "end_turn"
+                  : (sessionLastAssistant?.stopReason as string | undefined);
+              attempt.setTerminalLifecycleMeta?.({
+                replayInvalid,
+                livenessState,
+              });
+              return {
+                payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta,
+                  aborted,
+                  systemPromptReport: attempt.systemPromptReport,
+                  finalPromptText: attempt.finalPromptText,
+                  finalAssistantVisibleText,
+                  finalAssistantRawText,
+                  replayInvalid,
+                  livenessState,
+                  // Handle client tool calls (OpenResponses hosted tools)
+                  // Propagate the LLM stop reason so callers (lifecycle events,
+                  // ACP bridge) can distinguish end_turn from max_tokens.
+                  stopReason,
+                  pendingToolCalls: attempt.clientToolCall
                     ? [
-                        ...traceAttempts,
                         {
-                          provider: sessionLastAssistant?.provider ?? provider,
-                          model: sessionLastAssistant?.model ?? model.id,
-                          result: "success",
-                          stage: "assistant",
+                          id: randomBytes(5).toString("hex").slice(0, 9),
+                          name: attempt.clientToolCall.name,
+                          arguments: JSON.stringify(attempt.clientToolCall.params),
                         },
                       ]
                     : undefined,
-                fallbackUsed: traceAttempts.length > 0,
-                runner: "embedded",
-              },
-              requestShaping: {
-                ...(lastProfileId ? { authMode: "auth-profile" } : {}),
-                ...(thinkLevel ? { thinking: thinkLevel } : {}),
-                ...(params.reasoningLevel ? { reasoning: params.reasoningLevel } : {}),
-                ...(params.verboseLevel ? { verbose: params.verboseLevel } : {}),
-                ...(params.blockReplyBreak ? { blockStreaming: params.blockReplyBreak } : {}),
-              },
-              toolSummary: buildTraceToolSummary({
-                toolMetas: attempt.toolMetas,
-                hadFailure: Boolean(attempt.lastToolError),
-              }),
-              completion: {
-                ...(stopReason ? { stopReason } : {}),
-                ...(stopReason ? { finishReason: stopReason } : {}),
-                ...(stopReason?.toLowerCase().includes("refusal") ? { refusal: true } : {}),
-              },
-              contextManagement:
-                autoCompactionCount > 0 ? { lastTurnCompactions: autoCompactionCount } : undefined,
-            },
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-            messagingToolSentTexts: attempt.messagingToolSentTexts,
-            messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-            messagingToolSentTargets: attempt.messagingToolSentTargets,
-            successfulCronAdds: attempt.successfulCronAdds,
-          };
-        }
-      } finally {
-        await contextEngine.dispose?.();
-        stopRuntimeAuthRefreshTimer();
-        if (params.cleanupBundleMcpOnRunEnd === true) {
-          await retireSessionMcpRuntime({
-            sessionId: params.sessionId,
-            reason: "embedded-run-end",
-            onError: (error, sessionId) => {
-              log.warn(
-                `bundle-mcp cleanup failed after run for ${sessionId}: ${formatErrorMessage(error)}`,
-              );
-            },
-          });
-        }
-      }
-    });
+                  executionTrace: {
+                    winnerProvider: sessionLastAssistant?.provider ?? provider,
+                    winnerModel: sessionLastAssistant?.model ?? model.id,
+                    attempts:
+                      traceAttempts.length > 0 ||
+                      sessionLastAssistant?.provider ||
+                      sessionLastAssistant?.model
+                        ? [
+                            ...traceAttempts,
+                            {
+                              provider: sessionLastAssistant?.provider ?? provider,
+                              model: sessionLastAssistant?.model ?? model.id,
+                              result: "success",
+                              stage: "assistant",
+                            },
+                          ]
+                        : undefined,
+                    fallbackUsed: traceAttempts.length > 0,
+                    runner: "embedded",
+                  },
+                  requestShaping: {
+                    ...(lastProfileId ? { authMode: "auth-profile" } : {}),
+                    ...(thinkLevel ? { thinking: thinkLevel } : {}),
+                    ...(params.reasoningLevel ? { reasoning: params.reasoningLevel } : {}),
+                    ...(params.verboseLevel ? { verbose: params.verboseLevel } : {}),
+                    ...(params.blockReplyBreak ? { blockStreaming: params.blockReplyBreak } : {}),
+                  },
+                  toolSummary: buildTraceToolSummary({
+                    toolMetas: attempt.toolMetas,
+                    hadFailure: Boolean(attempt.lastToolError),
+                  }),
+                  completion: {
+                    ...(stopReason ? { stopReason } : {}),
+                    ...(stopReason ? { finishReason: stopReason } : {}),
+                    ...(stopReason?.toLowerCase().includes("refusal") ? { refusal: true } : {}),
+                  },
+                  contextManagement:
+                    autoCompactionCount > 0
+                      ? { lastTurnCompactions: autoCompactionCount }
+                      : undefined,
+                },
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                messagingToolSentTexts: attempt.messagingToolSentTexts,
+                messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                messagingToolSentTargets: attempt.messagingToolSentTargets,
+                successfulCronAdds: attempt.successfulCronAdds,
+              };
+            }
+          } finally {
+            await contextEngine.dispose?.();
+            stopRuntimeAuthRefreshTimer();
+            if (params.cleanupBundleMcpOnRunEnd === true) {
+              await retireSessionMcpRuntime({
+                sessionId: params.sessionId,
+                reason: "embedded-run-end",
+                onError: (error, sessionId) => {
+                  log.warn(
+                    `bundle-mcp cleanup failed after run for ${sessionId}: ${formatErrorMessage(error)}`,
+                  );
+                },
+              });
+            }
+          }
+        });
+      });
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
   });
 }

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -1,3 +1,4 @@
+import { trace, SpanStatusCode, context } from "@opentelemetry/api";
 import { copyPluginToolMeta } from "../plugins/tools.js";
 import { bindAbortRelay } from "../utils/fetch-timeout.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -70,3 +70,36 @@ export function wrapToolWithAbortSignal(
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   return wrappedTool;
 }
+
+export function wrapToolWithTracing(tool: AnyAgentTool): AnyAgentTool {
+  const execute = tool.execute;
+  if (!execute) {
+    return tool;
+  }
+  const wrappedTool: AnyAgentTool = {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const tracer = trace.getTracer("openclaw");
+      return tracer.startActiveSpan(`openclaw.tool.${tool.name}`, {}, context.active(), async (span) => {
+        try {
+          span.setAttributes({
+            "openclaw.tool.name": tool.name,
+            "openclaw.tool.call_id": toolCallId,
+          });
+          const result = await execute(toolCallId, params, signal, onUpdate);
+          span.setStatus({ code: SpanStatusCode.OK });
+          return result;
+        } catch (err) {
+          span.recordException(err as Error);
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          throw err;
+        } finally {
+          span.end();
+        }
+      });
+    },
+  };
+  copyPluginToolMeta(tool, wrappedTool);
+  copyChannelAgentToolMeta(tool as never, wrappedTool as never);
+  return wrappedTool;
+}

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -21,7 +21,7 @@ import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
-import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
+import { wrapToolWithAbortSignal, wrapToolWithTracing } from "./pi-tools.abort.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
@@ -720,5 +720,5 @@ export function createOpenClawCodingTools(options?: {
   // NOTE: Keep canonical (lowercase) tool names here.
   // pi-ai's Anthropic OAuth transport remaps tool names to Claude Code-style names
   // on the wire and maps them back for tool dispatch.
-  return withDeferredFollowupDescriptions;
+  return withDeferredFollowupDescriptions.map((tool) => wrapToolWithTracing(tool));
 }

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -1,3 +1,4 @@
+import { trace, SpanStatusCode, context } from "@opentelemetry/api";
 import { buildDockerExecArgs } from "../bash-tools.shared.js";
 import type { SandboxBackendCommandParams } from "./backend-handle.types.js";
 import type {
@@ -93,22 +94,40 @@ export function runDockerSandboxShellCommand(
     containerName: string;
   } & SandboxBackendCommandParams,
 ) {
-  const dockerArgs = [
-    "exec",
-    "-i",
-    params.containerName,
-    "sh",
-    "-c",
-    params.script,
-    "openclaw-sandbox-fs",
-  ];
-  if (params.args?.length) {
-    dockerArgs.push(...params.args);
-  }
-  return execDockerRaw(dockerArgs, {
-    input: params.stdin,
-    allowFailure: params.allowFailure,
-    signal: params.signal,
+  const tracer = trace.getTracer("openclaw");
+  return tracer.startActiveSpan("openclaw.sandbox.exec", {}, context.active(), async (span) => {
+    try {
+      span.setAttributes({
+        "openclaw.sandbox.container": params.containerName,
+        "openclaw.sandbox.script": params.script,
+      });
+
+      const dockerArgs = [
+        "exec",
+        "-i",
+        params.containerName,
+        "sh",
+        "-c",
+        params.script,
+        "openclaw-sandbox-fs",
+      ];
+      if (params.args?.length) {
+        dockerArgs.push(...params.args);
+      }
+      const result = await execDockerRaw(dockerArgs, {
+        input: params.stdin,
+        allowFailure: params.allowFailure,
+        signal: params.signal,
+      });
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
   });
 }
 


### PR DESCRIPTION


---
### **Update: Feedback Addressed**
- **Fixed ReferenceErrors**: Added missing `@opentelemetry/api` imports in `run.ts` and `pi-tools.abort.ts`.
- **Double-Initialization Guard**: `otel-preload.mjs` now automatically sets `OPENCLAW_OTEL_PRELOADED=1` upon successful startup.
- **Observability Restored**: Refactored `diagnostics-otel` to skip only the SDK initialization while preserving log transports and diagnostic event hooks.
- **Improved Shutdown**: Added `SIGINT` handler to the preload script for better development environment support.
- **Dependency Alignment**: Promoted OTel SDK dependencies to the root `package.json` to support core instrumentation.