### PR TITLE
google: nest thought_signature under functionCall

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -318,7 +318,11 @@ describe("google transport stream", () => {
       parts: [
         {
           thoughtSignature: "call_sig_1",
-          functionCall: { name: "lookup", args: { q: "hello" } },
+          functionCall: {
+            name: "lookup",
+            args: { q: "hello" },
+            thought_signature: "call_sig_1",
+          },
         },
       ],
     });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -357,7 +357,13 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
               name: block.name,
               args: coerceTransportToolCallArguments(block.arguments),
               ...(requiresToolCallId(model.id) ? { id: block.id } : {}),
+              // Gemini API requires the thought signature to be nested under the functionCall
+              // payload (snake_case) for tool calls to validate.
+              ...(isSameProviderAndModel && block.thoughtSignature
+                ? { thought_signature: block.thoughtSignature }
+                : {}),
             },
+            // Keep legacy field for backward-compat (other tooling/tests may still assert this)
             ...(isSameProviderAndModel && block.thoughtSignature
               ? { thoughtSignature: block.thoughtSignature }
               : {}),


### PR DESCRIPTION
Fix Gemini tool-calling replay failures by nesting snake_case thought_signature under functionCall parts (Gemini API requirement). Keeps existing camelCase sibling field for backward-compat.

- Change: extensions/google/transport-stream.ts
- Tests: updated transport-stream test; Google provider suite passes locally