### PR TITLE
fix(heartbeat): keep full tool array during heartbeat runs

### DIFF
--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -56,6 +56,7 @@ type FinalEffectiveToolPolicyParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   senderIsOwner?: boolean;
+  bootstrapContextRunKind?: string; // "heartbeat", "cron", or "default"
   warn: (message: string) => void;
 };
 
@@ -152,6 +153,7 @@ export function applyFinalEffectiveToolPolicy(
   const ownerFiltered = applyOwnerOnlyToolPolicy(
     params.bundledTools,
     params.senderIsOwner === true,
+    { keepOwnerTools: params.bootstrapContextRunKind === "heartbeat" },
   );
   // Suppress unavailable-core-tool warnings on every step of this pass.
   // `applyToolPolicyPipeline` infers `coreToolNames` from the `tools` array

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -726,6 +726,7 @@ export async function runEmbeddedAttempt(
       senderUsername: params.senderUsername,
       senderE164: params.senderE164,
       senderIsOwner: params.senderIsOwner,
+      bootstrapContextRunKind: params.bootstrapContextRunKind,
       warn: (message) => log.warn(message),
     });
     const effectiveTools = [...tools, ...filteredBundledTools];

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -110,6 +110,16 @@ describe("tool-policy", () => {
     expect(filtered.map((t) => t.name)).toEqual(["read", "cron", "gateway"]);
   });
 
+  it("keeps owner-only tools during heartbeat runs via keepOwnerTools", async () => {
+    const tools = createOwnerPolicyTools();
+    const filtered = applyOwnerOnlyToolPolicy(tools, false, { keepOwnerTools: true });
+    // Non-owner sender but with keepOwnerTools=true keeps owner tools (wrapped with guard)
+    expect(filtered.map((t) => t.name)).toEqual(["read", "cron", "gateway"]);
+    // Verify cron/gateway are still callable (execute is defined)
+    const cronTool = filtered.find((t) => t.name === "cron");
+    expect(cronTool?.execute).toBeDefined();
+  });
+
   it("honors ownerOnly metadata for custom tool names", async () => {
     const tools = [
       {

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -51,14 +51,19 @@ function isOwnerOnlyTool(tool: AnyAgentTool) {
   return tool.ownerOnly === true || isOwnerOnlyToolName(tool.name);
 }
 
-export function applyOwnerOnlyToolPolicy(tools: AnyAgentTool[], senderIsOwner: boolean) {
+export function applyOwnerOnlyToolPolicy(
+  tools: AnyAgentTool[],
+  senderIsOwner: boolean,
+  opts?: { keepOwnerTools?: boolean },
+): AnyAgentTool[] {
+  const keepOwnerTools = opts?.keepOwnerTools ?? false;
   const withGuard = tools.map((tool) => {
     if (!isOwnerOnlyTool(tool)) {
       return tool;
     }
     return wrapOwnerOnlyToolExecution(tool, senderIsOwner);
   });
-  if (senderIsOwner) {
+  if (senderIsOwner || keepOwnerTools) {
     return withGuard;
   }
   return withGuard.filter((tool) => !isOwnerOnlyTool(tool));


### PR DESCRIPTION
## Summary

Fixes heartbeat runs defeating their own cache-keep-alive purpose by restoring the tools-prefix cache alignment with conversation turns.

## Problem

Heartbeat runs (where `senderIsOwner=false`) were filtering out owner-restricted tools (`gateway`, `cron`, `nodes`) entirely from the tools array, causing the tools-prefix hash to differ from conversation runs. This broke Anthropic's prompt cache — every heartbeat paid full price for a new cache chain instead of refreshing the conversation's TTL.

## Solution

Instead of removing owner-only tools during heartbeat, keep them in the tool list with runtime guards that throw if invoked. This preserves the tools-prefix cache hash while maintaining the safety property that heartbeat runs cannot actually use privileged tools.

## Changes

- **`src/agents/tool-policy.ts`** — Added optional `keepOwnerTools` flag to `applyOwnerOnlyToolPolicy`. When `true`, owner-only tools are kept (wrapped with guard) instead of being removed.
- **`src/agents/pi-embedded-runner/effective-tool-policy.ts`** — Detect heartbeat runs via `bootstrapContextRunKind === "heartbeat"` and pass `keepOwnerTools: true`.
- **`src/agents/pi-embedded-runner/run/attempt.ts`** — Forward `bootstrapContextRunKind` to `applyFinalEffectiveToolPolicy`.
- **`src/agents/tool-policy.test.ts`** — Added regression test for `keepOwnerTools` behavior.

## Testing

- `applyOwnerOnlyToolPolicy(tools, false, { keepOwnerTools: true })` → owner tools are kept (wrapped), not removed
- `applyOwnerOnlyToolPolicy(tools, false)` → unchanged (owner tools removed for non-owner, as before)

## Related

- Closes #70417
- Related: #70418 (orthogonal cache-warmer proposal, independent of heartbeats)