### PR TITLE
fix(opencode-go): Add media-understanding provider for vision-capable models

### DIFF
--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -2,6 +2,7 @@ import { createOpencodeCatalogApiKeyAuthMethod } from "openclaw/plugin-sdk/openc
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { PASSTHROUGH_GEMINI_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
 import { applyOpencodeGoConfig, OPENCODE_GO_DEFAULT_MODEL_REF } from "./api.js";
+import { opencodeGoMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { normalizeOpencodeGoBaseUrl } from "./provider-catalog.js";
 
 const PROVIDER_ID = "opencode-go";
@@ -62,5 +63,6 @@ export default definePluginEntry({
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
       isModernModelRef: () => true,
     });
+    api.registerMediaUnderstandingProvider(opencodeGoMediaUnderstandingProvider);
   },
 });

--- a/extensions/opencode-go/media-understanding-provider.ts
+++ b/extensions/opencode-go/media-understanding-provider.ts
@@ -1,0 +1,14 @@
+import {
+  describeImageWithModel,
+  describeImagesWithModel,
+  type MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+
+export const opencodeGoMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: "opencode-go",
+  capabilities: ["image"],
+  defaultModels: { image: "kimi-k2.6" },
+  autoPriority: { image: 45 },
+  describeImage: describeImageWithModel,
+  describeImages: describeImagesWithModel,
+};


### PR DESCRIPTION
## 🎯 Changes

This PR adds a `MediaUnderstandingProvider` for the `opencode-go` provider, enabling the `image` tool to work with vision-capable models.

### What changed
- **New file**: `extensions/opencode-go/media-understanding-provider.ts`
  - Exports `opencodeGoMediaUnderstandingProvider` following the OpenAI-compatible pattern
  - Uses `describeImageWithModel` and `describeImagesWithModel` from `openclaw/plugin-sdk/media-understanding`
  - Sets default image model to `opencode-go/kimi-k2.6`
- **Modified file**: `extensions/opencode-go/index.ts`
  - Imports and registers `opencodeGoMediaUnderstandingProvider`

### Why
The `opencode-go` provider includes vision-capable models (kimi-k2.6, minimax-m2.7, glm-5, mimo-v2-omni, qwen3.6-plus, etc.) that support multimodal/vision capabilities through the OpenCode Go API. However, users could not use the `image` tool with these models because:
1. No `MediaUnderstandingProvider` was registered for `opencode-go`
2. Without a registered provider, `createImageTool()` returns `null` when no explicit `imageModel` is configured

### Fixes
- Fixes #70482

### Testing
- [ ] Verify `image` tool appears when using `opencode-go/kimi-k2.6` without explicit `imageModel` config
- [ ] Verify image analysis works with `opencode-go` models

## ✅ Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
