### PR TITLE
fix(agents): preserve Anthropic thinking signatures on replay (#69579)

### DIFF
--- a/src/agents/anthropic-stored-thinking-signature.test.ts
+++ b/src/agents/anthropic-stored-thinking-signature.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveAnthropicStoredThinkingSignature } from "./anthropic-stored-thinking-signature.js";
+
+describe("resolveAnthropicStoredThinkingSignature", () => {
+  it("prefers non-empty thinkingSignature", () => {
+    expect(
+      resolveAnthropicStoredThinkingSignature({
+        thinkingSignature: "a",
+        signature: "b",
+      }),
+    ).toBe("a");
+  });
+
+  it("falls back to signature when thinkingSignature is empty after trim", () => {
+    expect(
+      resolveAnthropicStoredThinkingSignature({
+        thinkingSignature: "",
+        signature: "sig",
+      }),
+    ).toBe("sig");
+  });
+
+  it("returns undefined when both are missing or blank", () => {
+    expect(resolveAnthropicStoredThinkingSignature({})).toBeUndefined();
+    expect(
+      resolveAnthropicStoredThinkingSignature({ thinkingSignature: "  " }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/anthropic-stored-thinking-signature.ts
+++ b/src/agents/anthropic-stored-thinking-signature.ts
@@ -1,0 +1,21 @@
+/**
+ * Session history may store `thinkingSignature` (stream assembler) or a raw
+ * `signature` field (some round-trips). If `thinkingSignature` is present but
+ * empty or whitespace-only, fall back to `signature` (not only when undefined —
+ * that keeps transport replay and stream conversion consistent).
+ */
+export function resolveAnthropicStoredThinkingSignature(block: {
+  thinkingSignature?: string;
+  signature?: string;
+}): string | undefined {
+  const fromPrimary =
+    typeof block.thinkingSignature === "string" ? block.thinkingSignature.trim() : "";
+  if (fromPrimary) {
+    return fromPrimary;
+  }
+  const fromSecondary = typeof block.signature === "string" ? block.signature.trim() : "";
+  if (fromSecondary) {
+    return fromSecondary;
+  }
+  return undefined;
+}

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -413,4 +413,88 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("preserves signed thinking bytes on replay without mutating text (#69579)", async () => {
+    const model = makeAnthropicTransportModel();
+    // `sanitizeTransportPayloadText` removes lone UTF-16 surrogates; doing that to signed
+    // thinking would change bytes vs Anthropic's signature and reject the next request.
+    const thinkingWithLoneSurrogate = "a\uD800b";
+    await runTransportStream(
+      model,
+      {
+        messages: [
+          { role: "user", content: "first" },
+          {
+            role: "assistant",
+            api: "anthropic-messages",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            content: [
+              {
+                type: "thinking",
+                thinking: thinkingWithLoneSurrogate,
+                thinkingSignature: "sig_replay_1",
+              },
+              { type: "text", text: "Visible reply" },
+            ],
+          },
+          { role: "user", content: "second turn" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const { payload } = latestAnthropicRequest();
+    const requestMessages = payload.messages as Array<{
+      role: string;
+      content: Array<{ type: string; thinking?: string; signature?: string; text?: string }>;
+    }>;
+    const assistantEntry = requestMessages.find((m) => m.role === "assistant");
+    const thinkingBlock = assistantEntry?.content.find((b) => b.type === "thinking");
+    expect(thinkingBlock?.thinking).toBe(thinkingWithLoneSurrogate);
+    expect(thinkingBlock).toMatchObject({ signature: "sig_replay_1" });
+  });
+
+  it("preserves signed thinking on replay when only `signature` is stored (no thinkingSignature) (#69579)", async () => {
+    const model = makeAnthropicTransportModel();
+    const thinkingWithLoneSurrogate = "a\uD800b";
+    await runTransportStream(
+      model,
+      {
+        messages: [
+          { role: "user", content: "first" },
+          {
+            role: "assistant",
+            api: "anthropic-messages",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            content: [
+              {
+                type: "thinking",
+                thinking: thinkingWithLoneSurrogate,
+                signature: "sig_replay_2",
+              },
+              { type: "text", text: "Visible reply" },
+            ],
+          },
+          { role: "user", content: "second turn" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const { payload } = latestAnthropicRequest();
+    const requestMessages = payload.messages as Array<{
+      role: string;
+      content: Array<{ type: string; thinking?: string; signature?: string; text?: string }>;
+    }>;
+    const assistantEntry = requestMessages.find((m) => m.role === "assistant");
+    const thinkingBlock = assistantEntry?.content.find((b) => b.type === "thinking");
+    expect(thinkingBlock?.thinking).toBe(thinkingWithLoneSurrogate);
+    expect(thinkingBlock).toMatchObject({ signature: "sig_replay_2" });
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -9,6 +9,7 @@ import {
   type SimpleStreamOptions,
   type ThinkingLevel,
 } from "@mariozechner/pi-ai";
+import { resolveAnthropicStoredThinkingSignature } from "./anthropic-stored-thinking-signature.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -316,26 +317,29 @@ function convertAnthropicMessages(
           continue;
         }
         if (block.type === "thinking") {
+          const thinkingSig = resolveAnthropicStoredThinkingSignature(block);
           if (block.redacted) {
             blocks.push({
               type: "redacted_thinking",
-              data: block.thinkingSignature,
+              data: thinkingSig ?? "",
             });
             continue;
           }
           if (block.thinking.trim().length === 0) {
             continue;
           }
-          if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
+          if (!thinkingSig) {
             blocks.push({
               type: "text",
               text: sanitizeTransportPayloadText(block.thinking),
             });
           } else {
+            // Anthropic cryptographically signs exact thinking bytes; do not run
+            // sanitizeTransportPayloadText (surrogate cleanup, etc.) on replay (#69579).
             blocks.push({
               type: "thinking",
-              thinking: sanitizeTransportPayloadText(block.thinking),
-              signature: block.thinkingSignature,
+              thinking: block.thinking,
+              signature: thinkingSig,
             });
           }
           continue;

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -1,4 +1,5 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { resolveAnthropicStoredThinkingSignature } from "./anthropic-stored-thinking-signature.js";
 
 const SYNTHETIC_TOOL_RESULT_APIS = new Set<string>([
   "anthropic-messages",
@@ -68,7 +69,8 @@ export function transformTransportMessages(
           }
           continue;
         }
-        if (isSameModel && block.thinkingSignature) {
+        const replaySig = resolveAnthropicStoredThinkingSignature(block);
+        if (isSameModel && replaySig) {
           content.push(block);
           continue;
         }


### PR DESCRIPTION
## Summary

- Problem: Multi-turn requests that replay assistant `thinking` blocks (extended thinking) failed with `Invalid signature in thinking block` because the transport layer ran `sanitizeTransportPayloadText` on stored `thinking` bytes, which can change character encoding (e.g. lone surrogates) and invalidates Anthropic’s cryptographic signature.
- Why it matters: Any channel (e.g. Telegram) that keeps conversation history and replays the prior turn’s assistant content hits this on turn 2+; the failure can look like a “silent” second reply.
- What changed: When a stored `thinking` block is signed, replay `thinking` verbatim; resolve signature via shared `resolveAnthropicStoredThinkingSignature` from `thinkingSignature` (if non-empty after trim) or `signature`. Use the same helper in `transformTransportMessages` and `convertAnthropicMessages`. Add regression tests (lone-surrogate, `signature`-only) plus a small unit test for the resolver (including `thinkingSignature: ""` falling back to `signature`).
- What did NOT change (scope boundary): No Telegram-specific code paths; no API contract or gateway protocol change; no CHANGELOG entry in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69579
- Related
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `convertAnthropicMessages` in `src/agents/anthropic-transport-stream.ts` always sanitized `block.thinking` in one branch; for signed thinking, bytes must match the server-issued `signature` exactly. Sanitization changed those bytes. The transform layer needed the same “has signature” resolution for both `thinkingSignature` and `signature`.
- Missing detection / guardrail: No unit test asserting that stored signed `thinking` is not passed through `sanitizeTransportPayloadText`, and no shared resolver between transform and stream paths.
- Contributing context (if known): Reported on Telegram + Opus extended thinking; the bug is in shared Anthropic transport, not Telegram.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`, `src/agents/anthropic-stored-thinking-signature.test.ts`
- Scenario the test should lock in: A stored `thinking` block with a valid signature and a lone UTF-16 surrogate in `thinking` is emitted to the request payload with `thinking` unchanged; same for blocks that only store `signature` (no `thinkingSignature`).

## User-visible / Behavior Changes

Multi-turn conversations with Anthropic models using extended thinking and prior assistant `thinking` blocks in history should no longer fail at the API with `Invalid signature in thinking block` when the prior turn’s thinking was stored with a signature.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Exposes or persists new secrets? No
- Network surface change? No

## Testing

- `pnpm test src/agents/anthropic-transport-stream.test.ts src/agents/anthropic-stored-thinking-signature.test.ts`
