### PR TITLE
fix(ui): add aria-label to STT button and aria-expanded to pinned toggle

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -966,6 +966,7 @@ function renderPinnedSection(
     <div class="agent-chat__pinned">
       <button
         class="agent-chat__pinned-toggle"
+        aria-expanded=${vs.pinnedExpanded}
         @click=${() => {
           vs.pinnedExpanded = !vs.pinnedExpanded;
           requestUpdate();
@@ -1613,6 +1614,7 @@ export function renderChat(props: ChatProps) {
                       }
                     }}
                     title=${vs.sttRecording ? "Stop recording" : "Voice input"}
+                    aria-label=${vs.sttRecording ? "Stop recording" : "Voice input"}
                     ?disabled=${!props.connected}
                   >
                     ${vs.sttRecording ? icons.micOff : icons.mic}


### PR DESCRIPTION
## Summary

Two small accessibility fixes for the Control UI chat view.

**1. Voice input (STT) button — missing `aria-label`**

The microphone button had a `title` tooltip but no `aria-label`, so screen readers announced it as a plain unnamed button. Added `aria-label` that mirrors the `title` and toggles dynamically between `"Voice input"` and `"Stop recording"` to match the active state.

**2. Pinned messages toggle — missing `aria-expanded`**

The "N pinned" toggle button controls a collapsible list of pinned messages but had no `aria-expanded` attribute. Screen readers could not announce whether the section was expanded or collapsed. Added `aria-expanded` bound to `vs.pinnedExpanded`.

Both follow the same pattern as the previous aria-label fixes in #67431.

## Files changed

**`ui/src/ui/views/chat.ts`**
- STT button: add `aria-label=${vs.sttRecording ? "Stop recording" : "Voice input"}`
- Pinned toggle: add `aria-expanded=${vs.pinnedExpanded}`

## Test plan

- [ ] Open Control UI with a screen reader (VoiceOver / NVDA)
- [ ] Tab to the microphone button — confirm it announces "Voice input"; activate it, then confirm it announces "Stop recording"
- [ ] Tab to the "N pinned" toggle — confirm screen reader announces expanded/collapsed state when toggled
- [ ] Confirm no visual change