### PR TITLE
fix(ui): include cache tokens in contextPercent calculation

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -402,8 +402,11 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
     return null;
   }
 
+  const totalInput = input + cacheRead + cacheWrite;
   const contextPercent =
-    contextWindow && input > 0 ? Math.min(Math.round((input / contextWindow) * 100), 100) : null;
+    contextWindow && totalInput > 0
+      ? Math.min(Math.round((totalInput / contextWindow) * 100), 100)
+      : null;
 
   return { input, output, cacheRead, cacheWrite, cost, model, contextPercent };
 }


### PR DESCRIPTION
## Summary

`extractGroupMeta` in `ui/src/ui/chat/grouped-render.ts` computed `contextPercent` from fresh `input` tokens only, ignoring `cacheRead` + `cacheWrite`. With Anthropic prompt caching, most of the context window arrives as cached tokens, so `input` is routinely in the single digits while cached tokens make up the real load — the UI renders "0% ctx" even on near-full sessions.

## Fix

Use `input + cacheRead + cacheWrite` as the numerator. Matches the intent of the `ctx %` indicator (how full the context window is), and the values are already aggregated in the same function.

```ts
const totalInput = input + cacheRead + cacheWrite;
const contextPercent =
  contextWindow && totalInput > 0
    ? Math.min(Math.round((totalInput / contextWindow) * 100), 100)
    : null;
```

## Evidence

Live session (`agent:main:main`, 2026-04-23):
- `inputTokens`: 3
- `cacheWrite`: 93,056
- `contextTokens`: 200,000
- Before: renders `0%`
- After: renders `47%`

## Gates

- [x] `pnpm check:changed` (typecheck core + core-test, lint, import-cycles, webhook/pairing guards, 171 ui tests)
- [x] `pnpm build`
- [x] Committed via `scripts/committer`