### PR TITLE
fix(codex): sanitize approval preview text

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -205,7 +205,7 @@ describe("Codex app-server approval bridge", () => {
         threadId: "thread-1",
         turnId: "turn-1",
         itemId: "cmd-bidi",
-        command: "echo safe\u202e cod.exe\u2066 hidden\u2069 \ufeffdone",
+        command: "echo safe\u202e cod.exe\u2066 hidden\u2069 \ufeffdone\u{e0100}",
       },
       paramsForRun: params,
       threadId: "thread-1",
@@ -252,9 +252,42 @@ describe("Codex app-server approval bridge", () => {
     expect(requestPayload).toEqual(
       expect.objectContaining({
         description:
-          "Command: [preview omitted: too long or unsafe]\nSession: agent:main:session-1",
+          "Command: [preview truncated or unsafe content omitted]\nSession: agent:main:session-1",
       }),
     );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({
+          commandPreviewOmitted: true,
+        }),
+      }),
+    );
+  });
+
+  it("marks clipped command previews even when a safe prefix remains", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-clipped-command",
+      decision: "allow-once",
+    });
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-clipped",
+        command: `${"a".repeat(5000)} tail`,
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    const description = (requestPayload as { description: string }).description;
+    expect(description).toContain("[preview truncated or unsafe content omitted]");
     expect(params.onAgentEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: "approval",

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -119,6 +119,152 @@ describe("Codex app-server approval bridge", () => {
     );
   });
 
+  it("sanitizes command previews before forwarding approval text and events", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-sanitized-command",
+      decision: "allow-once",
+    });
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-sanitized",
+        command: ["pnpm", "test\n--watch", "\u001b[31mextensions/codex/src/app-server\u001b[0m"],
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    expect(requestPayload).toEqual(
+      expect.objectContaining({
+        description:
+          "Command: pnpm test --watch extensions/codex/src/app-server\nSession: agent:main:session-1",
+      }),
+    );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({
+          status: "pending",
+          command: "pnpm test --watch extensions/codex/src/app-server",
+        }),
+      }),
+    );
+  });
+
+  it("preserves visible OSC-8 link labels in command previews", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-osc",
+      decision: "allow-once",
+    });
+    const esc = "\u001b";
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-osc",
+        command: `prefix ${esc}]8;;https://example.com${esc}\\VISIBLE${esc}]8;;${esc}\\ suffix`,
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    expect(requestPayload).toEqual(
+      expect.objectContaining({
+        description: "Command: prefix VISIBLE suffix\nSession: agent:main:session-1",
+      }),
+    );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({ command: "prefix VISIBLE suffix" }),
+      }),
+    );
+  });
+
+  it("strips bidi and invisible formatting controls from command previews", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-bidi",
+      decision: "allow-once",
+    });
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-bidi",
+        command: "echo safe\u202e cod.exe\u2066 hidden\u2069 \ufeffdone",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    expect(requestPayload).toEqual(
+      expect.objectContaining({
+        description: "Command: echo safe cod.exe hidden done\nSession: agent:main:session-1",
+      }),
+    );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({ command: "echo safe cod.exe hidden done" }),
+      }),
+    );
+  });
+
+  it("marks oversized unsafe command previews as omitted", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-omitted-command",
+      decision: "allow-once",
+    });
+    const esc = "\u001b";
+    const oversizedPrefix = `${esc}]8;;https://example.com${esc}\\`.repeat(300);
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-omitted",
+        command: [oversizedPrefix, "TAIL"],
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    expect(requestPayload).toEqual(
+      expect.objectContaining({
+        description:
+          "Command: [preview omitted: too long or unsafe]\nSession: agent:main:session-1",
+      }),
+    );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({
+          commandPreviewOmitted: true,
+        }),
+      }),
+    );
+  });
+
   it("fails closed when no approval route is available", async () => {
     const params = createParams();
     mockCallGatewayTool.mockResolvedValueOnce({
@@ -145,6 +291,43 @@ describe("Codex app-server approval bridge", () => {
       expect.objectContaining({
         stream: "approval",
         data: expect.objectContaining({ status: "unavailable", reason: "needs write access" }),
+      }),
+    );
+  });
+
+  it("sanitizes reason previews before forwarding approval text and events", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-sanitized-reason",
+      decision: null,
+    });
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/fileChange/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "patch-sanitized",
+        reason: "needs write access\nfor \u001b[31m/tmp\u001b[0m\tplease",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    expect(requestPayload).toEqual(
+      expect.objectContaining({
+        description: "Reason: needs write access for /tmp please\nSession: agent:main:session-1",
+      }),
+    );
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({
+          status: "unavailable",
+          reason: "needs write access for /tmp please",
+        }),
       }),
     );
   });
@@ -275,6 +458,39 @@ describe("Codex app-server approval bridge", () => {
     expect(description).toContain("readPaths: ~/.ssh/id_rsa, /etc/hosts (+1 more)");
     expect(description).toContain("writePaths: /tmp/output, /var/log/app (+1 more)");
     expect(description).toContain("High-risk targets:");
+  });
+
+  it("strips terminal and invisible controls from permission descriptions", async () => {
+    const params = createParams();
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:approval-permission-controls",
+      decision: "allow-once",
+    });
+
+    await handleCodexAppServerApprovalRequest({
+      method: "item/permissions/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "perm-controls",
+        permissions: {
+          network: { allowHosts: ["exa\u009b31mmple.com", "safe\u202e.example.com"] },
+          fileSystem: { roots: ["/tmp/\u001b[31mproject\u001b[0m"] },
+        },
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const [, , requestPayload] = mockCallGatewayTool.mock.calls[0] ?? [];
+    const description = (requestPayload as { description: string }).description;
+    expect(description).toContain("example.com");
+    expect(description).toContain("safe .example.com");
+    expect(description).toContain("/tmp/project");
+    expect(description).not.toContain("\u009b");
+    expect(description).not.toContain("\u202e");
+    expect(description).not.toContain("\u001b");
   });
 
   it("ignores approval requests that are missing explicit thread or turn ids", async () => {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -14,7 +14,7 @@ const PERMISSION_DESCRIPTION_MAX_LENGTH = 700;
 const PERMISSION_SAMPLE_LIMIT = 2;
 const PERMISSION_VALUE_MAX_LENGTH = 48;
 const APPROVAL_PREVIEW_SCAN_MAX_LENGTH = 4096;
-const APPROVAL_PREVIEW_OMITTED = "[preview omitted: too long or unsafe]";
+const APPROVAL_PREVIEW_OMITTED = "[preview truncated or unsafe content omitted]";
 const ANSI_OSC_SEQUENCE_RE = new RegExp(
   String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
   "g",
@@ -25,7 +25,7 @@ const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
 );
 const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
 const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
-  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f]|\u{e0100}-\u{e01ef}`,
+  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
   "gu",
 );
 const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
@@ -216,11 +216,11 @@ function buildApprovalContext(params: {
   const subject =
     permissionLines[0] ??
     (command
-      ? `Command: ${command}`
+      ? `Command: ${formatApprovalPreviewSubject(command, commandPreview.omitted)}`
       : commandPreview.omitted
         ? `Command: ${APPROVAL_PREVIEW_OMITTED}`
         : reason
-          ? `Reason: ${reason}`
+          ? `Reason: ${formatApprovalPreviewSubject(reason, reasonPreview.omitted)}`
           : reasonPreview.omitted
             ? `Reason: ${APPROVAL_PREVIEW_OMITTED}`
             : `Request method: ${params.method}`);
@@ -682,6 +682,10 @@ function sanitizeVisibleScalar(value: string): string {
     .replace(CONTROL_CHARACTER_RE, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function formatApprovalPreviewSubject(text: string, omitted: boolean): string {
+  return omitted ? `${text} ${APPROVAL_PREVIEW_OMITTED}` : text;
 }
 
 function joinDescriptionLinesWithinLimit(lines: string[], maxLength: number): string {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -13,6 +13,35 @@ import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 const PERMISSION_DESCRIPTION_MAX_LENGTH = 700;
 const PERMISSION_SAMPLE_LIMIT = 2;
 const PERMISSION_VALUE_MAX_LENGTH = 48;
+const APPROVAL_PREVIEW_SCAN_MAX_LENGTH = 4096;
+const APPROVAL_PREVIEW_OMITTED = "[preview omitted: too long or unsafe]";
+const ANSI_OSC_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
+  "g",
+);
+const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
+  "g",
+);
+const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
+const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
+  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f]|\u{e0100}-\u{e01ef}`,
+  "gu",
+);
+const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
+  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
+);
+
+type ApprovalPreviewSource = {
+  value: string;
+  clipped: boolean;
+};
+
+type SanitizedApprovalPreview = {
+  text?: string;
+  omitted: boolean;
+};
+
 export async function handleCodexAppServerApprovalRequest(params: {
   method: string;
   requestParams: JsonValue | undefined;
@@ -161,8 +190,16 @@ function buildApprovalContext(params: {
     readString(params.requestParams, "itemId") ??
     readString(params.requestParams, "callId") ??
     readString(params.requestParams, "approvalId");
-  const command = readDisplayCommand(params.requestParams);
-  const reason = readString(params.requestParams, "reason");
+  const commandPreview = sanitizeApprovalPreview(
+    readDisplayCommandPreview(params.requestParams),
+    180,
+  );
+  const reasonPreview = sanitizeApprovalPreview(
+    readStringPreview(params.requestParams, "reason"),
+    180,
+  );
+  const command = commandPreview.text;
+  const reason = reasonPreview.text;
   const kind = approvalKindForMethod(params.method);
   const permissionLines =
     params.method === "item/permissions/requestApproval"
@@ -179,10 +216,14 @@ function buildApprovalContext(params: {
   const subject =
     permissionLines[0] ??
     (command
-      ? `Command: ${truncate(command, 180)}`
-      : reason
-        ? `Reason: ${truncate(reason, 180)}`
-        : `Request method: ${params.method}`);
+      ? `Command: ${command}`
+      : commandPreview.omitted
+        ? `Command: ${APPROVAL_PREVIEW_OMITTED}`
+        : reason
+          ? `Reason: ${reason}`
+          : reasonPreview.omitted
+            ? `Reason: ${APPROVAL_PREVIEW_OMITTED}`
+            : `Request method: ${params.method}`);
   const description =
     permissionLines.length > 0
       ? joinDescriptionLinesWithinLimit(permissionLines, PERMISSION_DESCRIPTION_MAX_LENGTH)
@@ -205,7 +246,9 @@ function buildApprovalContext(params: {
     eventDetails: {
       ...(itemId ? { itemId } : {}),
       ...(command ? { command } : {}),
+      ...(commandPreview.omitted ? { commandPreviewOmitted: true } : {}),
       ...(reason ? { reason } : {}),
+      ...(reasonPreview.omitted ? { reasonPreviewOmitted: true } : {}),
     },
   };
 }
@@ -394,12 +437,7 @@ function sanitizePermissionPathValue(value: string): string {
 }
 
 function sanitizePermissionScalar(value: string): string {
-  let sanitized = "";
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    sanitized += code < 32 || code === 127 ? " " : value[index];
-  }
-  return sanitized.replace(/\s+/g, " ").trim();
+  return sanitizeVisibleScalar(value);
 }
 
 function permissionHostRisks(value: string): string[] {
@@ -531,34 +569,64 @@ function emitApprovalEvent(params: EmbeddedRunAttemptParams, data: AgentApproval
   params.onAgentEvent?.({ stream: "approval", data: data as unknown as Record<string, unknown> });
 }
 
-function readDisplayCommand(record: JsonObject | undefined): string | undefined {
-  const actionCommand = readCommandActions(record);
+function readDisplayCommandPreview(
+  record: JsonObject | undefined,
+): ApprovalPreviewSource | undefined {
+  const actionCommand = readCommandActionsPreview(record);
   if (actionCommand) {
     return actionCommand;
   }
-  return readCommand(record);
+  return readCommandPreview(record);
 }
 
-function readCommandActions(record: JsonObject | undefined): string | undefined {
+function readCommandActionsPreview(
+  record: JsonObject | undefined,
+): ApprovalPreviewSource | undefined {
   const actions = record?.commandActions;
   if (!Array.isArray(actions)) {
     return undefined;
   }
-  const commands = actions
-    .map((action) => (isJsonObject(action) ? readString(action, "command") : undefined))
-    .filter((command): command is string => Boolean(command));
-  return commands.length > 0 ? commands.join(" && ") : undefined;
+  let source: ApprovalPreviewSource | undefined;
+  for (const action of actions) {
+    const command = isJsonObject(action) ? readString(action, "command") : undefined;
+    if (!command) {
+      continue;
+    }
+    source = appendPreviewPart(source, command, " && ");
+    if (source.clipped) {
+      break;
+    }
+  }
+  return source;
 }
 
-function readCommand(record: JsonObject | undefined): string | undefined {
+function readCommandPreview(record: JsonObject | undefined): ApprovalPreviewSource | undefined {
   const command = record?.command;
   if (typeof command === "string") {
-    return command;
+    return previewSource(command);
   }
-  if (Array.isArray(command) && command.every((part) => typeof part === "string")) {
-    return command.join(" ");
+  if (!Array.isArray(command)) {
+    return undefined;
   }
-  return undefined;
+  let source: ApprovalPreviewSource | undefined;
+  for (const part of command) {
+    if (typeof part !== "string") {
+      return undefined;
+    }
+    source = appendPreviewPart(source, part, " ");
+    if (source.clipped) {
+      break;
+    }
+  }
+  return source;
+}
+
+function readStringPreview(
+  record: JsonObject | undefined,
+  key: string,
+): ApprovalPreviewSource | undefined {
+  const value = readString(record, key);
+  return value === undefined ? undefined : previewSource(value);
 }
 
 function readString(record: JsonObject | undefined, key: string): string | undefined {
@@ -568,6 +636,52 @@ function readString(record: JsonObject | undefined, key: string): string | undef
 
 function truncate(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function previewSource(value: string): ApprovalPreviewSource {
+  return {
+    value: value.slice(0, APPROVAL_PREVIEW_SCAN_MAX_LENGTH),
+    clipped: value.length > APPROVAL_PREVIEW_SCAN_MAX_LENGTH,
+  };
+}
+
+function appendPreviewPart(
+  source: ApprovalPreviewSource | undefined,
+  part: string,
+  separator: string,
+): ApprovalPreviewSource {
+  const prefix = source?.value ? `${source.value}${separator}` : "";
+  const value = `${prefix}${part}`;
+  const clipped = source?.clipped === true || value.length > APPROVAL_PREVIEW_SCAN_MAX_LENGTH;
+  return {
+    value: value.slice(0, APPROVAL_PREVIEW_SCAN_MAX_LENGTH),
+    clipped,
+  };
+}
+
+function sanitizeApprovalPreview(
+  source: ApprovalPreviewSource | undefined,
+  maxLength: number,
+): SanitizedApprovalPreview {
+  if (!source || !source.value) {
+    return { omitted: false };
+  }
+  const rawPreview = source.value.replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "");
+  const sanitized = sanitizeVisibleScalar(rawPreview);
+  if (!sanitized) {
+    return { omitted: true };
+  }
+  return { text: truncate(sanitized, maxLength), omitted: source.clipped };
+}
+
+function sanitizeVisibleScalar(value: string): string {
+  return value
+    .replace(ANSI_OSC_SEQUENCE_RE, "")
+    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
+    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
+    .replace(CONTROL_CHARACTER_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function joinDescriptionLinesWithinLimit(lines: string[], maxLength: number): string {


### PR DESCRIPTION
## Summary

- Problem: Codex app-server approval previews forward `command` and `reason` text nearly raw into `plugin.approval.request` descriptions and approval events.
- Why it matters: embedded newlines, ANSI escapes, and control characters can degrade forwarded approval UX and make event/chat previews harder to trust or scan.
- What changed: command/reason previews are now sanitized before they are used in approval descriptions or emitted in approval events, and regression tests lock in the sanitized output.
- What did NOT change (scope boundary): permission approval summaries, approval policy, session scoping, and the plugin approval roundtrip contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the bridge treated app-server `command` / `reason` fields as display-ready strings and reused them directly in human-facing approval payloads.
- Missing detection / guardrail: there was no regression test covering multiline/control-character approval previews.
- Contributing context (if known): permission approvals already had dedicated sanitization, but command/file approval previews did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/approval-bridge.test.ts`
- Scenario the test should lock in: command/reason values with newlines, ANSI escapes, and control characters are compacted before they reach approval descriptions and approval events.
- Why this is the smallest reliable guardrail: the bug is entirely inside the approval bridge formatting path.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Codex command/file approval previews now collapse multiline/control-character text into compact single-line summaries before forwarding them to the gateway approval UI/events.

## Diagram (if applicable)

```text
Before:
[app-server command/reason with ANSI/newlines] -> [approval bridge] -> [raw preview/event text]

After:
[app-server command/reason with ANSI/newlines] -> [approval bridge sanitization] -> [compact preview/event text]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Codex app-server bridge
- Relevant config (redacted): default local dev config

### Steps

1. Trigger `handleCodexAppServerApprovalRequest` with a command approval containing newlines / ANSI escapes in `requestParams.command`.
2. Trigger `handleCodexAppServerApprovalRequest` with a file approval containing newlines / ANSI escapes in `requestParams.reason`.
3. Inspect the forwarded `plugin.approval.request` payload and emitted approval events.

### Expected

- Approval descriptions and event payloads contain compact sanitized preview text.

### Actual

- Before this change, raw formatting/control characters were forwarded.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Codex approval bridge tests for command approval, unavailable file approval, and the new command/reason sanitization cases.
- Edge cases checked: ANSI escape stripping, multiline compaction, control-character stripping, unchanged permission approval behavior.
- What you did **not** verify: full GitHub CI and live chat-forwarded approval UX on a running gateway.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: over-sanitizing could remove legitimate formatting from previews.
  - Mitigation: only ANSI/control characters are stripped; printable content is preserved and regression-tested.
