### PR TITLE
Subagent announce: fall back to best-effort delivery

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testing, deliverSubagentAnnouncement } from "./subagent-announce-delivery.js";
 import { callGateway as runtimeCallGateway } from "./subagent-announce-delivery.runtime.js";
@@ -253,5 +256,79 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         }),
       }),
     );
+  });
+
+  it("falls back to best-effort queued delivery when the requester has no explicit channel target", async () => {
+    const callGateway = vi.fn(
+      async () => ({}) as Record<string, unknown>,
+    ) as unknown as typeof runtimeCallGateway;
+    const storeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-announce-store-"));
+    const storePath = path.join(storeRoot, "main", "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:paperclip:issue:123": {
+          sessionId: "requester-session-4",
+          channel: null,
+          lastChannel: null,
+          origin: null,
+          updatedAt: Date.now(),
+        },
+      }),
+      "utf8",
+    );
+
+    try {
+      __testing.setDepsForTest({
+        callGateway,
+        getRequesterSessionActivity: () => ({
+          sessionId: "requester-session-4",
+          isActive: true,
+        }),
+        queueEmbeddedPiMessage: () => false,
+        loadConfig: () =>
+          ({
+            session: {
+              store: path.join(storeRoot, "{agentId}", "sessions", "sessions.json"),
+            },
+            messages: {
+              queue: {
+                mode: "followup",
+                debounceMs: 0,
+              },
+            },
+          }) as never,
+      });
+
+      await deliverSubagentAnnouncement({
+        requesterSessionKey: "agent:main:paperclip:issue:123",
+        targetRequesterSessionKey: "agent:main:paperclip:issue:123",
+        triggerMessage: "child done",
+        steerMessage: "child done",
+        requesterOrigin: undefined,
+        requesterSessionOrigin: undefined,
+        completionDirectOrigin: undefined,
+        directOrigin: undefined,
+        requesterIsSubagent: false,
+        expectsCompletionMessage: true,
+        directIdempotencyKey: "announce-no-origin",
+      });
+
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "agent",
+          params: expect.objectContaining({
+            deliver: false,
+            bestEffortDeliver: true,
+            channel: undefined,
+            to: undefined,
+            threadId: undefined,
+          }),
+        }),
+      );
+    } finally {
+      await fs.rm(storeRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -301,6 +301,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
   const announceTimeoutMs = resolveSubagentAnnounceTimeoutMs(cfg);
   const requesterIsSubagent = isInternalAnnounceRequesterSession(item.sessionKey);
   const origin = item.origin;
+  const hasExplicitDeliveryTarget = Boolean(origin?.channel && origin?.to);
   const threadId =
     origin?.threadId != null && origin.threadId !== "" ? String(origin.threadId) : undefined;
   const idempotencyKey = buildAnnounceIdempotencyKey(
@@ -319,7 +320,10 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       accountId: requesterIsSubagent ? undefined : origin?.accountId,
       to: requesterIsSubagent ? undefined : origin?.to,
       threadId: requesterIsSubagent ? undefined : threadId,
-      deliver: !requesterIsSubagent,
+      deliver: !requesterIsSubagent && hasExplicitDeliveryTarget,
+      ...(requesterIsSubagent || hasExplicitDeliveryTarget
+        ? {}
+        : { bestEffortDeliver: true as const }),
       internalEvents: item.internalEvents,
       inputProvenance: {
         kind: "inter_session",


### PR DESCRIPTION
## Summary

- Problem: queued subagent announce delivery could still send `deliver: true` even when the requester session had no explicit `channel`/`to` target.
- Why it matters: on multi-channel gateways this falls into channel-resolution errors instead of degrading to best-effort internal delivery.
- What changed: the queued announce path now only sets `deliver: true` when a concrete external target exists; otherwise it marks the request as `bestEffortDeliver`.
- What did NOT change (scope boundary): this does not alter direct announce delivery, queue selection logic, or bound delivery routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59201
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/agents/subagent-announce-delivery.ts` used `deliver: !requesterIsSubagent` in the queued path without checking whether the origin actually had a routable `channel` + `to` pair.
- Missing detection / guardrail: there was no queued-path regression test covering a requester session with `origin: null` on a multi-channel host.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #59201 documented the divergence between the queued path and the direct path.
- Why this regressed now: the direct path already used best-effort target resolution, but the queued path lagged behind and kept the older unconditional `deliver` behavior.
- If unknown, what was ruled out: ruled out a generic ACP/subagent announce failure; the bad behavior was specifically in queued delivery when no explicit route target existed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/subagent-announce-delivery.test.ts`
- Scenario the test should lock in: an active requester with queued follow-up mode and no explicit external target should enqueue an announce that uses `deliver: false` and `bestEffortDeliver: true`.
- Why this is the smallest reliable guardrail: the bug is in the queued announce parameter shaping, so a focused delivery test covers the exact regression point.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Queued subagent completion announces no longer fail with “Channel is required when multiple channels are configured” for requester sessions that do not have an external origin target.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): queued subagent announce path
- Relevant config (redacted): multi-channel style queue delivery with requester sessions that may not have `origin`

### Steps

1. Have an active requester session enter queued follow-up mode.
2. Let the session store entry omit `channel`, `lastChannel`, and `origin`.
3. Trigger a subagent completion announce.

### Expected

- The queued announce should degrade to best-effort delivery instead of requesting explicit external channel delivery.

### Actual

- Before this fix, the queued path set `deliver: true` with no channel target and failed downstream.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test -- src/agents/subagent-announce-delivery.test.ts`
- Edge cases checked:
  - requester sessions with no explicit origin target
  - queued follow-up mode with zero debounce
- What you did **not** verify:
  - live multi-channel gateway reproduction
  - unrelated `check:changed` lane failures in `src/agents/tools/web-fetch.provider-fallback.test.ts` that reproduced in this environment and are outside the touched surface

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: queued announces without explicit targets now skip forced external delivery.
  - Mitigation: this aligns the queued path with the already-existing direct-path best-effort behavior and only changes the invalid no-target case.
