### PR TITLE
Measure Telegram QA reply RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- QA/Telegram: record per-scenario reply RTT in the live Telegram QA report and summary, starting with the canary response.
+- QA/Telegram: record per-scenario reply RTT in the live Telegram QA report and summary, starting with the canary response. (#70550) Thanks @obviyus.
 - Providers/xAI: add image generation, text-to-speech, and speech-to-text support, including `grok-imagine-image` / `grok-imagine-image-pro`, reference-image edits, six live xAI voices, MP3/WAV/PCM/G.711 TTS formats, `grok-stt` audio transcription, and xAI realtime transcription for Voice Call streaming. (#68694) Thanks @KateWilkins.
 - Providers/STT: add Voice Call streaming transcription for Deepgram, ElevenLabs, and Mistral, alongside the existing OpenAI and xAI realtime STT paths; ElevenLabs also gains Scribe v2 batch audio transcription for inbound media.
 - TUI: add local embedded mode for running terminal chats without a Gateway while keeping plugin approval gates enforced. (#66767) Thanks @fuller-stack-dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- QA/Telegram: record per-scenario reply RTT in the live Telegram QA report and summary, starting with the canary response.
 - Providers/xAI: add image generation, text-to-speech, and speech-to-text support, including `grok-imagine-image` / `grok-imagine-image-pro`, reference-image edits, six live xAI voices, MP3/WAV/PCM/G.711 TTS formats, `grok-stt` audio transcription, and xAI realtime transcription for Voice Call streaming. (#68694) Thanks @KateWilkins.
 - Providers/STT: add Voice Call streaming transcription for Deepgram, ElevenLabs, and Mistral, alongside the existing OpenAI and xAI realtime STT paths; ElevenLabs also gains Scribe v2 batch audio transcription for inbound media.
 - TUI: add local embedded mode for running terminal chats without a Gateway while keeping plugin approval gates enforced. (#66767) Thanks @fuller-stack-dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- QA/Telegram: record per-scenario reply RTT in the live Telegram QA report and summary, starting with the canary response. (#70550) Thanks @obviyus.
 - Providers/xAI: add image generation, text-to-speech, and speech-to-text support, including `grok-imagine-image` / `grok-imagine-image-pro`, reference-image edits, six live xAI voices, MP3/WAV/PCM/G.711 TTS formats, `grok-stt` audio transcription, and xAI realtime transcription for Voice Call streaming. (#68694) Thanks @KateWilkins.
 - Providers/STT: add Voice Call streaming transcription for Deepgram, ElevenLabs, and Mistral, alongside the existing OpenAI and xAI realtime STT paths; ElevenLabs also gains Scribe v2 batch audio transcription for inbound media.
 - TUI: add local embedded mode for running terminal chats without a Gateway while keeping plugin approval gates enforced. (#66767) Thanks @fuller-stack-dev.
@@ -38,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Codex harness/hooks: route native Codex app-server turns through `before_prompt_build` and emit `before_compaction` / `after_compaction` for native compaction items so prompt and compaction hooks stop drifting from Pi. Thanks @vincentkoc.
 - Codex harness/plugins: add a bundled-plugin Codex app-server extension seam for async `tool_result` middleware, fire `after_tool_call` for Codex tool runs, and route mirrored Codex transcript writes through `before_message_write` so tool integrations stop diverging from Pi. Thanks @vincentkoc.
 - Codex harness/hooks: fire `llm_input`, `llm_output`, and `agent_end` for native Codex app-server turns so lifecycle hooks stop drifting from Pi. Thanks @vincentkoc.
+- QA/Telegram: record per-scenario reply RTT in the live Telegram QA report and summary, starting with the canary response. (#70550) Thanks @obviyus.
 
 ### Fixes
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -82,6 +82,8 @@ observation works best when both bots have Bot-to-Bot Communication Mode
 enabled in `@BotFather`.
 The command exits non-zero when any scenario fails. Use `--allow-failures` when
 you want artifacts without a failing exit code.
+The Telegram report and summary include per-reply RTT from the driver message
+send request to the observed SUT reply, starting with the canary.
 
 Live transport lanes now share one smaller contract instead of each inventing
 their own scenario list shape:

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -133,7 +133,7 @@ runs the same lanes before release approval.
     want artifacts without a failing exit code.
   - Requires two distinct bots in the same private group, with the SUT bot exposing a Telegram username.
   - For stable bot-to-bot observation, enable Bot-to-Bot Communication Mode in `@BotFather` for both bots and ensure the driver bot can observe group bot traffic.
-  - Writes a Telegram QA report, summary, and observed-messages artifact under `.artifacts/qa-e2e/...`.
+  - Writes a Telegram QA report, summary, and observed-messages artifact under `.artifacts/qa-e2e/...`. Replying scenarios include RTT from driver send request to observed SUT reply.
 
 Live transport lanes share one standard contract so new transports do not drift:
 

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -594,6 +594,28 @@ describe("telegram live qa runtime", () => {
     ]);
   });
 
+  it("prints Telegram scenario RTT in the Markdown report", () => {
+    expect(
+      __testing.renderTelegramQaMarkdown({
+        cleanupIssues: [],
+        credentialSource: "env",
+        groupId: "-100123",
+        redactMetadata: false,
+        startedAt: "2026-04-23T00:00:00.000Z",
+        finishedAt: "2026-04-23T00:00:10.000Z",
+        scenarios: [
+          {
+            id: "telegram-canary",
+            title: "Telegram canary",
+            status: "pass",
+            details: "reply message 12 matched in 4321ms",
+            rttMs: 4321,
+          },
+        ],
+      }),
+    ).toContain("- RTT: 4321ms");
+  });
+
   it("formats phase-specific canary diagnostics with context", () => {
     const error = new Error(
       "SUT bot did not send any group reply after the canary command within 30s.",

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
@@ -595,6 +595,7 @@ async function waitForObservedMessage(params: {
       },
       timeoutSeconds * 1000 + 5_000,
     );
+    const batchObservedAtMs = Date.now();
     if (updates.length === 0) {
       continue;
     }
@@ -613,7 +614,7 @@ async function waitForObservedMessage(params: {
       };
       params.observedMessages.push(observedMessage);
       if (matchedScenario) {
-        return { message: observedMessage, nextOffset: offset, observedAtMs: Date.now() };
+        return { message: observedMessage, nextOffset: offset, observedAtMs: batchObservedAtMs };
       }
     }
   }

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
@@ -100,6 +100,11 @@ type TelegramQaScenarioResult = {
   title: string;
   status: "pass" | "fail";
   details: string;
+  rttMs?: number;
+  requestStartedAt?: string;
+  responseObservedAt?: string;
+  sentMessageId?: number;
+  responseMessageId?: number;
 };
 
 type TelegramQaCanaryPhase = "sut_reply_timeout" | "sut_reply_not_threaded" | "sut_reply_empty";
@@ -608,7 +613,7 @@ async function waitForObservedMessage(params: {
       };
       params.observedMessages.push(observedMessage);
       if (matchedScenario) {
-        return { message: observedMessage, nextOffset: offset };
+        return { message: observedMessage, nextOffset: offset, observedAtMs: Date.now() };
       }
     }
   }
@@ -671,6 +676,9 @@ function renderTelegramQaMarkdown(params: {
     lines.push("");
     lines.push(`- Status: ${scenario.status}`);
     lines.push(`- Details: ${scenario.details}`);
+    if (scenario.rttMs !== undefined) {
+      lines.push(`- RTT: ${scenario.rttMs}ms`);
+    }
     lines.push("");
   }
   if (params.cleanupIssues.length > 0) {
@@ -796,11 +804,13 @@ async function runCanary(params: {
   observedMessages: TelegramObservedMessage[];
 }) {
   const offset = await flushTelegramUpdates(params.driverToken);
+  const requestStartedAtMs = Date.now();
   const driverMessage = await sendGroupMessage(
     params.driverToken,
     params.groupId,
     `/help@${params.sutUsername}`,
   );
+  const requestStartedAt = new Date(requestStartedAtMs).toISOString();
   let firstUnthreadedReply:
     | Pick<TelegramObservedMessage, "messageId" | "replyToMessageId" | "text">
     | undefined;
@@ -871,6 +881,13 @@ async function runCanary(params: {
       },
     );
   }
+  return {
+    requestStartedAt,
+    responseObservedAt: new Date(sutObserved.observedAtMs).toISOString(),
+    rttMs: sutObserved.observedAtMs - requestStartedAtMs,
+    sentMessageId: driverMessage.message_id,
+    responseMessageId: sutObserved.message.messageId,
+  };
 }
 
 function canaryFailureMessage(params: {
@@ -1045,12 +1062,25 @@ export async function runTelegramQaLive(params: {
       assertLeaseHealthy();
       try {
         writeTelegramQaProgress(progressEnabled, "canary start");
-        await runCanary({
+        const canaryTiming = await runCanary({
           driverToken: runtimeEnv.driverToken,
           groupId: runtimeEnv.groupId,
           sutUsername,
           sutBotId: sutIdentity.id,
           observedMessages,
+        });
+        scenarioResults.push({
+          id: "telegram-canary",
+          title: "Telegram canary",
+          status: "pass",
+          details: redactPublicMetadata
+            ? `reply matched in ${canaryTiming.rttMs}ms`
+            : `reply message ${canaryTiming.responseMessageId} matched in ${canaryTiming.rttMs}ms`,
+          rttMs: canaryTiming.rttMs,
+          requestStartedAt: canaryTiming.requestStartedAt,
+          responseObservedAt: canaryTiming.responseObservedAt,
+          sentMessageId: redactPublicMetadata ? undefined : canaryTiming.sentMessageId,
+          responseMessageId: redactPublicMetadata ? undefined : canaryTiming.responseMessageId,
         });
         writeTelegramQaProgress(progressEnabled, "canary pass");
       } catch (error) {
@@ -1087,11 +1117,13 @@ export async function runTelegramQaLive(params: {
           assertLeaseHealthy();
           const scenarioRun = scenario.buildRun(sutUsername);
           try {
+            const requestStartedAtMs = Date.now();
             const sent = await sendGroupMessage(
               runtimeEnv.driverToken,
               runtimeEnv.groupId,
               scenarioRun.input,
             );
+            const requestStartedAt = new Date(requestStartedAtMs).toISOString();
             const matched = await waitForObservedMessage({
               token: runtimeEnv.driverToken,
               initialOffset: driverOffset,
@@ -1116,13 +1148,19 @@ export async function runTelegramQaLive(params: {
               expectedTextIncludes: scenarioRun.expectedTextIncludes,
               message: matched.message,
             });
+            const rttMs = matched.observedAtMs - requestStartedAtMs;
             const result = {
               id: scenario.id,
               title: scenario.title,
               status: "pass",
               details: redactPublicMetadata
-                ? "reply matched"
-                : `reply message ${matched.message.messageId} matched`,
+                ? `reply matched in ${rttMs}ms`
+                : `reply message ${matched.message.messageId} matched in ${rttMs}ms`,
+              rttMs,
+              requestStartedAt,
+              responseObservedAt: new Date(matched.observedAtMs).toISOString(),
+              sentMessageId: redactPublicMetadata ? undefined : sent.message_id,
+              responseMessageId: redactPublicMetadata ? undefined : matched.message.messageId,
             } satisfies TelegramQaScenarioResult;
             scenarioResults.push(result);
             writeTelegramQaProgress(
@@ -1295,4 +1333,5 @@ export const __testing = {
   sanitizeTelegramQaProgressValue,
   shouldLogTelegramQaLiveProgress,
   formatTelegramQaProgressDetails,
+  renderTelegramQaMarkdown,
 };

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -74,6 +74,20 @@ describe("resolveTelegramForumFlag", () => {
     expect(getChat).toHaveBeenCalledTimes(1);
   });
 
+  it("refreshes cached forum metadata from explicit Telegram updates", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: true }));
+    const params = {
+      chatId: -100654,
+      chatType: "supergroup" as const,
+      isGroup: true,
+      getChat,
+    };
+    await expect(resolveTelegramForumFlag(params)).resolves.toBe(true);
+    await expect(resolveTelegramForumFlag({ ...params, isForum: false })).resolves.toBe(false);
+    await expect(resolveTelegramForumFlag(params)).resolves.toBe(false);
+    expect(getChat).toHaveBeenCalledTimes(1);
+  });
+
   it("returns false when forum lookup is unavailable", async () => {
     const getChat = vi.fn(async () => {
       throw new Error("lookup failed");

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -52,13 +52,26 @@ describe("resolveTelegramForumFlag", () => {
     const getChat = vi.fn(async () => ({ is_forum: true }));
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100123,
+        chatId: -100789,
         chatType: "supergroup",
         isGroup: true,
         getChat,
       }),
     ).resolves.toBe(true);
-    expect(getChat).toHaveBeenCalledWith(-100123);
+    expect(getChat).toHaveBeenCalledWith(-100789);
+  });
+
+  it("reuses resolved forum metadata for later supergroup updates", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: true }));
+    const params = {
+      chatId: -100456,
+      chatType: "supergroup" as const,
+      isGroup: true,
+      getChat,
+    };
+    await expect(resolveTelegramForumFlag(params)).resolves.toBe(true);
+    await expect(resolveTelegramForumFlag(params)).resolves.toBe(true);
+    expect(getChat).toHaveBeenCalledTimes(1);
   });
 
   it("returns false when forum lookup is unavailable", async () => {
@@ -67,7 +80,7 @@ describe("resolveTelegramForumFlag", () => {
     });
     await expect(
       resolveTelegramForumFlag({
-        chatId: -100123,
+        chatId: -100999,
         chatType: "supergroup",
         isGroup: true,
         getChat,

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -40,7 +40,26 @@ export {
 };
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
-const telegramForumFlagByChatId = new Map<string, boolean>();
+const TELEGRAM_FORUM_FLAG_CACHE_MAX_CHATS = 1024;
+const TELEGRAM_FORUM_FLAG_CACHE_TTL_MS = 10 * 60_000;
+const telegramForumFlagByChatId = new Map<string, { expiresAtMs: number; isForum: boolean }>();
+
+function cacheTelegramForumFlag(chatId: string | number, isForum: boolean, nowMs = Date.now()) {
+  const cacheKey = String(chatId);
+  if (
+    !telegramForumFlagByChatId.has(cacheKey) &&
+    telegramForumFlagByChatId.size >= TELEGRAM_FORUM_FLAG_CACHE_MAX_CHATS
+  ) {
+    const oldestKey = telegramForumFlagByChatId.keys().next().value;
+    if (oldestKey !== undefined) {
+      telegramForumFlagByChatId.delete(oldestKey);
+    }
+  }
+  telegramForumFlagByChatId.set(cacheKey, {
+    expiresAtMs: nowMs + TELEGRAM_FORUM_FLAG_CACHE_TTL_MS,
+    isForum,
+  });
+}
 
 function hadUnsafeTelegramText(raw: unknown, sanitized: string): boolean {
   return typeof raw === "string" && raw.trim().length > 0 && sanitized.trim().length === 0;
@@ -67,19 +86,26 @@ export async function resolveTelegramForumFlag(params: {
   getChat?: TelegramGetChat;
 }): Promise<boolean> {
   if (typeof params.isForum === "boolean") {
+    if (params.isGroup && params.chatType === "supergroup") {
+      cacheTelegramForumFlag(params.chatId, params.isForum);
+    }
     return params.isForum;
   }
   if (!params.isGroup || params.chatType !== "supergroup" || !params.getChat) {
     return false;
   }
   const cacheKey = String(params.chatId);
+  const nowMs = Date.now();
   const cached = telegramForumFlagByChatId.get(cacheKey);
-  if (cached !== undefined) {
-    return cached;
+  if (cached && cached.expiresAtMs > nowMs) {
+    return cached.isForum;
+  }
+  if (cached) {
+    telegramForumFlagByChatId.delete(cacheKey);
   }
   try {
     const resolved = extractTelegramForumFlag(await params.getChat(params.chatId)) === true;
-    telegramForumFlagByChatId.set(cacheKey, resolved);
+    cacheTelegramForumFlag(params.chatId, resolved, nowMs);
     return resolved;
   } catch {
     return false;

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -40,6 +40,7 @@ export {
 };
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
+const telegramForumFlagByChatId = new Map<string, boolean>();
 
 function hadUnsafeTelegramText(raw: unknown, sanitized: string): boolean {
   return typeof raw === "string" && raw.trim().length > 0 && sanitized.trim().length === 0;
@@ -71,8 +72,15 @@ export async function resolveTelegramForumFlag(params: {
   if (!params.isGroup || params.chatType !== "supergroup" || !params.getChat) {
     return false;
   }
+  const cacheKey = String(params.chatId);
+  const cached = telegramForumFlagByChatId.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
   try {
-    return extractTelegramForumFlag(await params.getChat(params.chatId)) === true;
+    const resolved = extractTelegramForumFlag(await params.getChat(params.chatId)) === true;
+    telegramForumFlagByChatId.set(cacheKey, resolved);
+    return resolved;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- record per-scenario Telegram QA reply RTT in reports and JSON summaries
- cache Telegram forum metadata lookups so group command handling avoids repeated getChat calls

## Validation
- pnpm test extensions/telegram/src/bot/helpers.test.ts extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
- pnpm check:changed (pre-commit, both scoped commits)
- live Telegram QA command run: 4/4 passed; command RTTs 1255ms, 1159ms, 2220ms