### PR TITLE
fix(doctor): preflight bundled runtime dep repair before config loading

### DIFF
--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -36,9 +36,22 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   const { maybeRepairUiProtocolFreshness } = await import("../commands/doctor-ui.js");
   const { noteSourceInstallIssues } = await import("../commands/doctor-install.js");
   const { noteStartupOptimizationHints } = await import("../commands/doctor-platform-notes.js");
+  const { maybeRepairBundledPluginRuntimeDeps } =
+    await import("../commands/doctor-bundled-plugin-runtime-deps.js");
   await maybeRepairUiProtocolFreshness(effectiveRuntime, prompter);
   noteSourceInstallIssues(root);
   noteStartupOptimizationHints();
+
+  // Preflight: install missing bundled plugin runtime deps BEFORE loading config.
+  // Config loading may trigger plugin source code (e.g. feishu client) which requires
+  // these deps to be present. Without this preflight, `openclaw doctor --fix` enters
+  // a chicken-and-egg loop where config loading fails before the repair can run.
+  // See: https://github.com/openclaw/openclaw/issues/70521
+  await maybeRepairBundledPluginRuntimeDeps({
+    runtime: effectiveRuntime,
+    prompter,
+    packageRoot: root,
+  });
 
   const { loadAndMaybeMigrateDoctorConfig } = await import("../commands/doctor-config-flow.js");
   const configResult = await loadAndMaybeMigrateDoctorConfig({


### PR DESCRIPTION
## Summary

- Add a preflight step to install missing bundled plugin runtime deps **before** config loading in `openclaw doctor`
- Fixes a chicken-and-egg bug where `openclaw doctor --fix` cannot repair missing deps because config loading crashes first

## Problem

After upgrading OpenClaw (e.g. 2026.4.12 → 2026.4.21), bundled plugin staged runtime dependencies such as `@larksuiteoapi/node-sdk` (feishu plugin) may be missing. The existing repair runs inside `loadAndMaybeMigrateDoctorConfig`, but config loading itself triggers plugin source code via jiti (e.g. `feishu/client.js` → `import * as Lark from "@larksuiteoapi/node-sdk"`), which throws `MODULE_NOT_FOUND` before the repair is ever reached.

Result: `openclaw doctor --fix` prints "Config invalid; doctor will run with best-effort config" and never installs the missing deps.

## Fix

Move `maybeRepairBundledPluginRuntimeDeps` to a preflight step in `doctorCommand()` that runs **before** `loadAndMaybeMigrateDoctorConfig()`. The repair function (`scanBundledPluginRuntimeDeps`) only needs the package root and reads `package.json` files from the filesystem — it does **not** depend on config, making it safe to run early.

The existing health contribution (`doctor:bundled-plugin-runtime-deps`) and the call inside `loadAndMaybeMigrateDoctorConfig` remain in place for config-aware checks (e.g. `includeConfiguredChannels`).

## Testing

- Existing e2e test harness already mocks `maybeRepairBundledPluginRuntimeDeps` and will validate the call pattern
- Manual verification: after removing `@larksuiteoapi/node-sdk`, `openclaw doctor --fix` now installs it before attempting config loading

Closes: #70521