### PR TITLE
fix(skills/gh-issues): hoist stale-lock window into a single STALE_LOCK_MINUTES constant

### DIFF
--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -276,11 +276,15 @@ Run these checks sequentially via exec:
    fi
    ```
 
-   Parse the claims file. For each entry, check if the claim timestamp is older than 2 hours. If so, remove it (expired — the sub-agent likely finished or failed silently). Write back the cleaned file:
+   Parse the claims file. For each entry, check if the claim timestamp is older than `STALE_LOCK_MINUTES`. If so, remove it (expired — the sub-agent likely finished or failed silently). Write back the cleaned file.
+
+   `STALE_LOCK_MINUTES` is the single source of truth for the claim expiry window. Keep it tied to the sub-agent `runTimeoutSeconds` in Phase 5 (currently 3600s / 60min) plus a small grace window for shutdown/reporting — default 90 minutes. If you change one, change the other.
 
    ```
+   STALE_LOCK_MINUTES=90
    CLAIMS=$(cat "$CLAIMS_FILE")
-   CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%SZ)
+   CUTOFF=$(date -u -d "${STALE_LOCK_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+     || date -u -v-${STALE_LOCK_MINUTES}M +%Y-%m-%dT%H:%M:%SZ)
    CLAIMS=$(echo "$CLAIMS" | jq --arg cutoff "$CUTOFF" 'to_entries | map(select(.value > $cutoff)) | from_entries')
    echo "$CLAIMS" > "$CLAIMS_FILE"
    ```


### PR DESCRIPTION
## What

The claim-expiry window in the `gh-issues` skill's Phase 4 step 7 ("Check claim-based in-progress tracking") lived in three places that had to be kept in sync by hand:

1. Prose: *"check if the claim timestamp is older than 2 hours"*
2. GNU `date` branch: `-d '2 hours ago'`
3. BSD `date` branch: `-v-2H`

Hoist all three into a single `STALE_LOCK_MINUTES` shell variable at the top of the snippet, reused by both `date` branches.

## Why

- **Drift risk.** Any change had to be made in three places; easy to update one and forget the others, and the prose silently lies if code changes.
- **Too loose vs. runtime.** The 2h window was already out of step with the sub-agent `runTimeoutSeconds: 3600` (60 min) defined in Phase 5. When a sub-agent hits its hard timeout and is killed silently, its claim blocked retries for another full hour with no way to recover short of manually editing `gh-issues-claims.json`.

## How

```diff
-   Parse the claims file. For each entry, check if the claim timestamp is older than 2 hours. If so, remove it (expired — the sub-agent likely finished or failed silently). Write back the cleaned file:
+   Parse the claims file. For each entry, check if the claim timestamp is older than \`STALE_LOCK_MINUTES\`. If so, remove it (expired — the sub-agent likely finished or failed silently). Write back the cleaned file.
+
+   \`STALE_LOCK_MINUTES\` is the single source of truth for the claim expiry window. Keep it tied to the sub-agent \`runTimeoutSeconds\` in Phase 5 (currently 3600s / 60min) plus a small grace window for shutdown/reporting — default 90 minutes. If you change one, change the other.

    \`\`\`
+   STALE_LOCK_MINUTES=90
    CLAIMS=$(cat "$CLAIMS_FILE")
-   CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%SZ)
+   CUTOFF=$(date -u -d "${STALE_LOCK_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \\
+     || date -u -v-${STALE_LOCK_MINUTES}M +%Y-%m-%dT%H:%M:%SZ)
```

New default: **90 minutes** (60min runtime + 30min grace), tightened from 120.

## Verification

Both `date` branches expand correctly on macOS (BSD) and Linux (GNU):

```
$ STALE_LOCK_MINUTES=90 date -u -v-${STALE_LOCK_MINUTES}M +%Y-%m-%dT%H:%M:%SZ
2026-04-23T04:36:47Z
```

The skill is a Markdown SKILL.md consumed by the orchestrator agent — no runtime code path to test. Diff is 6+/2-, touches only `skills/gh-issues/SKILL.md`.

## Out of scope

Flagged while reviewing, but left for follow-up PRs:

- Make `REPOS`, `SESSION_KEY`, and the agent allowlist config-driven so the skill is portable across forks (currently implicit in `fork` logic and hardcoded paths like `/data/.clawdbot/`).
- Reconcile the `/data/.clawdbot/` default against the `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` pattern already used elsewhere in the skill — the claims file and cursor file don't yet honor those env vars.

Happy to send those as a second PR if you want them.