### PR TITLE
Fix dreaming narrative retries for gateway background runs

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -8,6 +8,10 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import * as memoryCoreHostRuntimeCoreModule from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearGatewaySubagentRuntime,
+  setGatewaySubagentRuntime,
+} from "../../../src/plugins/runtime/index.js";
 import { resolveGlobalMap } from "../../../src/shared/global-singleton.js";
 import {
   appendNarrativeEntry,
@@ -30,6 +34,7 @@ const DREAMS_FILE_LOCKS_KEY = Symbol.for("openclaw.memoryCore.dreamingNarrative.
 
 afterEach(() => {
   vi.restoreAllMocks();
+  clearGatewaySubagentRuntime();
   resolveGlobalMap<string, unknown>(DREAMS_FILE_LOCKS_KEY).clear();
 });
 
@@ -557,17 +562,30 @@ describe("appendNarrativeEntry", () => {
 });
 
 describe("generateAndAppendDreamNarrative", () => {
+  function createSessionResult(responseText: string) {
+    return {
+      messages: [
+        { role: "user", content: "prompt" },
+        { role: "assistant", content: responseText },
+      ],
+    };
+  }
+
   function createMockSubagent(responseText: string) {
+    const sessionResult = createSessionResult(responseText);
     return {
       run: vi.fn().mockResolvedValue({ runId: "run-123" }),
       waitForRun: vi.fn().mockResolvedValue({ status: "ok" }),
-      getSessionMessages: vi.fn().mockResolvedValue({
-        messages: [
-          { role: "user", content: "prompt" },
-          { role: "assistant", content: responseText },
-        ],
-      }),
+      getSessionMessages: vi.fn().mockResolvedValue(sessionResult),
       deleteSession: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function createMockGatewaySubagent(responseText: string) {
+    const sessionResult = createSessionResult(responseText);
+    return {
+      ...createMockSubagent(responseText),
+      getSession: vi.fn().mockResolvedValue(sessionResult),
     };
   }
 
@@ -603,8 +621,8 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.run.mock.calls[0][0]).toMatchObject({
       idempotencyKey: expectedSessionKey,
       sessionKey: expectedSessionKey,
-      lane: `dreaming-narrative:${expectedSessionKey}`,
-      lightContext: true,
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
       deliver: false,
     });
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
@@ -657,10 +675,12 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(exists).toBe(false);
   });
 
-  it("skips extra settle waits after timeout and still attempts cleanup", async () => {
+  it("waits once more before cleanup after timeout and logs cleanup failures", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");
-    subagent.waitForRun.mockResolvedValueOnce({ status: "timeout" });
+    subagent.waitForRun
+      .mockResolvedValueOnce({ status: "timeout" })
+      .mockResolvedValueOnce({ status: "ok" });
     subagent.deleteSession.mockRejectedValue(new Error("still active"));
     const logger = createMockLogger();
 
@@ -671,8 +691,8 @@ describe("generateAndAppendDreamNarrative", () => {
       logger,
     });
 
-    expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(subagent.waitForRun.mock.calls[0][0]).toMatchObject({ timeoutMs: 15_000 });
+    expect(subagent.waitForRun).toHaveBeenCalledTimes(2);
+    expect(subagent.waitForRun.mock.calls[1][0]).toMatchObject({ timeoutMs: 120_000 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed for rem phase"),
     );
@@ -721,7 +741,105 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(content).toContain("API endpoints need authentication");
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    expect(subagent.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("switches to the background gateway runtime when the request runtime is scoped", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const backgroundSubagent = createMockGatewaySubagent(
+      "A background narrative turned the fragments into prose.",
+    );
+    setGatewaySubagentRuntime(backgroundSubagent);
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["background retries should stay narrative-first"] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(subagent.run).toHaveBeenCalledOnce();
+    expect(backgroundSubagent.run).toHaveBeenCalledOnce();
+    expect(backgroundSubagent.run.mock.calls[0][0]).toMatchObject({
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
+    });
+    expect(backgroundSubagent.waitForRun).toHaveBeenCalledOnce();
+    expect(backgroundSubagent.getSessionMessages).toHaveBeenCalledOnce();
+    expect(backgroundSubagent.deleteSession).toHaveBeenCalledOnce();
+    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("switched to background gateway runtime"),
+    );
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("A background narrative turned the fragments into prose.");
+  });
+
+  it("surfaces non-transient background gateway failures instead of silently falling back", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const backgroundSubagent = createMockGatewaySubagent("");
+    backgroundSubagent.run.mockRejectedValue(new Error("schema validation exploded"));
+    setGatewaySubagentRuntime(backgroundSubagent);
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["background retries should not hide real failures"] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(subagent.run).toHaveBeenCalledOnce();
+    expect(backgroundSubagent.run).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("narrative generation failed for light phase"),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("narrative generation used fallback"),
+    );
+    await expect(fs.access(path.join(workspaceDir, "DREAMS.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("best-effort cleans up the background session after transient retry fallback without a run id", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const backgroundSubagent = createMockGatewaySubagent("");
+    backgroundSubagent.run.mockRejectedValue(new Error("fetch failed"));
+    setGatewaySubagentRuntime(backgroundSubagent);
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["transient retries should still clean up"] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(backgroundSubagent.deleteSession).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("background gateway runtime failed for light phase"),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("narrative generation used fallback for light phase"),
+    );
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("transient retries should still clean up");
   });
 
   it("falls back when the request-scoped runtime error is detected by stable code", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -17,7 +17,10 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { createAsyncLock } from "openclaw/plugin-sdk/infra-runtime";
-import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import {
+  getGatewaySubagentRuntime,
+  resolveStateDir,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -27,8 +30,8 @@ type SubagentSurface = {
     sessionKey: string;
     message: string;
     extraSystemPrompt?: string;
-    lane?: string;
-    lightContext?: boolean;
+    bootstrapContextMode?: "full" | "lightweight";
+    bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
     deliver?: boolean;
   }) => Promise<{ runId: string }>;
   waitForRun: (params: {
@@ -86,10 +89,8 @@ const NARRATIVE_SYSTEM_PROMPT = [
   "- Output ONLY the diary entry. No preamble, no sign-off, no commentary.",
 ].join("\n");
 
-// Narrative generation is best-effort. Keep the timeout short so a stalled
-// diary subagent does not leave the parent dreaming cron job "running" for
-// minutes after the reports have already been written.
-const NARRATIVE_TIMEOUT_MS = 15_000;
+const NARRATIVE_TIMEOUT_MS = 60_000;
+const NARRATIVE_DELETE_SETTLE_TIMEOUT_MS = 120_000;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
@@ -113,6 +114,34 @@ function isRequestScopedSubagentRuntimeError(err: unknown): boolean {
     (err instanceof Error &&
       err.name === "RequestScopedSubagentRuntimeError" &&
       extractErrorCode(err) === SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE)
+  );
+}
+
+function isTransientBackgroundGatewayError(err: unknown): boolean {
+  if (isRequestScopedSubagentRuntimeError(err)) {
+    return true;
+  }
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = (extractErrorCode(err) ?? "").toLowerCase();
+  const name = err.name.toLowerCase();
+  const message = err.message.toLowerCase();
+  return (
+    code.includes("timeout") ||
+    code.includes("timed_out") ||
+    code.includes("network") ||
+    code.includes("econn") ||
+    code.includes("fetch") ||
+    name.includes("timeout") ||
+    name.includes("network") ||
+    name.includes("abort") ||
+    message.includes("timed out") ||
+    message.includes("timeout") ||
+    message.includes("network") ||
+    message.includes("fetch failed") ||
+    message.includes("socket hang up") ||
+    message.includes("econn")
   );
 }
 
@@ -148,21 +177,47 @@ async function startNarrativeRunOrFallback(params: {
   nowMs: number;
   timezone?: string;
   logger: Logger;
-}): Promise<string | null> {
-  try {
-    const run = await params.subagent.run({
+}): Promise<
+  | { kind: "started"; runId: string; subagent: SubagentSurface }
+  | { kind: "fallback"; cleanupSubagent?: SubagentSurface }
+> {
+  const startNarrativeRun = async (
+    subagent: SubagentSurface,
+  ): Promise<{ kind: "started"; runId: string; subagent: SubagentSurface }> => {
+    const run = await subagent.run({
       idempotencyKey: params.sessionKey,
       sessionKey: params.sessionKey,
       message: params.message,
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
-      lane: `dreaming-narrative:${params.sessionKey}`,
-      lightContext: true,
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
       deliver: false,
     });
-    return run.runId;
+    return { kind: "started", runId: run.runId, subagent };
+  };
+
+  try {
+    return await startNarrativeRun(params.subagent);
   } catch (runErr) {
     if (!isRequestScopedSubagentRuntimeError(runErr)) {
       throw runErr;
+    }
+    const backgroundSubagent = getGatewaySubagentRuntime();
+    if (backgroundSubagent && backgroundSubagent !== params.subagent) {
+      try {
+        const backgroundRun = await startNarrativeRun(backgroundSubagent);
+        params.logger.info(
+          `memory-core: narrative generation switched to background gateway runtime for ${params.data.phase} phase.`,
+        );
+        return backgroundRun;
+      } catch (backgroundErr) {
+        if (!isTransientBackgroundGatewayError(backgroundErr)) {
+          throw backgroundErr;
+        }
+        params.logger.warn(
+          `memory-core: background gateway runtime failed for ${params.data.phase} phase: ${formatErrorMessage(backgroundErr)}`,
+        );
+      }
     }
     try {
       await appendNarrativeEntry({
@@ -179,7 +234,11 @@ async function startNarrativeRunOrFallback(params: {
         `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
       );
     }
-    return null;
+    return {
+      kind: "fallback",
+      cleanupSubagent:
+        backgroundSubagent && backgroundSubagent !== params.subagent ? backgroundSubagent : undefined,
+    };
   }
 }
 
@@ -861,8 +920,12 @@ export async function generateAndAppendDreamNarrative(params: {
   });
   const message = buildNarrativePrompt(params.data);
   let runId: string | null = null;
+  let waitStatus: string | null = null;
+  let activeSubagent: SubagentSurface = params.subagent;
+  let cleanupSubagent: SubagentSurface | null = null;
+
   try {
-    runId = await startNarrativeRunOrFallback({
+    const run = await startNarrativeRunOrFallback({
       subagent: params.subagent,
       sessionKey,
       message,
@@ -872,14 +935,19 @@ export async function generateAndAppendDreamNarrative(params: {
       timezone: params.timezone,
       logger: params.logger,
     });
-    if (!runId) {
+    if (run.kind === "fallback") {
+      cleanupSubagent = run.cleanupSubagent ?? null;
       return;
     }
+    runId = run.runId;
+    activeSubagent = run.subagent;
+    cleanupSubagent = run.subagent;
 
-    const result = await params.subagent.waitForRun({
+    const result = await activeSubagent.waitForRun({
       runId,
       timeoutMs: NARRATIVE_TIMEOUT_MS,
     });
+    waitStatus = result.status;
 
     if (result.status !== "ok") {
       params.logger.warn(
@@ -888,7 +956,7 @@ export async function generateAndAppendDreamNarrative(params: {
       return;
     }
 
-    const { messages } = await params.subagent.getSessionMessages({
+    const { messages } = await activeSubagent.getSessionMessages({
       sessionKey,
       limit: 5,
     });
@@ -917,10 +985,28 @@ export async function generateAndAppendDreamNarrative(params: {
       `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(err)}`,
     );
   } finally {
-    // Guard against subagent becoming unavailable mid-flight (throws TypeError without this).
-    if (params.subagent) {
+    if (runId && waitStatus === "timeout") {
       try {
-        await params.subagent.deleteSession({ sessionKey });
+        const settle = await activeSubagent.waitForRun({
+          runId,
+          timeoutMs: NARRATIVE_DELETE_SETTLE_TIMEOUT_MS,
+        });
+        if (settle.status !== "ok" && settle.status !== "error") {
+          params.logger.warn(
+            `memory-core: narrative cleanup wait ended with status=${settle.status} for ${params.data.phase} phase.`,
+          );
+        }
+      } catch (cleanupWaitErr) {
+        params.logger.warn(
+          `memory-core: narrative cleanup wait failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupWaitErr)}`,
+        );
+      }
+    }
+
+    // Guard against subagent becoming unavailable mid-flight (throws TypeError without this).
+    if (cleanupSubagent) {
+      try {
+        await cleanupSubagent.deleteSession({ sessionKey });
       } catch (cleanupErr) {
         params.logger.warn(
           `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -53,6 +53,8 @@ export type GetReplyOptions = {
   heartbeatModelOverride?: string;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
+  /** Classifies the bootstrap run so downstream runtimes can tailor retrieval and prompts. */
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
   /**

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1041,11 +1041,20 @@ export async function runAgentTurnWithFallback(params: {
             return (async () => {
               let lifecycleTerminalEmitted = false;
               try {
+                const cliBootstrapRunKind = params.isHeartbeat
+                  ? "heartbeat"
+                  : params.opts?.bootstrapContextRunKind ?? "default";
+                const cliTrigger =
+                  cliBootstrapRunKind === "cron"
+                    ? "cron"
+                    : cliBootstrapRunKind === "heartbeat"
+                      ? "heartbeat"
+                      : "user";
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
                   sessionKey: params.sessionKey,
                   agentId: params.followupRun.run.agentId,
-                  trigger: params.isHeartbeat ? "heartbeat" : "user",
+                  trigger: cliTrigger,
                   sessionFile: params.followupRun.run.sessionFile,
                   workspaceDir: params.followupRun.run.workspaceDir,
                   config: runtimeConfig,
@@ -1160,10 +1169,19 @@ export async function runAgentTurnWithFallback(params: {
           return (async () => {
             let attemptCompactionCount = 0;
             try {
+              const embeddedBootstrapRunKind = params.isHeartbeat
+                ? "heartbeat"
+                : params.opts?.bootstrapContextRunKind ?? "default";
+              const embeddedTrigger =
+                embeddedBootstrapRunKind === "cron"
+                  ? "cron"
+                  : embeddedBootstrapRunKind === "heartbeat"
+                    ? "heartbeat"
+                    : "user";
               const result = await runEmbeddedPiAgent({
                 ...embeddedContext,
                 allowGatewaySubagentBinding: true,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
+                trigger: embeddedTrigger,
                 groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
                 groupChannel:
                   normalizeOptionalString(params.sessionCtx.GroupChannel) ??
@@ -1193,7 +1211,7 @@ export async function runAgentTurnWithFallback(params: {
                 })(),
                 suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
-                bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+                bootstrapContextRunKind: embeddedBootstrapRunKind,
                 images: params.opts?.images,
                 imageOrder: params.opts?.imageOrder,
                 abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -337,8 +337,14 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.provider && { provider: params.provider }),
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
-          ...(params.lane && { lane: params.lane }),
           ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
+          ...(params.bootstrapContextMode && {
+            bootstrapContextMode: params.bootstrapContextMode,
+          }),
+          ...(params.bootstrapContextRunKind && {
+            bootstrapContextRunKind: params.bootstrapContextRunKind,
+          }),
+          ...(params.lane && { lane: params.lane }),
           // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
           // so fall back to a generated UUID when the caller omits it. Without
           // this, plugin subagent runs (for example memory-core dreaming

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -6,3 +6,4 @@ export type {
   MemoryCorpusSupplementRegistration,
 } from "../plugins/memory-state.js";
 export { listMemoryCorpusSupplements } from "../plugins/memory-state.js";
+export { getGatewaySubagentRuntime } from "../plugins/runtime/gateway-bindings.js";

--- a/src/plugins/runtime/gateway-bindings.ts
+++ b/src/plugins/runtime/gateway-bindings.ts
@@ -28,6 +28,10 @@ export function setGatewaySubagentRuntime(subagent: PluginRuntime["subagent"]): 
   gatewaySubagentState.subagent = subagent;
 }
 
+export function getGatewaySubagentRuntime(): PluginRuntime["subagent"] | undefined {
+  return gatewaySubagentState.subagent;
+}
+
 export function setGatewayNodesRuntime(nodes: PluginRuntime["nodes"]): void {
   gatewaySubagentState.nodes = nodes;
 }

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -11,6 +11,8 @@ export type SubagentRunParams = {
   provider?: string;
   model?: string;
   extraSystemPrompt?: string;
+  bootstrapContextMode?: "full" | "lightweight";
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   lane?: string;
   lightContext?: boolean;
   deliver?: boolean;


### PR DESCRIPTION
## Summary
- retry dreaming narrative generation with the process-global gateway subagent when the injected runtime is request-scoped
- forward bootstrap context mode/run kind through gateway subagent dispatch so narrative runs stay lightweight cron sessions
- preserve upstream bootstrap run kind inside reply agent execution instead of forcing non-heartbeat runs back to `default`
- narrow the background runtime accessor to the memory-core host runtime surface instead of the general `plugin-sdk/runtime` barrel
- best-effort clean up gateway dreaming sessions even when a transient retry failure returns before a `runId` is captured
- add regression coverage for both the non-transient rethrow path and the transient cleanup fallback path

## Why
Managed dreaming can run outside a request-scoped plugin runtime. In that path `api.runtime.subagent` may intentionally throw `RequestScopedSubagentRuntimeError`, which made narrative generation fall back to a plain snippet write instead of running a real dream diary session.

## Notes
- AI-assisted PR.
- Added the host-runtime getter needed by memory-core to resolve the gateway-owned background subagent without exposing that handle from the generic SDK runtime barrel.
- Added bootstrap run fields to plugin subagent params so the gateway path can keep dreaming runs in `lightweight + cron` mode.
- I added focused regression coverage for the new background retry / cleanup paths.
- I could not run the full local test suite in this environment, so final validation relies on CI for this branch.
