### PR TITLE
Agent CLI: write local JSON to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/agents: write `openclaw agent --local --json` result envelopes through the runtime JSON writer so local JSON output goes to stdout while plain runtime shims keep their log fallback. Fixes #62440; carries forward #70589 and supersedes #62453. Thanks @koen666 and @ye-zi-233.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -4,7 +4,7 @@ import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import type { OutputRuntimeEnv, RuntimeEnv } from "../../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -183,47 +183,6 @@ describe("deliverAgentCommandResult", () => {
     expect(delivered.payloads).toMatchObject([{ text: "Options: on, off." }]);
   });
 
-  it("writes JSON envelopes to runtime.writeJson when available", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-      writeStdout: vi.fn(),
-      writeJson: vi.fn(),
-    } as unknown as RuntimeEnv & {
-      writeJson: ReturnType<typeof vi.fn>;
-      writeStdout: ReturnType<typeof vi.fn>;
-      log: ReturnType<typeof vi.fn>;
-    };
-
-    await deliverAgentCommandResult({
-      cfg: {} as OpenClawConfig,
-      deps: {} as CliDeps,
-      runtime,
-      opts: {
-        message: "test",
-        json: true,
-      } as AgentCommandOpts,
-      outboundSession: undefined,
-      sessionEntry: undefined,
-      payloads: [{ text: "pong" }],
-      result: createResult({
-        meta: {
-          durationMs: 1,
-        },
-      }),
-    });
-
-    expect(runtime.writeJson).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payloads: [expect.objectContaining({ text: "pong" })],
-        meta: { durationMs: 1 },
-      }),
-      2,
-    );
-    expect(runtime.log).not.toHaveBeenCalled();
-  });
-
   it("normalizes reply-media paths before outbound delivery", async () => {
     const normalizerFn = vi.fn(
       async (payload: ReplyPayload): Promise<ReplyPayload> => ({
@@ -308,47 +267,121 @@ describe("deliverAgentCommandResult", () => {
     ]);
   });
 
-  it("merges result metadata overrides into JSON output and returned results", async () => {
-    const runtime = {
-      log: vi.fn(),
-      writeStdout: vi.fn(),
-      writeJson: vi.fn(),
-    };
+  describe("JSON output", () => {
+    it("writes JSON envelopes to runtime.writeJson when stdout output is available", async () => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+        writeStdout: vi.fn(),
+        writeJson: vi.fn(),
+      } satisfies OutputRuntimeEnv;
 
-    const delivered = await deliverAgentCommandResult({
-      cfg: {} as OpenClawConfig,
-      deps: {} as CliDeps,
-      runtime: runtime as never,
-      opts: {
-        message: "test",
-        json: true,
-        resultMetaOverrides: {
-          transport: "embedded",
-          fallbackFrom: "gateway",
-        },
-      } as AgentCommandOpts,
-      outboundSession: undefined,
-      sessionEntry: undefined,
-      payloads: [{ text: "local" }],
-      result: createResult(),
+      await deliverAgentCommandResult({
+        cfg: {} as OpenClawConfig,
+        deps: {} as CliDeps,
+        runtime,
+        opts: {
+          message: "test",
+          json: true,
+        } as AgentCommandOpts,
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        payloads: [{ text: "pong" }],
+        result: createResult({
+          meta: {
+            durationMs: 1,
+          },
+        }),
+      });
+
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payloads: [expect.objectContaining({ text: "pong" })],
+          meta: { durationMs: 1 },
+        }),
+        2,
+      );
+      expect(runtime.log).not.toHaveBeenCalled();
     });
 
-    expect(runtime.log).not.toHaveBeenCalled();
-    expect(runtime.writeJson).toHaveBeenCalledWith(
-      {
-        payloads: [{ text: "local", mediaUrl: null }],
-        meta: {
-          durationMs: 1,
-          transport: "embedded",
-          fallbackFrom: "gateway",
+    it("falls back to runtime.log for plain RuntimeEnv JSON output", async () => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      } satisfies RuntimeEnv;
+
+      await deliverAgentCommandResult({
+        cfg: {} as OpenClawConfig,
+        deps: {} as CliDeps,
+        runtime,
+        opts: {
+          message: "test",
+          json: true,
+        } as AgentCommandOpts,
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        payloads: [{ text: "pong" }],
+        result: createResult(),
+      });
+
+      expect(runtime.log).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            payloads: [{ text: "pong", mediaUrl: null }],
+            meta: { durationMs: 1 },
+          },
+          null,
+          2,
+        ),
+      );
+    });
+
+    it("merges result metadata overrides into JSON output and returned results", async () => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+        writeStdout: vi.fn(),
+        writeJson: vi.fn(),
+      } satisfies OutputRuntimeEnv;
+
+      const delivered = await deliverAgentCommandResult({
+        cfg: {} as OpenClawConfig,
+        deps: {} as CliDeps,
+        runtime,
+        opts: {
+          message: "test",
+          json: true,
+          resultMetaOverrides: {
+            transport: "embedded",
+            fallbackFrom: "gateway",
+          },
+        } as AgentCommandOpts,
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        payloads: [{ text: "local" }],
+        result: createResult(),
+      });
+
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        {
+          payloads: [{ text: "local", mediaUrl: null }],
+          meta: {
+            durationMs: 1,
+            transport: "embedded",
+            fallbackFrom: "gateway",
+          },
         },
-      },
-      2,
-    );
-    expect(delivered.meta).toMatchObject({
-      durationMs: 1,
-      transport: "embedded",
-      fallbackFrom: "gateway",
+        2,
+      );
+      expect(delivered.meta).toMatchObject({
+        durationMs: 1,
+        transport: "embedded",
+        fallbackFrom: "gateway",
+      });
     });
   });
 });

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -4,6 +4,7 @@ import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -88,15 +89,15 @@ async function deliverMediaReplyForTest(outboundSession: DeliverParams["outbound
   });
 }
 
+beforeEach(() => {
+  setActivePluginRegistry(slackRegistry);
+});
+
+afterEach(() => {
+  setActivePluginRegistry(emptyRegistry);
+});
+
 describe("normalizeAgentCommandReplyPayloads", () => {
-  beforeEach(() => {
-    setActivePluginRegistry(slackRegistry);
-  });
-
-  afterEach(() => {
-    setActivePluginRegistry(emptyRegistry);
-  });
-
   it("keeps Slack directives in text for direct agent deliveries", () => {
     const normalized = normalizeAgentCommandReplyPayloads({
       cfg: {
@@ -149,7 +150,9 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       },
     ]);
   });
+});
 
+describe("deliverAgentCommandResult", () => {
   it("keeps Slack options text intact for local preview when delivery is disabled", async () => {
     const runtime = {
       log: vi.fn(),
@@ -178,6 +181,47 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(runtime.log).toHaveBeenCalledTimes(1);
     expect(runtime.log).toHaveBeenCalledWith("Options: on, off.");
     expect(delivered.payloads).toMatchObject([{ text: "Options: on, off." }]);
+  });
+
+  it("writes JSON envelopes to runtime.writeJson when available", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    } as unknown as RuntimeEnv & {
+      writeJson: ReturnType<typeof vi.fn>;
+      writeStdout: ReturnType<typeof vi.fn>;
+      log: ReturnType<typeof vi.fn>;
+    };
+
+    await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime,
+      opts: {
+        message: "test",
+        json: true,
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: "pong" }],
+      result: createResult({
+        meta: {
+          durationMs: 1,
+        },
+      }),
+    });
+
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [expect.objectContaining({ text: "pong" })],
+        meta: { durationMs: 1 },
+      }),
+      2,
+    );
+    expect(runtime.log).not.toHaveBeenCalled();
   });
 
   it("normalizes reply-media paths before outbound delivery", async () => {


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent --local --json` wrote its JSON envelope through `runtime.log()`, so JSON mode inherited the stderr log redirection path instead of stdout.
- Why it matters: scripts reading stdout saw an empty result even though the local agent run succeeded.
- What changed: the local delivery path now uses `writeRuntimeJson()` with the existing outbound envelope, so JSON output follows the same stdout writer path as other CLI JSON commands.
- What did NOT change (scope boundary): this does not change the JSON envelope shape, gateway-mode output, or non-JSON local agent behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62440
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/agents/command/delivery.ts` serialized the local JSON envelope via `runtime.log(JSON.stringify(...))` instead of the runtime JSON writer.
- Missing detection / guardrail: there was no regression test asserting that local JSON mode calls `runtime.writeJson()` when the runtime exposes structured stdout writers.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #62440 compared the local path against the gateway path and identified the inconsistent output API usage.
- Why this regressed now: the bug is a path-specific output mismatch rather than a new logging regression.
- If unknown, what was ruled out: ruled out an envelope-shape mismatch; the problem was the output channel, not the payload contents.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/command/delivery.test.ts`
- Scenario the test should lock in: local JSON delivery uses `runtime.writeJson()` instead of logging the serialized envelope.
- Why this is the smallest reliable guardrail: the bug is isolated to the runtime output call site, and the delivery unit test exercises that exact seam.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw agent --local --json` now emits its JSON envelope to stdout instead of stderr.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): local CLI agent path
- Relevant config (redacted): `openclaw agent --local --json`

### Steps

1. Run `openclaw agent --local --json --message "..."`.
2. Capture stdout and stderr separately.

### Expected

- stdout contains the JSON envelope.
- stderr only contains diagnostics if any.

### Actual

- Before this fix, the JSON envelope was written through the log path and ended up on stderr.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test -- src/agents/command/delivery.test.ts`
- Edge cases checked:
  - output still uses the existing outbound result envelope
  - non-JSON delivery flow remains unchanged
- What you did **not** verify:
  - end-to-end invocation of `openclaw agent --local --json` from the built CLI binary

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: local JSON mode now depends on the runtime structured writer path when available.
  - Mitigation: this reuses the shared `writeRuntimeJson()` helper that already handles stdout-vs-log routing for the rest of the CLI.
