### PR TITLE
fix(ui): include cacheRead in contextPercent calculation

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -286,8 +286,11 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
     return null;
   }
 
+  const totalContextTokens = input + cacheRead;
   const contextPercent =
-    contextWindow && input > 0 ? Math.min(Math.round((input / contextWindow) * 100), 100) : null;
+    contextWindow && totalContextTokens > 0
+      ? Math.min(Math.round((totalContextTokens / contextWindow) * 100), 100)
+      : null;
 
   return { input, output, cacheRead, cacheWrite, cost, model, contextPercent };
 }


### PR DESCRIPTION
Closes #70491

## Summary

The `% ctx` status pill under assistant messages showed `0%` in sessions that rely on prompt caching — even when the actual context window consumption was 44%+.

**Root cause:** `contextPercent` was computed from `inputTokens` alone. With prompt caching, `inputTokens` is just the small per-turn delta (e.g. 6 tokens), while `cacheRead` holds the bulk of the tokens consuming the context budget (e.g. 440k tokens). The existing code accumulated `cacheRead` correctly but then ignored it when computing the percentage.

**Fix:** Sum `input + cacheRead` as `totalContextTokens` before computing the percentage, matching the same accounting used by the `/status` slash command.

## Files changed

**`ui/src/ui/chat/grouped-render.ts`**
- `extractGroupMeta`: derive `contextPercent` from `input + cacheRead` instead of `input` alone

## Test plan

- [ ] Open a cache-heavy session (long session with a large model like claude-opus-4-7)
- [ ] Confirm the `% ctx` status pill now shows a non-zero percentage matching `/status` output
- [ ] Confirm fresh sessions (no cache) still show correct percentage
- [ ] Confirm `% ctx` stays capped at 100% even if tokens exceed window