### PR TITLE
Fix Telegram reply mode by chat type

### DIFF
--- a/extensions/telegram/config-api.ts
+++ b/extensions/telegram/config-api.ts
@@ -1,7 +1,7 @@
 export {
   buildChannelConfigSchema,
   TelegramConfigSchema,
-} from "openclaw/plugin-sdk/channel-config-schema";
+} from "../../src/plugin-sdk/channel-config-schema.js";
 export {
   normalizeTelegramCommandDescription,
   normalizeTelegramCommandName,

--- a/extensions/telegram/openclaw.plugin.json
+++ b/extensions/telegram/openclaw.plugin.json
@@ -8,5 +8,2199 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "channelConfigs": {
+    "telegram": {
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "capabilities": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "inlineButtons": {
+                    "type": "string",
+                    "enum": ["off", "dm", "group", "all", "allowlist"]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "execApprovals": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "approvers": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              },
+              "agentFilter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sessionFilter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "target": {
+                "type": "string",
+                "enum": ["dm", "channel", "both"]
+              }
+            },
+            "additionalProperties": false
+          },
+          "markdown": {
+            "type": "object",
+            "properties": {
+              "tables": {
+                "type": "string",
+                "enum": ["off", "bullets", "code", "block"]
+              }
+            },
+            "additionalProperties": false
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "commands": {
+            "type": "object",
+            "properties": {
+              "native": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "string",
+                    "const": "auto"
+                  }
+                ]
+              },
+              "nativeSkills": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "string",
+                    "const": "auto"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "customCommands": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": ["command", "description"],
+              "additionalProperties": false
+            }
+          },
+          "configWrites": {
+            "type": "boolean"
+          },
+          "dmPolicy": {
+            "default": "pairing",
+            "type": "string",
+            "enum": ["pairing", "allowlist", "open", "disabled"]
+          },
+          "botToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "env"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "file"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "exec"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            ]
+          },
+          "tokenFile": {
+            "type": "string"
+          },
+          "replyToModeByChatType": {
+            "type": "object",
+            "properties": {
+              "direct": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              },
+              "channel": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "off"
+                  },
+                  {
+                    "type": "string",
+                    "const": "first"
+                  },
+                  {
+                    "type": "string",
+                    "const": "all"
+                  },
+                  {
+                    "type": "string",
+                    "const": "batched"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "replyToMode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "off"
+              },
+              {
+                "type": "string",
+                "const": "first"
+              },
+              {
+                "type": "string",
+                "const": "all"
+              },
+              {
+                "type": "string",
+                "const": "batched"
+              }
+            ]
+          },
+          "groups": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "requireMention": {
+                  "type": "boolean"
+                },
+                "ingest": {
+                  "type": "boolean"
+                },
+                "disableAudioPreflight": {
+                  "type": "boolean"
+                },
+                "groupPolicy": {
+                  "type": "string",
+                  "enum": ["open", "disabled", "allowlist"]
+                },
+                "tools": {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alsoAllow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolsBySender": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "allow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "alsoAllow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deny": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "skills": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "topics": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "agentId": {
+                        "type": "string"
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "defaultTo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "groupAllowFrom": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "groupPolicy": {
+            "default": "allowlist",
+            "type": "string",
+            "enum": ["open", "disabled", "allowlist"]
+          },
+          "contextVisibility": {
+            "type": "string",
+            "enum": ["all", "allowlist", "allowlist_quote"]
+          },
+          "historyLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "dmHistoryLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "dms": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "historyLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "direct": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "dmPolicy": {
+                  "type": "string",
+                  "enum": ["pairing", "allowlist", "open", "disabled"]
+                },
+                "tools": {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alsoAllow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolsBySender": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "allow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "alsoAllow": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "deny": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "skills": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "systemPrompt": {
+                  "type": "string"
+                },
+                "topics": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "agentId": {
+                        "type": "string"
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "requireTopic": {
+                  "type": "boolean"
+                },
+                "autoTopicLabel": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "prompt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "streaming": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["off", "partial", "block", "progress"]
+              },
+              "chunkMode": {
+                "type": "string",
+                "enum": ["length", "newline"]
+              },
+              "preview": {
+                "type": "object",
+                "properties": {
+                  "chunk": {
+                    "type": "object",
+                    "properties": {
+                      "minChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "maxChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "breakPreference": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "const": "paragraph"
+                          },
+                          {
+                            "type": "string",
+                            "const": "newline"
+                          },
+                          {
+                            "type": "string",
+                            "const": "sentence"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "block": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "coalesce": {
+                    "type": "object",
+                    "properties": {
+                      "minChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "maxChars": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "idleMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "mediaMaxMb": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "timeoutSeconds": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "retry": {
+            "type": "object",
+            "properties": {
+              "attempts": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 9007199254740991
+              },
+              "minDelayMs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "maxDelayMs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "jitter": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "network": {
+            "type": "object",
+            "properties": {
+              "autoSelectFamily": {
+                "type": "boolean"
+              },
+              "dnsResultOrder": {
+                "type": "string",
+                "enum": ["ipv4first", "verbatim"]
+              },
+              "dangerouslyAllowPrivateNetwork": {
+                "description": "Dangerous opt-in for trusted Telegram fake-IP or transparent-proxy environments where api.telegram.org resolves to private/internal/special-use addresses during media downloads.",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "proxy": {
+            "type": "string"
+          },
+          "webhookUrl": {
+            "description": "Public HTTPS webhook URL registered with Telegram for inbound updates. This must be internet-reachable and requires channels.telegram.webhookSecret.",
+            "type": "string"
+          },
+          "webhookSecret": {
+            "description": "Secret token sent to Telegram during webhook registration and verified on inbound webhook requests. Telegram returns this value for verification; this is not the gateway auth token and not the bot token.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "env"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "file"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "const": "exec"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["source", "provider", "id"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            ]
+          },
+          "webhookPath": {
+            "description": "Local webhook route path served by the gateway listener. Defaults to /telegram-webhook.",
+            "type": "string"
+          },
+          "webhookHost": {
+            "description": "Local bind host for the webhook listener. Defaults to 127.0.0.1; keep loopback unless you intentionally expose direct ingress.",
+            "type": "string"
+          },
+          "webhookPort": {
+            "description": "Local bind port for the webhook listener. Defaults to 8787; set to 0 to let the OS assign an ephemeral port.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "webhookCertPath": {
+            "description": "Path to the self-signed certificate (PEM) to upload to Telegram during webhook registration. Required for self-signed certs (direct IP or no domain).",
+            "type": "string"
+          },
+          "actions": {
+            "type": "object",
+            "properties": {
+              "reactions": {
+                "type": "boolean"
+              },
+              "sendMessage": {
+                "type": "boolean"
+              },
+              "poll": {
+                "type": "boolean"
+              },
+              "deleteMessage": {
+                "type": "boolean"
+              },
+              "editMessage": {
+                "type": "boolean"
+              },
+              "sticker": {
+                "type": "boolean"
+              },
+              "createForumTopic": {
+                "type": "boolean"
+              },
+              "editForumTopic": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "threadBindings": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "idleHours": {
+                "type": "number",
+                "minimum": 0
+              },
+              "maxAgeHours": {
+                "type": "number",
+                "minimum": 0
+              },
+              "spawnSubagentSessions": {
+                "type": "boolean"
+              },
+              "spawnAcpSessions": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "reactionNotifications": {
+            "type": "string",
+            "enum": ["off", "own", "all"]
+          },
+          "reactionLevel": {
+            "type": "string",
+            "enum": ["off", "ack", "minimal", "extensive"]
+          },
+          "heartbeat": {
+            "type": "object",
+            "properties": {
+              "showOk": {
+                "type": "boolean"
+              },
+              "showAlerts": {
+                "type": "boolean"
+              },
+              "useIndicator": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "healthMonitor": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "linkPreview": {
+            "type": "boolean"
+          },
+          "silentErrorReplies": {
+            "type": "boolean"
+          },
+          "responsePrefix": {
+            "type": "string"
+          },
+          "ackReaction": {
+            "type": "string"
+          },
+          "errorPolicy": {
+            "type": "string",
+            "enum": ["always", "once", "silent"]
+          },
+          "errorCooldownMs": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "apiRoot": {
+            "type": "string",
+            "format": "uri"
+          },
+          "trustedLocalFileRoots": {
+            "description": "Trusted local filesystem roots for self-hosted Telegram Bot API absolute file_path values. Only absolute paths under these roots are read directly; all other absolute paths are rejected.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "autoTopicLabel": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "accounts": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "capabilities": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "inlineButtons": {
+                          "type": "string",
+                          "enum": ["off", "dm", "group", "all", "allowlist"]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "execApprovals": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "approvers": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      }
+                    },
+                    "agentFilter": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "sessionFilter": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "target": {
+                      "type": "string",
+                      "enum": ["dm", "channel", "both"]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "markdown": {
+                  "type": "object",
+                  "properties": {
+                    "tables": {
+                      "type": "string",
+                      "enum": ["off", "bullets", "code", "block"]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "commands": {
+                  "type": "object",
+                  "properties": {
+                    "native": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "auto"
+                        }
+                      ]
+                    },
+                    "nativeSkills": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "auto"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "customCommands": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["command", "description"],
+                    "additionalProperties": false
+                  }
+                },
+                "configWrites": {
+                  "type": "boolean"
+                },
+                "dmPolicy": {
+                  "default": "pairing",
+                  "type": "string",
+                  "enum": ["pairing", "allowlist", "open", "disabled"]
+                },
+                "botToken": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "env"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "file"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "exec"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "tokenFile": {
+                  "type": "string"
+                },
+                "replyToModeByChatType": {
+                  "type": "object",
+                  "properties": {
+                    "direct": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "off"
+                        },
+                        {
+                          "type": "string",
+                          "const": "first"
+                        },
+                        {
+                          "type": "string",
+                          "const": "all"
+                        },
+                        {
+                          "type": "string",
+                          "const": "batched"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "replyToMode": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "off"
+                    },
+                    {
+                      "type": "string",
+                      "const": "first"
+                    },
+                    {
+                      "type": "string",
+                      "const": "all"
+                    },
+                    {
+                      "type": "string",
+                      "const": "batched"
+                    }
+                  ]
+                },
+                "groups": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "requireMention": {
+                        "type": "boolean"
+                      },
+                      "ingest": {
+                        "type": "boolean"
+                      },
+                      "disableAudioPreflight": {
+                        "type": "boolean"
+                      },
+                      "groupPolicy": {
+                        "type": "string",
+                        "enum": ["open", "disabled", "allowlist"]
+                      },
+                      "tools": {
+                        "type": "object",
+                        "properties": {
+                          "allow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "alsoAllow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "deny": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "toolsBySender": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "allow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "alsoAllow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deny": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "topics": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "requireMention": {
+                              "type": "boolean"
+                            },
+                            "ingest": {
+                              "type": "boolean"
+                            },
+                            "disableAudioPreflight": {
+                              "type": "boolean"
+                            },
+                            "groupPolicy": {
+                              "type": "string",
+                              "enum": ["open", "disabled", "allowlist"]
+                            },
+                            "skills": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "allowFrom": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              }
+                            },
+                            "systemPrompt": {
+                              "type": "string"
+                            },
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "errorPolicy": {
+                              "type": "string",
+                              "enum": ["always", "once", "silent"]
+                            },
+                            "errorCooldownMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "allowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "defaultTo": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "groupAllowFrom": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                },
+                "groupPolicy": {
+                  "default": "allowlist",
+                  "type": "string",
+                  "enum": ["open", "disabled", "allowlist"]
+                },
+                "contextVisibility": {
+                  "type": "string",
+                  "enum": ["all", "allowlist", "allowlist_quote"]
+                },
+                "historyLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "dmHistoryLimit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "dms": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "historyLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "direct": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "dmPolicy": {
+                        "type": "string",
+                        "enum": ["pairing", "allowlist", "open", "disabled"]
+                      },
+                      "tools": {
+                        "type": "object",
+                        "properties": {
+                          "allow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "alsoAllow": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "deny": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "toolsBySender": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "allow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "alsoAllow": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "deny": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "allowFrom": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "systemPrompt": {
+                        "type": "string"
+                      },
+                      "topics": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "requireMention": {
+                              "type": "boolean"
+                            },
+                            "ingest": {
+                              "type": "boolean"
+                            },
+                            "disableAudioPreflight": {
+                              "type": "boolean"
+                            },
+                            "groupPolicy": {
+                              "type": "string",
+                              "enum": ["open", "disabled", "allowlist"]
+                            },
+                            "skills": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "allowFrom": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              }
+                            },
+                            "systemPrompt": {
+                              "type": "string"
+                            },
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "errorPolicy": {
+                              "type": "string",
+                              "enum": ["always", "once", "silent"]
+                            },
+                            "errorCooldownMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "errorPolicy": {
+                        "type": "string",
+                        "enum": ["always", "once", "silent"]
+                      },
+                      "errorCooldownMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "requireTopic": {
+                        "type": "boolean"
+                      },
+                      "autoTopicLabel": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "prompt": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "textChunkLimit": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "streaming": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": ["off", "partial", "block", "progress"]
+                    },
+                    "chunkMode": {
+                      "type": "string",
+                      "enum": ["length", "newline"]
+                    },
+                    "preview": {
+                      "type": "object",
+                      "properties": {
+                        "chunk": {
+                          "type": "object",
+                          "properties": {
+                            "minChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "maxChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "breakPreference": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "paragraph"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "newline"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "sentence"
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "block": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "coalesce": {
+                          "type": "object",
+                          "properties": {
+                            "minChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "maxChars": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "idleMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "mediaMaxMb": {
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                },
+                "timeoutSeconds": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "retry": {
+                  "type": "object",
+                  "properties": {
+                    "attempts": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
+                    },
+                    "minDelayMs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "maxDelayMs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "jitter": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "network": {
+                  "type": "object",
+                  "properties": {
+                    "autoSelectFamily": {
+                      "type": "boolean"
+                    },
+                    "dnsResultOrder": {
+                      "type": "string",
+                      "enum": ["ipv4first", "verbatim"]
+                    },
+                    "dangerouslyAllowPrivateNetwork": {
+                      "description": "Dangerous opt-in for trusted Telegram fake-IP or transparent-proxy environments where api.telegram.org resolves to private/internal/special-use addresses during media downloads.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "proxy": {
+                  "type": "string"
+                },
+                "webhookUrl": {
+                  "description": "Public HTTPS webhook URL registered with Telegram for inbound updates. This must be internet-reachable and requires channels.telegram.webhookSecret.",
+                  "type": "string"
+                },
+                "webhookSecret": {
+                  "description": "Secret token sent to Telegram during webhook registration and verified on inbound webhook requests. Telegram returns this value for verification; this is not the gateway auth token and not the bot token.",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "env"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "file"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "const": "exec"
+                            },
+                            "provider": {
+                              "type": "string",
+                              "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                            },
+                            "id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "provider", "id"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "webhookPath": {
+                  "description": "Local webhook route path served by the gateway listener. Defaults to /telegram-webhook.",
+                  "type": "string"
+                },
+                "webhookHost": {
+                  "description": "Local bind host for the webhook listener. Defaults to 127.0.0.1; keep loopback unless you intentionally expose direct ingress.",
+                  "type": "string"
+                },
+                "webhookPort": {
+                  "description": "Local bind port for the webhook listener. Defaults to 8787; set to 0 to let the OS assign an ephemeral port.",
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "webhookCertPath": {
+                  "description": "Path to the self-signed certificate (PEM) to upload to Telegram during webhook registration. Required for self-signed certs (direct IP or no domain).",
+                  "type": "string"
+                },
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "reactions": {
+                      "type": "boolean"
+                    },
+                    "sendMessage": {
+                      "type": "boolean"
+                    },
+                    "poll": {
+                      "type": "boolean"
+                    },
+                    "deleteMessage": {
+                      "type": "boolean"
+                    },
+                    "editMessage": {
+                      "type": "boolean"
+                    },
+                    "sticker": {
+                      "type": "boolean"
+                    },
+                    "createForumTopic": {
+                      "type": "boolean"
+                    },
+                    "editForumTopic": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "threadBindings": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "idleHours": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "maxAgeHours": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "spawnSubagentSessions": {
+                      "type": "boolean"
+                    },
+                    "spawnAcpSessions": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reactionNotifications": {
+                  "type": "string",
+                  "enum": ["off", "own", "all"]
+                },
+                "reactionLevel": {
+                  "type": "string",
+                  "enum": ["off", "ack", "minimal", "extensive"]
+                },
+                "heartbeat": {
+                  "type": "object",
+                  "properties": {
+                    "showOk": {
+                      "type": "boolean"
+                    },
+                    "showAlerts": {
+                      "type": "boolean"
+                    },
+                    "useIndicator": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "healthMonitor": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "linkPreview": {
+                  "type": "boolean"
+                },
+                "silentErrorReplies": {
+                  "type": "boolean"
+                },
+                "responsePrefix": {
+                  "type": "string"
+                },
+                "ackReaction": {
+                  "type": "string"
+                },
+                "errorPolicy": {
+                  "type": "string",
+                  "enum": ["always", "once", "silent"]
+                },
+                "errorCooldownMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "apiRoot": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "trustedLocalFileRoots": {
+                  "description": "Trusted local filesystem roots for self-hosted Telegram Bot API absolute file_path values. Only absolute paths under these roots are read directly; all other absolute paths are rejected.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "autoTopicLabel": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "prompt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "required": ["dmPolicy", "groupPolicy"],
+              "additionalProperties": false
+            }
+          },
+          "defaultAccount": {
+            "type": "string"
+          }
+        },
+        "required": ["dmPolicy", "groupPolicy"],
+        "additionalProperties": false
+      }
+    }
   }
 }

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -7,6 +7,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-core";
 import type {
+  ReplyToMode,
   TelegramAccountConfig,
   TelegramActionConfig,
 } from "openclaw/plugin-sdk/config-runtime";
@@ -23,12 +24,10 @@ import { resolveTelegramToken } from "./token.js";
 
 export { mergeTelegramAccountConfig, resolveTelegramAccountConfig } from "./account-config.js";
 
-let log: ReturnType<typeof createSubsystemLogger> | null = null;
+let log: ReturnType<typeof createSubsystemLogger>;
 
 function getLog() {
-  if (!log) {
-    log = createSubsystemLogger("telegram/accounts");
-  }
+  log ??= createSubsystemLogger("telegram/accounts");
   return log;
 }
 
@@ -183,4 +182,21 @@ export function listEnabledTelegramAccounts(cfg: OpenClawConfig): ResolvedTelegr
   return listTelegramAccountIds(cfg)
     .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
+}
+
+export function resolveTelegramReplyToMode(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+  chatType?: string | null,
+): ReplyToMode {
+  const account = mergeTelegramAccountConfig(cfg, normalizeAccountId(accountId));
+  const normalized =
+    chatType === "direct" || chatType === "group" || chatType === "channel" ? chatType : undefined;
+  if (normalized && account.replyToModeByChatType?.[normalized] !== undefined) {
+    return account.replyToModeByChatType[normalized];
+  }
+  if (account.replyToMode !== undefined) {
+    return account.replyToMode;
+  }
+  return normalized && normalized !== "direct" ? "all" : "off";
 }

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -2,6 +2,7 @@ import type { ReplyToMode } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramReplyToMode } from "./accounts.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   buildTelegramMessageContext,
@@ -47,7 +48,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     loadFreshConfig,
     sendChatActionHandler,
     runtime,
-    replyToMode,
+    replyToMode: _replyToMode,
     streamMode,
     textLimit,
     telegramDeps,
@@ -108,12 +109,17 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       );
     }
     try {
+      const effectiveReplyToMode = resolveTelegramReplyToMode(
+        cfg,
+        context.route?.accountId,
+        context.msg.chat.type === "channel" ? "channel" : context.isGroup ? "group" : "direct",
+      );
       await dispatchTelegramMessage({
         context,
         bot,
         cfg,
         runtime,
-        replyToMode,
+        replyToMode: effectiveReplyToMode,
         streamMode,
         textLimit,
         telegramCfg,

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -80,6 +80,30 @@ export function createTelegramPrivateCommandContext(params?: {
   };
 }
 
+export function createTelegramGroupCommandContext(params?: {
+  match?: string;
+  messageId?: number;
+  date?: number;
+  chatId?: number;
+  title?: string;
+  userId?: number;
+  username?: string;
+}) {
+  return {
+    match: params?.match ?? "",
+    message: {
+      message_id: params?.messageId ?? 2,
+      date: params?.date ?? Math.floor(Date.now() / 1000),
+      chat: {
+        id: params?.chatId ?? -1001234567890,
+        type: "supergroup" as const,
+        title: params?.title ?? "OpenClaw",
+      },
+      from: { id: params?.userId ?? 200, username: params?.username ?? "bob" },
+    },
+  };
+}
+
 export function createTelegramTopicCommandContext(params?: {
   match?: string;
   messageId?: number;

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import {
   createNativeCommandTestParams as createBaseNativeCommandTestParams,
+  createTelegramGroupCommandContext,
   createTelegramPrivateCommandContext,
   type NativeCommandTestParams as RegisterTelegramNativeCommandsParams,
 } from "./bot-native-commands.fixture-test-support.js";
@@ -129,4 +130,10 @@ export function createPrivateCommandContext(
   params?: Parameters<typeof createTelegramPrivateCommandContext>[0],
 ) {
   return createTelegramPrivateCommandContext(params);
+}
+
+export function createGroupCommandContext(
+  params?: Parameters<typeof createTelegramGroupCommandContext>[0],
+) {
+  return createTelegramGroupCommandContext(params);
 }

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCommandBot,
   createNativeCommandTestParams,
+  createGroupCommandContext,
   createPrivateCommandContext,
   deliverReplies,
   editMessageTelegram,
@@ -239,6 +240,34 @@ describe("registerTelegramNativeCommands", () => {
     expect(registeredCommands.some((entry) => entry.command === "plugin_status")).toBe(true);
     expect(registeredCommands.some((entry) => entry.command === "plugin-status")).toBe(false);
     expect(registeredCommands.some((entry) => entry.command === "custom-bad")).toBe(false);
+  });
+
+  it("uses group replyToModeByChatType for built-in native command delivery", async () => {
+    const { commandHandlers } = createCommandBot();
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(
+        {
+          channels: {
+            telegram: {
+              replyToModeByChatType: { direct: "off", group: "all" },
+            },
+          },
+        },
+        { accountId: "default" },
+      ),
+    });
+
+    const handler = commandHandlers.get("model");
+    expect(handler).toBeTruthy();
+    await handler?.(createGroupCommandContext({ messageId: 77 }));
+
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentMessageId: "77",
+        replyToMode: "all",
+      }),
+    );
   });
 
   it("prefixes native command menu callback data so callback handlers can preserve native routing", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -19,6 +19,7 @@ import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import type {
   ReplyToMode,
   TelegramAccountConfig,
+  TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-runtime";
@@ -30,7 +31,6 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
-import { resolveTelegramReplyToMode } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -90,6 +90,10 @@ type TelegramNativeReplyChannelData = {
   buttons?: TelegramInlineButtons;
   pin?: boolean;
 };
+type TelegramResolvedGroupConfig = {
+  groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
+  topicConfig?: TelegramTopicConfig;
+};
 
 type TelegramCommandAuthResult = {
   chatId: number;
@@ -98,7 +102,7 @@ type TelegramCommandAuthResult = {
   resolvedThreadId?: number;
   senderId: string;
   senderUsername: string;
-  groupConfig?: TelegramGroupConfig;
+  groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
   commandAuthorized: boolean;
 };
@@ -187,7 +191,7 @@ export type RegisterTelegramHandlerParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => TelegramResolvedGroupConfig;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: TelegramContext,
@@ -230,7 +234,7 @@ export type RegisterTelegramNativeCommandsParams = {
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
-  replyToMode?: ReplyToMode;
+  replyToMode: ReplyToMode;
   textLimit: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
@@ -240,7 +244,7 @@ export type RegisterTelegramNativeCommandsParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => TelegramResolvedGroupConfig;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   telegramDeps?: TelegramNativeCommandDeps;
   opts: { token: string };
@@ -260,7 +264,7 @@ async function resolveTelegramCommandAuth(params: {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  ) => TelegramResolvedGroupConfig;
   requireAuth: boolean;
 }): Promise<TelegramCommandAuthResult | null> {
   const {
@@ -322,7 +326,8 @@ async function resolveTelegramCommandAuth(params: {
     !isGroup && groupConfig && "dmPolicy" in groupConfig
       ? (groupConfig.dmPolicy ?? telegramCfg.dmPolicy ?? "pairing")
       : (telegramCfg.dmPolicy ?? "pairing");
-  const requireTopic = groupConfig?.requireTopic;
+  const requireTopic =
+    !isGroup && groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
   if (!isGroup && requireTopic === true && dmThreadId == null) {
     logVerbose(`Blocked telegram command in DM ${chatId}: requireTopic=true but no topic present`);
     return null;
@@ -469,7 +474,7 @@ export const registerTelegramNativeCommands = ({
   telegramCfg,
   allowFrom,
   groupAllowFrom,
-  replyToMode: _replyToMode,
+  replyToMode,
   textLimit,
   useAccessGroups,
   nativeEnabled,
@@ -683,10 +688,12 @@ export const registerTelegramNativeCommands = ({
     return { chatId, threadSpec, route, mediaLocalRoots, tableMode, chunkMode };
   };
   const buildCommandDeliveryBaseOptions = (params: {
+    cfg: OpenClawConfig;
     chatId: string | number;
-    currentMessageId?: string;
     accountId: string;
+    currentMessageId?: string | number;
     sessionKeyForInternalHooks?: string;
+    policySessionKey?: string;
     mirrorIsGroup?: boolean;
     mirrorGroupId?: string;
     mediaLocalRoots?: readonly string[];
@@ -694,19 +701,21 @@ export const registerTelegramNativeCommands = ({
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: TelegramChunkMode;
     linkPreview?: boolean;
-    chatType: "direct" | "group";
   }) => ({
+    cfg: params.cfg,
     chatId: String(params.chatId),
-    currentMessageId: params.currentMessageId,
     accountId: params.accountId,
+    currentMessageId:
+      params.currentMessageId == null ? undefined : String(params.currentMessageId),
     sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+    policySessionKey: params.policySessionKey,
     mirrorIsGroup: params.mirrorIsGroup,
     mirrorGroupId: params.mirrorGroupId,
     token: opts.token,
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode: resolveTelegramReplyToMode(cfg, params.accountId, params.chatType),
+    replyToMode,
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -854,10 +863,12 @@ export const registerTelegramNativeCommands = ({
             targetSessionKey: sessionKey,
           });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
+          cfg: executionCfg,
           chatId,
-          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
+          currentMessageId: msg.message_id,
           sessionKeyForInternalHooks: commandSessionKey,
+          policySessionKey: commandTargetSessionKey,
           mirrorIsGroup: isGroup,
           mirrorGroupId: isGroup ? String(chatId) : undefined,
           mediaLocalRoots,
@@ -865,7 +876,6 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
-          chatType: isGroup ? "group" : "direct",
         });
         const conversationLabel = isGroup
           ? msg.chat.title
@@ -1041,10 +1051,12 @@ export const registerTelegramNativeCommands = ({
         }
         const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
+          cfg: runtimeCfg,
           chatId,
-          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
+          currentMessageId: msg.message_id,
           sessionKeyForInternalHooks: route.sessionKey,
+          policySessionKey: route.sessionKey,
           mirrorIsGroup: isGroup,
           mirrorGroupId: isGroup ? String(chatId) : undefined,
           mediaLocalRoots,
@@ -1052,7 +1064,6 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
-          chatType: isGroup ? "group" : "direct",
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -19,7 +19,6 @@ import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import type {
   ReplyToMode,
   TelegramAccountConfig,
-  TelegramDirectConfig,
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-runtime";
@@ -31,6 +30,7 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { resolveTelegramAccount } from "./accounts.js";
+import { resolveTelegramReplyToMode } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -90,10 +90,6 @@ type TelegramNativeReplyChannelData = {
   buttons?: TelegramInlineButtons;
   pin?: boolean;
 };
-type TelegramResolvedGroupConfig = {
-  groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
-  topicConfig?: TelegramTopicConfig;
-};
 
 type TelegramCommandAuthResult = {
   chatId: number;
@@ -102,7 +98,7 @@ type TelegramCommandAuthResult = {
   resolvedThreadId?: number;
   senderId: string;
   senderUsername: string;
-  groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
+  groupConfig?: TelegramGroupConfig;
   topicConfig?: TelegramTopicConfig;
   commandAuthorized: boolean;
 };
@@ -191,7 +187,7 @@ export type RegisterTelegramHandlerParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => TelegramResolvedGroupConfig;
+  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: TelegramContext,
@@ -234,7 +230,7 @@ export type RegisterTelegramNativeCommandsParams = {
   telegramCfg: TelegramAccountConfig;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
-  replyToMode: ReplyToMode;
+  replyToMode?: ReplyToMode;
   textLimit: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
@@ -244,7 +240,7 @@ export type RegisterTelegramNativeCommandsParams = {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => TelegramResolvedGroupConfig;
+  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   telegramDeps?: TelegramNativeCommandDeps;
   opts: { token: string };
@@ -264,7 +260,7 @@ async function resolveTelegramCommandAuth(params: {
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
-  ) => TelegramResolvedGroupConfig;
+  ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
   requireAuth: boolean;
 }): Promise<TelegramCommandAuthResult | null> {
   const {
@@ -326,8 +322,7 @@ async function resolveTelegramCommandAuth(params: {
     !isGroup && groupConfig && "dmPolicy" in groupConfig
       ? (groupConfig.dmPolicy ?? telegramCfg.dmPolicy ?? "pairing")
       : (telegramCfg.dmPolicy ?? "pairing");
-  const requireTopic =
-    !isGroup && groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
+  const requireTopic = groupConfig?.requireTopic;
   if (!isGroup && requireTopic === true && dmThreadId == null) {
     logVerbose(`Blocked telegram command in DM ${chatId}: requireTopic=true but no topic present`);
     return null;
@@ -474,7 +469,7 @@ export const registerTelegramNativeCommands = ({
   telegramCfg,
   allowFrom,
   groupAllowFrom,
-  replyToMode,
+  replyToMode: _replyToMode,
   textLimit,
   useAccessGroups,
   nativeEnabled,
@@ -688,11 +683,10 @@ export const registerTelegramNativeCommands = ({
     return { chatId, threadSpec, route, mediaLocalRoots, tableMode, chunkMode };
   };
   const buildCommandDeliveryBaseOptions = (params: {
-    cfg: OpenClawConfig;
     chatId: string | number;
+    currentMessageId?: string;
     accountId: string;
     sessionKeyForInternalHooks?: string;
-    policySessionKey?: string;
     mirrorIsGroup?: boolean;
     mirrorGroupId?: string;
     mediaLocalRoots?: readonly string[];
@@ -700,19 +694,19 @@ export const registerTelegramNativeCommands = ({
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: TelegramChunkMode;
     linkPreview?: boolean;
+    chatType: "direct" | "group";
   }) => ({
-    cfg: params.cfg,
     chatId: String(params.chatId),
+    currentMessageId: params.currentMessageId,
     accountId: params.accountId,
     sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
-    policySessionKey: params.policySessionKey,
     mirrorIsGroup: params.mirrorIsGroup,
     mirrorGroupId: params.mirrorGroupId,
     token: opts.token,
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode,
+    replyToMode: resolveTelegramReplyToMode(cfg, params.accountId, params.chatType),
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -860,11 +854,10 @@ export const registerTelegramNativeCommands = ({
             targetSessionKey: sessionKey,
           });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
-          cfg: executionCfg,
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: commandSessionKey,
-          policySessionKey: commandTargetSessionKey,
           mirrorIsGroup: isGroup,
           mirrorGroupId: isGroup ? String(chatId) : undefined,
           mediaLocalRoots,
@@ -872,6 +865,7 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          chatType: isGroup ? "group" : "direct",
         });
         const conversationLabel = isGroup
           ? msg.chat.title
@@ -1047,11 +1041,10 @@ export const registerTelegramNativeCommands = ({
         }
         const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
-          cfg: runtimeCfg,
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: route.sessionKey,
-          policySessionKey: route.sessionKey,
           mirrorIsGroup: isGroup,
           mirrorGroupId: isGroup ? String(chatId) : undefined,
           mediaLocalRoots,
@@ -1059,6 +1052,7 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          chatType: isGroup ? "group" : "direct",
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;
@@ -1136,7 +1130,7 @@ export const registerTelegramNativeCommands = ({
               linkPreview: runtimeTelegramCfg.linkPreview,
               buttons: telegramResultData?.buttons,
             });
-            recordSentMessage(chatId, progressMessageId, runtimeCfg);
+            recordSentMessage(chatId, progressMessageId);
             emitTelegramMessageSentHooks({
               sessionKeyForInternalHooks: route.sessionKey,
               chatId: String(chatId),

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -30,7 +30,7 @@ import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
-import { resolveTelegramAccount } from "./accounts.js";
+import { resolveTelegramAccount, resolveTelegramReplyToMode } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -822,12 +822,25 @@ export const registerTelegramNativeCommands = ({
             );
           }
           const replyMarkup = buildInlineKeyboard(rows);
+          const effectiveReplyToMode = resolveTelegramReplyToMode(
+            executionCfg,
+            route.accountId,
+            isGroup ? "group" : "direct",
+          );
+          const menuReplyParams =
+            effectiveReplyToMode === "off"
+              ? {}
+              : {
+                  reply_to_message_id: msg.message_id,
+                  allow_sending_without_reply: true as const,
+                };
           await withTelegramApiErrorLogging({
             operation: "sendMessage",
             runtime,
             fn: () =>
               bot.api.sendMessage(chatId, title, {
                 ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+                ...menuReplyParams,
                 ...threadParams,
               }),
           });

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -75,12 +75,6 @@ type TelegramCompatFetch = (
   input: TelegramFetchInput,
   init?: TelegramFetchInit,
 ) => ReturnType<TelegramClientFetch>;
-type TelegramAbortSignalLike = {
-  aborted: boolean;
-  reason?: unknown;
-  addEventListener: (type: "abort", listener: () => void, options?: { once?: boolean }) => void;
-  removeEventListener: (type: "abort", listener: () => void) => void;
-};
 
 function asTelegramClientFetch(
   fetchImpl: TelegramCompatFetch | typeof globalThis.fetch,
@@ -90,17 +84,6 @@ function asTelegramClientFetch(
 
 function asTelegramCompatFetch(fetchImpl: TelegramClientFetch): TelegramCompatFetch {
   return fetchImpl as unknown as TelegramCompatFetch;
-}
-
-function isTelegramAbortSignalLike(value: unknown): value is TelegramAbortSignalLike {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "aborted" in value &&
-    typeof (value as { aborted?: unknown }).aborted === "boolean" &&
-    typeof (value as { addEventListener?: unknown }).addEventListener === "function" &&
-    typeof (value as { removeEventListener?: unknown }).removeEventListener === "function"
-  );
 }
 
 function readRequestUrl(input: TelegramFetchInput): string | null {
@@ -148,7 +131,6 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
   });
   const threadBindingManager = threadBindingPolicy.enabled
     ? createTelegramThreadBindingManager({
-        cfg,
         accountId: account.accountId,
         idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
           cfg,
@@ -189,11 +171,8 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
     // causing "signals[0] must be an instance of AbortSignal" errors).
     finalFetch = (input: TelegramFetchInput, init?: TelegramFetchInit) => {
       const controller = new AbortController();
-      const abortWith = (signal: Pick<TelegramAbortSignalLike, "reason">) =>
-        controller.abort(signal.reason);
-      const shutdownSignal = isTelegramAbortSignalLike(opts.fetchAbortSignal)
-        ? opts.fetchAbortSignal
-        : undefined;
+      const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
+      const shutdownSignal = opts.fetchAbortSignal;
       const onShutdown = () => {
         if (shutdownSignal) {
           abortWith(shutdownSignal);
@@ -203,7 +182,7 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
       const requestTimeoutMs = resolveTelegramRequestTimeoutMs(method);
       let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
-      const requestSignal = isTelegramAbortSignalLike(init?.signal) ? init.signal : undefined;
+      const requestSignal = init?.signal;
       if (shutdownSignal?.aborted) {
         abortWith(shutdownSignal);
       } else if (shutdownSignal) {
@@ -461,7 +440,8 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
   const allowFrom = opts.allowFrom ?? telegramCfg.allowFrom;
   const groupAllowFrom =
     opts.groupAllowFrom ?? telegramCfg.groupAllowFrom ?? telegramCfg.allowFrom ?? allowFrom;
-  const replyToMode = opts.replyToMode ?? telegramCfg.replyToMode ?? "off";
+  const replyToMode = opts.replyToMode ?? telegramCfg.replyToMode;
+  const processorReplyToMode = replyToMode ?? "off";
   const nativeEnabled = resolveNativeCommandsEnabled({
     providerId: "telegram",
     providerSetting: telegramCfg.commands?.native,
@@ -594,7 +574,7 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
     loadFreshConfig: () => telegramDeps.loadConfig(),
     sendChatActionHandler,
     runtime,
-    replyToMode,
+    replyToMode: processorReplyToMode,
     streamMode,
     textLimit,
     opts,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -677,7 +677,7 @@ export async function deliverReplies(params: {
       const replyToId =
         effectiveReplyToMode === "off" && !explicitReplyOverride
           ? undefined
-          : resolveTelegramReplyId(reply.replyToId);
+          : resolveTelegramReplyId(reply.replyToId) ?? resolveTelegramReplyId(params.currentMessageId);
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -9,21 +9,16 @@ import {
   toPluginMessageContext,
   toPluginMessageSentEvent,
 } from "openclaw/plugin-sdk/hook-runtime";
-import type { ReplyPayloadDelivery } from "openclaw/plugin-sdk/interactive-runtime";
 import { buildOutboundMediaLoadOptions } from "openclaw/plugin-sdk/media-runtime";
 import { isGifMedia, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
-import {
-  createOutboundPayloadPlan,
-  projectOutboundPayloadPlanForDelivery,
-} from "openclaw/plugin-sdk/outbound-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
+import { normalizeReplyPayloadsForDelivery } from "../../../../src/infra/outbound/payloads.js";
 import type { TelegramInlineButtons } from "../button-types.js";
 import { splitTelegramCaption } from "../caption.js";
 import {
@@ -47,11 +42,10 @@ import {
   type DeliveryProgress as ReplyThreadDeliveryProgress,
 } from "./reply-threading.js";
 
-const VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
+const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
-const silentReplyLogger = createSubsystemLogger("telegram/silent-reply");
 
 type DeliveryProgress = ReplyThreadDeliveryProgress & {
   deliveredCount: number;
@@ -193,9 +187,9 @@ async function sendPendingFollowUpText(params: {
 
 function isVoiceMessagesForbidden(err: unknown): boolean {
   if (GrammyErrorCtor && err instanceof GrammyErrorCtor) {
-    return err.description.includes(VOICE_FORBIDDEN_MARKER);
+    return err.description.includes("VOICE_MESSAGES_FORBIDDEN");
   }
-  return formatErrorMessage(err).includes(VOICE_FORBIDDEN_MARKER);
+  return VOICE_FORBIDDEN_RE.test(formatErrorMessage(err));
 }
 
 function isCaptionTooLong(err: unknown): boolean {
@@ -488,20 +482,18 @@ async function deliverMediaReply(params: {
 }
 
 async function maybePinFirstDeliveredMessage(params: {
-  pin: ReplyPayloadDelivery["pin"];
+  shouldPin: boolean;
   bot: Bot;
   chatId: string;
   runtime: RuntimeEnv;
   firstDeliveredMessageId?: number;
 }): Promise<void> {
-  const shouldPin = params.pin === true || (typeof params.pin === "object" && params.pin.enabled);
-  if (!shouldPin || typeof params.firstDeliveredMessageId !== "number") {
+  if (!params.shouldPin || typeof params.firstDeliveredMessageId !== "number") {
     return;
   }
-  const notify = typeof params.pin === "object" && params.pin.notify === true;
   try {
     await params.bot.api.pinChatMessage(params.chatId, params.firstDeliveredMessageId, {
-      disable_notification: !notify,
+      disable_notification: true,
     });
   } catch (err) {
     logVerbose(
@@ -590,18 +582,17 @@ export function emitTelegramMessageSentHooks(params: EmitMessageSentHookParams):
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
-  cfg?: import("openclaw/plugin-sdk/config-runtime").OpenClawConfig;
+  currentMessageId?: string;
   chatId: string;
   accountId?: string;
   sessionKeyForInternalHooks?: string;
-  policySessionKey?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
   token: string;
   runtime: RuntimeEnv;
   bot: Bot;
   mediaLocalRoots?: readonly string[];
-  replyToMode: ReplyToMode;
+  replyToMode?: ReplyToMode;
   textLimit: number;
   thread?: TelegramThreadSpec | null;
   tableMode?: MarkdownTableMode;
@@ -626,39 +617,16 @@ export async function deliverReplies(params: {
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  const effectiveReplyToMode =
+    params.replyToMode ?? (params.thread?.scope === "dm" ? "off" : "all");
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
-  const candidateReplies: ReplyPayload[] = [];
-  for (const reply of params.replies) {
-    if (!reply || typeof reply !== "object") {
-      params.runtime.error?.(danger("reply missing text/media"));
-      continue;
-    }
-    candidateReplies.push(reply);
-  }
-  const normalizedReplies = projectOutboundPayloadPlanForDelivery(
-    createOutboundPayloadPlan(candidateReplies, {
-      cfg: params.cfg,
-      sessionKey: params.policySessionKey ?? params.sessionKeyForInternalHooks,
-      surface: "telegram",
-    }),
-  );
-  const originalExactSilentCount = candidateReplies.filter(
-    (reply) => typeof reply.text === "string" && reply.text.trim().toUpperCase() === "NO_REPLY",
-  ).length;
-  if (originalExactSilentCount > 0) {
-    silentReplyLogger.debug("telegram delivery normalized NO_REPLY candidates", {
-      hasSessionKey: Boolean(params.sessionKeyForInternalHooks),
-      hasChatId: params.chatId.length > 0,
-      originalCount: candidateReplies.length,
-      normalizedCount: normalizedReplies.length,
-      originalExactSilentCount,
-    });
-  }
-  for (const originalReply of normalizedReplies) {
+  for (const originalReply of normalizeReplyPayloadsForDelivery(params.replies, {
+    currentMessageId: params.currentMessageId,
+  })) {
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls
@@ -676,15 +644,11 @@ export async function deliverReplies(params: {
     }
 
     const rawContent = reply.text || "";
-    const replyToId =
-      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
     if (hasMessageSendingHooks) {
       const hookResult = await hookRunner?.runMessageSending(
         {
           to: params.chatId,
           content: rawContent,
-          replyToId,
-          threadId: params.thread?.id,
           metadata: {
             channel: "telegram",
             mediaUrls: mediaList,
@@ -709,7 +673,13 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
+      const explicitReplyOverride = Boolean(reply.replyToTag) || Boolean(reply.replyToCurrent);
+      const replyToId =
+        effectiveReplyToMode === "off" && !explicitReplyOverride
+          ? undefined
+          : resolveTelegramReplyId(reply.replyToId);
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
+      const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
       let firstDeliveredMessageId: number | undefined;
       if (mediaList.length === 0) {
@@ -725,7 +695,7 @@ export async function deliverReplies(params: {
           linkPreview: params.linkPreview,
           silent: params.silent,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       } else {
@@ -746,12 +716,12 @@ export async function deliverReplies(params: {
           replyQuoteText: params.replyQuoteText,
           replyMarkup,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       }
       await maybePinFirstDeliveredMessage({
-        pin: reply.delivery?.pin,
+        shouldPin: shouldPinFirstMessage,
         bot: params.bot,
         chatId: params.chatId,
         runtime: params.runtime,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,7 +1,6 @@
 import type { Bot } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
@@ -292,6 +291,56 @@ describe("deliverReplies", () => {
     });
 
     expect(triggerInternalHook).not.toHaveBeenCalled();
+  });
+
+  it("rewrites exact NO_REPLY for direct Telegram sessions", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 12, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:direct:123",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toEqual(expect.any(String));
+    expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
+  });
+
+  it("uses the policy session key for exact NO_REPLY policy", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 121, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:slash:123",
+      policySessionKey: "agent:test:telegram:direct:123",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toEqual(expect.any(String));
+    expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
+  });
+
+  it("suppresses exact NO_REPLY for group Telegram sessions", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 13, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:group:123",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("emits internal message:sent with success=false on delivery failure", async () => {
@@ -617,6 +666,57 @@ describe("deliverReplies", () => {
       }),
     ).resolves.toEqual({ delivered: false });
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("parses reply tags from telegram reply text before delivery", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 23, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "[[reply_to:42]] hello" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("hello"),
+      expect.objectContaining({
+        reply_to_message_id: 42,
+      }),
+    );
+  });
+
+  it("honors [[reply_to_current]] even when replyToMode is off", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 24, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "[[reply_to_current]] hello" }],
+      currentMessageId: "77",
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("hello"),
+      expect.objectContaining({
+        reply_to_message_id: 77,
+      }),
+    );
   });
 
   it("uses reply_to_message_id when quote text is provided", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,6 +1,7 @@
 import type { Bot } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
@@ -293,56 +294,6 @@ describe("deliverReplies", () => {
     expect(triggerInternalHook).not.toHaveBeenCalled();
   });
 
-  it("rewrites exact NO_REPLY for direct Telegram sessions", async () => {
-    const runtime = createRuntime(false);
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 12, chat: { id: "123" } });
-    const bot = createBot({ sendMessage });
-
-    await deliverWith({
-      sessionKeyForInternalHooks: "agent:test:telegram:direct:123",
-      replies: [{ text: "NO_REPLY" }],
-      runtime,
-      bot,
-    });
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[1]).toEqual(expect.any(String));
-    expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
-  });
-
-  it("uses the policy session key for exact NO_REPLY policy", async () => {
-    const runtime = createRuntime(false);
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 121, chat: { id: "123" } });
-    const bot = createBot({ sendMessage });
-
-    await deliverWith({
-      sessionKeyForInternalHooks: "agent:test:telegram:slash:123",
-      policySessionKey: "agent:test:telegram:direct:123",
-      replies: [{ text: "NO_REPLY" }],
-      runtime,
-      bot,
-    });
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[1]).toEqual(expect.any(String));
-    expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
-  });
-
-  it("suppresses exact NO_REPLY for group Telegram sessions", async () => {
-    const runtime = createRuntime(false);
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 13, chat: { id: "123" } });
-    const bot = createBot({ sendMessage });
-
-    await deliverWith({
-      sessionKeyForInternalHooks: "agent:test:telegram:group:123",
-      replies: [{ text: "NO_REPLY" }],
-      runtime,
-      bot,
-    });
-
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
   it("emits internal message:sent with success=false on delivery failure", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockRejectedValue(new Error("network error"));
@@ -396,36 +347,6 @@ describe("deliverReplies", () => {
         metadata: expect.objectContaining({
           channel: "telegram",
           mediaUrls: ["https://example.com/photo.jpg"],
-        }),
-      }),
-      expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
-    );
-  });
-
-  it("passes shared routing fields to message_sending hooks", async () => {
-    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
-
-    const runtime = createRuntime(false);
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 3, chat: { id: "123" } });
-    const bot = createBot({ sendMessage });
-
-    await deliverWith({
-      replies: [{ text: "caption", replyToId: "500" }],
-      runtime,
-      bot,
-      replyToMode: "all",
-      thread: { id: 42, scope: "forum" },
-    });
-
-    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "123",
-        content: "caption",
-        replyToId: 500,
-        threadId: 42,
-        metadata: expect.objectContaining({
-          channel: "telegram",
-          threadId: 42,
         }),
       }),
       expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
@@ -966,7 +887,7 @@ describe("deliverReplies", () => {
     const bot = createBot({ sendMessage, pinChatMessage });
 
     await deliverReplies({
-      replies: [{ text: "chunk-one\n\nchunk-two", delivery: { pin: true } }],
+      replies: [{ text: "chunk-one\n\nchunk-two", channelData: { telegram: { pin: true } } }],
       chatId: "123",
       token: "tok",
       runtime,
@@ -979,25 +900,6 @@ describe("deliverReplies", () => {
     expect(pinChatMessage).toHaveBeenCalledWith("123", 101, { disable_notification: true });
   });
 
-  it("honors notify on reply delivery pins", async () => {
-    const runtime = createRuntime();
-    const sendMessage = vi.fn().mockResolvedValue({ message_id: 101, chat: { id: "123" } });
-    const pinChatMessage = vi.fn().mockResolvedValue(true);
-    const bot = createBot({ sendMessage, pinChatMessage });
-
-    await deliverReplies({
-      replies: [{ text: "hello", delivery: { pin: { enabled: true, notify: true } } }],
-      chatId: "123",
-      token: "tok",
-      runtime,
-      bot,
-      replyToMode: "off",
-      textLimit: 4096,
-    });
-
-    expect(pinChatMessage).toHaveBeenCalledWith("123", 101, { disable_notification: false });
-  });
-
   it("continues when pinning fails", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 201, chat: { id: "123" } });
@@ -1005,7 +907,7 @@ describe("deliverReplies", () => {
     const bot = createBot({ sendMessage, pinChatMessage });
 
     await deliverWith({
-      replies: [{ text: "hello", delivery: { pin: true } }],
+      replies: [{ text: "hello", channelData: { telegram: { pin: true } } }],
       runtime,
       bot,
     });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -4,14 +4,9 @@ import {
   createNestedAllowlistOverrideResolver,
 } from "openclaw/plugin-sdk/allowlist-config-edit";
 import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
-import {
-  buildChannelOutboundSessionRoute,
-  buildThreadAwareOutboundSessionRoute,
-  clearAccountEntryFields,
-  createChatChannelPlugin,
-} from "openclaw/plugin-sdk/channel-core";
-import { createAccountStatusSink } from "openclaw/plugin-sdk/channel-lifecycle";
+import { clearAccountEntryFields, createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
+import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import {
   PAIRING_APPROVED_MESSAGE,
@@ -20,13 +15,19 @@ import {
   resolveConfiguredFromCredentialStatuses,
 } from "openclaw/plugin-sdk/channel-status";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { createScopedAccountReplyToModeResolver } from "openclaw/plugin-sdk/conversation-runtime";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveOutboundSendDep,
   type OutboundSendDeps,
 } from "openclaw/plugin-sdk/outbound-runtime";
-import { type RoutePeer } from "openclaw/plugin-sdk/routing";
+import {
+  buildOutboundBaseSessionKey,
+  normalizeOutboundThreadId,
+  resolveThreadSessionKeys,
+  type RoutePeer,
+} from "openclaw/plugin-sdk/routing";
 import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
@@ -35,7 +36,11 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
-import { resolveTelegramAccount, type ResolvedTelegramAccount } from "./accounts.js";
+import {
+  resolveTelegramAccount,
+  resolveTelegramReplyToMode,
+  type ResolvedTelegramAccount,
+} from "./accounts.js";
 import { resolveTelegramAutoThreadId } from "./action-threading.js";
 import { lookupTelegramChatId } from "./api-fetch.js";
 import { telegramApprovalCapability } from "./approval-native.js";
@@ -62,7 +67,7 @@ import type { TelegramProbe } from "./probe.js";
 import * as probeModule from "./probe.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import { getTelegramRuntime } from "./runtime.js";
-import { telegramSecurityAdapter } from "./security.js";
+import { collectTelegramSecurityAuditFindings } from "./security-audit.js";
 import { resolveTelegramSessionConversation } from "./session-conversation.js";
 import { telegramSetupAdapter } from "./setup-core.js";
 import { telegramSetupWizard } from "./setup-surface.js";
@@ -445,22 +450,30 @@ function shouldStripTelegramThreadFromAnnounceOrigin(params: {
   return entryTarget.to !== requesterTarget.to;
 }
 
+function buildTelegramBaseSessionKey(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  accountId?: string | null;
+  peer: RoutePeer;
+}) {
+  return buildOutboundBaseSessionKey({ ...params, channel: "telegram" });
+}
+
 function resolveTelegramOutboundSessionRoute(params: {
   cfg: OpenClawConfig;
   agentId: string;
   accountId?: string | null;
   target: string;
   resolvedTarget?: { kind: string };
-  replyToId?: string | null;
   threadId?: string | number | null;
-  currentSessionKey?: string | null;
 }) {
   const parsed = parseTelegramTarget(params.target);
   const chatId = parsed.chatId.trim();
   if (!chatId) {
     return null;
   }
-  const resolvedThreadId = parsed.messageThreadId ?? parseTelegramThreadId(params.threadId);
+  const fallbackThreadId = normalizeOutboundThreadId(params.threadId);
+  const resolvedThreadId = parsed.messageThreadId ?? parseTelegramThreadId(fallbackThreadId);
   const isGroup =
     parsed.chatType === "group" ||
     (parsed.chatType === "unknown" &&
@@ -472,11 +485,19 @@ function resolveTelegramOutboundSessionRoute(params: {
     kind: isGroup ? "group" : "direct",
     id: peerId,
   };
-  const baseRoute = buildChannelOutboundSessionRoute({
+  const baseSessionKey = buildTelegramBaseSessionKey({
     cfg: params.cfg,
     agentId: params.agentId,
-    channel: "telegram",
     accountId: params.accountId,
+    peer,
+  });
+  const threadKeys =
+    resolvedThreadId && !isGroup
+      ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(resolvedThreadId) })
+      : null;
+  return {
+    sessionKey: threadKeys?.sessionKey ?? baseSessionKey,
+    baseSessionKey,
     peer,
     chatType: isGroup ? ("group" as const) : ("direct" as const),
     from: isGroup
@@ -485,25 +506,7 @@ function resolveTelegramOutboundSessionRoute(params: {
         ? `telegram:${chatId}:topic:${resolvedThreadId}`
         : `telegram:${chatId}`,
     to: `telegram:${chatId}`,
-    ...(isGroup && resolvedThreadId !== undefined ? { threadId: resolvedThreadId } : {}),
-  });
-  if (isGroup) {
-    return baseRoute;
-  }
-  const route = buildThreadAwareOutboundSessionRoute({
-    route: baseRoute,
     threadId: resolvedThreadId,
-    currentSessionKey: params.currentSessionKey,
-    precedence: ["threadId", "currentSession"],
-    canRecoverCurrentThread: ({ route }) =>
-      route.chatType !== "direct" || (params.cfg.session?.dmScope ?? "main") !== "main",
-  });
-  return {
-    ...route,
-    from:
-      route.threadId !== undefined
-        ? `telegram:${chatId}:topic:${route.threadId}`
-        : `telegram:${chatId}`,
   };
 }
 
@@ -582,6 +585,27 @@ const resolveTelegramAllowlistGroupOverrides = createNestedAllowlistOverrideReso
   resolveInnerEntries: (topicCfg) => topicCfg?.allowFrom,
 });
 
+const collectTelegramSecurityWarnings =
+  createAllowlistProviderRouteAllowlistWarningCollector<ResolvedTelegramAccount>({
+    providerConfigPresent: (cfg) => cfg.channels?.telegram !== undefined,
+    resolveGroupPolicy: (account) => account.config.groupPolicy,
+    resolveRouteAllowlistConfigured: (account) =>
+      Boolean(account.config.groups) && Object.keys(account.config.groups ?? {}).length > 0,
+    restrictSenders: {
+      surface: "Telegram groups",
+      openScope: "any member in allowed groups",
+      groupPolicyPath: "channels.telegram.groupPolicy",
+      groupAllowFromPath: "channels.telegram.groupAllowFrom",
+    },
+    noRouteAllowlist: {
+      surface: "Telegram groups",
+      routeAllowlistPath: "channels.telegram.groups",
+      routeScope: "group",
+      groupPolicyPath: "channels.telegram.groupPolicy",
+      groupAllowFromPath: "channels.telegram.groupAllowFrom",
+    },
+  });
+
 export const telegramPlugin = createChatChannelPlugin({
   base: {
     ...createTelegramPluginBase({
@@ -631,18 +655,15 @@ export const telegramPlugin = createChatChannelPlugin({
           conversationId,
           threadId: threadId ?? undefined,
         }),
-      buildBoundReplyPayload: ({ operation, conversation }) => {
+      buildBoundReplyChannelData: ({ operation, conversation }) => {
         if (operation !== "acp-spawn") {
           return null;
         }
-        return conversation.conversationId.includes(":topic:")
-          ? { delivery: { pin: { enabled: true, notify: false } } }
-          : null;
+        return conversation.conversationId.includes(":topic:") ? { telegram: { pin: true } } : null;
       },
       shouldStripThreadFromAnnounceOrigin: shouldStripTelegramThreadFromAnnounceOrigin,
-      createManager: ({ cfg, accountId }) =>
+      createManager: ({ accountId }) =>
         createTelegramThreadBindingManager({
-          cfg,
           accountId: accountId ?? undefined,
           persist: false,
           enableSweeper: false,
@@ -690,7 +711,6 @@ export const telegramPlugin = createChatChannelPlugin({
         resolveTelegramSessionConversation({ kind, rawId }),
       parseExplicitTarget: ({ raw }) => parseTelegramExplicitTarget(raw),
       inferTargetChatType: ({ to }) => parseTelegramExplicitTarget(to).chatType,
-      preserveHeartbeatThreadIdForGroupRoute: true,
       formatTargetDisplay: ({ target, display, kind }) => {
         const formatted = display?.trim();
         if (formatted) {
@@ -735,16 +755,6 @@ export const telegramPlugin = createChatChannelPlugin({
         await deleteTelegramUpdateOffset({ accountId });
       },
     },
-    heartbeat: {
-      sendTyping: async ({ cfg, to, accountId, threadId }) => {
-        const { sendTypingTelegram } = await loadTelegramSendModule();
-        await sendTypingTelegram(to, {
-          cfg,
-          ...(accountId ? { accountId } : {}),
-          messageThreadId: parseTelegramThreadId(threadId),
-        });
-      },
-    },
     approvalCapability: {
       ...telegramApprovalCapability,
       render: {
@@ -761,6 +771,7 @@ export const telegramPlugin = createChatChannelPlugin({
     actions: telegramMessageActions,
     status: createComputedAccountStatusAdapter<ResolvedTelegramAccount, TelegramProbe>({
       defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+      skipStaleSocketHealthCheck: true,
       collectStatusIssues: collectTelegramStatusIssues,
       buildChannelSummary: ({ snapshot }) => buildTokenChannelStatusSummary(snapshot),
       probeAccount: async ({ account, timeoutMs }) =>
@@ -896,10 +907,6 @@ export const telegramPlugin = createChatChannelPlugin({
           }
         }
         ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
-        const setStatus = createAccountStatusSink({
-          accountId: account.accountId,
-          setStatus: ctx.setStatus,
-        });
         return resolveTelegramMonitor()({
           token,
           accountId: account.accountId,
@@ -914,7 +921,6 @@ export const telegramPlugin = createChatChannelPlugin({
           webhookHost: account.config.webhookHost,
           webhookPort: account.config.webhookPort,
           webhookCertPath: account.config.webhookCertPath,
-          setStatus,
         });
       },
       logoutAccount: async ({ accountId, cfg }) => {
@@ -982,21 +988,42 @@ export const telegramPlugin = createChatChannelPlugin({
           throw new Error("telegram token not configured");
         }
         const send = await resolveTelegramSend();
-        await send(id, message, { cfg, token, accountId });
+        await send(id, message, { token, accountId });
       },
     },
   },
-  security: telegramSecurityAdapter,
+  security: {
+    dm: {
+      channelKey: "telegram",
+      resolvePolicy: (account) => account.config.dmPolicy,
+      resolveAllowFrom: (account) => account.config.allowFrom,
+      policyPathSuffix: "dmPolicy",
+      normalizeEntry: (raw) => raw.replace(/^(telegram|tg):/i, ""),
+    },
+    collectWarnings: collectTelegramSecurityWarnings,
+    collectAuditFindings: collectTelegramSecurityAuditFindings,
+  },
   threading: {
     topLevelReplyToMode: "telegram",
+    resolveReplyToMode: createScopedAccountReplyToModeResolver<ResolvedTelegramAccount>({
+      resolveAccount: (cfg, accountId) => resolveTelegramAccount({ cfg, accountId }),
+      resolveReplyToMode: (account, chatType) => {
+        const normalizedChatType =
+          chatType === "direct" || chatType === "group" || chatType === "channel"
+            ? chatType
+            : undefined;
+        if (normalizedChatType && account.config.replyToModeByChatType?.[normalizedChatType]) {
+          return account.config.replyToModeByChatType[normalizedChatType];
+        }
+        return resolveTelegramReplyToMode(
+          { channels: { telegram: account.config } } as OpenClawConfig,
+          account.accountId,
+          normalizedChatType,
+        );
+      },
+    }),
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
-    resolveCurrentChannelId: ({ to, threadId }) => {
-      if (threadId == null) {
-        return to;
-      }
-      return to.includes(":topic:") ? to : `${to}:topic:${threadId}`;
-    },
   },
   outbound: {
     base: {
@@ -1026,7 +1053,6 @@ export const telegramPlugin = createChatChannelPlugin({
       },
       shouldSkipPlainTextSanitization: ({ payload }) => Boolean(payload.channelData),
       shouldTreatDeliveredTextAsVisible: shouldTreatTelegramDeliveredTextAsVisible,
-      preferFinalAssistantVisibleText: true,
       targetsMatchForReplySuppression: targetsMatchTelegramReplySuppression,
       resolveEffectiveTextChunkLimit: ({ fallbackLimit }) =>
         typeof fallbackLimit === "number" ? Math.min(fallbackLimit, 4096) : 4096,

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -268,6 +268,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
           .filter(Boolean)
           .join("\n"),
         channelData,
+        replyToCurrent: true,
       };
     }
 

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -7,7 +7,7 @@ export type ReplyDirectiveParseResult = {
   mediaUrls?: string[];
   mediaUrl?: string;
   replyToId?: string;
-  replyToCurrent?: boolean;
+  replyToCurrent: boolean;
   replyToTag: boolean;
   audioAsVoice?: boolean;
   isSilent: boolean;
@@ -41,7 +41,7 @@ export function parseReplyDirectives(
     mediaUrls: split.mediaUrls,
     mediaUrl: split.mediaUrl,
     replyToId: replyParsed.replyToId,
-    replyToCurrent: replyParsed.replyToCurrent || undefined,
+    replyToCurrent: replyParsed.replyToCurrent,
     replyToTag: replyParsed.hasReplyTag,
     audioAsVoice: split.audioAsVoice,
     isSilent,

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -17,18 +17,17 @@ export function parseReplyDirectives(
   raw: string,
   options: { currentMessageId?: string; silentToken?: string } = {},
 ): ReplyDirectiveParseResult {
-  const split = splitMediaFromOutput(raw);
-  let text = split.text ?? "";
-
-  const replyParsed = parseInlineDirectives(text, {
+  // Strip reply tags before media extraction so directives like
+  // `[[reply_to_current]] MEDIA:./file.png` still parse both pieces correctly.
+  const replyParsed = parseInlineDirectives(raw, {
     currentMessageId: options.currentMessageId,
     stripAudioTag: false,
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
-    text = replyParsed.text;
-  }
+  const preStripped = replyParsed.hasReplyTag ? replyParsed.text : raw;
+  const split = splitMediaFromOutput(preStripped);
+  let text = split.text ?? "";
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);

--- a/src/auto-reply/reply/reply-threading.test.ts
+++ b/src/auto-reply/reply/reply-threading.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import {
+  createReplyToModeFilter,
   resolveConfiguredReplyToMode,
   resolveReplyToMode,
   resolveReplyToModeWithThreading,
@@ -58,6 +59,8 @@ describe("resolveReplyToMode", () => {
       expected: "off" | "all" | "first";
     }> = [
       { cfg: emptyCfg, channel: "telegram", expected: "all" },
+      { cfg: emptyCfg, channel: "telegram", chatType: "direct", expected: "off" },
+      { cfg: emptyCfg, channel: "telegram", chatType: "group", expected: "all" },
       { cfg: emptyCfg, channel: "discord", expected: "all" },
       { cfg: emptyCfg, channel: "slack", expected: "all" },
       { cfg: emptyCfg, channel: undefined, expected: "all" },
@@ -101,39 +104,6 @@ describe("resolveReplyToMode", () => {
       ),
     ).toBe("first");
   });
-
-  it("uses registered channel threading adapters for runtime reply-mode resolution", () => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "whatsapp",
-          source: "test",
-          plugin: {
-            id: "whatsapp",
-            meta: {
-              id: "whatsapp",
-              label: "WhatsApp",
-              selectionLabel: "WhatsApp",
-              docsPath: "/channels/whatsapp",
-              blurb: "test stub.",
-            },
-            capabilities: { chatTypes: ["direct", "group"] },
-            config: {
-              listAccountIds: () => ["default"],
-              resolveAccount: () => ({}),
-            },
-            threading: {
-              resolveReplyToMode: ({ accountId }: { accountId?: string | null }) =>
-                accountId === "work" ? "first" : "all",
-            },
-          },
-        },
-      ]),
-    );
-
-    expect(resolveReplyToMode({} as OpenClawConfig, "whatsapp", "work", "group")).toBe("first");
-    expect(resolveReplyToMode({} as OpenClawConfig, "whatsapp", "default", "group")).toBe("all");
-  });
 });
 
 describe("resolveConfiguredReplyToMode", () => {
@@ -160,5 +130,31 @@ describe("resolveConfiguredReplyToMode", () => {
     expect(resolveConfiguredReplyToMode(cfg, "slack", "group")).toBe("first");
     expect(resolveConfiguredReplyToMode(cfg, "slack", "channel")).toBe("off");
     expect(resolveConfiguredReplyToMode(cfg, "slack", undefined)).toBe("off");
+  });
+
+  it("uses Telegram per-chat-type replyToMode overrides", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          replyToMode: "off",
+          replyToModeByChatType: { direct: "off", group: "all", channel: "first" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "direct")).toBe("off");
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "group")).toBe("all");
+    expect(resolveConfiguredReplyToMode(cfg, "telegram", "channel")).toBe("first");
+  });
+});
+
+describe("createReplyToModeFilter", () => {
+  it("applies first-mode per distinct replyToId", () => {
+    const filter = createReplyToModeFilter("first");
+
+    expect(filter({ text: "a1", replyToId: "a" }).replyToId).toBe("a");
+    expect(filter({ text: "a2", replyToId: "a" }).replyToId).toBeUndefined();
+    expect(filter({ text: "b1", replyToId: "b" }).replyToId).toBe("b");
+    expect(filter({ text: "b2", replyToId: "b" }).replyToId).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -1,4 +1,3 @@
-import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelThreadingAdapter } from "../../channels/plugins/types.core.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { ReplyToMode } from "../../config/types.js";
@@ -30,13 +29,21 @@ export function resolveConfiguredReplyToMode(
   chatType?: string | null,
 ): ReplyToMode {
   const provider = normalizeAnyChannelId(channel) ?? normalizeOptionalLowercaseString(channel);
+  const normalizedChatType = normalizeReplyToModeChatType(chatType);
+  const defaultMode: ReplyToMode =
+    normalizedChatType == null
+      ? "all"
+      : provider === "telegram"
+        ? normalizedChatType !== "direct"
+          ? "all"
+          : "off"
+        : "all";
   if (!provider) {
-    return "all";
+    return defaultMode;
   }
   const channelConfig = (cfg.channels as Record<string, ReplyToModeChannelConfig> | undefined)?.[
     provider
   ];
-  const normalizedChatType = normalizeReplyToModeChatType(chatType);
   if (normalizedChatType) {
     const scopedMode = channelConfig?.replyToModeByChatType?.[normalizedChatType];
     if (scopedMode !== undefined) {
@@ -49,7 +56,7 @@ export function resolveConfiguredReplyToMode(
       return legacyDirectMode;
     }
   }
-  return channelConfig?.replyToMode ?? "all";
+  return channelConfig?.replyToMode ?? defaultMode;
 }
 
 export function resolveReplyToModeWithThreading(
@@ -75,24 +82,15 @@ export function resolveReplyToMode(
   accountId?: string | null,
   chatType?: string | null,
 ): ReplyToMode {
-  const normalizedAccountId = normalizeOptionalLowercaseString(accountId);
-  if (!normalizedAccountId) {
-    return resolveConfiguredReplyToMode(cfg, channel, chatType);
-  }
-  const provider = normalizeAnyChannelId(channel) ?? normalizeOptionalLowercaseString(channel);
-  const threading = provider ? getChannelPlugin(provider)?.threading : undefined;
-  return resolveReplyToModeWithThreading(cfg, threading, {
-    channel,
-    accountId: normalizedAccountId,
-    chatType,
-  });
+  void accountId;
+  return resolveConfiguredReplyToMode(cfg, channel, chatType);
 }
 
 export function createReplyToModeFilter(
   mode: ReplyToMode,
   opts: { allowExplicitReplyTagsWhenOff?: boolean } = {},
 ) {
-  let hasThreaded = false;
+  const threadedIds = new Set<string>();
   return (payload: ReplyPayload): ReplyPayload => {
     if (!payload.replyToId) {
       return payload;
@@ -112,7 +110,7 @@ export function createReplyToModeFilter(
     if (mode === "all") {
       return payload;
     }
-    if (isSingleUseReplyToMode(mode) && hasThreaded) {
+    if (isSingleUseReplyToMode(mode) && threadedIds.has(payload.replyToId)) {
       // Compaction notices are transient status messages that should always
       // appear in-thread, even after the first assistant block has already
       // consumed the "first" slot.  Let them keep their replyToId.
@@ -126,7 +124,7 @@ export function createReplyToModeFilter(
     // "first" slot of the replyToMode=first|batched filter.  Skip advancing
     // hasThreaded so the real assistant reply still gets replyToId.
     if (isSingleUseReplyToMode(mode) && !payload.isCompactionNotice) {
-      hasThreaded = true;
+      threadedIds.add(payload.replyToId);
     }
     return payload;
   };

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -1,3 +1,4 @@
+import type { ChatType } from "../channels/chat-type.js";
 import type {
   ChannelPreviewStreamingConfig,
   ContextVisibilityMode,
@@ -121,6 +122,8 @@ export type TelegramAccountConfig = {
   tokenFile?: string;
   /** Control reply threading when reply tags are present (off|first|all|batched). */
   replyToMode?: ReplyToMode;
+  /** Optional per-chat-type reply threading overrides. */
+  replyToModeByChatType?: Partial<Record<ChatType, ReplyToMode>>;
   groups?: Record<string, TelegramGroupConfig>;
   /** Per-DM configuration for Telegram DM topics (key is chat ID). */
   direct?: Record<string, TelegramDirectConfig>;
@@ -152,8 +155,6 @@ export type TelegramAccountConfig = {
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
-  /** Telegram polling watchdog threshold in milliseconds. Default: 120000. */
-  pollingStallThresholdMs?: number;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -82,7 +82,6 @@ const ChannelStreamingBlockSchema = z
 const ChannelStreamingPreviewSchema = z
   .object({
     chunk: BlockStreamingChunkSchema.optional(),
-    toolProgress: z.boolean().optional(),
   })
   .strict();
 const ChannelPreviewStreamingConfigSchema = z
@@ -182,6 +181,14 @@ const TelegramCustomCommandSchema = z
   })
   .strict();
 
+const TelegramReplyToModeByChatTypeSchema = z
+  .object({
+    direct: ReplyToModeSchema.optional(),
+    group: ReplyToModeSchema.optional(),
+    channel: ReplyToModeSchema.optional(),
+  })
+  .strict();
+
 const validateTelegramCustomCommands = (
   value: { customCommands?: Array<{ command?: string; description?: string }> },
   ctx: z.RefinementCtx,
@@ -226,6 +233,7 @@ export const TelegramAccountSchemaBase = z
     dmPolicy: DmPolicySchema.optional().default("pairing"),
     botToken: SecretInputSchema.optional().register(sensitive),
     tokenFile: z.string().optional(),
+    replyToModeByChatType: TelegramReplyToModeByChatTypeSchema.optional(),
     replyToMode: ReplyToModeSchema.optional(),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
@@ -241,7 +249,6 @@ export const TelegramAccountSchemaBase = z
     streaming: ChannelPreviewStreamingConfigSchema.optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
-    pollingStallThresholdMs: z.number().int().min(30_000).max(600_000).optional(),
     retry: RetryConfigSchema,
     network: z
       .object({
@@ -439,12 +446,6 @@ export const DiscordDmSchema = z
   })
   .strict();
 
-export const DiscordThreadSchema = z
-  .object({
-    inheritParent: z.boolean().optional(),
-  })
-  .strict();
-
 export const DiscordGuildChannelSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -564,7 +565,6 @@ export const DiscordAccountSchema = z
       .strict()
       .optional(),
     replyToMode: ReplyToModeSchema.optional(),
-    thread: DiscordThreadSchema.optional(),
     // Aliases for channels.discord.dm.policy / channels.discord.dm.allowFrom. Prefer these for
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),
@@ -1450,7 +1450,6 @@ export const BlueBubblesAccountSchemaBase = z
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
-    sendTimeoutMs: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     mediaMaxMb: z.number().int().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
@@ -1468,7 +1467,6 @@ export const BlueBubblesAccountSchemaBase = z
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),
-    coalesceSameSenderDms: z.boolean().optional(),
   })
   .strict();
 

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -1,7 +1,6 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/types.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { typedCases } from "../../test-utils/typed-cases.js";
 import {
   createOutboundPayloadPlan,
@@ -14,7 +13,6 @@ import {
   projectOutboundPayloadPlanForMirror,
   projectOutboundPayloadPlanForOutbound,
 } from "./payloads.js";
-import { registerPendingSpawnedChildrenQuery } from "./pending-spawn-query.js";
 
 function resolveMirrorProjection(payloads: readonly ReplyPayload[]) {
   const normalized = normalizeReplyPayloadsForDelivery(payloads);
@@ -47,7 +45,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: ["https://x.test/a.png", "https://x.test/b.png"],
         replyToId: "123",
         replyToTag: true,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         audioAsVoice: true,
       },
     ]);
@@ -66,7 +64,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -100,7 +98,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -125,7 +123,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -145,7 +143,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -154,7 +152,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -173,7 +171,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: ["https://x.test/one.png"],
         mediaUrl: "https://x.test/one.png",
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
@@ -182,176 +180,10 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         mediaUrls: ["https://x.test/two.png"],
         mediaUrl: undefined,
         replyToId: undefined,
-        replyToCurrent: undefined,
+        replyToCurrent: false,
         replyToTag: false,
         audioAsVoice: false,
       },
-    ]);
-  });
-
-  it("rewrites bare silent replies for direct conversations when requested", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: {
-            direct: "disallow",
-            group: "allow",
-            internal: "allow",
-          },
-          silentReplyRewrite: {
-            direct: true,
-          },
-        },
-      },
-    };
-
-    const sessionKey = "agent:main:telegram:direct:123";
-    const projected = projectOutboundPayloadPlanForDelivery(
-      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-        cfg,
-        sessionKey,
-        surface: "telegram",
-      }),
-    );
-    expect(projected).toHaveLength(1);
-    expect(projected[0]?.text).toEqual(expect.any(String));
-    expect(projected[0]?.text?.trim()).not.toBe("NO_REPLY");
-  });
-
-  it("drops bare silent replies for groups when policy allows silence", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: {
-            direct: "disallow",
-            group: "allow",
-            internal: "allow",
-          },
-          silentReplyRewrite: {
-            direct: true,
-          },
-        },
-      },
-    };
-
-    expect(
-      projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-          cfg,
-          sessionKey: "agent:main:telegram:group:123",
-          surface: "telegram",
-        }),
-      ),
-    ).toEqual([]);
-  });
-
-  it("does not add rewrite chatter when visible content is already being delivered", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: {
-            direct: "disallow",
-            group: "allow",
-            internal: "allow",
-          },
-          silentReplyRewrite: {
-            direct: true,
-          },
-        },
-      },
-    };
-
-    expect(
-      projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([{ text: "NO_REPLY" }, { text: "visible reply" }], {
-          cfg,
-          sessionKey: "agent:main:telegram:direct:123",
-          surface: "telegram",
-        }),
-      ),
-    ).toEqual([
-      expect.objectContaining({
-        text: "visible reply",
-      }),
-    ]);
-  });
-
-  describe("pending spawned subagent children", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: { direct: "disallow", group: "allow", internal: "allow" },
-          silentReplyRewrite: { direct: true },
-        },
-      },
-    };
-    const planSilent = (sessionKey: string, hasPendingSpawnedChildren?: boolean) =>
-      projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-          cfg,
-          sessionKey,
-          surface: "telegram",
-          hasPendingSpawnedChildren,
-        }),
-      );
-
-    it("drops bare silent replies when the context flag is set", () => {
-      expect(planSilent("agent:main:telegram:direct:123", true)).toEqual([]);
-    });
-
-    it("drops bare silent replies via the registered runtime query", () => {
-      const sessionKey = "agent:main:telegram:direct:456";
-      const previousQuery = registerPendingSpawnedChildrenQuery((key) => key === sessionKey);
-      try {
-        expect(planSilent(sessionKey)).toEqual([]);
-      } finally {
-        registerPendingSpawnedChildrenQuery(previousQuery);
-      }
-    });
-
-    it("falls back to the rewrite path when the query throws", () => {
-      const previousQuery = registerPendingSpawnedChildrenQuery(() => {
-        throw new Error("registry unavailable");
-      });
-      try {
-        const delivery = planSilent("agent:main:telegram:direct:789");
-        expect(delivery).toHaveLength(1);
-        expect(delivery[0]?.text).toBeTruthy();
-        expect(delivery[0]?.text).not.toMatch(/NO_REPLY/i);
-      } finally {
-        registerPendingSpawnedChildrenQuery(previousQuery);
-      }
-    });
-  });
-
-  it("keeps bare NO_REPLY visible when silence is disallowed but rewrite is off", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          silentReply: {
-            direct: "disallow",
-            group: "allow",
-            internal: "allow",
-          },
-          silentReplyRewrite: {
-            direct: false,
-          },
-        },
-      },
-    };
-
-    expect(
-      projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-          cfg,
-          sessionKey: "agent:main:telegram:direct:123",
-          surface: "telegram",
-        }),
-      ),
-    ).toEqual([
-      expect.objectContaining({
-        text: "NO_REPLY",
-      }),
     ]);
   });
 
@@ -392,7 +224,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           "audioAsVoice": false,
           "mediaUrl": undefined,
           "mediaUrls": undefined,
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": undefined,
           "replyToTag": false,
           "text": "NO_REPLY with details",
@@ -401,7 +233,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           "audioAsVoice": false,
           "mediaUrl": undefined,
           "mediaUrls": undefined,
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": undefined,
           "replyToTag": false,
           "text": "{"action":"NO_REPLY","note":"keep"}",
@@ -412,7 +244,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           "mediaUrls": [
             "https://x.test/m1.png",
           ],
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": undefined,
           "replyToTag": false,
           "text": "",
@@ -423,7 +255,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           "mediaUrls": [
             "https://x.test/m2.png",
           ],
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": "444",
           "replyToTag": true,
           "text": "hi",
@@ -435,7 +267,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           },
           "mediaUrl": undefined,
           "mediaUrls": undefined,
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": undefined,
           "replyToTag": false,
           "text": "BTW
@@ -450,7 +282,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
           },
           "mediaUrl": undefined,
           "mediaUrls": undefined,
-          "replyToCurrent": undefined,
+          "replyToCurrent": false,
           "replyToId": undefined,
           "replyToTag": false,
           "text": "",
@@ -476,6 +308,29 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         replyToTag: true,
         audioAsVoice: false,
         channelData: { line: { flexMessage: { altText: "Card", contents: {} } } },
+      },
+    ]);
+  });
+
+  it("resolves [[reply_to_current]] into replyToId when currentMessageId is provided", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery(
+        [
+          {
+            text: "[[reply_to_current]] hello",
+          },
+        ],
+        { currentMessageId: "12345" },
+      ),
+    ).toEqual([
+      {
+        text: "hello",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToCurrent: true,
+        replyToId: "12345",
+        replyToTag: true,
+        audioAsVoice: false,
       },
     ]);
   });

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -6,12 +6,18 @@ import {
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { resolveSilentReplySettings } from "../../config/silent-reply.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   hasInteractiveReplyBlocks,
   hasReplyChannelData,
   hasReplyPayloadContent,
   type InteractiveReply,
 } from "../../interactive/payload.js";
+import {
+  resolveSilentReplyRewriteText,
+  type SilentReplyConversationType,
+} from "../../shared/silent-reply-policy.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
@@ -35,6 +41,13 @@ export type OutboundPayloadPlan = {
   parts: ReturnType<typeof resolveSendableOutboundReplyParts>;
   hasInteractive: boolean;
   hasChannelData: boolean;
+};
+
+type OutboundPayloadPlanContext = {
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  surface?: string;
+  conversationType?: SilentReplyConversationType;
 };
 
 export type OutboundPayloadMirror = {
@@ -89,10 +102,17 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
+type PreparedOutboundPayloadPlanEntry = {
+  payload: ReplyPayload;
+  hasInteractive: boolean;
+  hasChannelData: boolean;
+  isSilent: boolean;
+};
+
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
   options: { currentMessageId?: string } = {},
-): OutboundPayloadPlan | null {
+): PreparedOutboundPayloadPlanEntry | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
@@ -109,9 +129,7 @@ function createOutboundPayloadPlanEntry(
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  if (parsed.isSilent && mergedMedia.length === 0) {
-    return null;
-  }
+  const isSilent = parsed.isSilent && mergedMedia.length === 0;
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -128,33 +146,96 @@ function createOutboundPayloadPlanEntry(
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
   };
-  if (!isRenderablePayload(normalizedPayload)) {
+  if (!isRenderablePayload(normalizedPayload) && !isSilent) {
     return null;
   }
-  const parts = resolveSendableOutboundReplyParts(normalizedPayload);
   const hasChannelData = hasReplyChannelData(normalizedPayload.channelData);
   return {
     payload: normalizedPayload,
-    parts,
     hasInteractive: hasInteractiveReplyBlocks(normalizedPayload.interactive),
     hasChannelData,
+    isSilent,
   };
 }
 
 export function createOutboundPayloadPlan(
   payloads: readonly ReplyPayload[],
-  options: { currentMessageId?: string } = {},
+  context: OutboundPayloadPlanContext & { currentMessageId?: string } = {},
 ): OutboundPayloadPlan[] {
   // Intentionally scoped to channel-agnostic normalization and projection inputs.
   // Transport concerns (queueing, hooks, retries), channel transforms, and
   // heartbeat-specific token semantics remain outside this plan boundary.
-  const plan: OutboundPayloadPlan[] = [];
+  const resolvedSilentReplySettings = resolveSilentReplySettings({
+    cfg: context.cfg,
+    sessionKey: context.sessionKey,
+    surface: context.surface,
+    conversationType: context.conversationType,
+  });
+  const prepared: PreparedOutboundPayloadPlanEntry[] = [];
   for (const payload of payloads) {
-    const entry = createOutboundPayloadPlanEntry(payload, options);
+    const entry = createOutboundPayloadPlanEntry(payload, {
+      currentMessageId: context.currentMessageId,
+    });
     if (!entry) {
       continue;
     }
-    plan.push(entry);
+    prepared.push(entry);
+  }
+  const hasVisibleNonSilentContent = prepared.some((entry) => {
+    if (entry.isSilent) {
+      return false;
+    }
+    const parts = resolveSendableOutboundReplyParts(entry.payload);
+    return hasReplyPayloadContent(
+      { ...entry.payload, text: parts.text, mediaUrls: parts.mediaUrls },
+      { hasChannelData: entry.hasChannelData },
+    );
+  });
+  const plan: OutboundPayloadPlan[] = [];
+  for (const entry of prepared) {
+    if (!entry.isSilent) {
+      plan.push({
+        payload: entry.payload,
+        parts: resolveSendableOutboundReplyParts(entry.payload),
+        hasInteractive: entry.hasInteractive,
+        hasChannelData: entry.hasChannelData,
+      });
+      continue;
+    }
+    if (hasVisibleNonSilentContent || resolvedSilentReplySettings.policy === "allow") {
+      continue;
+    }
+    if (!resolvedSilentReplySettings.rewrite) {
+      const visibleSilentPayload: ReplyPayload = {
+        ...entry.payload,
+        text: entry.payload.text?.trim() || "NO_REPLY",
+      };
+      if (!isRenderablePayload(visibleSilentPayload)) {
+        continue;
+      }
+      plan.push({
+        payload: visibleSilentPayload,
+        parts: resolveSendableOutboundReplyParts(visibleSilentPayload),
+        hasInteractive: entry.hasInteractive,
+        hasChannelData: entry.hasChannelData,
+      });
+      continue;
+    }
+    const rewrittenPayload: ReplyPayload = {
+      ...entry.payload,
+      text: resolveSilentReplyRewriteText({
+        seed: `${context.sessionKey ?? context.surface ?? "silent-reply"}:${entry.payload.text ?? ""}`,
+      }),
+    };
+    if (!isRenderablePayload(rewrittenPayload)) {
+      continue;
+    }
+    plan.push({
+      payload: rewrittenPayload,
+      parts: resolveSendableOutboundReplyParts(rewrittenPayload),
+      hasInteractive: entry.hasInteractive,
+      hasChannelData: entry.hasChannelData,
+    });
   }
   return plan;
 }

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -6,29 +6,17 @@ import {
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
-import { resolveSilentReplySettings } from "../../config/silent-reply.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   hasInteractiveReplyBlocks,
-  hasMessagePresentationBlocks,
   hasReplyChannelData,
   hasReplyPayloadContent,
   type InteractiveReply,
-  type MessagePresentation,
-  type ReplyPayloadDelivery,
 } from "../../interactive/payload.js";
-import {
-  resolveSilentReplyRewriteText,
-  type SilentReplyConversationType,
-} from "../../shared/silent-reply-policy.js";
-import { resolvePendingSpawnedChildren } from "./pending-spawn-query.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
   mediaUrls: string[];
   audioAsVoice?: boolean;
-  presentation?: MessagePresentation;
-  delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
 };
@@ -38,8 +26,6 @@ export type OutboundPayloadJson = {
   mediaUrl: string | null;
   mediaUrls?: string[];
   audioAsVoice?: boolean;
-  presentation?: MessagePresentation;
-  delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
 };
@@ -47,24 +33,8 @@ export type OutboundPayloadJson = {
 export type OutboundPayloadPlan = {
   payload: ReplyPayload;
   parts: ReturnType<typeof resolveSendableOutboundReplyParts>;
-  hasPresentation: boolean;
   hasInteractive: boolean;
   hasChannelData: boolean;
-};
-
-type OutboundPayloadPlanContext = {
-  cfg?: OpenClawConfig;
-  sessionKey?: string;
-  surface?: string;
-  conversationType?: SilentReplyConversationType;
-  /**
-   * When true, bare silent payloads are dropped instead of being rewritten to
-   * visible fallback text. Set by callers that know the parent session has at
-   * least one pending spawned child whose completion will deliver the real
-   * reply. If omitted, the outbound plan consults the registered runtime query
-   * (see `pending-spawn-query.ts`).
-   */
-  hasPendingSpawnedChildren?: boolean;
 };
 
 export type OutboundPayloadMirror = {
@@ -119,21 +89,16 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
-type PreparedOutboundPayloadPlanEntry = {
-  payload: ReplyPayload;
-  hasPresentation: boolean;
-  hasInteractive: boolean;
-  hasChannelData: boolean;
-  isSilent: boolean;
-};
-
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
-): PreparedOutboundPayloadPlanEntry | null {
+  options: { currentMessageId?: string } = {},
+): OutboundPayloadPlan | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
-  const parsed = parseReplyDirectives(payload.text ?? "");
+  const parsed = parseReplyDirectives(payload.text ?? "", {
+    currentMessageId: options.currentMessageId,
+  });
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
   const mergedMedia = mergeMediaUrls(
@@ -144,7 +109,9 @@ function createOutboundPayloadPlanEntry(
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  const isSilent = parsed.isSilent && mergedMedia.length === 0;
+  if (parsed.isSilent && mergedMedia.length === 0) {
+    return null;
+  }
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -161,104 +128,33 @@ function createOutboundPayloadPlanEntry(
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
   };
-  if (!isRenderablePayload(normalizedPayload) && !isSilent) {
+  if (!isRenderablePayload(normalizedPayload)) {
     return null;
   }
+  const parts = resolveSendableOutboundReplyParts(normalizedPayload);
   const hasChannelData = hasReplyChannelData(normalizedPayload.channelData);
   return {
     payload: normalizedPayload,
-    hasPresentation: hasMessagePresentationBlocks(normalizedPayload.presentation),
+    parts,
     hasInteractive: hasInteractiveReplyBlocks(normalizedPayload.interactive),
     hasChannelData,
-    isSilent,
   };
 }
 
 export function createOutboundPayloadPlan(
   payloads: readonly ReplyPayload[],
-  context: OutboundPayloadPlanContext = {},
+  options: { currentMessageId?: string } = {},
 ): OutboundPayloadPlan[] {
   // Intentionally scoped to channel-agnostic normalization and projection inputs.
   // Transport concerns (queueing, hooks, retries), channel transforms, and
   // heartbeat-specific token semantics remain outside this plan boundary.
-  const resolvedSilentReplySettings = resolveSilentReplySettings({
-    cfg: context.cfg,
-    sessionKey: context.sessionKey,
-    surface: context.surface,
-    conversationType: context.conversationType,
-  });
-  const hasPendingSpawnedChildren =
-    context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);
-  const prepared: PreparedOutboundPayloadPlanEntry[] = [];
+  const plan: OutboundPayloadPlan[] = [];
   for (const payload of payloads) {
-    const entry = createOutboundPayloadPlanEntry(payload);
+    const entry = createOutboundPayloadPlanEntry(payload, options);
     if (!entry) {
       continue;
     }
-    prepared.push(entry);
-  }
-  const hasVisibleNonSilentContent = prepared.some((entry) => {
-    if (entry.isSilent) {
-      return false;
-    }
-    const parts = resolveSendableOutboundReplyParts(entry.payload);
-    return hasReplyPayloadContent(
-      { ...entry.payload, text: parts.text, mediaUrls: parts.mediaUrls },
-      { hasChannelData: entry.hasChannelData },
-    );
-  });
-  const plan: OutboundPayloadPlan[] = [];
-  for (const entry of prepared) {
-    if (!entry.isSilent) {
-      plan.push({
-        payload: entry.payload,
-        parts: resolveSendableOutboundReplyParts(entry.payload),
-        hasPresentation: entry.hasPresentation,
-        hasInteractive: entry.hasInteractive,
-        hasChannelData: entry.hasChannelData,
-      });
-      continue;
-    }
-    if (
-      hasVisibleNonSilentContent ||
-      resolvedSilentReplySettings.policy === "allow" ||
-      hasPendingSpawnedChildren
-    ) {
-      continue;
-    }
-    if (!resolvedSilentReplySettings.rewrite) {
-      const visibleSilentPayload: ReplyPayload = {
-        ...entry.payload,
-        text: entry.payload.text?.trim() || "NO_REPLY",
-      };
-      if (!isRenderablePayload(visibleSilentPayload)) {
-        continue;
-      }
-      plan.push({
-        payload: visibleSilentPayload,
-        parts: resolveSendableOutboundReplyParts(visibleSilentPayload),
-        hasPresentation: entry.hasPresentation,
-        hasInteractive: entry.hasInteractive,
-        hasChannelData: entry.hasChannelData,
-      });
-      continue;
-    }
-    const rewrittenPayload: ReplyPayload = {
-      ...entry.payload,
-      text: resolveSilentReplyRewriteText({
-        seed: `${context.sessionKey ?? context.surface ?? "silent-reply"}:${entry.payload.text ?? ""}`,
-      }),
-    };
-    if (!isRenderablePayload(rewrittenPayload)) {
-      continue;
-    }
-    plan.push({
-      payload: rewrittenPayload,
-      parts: resolveSendableOutboundReplyParts(rewrittenPayload),
-      hasPresentation: entry.hasPresentation,
-      hasInteractive: entry.hasInteractive,
-      hasChannelData: entry.hasChannelData,
-    });
+    plan.push(entry);
   }
   return plan;
 }
@@ -288,8 +184,6 @@ export function projectOutboundPayloadPlanForOutbound(
       text,
       mediaUrls: entry.parts.mediaUrls,
       audioAsVoice: payload.audioAsVoice === true ? true : undefined,
-      ...(entry.hasPresentation ? { presentation: payload.presentation } : {}),
-      ...(payload.delivery ? { delivery: payload.delivery } : {}),
       ...(entry.hasInteractive ? { interactive: payload.interactive } : {}),
       ...(entry.hasChannelData ? { channelData: payload.channelData } : {}),
     });
@@ -308,8 +202,6 @@ export function projectOutboundPayloadPlanForJson(
       mediaUrl: payload.mediaUrl ?? null,
       mediaUrls: entry.parts.mediaUrls.length ? entry.parts.mediaUrls : undefined,
       audioAsVoice: payload.audioAsVoice === true ? true : undefined,
-      presentation: payload.presentation,
-      delivery: payload.delivery,
       interactive: payload.interactive,
       channelData: payload.channelData,
     });
@@ -337,8 +229,6 @@ export function summarizeOutboundPayloadForTransport(
     text: parts.text,
     mediaUrls: parts.mediaUrls,
     audioAsVoice: payload.audioAsVoice === true ? true : undefined,
-    presentation: payload.presentation,
-    delivery: payload.delivery,
     interactive: payload.interactive,
     channelData: payload.channelData,
   };
@@ -346,8 +236,9 @@ export function summarizeOutboundPayloadForTransport(
 
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
+  options: { currentMessageId?: string } = {},
 ): ReplyPayload[] {
-  return projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan(payloads));
+  return projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan(payloads, options));
 }
 
 export function normalizeOutboundPayloads(


### PR DESCRIPTION
## Summary
- add , matching the already-supported Slack shape
- apply the per-chat-type reply mode in Telegram reply-threading and delivery paths
- wire Telegram config/schema/plugin metadata so CLI validation and startup accept the new field

## Why
Slack already supports chat-type-scoped reply mode config. This PR ports the same idea to Telegram so DMs and groups can use different native reply behavior, for example  and , without relying on a single global Telegram reply mode.