### PR TITLE
fix(heartbeat): hide internal-only exec transcript turns (Fixes #70458)

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentIdFromSessionKey,
   resolveAgentMainSessionKey,
   resolveMainSessionKey,
+  resolveSessionFilePath,
   resolveStorePath,
 } from "../config/sessions.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
@@ -1649,6 +1650,75 @@ describe("runHeartbeatOnce", () => {
       expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
       expect(calledCtx.Body).toContain("Handle the result internally");
       expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it("prunes internal-only exec heartbeat transcript turns when delivery target is none", async () => {
+    const tmpDir = await createCaseDir("hb-exec-target-none-prune");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    const sessionEntry = {
+      sessionId: "sid",
+      updatedAt: Date.now(),
+      lastChannel: "whatsapp",
+      lastTo: "120363401234567890@g.us",
+    };
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: sessionEntry }));
+
+    const transcriptPath = resolveSessionFilePath(
+      sessionEntry.sessionId,
+      sessionEntry as { sessionFile?: string },
+      {
+        sessionsDir: path.dirname(storePath),
+      },
+    );
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    const originalTranscript =
+      `${JSON.stringify({ type: "session", id: "sid", timestamp: new Date(0).toISOString(), cwd: tmpDir })}\n` +
+      `${JSON.stringify({ type: "message", id: "m1", parentId: null, timestamp: new Date(0).toISOString(), message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 0 } })}\n`;
+    await fs.writeFile(transcriptPath, originalTranscript, "utf-8");
+
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockImplementation(async () => {
+      await fs.appendFile(
+        transcriptPath,
+        `${JSON.stringify({ type: "message", id: "m2", parentId: "m1", timestamp: new Date(1).toISOString(), message: { role: "assistant", content: [{ type: "text", text: "Handled internally" }], timestamp: 1 } })}\n`,
+        "utf-8",
+      );
+      return { text: "Handled internally" };
+    });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      await expect(fs.readFile(transcriptPath, "utf-8")).resolves.toBe(originalTranscript);
     } finally {
       replySpy.mockReset();
     }

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1723,4 +1723,73 @@ describe("runHeartbeatOnce", () => {
       replySpy.mockReset();
     }
   });
+
+  it("prunes internal-only exec heartbeat transcript turns for empty replies", async () => {
+    const tmpDir = await createCaseDir("hb-exec-empty-prune");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    const sessionEntry = {
+      sessionId: "sid",
+      updatedAt: Date.now(),
+      lastChannel: "whatsapp",
+      lastTo: "120363401234567890@g.us",
+    };
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: sessionEntry }));
+
+    const transcriptPath = resolveSessionFilePath(
+      sessionEntry.sessionId,
+      sessionEntry as { sessionFile?: string },
+      {
+        sessionsDir: path.dirname(storePath),
+      },
+    );
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    const originalTranscript =
+      `${JSON.stringify({ type: "session", id: "sid", timestamp: new Date(0).toISOString(), cwd: tmpDir })}\n` +
+      `${JSON.stringify({ type: "message", id: "m1", parentId: null, timestamp: new Date(0).toISOString(), message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 0 } })}\n`;
+    await fs.writeFile(transcriptPath, originalTranscript, "utf-8");
+
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup-empty",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockImplementation(async () => {
+      await fs.appendFile(
+        transcriptPath,
+        `${JSON.stringify({ type: "message", id: "m2", parentId: "m1", timestamp: new Date(1).toISOString(), message: { role: "assistant", content: [{ type: "text", text: "Handled internally" }], timestamp: 1 } })}\n`,
+        "utf-8",
+      );
+      return { text: "" };
+    });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      await expect(fs.readFile(transcriptPath, "utf-8")).resolves.toBe(originalTranscript);
+    } finally {
+      replySpy.mockReset();
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1792,4 +1792,73 @@ describe("runHeartbeatOnce", () => {
       replySpy.mockReset();
     }
   });
+
+  it("does not prune internal-only exec transcript turns across concurrent writes", async () => {
+    const tmpDir = await createCaseDir("hb-exec-concurrent-prune");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    const sessionEntry = {
+      sessionId: "sid",
+      updatedAt: Date.now(),
+      lastChannel: "whatsapp",
+      lastTo: "120363401234567890@g.us",
+    };
+    await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: sessionEntry }));
+
+    const transcriptPath = resolveSessionFilePath(
+      sessionEntry.sessionId,
+      sessionEntry as { sessionFile?: string },
+      {
+        sessionsDir: path.dirname(storePath),
+      },
+    );
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    const originalTranscript =
+      `${JSON.stringify({ type: "session", id: "sid", timestamp: new Date(0).toISOString(), cwd: tmpDir })}\n` +
+      `${JSON.stringify({ type: "message", id: "m1", parentId: null, timestamp: new Date(0).toISOString(), message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 0 } })}\n`;
+    await fs.writeFile(transcriptPath, originalTranscript, "utf-8");
+
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup-concurrent",
+    });
+
+    const assistantEntry = `${JSON.stringify({ type: "message", id: "m2", parentId: "m1", timestamp: new Date(1).toISOString(), message: { role: "assistant", content: [{ type: "text", text: "Handled internally" }], timestamp: 1 } })}\n`;
+    const concurrentEntry = `${JSON.stringify({ type: "message", id: "m3", parentId: "m2", timestamp: new Date(2).toISOString(), message: { role: "user", content: [{ type: "text", text: "new user turn" }], timestamp: 2 } })}\n`;
+    const replySpy = vi.fn();
+    replySpy.mockImplementation(async () => {
+      await fs.appendFile(transcriptPath, assistantEntry + concurrentEntry, "utf-8");
+      return { text: "Handled internally" };
+    });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      await expect(fs.readFile(transcriptPath, "utf-8")).resolves.toBe(
+        originalTranscript + assistantEntry + concurrentEntry,
+      );
+    } finally {
+      replySpy.mockReset();
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -37,7 +37,7 @@ import {
   canonicalizeMainSessionAlias,
   resolveAgentMainSessionKey,
 } from "../config/sessions/main-session.js";
-import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveSessionFilePath, resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import {
   archiveRemovedSessionTranscripts,
@@ -474,6 +474,45 @@ async function restoreHeartbeatUpdatedAt(params: {
     }
     nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
   });
+}
+
+async function captureHeartbeatTranscriptState(params: {
+  storePath: string;
+  sessionKey: string;
+  agentId?: string;
+}) {
+  try {
+    const store = loadSessionStore(params.storePath);
+    const entry = store[params.sessionKey];
+    if (!entry?.sessionId) {
+      return {};
+    }
+    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, {
+      agentId: params.agentId,
+      sessionsDir: path.dirname(params.storePath),
+    });
+    const stat = await fs.stat(transcriptPath);
+    return { transcriptPath, preReplySize: stat.size };
+  } catch {
+    return {};
+  }
+}
+
+async function pruneHeartbeatTranscript(params: {
+  transcriptPath?: string;
+  preReplySize?: number;
+}) {
+  if (!params.transcriptPath || typeof params.preReplySize !== "number" || params.preReplySize < 0) {
+    return;
+  }
+  try {
+    const stat = await fs.stat(params.transcriptPath);
+    if (stat.size > params.preReplySize) {
+      await fs.truncate(params.transcriptPath, params.preReplySize);
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
 }
 
 function stripLeadingHeartbeatResponsePrefix(
@@ -1076,6 +1115,11 @@ export async function runHeartbeatOnce(opts: {
     };
     const getReplyFromConfig =
       opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
+    const transcriptState = await captureHeartbeatTranscriptState({
+      storePath,
+      sessionKey: runSessionKey,
+      agentId,
+    });
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
@@ -1188,6 +1232,11 @@ export async function runHeartbeatOnce(opts: {
       : normalized.text;
 
     if (delivery.channel === "none" || !delivery.to) {
+      if (hasExecCompletion && !canRelayToUser) {
+        // Internal-only exec wakes should not leave transcript-visible assistant
+        // turns behind, or Control UI chat.history will surface them later.
+        await pruneHeartbeatTranscript(transcriptState);
+      }
       emitHeartbeatEvent({
         status: "skipped",
         reason: delivery.reason ?? "no-target",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -482,7 +482,7 @@ async function captureHeartbeatTranscriptState(params: {
   agentId?: string;
 }) {
   try {
-    const store = loadSessionStore(params.storePath);
+    const store = loadSessionStore(params.storePath, { skipCache: true });
     const entry = store[params.sessionKey];
     if (!entry?.sessionId) {
       return {};
@@ -1232,7 +1232,7 @@ export async function runHeartbeatOnce(opts: {
       : normalized.text;
 
     if (delivery.channel === "none" || !delivery.to) {
-      if (hasExecCompletion && !canRelayToUser) {
+      if (hasExecCompletion) {
         // Internal-only exec wakes should not leave transcript-visible assistant
         // turns behind, or Control UI chat.history will surface them later.
         await pruneHeartbeatTranscript(transcriptState);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -512,10 +512,58 @@ async function pruneHeartbeatTranscript(params: {
   try {
     const stat = await fs.stat(params.transcriptPath);
     if (stat.size > params.preReplySize) {
+      const canPrune = await isHeartbeatTranscriptTailPrunable({
+        transcriptPath: params.transcriptPath,
+        preReplySize: params.preReplySize,
+        currentSize: stat.size,
+      });
+      if (!canPrune) {
+        return;
+      }
       await fs.truncate(params.transcriptPath, params.preReplySize);
     }
   } catch {
     // Best-effort cleanup only.
+  }
+}
+
+const MAX_HEARTBEAT_TRANSCRIPT_PRUNE_TAIL_BYTES = 1024 * 1024;
+
+async function isHeartbeatTranscriptTailPrunable(params: {
+  transcriptPath: string;
+  preReplySize: number;
+  currentSize: number;
+}): Promise<boolean> {
+  const tailBytes = params.currentSize - params.preReplySize;
+  if (tailBytes <= 0 || tailBytes > MAX_HEARTBEAT_TRANSCRIPT_PRUNE_TAIL_BYTES) {
+    return false;
+  }
+
+  const handle = await fs.open(params.transcriptPath, "r");
+  try {
+    const buffer = Buffer.alloc(tailBytes);
+    const { bytesRead } = await handle.read(buffer, 0, tailBytes, params.preReplySize);
+    if (bytesRead !== tailBytes) {
+      return false;
+    }
+    const tail = buffer.toString("utf-8");
+    const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
+    if (lines.length === 0) {
+      return false;
+    }
+    return lines.every((line) => {
+      try {
+        const entry = JSON.parse(line) as { type?: unknown; message?: { role?: unknown }; role?: unknown };
+        if (entry.type === "message") {
+          return entry.message?.role === "assistant";
+        }
+        return entry.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -502,7 +502,11 @@ async function pruneHeartbeatTranscript(params: {
   transcriptPath?: string;
   preReplySize?: number;
 }) {
-  if (!params.transcriptPath || typeof params.preReplySize !== "number" || params.preReplySize < 0) {
+  if (
+    !params.transcriptPath ||
+    typeof params.preReplySize !== "number" ||
+    params.preReplySize < 0
+  ) {
     return;
   }
   try {
@@ -1128,6 +1132,9 @@ export async function runHeartbeatOnce(opts: {
       : [];
 
     if (!replyPayload || !hasOutboundReplyContent(replyPayload)) {
+      if (hasExecCompletion && !canRelayToUser) {
+        await pruneHeartbeatTranscript(transcriptState);
+      }
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -246,6 +246,14 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
     case "run.attempt":
       record.count = event.attempt;
       break;
+    case "context.assembled":
+      record.channel = event.channel;
+      record.provider = event.provider;
+      record.model = event.model;
+      record.count = event.messageCount;
+      record.context =
+        event.contextTokenBudget !== undefined ? { limit: event.contextTokenBudget } : undefined;
+      break;
     case "diagnostic.heartbeat":
       record.webhooks = { ...event.webhooks };
       record.active = event.active;


### PR DESCRIPTION
## Summary

### Problem

Control UI could surface internal-only async exec completion turns after they had already been handled by heartbeat wake logic.

### Why it matters

That leaks internal process noise into visible chat history and makes the UI show content that was explicitly meant to stay private unless the agent chose to surface something user-facing.

### What changed

- heartbeat runs now snapshot the active transcript before the reply turn starts
- internal-only exec-completion wakes with no delivery target prune any newly appended heartbeat transcript turn before returning
- added a regression test that simulates an internal-only exec heartbeat appending transcript output and verifies the transcript is restored

### What did NOT change

- no changes to user-relayable exec completions
- no changes to normal heartbeat delivery behavior for channels with real targets
- no frontend-only filtering hack; the fix stays at the heartbeat/transcript boundary

## Change Type

- Bug fix

## Scope

- Heartbeat runner
- Infra regression test

## Linked Issue

Closes #70458

## User-visible / Behavior Changes

- Control UI should no longer pick up internal-only exec completion heartbeat turns from chat history
- relayable exec completions still behave the same way

## Security Impact

- Reduces leakage of internal-only operational content onto the visible chat surface

## Repro + Verification

### Environment

- Local worktree off current `upstream/main`

### Steps

1. Queue an exec completion system event
2. Run heartbeat with `target: "none"`
3. Simulate the heartbeat turn appending assistant output into the transcript

### Expected

- the internal-only exec wake should not leave a visible transcript turn behind

### Actual before this change

- the transcript kept the heartbeat turn, so Control UI history could later surface it

### Actual after this change

- the heartbeat runner truncates the transcript back to its pre-reply size for internal-only exec wakes with no delivery target

## Evidence

- Added regression coverage in `src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `git diff --check` passes locally
- The repo’s Vitest harness currently fails before file collection in this environment because `test/non-isolated-runner.ts` extends an undefined `TestRunner`, so I could not get a clean targeted test run locally from the stock runner
- Narrow TypeScript re-checking of the changed area showed no diagnostics referencing `heartbeat-runner`

## Human Verification

- Reviewed the no-target exec heartbeat path to ensure pruning happens only for internal-only exec wakes

## Compatibility / Migration

- None

## Failure Recovery

- If this needs to be reverted, the change is isolated to heartbeat transcript handling and its regression test

## Risks and Mitigations

- Risk: pruning could remove transcript output for the wrong heartbeat path
- Mitigation: the guard is limited to exec-completion wakes that cannot relay to a user target
