### PR TITLE
fix(logging): tolerate malformed subsystem labels (#70502)

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -130,12 +130,27 @@ export function setConsoleTimestampPrefix(enabled: boolean): void {
   loggingState.consoleTimestampPrefix = enabled;
 }
 
-export function shouldLogSubsystemToConsole(subsystem: string): boolean {
+function normalizeConsoleSubsystem(subsystem?: string | null): string | null {
+  if (typeof subsystem !== "string") {
+    return null;
+  }
+  const normalized = subsystem.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function shouldLogSubsystemToConsole(subsystem?: string | null): boolean {
   const filter = loggingState.consoleSubsystemFilter;
   if (!filter || filter.length === 0) {
     return true;
   }
-  return filter.some((prefix) => subsystem === prefix || subsystem.startsWith(`${prefix}/`));
+  const normalizedSubsystem = normalizeConsoleSubsystem(subsystem);
+  if (!normalizedSubsystem) {
+    return false;
+  }
+  return filter.some(
+    (prefix) =>
+      normalizedSubsystem === prefix || normalizedSubsystem.startsWith(`${prefix}/`),
+  );
 }
 
 const SUPPRESSED_CONSOLE_PREFIXES = [

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setConsoleSubsystemFilter } from "./console.js";
+import { setConsoleSubsystemFilter, shouldLogSubsystemToConsole } from "./console.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -85,6 +85,32 @@ describe("createSubsystemLogger().isEnabled", () => {
 
     expect(log.isEnabled("info", "file")).toBe(true);
     expect(log.isEnabled("info")).toBe(true);
+  });
+
+  it("treats missing subsystem labels as non-matches when filters are active", () => {
+    setConsoleSubsystemFilter(["gateway"]);
+
+    expect(() => shouldLogSubsystemToConsole(undefined as unknown as string)).not.toThrow();
+    expect(shouldLogSubsystemToConsole(undefined as unknown as string)).toBe(false);
+  });
+
+  it("does not throw when a malformed subsystem logger checks console enablement", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    setConsoleSubsystemFilter(["gateway"]);
+    const log = createSubsystemLogger(undefined as unknown as string);
+
+    expect(() => log.isEnabled("info", "console")).not.toThrow();
+    expect(log.isEnabled("info", "console")).toBe(false);
+  });
+
+  it("falls back to an unknown subsystem label when a malformed logger emits", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = installConsoleMethodSpy("warn");
+    const log = createSubsystemLogger(undefined as unknown as string);
+
+    expect(() => log.warn("missing subsystem label")).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("[unknown]");
   });
 
   it("suppresses probe warnings for embedded subsystems based on structured run metadata", () => {

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -29,6 +29,14 @@ export type SubsystemLogger = {
   child: (name: string) => SubsystemLogger;
 };
 
+function normalizeSubsystemLabel(subsystem?: string | null): string {
+  if (typeof subsystem !== "string") {
+    return "unknown";
+  }
+  const normalized = subsystem.trim();
+  return normalized.length > 0 ? normalized : "unknown";
+}
+
 function shouldLogToConsole(level: LogLevel, settings: { level: LogLevel }): boolean {
   if (level === "silent") {
     return false;
@@ -259,8 +267,8 @@ function writeConsoleLine(level: LogLevel, line: string) {
 
 function shouldSuppressProbeConsoleLine(params: {
   level: LogLevel;
-  subsystem: string;
-  message: string;
+  subsystem?: string | null;
+  message?: string | null;
   meta?: Record<string, unknown>;
 }): boolean {
   if (isVerbose()) {
@@ -269,11 +277,13 @@ function shouldSuppressProbeConsoleLine(params: {
   if (params.level === "error" || params.level === "fatal") {
     return false;
   }
+  const subsystem = normalizeSubsystemLabel(params.subsystem);
+  const message = typeof params.message === "string" ? params.message : "";
   const isProbeSuppressedSubsystem =
-    params.subsystem === "agent/embedded" ||
-    params.subsystem.startsWith("agent/embedded/") ||
-    params.subsystem === "model-fallback" ||
-    params.subsystem.startsWith("model-fallback/");
+    subsystem === "agent/embedded" ||
+    subsystem.startsWith("agent/embedded/") ||
+    subsystem === "model-fallback" ||
+    subsystem.startsWith("model-fallback/");
   if (!isProbeSuppressedSubsystem) {
     return false;
   }
@@ -286,7 +296,7 @@ function shouldSuppressProbeConsoleLine(params: {
   if (runLikeId?.startsWith("probe-")) {
     return true;
   }
-  return /(sessionId|runId)=probe-/.test(params.message);
+  return /(sessionId|runId)=probe-/.test(message);
 }
 
 function logToFile(
@@ -313,13 +323,14 @@ function logToFile(
 }
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
+  const resolvedSubsystem = normalizeSubsystemLabel(subsystem);
   let fileLogger: TsLogger<LogObj> | null = null;
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
     const consoleEnabled =
       shouldLogToConsole(level, { level: consoleSettings.level }) &&
-      shouldLogSubsystemToConsole(subsystem);
+      shouldLogSubsystemToConsole(resolvedSubsystem);
     const fileEnabled = isFileLogLevelEnabled(level);
     if (!consoleEnabled && !fileEnabled) {
       return;
@@ -337,7 +348,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     }
     if (fileEnabled) {
       if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
+        fileLogger = getChildLogger({ subsystem: resolvedSubsystem });
       }
       logToFile(fileLogger, level, message, fileMeta);
     }
@@ -348,7 +359,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     if (
       shouldSuppressProbeConsoleLine({
         level,
-        subsystem,
+        subsystem: resolvedSubsystem,
         message: consoleMessage,
         meta: fileMeta,
       })
@@ -359,7 +370,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       level,
       formatConsoleLine({
         level,
-        subsystem,
+        subsystem: resolvedSubsystem,
         message: consoleSettings.style === "json" ? message : consoleMessage,
         style: consoleSettings.style,
         meta: fileMeta,
@@ -368,11 +379,11 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   };
 
   const logger: SubsystemLogger = {
-    subsystem,
+    subsystem: resolvedSubsystem,
     isEnabled(level, target = "any") {
       const isConsoleEnabled =
         shouldLogToConsole(level, { level: getConsoleSettings().level }) &&
-        shouldLogSubsystemToConsole(subsystem);
+        shouldLogSubsystemToConsole(resolvedSubsystem);
       const isFileEnabled = isFileLogLevelEnabled(level);
       if (target === "console") {
         return isConsoleEnabled;
@@ -403,22 +414,28 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
         if (!fileLogger) {
-          fileLogger = getChildLogger({ subsystem });
+          fileLogger = getChildLogger({ subsystem: resolvedSubsystem });
         }
         logToFile(fileLogger, "info", message, { raw: true });
       }
       if (
         shouldLogToConsole("info", { level: getConsoleSettings().level }) &&
-        shouldLogSubsystemToConsole(subsystem)
+        shouldLogSubsystemToConsole(resolvedSubsystem)
       ) {
-        if (shouldSuppressProbeConsoleLine({ level: "info", subsystem, message })) {
+        if (
+          shouldSuppressProbeConsoleLine({
+            level: "info",
+            subsystem: resolvedSubsystem,
+            message,
+          })
+        ) {
           return;
         }
         writeConsoleLine("info", message);
       }
     },
     child(name) {
-      return createSubsystemLogger(`${subsystem}/${name}`);
+      return createSubsystemLogger(`${resolvedSubsystem}/${name}`);
     },
   };
   return logger;

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -104,6 +104,7 @@ function collectExtensionCoreImportLeaks(): Array<{ file: string; specifier: str
     if (
       /(?:^|\/)(?:__tests__|tests|test-support)(?:\/|$)/.test(repoRelativePath) ||
       /(?:^|\/)test-support\.[cm]?tsx?$/.test(repoRelativePath) ||
+      /\.test-support\.[cm]?tsx?$/.test(repoRelativePath) ||
       /\.test\.[cm]?tsx?$/.test(repoRelativePath)
     ) {
       continue;


### PR DESCRIPTION
## Summary

- Problem: the logging console filter path assumed `subsystem` was always a string and could throw on `startsWith(...)` when a malformed log entry reached it.
- Why it matters: this shows up while the gateway is already in trouble, so a logging exception can turn one bad event into a repeated error loop.
- What changed: made the console subsystem filter null-safe, normalized malformed subsystem labels inside subsystem loggers, and added regression coverage for both the filter check and console emission paths.
- What did NOT change (scope boundary): this does not change normal subsystem filtering behavior for valid labels, and it does not change log-level policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70502
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: logging helpers called `startsWith(...)` on subsystem/message values that were typed as strings but could still be malformed at runtime during error handling.
- Missing detection / guardrail: there was no regression test for malformed subsystem labels under an active console filter or during console emission.
- Contributing context (if known): once the gateway enters an error path, logging code gets exercised repeatedly, so a small null-safety hole can keep the loop alive.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/logging/subsystem.test.ts`
- Scenario the test should lock in: missing subsystem labels do not throw when filters are active, `isEnabled()` stays safe, and console emission falls back to `[unknown]` instead of crashing.
- Why this is the smallest reliable guardrail: the failure is inside pure logging helpers, so a focused logging unit test catches it without needing a flaky gateway repro.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed subsystem labels no longer crash console logging. If one slips through, console output falls back to `[unknown]`.

## Diagram (if applicable)

```text
Before:
bad log entry -> subsystem filter/probe suppression -> startsWith on undefined -> logging crash

After:
bad log entry -> subsystem normalized/guarded -> console logging continues -> gateway stays up
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local focused validation)
- Runtime/container: repo unit-fast Vitest harness
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): console subsystem filter enabled

### Steps

1. Enable a console subsystem filter.
2. Route a malformed or missing subsystem label through subsystem logging.
3. Check whether the logging helper throws or safely ignores/emits the line.

### Expected

- Logging should not throw. Filter checks should treat missing subsystem labels as non-matches, and console output should stay stable.

### Actual

- Before this patch, a malformed subsystem label could hit `startsWith(...)` and crash inside the logging path.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation:

- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-70502-vitest-include.json pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts`
- Passed:
  - `src/logging/subsystem.test.ts`

Issue evidence:

- Reported repeated gateway failure: `TypeError: Cannot read properties of undefined (reading 'startsWith')`

## Human Verification (required)

- Verified scenarios: exercised filter checks and subsystem logger emission with malformed subsystem labels; both paths now stay non-throwing.
- Edge cases checked: active console filter, `isEnabled(..., "console")`, and warn-level console emission with a missing subsystem label.
- What you did **not** verify: I did not reproduce the original long-running gateway failure loop end to end, and I did not run the full repo test suite in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: malformed subsystem labels now render as `[unknown]`, which is less specific than a real label.
  - Mitigation: the fallback is only used for invalid input, and it keeps the logging path alive instead of crashing.
