### PR TITLE
fix(gateway): preserve control UI chat images in history (Fixes #70507)

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -86,6 +86,7 @@ import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
 import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import type { GatewayClient } from "./shared-types.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -144,6 +145,13 @@ export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES = 48 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const CHAT_HISTORY_INLINE_IMAGE_MEDIA_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+]);
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -706,10 +714,7 @@ function sanitizeChatHistoryContentBlock(
     delete entry.data;
     entry.source = {
       type: "base64",
-      media_type:
-        typeof entry.mimeType === "string" && entry.mimeType.trim().length > 0
-          ? entry.mimeType
-          : "image/png",
+      media_type: resolveChatHistoryInlineImageMediaType(entry.mimeType),
     };
     if (
       opts?.preserveInlineImageData === true &&
@@ -739,6 +744,15 @@ function sanitizeChatHistoryContentBlock(
     }
   }
   return { block: changed ? entry : block, changed };
+}
+
+function resolveChatHistoryInlineImageMediaType(value: unknown): string {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return CHAT_HISTORY_INLINE_IMAGE_MEDIA_TYPES.has(normalized) ? normalized : "image/png";
+}
+
+function canPreserveInlineChatHistoryImages(client: GatewayClient | undefined): boolean {
+  return (client?.connect?.scopes ?? []).includes(ADMIN_SCOPE);
 }
 
 function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {
@@ -1690,7 +1704,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const preserveInlineImageData = isWebchatClient(client?.connect?.client);
+    const preserveInlineImageData = canPreserveInlineChatHistoryImages(client);
     const normalized = augmentChatHistoryWithCanvasBlocks(
       sanitizeChatHistoryMessages(sanitized, effectiveMaxChars, {
         preserveInlineImageData,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -695,10 +695,16 @@ function sanitizeChatHistoryContentBlock(
   }
   const type = typeof entry.type === "string" ? entry.type : "";
   if (type === "image" && typeof entry.data === "string") {
-    const bytes = Buffer.byteLength(entry.data, "utf8");
+    const data = entry.data;
     delete entry.data;
-    entry.omitted = true;
-    entry.bytes = bytes;
+    entry.source = {
+      type: "base64",
+      media_type:
+        typeof entry.mimeType === "string" && entry.mimeType.trim().length > 0
+          ? entry.mimeType
+          : "image/png",
+      data,
+    };
     changed = true;
   }
   if (type === "audio" && entry.source && typeof entry.source === "object") {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -142,6 +142,7 @@ async function buildWebchatAssistantMediaMessage(
 
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
+const CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES = 48 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
@@ -696,6 +697,7 @@ function sanitizeChatHistoryContentBlock(
   const type = typeof entry.type === "string" ? entry.type : "";
   if (type === "image" && typeof entry.data === "string") {
     const data = entry.data;
+    const bytes = Buffer.byteLength(data, "utf8");
     delete entry.data;
     entry.source = {
       type: "base64",
@@ -703,8 +705,14 @@ function sanitizeChatHistoryContentBlock(
         typeof entry.mimeType === "string" && entry.mimeType.trim().length > 0
           ? entry.mimeType
           : "image/png",
-      data,
     };
+    if (bytes <= CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES) {
+      (entry.source as { data?: string }).data = data;
+    } else {
+      (entry.source as { omitted?: boolean; bytes?: number }).omitted = true;
+      (entry.source as { omitted?: boolean; bytes?: number }).bytes = bytes;
+    }
+    delete entry.mimeType;
     changed = true;
   }
   if (type === "audio" && entry.source && typeof entry.source === "object") {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -639,7 +639,11 @@ function extractChatHistoryBlockText(message: unknown): string | undefined {
 
 function sanitizeChatHistoryContentBlock(
   block: unknown,
-  opts?: { preserveExactToolPayload?: boolean; maxChars?: number },
+  opts?: {
+    preserveExactToolPayload?: boolean;
+    maxChars?: number;
+    inlineImageBudget?: { remainingBytes: number };
+  },
 ): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
@@ -706,8 +710,14 @@ function sanitizeChatHistoryContentBlock(
           ? entry.mimeType
           : "image/png",
     };
-    if (bytes <= CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES) {
+    if (
+      bytes <= CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES &&
+      (!opts?.inlineImageBudget || opts.inlineImageBudget.remainingBytes >= bytes)
+    ) {
       (entry.source as { data?: string }).data = data;
+      if (opts?.inlineImageBudget) {
+        opts.inlineImageBudget.remainingBytes -= bytes;
+      }
     } else {
       (entry.source as { omitted?: boolean; bytes?: number }).omitted = true;
       (entry.source as { omitted?: boolean; bytes?: number }).bytes = bytes;
@@ -892,8 +902,13 @@ function sanitizeChatHistoryMessage(
       changed ||= stripped.changed || res.truncated;
     }
   } else if (Array.isArray(entry.content)) {
+    const inlineImageBudget = { remainingBytes: CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES };
     const updated = entry.content.map((block) =>
-      sanitizeChatHistoryContentBlock(block, { preserveExactToolPayload, maxChars }),
+      sanitizeChatHistoryContentBlock(block, {
+        preserveExactToolPayload,
+        maxChars,
+        inlineImageBudget,
+      }),
     );
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -643,6 +643,7 @@ function sanitizeChatHistoryContentBlock(
     preserveExactToolPayload?: boolean;
     maxChars?: number;
     inlineImageBudget?: { remainingBytes: number };
+    preserveInlineImageData?: boolean;
   },
 ): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
@@ -711,6 +712,7 @@ function sanitizeChatHistoryContentBlock(
           : "image/png",
     };
     if (
+      opts?.preserveInlineImageData === true &&
       bytes <= CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES &&
       (!opts?.inlineImageBudget || opts.inlineImageBudget.remainingBytes >= bytes)
     ) {
@@ -836,6 +838,7 @@ function sanitizeCost(raw: unknown): { total?: number } | undefined {
 function sanitizeChatHistoryMessage(
   message: unknown,
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  opts?: { preserveInlineImageData?: boolean },
 ): { message: unknown; changed: boolean } {
   if (!message || typeof message !== "object") {
     return { message, changed: false };
@@ -908,6 +911,7 @@ function sanitizeChatHistoryMessage(
         preserveExactToolPayload,
         maxChars,
         inlineImageBudget,
+        preserveInlineImageData: opts?.preserveInlineImageData,
       }),
     );
     if (updated.some((item) => item.changed)) {
@@ -1010,6 +1014,7 @@ function shouldDropAssistantHistoryMessage(message: unknown): boolean {
 export function sanitizeChatHistoryMessages(
   messages: unknown[],
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  opts?: { preserveInlineImageData?: boolean },
 ): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -1021,7 +1026,7 @@ export function sanitizeChatHistoryMessages(
       changed = true;
       continue;
     }
-    const res = sanitizeChatHistoryMessage(message, maxChars);
+    const res = sanitizeChatHistoryMessage(message, maxChars, opts);
     changed ||= res.changed;
     if (shouldDropAssistantHistoryMessage(res.message)) {
       changed = true;
@@ -1650,7 +1655,7 @@ function broadcastChatError(params: {
 }
 
 export const chatHandlers: GatewayRequestHandlers = {
-  "chat.history": async ({ params, respond, context }) => {
+  "chat.history": async ({ params, respond, context, client }) => {
     if (!validateChatHistoryParams(params)) {
       respond(
         false,
@@ -1685,8 +1690,11 @@ export const chatHandlers: GatewayRequestHandlers = {
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
+    const preserveInlineImageData = isWebchatClient(client?.connect?.client);
     const normalized = augmentChatHistoryWithCanvasBlocks(
-      sanitizeChatHistoryMessages(sanitized, effectiveMaxChars),
+      sanitizeChatHistoryMessages(sanitized, effectiveMaxChars, {
+        preserveInlineImageData,
+      }),
     );
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -146,11 +146,13 @@ export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_MAX_INLINE_IMAGE_DATA_BYTES = 48 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 const CHAT_HISTORY_INLINE_IMAGE_MEDIA_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
+  "image/apng",
   "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
 ]);
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
@@ -752,7 +754,10 @@ function resolveChatHistoryInlineImageMediaType(value: unknown): string {
 }
 
 function canPreserveInlineChatHistoryImages(client: GatewayClient | undefined): boolean {
-  return (client?.connect?.scopes ?? []).includes(ADMIN_SCOPE);
+  return (
+    isWebchatClient(client?.connect?.client) &&
+    (client?.connect?.scopes ?? []).includes(ADMIN_SCOPE)
+  );
 }
 
 function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -542,6 +542,37 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history rewrites transcript image blocks into renderable control ui sources", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "see image" },
+          { type: "image", data: "abc123==", mimeType: "image/png" },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const firstMessage = historyMessages[0] as
+      | {
+          content?: Array<{
+            type?: string;
+            data?: string;
+            source?: { type?: string; media_type?: string; data?: string };
+          }>;
+        }
+      | undefined;
+    const imageBlock = firstMessage?.content?.[1];
+    expect(imageBlock?.type).toBe("image");
+    expect(imageBlock).not.toHaveProperty("data");
+    expect(imageBlock?.source).toEqual({
+      type: "base64",
+      media_type: "image/png",
+      data: "abc123==",
+    });
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -566,11 +566,51 @@ describe("gateway server chat", () => {
     const imageBlock = firstMessage?.content?.[1];
     expect(imageBlock?.type).toBe("image");
     expect(imageBlock).not.toHaveProperty("data");
+    expect(imageBlock).not.toHaveProperty("mimeType");
     expect(imageBlock?.source).toEqual({
       type: "base64",
       media_type: "image/png",
       data: "abc123==",
     });
+  });
+
+  test("chat.history omits oversized inline image payloads without replacing the full turn", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "keep this text" },
+          { type: "image", data: "A".repeat(70_000), mimeType: "image/png" },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const firstMessage = historyMessages[0] as
+      | {
+          content?: Array<{
+            type?: string;
+            source?: {
+              type?: string;
+              media_type?: string;
+              omitted?: boolean;
+              bytes?: number;
+              data?: string;
+            };
+          }>;
+        }
+      | undefined;
+    const textBlock = firstMessage?.content?.[0] as { text?: string } | undefined;
+    const imageBlock = firstMessage?.content?.[1];
+    expect(textBlock?.text).toBe("keep this text");
+    expect(imageBlock?.type).toBe("image");
+    expect(imageBlock?.source).toMatchObject({
+      type: "base64",
+      media_type: "image/png",
+      omitted: true,
+      bytes: 70_000,
+    });
+    expect(imageBlock?.source).not.toHaveProperty("data");
   });
 
   test("chat.history hides commentary-only assistant entries", async () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -80,12 +80,13 @@ describe("gateway server chat", () => {
 
   const loadChatHistoryWithMessages = async (
     messages: Array<Record<string, unknown>>,
+    historyWs: WebSocket = ws,
   ): Promise<unknown[]> => {
     return withMainSessionStore(async (dir) => {
       const lines = messages.map((message) => JSON.stringify({ message }));
       await fs.writeFile(path.join(dir, "sess-main.jsonl"), lines.join("\n"), "utf-8");
 
-      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+      const res = await rpcReq<{ messages?: unknown[] }>(historyWs, "chat.history", {
         sessionKey: "main",
       });
       expect(res.ok).toBe(true);
@@ -572,6 +573,67 @@ describe("gateway server chat", () => {
       media_type: "image/png",
       data: "abc123==",
     });
+  });
+
+  test("chat.history omits inline image payloads for non-webchat clients", async () => {
+    const testWs = new WebSocket(`ws://127.0.0.1:${port}`, {
+      headers: { origin: `http://127.0.0.1:${port}` },
+    });
+    trackConnectChallengeNonce(testWs);
+    await new Promise<void>((resolve) => testWs.once("open", resolve));
+    await connectOk(testWs, {
+      client: {
+        id: GATEWAY_CLIENT_NAMES.TEST,
+        version: "1.0.0",
+        platform: "test",
+        mode: GATEWAY_CLIENT_MODES.TEST,
+      },
+    });
+
+    try {
+      const historyMessages = await loadChatHistoryWithMessages(
+        [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "see image" },
+              { type: "image", data: "abc123==", mimeType: "image/png" },
+            ],
+            timestamp: 1,
+          },
+        ],
+        testWs,
+      );
+
+      const firstMessage = historyMessages[0] as
+        | {
+            content?: Array<{
+              type?: string;
+              data?: string;
+              source?: {
+                type?: string;
+                media_type?: string;
+                omitted?: boolean;
+                bytes?: number;
+                data?: string;
+              };
+            }>;
+          }
+        | undefined;
+      const imageBlock = firstMessage?.content?.[1];
+      expect(imageBlock?.type).toBe("image");
+      expect(imageBlock).not.toHaveProperty("data");
+      expect(imageBlock).not.toHaveProperty("mimeType");
+      expect(imageBlock?.source).toMatchObject({
+        type: "base64",
+        media_type: "image/png",
+        omitted: true,
+        bytes: 8,
+      });
+      expect(imageBlock?.source).not.toHaveProperty("data");
+    } finally {
+      testWs.close();
+    }
   });
 
   test("chat.history omits oversized inline image payloads without replacing the full turn", async () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -613,6 +613,55 @@ describe("gateway server chat", () => {
     expect(imageBlock?.source).not.toHaveProperty("data");
   });
 
+  test("chat.history enforces the inline image budget across the full message", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "keep this text" },
+          { type: "image", data: "A".repeat(20_000), mimeType: "image/png" },
+          { type: "image", data: "B".repeat(20_000), mimeType: "image/png" },
+          { type: "image", data: "C".repeat(20_000), mimeType: "image/png" },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const firstMessage = historyMessages[0] as
+      | {
+          content?: Array<{
+            type?: string;
+            text?: string;
+            source?: {
+              type?: string;
+              media_type?: string;
+              omitted?: boolean;
+              bytes?: number;
+              data?: string;
+            };
+          }>;
+        }
+      | undefined;
+    expect(firstMessage?.content?.[0]?.text).toBe("keep this text");
+    expect(firstMessage?.content?.[1]?.source).toMatchObject({
+      type: "base64",
+      media_type: "image/png",
+      data: "A".repeat(20_000),
+    });
+    expect(firstMessage?.content?.[2]?.source).toMatchObject({
+      type: "base64",
+      media_type: "image/png",
+      data: "B".repeat(20_000),
+    });
+    expect(firstMessage?.content?.[3]?.source).toMatchObject({
+      type: "base64",
+      media_type: "image/png",
+      omitted: true,
+      bytes: 20_000,
+    });
+    expect(firstMessage?.content?.[3]?.source).not.toHaveProperty("data");
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -636,6 +636,99 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.history omits inline image payloads when webchat metadata lacks admin scope", async () => {
+    const testWs = new WebSocket(`ws://127.0.0.1:${port}`, {
+      headers: { origin: `http://127.0.0.1:${port}` },
+    });
+    trackConnectChallengeNonce(testWs);
+    await new Promise<void>((resolve) => testWs.once("open", resolve));
+    await connectOk(testWs, {
+      client: {
+        id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+        version: "1.0.0",
+        platform: "test",
+        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      },
+      scopes: ["operator.read"],
+    });
+
+    try {
+      const historyMessages = await loadChatHistoryWithMessages(
+        [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "see image" },
+              { type: "image", data: "abc123==", mimeType: "image/png" },
+            ],
+            timestamp: 1,
+          },
+        ],
+        testWs,
+      );
+
+      const firstMessage = historyMessages[0] as
+        | {
+            content?: Array<{
+              type?: string;
+              data?: string;
+              source?: {
+                type?: string;
+                media_type?: string;
+                omitted?: boolean;
+                bytes?: number;
+                data?: string;
+              };
+            }>;
+          }
+        | undefined;
+      const imageBlock = firstMessage?.content?.[1];
+      expect(imageBlock?.type).toBe("image");
+      expect(imageBlock).not.toHaveProperty("data");
+      expect(imageBlock).not.toHaveProperty("mimeType");
+      expect(imageBlock?.source).toMatchObject({
+        type: "base64",
+        media_type: "image/png",
+        omitted: true,
+        bytes: 8,
+      });
+      expect(imageBlock?.source).not.toHaveProperty("data");
+    } finally {
+      testWs.close();
+    }
+  });
+
+  test("chat.history normalizes inline image media types through an allowlist", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [
+          { type: "image", data: "abc123==", mimeType: " IMAGE/JPEG " },
+          { type: "image", data: "def456==", mimeType: "image/svg+xml" },
+        ],
+        timestamp: 1,
+      },
+    ]);
+
+    const firstMessage = historyMessages[0] as
+      | {
+          content?: Array<{
+            source?: { type?: string; media_type?: string; data?: string };
+          }>;
+        }
+      | undefined;
+    expect(firstMessage?.content?.[0]?.source).toEqual({
+      type: "base64",
+      media_type: "image/jpeg",
+      data: "abc123==",
+    });
+    expect(firstMessage?.content?.[1]?.source).toEqual({
+      type: "base64",
+      media_type: "image/png",
+      data: "def456==",
+    });
+  });
+
   test("chat.history omits oversized inline image payloads without replacing the full turn", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -94,6 +94,31 @@ describe("gateway server chat", () => {
     });
   };
 
+  const loadWebchatHistoryWithMessages = async (
+    messages: Array<Record<string, unknown>>,
+  ): Promise<unknown[]> => {
+    const webchatWs = new WebSocket(`ws://127.0.0.1:${port}`, {
+      headers: { origin: `http://127.0.0.1:${port}` },
+    });
+    trackConnectChallengeNonce(webchatWs);
+    await new Promise<void>((resolve) => webchatWs.once("open", resolve));
+    await connectOk(webchatWs, {
+      client: {
+        id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+        version: "1.0.0",
+        platform: "test",
+        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      },
+      scopes: ["operator.admin"],
+    });
+
+    try {
+      return await loadChatHistoryWithMessages(messages, webchatWs);
+    } finally {
+      webchatWs.close();
+    }
+  };
+
   const withMainSessionStore = async <T>(run: (dir: string) => Promise<T>): Promise<T> => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {
@@ -544,7 +569,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.history rewrites transcript image blocks into renderable control ui sources", async () => {
-    const historyMessages = await loadChatHistoryWithMessages([
+    const historyMessages = await loadWebchatHistoryWithMessages([
       {
         role: "user",
         content: [
@@ -699,10 +724,12 @@ describe("gateway server chat", () => {
   });
 
   test("chat.history normalizes inline image media types through an allowlist", async () => {
-    const historyMessages = await loadChatHistoryWithMessages([
+    const historyMessages = await loadWebchatHistoryWithMessages([
       {
         role: "user",
         content: [
+          { type: "image", data: "apng123==", mimeType: "image/apng" },
+          { type: "image", data: "bmp123==", mimeType: "image/bmp" },
           { type: "image", data: "abc123==", mimeType: " IMAGE/JPEG " },
           { type: "image", data: "def456==", mimeType: "image/svg+xml" },
         ],
@@ -719,10 +746,20 @@ describe("gateway server chat", () => {
       | undefined;
     expect(firstMessage?.content?.[0]?.source).toEqual({
       type: "base64",
+      media_type: "image/apng",
+      data: "apng123==",
+    });
+    expect(firstMessage?.content?.[1]?.source).toEqual({
+      type: "base64",
+      media_type: "image/bmp",
+      data: "bmp123==",
+    });
+    expect(firstMessage?.content?.[2]?.source).toEqual({
+      type: "base64",
       media_type: "image/jpeg",
       data: "abc123==",
     });
-    expect(firstMessage?.content?.[1]?.source).toEqual({
+    expect(firstMessage?.content?.[3]?.source).toEqual({
       type: "base64",
       media_type: "image/png",
       data: "def456==",
@@ -730,7 +767,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.history omits oversized inline image payloads without replacing the full turn", async () => {
-    const historyMessages = await loadChatHistoryWithMessages([
+    const historyMessages = await loadWebchatHistoryWithMessages([
       {
         role: "user",
         content: [
@@ -769,7 +806,7 @@ describe("gateway server chat", () => {
   });
 
   test("chat.history enforces the inline image budget across the full message", async () => {
-    const historyMessages = await loadChatHistoryWithMessages([
+    const historyMessages = await loadWebchatHistoryWithMessages([
       {
         role: "user",
         content: [


### PR DESCRIPTION
## Summary

### Problem

Control UI shows pasted or uploaded chat images immediately after send, but they disappear once the UI reloads history from `chat.history`.

### Why it matters

The user turn was accepted and persisted, but the follow-up history view dropped the renderable image payload. That makes Control UI look like the upload never stuck.

### What changed

- Rewrote `chat.history` sanitization for transcript image blocks so persisted `{ type: "image", data, mimeType }` entries come back as `{ type: "image", source: { type: "base64", media_type, data } }`.
- Added a gateway regression test that loads a persisted transcript message with an image block and verifies history returns the renderable Control UI shape.

### What did NOT change

- No changes to the outbound `chat.send` attachment flow.
- No changes to Control UI rendering logic.
- No changes to audio history sanitization.

## Change Type

- Bug fix

## Scope

- Gateway `chat.history` sanitization
- Gateway regression coverage

## Linked Issue

Closes #70507

## User-visible / Behavior Changes

- User-uploaded images in Control UI chat history stay renderable after history reload instead of disappearing.

## Security Impact

- No new capability added.
- This keeps the already-persisted image payload renderable in Control UI history rather than replacing it with an omitted marker.

## Repro + Verification

### Environment

- Local branch based on `upstream/main` from April 22, 2026

### Steps

1. Persist a user transcript message containing a text block plus an image block in the transcript format produced by the agent session.
2. Request `chat.history`.

### Expected

- History should return the image block in the shape already rendered by Control UI.

### Actual before this change

- History stripped the top-level image `data` and replaced it with an omitted marker, so the Control UI renderer had nothing it could display.

## Evidence

- Added regression coverage in `src/gateway/server.chat.gateway-server-chat.test.ts`.
- `git diff --check` passes.
- Direct Vitest execution is blocked in this environment by the repo's existing `test/non-isolated-runner.ts` failure (`Class extends value undefined is not a constructor or null`), so I relied on focused code inspection plus the regression test addition and will let CI run the full gateway suite.
- Standalone `tsc` validation in this environment also hits unrelated pre-existing module resolution / union narrowing issues outside the touched lines.

## Human Verification

- Reviewed the Control UI renderer path and matched the returned history block shape to the existing `source.type === "base64"` rendering branch.

## Compatibility / Migration

- No migration required.

## Failure Recovery

- Revert this PR to restore the prior history sanitization behavior.

## Risks and Mitigations

- Risk: returning image payloads in history can increase message size.
- Mitigation: the existing chat history byte caps and final-budget enforcement remain unchanged.
