### PR TITLE
Fix memory_search failures from corrupted singleton cache state

### DIFF
--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -22,6 +22,7 @@ export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
   };
+  console.warn("[memory-core] managed cache had invalid shape; rebuilding shared store");
   (globalThis as Record<symbol, unknown>)[cacheKey] = repaired;
   return repaired;
 }

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -10,10 +10,20 @@ export type ManagedCache<T> = {
 };
 
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
-  return resolveGlobalSingleton<ManagedCache<T>>(cacheKey, () => ({
+  const existing = resolveGlobalSingleton<ManagedCache<T>>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
   }));
+  if (existing.cache instanceof Map && existing.pending instanceof Map) {
+    return existing;
+  }
+  const repaired: ManagedCache<T> = {
+    ...(existing && typeof existing === "object" ? existing : {}),
+    cache: new Map<string, T>(),
+    pending: new Map<string, Promise<T>>(),
+  };
+  (globalThis as Record<symbol, unknown>)[cacheKey] = repaired;
+  return repaired;
 }
 
 export async function getOrCreateManagedCacheEntry<T>(params: {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -44,13 +44,27 @@ type MemorySearchManagerCacheStore = {
 
 function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   // Keep caches reachable across `vi.resetModules()` so later cleanup can close older instances.
-  return resolveGlobalSingleton<MemorySearchManagerCacheStore>(
+  const existing = resolveGlobalSingleton<MemorySearchManagerCacheStore>(
     MEMORY_SEARCH_MANAGER_CACHE_KEY,
     () => ({
       qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
       pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
     }),
   );
+  if (
+    existing.qmdManagerCache instanceof Map &&
+    existing.pendingQmdManagerCreates instanceof Map
+  ) {
+    return existing;
+  }
+  const repaired: MemorySearchManagerCacheStore = {
+    ...(existing && typeof existing === "object" ? existing : {}),
+    qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
+    pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
+  };
+  log.warn("memory search manager cache had invalid shape; rebuilding shared store");
+  (globalThis as Record<symbol, unknown>)[MEMORY_SEARCH_MANAGER_CACHE_KEY] = repaired;
+  return repaired;
 }
 
 const log = createSubsystemLogger("memory");


### PR DESCRIPTION
Closes #70527

## Summary
- validate the shared singleton store used by memory search manager caching
- rebuild corrupted singleton cache objects instead of crashing on undefined `.get(...)` access
- apply the same repair logic to the shared managed cache helper used by memory index managers

## Why
A corrupted global singleton cache shape can cause `memory_search` to fail with `Cannot read properties of undefined (reading 'get')`. In the current runtime this gets surfaced as an embedding/provider error, even though the actual failure is shared cache state corruption in a long-lived process.

This change makes the cache access path defensive so the runtime can recover by rebuilding the shared store instead of crashing.