### PR TITLE
feat(provider): add WaveSpeed provider

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -70,6 +70,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [vLLM (local models)](/providers/vllm)
 - [Volcengine (Doubao)](/providers/volcengine)
 - [Vydra](/providers/vydra)
+- [WaveSpeed](/providers/wavespeed)
 - [xAI](/providers/xai)
 - [Xiaomi](/providers/xiaomi)
 - [Z.AI](/providers/zai)

--- a/docs/providers/wavespeed.md
+++ b/docs/providers/wavespeed.md
@@ -10,11 +10,11 @@ read_when:
 
 [WaveSpeed](https://wavespeed.ai) provides OpenAI-compatible access to hosted LLMs through a unified endpoint. OpenClaw treats WaveSpeed as a first-class named provider, so onboarding, default model selection, and provider docs all work without hand-writing a custom endpoint block.
 
-| Property | Value |
-| -------- | ----- |
-| Provider | `wavespeed` |
-| Auth | `WAVESPEED_API_KEY` |
-| API | OpenAI-compatible |
+| Property | Value                         |
+| -------- | ----------------------------- |
+| Provider | `wavespeed`                   |
+| Auth     | `WAVESPEED_API_KEY`           |
+| API      | OpenAI-compatible             |
 | Base URL | `https://llm.wavespeed.ai/v1` |
 
 ## Getting started
@@ -54,12 +54,12 @@ openclaw onboard --non-interactive \
 
 OpenClaw currently ships this bundled WaveSpeed starter catalog:
 
-| Model ref | Name | Input | Context | Notes |
-| --------- | ---- | ----- | ------- | ----- |
-| `wavespeed/google/gemini-2.5-flash` | Gemini 2.5 Flash | text, image | 1M | Default model; fast general-purpose multimodal option |
-| `wavespeed/anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | text, image | 200K | Strong coding and reasoning |
-| `wavespeed/anthropic/claude-opus-4.6` | Claude Opus 4.6 | text, image | 200K | Highest-capability Anthropic option |
-| `wavespeed/openai/gpt-4.1` | GPT-4.1 | text, image | 1M | Broad OpenAI-compatible baseline |
+| Model ref                               | Name              | Input       | Context | Notes                                                 |
+| --------------------------------------- | ----------------- | ----------- | ------- | ----------------------------------------------------- |
+| `wavespeed/google/gemini-2.5-flash`     | Gemini 2.5 Flash  | text, image | 1M      | Default model; fast general-purpose multimodal option |
+| `wavespeed/anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | text, image | 200K    | Strong coding and reasoning                           |
+| `wavespeed/anthropic/claude-opus-4.6`   | Claude Opus 4.6   | text, image | 200K    | Highest-capability Anthropic option                   |
+| `wavespeed/openai/gpt-4.1`              | GPT-4.1           | text, image | 1M      | Broad OpenAI-compatible baseline                      |
 
 <Tip>
 The onboarding preset sets `wavespeed/google/gemini-2.5-flash` as the default model.
@@ -67,12 +67,12 @@ The onboarding preset sets `wavespeed/google/gemini-2.5-flash` as the default mo
 
 ## Supported features
 
-| Feature | Supported |
-| ------- | --------- |
-| Streaming | Yes |
-| Tool use / function calling | Yes |
-| Structured output | Yes |
-| Vision input | Yes |
+| Feature                     | Supported |
+| --------------------------- | --------- |
+| Streaming                   | Yes       |
+| Tool use / function calling | Yes       |
+| Structured output           | Yes       |
+| Vision input                | Yes       |
 
 <AccordionGroup>
   <Accordion title="Environment note">

--- a/docs/providers/wavespeed.md
+++ b/docs/providers/wavespeed.md
@@ -1,0 +1,99 @@
+---
+title: "WaveSpeed"
+summary: "WaveSpeed setup (auth + model selection)"
+read_when:
+  - You want to use WaveSpeed with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+# WaveSpeed
+
+[WaveSpeed](https://wavespeed.ai) provides OpenAI-compatible access to hosted LLMs through a unified endpoint. OpenClaw treats WaveSpeed as a first-class named provider, so onboarding, default model selection, and provider docs all work without hand-writing a custom endpoint block.
+
+| Property | Value |
+| -------- | ----- |
+| Provider | `wavespeed` |
+| Auth | `WAVESPEED_API_KEY` |
+| API | OpenAI-compatible |
+| Base URL | `https://llm.wavespeed.ai/v1` |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an API key from the [WaveSpeed dashboard](https://wavespeed.ai).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice wavespeed-api-key
+    ```
+  </Step>
+  <Step title="Set a default model">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "wavespeed/google/gemini-2.5-flash" },
+        },
+      },
+    }
+    ```
+  </Step>
+</Steps>
+
+## Non-interactive setup
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice wavespeed-api-key \
+  --wavespeed-api-key "$WAVESPEED_API_KEY"
+```
+
+## Built-in catalog
+
+OpenClaw currently ships this bundled WaveSpeed starter catalog:
+
+| Model ref | Name | Input | Context | Notes |
+| --------- | ---- | ----- | ------- | ----- |
+| `wavespeed/google/gemini-2.5-flash` | Gemini 2.5 Flash | text, image | 1M | Default model; fast general-purpose multimodal option |
+| `wavespeed/anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | text, image | 200K | Strong coding and reasoning |
+| `wavespeed/anthropic/claude-opus-4.6` | Claude Opus 4.6 | text, image | 200K | Highest-capability Anthropic option |
+| `wavespeed/openai/gpt-4.1` | GPT-4.1 | text, image | 1M | Broad OpenAI-compatible baseline |
+
+<Tip>
+The onboarding preset sets `wavespeed/google/gemini-2.5-flash` as the default model.
+</Tip>
+
+## Supported features
+
+| Feature | Supported |
+| ------- | --------- |
+| Streaming | Yes |
+| Tool use / function calling | Yes |
+| Structured output | Yes |
+| Vision input | Yes |
+
+<AccordionGroup>
+  <Accordion title="Environment note">
+    If the Gateway runs as a daemon, make sure `WAVESPEED_API_KEY` is available
+    to that process (for example, in `~/.openclaw/.env` or via `env.shellEnv`).
+  </Accordion>
+
+  <Accordion title="Pricing note">
+    WaveSpeed routes to upstream hosted models. OpenClaw's bundled catalog is
+    focused on stable defaults and does not try to mirror WaveSpeed's full live
+    catalog or pricing surface yet.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Provider directory" href="/providers" icon="book-open">
+    Browse all built-in OpenClaw provider integrations.
+  </Card>
+</CardGroup>

--- a/extensions/wavespeed/index.test.ts
+++ b/extensions/wavespeed/index.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
+import { resolveProviderAuthEnvVarCandidates } from "../../src/secrets/provider-env-vars.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import wavespeedPlugin from "./index.js";
+import { WAVESPEED_BASE_URL, WAVESPEED_DEFAULT_MODEL_REF } from "./models.js";
+
+describe("wavespeed provider plugin", () => {
+  it("registers WaveSpeed with an API key auth choice", async () => {
+    const provider = await registerSingleProviderPlugin(wavespeedPlugin);
+
+    expect(provider.id).toBe("wavespeed");
+    expect(provider.label).toBe("WaveSpeed");
+    expect(provider.envVars).toEqual(["WAVESPEED_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+
+    const choice = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "wavespeed-api-key",
+    });
+    expect(choice).not.toBeNull();
+    expect(choice?.provider.id).toBe("wavespeed");
+    expect(choice?.method.id).toBe("wavespeed-platform");
+  });
+
+  it("writes the default WaveSpeed provider config during onboarding", async () => {
+    const provider = await registerSingleProviderPlugin(wavespeedPlugin);
+    const method = provider.auth?.find((entry) => entry.id === "wavespeed-platform");
+    if (!method?.runNonInteractive) {
+      throw new Error("expected non-interactive WaveSpeed auth");
+    }
+
+    const config = await method.runNonInteractive({
+      config: {},
+      opts: {},
+      env: {},
+      runtime: {
+        error: () => {},
+        exit: () => {},
+        log: () => {},
+      },
+      resolveApiKey: async () => ({
+        key: "ws-test-key",
+        source: "profile",
+      }),
+      toApiKeyCredential: () => null,
+    } as never);
+
+    expect(config?.models?.providers?.wavespeed).toMatchObject({
+      baseUrl: WAVESPEED_BASE_URL,
+      api: "openai-completions",
+    });
+    expect(config?.models?.providers?.wavespeed?.models?.map((model) => model.id)).toEqual([
+      "google/gemini-2.5-flash",
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-opus-4.6",
+      "openai/gpt-4.1",
+    ]);
+    expect(config?.agents?.defaults?.model).toMatchObject({
+      primary: WAVESPEED_DEFAULT_MODEL_REF,
+    });
+  });
+
+  it("declares its env var candidate for provider auth resolution", () => {
+    const candidates = resolveProviderAuthEnvVarCandidates();
+
+    expect(candidates.wavespeed).toEqual(["WAVESPEED_API_KEY"]);
+  });
+
+  it("builds the direct WaveSpeed model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(wavespeedPlugin);
+    const catalogProvider = await runSingleProviderCatalog(provider, {
+      resolveProviderApiKey: (id?: string) =>
+        id === "wavespeed" ? { apiKey: "ws-test-key" } : { apiKey: undefined },
+    });
+
+    expect(catalogProvider.api).toBe("openai-completions");
+    expect(catalogProvider.baseUrl).toBe(WAVESPEED_BASE_URL);
+    expect(catalogProvider.models?.map((model) => model.id)).toEqual([
+      "google/gemini-2.5-flash",
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-opus-4.6",
+      "openai/gpt-4.1",
+    ]);
+  });
+});

--- a/extensions/wavespeed/index.ts
+++ b/extensions/wavespeed/index.ts
@@ -1,0 +1,70 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import {
+  readConfiguredProviderCatalogEntries,
+  type ProviderCatalogContext,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
+import { OPENAI_COMPATIBLE_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyWaveSpeedConfig } from "./onboard.js";
+import { WAVESPEED_DEFAULT_MODEL_REF } from "./models.js";
+import { buildWaveSpeedProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "wavespeed";
+
+function buildWaveSpeedAuthMethods() {
+  return [
+    createProviderApiKeyAuthMethod({
+      providerId: PROVIDER_ID,
+      methodId: "wavespeed-platform",
+      label: "WaveSpeed API key",
+      hint: "Direct access to WaveSpeed LLM",
+      optionKey: "wavespeedApiKey",
+      flagName: "--wavespeed-api-key",
+      envVar: "WAVESPEED_API_KEY",
+      promptMessage: "Enter WaveSpeed API key",
+      defaultModel: WAVESPEED_DEFAULT_MODEL_REF,
+      expectedProviders: [PROVIDER_ID],
+      applyConfig: (cfg) => applyWaveSpeedConfig(cfg),
+      wizard: {
+        choiceId: "wavespeed-api-key",
+        choiceLabel: "WaveSpeed API key",
+        choiceHint: "Direct (llm.wavespeed.ai)",
+        groupId: "wavespeed",
+        groupLabel: "WaveSpeed",
+        groupHint: "OpenAI-compatible LLM access",
+      },
+    }),
+  ];
+}
+
+async function resolveWaveSpeedCatalog(ctx: ProviderCatalogContext) {
+  const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+  if (!apiKey) {
+    return null;
+  }
+  return { provider: { ...buildWaveSpeedProvider(), apiKey } };
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "WaveSpeed Provider",
+  description: "Bundled WaveSpeed provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "WaveSpeed",
+      docsPath: "/providers/wavespeed",
+      envVars: ["WAVESPEED_API_KEY"],
+      auth: buildWaveSpeedAuthMethods(),
+      catalog: {
+        run: resolveWaveSpeedCatalog,
+      },
+      augmentModelCatalog: ({ config }) =>
+        readConfiguredProviderCatalogEntries({
+          config,
+          providerId: PROVIDER_ID,
+        }),
+      ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+    });
+  },
+});

--- a/extensions/wavespeed/models.ts
+++ b/extensions/wavespeed/models.ts
@@ -1,0 +1,64 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const WAVESPEED_BASE_URL = "https://llm.wavespeed.ai/v1";
+export const WAVESPEED_DEFAULT_MODEL_ID = "google/gemini-2.5-flash";
+export const WAVESPEED_DEFAULT_MODEL_REF = `wavespeed/${WAVESPEED_DEFAULT_MODEL_ID}`;
+
+// WaveSpeed routes to multiple upstream vendors, so keep the bundled catalog
+// pricing neutral until OpenClaw ships a provider-owned public pricing mapping.
+const WAVESPEED_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export const WAVESPEED_MODEL_CATALOG = [
+  {
+    id: "google/gemini-2.5-flash",
+    name: "Gemini 2.5 Flash",
+    reasoning: true,
+    input: ["text", "image"] as const,
+    contextWindow: 1048576,
+    maxTokens: 65536,
+  },
+  {
+    id: "anthropic/claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    reasoning: true,
+    input: ["text", "image"] as const,
+    contextWindow: 200000,
+    maxTokens: 32000,
+  },
+  {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6",
+    reasoning: true,
+    input: ["text", "image"] as const,
+    contextWindow: 200000,
+    maxTokens: 32000,
+  },
+  {
+    id: "openai/gpt-4.1",
+    name: "GPT-4.1",
+    reasoning: false,
+    input: ["text", "image"] as const,
+    contextWindow: 1048576,
+    maxTokens: 32768,
+  },
+] as const;
+
+export function buildWaveSpeedModelDefinition(
+  model: (typeof WAVESPEED_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    id: model.id,
+    name: model.name,
+    api: "openai-completions",
+    reasoning: model.reasoning,
+    input: [...model.input],
+    cost: WAVESPEED_DEFAULT_COST,
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+  };
+}

--- a/extensions/wavespeed/onboard.ts
+++ b/extensions/wavespeed/onboard.ts
@@ -1,0 +1,25 @@
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { WAVESPEED_BASE_URL, WAVESPEED_DEFAULT_MODEL_REF } from "./models.js";
+import { buildWaveSpeedCatalogModels } from "./provider-catalog.js";
+
+const wavespeedPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: WAVESPEED_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "wavespeed",
+    api: "openai-completions",
+    baseUrl: WAVESPEED_BASE_URL,
+    catalogModels: buildWaveSpeedCatalogModels(),
+    aliases: [{ modelRef: WAVESPEED_DEFAULT_MODEL_REF, alias: "WaveSpeed" }],
+  }),
+});
+
+export function applyWaveSpeedProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return wavespeedPresetAppliers.applyProviderConfig(cfg);
+}
+
+export function applyWaveSpeedConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return wavespeedPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/wavespeed/openclaw.plugin.json
+++ b/extensions/wavespeed/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "wavespeed",
+  "enabledByDefault": true,
+  "providers": ["wavespeed"],
+  "providerAuthEnvVars": {
+    "wavespeed": ["WAVESPEED_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "wavespeed",
+      "method": "wavespeed-platform",
+      "choiceId": "wavespeed-api-key",
+      "choiceLabel": "WaveSpeed API key",
+      "choiceHint": "Direct (llm.wavespeed.ai)",
+      "groupId": "wavespeed",
+      "groupLabel": "WaveSpeed",
+      "groupHint": "OpenAI-compatible LLM access",
+      "optionKey": "wavespeedApiKey",
+      "cliFlag": "--wavespeed-api-key",
+      "cliOption": "--wavespeed-api-key <key>",
+      "cliDescription": "WaveSpeed API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/wavespeed/package.json
+++ b/extensions/wavespeed/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/wavespeed-provider",
+  "version": "2026.4.23",
+  "private": true,
+  "description": "OpenClaw WaveSpeed provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/wavespeed/provider-catalog.ts
+++ b/extensions/wavespeed/provider-catalog.ts
@@ -1,0 +1,18 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildWaveSpeedModelDefinition,
+  WAVESPEED_BASE_URL,
+  WAVESPEED_MODEL_CATALOG,
+} from "./models.js";
+
+export function buildWaveSpeedCatalogModels(): NonNullable<ModelProviderConfig["models"]> {
+  return WAVESPEED_MODEL_CATALOG.map(buildWaveSpeedModelDefinition);
+}
+
+export function buildWaveSpeedProvider(): ModelProviderConfig {
+  return {
+    baseUrl: WAVESPEED_BASE_URL,
+    api: "openai-completions",
+    models: buildWaveSpeedCatalogModels(),
+  };
+}

--- a/extensions/wavespeed/tsconfig.json
+++ b/extensions/wavespeed/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1322,6 +1322,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/wavespeed:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/webhooks:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary

This adds WaveSpeed as a bundled OpenClaw provider plugin.

Included in this PR:
- a new `wavespeed` provider extension
- API-key onboarding via `wavespeed-api-key`
- `WAVESPEED_API_KEY` env-var support
- a bundled starter model catalog for WaveSpeed's OpenAI-compatible LLM surface
- provider docs under `/providers/wavespeed`
- extension tests covering auth choice registration, onboarding config, env-var discovery, and catalog resolution

## Why

WaveSpeed exposes an OpenAI-compatible LLM endpoint, so it fits OpenClaw's existing bundled provider model well. This makes WaveSpeed available as a first-class provider in onboarding and docs instead of requiring users to hand-configure a custom endpoint.

## Notes

- The bundled catalog is intentionally a small starter catalog rather than a full mirrored live catalog.
- Pricing is left neutral in the bundled definitions because WaveSpeed routes to multiple upstream vendors and this PR focuses on provider integration, onboarding, and discoverability.
- This PR follows OpenClaw's current provider extension architecture instead of modifying older core-provider wiring paths.

## Validation

- `openclaw onboard --help` shows `wavespeed-api-key` and `--wavespeed-api-key`
- targeted test passed:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/wavespeed/index.test.ts`
- extension boundary compile check passed:
  - `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile`
- local embedded agent smoke test succeeded with OpenClaw selecting:
  - `provider: "wavespeed"`
  - `model: "google/gemini-2.5-flash"`
