### PR TITLE
fix(telegram): pass modelNames to buildModelsKeyboard in button-click callback handler

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1563,7 +1563,7 @@ export const registerTelegramHandlers = ({
         } catch (err) {
           throw new TelegramRetryableCallbackError(err);
         }
-        const { byProvider, providers } = modelData;
+        const { byProvider, providers, modelNames } = modelData;
 
         const editMessageWithButtons = async (
           text: string,
@@ -1647,6 +1647,7 @@ export const registerTelegramHandlers = ({
             currentPage: safePage,
             totalPages,
             pageSize,
+            modelNames,
           });
           const text = formatModelsAvailableHeader({
             provider,


### PR DESCRIPTION
## Summary

- The Telegram model picker showed raw model IDs (e.g. `gemini-3.1-pro-preview`) instead of configured display names (e.g. `Gemini 3.1 Pro (Bridge)`) when navigating via provider button click.
- The text-command path (`/models <provider>`) worked correctly because it passes `modelNames` through `buildTelegramModelsListChannelData`.
- The button-click callback handler in `extensions/telegram/src/bot-handlers.runtime.ts` destructured `buildModelsProviderData()` but omitted `modelNames` from the result, then called `buildModelsKeyboard()` without it.
- `buildModelsKeyboard` in `model-buttons.ts` has `modelNames?.get(...) ?? model` as fallback, so without the Map it always renders the raw model ID.
- Fix: destructure `modelNames` from `modelData` and forward it to `buildModelsKeyboard`.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

Closes #70560

- [x] This PR fixes a bug or regression

## Root Cause

In `extensions/telegram/src/bot-handlers.runtime.ts`, the `modelCallback.type === "list"` branch destructured `buildModelsProviderData()` as `{ byProvider, providers }`, omitting `modelNames`. The `buildModelsKeyboard` call in that branch therefore received no `modelNames` argument and fell back to raw model IDs via the nullish-coalescing operator in `model-buttons.ts`.

## Regression Test Plan

Existing unit tests in `extensions/telegram/src/bot-handlers.runtime.test.ts` and `extensions/telegram/src/model-buttons.test.ts` cover the affected code paths. No new test added since the fix is a straightforward one-parameter addition matching what the working text-command path already does.

## User-visible / Behavior Changes

Model picker button navigation in Telegram now shows configured display names instead of raw model IDs for custom provider bridges.

## Diagram

N/A

## Security Impact

- New permissions: No
- Secrets handling: No
- Network calls: No
- Command execution: No
- Data access scope: No

## Repro + Verification

- **Environment:** Telegram bot with custom provider having `name` field set in config
- **Steps:** Type `/models` → click provider button → observe model list
- **Expected:** Display names from `name` field (e.g. `Gemini 3.1 Pro (Bridge)`)
- **Actual (before fix):** Raw model IDs (e.g. `gemini-3.1-pro-preview`)

## Evidence

The `modelNames` Map is returned by `buildModelsProviderData` (bot-deps.ts line 150) and accepted by `buildModelsKeyboard` (model-buttons.ts line 39), but was not being threaded through the button-click handler. The text-command path at bot-deps.ts line 343 already destructures and passes `modelNames` correctly, confirming the fix approach.

## Human Verification

Verified that `buildModelsProviderData` returns `modelNames` in its result object, that `buildModelsKeyboard` accepts `modelNames` as an optional parameter, and that the text-command path already uses this parameter correctly. Did not verify on a live Telegram instance.

## Review Conversations

- [x] I have replied to and resolved all bot review conversations

Fixes #70560
