### PR TITLE
fix(loop-detection): escalate generic_repeat to critical at criticalThreshold

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -317,7 +317,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("escalates generic loops to critical at criticalThreshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -327,7 +327,24 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.message).toContain("CRITICAL");
+      }
+    });
+
+    it("keeps generic loops at warning between warningThreshold and criticalThreshold", () => {
+      const fixture = createReadNoProgressFixture();
+      const loopResult = detectLoopAfterRepeatedCalls({
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: CRITICAL_THRESHOLD - 1,
+      });
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
         expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -538,10 +538,28 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: escalate from warning to critical for repeated identical calls.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(
+      `Critical generic loop detected: ${toolName} called ${recentCount} times with identical arguments`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `CRITICAL: You have called ${toolName} ${recentCount} times with identical arguments and no progress. Session execution blocked to prevent runaway loops. Stop retrying and answer without this tool.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&


### PR DESCRIPTION
## Problem

The `generic_repeat` detector in `tool-loop-detection.ts` only ever returns `level: "warning"`, meaning it can never block execution — even when a tool has been called 20+ times with identical arguments and zero progress.

Every other detector (`known_poll_no_progress`, `ping_pong`, `global_circuit_breaker`, `unknown_tool_repeat`) properly escalates to `level: "critical"` at the configured `criticalThreshold`, which triggers the blocking path in `pi-tools.before-tool-call.ts` (line ~149):

```ts
if (loopResult.level === "critical") {
  return { blocked: true, reason: loopResult.message };
}
```

But `generic_repeat` only checks against `warningThreshold` and always returns `level: "warning"`. The `criticalThreshold` config value exists and is read — it's just never compared against.

## Impact

Sessions can loop 20+ times with identical tool calls (same tool, same arguments) without being blocked. The only backstop is the `global_circuit_breaker` at 30 calls — but that requires matching result hashes too, so it may never fire if the tool returns slightly different error messages each time.

This is a reliability and cost issue: runaway loops burn tokens and API calls for no progress.

## Fix

Add a critical escalation branch to `generic_repeat` that fires when `recentCount >= resolvedConfig.criticalThreshold` (default 20), returning `level: "critical"` to block execution. The existing warning at `warningThreshold` (default 10) is unchanged.

The check order is: critical first, then warning — matching the pattern used by `known_poll_no_progress` and `ping_pong`.

## Tests

- **New:** `escalates generic loops to critical at criticalThreshold` — verifies `level: "critical"` and `detector: "generic_repeat"` at exactly `CRITICAL_THRESHOLD` (20) calls
- **New:** `keeps generic loops at warning between warningThreshold and criticalThreshold` — verifies `level: "warning"` at `CRITICAL_THRESHOLD - 1` (19) calls
- All 32 tests pass (run via `vitest.unit-fast.config.ts`)

## Changes

- `src/agents/tool-loop-detection.ts`: +13 lines (critical branch before warning branch)
- `src/agents/tool-loop-detection.test.ts`: +17 lines (split old test into two, added critical test)

Closes #70546