### PR TITLE
fix(config): surface backup restore copy failures in audit and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
+
 ## 2026.4.30
 
 ### Changes

--- a/src/config/io.audit.ts
+++ b/src/config/io.audit.ts
@@ -227,6 +227,8 @@ export type ConfigObserveAuditRecord = {
   clobberedPath: string | null;
   restoredFromBackup: boolean;
   restoredBackupPath: string | null;
+  restoreErrorCode: string | null;
+  restoreErrorMessage: string | null;
 };
 
 export type ConfigAuditRecord = ConfigWriteAuditRecord | ConfigObserveAuditRecord;

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -316,6 +316,44 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("sync recovery records copyFileSync failure instead of falsely claiming restore succeeded", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, auditPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const failingFs: ObserveRecoveryDeps["fs"] = {
+        ...deps.fs,
+        copyFileSync: () => {
+          throw copyError;
+        },
+      };
+      const recovered = maybeRecoverSuspiciousConfigReadSync({
+        deps: { ...deps, fs: failingFs },
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expect((recovered.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Config auto-restore from backup failed:"),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("EACCES: permission denied"));
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Config auto-restored from backup:"),
+      );
+
+      const observe = await readLastObserveEvent(auditPath);
+      expect(observe?.restoredFromBackup).toBe(false);
+      expect(observe?.valid).toBe(false);
+      expect(observe?.restoreErrorCode).toBe("EACCES");
+      expect(observe?.restoreErrorMessage).toBe("EACCES: permission denied");
+    });
+  });
+
   it("dedupes repeated suspicious hashes", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath } = makeDeps(home);

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -278,6 +278,44 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("records copyFile failure instead of falsely claiming restore succeeded", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, auditPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const failingFs: ObserveRecoveryDeps["fs"] = {
+        ...deps.fs,
+        promises: {
+          ...deps.fs.promises,
+          copyFile: () => Promise.reject(copyError),
+        },
+      };
+      const recovered = await maybeRecoverSuspiciousConfigRead({
+        deps: { ...deps, fs: failingFs },
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expect((recovered.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Config auto-restore from backup failed:"),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Config auto-restored from backup:"),
+      );
+
+      const observe = await readLastObserveEvent(auditPath);
+      expect(observe?.restoredFromBackup).toBe(false);
+      expect(observe?.valid).toBe(false);
+      expect(observe?.restoreErrorCode).toBe("EACCES");
+      expect(observe?.restoreErrorMessage).toBe("EACCES: permission denied");
+    });
+  });
+
   it("dedupes repeated suspicious hashes", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath } = makeDeps(home);

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -127,6 +127,8 @@ function createConfigObserveAuditRecord(params: {
   clobberedPath: string | null;
   restoredFromBackup: boolean;
   restoredBackupPath: string | null;
+  restoreErrorCode?: string | null;
+  restoreErrorMessage?: string | null;
 }): ConfigObserveAuditRecord {
   return {
     ts: params.ts,
@@ -175,6 +177,8 @@ function createConfigObserveAuditRecord(params: {
     clobberedPath: params.clobberedPath,
     restoredFromBackup: params.restoredFromBackup,
     restoredBackupPath: params.restoredBackupPath,
+    restoreErrorCode: params.restoreErrorCode ?? null,
+    restoreErrorMessage: params.restoreErrorMessage ?? null,
   };
 }
 
@@ -190,6 +194,35 @@ function createConfigObserveAuditAppendParams(
     homedir: deps.homedir,
     record: createConfigObserveAuditRecord(params),
   };
+}
+
+function extractRestoreErrorDetails(error: unknown): {
+  code: string | null;
+  message: string | null;
+} {
+  if (!error || typeof error !== "object") {
+    return { code: null, message: typeof error === "string" ? error : null };
+  }
+  const code =
+    "code" in error && typeof (error as { code?: unknown }).code === "string"
+      ? (error as { code: string }).code
+      : null;
+  const message =
+    "message" in error && typeof (error as { message?: unknown }).message === "string"
+      ? (error as { message: string }).message
+      : null;
+  return { code, message };
+}
+
+function createConfigObserveAnomalyAuditAppendParams(
+  deps: ObserveRecoveryDeps,
+  params: Omit<ConfigObserveAuditRecordParams, "restoredFromBackup" | "restoredBackupPath">,
+) {
+  return createConfigObserveAuditAppendParams(deps, {
+    ...params,
+    restoredFromBackup: false,
+    restoredBackupPath: null,
+  });
 }
 
 function hashConfigRaw(raw: string | null): string {
@@ -637,19 +670,34 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
   });
 
   let restoredFromBackup = false;
+  let restoreError: unknown;
   try {
     await params.deps.fs.promises.copyFile(backupPath, params.configPath);
     restoredFromBackup = true;
-  } catch {}
+  } catch (error) {
+    restoreError = error;
+  }
 
-  params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
-  );
+  const restoreErrorDetails = restoredFromBackup
+    ? { code: null, message: null }
+    : extractRestoreErrorDetails(restoreError);
+
+  if (restoredFromBackup) {
+    params.deps.logger.warn(
+      `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  } else {
+    params.deps.logger.warn(
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})${
+        restoreErrorDetails.message ? `: ${restoreErrorDetails.message}` : ""
+      }`,
+    );
+  }
   await appendConfigAuditRecord(
     createConfigObserveAuditAppendParams(params.deps, {
       ts: now,
       configPath: params.configPath,
-      valid: true,
+      valid: restoredFromBackup,
       current,
       suspicious,
       lastKnownGood: entry.lastKnownGood,
@@ -657,6 +705,8 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
       clobberedPath,
       restoredFromBackup,
       restoredBackupPath: backupPath,
+      restoreErrorCode: restoreErrorDetails.code,
+      restoreErrorMessage: restoreErrorDetails.message,
     }),
   );
 
@@ -727,19 +777,34 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
   });
 
   let restoredFromBackup = false;
+  let restoreError: unknown;
   try {
     params.deps.fs.copyFileSync(backupPath, params.configPath);
     restoredFromBackup = true;
-  } catch {}
+  } catch (error) {
+    restoreError = error;
+  }
 
-  params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
-  );
+  const restoreErrorDetails = restoredFromBackup
+    ? { code: null, message: null }
+    : extractRestoreErrorDetails(restoreError);
+
+  if (restoredFromBackup) {
+    params.deps.logger.warn(
+      `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  } else {
+    params.deps.logger.warn(
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})${
+        restoreErrorDetails.message ? `: ${restoreErrorDetails.message}` : ""
+      }`,
+    );
+  }
   appendConfigAuditRecordSync(
     createConfigObserveAuditAppendParams(params.deps, {
       ts: now,
       configPath: params.configPath,
-      valid: true,
+      valid: restoredFromBackup,
       current,
       suspicious,
       lastKnownGood: entry.lastKnownGood,
@@ -747,6 +812,8 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
       clobberedPath,
       restoredFromBackup,
       restoredBackupPath: backupPath,
+      restoreErrorCode: restoreErrorDetails.code,
+      restoreErrorMessage: restoreErrorDetails.message,
     }),
   );
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -214,17 +214,6 @@ function extractRestoreErrorDetails(error: unknown): {
   return { code, message };
 }
 
-function createConfigObserveAnomalyAuditAppendParams(
-  deps: ObserveRecoveryDeps,
-  params: Omit<ConfigObserveAuditRecordParams, "restoredFromBackup" | "restoredBackupPath">,
-) {
-  return createConfigObserveAuditAppendParams(deps, {
-    ...params,
-    restoredFromBackup: false,
-    restoredBackupPath: null,
-  });
-}
-
 function hashConfigRaw(raw: string | null): string {
   return crypto
     .createHash("sha256")

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -688,9 +688,9 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
     );
   } else {
     params.deps.logger.warn(
-      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})${
-        restoreErrorDetails.message ? `: ${restoreErrorDetails.message}` : ""
-      }`,
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")}${
+        restoreErrorDetails.message ? `; ${restoreErrorDetails.message}` : ""
+      })`,
     );
   }
   await appendConfigAuditRecord(
@@ -795,9 +795,9 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
     );
   } else {
     params.deps.logger.warn(
-      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})${
-        restoreErrorDetails.message ? `: ${restoreErrorDetails.message}` : ""
-      }`,
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")}${
+        restoreErrorDetails.message ? `; ${restoreErrorDetails.message}` : ""
+      })`,
     );
   }
   appendConfigAuditRecordSync(

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -765,6 +765,8 @@ async function observeConfigSnapshot(
       clobberedPath,
       restoredFromBackup: false,
       restoredBackupPath: null,
+      restoreErrorCode: null,
+      restoreErrorMessage: null,
     },
   });
 
@@ -895,6 +897,8 @@ function observeConfigSnapshotSync(
       clobberedPath,
       restoredFromBackup: false,
       restoredBackupPath: null,
+      restoreErrorCode: null,
+      restoreErrorMessage: null,
     },
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** During suspicious-read recovery in `maybeRecoverSuspiciousConfigRead` (async and sync), `copyFile(backupPath, configPath)` is wrapped in a bare `catch {}`. When the copy fails (disk full, EACCES), the code still logs "Config auto-restored from backup" and writes the audit record with `valid: true`.
- **Why it matters:** Users and audit tooling believe the config was repaired when it was not. A corrupted config persists silently.
- **What changed:** Capture the copyFile error, emit a distinct failure warning, set `valid` to `restoredFromBackup`, and persist `restoreErrorCode` / `restoreErrorMessage` on the audit record.
- **What did NOT change:** No changes to the merge-patch pipeline, config reload watcher, or any other recovery path.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway / orchestration

## Linked Issue/PR
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: Bare `catch {}` around `copyFile` in `io.observe-recovery.ts` lines 659-662 swallowed all errors unconditionally.
- Missing detection / guardrail: No test covered a failing copyFile during recovery.
- Contributing context: Pattern appears in multiple sites in observe-recovery.ts, this PR addresses the backup-restore path.

## Regression Test Plan (if applicable)
- Coverage level:
  - [x] Unit test
- Target test or file: `src/config/io.observe-recovery.test.ts`
- Scenario: `records copyFile failure instead of falsely claiming restore succeeded` — injects a failing copyFile (EACCES), asserts failure warning fires, success warning does not, audit record has `restoredFromBackup: false`, `valid: false`, `restoreErrorCode: "EACCES"`.
- Why smallest reliable guardrail: Unit test with injected fs failure covers the exact branch.

## User-visible / Behavior Changes
- Failed backup restores now log a warning instead of falsely claiming success.
- Audit records for failed restores now show `valid: false` with error details.

## Diagram (if applicable)
```text
Before:
[copyFile fails] -> [log "restored from backup"] -> [audit: valid: true]

After:
[copyFile fails] -> [log "restore FAILED: <error>"] -> [audit: valid: false, restoreErrorCode: "EACCES"]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Linux (Ubuntu 24)
- Runtime/container: Node 24

### Steps
1. Trigger a suspicious config read with a valid `.bak` file present
2. Make the `.bak` -> config copyFile fail (simulate EACCES)
3. Observe logs and audit record

### Expected
- Warning log: "Config auto-restore from backup failed"
- Audit record: `valid: false`, `restoreErrorCode: "EACCES"`

### Actual (before fix)
- Success log: "Config auto-restored from backup"
- Audit record: `valid: true`, no error info

## Evidence
- [x] Failing test/log before + passing after

## Human Verification (required)
- Verified scenarios: Unit test with injected EACCES copyFile failure
- Edge cases checked: Both async and sync recovery paths
- What I did **not** verify: Full integration test with real disk-full scenario

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Audit record schema gains two new nullable fields (`restoreErrorCode`, `restoreErrorMessage`)
  - Mitigation: Fields default to `null` on non-recovery paths, no breaking change for consumers

