### PR TITLE
fix(gateway): await sidecars by default to prevent Discord multi-account startup hang

### DIFF
--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -484,7 +484,7 @@ export async function startGatewayPostAttachRuntime(
       params.log.warn(`gateway sidecars failed to start: ${String(err)}`);
     });
 
-  if (params.awaitSidecars === true) {
+  if (params.awaitSidecars !== false) {
     const [stopGatewayUpdateCheck, tailscaleCleanup, sidecarsResult] = await Promise.all([
       stopGatewayUpdateCheckPromise,
       tailscaleCleanupPromise,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -228,7 +228,9 @@ export type GatewayServerOptions = {
     prompter: import("../wizard/prompts.js").WizardPrompter,
   ) => Promise<void>;
   /**
-   * Test-only: wait for post-listen sidecars such as plugin services before returning.
+   * Whether to wait for post-listen sidecars (channels, plugin services) to finish
+   * starting before marking the gateway as ready. Defaults to true; pass false to
+   * let sidecars start in the background.
    */
   awaitStartupSidecars?: boolean;
   /**


### PR DESCRIPTION
## Problem

Upgrading to `2026.4.21` causes multiple Discord bots to permanently hang at `awaiting gateway readiness` during startup. Only 1-2 bots succeed; the rest never connect.

### Reproduction

1. Configure multiple Discord bot accounts (4+ with 10s stagger)
2. `npm install -g openclaw@2026.4.21`
3. `openclaw gateway restart`
4. Observe logs — most bots stuck at "awaiting gateway readiness"

### Logs

```
19:57:09 [gateway] ready (10 plugins; 16.2s)
19:57:20 [discord] client initialized as Allen; awaiting gateway readiness
19:57:31 [discord] client initialized as Angie; awaiting gateway readiness
19:57:41 [discord] logged in as 我的伦敦乡下管家  ← only this one succeeds
19:57:55 [discord] client initialized as Ken; awaiting gateway readiness
```

Previous version `2026.4.14` does not exhibit this issue.

## Root Cause

The 4.21 refactor in `server-startup-post-attach.ts` wrapped sidecars (including channel startup) in a `setImmediate` + async Promise, with an `awaitSidecars` gate that defaults to **not waiting** (`=== true` check against an `undefined` default).

This means `server.impl.ts` calls `startupTrace.mark("ready")` before channels finish starting. Discord multi-account startup uses a 10s stagger (`DISCORD_ACCOUNT_STARTUP_STAGGER_MS`), so later accounts miss the one-shot gateway readiness signal.

In 4.14, `startChannels()` was directly awaited inline before `ready` was logged, ensuring all accounts could start and connect.

## Fix

- **`server-startup-post-attach.ts`**: Change `if (params.awaitSidecars === true)` → `if (params.awaitSidecars !== false)` so the default (`undefined`) awaits sidecars, restoring 4.14 semantics.
- **`server.impl.ts`**: Update the `awaitStartupSidecars` JSDoc from the misleading "Test-only" to accurately describe its behavior.

The `setImmediate` wrapper is preserved (HTTP can become responsive before channels start), and the opt-out (`awaitSidecars: false`) remains available for future use.

## Changes

- 2 files changed, +4/-2
- Zero breaking changes (existing `awaitStartupSidecars: true` in tests still works)