### PR TITLE
fix(slack): fire trackEvent from message events for socket-health liveness (follow-up to #69833)

### DIFF
--- a/extensions/slack/src/monitor/events.ts
+++ b/extensions/slack/src/monitor/events.ts
@@ -18,6 +18,7 @@ export function registerSlackMonitorEvents(params: {
   registerSlackMessageEvents({
     ctx: params.ctx,
     handleSlackMessage: params.handleSlackMessage,
+    trackEvent: params.trackEvent,
   });
   registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -34,12 +34,23 @@ type MessageCase = {
   body?: unknown;
 };
 
-function createHandlers(eventName: RegisteredEventName, overrides?: SlackSystemEventTestOverrides) {
+function createHandlers(
+  eventName: RegisteredEventName,
+  overrides?: SlackSystemEventTestOverrides,
+  extras?: {
+    trackEvent?: () => void;
+    shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+  },
+) {
   const harness = createSlackSystemEventTestHarness(overrides);
+  if (extras?.shouldDropMismatchedSlackEvent) {
+    harness.ctx.shouldDropMismatchedSlackEvent = extras.shouldDropMismatchedSlackEvent;
+  }
   const handleSlackMessage = vi.fn(async () => {});
   registerSlackMessageEvents({
     ctx: harness.ctx,
     handleSlackMessage,
+    trackEvent: extras?.trackEvent,
   });
   return {
     handler: harness.getHandler(eventName) as MessageHandler | null,
@@ -273,5 +284,92 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks accepted regular message events", async () => {
+    const trackEvent = vi.fn();
+    const { handler } = createHandlers("message", { dmPolicy: "open" }, { trackEvent });
+    expect(handler).toBeTruthy();
+    await handler!({
+      event: {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        text: "hello",
+        ts: "123.456",
+      },
+      body: {},
+    });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks subtype system-event messages", async () => {
+    const trackEvent = vi.fn();
+    const { handler } = createHandlers(
+      "message",
+      { dmPolicy: "open", channelType: "channel" },
+      { trackEvent },
+    );
+    expect(handler).toBeTruthy();
+    await handler!({
+      event: {
+        ...makeChangedEvent({ channel: "C1", user: "U1" }),
+        channel_type: "channel",
+      },
+      body: {},
+    });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks accepted app_mention events", async () => {
+    const trackEvent = vi.fn();
+    const { handler } = createHandlers("app_mention", { dmPolicy: "open" }, { trackEvent });
+    expect(handler).toBeTruthy();
+    await handler!({
+      event: makeAppMentionEvent({ channel: "C123", channelType: "channel", ts: "123.789" }),
+      body: {},
+    });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not track mismatched message events", async () => {
+    const trackEvent = vi.fn();
+    const { handler } = createHandlers(
+      "message",
+      { dmPolicy: "open" },
+      { trackEvent, shouldDropMismatchedSlackEvent: () => true },
+    );
+    expect(handler).toBeTruthy();
+    await handler!({
+      event: {
+        type: "message",
+        channel: "D1",
+        user: "U1",
+        text: "hello",
+        ts: "123.456",
+      },
+      body: { api_app_id: "A_OTHER" },
+    });
+
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not track mismatched app_mention events", async () => {
+    const trackEvent = vi.fn();
+    const { handler } = createHandlers(
+      "app_mention",
+      { dmPolicy: "open" },
+      { trackEvent, shouldDropMismatchedSlackEvent: () => true },
+    );
+    expect(handler).toBeTruthy();
+    await handler!({
+      event: makeAppMentionEvent({ channel: "C123", channelType: "channel", ts: "123.789" }),
+      body: { api_app_id: "A_OTHER" },
+    });
+
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -12,14 +12,16 @@ import { authorizeAndResolveSlackSystemEventContext } from "./system-event-conte
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
   handleSlackMessage: SlackMessageHandler;
+  trackEvent?: () => void;
 }) {
-  const { ctx, handleSlackMessage } = params;
+  const { ctx, handleSlackMessage, trackEvent } = params;
 
   const handleIncomingMessageEvent = async ({ event, body }: { event: unknown; body: unknown }) => {
     try {
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
+      trackEvent?.();
 
       const message = event as SlackMessageEvent;
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
@@ -63,6 +65,7 @@ export function registerSlackMessageEvents(params: {
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
+      trackEvent?.();
 
       const mention = event as SlackAppMentionEvent;
 


### PR DESCRIPTION
## Summary

PR #69833 made Slack socket liveness tracking event-driven via a `trackEvent?: () => void` callback, but the thread-through missed `registerSlackMessageEvents`. That means inbound messages, subtype system events (channel topic/purpose changes that `enqueueSystemEvent` + `return`), and `app_mention` events never update `lastEventAt` / `lastInboundAt`. When message traffic is the only live signal on a socket, the health check can stale-flag a healthy connection.

## Change

Thread `trackEvent?` into `registerSlackMessageEvents`, mirroring the 5 sibling registrars. In `messages.ts`, invoke `trackEvent?.()` at the top of both the `message` and `app_mention` handlers — placed **after** `shouldDropMismatchedSlackEvent` (keep the drop-guard) and **before** subtype / DM-skip branching, so subtype system events and DM-skipped mentions still tick liveness. Matches `reactions.ts:17-21` where `trackEvent` fires once the event is confirmed valid for the bot.

## Testing

- `extensions/slack/src/monitor/events/messages.test.ts`: 5 new cases — regular message, subtype system-event, app_mention, mismatched message (does NOT track), mismatched app_mention (does NOT track).
- Full Slack vitest slice: 753/753 passed.
- Pre-commit hook (`check:no-conflict-markers`, `tsgo:extensions`, `tsgo:extensions:test`, `lint:extensions`, `check:import-cycles`, full slack vitest): clean.

## Linked

Follow-up to #69833 — closes a symmetric gap in the same socket-health liveness feature.
