### PR TITLE
fix(models/auth): merge agents.defaults.models on provider login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/auth: merge provider-owned default-model additions from `openclaw models auth login` instead of replacing `agents.defaults.models`, so re-authenticating an OAuth provider such as OpenAI Codex no longer wipes other providers' aliases and per-model params. Migrations that must rename keys (Anthropic -> Claude CLI) opt in with `replaceDefaultModels`. Fixes #69414. (#70435) Thanks @neeravmakwana.
 - Media understanding/audio: prefer configured or key-backed STT providers before auto-detected local Whisper CLIs, so installed local transcription tools no longer shadow API providers such as Groq/OpenAI in `tools.media.audio` auto mode. Fixes #68727.
 - Providers/OpenAI: lock the auth picker wording for OpenAI API key, Codex browser login, and Codex device pairing so the setup choices no longer imply a mixed Codex/API-key auth path. (#67848) Thanks @tmlxrd.
 - Agents/BTW: route `/btw` side questions through provider stream registration with the session workspace, so Ollama provider URL construction and workspace-scoped hooks apply correctly. Fixes #68336. (#70413) Thanks @suboss87.

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -180,6 +180,8 @@ export function buildAnthropicCliMigrationResult(
         },
       },
     },
+    // Rewrites `anthropic/*` -> `claude-cli/*`; merge would keep stale keys.
+    replaceDefaultModels: true,
     defaultModel,
     notes: [
       "Claude CLI auth detected; switched Anthropic model selection to the local Claude CLI backend.",

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -513,6 +513,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
             },
           },
         },
+        replaceDefaultModels: true,
         defaultModel: "claude-cli/claude-sonnet-4-6",
       }),
     };

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -154,23 +154,28 @@ vi.mock("../provider-auth-helpers.js", () => {
         null
       );
     }),
-    applyProviderAuthConfigPatch: vi.fn((cfg: OpenClawConfig, patch: unknown) => {
-      const merged = mergePatch(cfg, patch);
-      const patchModels = (patch as { agents?: { defaults?: { models?: unknown } } })?.agents
-        ?.defaults?.models;
-      return isRecord(patchModels)
-        ? {
-            ...merged,
-            agents: {
-              ...merged.agents,
-              defaults: {
-                ...merged.agents?.defaults,
-                models: patchModels,
+    applyProviderAuthConfigPatch: vi.fn(
+      (cfg: OpenClawConfig, patch: unknown, options?: { replaceDefaultModels?: boolean }) => {
+        const merged = mergePatch(cfg, patch);
+        if (!options?.replaceDefaultModels) {
+          return merged;
+        }
+        const patchModels = (patch as { agents?: { defaults?: { models?: unknown } } })?.agents
+          ?.defaults?.models;
+        return isRecord(patchModels)
+          ? {
+              ...merged,
+              agents: {
+                ...merged.agents,
+                defaults: {
+                  ...merged.agents?.defaults,
+                  models: patchModels,
+                },
               },
-            },
-          }
-        : merged;
-    }),
+            }
+          : merged;
+      },
+    ),
     applyDefaultModel: vi.fn((cfg: OpenClawConfig, model: string) => ({
       ...cfg,
       agents: {
@@ -482,6 +487,7 @@ describe("modelsAuthLoginCommand", () => {
             },
           },
         },
+        replaceDefaultModels: true,
         notes: [
           "Claude CLI auth detected; switched Anthropic model selection to the local Claude CLI backend.",
           "Existing Anthropic auth profiles are kept for rollback.",
@@ -571,6 +577,38 @@ describe("modelsAuthLoginCommand", () => {
       "Provider notes",
     );
     expect(runtime.log).toHaveBeenCalledWith("Default model set to claude-cli/claude-sonnet-4-6");
+  });
+
+  it("preserves other providers' allowlist entries on an openai-codex OAuth login", async () => {
+    const runtime = createRuntime();
+    const existingModels = {
+      "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "opus" },
+      "moonshot/kimi-k2.5": { alias: "kimi" },
+      "openai-codex/gpt-5.4": { alias: "gpt54" },
+    };
+    currentConfig = { agents: { defaults: { models: existingModels } } };
+    runProviderAuth.mockResolvedValue({
+      profiles: [
+        {
+          profileId: "openai-codex:user@example.com",
+          credential: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "a",
+            refresh: "r",
+            expires: Date.now() + 60_000,
+            email: "user@example.com",
+          },
+        },
+      ],
+      configPatch: { agents: { defaults: { models: { "openai-codex/gpt-5.4": {} } } } },
+      defaultModel: "openai-codex/gpt-5.4",
+    });
+
+    await modelsAuthLoginCommand({ provider: "openai-codex" }, runtime);
+
+    expect(lastUpdatedConfig?.agents?.defaults?.models).toEqual(existingModels);
   });
 
   it("survives lockout clearing failure without blocking login", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -246,7 +246,9 @@ async function persistProviderAuthResult(params: {
   await updateConfig((cfg) => {
     let next = cfg;
     if (params.result.configPatch) {
-      next = applyProviderAuthConfigPatch(next, params.result.configPatch);
+      next = applyProviderAuthConfigPatch(next, params.result.configPatch, {
+        replaceDefaultModels: params.result.replaceDefaultModels,
+      });
     }
     for (const profile of params.result.profiles) {
       next = applyAuthProfileConfig(next, {

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -42,6 +42,14 @@ describe("applyProviderAuthConfigPatch", () => {
     expect(next.agents?.defaults?.model).toEqual(base.agents.defaults.model);
   });
 
+  it("drops prototype-pollution keys from the merge", () => {
+    const patch = JSON.parse('{"__proto__":{"polluted":true},"agents":{"defaults":{}}}');
+    const next = applyProviderAuthConfigPatch(base, patch);
+    expect(next.agents?.defaults?.models).toEqual(base.agents.defaults.models);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(next).polluted).toBeUndefined();
+  });
+
   it("keeps normal recursive merges for unrelated provider auth patch fields", () => {
     const base = {
       agents: {

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -3,38 +3,43 @@ import type { OpenClawConfig } from "../config/config.js";
 import { applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
 
 describe("applyProviderAuthConfigPatch", () => {
-  it("replaces patched default model maps instead of recursively merging them", () => {
-    const base = {
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-sonnet-4-6",
-            fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-5.2"],
-          },
-          models: {
-            "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
-            "anthropic/claude-opus-4-6": { alias: "Opus" },
-            "openai/gpt-5.2": {},
-          },
+  const base = {
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5.2"] },
+        models: {
+          "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+          "anthropic/claude-opus-4-6": { alias: "Opus" },
+          "openai/gpt-5.2": {},
         },
       },
-    };
+    },
+  };
+
+  it("merges default model maps by default so other providers survive login", () => {
+    const patch = { agents: { defaults: { models: { "openai-codex/gpt-5.4": {} } } } };
+    const next = applyProviderAuthConfigPatch(base, patch);
+    expect(next.agents?.defaults?.models).toEqual({
+      ...base.agents.defaults.models,
+      "openai-codex/gpt-5.4": {},
+    });
+    expect(next.agents?.defaults?.model).toEqual(base.agents.defaults.model);
+  });
+
+  it("replaces the allowlist only when replaceDefaultModels is set", () => {
     const patch = {
       agents: {
         defaults: {
           models: {
             "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
-            "claude-cli/claude-opus-4-6": { alias: "Opus" },
             "openai/gpt-5.2": {},
           },
         },
       },
     };
-
-    const next = applyProviderAuthConfigPatch(base, patch);
-
+    const next = applyProviderAuthConfigPatch(base, patch, { replaceDefaultModels: true });
     expect(next.agents?.defaults?.models).toEqual(patch.agents.defaults.models);
-    expect(next.agents?.defaults?.model).toEqual(base.agents?.defaults?.model);
+    expect(next.agents?.defaults?.model).toEqual(base.agents.defaults.model);
   });
 
   it("keeps normal recursive merges for unrelated provider auth patch fields", () => {

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -50,6 +50,23 @@ describe("applyProviderAuthConfigPatch", () => {
     expect(Object.getPrototypeOf(next).polluted).toBeUndefined();
   });
 
+  it("drops prototype-pollution keys from opt-in model replacement", () => {
+    const patch = JSON.parse(
+      '{"agents":{"defaults":{"models":{"__proto__":{"polluted":true},"claude-cli/claude-sonnet-4-6":{"alias":"Sonnet","params":{"constructor":{"polluted":true},"maxTokens":12000}}}}}}',
+    );
+    const next = applyProviderAuthConfigPatch(base, patch, { replaceDefaultModels: true });
+    const models = next.agents?.defaults?.models;
+    expect(models).toEqual({
+      "claude-cli/claude-sonnet-4-6": {
+        alias: "Sonnet",
+        params: { maxTokens: 12000 },
+      },
+    });
+    expect(Object.prototype.hasOwnProperty.call(models, "__proto__")).toBe(false);
+    expect(Object.getPrototypeOf(Object.assign({}, models)).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it("keeps normal recursive merges for unrelated provider auth patch fields", () => {
     const base = {
       agents: {

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -63,9 +63,13 @@ export function mergeConfigPatch<T>(base: T, patch: unknown): T {
   return next as T;
 }
 
-export function applyProviderAuthConfigPatch(cfg: OpenClawConfig, patch: unknown): OpenClawConfig {
+export function applyProviderAuthConfigPatch(
+  cfg: OpenClawConfig,
+  patch: unknown,
+  options?: { replaceDefaultModels?: boolean },
+): OpenClawConfig {
   const merged = mergeConfigPatch(cfg, patch);
-  if (!isPlainRecord(patch)) {
+  if (!options?.replaceDefaultModels || !isPlainRecord(patch)) {
     return merged;
   }
 
@@ -81,7 +85,7 @@ export function applyProviderAuthConfigPatch(cfg: OpenClawConfig, patch: unknown
       ...merged.agents,
       defaults: {
         ...merged.agents?.defaults,
-        // Provider auth migrations can intentionally replace the exact allowlist.
+        // Opt-in replacement for migrations that rename/remove model keys.
         models: patchModels as NonNullable<
           NonNullable<OpenClawConfig["agents"]>["defaults"]
         >["models"],

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -46,13 +46,31 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-// Guard the recursive merge against prototype-pollution payloads if a
-// patch ever arrives from a JSON-parsed source that preserves these keys.
+// Guard config patches against prototype-pollution payloads if a patch ever
+// arrives from a JSON-parsed source that preserves these keys.
 const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function sanitizeConfigPatchValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeConfigPatchValue(entry));
+  }
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (BLOCKED_MERGE_KEYS.has(key)) {
+      continue;
+    }
+    next[key] = sanitizeConfigPatchValue(nestedValue);
+  }
+  return next;
+}
 
 export function mergeConfigPatch<T>(base: T, patch: unknown): T {
   if (!isPlainRecord(base) || !isPlainRecord(patch)) {
-    return patch as T;
+    return sanitizeConfigPatchValue(patch) as T;
   }
 
   const next: Record<string, unknown> = { ...base };
@@ -64,7 +82,7 @@ export function mergeConfigPatch<T>(base: T, patch: unknown): T {
     if (isPlainRecord(existing) && isPlainRecord(value)) {
       next[key] = mergeConfigPatch(existing, value);
     } else {
-      next[key] = value;
+      next[key] = sanitizeConfigPatchValue(value);
     }
   }
   return next as T;
@@ -93,7 +111,7 @@ export function applyProviderAuthConfigPatch(
       defaults: {
         ...merged.agents?.defaults,
         // Opt-in replacement for migrations that rename/remove model keys.
-        models: patchModels as NonNullable<
+        models: sanitizeConfigPatchValue(patchModels) as NonNullable<
           NonNullable<OpenClawConfig["agents"]>["defaults"]
         >["models"],
       },

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -46,6 +46,10 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+// Guard the recursive merge against prototype-pollution payloads if a
+// patch ever arrives from a JSON-parsed source that preserves these keys.
+const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 export function mergeConfigPatch<T>(base: T, patch: unknown): T {
   if (!isPlainRecord(base) || !isPlainRecord(patch)) {
     return patch as T;
@@ -53,6 +57,9 @@ export function mergeConfigPatch<T>(base: T, patch: unknown): T {
 
   const next: Record<string, unknown> = { ...base };
   for (const [key, value] of Object.entries(patch)) {
+    if (BLOCKED_MERGE_KEYS.has(key)) {
+      continue;
+    }
     const existing = next[key];
     if (isPlainRecord(existing) && isPlainRecord(value)) {
       next[key] = mergeConfigPatch(existing, value);

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -155,7 +155,9 @@ export async function runProviderPluginAuthMethod(params: {
 
   let nextConfig = params.config;
   if (result.configPatch) {
-    nextConfig = applyProviderAuthConfigPatch(nextConfig, result.configPatch);
+    nextConfig = applyProviderAuthConfigPatch(nextConfig, result.configPatch, {
+      replaceDefaultModels: result.replaceDefaultModels,
+    });
   }
 
   for (const profile of result.profiles) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -240,6 +240,12 @@ export type ProviderAuthResult = {
   configPatch?: Partial<OpenClawConfig>;
   defaultModel?: string;
   notes?: string[];
+  /**
+   * Opt in to replace `agents.defaults.models` wholesale with the patch map.
+   * Default behavior merges the map so other providers' entries survive.
+   * Set only from migrations that intentionally rename/remove model keys.
+   */
+  replaceDefaultModels?: boolean;
 };
 
 /** Interactive auth context passed to provider login/setup methods. */


### PR DESCRIPTION
## Root cause

`openclaw models auth login --provider <id>` funnels the provider's
`ProviderAuthResult.configPatch` through `applyProviderAuthConfigPatch`
in `src/plugins/provider-auth-choice-helpers.ts`. That helper always
replaced `agents.defaults.models` whole when the patch contained that
key, regardless of whether the caller meant to rename models or just
record a default for the freshly authenticated provider.

Most OAuth flows (including the OpenAI Codex login driven through
`buildOauthProviderAuthResult`) return a patch like
`agents.defaults.models: { "openai-codex/gpt-5.4": {} }`. Feeding that
into the replacement branch dropped every other entry the operator had
configured — aliases, per-model `cacheRetention`, `maxTokens`,
`fastMode`, fallback-only models, and so on.

The one legitimate consumer of replacement semantics is the Anthropic
CLI migration (`extensions/anthropic/cli-migration.ts`), which rewrites
`anthropic/*` keys to `claude-cli/*` and needs the old keys gone.

## Fix

Make replacement opt-in on `ProviderAuthResult`:

- Add `replaceDefaultModels?: boolean` to the result type.
- `applyProviderAuthConfigPatch` takes an `options.replaceDefaultModels`
  flag; when unset it merges the allowlist (existing + patch), matching
  the behavior operators expect from `config set --merge`.
- The two call sites (`persistProviderAuthResult` in the models auth
  command and `runProviderPluginAuthMethod` in the provider auth-choice
  runtime) thread the flag from the provider's result.
- `buildAnthropicCliMigrationResult` sets
  `replaceDefaultModels: true` so the CLI migration keeps its existing
  rename semantics.

## Why this is safe

- Behavior change is strictly narrower than before: the only path that
  still replaces `agents.defaults.models` is the one explicit migration
  that already relied on the replacement, and it now opts in by name.
- Defaults for every other provider (`buildOauthProviderAuthResult`,
  self-hosted setup, LM Studio, Copilot proxy, Ollama, Minimax, etc.)
  become additive: the OAuth default the provider registers is merged
  into the operator's existing allowlist, preserving aliases and params.
- New field on the public `ProviderAuthResult` type is optional, so
  third-party provider plugins that do not set it keep working and pick
  up the merge behavior for free.
- No credential storage, auth-profile upsert, OAuth exchange, or model
  gating logic is touched. The only surface modified is how an already
  trusted provider patch is composed into the final config.

## Security / runtime controls unchanged

- Auth-profile persistence (`upsertAuthProfile`), credential shape
  validation, and OAuth PKCE handling are untouched.
- Agent-level model allowlists, provider API-key resolution, and gateway
  permission gating are enforced elsewhere and are not sensitive to
  whether the allowlist patch merged or replaced.
- Isolation between providers (`models.providers.<id>` namespaces) is
  unaffected; this change only covers the agents-wide default-model
  allowlist block.
- No prompt-based safety is involved — the decision is fully runtime
  and structural.

## Tests

- `pnpm test src/plugins/provider-auth-choice-helpers.test.ts` — reworked
  to cover both default-merge and opt-in-replace shapes.
- `pnpm test src/commands/models/auth.test.ts` — adds a regression test
  that exercises an OpenAI Codex OAuth login against a multi-provider
  allowlist and asserts the untouched entries survive.
- `pnpm test extensions/anthropic/cli-migration.test.ts` — verifies the
  CLI migration keeps its rename semantics with the new opt-in flag.
- `pnpm test:contracts:plugins` — 51 files / 631 tests green.
- `pnpm tsgo` + `pnpm tsgo:core:test` — clean. Pre-existing
  `tsgo:extensions` errors for `@tencent-connect/qqbot-connector` and
  `tokenjuice/openclaw` reproduce on `origin/main` and are unrelated.
- `pnpm oxfmt` — clean.

Fixes #69414.

Made with [Cursor](https://cursor.com)