### PR TITLE
fix(gateway): tear down nested-lane MCP cohort on run end

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1436,4 +1436,34 @@ describe("gateway agent handler", () => {
       }),
     );
   });
+
+  it("sets cleanupBundleMcpOnRunEnd=true for nested lane runs, false for regular runs", async () => {
+    primeMainAgentRun();
+    await invokeAgent(
+      {
+        message: "hi nested",
+        sessionKey: "agent:main:main",
+        lane: "nested",
+        idempotencyKey: "test-nested-mcp-cleanup",
+      },
+      { reqId: "mcp-cleanup-nested" },
+    );
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const nestedCall = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(nestedCall?.cleanupBundleMcpOnRunEnd).toBe(true);
+
+    mocks.agentCommand.mockClear();
+    primeMainAgentRun();
+    await invokeAgent(
+      {
+        message: "hi regular",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-regular-mcp-cleanup",
+      },
+      { reqId: "mcp-cleanup-regular" },
+    );
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const regularCall = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(regularCall?.cleanupBundleMcpOnRunEnd).toBe(false);
+  });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
+import { isNestedAgentLane } from "../../agents/lanes.js";
 import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
@@ -958,6 +959,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         }),
         senderIsOwner,
         allowModelOverride,
+        // Nested lane runs are ephemeral: they spawn their own MCP cohort and
+        // must tear it down when done. Top-level gateway sessions keep MCP
+        // processes warm across turns, so cleanup is skipped for those.
+        cleanupBundleMcpOnRunEnd: isNestedAgentLane(request.lane),
       },
       runId,
       idempotencyKey: idem,


### PR DESCRIPTION
## Summary

Fixes #70364. Nested agent runs dispatched via `sessions_send` (one agent sending to another) spawn their own MCP cohort per session but never called `retireSessionMcpRuntime` on completion. Each dispatch leaked a full cohort of MCP child processes, growing unboundedly until gateway restart.

## Root cause

`cleanupBundleMcpOnRunEnd` was only set to `true` in the CLI `--local` path (`src/cli/cli-runner.ts`). When a gateway nested lane dispatched through `dispatchAgentRunFromGateway` in `src/gateway/server-methods/agent.ts:958`, the `ingressOpts` had no `cleanupBundleMcpOnRunEnd`, so `pi-embedded-runner` never tore down the session's MCP runtime. Top-level gateway sessions are fine (they keep MCP warm across turns by design), but nested lane runs should be ephemeral.

## Fix

Wire `isNestedAgentLane(request.lane)` into the `ingressOpts` passed to `dispatchAgentRunFromGateway`. Nested lane runs now tear down their MCP cohort on completion. Top-level gateway sessions continue to keep processes warm.

## Evidence

- **Symptom:** reporter in #70364 describes 9 agents configured, each `sessions_send` adds 9 new MCP children that are never reaped.
- **Root cause in code:** `src/gateway/server-methods/agent.ts:958` was missing the cleanup flag that existed in the `--local` CLI path.
- **Fix touches the implicated path:** single-line addition at the same site, plus reusing the existing `isNestedAgentLane` helper from `src/agents/lanes.ts`.
- **Regression test:** new test in `src/gateway/server-methods/agent.test.ts` asserts that nested-lane dispatches pass `cleanupBundleMcpOnRunEnd: true` while top-level dispatches do not.

## Test plan

- [x] New regression test covers nested-lane cleanup flag
- [x] Top-level lane path unchanged (verified by existing tests)
- [x] All 32 `agent.test.ts` tests pass
- [x] Fix diff under 40 lines

Closes #70364.