### PR TITLE
Model menu: bypass stale catalog cache

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -214,6 +214,15 @@ function buildParams(
 }
 
 describe("handleModelsCommand", () => {
+  it("bypasses the long-lived model catalog cache for interactive model menus", async () => {
+    await handleModelsCommand(buildParams("/models"), true);
+
+    expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledWith({
+      config: expect.any(Object),
+      useCache: false,
+    });
+  });
+
   it("shows a simple providers menu on text surfaces", async () => {
     const result = await handleModelsCommand(buildParams("/models"), true);
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -67,7 +67,7 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelCatalog({ config: cfg });
+  const catalog = await loadModelCatalog({ config: cfg, useCache: false });
   const allowed = buildAllowedModelSet({
     cfg,
     catalog,


### PR DESCRIPTION
## Summary

- Problem: Telegram `/model` was the only model-picker path still reading the long-lived in-process model catalog cache, so newly added models stayed invisible until a gateway restart.
- Why it matters: users could see a new model in `openclaw models list` and other picker paths, but not in Telegram, which made config edits look broken.
- What changed: make `buildModelsProviderData()` bypass the cache for interactive model-menu reads, matching the other picker flows.
- What did NOT change (scope boundary): this does not change the catalog cache implementation itself, config reload hooks, or non-interactive catalog callers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69750
- Related #42854
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/auto-reply/reply/commands-models.ts` called `loadModelCatalog({ config: cfg })` without `useCache: false`, unlike the other interactive model-picker flows.
- Missing detection / guardrail: there was no command-level regression test asserting that interactive `/models` reads opt out of the process-wide catalog cache.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #69750 traced the divergence between Telegram and the other picker paths.
- Why this regressed now: the stale behavior comes from a caller inconsistency rather than a new cache implementation change.
- If unknown, what was ruled out: ruled out a Telegram button-rendering problem; the stale data was already coming from `buildModelsProviderData()`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/commands-models.test.ts`
- Scenario the test should lock in: interactive `/models` requests call `loadModelCatalog()` with `useCache: false`.
- Why this is the smallest reliable guardrail: the bug is a single caller-level cache flag omission, so the command-level unit test covers the exact seam that regressed.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram `/model` and `/models` menus now pick up newly added models from the active config without requiring a gateway restart.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram interactive model picker
- Relevant config (redacted): dynamic models under `models.providers.*`

### Steps

1. Add a new model to `models.providers.<provider>.models` and the allowlist/defaults.
2. Open Telegram `/model` or `/models` without restarting the gateway.

### Expected

- The new model appears immediately in the interactive picker.

### Actual

- Before this fix, Telegram kept serving the stale in-process catalog until the gateway restarted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test -- src/auto-reply/reply/commands-models.test.ts`
  - Pre-commit scoped checks from `scripts/committer` passed
- Edge cases checked:
  - interactive `/models` command path still renders provider listings normally
- What you did **not** verify:
  - live Telegram gateway interaction against a running bot

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: interactive `/models` reads now rebuild the catalog instead of reusing the long-lived cache.
  - Mitigation: this matches the existing behavior of the other picker/auth-choice paths and keeps the change tightly scoped to interactive model browsing.
