### PR TITLE
fix(reply): dedupe MEDIA URLs between block and final payloads (#65468)

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -187,6 +187,57 @@ describe("buildReplyPayloads media filter integration", () => {
     await expectSameTargetRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
   });
 
+  it("normalizes block-pipeline sent media URLs before deduping against normalized final payloads (#65468)", async () => {
+    // Regression for the Greptile P1 gap: the block pipeline records a raw
+    // source URL (e.g. `/tmp/voice.ogg`) before the final reply goes through
+    // `normalizeReplyPayloadMedia`, which rewrites the URL to an outbound
+    // path. Without re-normalizing the pipeline's sent URLs through the same
+    // `normalizeMediaPaths`, the comparison happens across two different URL
+    // spaces and the duplicate attachment is never stripped.
+    const normalizeMediaPaths = async (payload: {
+      mediaUrl?: string;
+      mediaUrls?: string[];
+    }) => {
+      const rewrite = (value?: string) =>
+        value === "file:///tmp/voice.ogg" ? "file:///tmp/outbound/abc.ogg" : value;
+      return {
+        ...payload,
+        mediaUrl: rewrite(payload.mediaUrl),
+        mediaUrls: payload.mediaUrls?.map((value) => rewrite(value) ?? value),
+      };
+    };
+
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => false,
+      isAborted: () => false,
+      hasSentPayload: () => false,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      // Pipeline records the raw source URL (pre-normalization).
+      getSentMediaUrls: () => ["file:///tmp/voice.ogg"],
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      normalizeMediaPaths,
+      // Final payload carries the same raw URL; it will be normalized to the
+      // outbound path by `normalizeReplyPayloadMedia` before dedupe runs.
+      payloads: [{ text: "caption", mediaUrl: "file:///tmp/voice.ogg" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    // The attachment must be stripped; only the caption text survives.
+    expect(replyPayloads[0]).toMatchObject({
+      text: "caption",
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+  });
+
   it("drops all final payloads when block pipeline streamed successfully", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -194,10 +194,7 @@ describe("buildReplyPayloads media filter integration", () => {
     // path. Without re-normalizing the pipeline's sent URLs through the same
     // `normalizeMediaPaths`, the comparison happens across two different URL
     // spaces and the duplicate attachment is never stripped.
-    const normalizeMediaPaths = async (payload: {
-      mediaUrl?: string;
-      mediaUrls?: string[];
-    }) => {
+    const normalizeMediaPaths = async (payload: { mediaUrl?: string; mediaUrls?: string[] }) => {
       const rewrite = (value?: string) =>
         value === "file:///tmp/voice.ogg" ? "file:///tmp/outbound/abc.ogg" : value;
       return {
@@ -236,6 +233,53 @@ describe("buildReplyPayloads media filter integration", () => {
       mediaUrl: undefined,
       mediaUrls: undefined,
     });
+  });
+
+  it("suppresses a final text+media payload that exactly matches an already-sent block (regression #70441)", async () => {
+    // Codex flagged on PR #70441: if the media filter runs BEFORE hasSentPayload,
+    // a text+media payload already dispatched as a block gets stripped of its
+    // media first. `hasSentPayload` then hashes the payload without media and
+    // never matches the original {text, mediaList} content key, so the text
+    // portion gets re-emitted as a duplicate. The fix is to run content-key
+    // suppression first, THEN strip leftover block-streamed media.
+    const sentBlockKey = JSON.stringify({
+      text: "caption",
+      mediaList: ["file:///tmp/outbound/abc.ogg"],
+    });
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => false,
+      isAborted: () => false,
+      hasSentPayload: (payload) => {
+        const reply = {
+          text: (payload.text ?? "").trim(),
+          mediaList: [
+            ...(payload.mediaUrl ? [payload.mediaUrl] : []),
+            ...(payload.mediaUrls ?? []),
+          ],
+        };
+        return JSON.stringify({ text: reply.text, mediaList: reply.mediaList }) === sentBlockKey;
+      },
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      getSentMediaUrls: () => ["file:///tmp/outbound/abc.ogg"],
+    };
+
+    const normalizeMediaPaths = async (payload: { mediaUrl?: string; mediaUrls?: string[] }) =>
+      payload;
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      normalizeMediaPaths,
+      payloads: [{ text: "caption", mediaUrl: "file:///tmp/outbound/abc.ogg" }],
+    });
+
+    // The entire payload should be suppressed — neither the text nor the media
+    // should be re-emitted.
+    expect(replyPayloads).toHaveLength(0);
   });
 
   it("drops all final payloads when block pipeline streamed successfully", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -196,6 +196,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      getSentMediaUrls: () => [],
     };
     // shouldDropFinalPayloads short-circuits to [] when the pipeline streamed
     // without aborting, so hasSentPayload is never reached.
@@ -219,6 +220,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      getSentMediaUrls: () => [],
     };
 
     const { replyPayloads } = await buildReplyPayloads({

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -213,18 +213,37 @@ export async function buildReplyPayloads(params: {
         sentMediaUrls: messagingToolSentMediaUrls,
       })
     : dedupedPayloads;
+  // Strip media URLs from final payloads that were already delivered via the
+  // block-reply pipeline. Fixes GH #65468: when MEDIA: appears at a streaming
+  // block boundary it gets dispatched as a media-only block, and then the
+  // same media URL is carried into the final reply text — causing the
+  // attachment to be sent twice (e.g. duplicate voice notes on Telegram).
+  // This complements the existing content-key dedupe (hasSentPayload) which
+  // only matches when text+media match exactly.
+  const blockSentMediaUrls = params.blockStreamingEnabled
+    ? (params.blockReplyPipeline?.getSentMediaUrls?.() ?? [])
+    : [];
+  const blockMediaFilteredPayloads =
+    blockSentMediaUrls.length > 0
+      ? (
+          dedupeRuntime ?? (await loadReplyPayloadsDedupeRuntime())
+        ).filterMessagingToolMediaDuplicates({
+          payloads: mediaFilteredPayloads,
+          sentMediaUrls: blockSentMediaUrls,
+        })
+      : mediaFilteredPayloads;
   // Filter out payloads already sent via pipeline or directly during tool flush.
   const filteredPayloads = shouldDropFinalPayloads
-    ? mediaFilteredPayloads.filter((payload) => payload.isError)
+    ? blockMediaFilteredPayloads.filter((payload) => payload.isError)
     : params.blockStreamingEnabled
-      ? mediaFilteredPayloads.filter(
+      ? blockMediaFilteredPayloads.filter(
           (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
         )
       : params.directlySentBlockKeys?.size
-        ? mediaFilteredPayloads.filter(
+        ? blockMediaFilteredPayloads.filter(
             (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
           )
-        : mediaFilteredPayloads;
+        : blockMediaFilteredPayloads;
   const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
 
   return {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -220,8 +220,19 @@ export async function buildReplyPayloads(params: {
   // attachment to be sent twice (e.g. duplicate voice notes on Telegram).
   // This complements the existing content-key dedupe (hasSentPayload) which
   // only matches when text+media match exactly.
+  // Normalize block-pipeline sent URLs through the same path that the final
+  // payloads have already been run through, so the subsequent comparison
+  // happens in a consistent space. Without this, a raw source URL
+  // (`/tmp/aurora-voice-<id>.ogg`) is compared against a normalized outbound
+  // URL (e.g. `/tmp/outbound/<uuid>.ogg`) and never matches — silently
+  // leaving the duplicate delivery bug in place for any deployment that
+  // rewrites media URLs during normalization. This mirrors the messaging-
+  // tool path above.
   const blockSentMediaUrls = params.blockStreamingEnabled
-    ? (params.blockReplyPipeline?.getSentMediaUrls?.() ?? [])
+    ? await normalizeSentMediaUrlsForDedupe({
+        sentMediaUrls: params.blockReplyPipeline?.getSentMediaUrls() ?? [],
+        normalizeMediaPaths: params.normalizeMediaPaths,
+      })
     : [];
   const blockMediaFilteredPayloads =
     blockSentMediaUrls.length > 0

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -228,33 +228,41 @@ export async function buildReplyPayloads(params: {
   // leaving the duplicate delivery bug in place for any deployment that
   // rewrites media URLs during normalization. This mirrors the messaging-
   // tool path above.
+  // Order matters: run the exact-content `hasSentPayload` / `directlySentBlockKeys`
+  // suppression BEFORE stripping block-streamed media URLs. `createBlockReplyContentKey`
+  // hashes both text and media, so any mutation of the media list before that check
+  // causes an already-sent text+media block to be re-emitted (its text without media)
+  // in the final payload path. Codex flagged this regression on PR #70441.
+  const contentSuppressedPayloads = shouldDropFinalPayloads
+    ? mediaFilteredPayloads.filter((payload) => payload.isError)
+    : params.blockStreamingEnabled
+      ? mediaFilteredPayloads.filter(
+          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
+        )
+      : params.directlySentBlockKeys?.size
+        ? mediaFilteredPayloads.filter(
+            (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
+          )
+        : mediaFilteredPayloads;
   const blockSentMediaUrls = params.blockStreamingEnabled
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.blockReplyPipeline?.getSentMediaUrls() ?? [],
         normalizeMediaPaths: params.normalizeMediaPaths,
       })
     : [];
-  const blockMediaFilteredPayloads =
+  // After exact-content suppression, strip any block-streamed media URLs from the
+  // remaining final payloads. This handles the mixed case where a MEDIA block was
+  // dispatched mid-stream and the same URL then leaks into a distinct final text
+  // payload: the text should still be delivered, but without the duplicate media.
+  const filteredPayloads =
     blockSentMediaUrls.length > 0
       ? (
           dedupeRuntime ?? (await loadReplyPayloadsDedupeRuntime())
         ).filterMessagingToolMediaDuplicates({
-          payloads: mediaFilteredPayloads,
+          payloads: contentSuppressedPayloads,
           sentMediaUrls: blockSentMediaUrls,
         })
-      : mediaFilteredPayloads;
-  // Filter out payloads already sent via pipeline or directly during tool flush.
-  const filteredPayloads = shouldDropFinalPayloads
-    ? blockMediaFilteredPayloads.filter((payload) => payload.isError)
-    : params.blockStreamingEnabled
-      ? blockMediaFilteredPayloads.filter(
-          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
-        )
-      : params.directlySentBlockKeys?.size
-        ? blockMediaFilteredPayloads.filter(
-            (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
-          )
-        : blockMediaFilteredPayloads;
+      : contentSuppressedPayloads;
   const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
 
   return {

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -78,6 +78,44 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.hasSentPayload({ text: "response text", replyToId: "other-id" })).toBe(true);
   });
 
+  // Regression test for GH #65468 — duplicate MEDIA: delivery.
+  // When MEDIA: appears at a streaming block boundary it is dispatched as a
+  // media-only block. The same media URL is then carried in the final reply
+  // text and normalised a second time, producing a duplicate attachment on
+  // the wire. getSentMediaUrls() lets the final-reply path strip media that
+  // was already delivered in a preceding block.
+  it("getSentMediaUrls returns media URLs delivered via block pipeline", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    // Initially empty before anything is sent.
+    expect(pipeline.getSentMediaUrls()).toEqual([]);
+
+    pipeline.enqueue({ text: "caption", mediaUrl: "file:///a.ogg" });
+    pipeline.enqueue({ text: "", mediaUrls: ["file:///b.ogg", "file:///c.ogg"] });
+    await pipeline.flush({ force: true });
+
+    const sent = pipeline.getSentMediaUrls();
+    expect(sent).toContain("file:///a.ogg");
+    expect(sent).toContain("file:///b.ogg");
+    expect(sent).toContain("file:///c.ogg");
+  });
+
+  it("getSentMediaUrls stays empty when no media is delivered", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "hello" });
+    pipeline.enqueue({ text: "world" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.getSentMediaUrls()).toEqual([]);
+  });
+
   it("does not coalesce logical assistant blocks across assistantMessageIndex boundaries", async () => {
     const sent: string[] = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -13,6 +13,11 @@ export type BlockReplyPipeline = {
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
+  /** Media URLs that have been successfully delivered via block replies.
+   *  Used by the final-reply path to strip media that was already sent in
+   *  a preceding block (e.g. when MEDIA: appears at a block boundary and
+   *  then again inside the final reply text). */
+  getSentMediaUrls: () => string[];
 };
 
 export type BlockReplyBuffer = {
@@ -86,6 +91,7 @@ export function createBlockReplyPipeline(params: {
   const { onBlockReply, timeoutMs, coalescing, buffer } = params;
   const sentKeys = new Set<string>();
   const sentContentKeys = new Set<string>();
+  const sentMediaUrls = new Set<string>();
   const pendingKeys = new Set<string>();
   const seenKeys = new Set<string>();
   const bufferedKeys = new Set<string>();
@@ -147,6 +153,15 @@ export function createBlockReplyPipeline(params: {
         }
         sentKeys.add(payloadKey);
         sentContentKeys.add(contentKey);
+        // Track media URLs so the final-reply path can strip duplicates.
+        // See GH #65468 — MEDIA: directives at block boundaries were being
+        // delivered twice (once as a streamed block, once in the final reply).
+        const sentReply = resolveSendableOutboundReplyParts(payload);
+        for (const url of sentReply.mediaUrls ?? []) {
+          if (url) {
+            sentMediaUrls.add(url);
+          }
+        }
         didStream = true;
       })
       .catch((err) => {
@@ -268,5 +283,6 @@ export function createBlockReplyPipeline(params: {
       const payloadKey = createBlockReplyContentKey(payload);
       return sentContentKeys.has(payloadKey);
     },
+    getSentMediaUrls: () => Array.from(sentMediaUrls),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #65468 — the `MEDIA:` directive delivers its attachment twice on Telegram (and any other channel with block streaming), producing duplicate voice notes / audio files.

## Root cause

When an assistant response contains a `MEDIA:` line that sits at a streaming block boundary (for example: text → tool call → `MEDIA:` → more text), the block-reply pipeline emits the `MEDIA:` as its own block with empty text. The same media URL is then carried into the final reply text and dispatched again.

Both payloads go through `normalizeReplyMediaPayload`, which copies the source file into the outbound media directory with a fresh UUID. The result is two separate outbound files pointing at the same source, each delivered to the channel.

The existing `hasSentPayload` content-key dedupe in `agent-runner-payloads.ts` did not catch this, because its key is `(trimmedText, mediaUrls)`:

- block: `{text: "", media: [X]}`
- final: `{text: "caption text", media: [X]}`

Different keys → no dedupe → duplicate delivery.

## Fix

1. `createBlockReplyPipeline` now records the media URLs it successfully delivered and exposes them via `getSentMediaUrls()`.
2. `buildReplyPayloads` consults this list when `blockStreamingEnabled` and reuses the existing `filterMessagingToolMediaDuplicates` helper to strip any already-sent media URLs from the final payloads. The content-key dedupe still runs afterwards for pure text duplicates.

This keeps the fix localised to the reply-dispatch layer and reuses the dedupe primitive that already exists for the messaging-tool path.

## Verification

Reproduced locally on 2026.4.21 with a Chatterbox TTS wrapper that prints `MEDIA:/tmp/aurora-voice-<id>.ogg` and a short text caption. Before the fix Telegram received two voice notes with different outbound UUIDs plus the text; after the fix it receives one voice + one text.

Dispatch-level trace (instrumented locally, not part of this PR) shows the second `sendPayload` call losing its `mediaUrl` / `mediaUrls`, exactly as expected.

## Tests

- Adds two unit tests in `block-reply-pipeline.test.ts` covering `getSentMediaUrls()`:
  - returns URLs delivered via the pipeline (both `mediaUrl` and `mediaUrls`)
  - stays empty when no media is delivered
- Extends the existing pipeline mocks in `agent-runner-payloads.test.ts` with `getSentMediaUrls: () => []` to satisfy the widened `BlockReplyPipeline` type.

All existing `auto-reply-reply` tests (1162) continue to pass. New block-reply-pipeline test file: 10/10 pass. `agent-runner-payloads`: 15/15 pass.

## Scope

- `src/auto-reply/reply/block-reply-pipeline.ts` — adds `getSentMediaUrls()` + tracking
- `src/auto-reply/reply/agent-runner-payloads.ts` — filters final payloads against block-sent media URLs
- Tests for both

No changes to parser, media normaliser, or channel-specific code. No public behavioural changes other than eliminating the duplicate send.

Reported & confirmed on Telegram. The same logic path feeds every channel that uses block streaming, so the fix should also resolve duplicate attachments on Discord / Slack / etc. when the same pattern occurs.
