### PR TITLE
fix(runtime-deps): repair bundled deps before startup (#70521)

### DIFF
--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callOrder: string[] = [];
+
+const maybeRepairBundledPluginRuntimeDeps = vi.fn(async () => {
+  callOrder.push("repair");
+});
+const loadAndMaybeMigrateDoctorConfig = vi.fn(async () => {
+  callOrder.push("config");
+  return {
+    cfg: {},
+    path: "/tmp/openclaw.json",
+    sourceConfigValid: true,
+  };
+});
+
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+}));
+
+vi.mock("../commands/doctor-prompter.js", () => ({
+  createDoctorPrompter: vi.fn(() => ({
+    confirm: vi.fn(async () => true),
+    confirmAutoFix: vi.fn(async () => true),
+    confirmAggressiveAutoFix: vi.fn(async () => true),
+    confirmRuntimeRepair: vi.fn(async () => true),
+    select: vi.fn(async (_params: unknown, fallback: unknown) => fallback),
+    shouldRepair: true,
+    shouldForce: false,
+    repairMode: {
+      shouldRepair: true,
+      shouldForce: false,
+      nonInteractive: false,
+      canPrompt: false,
+    },
+  })),
+}));
+
+vi.mock("../commands/onboard-helpers.js", () => ({
+  printWizardHeader: vi.fn(),
+}));
+
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: vi.fn(async () => "/tmp/openclaw"),
+}));
+
+vi.mock("../commands/doctor-update.js", () => ({
+  maybeOfferUpdateBeforeDoctor: vi.fn(async () => ({ handled: false })),
+}));
+
+vi.mock("../commands/doctor-ui.js", () => ({
+  maybeRepairUiProtocolFreshness: vi.fn(async () => {}),
+}));
+
+vi.mock("../commands/doctor-install.js", () => ({
+  noteSourceInstallIssues: vi.fn(),
+}));
+
+vi.mock("../commands/doctor-platform-notes.js", () => ({
+  noteStartupOptimizationHints: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  CONFIG_PATH: "/tmp/openclaw.json",
+  readConfigFileSnapshot: vi.fn(async () => ({
+    config: {
+      channels: {
+        feishu: {
+          appId: "app-123",
+        },
+      },
+    },
+  })),
+}));
+
+vi.mock("../commands/doctor-bundled-plugin-runtime-deps.js", () => ({
+  maybeRepairBundledPluginRuntimeDeps,
+}));
+
+vi.mock("../commands/doctor-config-flow.js", () => ({
+  loadAndMaybeMigrateDoctorConfig,
+}));
+
+vi.mock("./doctor-health-contributions.js", () => ({
+  runDoctorHealthContributions: vi.fn(async () => {}),
+}));
+
+describe("doctor command bundled runtime deps preflight", () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    maybeRepairBundledPluginRuntimeDeps.mockClear();
+    loadAndMaybeMigrateDoctorConfig.mockClear();
+  });
+
+  it("repairs bundled runtime deps before doctor config loading", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const { doctorCommand } = await import("./doctor-health.js");
+
+    await doctorCommand(runtime, { nonInteractive: true });
+
+    expect(callOrder.slice(0, 2)).toEqual(["repair", "config"]);
+    expect(maybeRepairBundledPluginRuntimeDeps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime,
+        packageRoot: "/tmp/openclaw",
+        includeConfiguredChannels: true,
+        config: expect.objectContaining({
+          channels: expect.objectContaining({
+            feishu: expect.objectContaining({
+              appId: "app-123",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -40,6 +40,19 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   noteSourceInstallIssues(root);
   noteStartupOptimizationHints();
 
+  const { readConfigFileSnapshot } = await import("../config/config.js");
+  const { maybeRepairBundledPluginRuntimeDeps } = await import(
+    "../commands/doctor-bundled-plugin-runtime-deps.js"
+  );
+  const configSnapshot = await readConfigFileSnapshot();
+  await maybeRepairBundledPluginRuntimeDeps({
+    runtime: effectiveRuntime,
+    prompter,
+    config: configSnapshot.config,
+    packageRoot: root,
+    includeConfiguredChannels: true,
+  });
+
   const { loadAndMaybeMigrateDoctorConfig } = await import("../commands/doctor-config-flow.js");
   const configResult = await loadAndMaybeMigrateDoctorConfig({
     options,

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -221,4 +221,87 @@ describe("gateway startup plugin bootstrap", () => {
       env: process.env,
     });
   });
+
+  it("warns and continues when bundled runtime dep scan fails during startup preflight", async () => {
+    scanBundledPluginRuntimeDeps.mockImplementation(() => {
+      throw new Error("unsupported spec");
+    });
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    await prepareGatewayPluginBootstrap({
+      cfgAtStart: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      startupRuntimeConfig: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "gateway: unable to scan bundled plugin runtime deps during startup preflight; continuing without repair",
+      ),
+    );
+    expect(callOrder).toContain("maintenance");
+    expect(callOrder).toContain("migration");
+    expect(callOrder).toContain("plugins");
+    expect(installBundledRuntimeDeps).not.toHaveBeenCalled();
+  });
+
+  it("warns and continues when bundled runtime dep install fails during startup preflight", async () => {
+    installBundledRuntimeDeps.mockImplementation(() => {
+      throw new Error("unwritable stage dir");
+    });
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    await prepareGatewayPluginBootstrap({
+      cfgAtStart: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      startupRuntimeConfig: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "gateway: unable to install bundled plugin runtime deps during startup preflight; continuing without repair",
+      ),
+    );
+    expect(callOrder).toContain("maintenance");
+    expect(callOrder).toContain("migration");
+    expect(callOrder).toContain("plugins");
+  });
 });

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callOrder: string[] = [];
+
+const installBundledRuntimeDeps = vi.fn(() => {
+  callOrder.push("repair");
+});
+const runChannelPluginStartupMaintenance = vi.fn(async () => {
+  callOrder.push("maintenance");
+});
+const runStartupSessionMigration = vi.fn(async () => {
+  callOrder.push("migration");
+});
+const loadGatewayStartupPlugins = vi.fn(() => {
+  callOrder.push("plugins");
+  return {
+    pluginRegistry: { diagnostics: [] },
+    gatewayMethods: ["chat.send"],
+  };
+});
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+}));
+
+vi.mock("../agents/subagent-registry.js", () => ({
+  initSubagentRegistry: vi.fn(() => {
+    callOrder.push("init");
+  }),
+}));
+
+vi.mock("../channels/plugins/lifecycle-startup.js", () => ({
+  runChannelPluginStartupMaintenance,
+}));
+
+vi.mock("../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: vi.fn(({ config }) => ({ config, changes: [] })),
+}));
+
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRootSync: vi.fn(() => "/opt/openclaw"),
+}));
+
+vi.mock("../plugins/bundled-runtime-deps.js", () => ({
+  installBundledRuntimeDeps,
+  resolveBundledRuntimeDependencyPackageInstallRoot: vi.fn(() => "/opt/openclaw"),
+  scanBundledPluginRuntimeDeps: vi.fn(() => ({
+    deps: [
+      {
+        name: "@larksuiteoapi/node-sdk",
+        version: "1.41.0",
+        pluginIds: ["feishu"],
+      },
+    ],
+    missing: [
+      {
+        name: "@larksuiteoapi/node-sdk",
+        version: "1.41.0",
+        pluginIds: ["feishu"],
+      },
+    ],
+    conflicts: [],
+  })),
+}));
+
+vi.mock("../plugins/channel-plugin-ids.js", () => ({
+  resolveConfiguredDeferredChannelPluginIds: vi.fn(() => []),
+  resolveGatewayStartupPluginIds: vi.fn(() => ["feishu"]),
+}));
+
+vi.mock("../plugins/registry.js", () => ({
+  createEmptyPluginRegistry: vi.fn(() => ({ diagnostics: [] })),
+}));
+
+vi.mock("../plugins/runtime.js", () => ({
+  getActivePluginRegistry: vi.fn(() => null),
+  setActivePluginRegistry: vi.fn(),
+}));
+
+vi.mock("./server-methods-list.js", () => ({
+  listGatewayMethods: vi.fn(() => ["chat.send"]),
+}));
+
+vi.mock("./server-methods.js", () => ({
+  coreGatewayHandlers: {},
+}));
+
+vi.mock("./server-plugin-bootstrap.js", () => ({
+  loadGatewayStartupPlugins,
+}));
+
+vi.mock("./server-startup-session-migration.js", () => ({
+  runStartupSessionMigration,
+}));
+
+describe("gateway startup plugin bootstrap", () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    installBundledRuntimeDeps.mockClear();
+    runChannelPluginStartupMaintenance.mockClear();
+    runStartupSessionMigration.mockClear();
+    loadGatewayStartupPlugins.mockClear();
+  });
+
+  it("repairs bundled runtime deps before startup plugin maintenance and loading", async () => {
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    await prepareGatewayPluginBootstrap({
+      cfgAtStart: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      startupRuntimeConfig: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+        },
+      },
+      minimalTestGateway: false,
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+
+    expect(callOrder).toContain("repair");
+    expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("maintenance"));
+    expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("migration"));
+    expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("plugins"));
+    expect(installBundledRuntimeDeps).toHaveBeenCalledWith({
+      installRoot: "/opt/openclaw",
+      missingSpecs: ["@larksuiteoapi/node-sdk@1.41.0"],
+      env: process.env,
+    });
+  });
+});

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -5,6 +5,23 @@ const callOrder: string[] = [];
 const installBundledRuntimeDeps = vi.fn(() => {
   callOrder.push("repair");
 });
+const scanBundledPluginRuntimeDeps = vi.fn(() => ({
+  deps: [
+    {
+      name: "@larksuiteoapi/node-sdk",
+      version: "1.41.0",
+      pluginIds: ["feishu"],
+    },
+  ],
+  missing: [
+    {
+      name: "@larksuiteoapi/node-sdk",
+      version: "1.41.0",
+      pluginIds: ["feishu"],
+    },
+  ],
+  conflicts: [],
+}));
 const runChannelPluginStartupMaintenance = vi.fn(async () => {
   callOrder.push("maintenance");
 });
@@ -45,23 +62,7 @@ vi.mock("../infra/openclaw-root.js", () => ({
 vi.mock("../plugins/bundled-runtime-deps.js", () => ({
   installBundledRuntimeDeps,
   resolveBundledRuntimeDependencyPackageInstallRoot: vi.fn(() => "/opt/openclaw"),
-  scanBundledPluginRuntimeDeps: vi.fn(() => ({
-    deps: [
-      {
-        name: "@larksuiteoapi/node-sdk",
-        version: "1.41.0",
-        pluginIds: ["feishu"],
-      },
-    ],
-    missing: [
-      {
-        name: "@larksuiteoapi/node-sdk",
-        version: "1.41.0",
-        pluginIds: ["feishu"],
-      },
-    ],
-    conflicts: [],
-  })),
+  scanBundledPluginRuntimeDeps,
 }));
 
 vi.mock("../plugins/channel-plugin-ids.js", () => ({
@@ -98,6 +99,24 @@ describe("gateway startup plugin bootstrap", () => {
   beforeEach(() => {
     callOrder.length = 0;
     installBundledRuntimeDeps.mockClear();
+    scanBundledPluginRuntimeDeps.mockReset();
+    scanBundledPluginRuntimeDeps.mockReturnValue({
+      deps: [
+        {
+          name: "@larksuiteoapi/node-sdk",
+          version: "1.41.0",
+          pluginIds: ["feishu"],
+        },
+      ],
+      missing: [
+        {
+          name: "@larksuiteoapi/node-sdk",
+          version: "1.41.0",
+          pluginIds: ["feishu"],
+        },
+      ],
+      conflicts: [],
+    });
     runChannelPluginStartupMaintenance.mockClear();
     runStartupSessionMigration.mockClear();
     loadGatewayStartupPlugins.mockClear();
@@ -134,6 +153,68 @@ describe("gateway startup plugin bootstrap", () => {
     expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("maintenance"));
     expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("migration"));
     expect(callOrder.indexOf("repair")).toBeLessThan(callOrder.indexOf("plugins"));
+    expect(installBundledRuntimeDeps).toHaveBeenCalledWith({
+      installRoot: "/opt/openclaw",
+      missingSpecs: ["@larksuiteoapi/node-sdk@1.41.0"],
+      env: process.env,
+    });
+  });
+
+  it("installs only the missing bundled runtime deps during gateway startup preflight", async () => {
+    scanBundledPluginRuntimeDeps.mockReturnValue({
+      deps: [
+        {
+          name: "@larksuiteoapi/node-sdk",
+          version: "1.41.0",
+          pluginIds: ["feishu"],
+        },
+        {
+          name: "@slack/web-api",
+          version: "7.11.0",
+          pluginIds: ["slack"],
+        },
+      ],
+      missing: [
+        {
+          name: "@larksuiteoapi/node-sdk",
+          version: "1.41.0",
+          pluginIds: ["feishu"],
+        },
+      ],
+      conflicts: [],
+    });
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    await prepareGatewayPluginBootstrap({
+      cfgAtStart: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+          slack: {
+            botToken: "xoxb-test",
+          },
+        },
+      },
+      startupRuntimeConfig: {
+        channels: {
+          feishu: {
+            appId: "cli-app",
+          },
+          slack: {
+            botToken: "xoxb-test",
+          },
+        },
+      },
+      minimalTestGateway: false,
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+
     expect(installBundledRuntimeDeps).toHaveBeenCalledWith({
       installRoot: "/opt/openclaw",
       missingSpecs: ["@larksuiteoapi/node-sdk@1.41.0"],

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -32,7 +32,11 @@ async function maybeRepairBundledPluginRuntimeDepsForGatewayStartup(params: {
   env?: NodeJS.ProcessEnv;
   log: GatewayPluginBootstrapLog;
   packageRoot?: string | null;
-  installDeps?: (params: { installRoot: string; missingSpecs: string[]; installSpecs: string[] }) => void;
+  installDeps?: (params: {
+    installRoot: string;
+    missingSpecs: string[];
+    installSpecs: string[];
+  }) => void;
 }) {
   const env = params.env ?? process.env;
   const packageRoot =
@@ -46,12 +50,22 @@ async function maybeRepairBundledPluginRuntimeDepsForGatewayStartup(params: {
     return;
   }
 
-  const { deps, missing, conflicts } = scanBundledPluginRuntimeDeps({
-    packageRoot,
-    config: params.cfg,
-    includeConfiguredChannels: true,
-    env,
-  });
+  let deps: { name: string; version: string }[] = [];
+  let missing: { name: string; version: string }[] = [];
+  let conflicts: { name: string }[] = [];
+  try {
+    ({ deps, missing, conflicts } = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: params.cfg,
+      includeConfiguredChannels: true,
+      env,
+    }));
+  } catch (error) {
+    params.log.warn(
+      `gateway: unable to scan bundled plugin runtime deps during startup preflight; continuing without repair (${String(error)})`,
+    );
+    return;
+  }
   if (conflicts.length > 0) {
     params.log.warn(
       `gateway: bundled plugin runtime deps have version conflicts; skipping preflight repair for ${conflicts.map((conflict) => conflict.name).join(", ")}`,
@@ -75,7 +89,13 @@ async function maybeRepairBundledPluginRuntimeDepsForGatewayStartup(params: {
         missingSpecs: installParams.missingSpecs,
         env,
       }));
-  install({ installRoot, missingSpecs, installSpecs });
+  try {
+    install({ installRoot, missingSpecs, installSpecs });
+  } catch (error) {
+    params.log.warn(
+      `gateway: unable to install bundled plugin runtime deps during startup preflight; continuing without repair (${String(error)})`,
+    );
+  }
 }
 
 export async function prepareGatewayPluginBootstrap(params: {

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -3,6 +3,12 @@ import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { runChannelPluginStartupMaintenance } from "../channels/plugins/lifecycle-startup.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import {
+  installBundledRuntimeDeps,
+  resolveBundledRuntimeDependencyPackageInstallRoot,
+  scanBundledPluginRuntimeDeps,
+} from "../plugins/bundled-runtime-deps.js";
 import {
   resolveConfiguredDeferredChannelPluginIds,
   resolveGatewayStartupPluginIds,
@@ -21,6 +27,57 @@ type GatewayPluginBootstrapLog = {
   debug: (message: string) => void;
 };
 
+async function maybeRepairBundledPluginRuntimeDepsForGatewayStartup(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  log: GatewayPluginBootstrapLog;
+  packageRoot?: string | null;
+  installDeps?: (params: { installRoot: string; missingSpecs: string[]; installSpecs: string[] }) => void;
+}) {
+  const env = params.env ?? process.env;
+  const packageRoot =
+    params.packageRoot ??
+    resolveOpenClawPackageRootSync({
+      argv1: process.argv[1],
+      cwd: process.cwd(),
+      moduleUrl: import.meta.url,
+    });
+  if (!packageRoot) {
+    return;
+  }
+
+  const { deps, missing, conflicts } = scanBundledPluginRuntimeDeps({
+    packageRoot,
+    config: params.cfg,
+    includeConfiguredChannels: true,
+    env,
+  });
+  if (conflicts.length > 0) {
+    params.log.warn(
+      `gateway: bundled plugin runtime deps have version conflicts; skipping preflight repair for ${conflicts.map((conflict) => conflict.name).join(", ")}`,
+    );
+  }
+  if (missing.length === 0) {
+    return;
+  }
+
+  const installRoot = resolveBundledRuntimeDependencyPackageInstallRoot(packageRoot, { env });
+  const missingSpecs = missing.map((dep) => `${dep.name}@${dep.version}`);
+  const installSpecs = deps.map((dep) => `${dep.name}@${dep.version}`);
+  params.log.info(
+    `gateway: installing missing bundled plugin runtime deps before startup: ${missingSpecs.join(", ")}`,
+  );
+  const install =
+    params.installDeps ??
+    ((installParams) =>
+      installBundledRuntimeDeps({
+        installRoot: installParams.installRoot,
+        missingSpecs: installParams.installSpecs,
+        env,
+      }));
+  install({ installRoot, missingSpecs, installSpecs });
+}
+
 export async function prepareGatewayPluginBootstrap(params: {
   cfgAtStart: OpenClawConfig;
   startupRuntimeConfig: OpenClawConfig;
@@ -36,6 +93,10 @@ export async function prepareGatewayPluginBootstrap(params: {
       : params.cfgAtStart;
 
   if (!params.minimalTestGateway) {
+    await maybeRepairBundledPluginRuntimeDepsForGatewayStartup({
+      cfg: startupMaintenanceConfig,
+      log: params.log,
+    });
     await Promise.all([
       runChannelPluginStartupMaintenance({
         cfg: startupMaintenanceConfig,

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -72,7 +72,7 @@ async function maybeRepairBundledPluginRuntimeDepsForGatewayStartup(params: {
     ((installParams) =>
       installBundledRuntimeDeps({
         installRoot: installParams.installRoot,
-        missingSpecs: installParams.installSpecs,
+        missingSpecs: installParams.missingSpecs,
         env,
       }));
   install({ installRoot, missingSpecs, installSpecs });

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -104,6 +104,7 @@ function collectExtensionCoreImportLeaks(): Array<{ file: string; specifier: str
     if (
       /(?:^|\/)(?:__tests__|tests|test-support)(?:\/|$)/.test(repoRelativePath) ||
       /(?:^|\/)test-support\.[cm]?tsx?$/.test(repoRelativePath) ||
+      /\.test-support\.[cm]?tsx?$/.test(repoRelativePath) ||
       /\.test\.[cm]?tsx?$/.test(repoRelativePath)
     ) {
       continue;


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor --fix` and gateway startup could both fail before bundled plugin runtime deps were repaired, so a missing staged dep like `@larksuiteoapi/node-sdk` could brick the recovery path.
- Why it matters: once config loading touches a bundled plugin that needs a missing staged dep, the process fails before the existing repair logic gets a chance to run.
- What changed: added a bundled-runtime-deps preflight before doctor config loading, and added the same kind of preflight before gateway startup maintenance/plugin bootstrap.
- What did NOT change (scope boundary): this does not change how bundled runtime deps are scanned or installed, and it does not add any new config knobs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70521
- Related #70339
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the repair path for staged bundled runtime deps ran after doctor config loading and after gateway startup had already moved into plugin/bootstrap work, so missing deps could break startup before repair was attempted.
- Missing detection / guardrail: there was no regression coverage locking in "repair missing bundled runtime deps before config/bootstrap touches configured channel modules."
- Contributing context (if known): this shows up after upgrades where bundled staged deps are missing but the config still enables the affected channel.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/flows/doctor-health.test.ts`, `src/gateway/server-startup-plugins.test.ts`
- Scenario the test should lock in: doctor and gateway startup both repair missing bundled runtime deps before config loading or startup maintenance proceeds.
- Why this is the smallest reliable guardrail: the bug is about call ordering, and these tests pin that ordering directly without needing a full upgrade/install harness.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw doctor --fix` can now repair missing bundled plugin runtime deps before config loading trips over them, and normal gateway startup gets the same preflight repair path.

## Diagram (if applicable)

```text
Before:
doctor/gateway startup -> config/plugin load touches missing dep -> crash before repair

After:
doctor/gateway startup -> bundled runtime deps preflight -> missing dep installed -> config/plugin load continues
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: gateway startup now reuses the existing bundled runtime dep installer earlier in startup, but only after the scan finds missing staged deps for configured channels. The installer path and package-root detection are unchanged.

## Repro + Verification

### Environment

- OS: macOS (local focused validation)
- Runtime/container: repo unit-fast Vitest harness
- Model/provider: N/A
- Integration/channel (if any): bundled channel deps, including the feishu-style staged runtime dep case from the report
- Relevant config (redacted): configured channel with bundled staged runtime deps enabled

### Steps

1. Start from a config that enables a bundled channel whose staged runtime dep is missing after upgrade.
2. Run `openclaw doctor --fix`, or start the gateway.
3. Observe whether repair runs before config/plugin startup reaches the missing module.

### Expected

- Repair runs first, installs any missing bundled staged runtime deps, then doctor/gateway continues.

### Actual

- Before this patch, config/plugin loading could fail first with `Cannot find module ...`, so the repair path never ran.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation:

- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-70521-vitest-include.json pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts`
- Passed:
  - `src/flows/doctor-health.test.ts`
  - `src/gateway/server-startup-plugins.test.ts`

Issue evidence:

- Reported failure during doctor config loading: `Cannot find module '@larksuiteoapi/node-sdk'`

## Human Verification (required)

- Verified scenarios: confirmed both doctor flow and gateway startup run the bundled-runtime-deps repair path before the later config/bootstrap steps touched by the issue.
- Edge cases checked: no-op when package root is unavailable, no-op when nothing is missing, warning path when version conflicts are detected, and minimal-test gateway mode still skips the startup preflight.
- What you did **not** verify: I did not run a full global-upgrade repro with a real missing feishu install, and I did not run the full repo test suite in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: gateway startup may spend extra time on the preflight when bundled deps are actually missing.
  - Mitigation: the scan runs first and the install path is only taken when missing deps are detected.
- Risk: conflicting bundled dep versions are still a messy startup state.
  - Mitigation: the preflight warns on conflicts and otherwise leaves the existing install logic untouched.
