### PR TITLE
feat(plugin-sdk): add persistent keyed store helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Channels: add Yuanbao channel docs entrance so the Tencent Yuanbao bot appears in the channel listing and sidebar navigation. (#73443) Thanks @loongfay.
 - Active Memory: add optional per-conversation `allowedChatIds` and `deniedChatIds` filters so operators can enable recall only for selected direct, group, or channel conversations while keeping broad sessions skipped. (#67977) Thanks @quengh.
 - Active Memory: return bounded partial recall summaries when the hidden memory sub-agent times out, including the default temporary-transcript path, so useful recovered context is not discarded. (#73219) Thanks @joeykrug.
+- Plugin SDK: add a persistent keyed store helper so plugins can safely persist namespaced JSON values behind a file-lock-backed update queue. (#70626) Thanks @amknight.
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 
 ### Fixes

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1b545ffc4f0704382a16765a6cc26eb8da6df3d7ffdd9f489f0ca31399fe9833  plugin-sdk-api-baseline.json
-c192f0a2a827c4f756c22ba15eec90728e1edc4bd4a7d96cd097438242c3885a  plugin-sdk-api-baseline.jsonl
+3c491b3f408466f3cf225b74c503566523c10cfe29c608fb5eeb469f3e2ddb4a  plugin-sdk-api-baseline.json
+dc0328fed24437abebb6c4e76024dadc4bfa7b111a20ceba3314c76878301c3e  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e7d03a0d5aed4f1afb5c7d5e235a166e1e248090632248eaa92b0016531e7f3b  plugin-sdk-api-baseline.json
-b9bbf8e444b358485cb33c634d3f6f6588004a5c32482c1a473167957269ae58  plugin-sdk-api-baseline.jsonl
+559c16ceb0165f06d43b050169b897c1bc0271ece637e28eaf7bd8dc42031a52  plugin-sdk-api-baseline.json
+cb36670cf9a1d9c2c208a44eebda4db8a49086923f1f839f2217727c8ac62614  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c7d41f02736e682f4f453be85c8d0272b6ce0c8490a269d95c3618c05e3dfb7d  plugin-sdk-api-baseline.json
-56931624a426332ade00ba828bf44a3e0115808a796739f8d713816506bfb2ac  plugin-sdk-api-baseline.jsonl
+03cde1711860eb5daccdaa81e9019af7116175ce8de498df0df683d60733543d  plugin-sdk-api-baseline.json
+f6244d690eb7176883f098c03eedfa43e0caab4cd3840ad29338d630666b0657  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-03cde1711860eb5daccdaa81e9019af7116175ce8de498df0df683d60733543d  plugin-sdk-api-baseline.json
-f6244d690eb7176883f098c03eedfa43e0caab4cd3840ad29338d630666b0657  plugin-sdk-api-baseline.jsonl
+1b545ffc4f0704382a16765a6cc26eb8da6df3d7ffdd9f489f0ca31399fe9833  plugin-sdk-api-baseline.json
+c192f0a2a827c4f756c22ba15eec90728e1edc4bd4a7d96cd097438242c3885a  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-559c16ceb0165f06d43b050169b897c1bc0271ece637e28eaf7bd8dc42031a52  plugin-sdk-api-baseline.json
-cb36670cf9a1d9c2c208a44eebda4db8a49086923f1f839f2217727c8ac62614  plugin-sdk-api-baseline.jsonl
+c7d41f02736e682f4f453be85c8d0272b6ce0c8490a269d95c3618c05e3dfb7d  plugin-sdk-api-baseline.json
+56931624a426332ade00ba828bf44a3e0115808a796739f8d713816506bfb2ac  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -212,6 +212,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/json-store` | Small JSON state read/write helpers |
     | `plugin-sdk/file-lock` | Re-entrant file-lock helpers |
     | `plugin-sdk/persistent-dedupe` | Disk-backed dedupe cache helpers |
+    | `plugin-sdk/persistent-keyed-store` | Persistent keyed registry helper with TTL, deterministic enumeration, and quarantine-on-corruption behavior for restart-safe lifecycle state |
     | `plugin-sdk/acp-runtime` | ACP runtime/session and reply-dispatch helpers |
     | `plugin-sdk/acp-runtime-backend` | Lightweight ACP backend registration and reply-dispatch helpers for startup-loaded plugins |
     | `plugin-sdk/acp-binding-resolve-runtime` | Read-only ACP binding resolution without lifecycle startup imports |

--- a/package.json
+++ b/package.json
@@ -933,6 +933,10 @@
       "types": "./dist/plugin-sdk/persistent-dedupe.d.ts",
       "default": "./dist/plugin-sdk/persistent-dedupe.js"
     },
+    "./plugin-sdk/persistent-keyed-store": {
+      "types": "./dist/plugin-sdk/persistent-keyed-store.d.ts",
+      "default": "./dist/plugin-sdk/persistent-keyed-store.js"
+    },
     "./plugin-sdk/keyed-async-queue": {
       "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
       "default": "./dist/plugin-sdk/keyed-async-queue.js"

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -104,6 +104,9 @@ export const pluginSdkDocMetadata = {
   "reply-payload": {
     category: "utilities",
   },
+  "persistent-keyed-store": {
+    category: "utilities",
+  },
   testing: {
     category: "utilities",
   },

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -216,6 +216,7 @@
   "runtime-store",
   "json-store",
   "persistent-dedupe",
+  "persistent-keyed-store",
   "keyed-async-queue",
   "qa-runner-runtime",
   "memory-core-engine-runtime",

--- a/src/plugin-sdk/file-lock.test.ts
+++ b/src/plugin-sdk/file-lock.test.ts
@@ -19,6 +19,7 @@ describe("acquireFileLock", () => {
 
   afterEach(async () => {
     await drainFileLockStateForTest();
+    vi.restoreAllMocks();
     if (tempDir) {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/plugin-sdk/file-lock.test.ts
+++ b/src/plugin-sdk/file-lock.test.ts
@@ -79,4 +79,29 @@ describe("acquireFileLock", () => {
 
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it("does not steal a young lock only because the recorded pid is gone", async () => {
+    const filePath = path.join(tempDir, "young-dead-pid");
+    const lockPath = `${filePath}.lock`;
+    const options = {
+      retries: {
+        retries: 1,
+        factor: 1,
+        minTimeout: 5,
+        maxTimeout: 5,
+      },
+      stale: 60_000,
+    } as const;
+
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: 999_999_999, createdAt: new Date().toISOString() }, null, 2),
+      "utf8",
+    );
+
+    await expect(acquireFileLock(filePath, options)).rejects.toMatchObject({
+      code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+    });
+    await expect(fs.access(lockPath)).resolves.toBeUndefined();
+  });
 });

--- a/src/plugin-sdk/file-lock.ts
+++ b/src/plugin-sdk/file-lock.ts
@@ -29,6 +29,7 @@ type HeldLock = {
 const HELD_LOCKS_KEY = Symbol.for("openclaw.fileLockHeldLocks");
 const HELD_LOCKS = resolveProcessScopedMap<HeldLock>(HELD_LOCKS_KEY);
 const CLEANUP_REGISTERED_KEY = Symbol.for("openclaw.fileLockCleanupRegistered");
+const DEAD_PID_STALE_GRACE_MS = 1_000;
 
 function releaseAllLocksSync(): void {
   for (const [normalizedFile, held] of HELD_LOCKS) {
@@ -101,8 +102,15 @@ async function resolveNormalizedFilePath(filePath: string): Promise<string> {
 
 async function isStaleLock(lockPath: string, staleMs: number): Promise<boolean> {
   const payload = await readLockPayload(lockPath);
-  if (payload?.pid && !isPidAlive(payload.pid)) {
+  let statAgeMs: number | null = null;
+  try {
+    const stat = await fs.stat(lockPath);
+    statAgeMs = Date.now() - stat.mtimeMs;
+  } catch {
     return true;
+  }
+  if (payload?.pid && !isPidAlive(payload.pid)) {
+    return statAgeMs > Math.min(staleMs, DEAD_PID_STALE_GRACE_MS);
   }
   if (payload?.createdAt) {
     const createdAt = Date.parse(payload.createdAt);
@@ -110,12 +118,7 @@ async function isStaleLock(lockPath: string, staleMs: number): Promise<boolean> 
       return true;
     }
   }
-  try {
-    const stat = await fs.stat(lockPath);
-    return Date.now() - stat.mtimeMs > staleMs;
-  } catch {
-    return true;
-  }
+  return statAgeMs > staleMs;
 }
 
 export type FileLockHandle = {

--- a/src/plugin-sdk/persistent-dedupe.ts
+++ b/src/plugin-sdk/persistent-dedupe.ts
@@ -1,9 +1,14 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createDedupeCache } from "../infra/dedupe.js";
+import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 import type { FileLockOptions } from "./file-lock.js";
 import { withFileLock } from "./file-lock.js";
 import { readJsonFileWithFallback, writeJsonFileAtomically } from "./json-store.js";
 
 type PersistentDedupeData = Record<string, number>;
+const FILE_WRITE_QUEUE_KEY = Symbol.for("openclaw.persistentDedupeFileWriteQueues");
+const FILE_WRITE_QUEUES = resolveProcessScopedMap<Promise<unknown>>(FILE_WRITE_QUEUE_KEY);
 
 export type PersistentDedupeOptions = {
   ttlMs: number;
@@ -80,6 +85,7 @@ const DEFAULT_LOCK_OPTIONS: FileLockOptions = {
   },
   stale: 60_000,
 };
+const DEDUPE_DIR_MODE = 0o700;
 
 function mergeLockOptions(overrides?: Partial<FileLockOptions>): FileLockOptions {
   return {
@@ -146,6 +152,19 @@ function isRecentTimestamp(seenAt: number | undefined, ttlMs: number, now: numbe
   return seenAt != null && (ttlMs <= 0 || now - seenAt < ttlMs);
 }
 
+async function resolveFileWriteQueueKey(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  const dir = path.dirname(resolved);
+  await fs.mkdir(dir, { recursive: true, mode: DEDUPE_DIR_MODE });
+  await fs.chmod(dir, DEDUPE_DIR_MODE).catch(() => undefined);
+  try {
+    const realDir = await fs.realpath(dir);
+    return path.join(realDir, path.basename(resolved));
+  } catch {
+    return resolved;
+  }
+}
+
 /** Create a dedupe helper that combines in-memory fast checks with a lock-protected disk store. */
 export function createPersistentDedupe(options: PersistentDedupeOptions): PersistentDedupe {
   const ttlMs = Math.max(0, Math.floor(options.ttlMs));
@@ -154,7 +173,7 @@ export function createPersistentDedupe(options: PersistentDedupeOptions): Persis
   const lockOptions = mergeLockOptions(options.lockOptions);
   const memory = createDedupeCache({ ttlMs, maxSize: memoryMaxSize });
   const inflight = new Map<string, Promise<boolean>>();
-  // In-process write queue per file path. `withFileLock` is re-entrant
+  // In-process write queue per physical file path. `withFileLock` is re-entrant
   // within the same process (a second caller for the same path gets
   // immediate access instead of waiting), so two concurrent
   // checkAndRecordInner calls for different keys but the same file can
@@ -164,20 +183,20 @@ export function createPersistentDedupe(options: PersistentDedupeOptions): Persis
   // targeting the same file within this process, preventing the lost
   // update while still allowing cross-process file-lock contention to
   // be handled by the file lock itself.
-  const fileWriteQueues = new Map<string, Promise<unknown>>();
 
-  function enqueueFileWrite<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-    const prev = fileWriteQueues.get(filePath) ?? Promise.resolve();
+  async function enqueueFileWrite<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+    const queueKey = await resolveFileWriteQueueKey(filePath);
+    const prev = FILE_WRITE_QUEUES.get(queueKey) ?? Promise.resolve();
     const next = prev.then(fn, fn);
-    fileWriteQueues.set(filePath, next);
+    FILE_WRITE_QUEUES.set(queueKey, next);
     // Cleanup: remove the queue entry once this link settles, but only if
     // no newer work was chained after us. The `.catch(() => {})` prevents
     // an unhandled rejection when `next` rejects — callers still observe
     // the rejection through the returned `next` promise directly.
     next
       .finally(() => {
-        if (fileWriteQueues.get(filePath) === next) {
-          fileWriteQueues.delete(filePath);
+        if (FILE_WRITE_QUEUES.get(queueKey) === next) {
+          FILE_WRITE_QUEUES.delete(queueKey);
         }
       })
       .catch(() => {});

--- a/src/plugin-sdk/persistent-keyed-store.test.ts
+++ b/src/plugin-sdk/persistent-keyed-store.test.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { drainFileLockStateForTest, resetFileLockStateForTest } from "./file-lock.js";
+import { createPersistentKeyedStore } from "./persistent-keyed-store.js";
+import { createPluginSdkTestHarness } from "./test-helpers.js";
+
+type DemoRecord = {
+  value: string | number;
+};
+
+const { createTempDir } = createPluginSdkTestHarness();
+
+function createStore(
+  stateDir: string,
+  overrides?: {
+    namespace?: string;
+    maxEntries?: number;
+    defaultTtlMs?: number;
+    logger?: { warn: (message: string, meta?: unknown) => void };
+  },
+) {
+  return createPersistentKeyedStore<DemoRecord>({
+    namespace: overrides?.namespace ?? "demo-store",
+    stateDir,
+    defaultTtlMs: overrides?.defaultTtlMs,
+    maxEntries: overrides?.maxEntries ?? 100,
+    logger: overrides?.logger,
+  });
+}
+
+function resolveStoreFile(stateDir: string, namespace = "demo-store"): string {
+  return path.join(stateDir, "lifecycle", namespace, "store.json");
+}
+
+async function readStoreEnvelope(stateDir: string, namespace = "demo-store") {
+  const raw = await fs.readFile(resolveStoreFile(stateDir, namespace), "utf8");
+  return JSON.parse(raw) as {
+    version: number;
+    entries: Record<
+      string,
+      {
+        record: DemoRecord;
+        createdAt: number;
+        expiresAt?: number;
+      }
+    >;
+  };
+}
+
+describe("createPersistentKeyedStore", () => {
+  beforeEach(() => {
+    resetFileLockStateForTest();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await drainFileLockStateForTest();
+  });
+
+  it("registers and looks up records within one instance", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.register("message-1", { value: "hello" });
+
+    await expect(store.lookup("message-1")).resolves.toEqual({ value: "hello" });
+  });
+
+  it("persists records across new instances", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const writer = createStore(stateDir);
+
+    await writer.register("message-1", { value: "hello" });
+
+    const reader = createStore(stateDir);
+    await expect(reader.lookup("message-1")).resolves.toEqual({ value: "hello" });
+  });
+
+  it("expires per-call ttl entries on lookup after the clock advances", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.000Z"));
+    await store.register("message-1", { value: "hello" }, { ttlMs: 100 });
+
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.100Z"));
+    await expect(store.lookup("message-1")).resolves.toBeUndefined();
+    await expect(store.entries()).resolves.toEqual([]);
+  });
+
+  it("uses defaultTtlMs when register omits ttlMs", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir, { defaultTtlMs: 100 });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.000Z"));
+    await store.register("message-1", { value: "hello" });
+
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.100Z"));
+    await expect(store.lookup("message-1")).resolves.toBeUndefined();
+  });
+
+  it("consumes records atomically", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.register("message-1", { value: "hello" });
+
+    await expect(store.consume("message-1")).resolves.toEqual({ value: "hello" });
+    await expect(store.lookup("message-1")).resolves.toBeUndefined();
+  });
+
+  it("returns entries in deterministic order with metadata", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.000Z"));
+    const firstTimestamp = Date.now();
+    await store.register("b", { value: "b" });
+    await store.register("a", { value: "a" });
+
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.001Z"));
+    const secondTimestamp = Date.now();
+    await store.register("c", { value: "c" });
+
+    await expect(store.entries()).resolves.toEqual([
+      { id: "a", record: { value: "a" }, createdAt: firstTimestamp },
+      { id: "b", record: { value: "b" }, createdAt: firstTimestamp },
+      { id: "c", record: { value: "c" }, createdAt: secondTimestamp },
+    ]);
+  });
+
+  it("clears the store", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.register("message-1", { value: "hello" });
+    await store.clear();
+
+    await expect(store.entries()).resolves.toEqual([]);
+    await expect(readStoreEnvelope(stateDir)).resolves.toEqual({
+      version: 1,
+      entries: {},
+    });
+  });
+
+  it("treats a missing file as empty without warning", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const warn = vi.fn();
+    const store = createStore(stateDir, { logger: { warn } });
+
+    await expect(store.lookup("missing")).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("quarantines corrupt json, warns, and starts empty", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const storeFile = resolveStoreFile(stateDir);
+    const warn = vi.fn();
+    await fs.mkdir(path.dirname(storeFile), { recursive: true });
+    await fs.writeFile(storeFile, "{not-json", "utf8");
+
+    const store = createStore(stateDir, { logger: { warn } });
+
+    await expect(store.entries()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const files = await fs.readdir(path.dirname(storeFile));
+    expect(files).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^store\.vunknown\.corrupt-\d+\.json$/)]),
+    );
+    expect(files).not.toContain("store.json");
+  });
+
+  it("quarantines higher-version files, warns, and starts empty", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const storeFile = resolveStoreFile(stateDir);
+    const warn = vi.fn();
+    await fs.mkdir(path.dirname(storeFile), { recursive: true });
+    await fs.writeFile(storeFile, JSON.stringify({ version: 2, entries: {} }, null, 2), "utf8");
+
+    const store = createStore(stateDir, { logger: { warn } });
+
+    await expect(store.entries()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const files = await fs.readdir(path.dirname(storeFile));
+    expect(files).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^store\.v2\.corrupt-\d+\.json$/)]),
+    );
+    expect(files).not.toContain("store.json");
+  });
+
+  it("rejects invalid namespaces before any file io", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+
+    expect(() =>
+      createPersistentKeyedStore<DemoRecord>({
+        namespace: "../escape",
+        stateDir,
+        maxEntries: 1,
+      }),
+    ).toThrow(/namespace/i);
+
+    await expect(fs.access(path.join(stateDir, "lifecycle"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("prunes the oldest live entries when maxEntries is exceeded", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir, { maxEntries: 2 });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.000Z"));
+    await store.register("a", { value: "a" });
+
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.001Z"));
+    await store.register("b", { value: "b" });
+
+    vi.setSystemTime(new Date("2026-04-23T12:00:00.002Z"));
+    await store.register("c", { value: "c" });
+
+    await expect(store.entries()).resolves.toEqual([
+      { id: "b", record: { value: "b" }, createdAt: Date.parse("2026-04-23T12:00:00.001Z") },
+      { id: "c", record: { value: "c" }, createdAt: Date.parse("2026-04-23T12:00:00.002Z") },
+    ]);
+  });
+
+  it("serializes concurrent registers across two instances", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const first = createStore(stateDir);
+    const second = createStore(stateDir);
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        (index % 2 === 0 ? first : second).register(`message-${index}`, { value: index }),
+      ),
+    );
+
+    const entries = await first.entries();
+    expect(entries).toHaveLength(20);
+    expect(entries.map((entry) => entry.id).toSorted()).toEqual(
+      Array.from({ length: 20 }, (_, index) => `message-${index}`).toSorted(),
+    );
+  });
+
+  it("keeps only the latest record when overwriting an existing id", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.register("message-1", { value: "first" });
+    await store.register("message-1", { value: "second" });
+
+    await expect(store.lookup("message-1")).resolves.toEqual({ value: "second" });
+    await expect(store.entries()).resolves.toEqual([
+      expect.objectContaining({ id: "message-1", record: { value: "second" } }),
+    ]);
+  });
+});

--- a/src/plugin-sdk/persistent-keyed-store.test.ts
+++ b/src/plugin-sdk/persistent-keyed-store.test.ts
@@ -1,5 +1,7 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFileLockStateForTest, resetFileLockStateForTest } from "./file-lock.js";
 import { createPersistentKeyedStore } from "./persistent-keyed-store.js";
@@ -11,6 +13,7 @@ type DemoRecord = {
 
 const { createTempDir } = createPluginSdkTestHarness();
 const itWithDirectorySymlinks = process.platform === "win32" ? it.skip : it;
+const itWithPosixModes = process.platform === "win32" ? it.skip : it;
 
 function createStore(
   stateDir: string,
@@ -47,6 +50,46 @@ async function readStoreEnvelope(stateDir: string, namespace = "demo-store") {
       }
     >;
   };
+}
+
+function formatMode(mode: number): string {
+  return (mode & 0o777).toString(8);
+}
+
+async function runRegisterInChildProcess(params: {
+  stateDir: string;
+  key: string;
+}): Promise<{ code: number | null; stderr: string }> {
+  const moduleUrl = pathToFileURL(path.resolve("src/plugin-sdk/persistent-keyed-store.ts")).href;
+  const script = `
+    import { createPersistentKeyedStore } from ${JSON.stringify(moduleUrl)};
+    const store = createPersistentKeyedStore({
+      namespace: "demo-store",
+      stateDir: process.env.OPENCLAW_TEST_KEYED_STORE_STATE_DIR,
+      maxEntries: 100,
+    });
+    await store.register(process.env.OPENCLAW_TEST_KEYED_STORE_KEY, {
+      value: process.env.OPENCLAW_TEST_KEYED_STORE_KEY,
+    });
+  `;
+  return await new Promise((resolve) => {
+    const child = spawn(process.execPath, ["--import", "tsx", "--eval", script], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OPENCLAW_TEST_KEYED_STORE_STATE_DIR: params.stateDir,
+        OPENCLAW_TEST_KEYED_STORE_KEY: params.key,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("close", (code) => {
+      resolve({ code, stderr });
+    });
+  });
 }
 
 describe("createPersistentKeyedStore", () => {
@@ -116,6 +159,23 @@ describe("createPersistentKeyedStore", () => {
 
     vi.setSystemTime(new Date("2026-04-23T12:00:00.100Z"));
     await expect(store.lookup("message-1")).resolves.toBeUndefined();
+  });
+
+  it("rejects records that cannot round-trip through JSON", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createPersistentKeyedStore<unknown>({
+      namespace: "demo-store",
+      stateDir,
+      maxEntries: 100,
+    });
+
+    await expect(store.register("missing-record", undefined)).rejects.toThrow(/JSON/i);
+    await expect(
+      store.register("infinite-number", { value: Number.POSITIVE_INFINITY }),
+    ).rejects.toThrow(/JSON/i);
+    await expect(fs.access(resolveStoreFile(stateDir))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("consumes records atomically", async () => {
@@ -210,6 +270,24 @@ describe("createPersistentKeyedStore", () => {
     expect(files).not.toContain("store.json");
   });
 
+  it("quarantines entries missing a record field", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const storeFile = resolveStoreFile(stateDir);
+    const warn = vi.fn();
+    await fs.mkdir(path.dirname(storeFile), { recursive: true });
+    await fs.writeFile(
+      storeFile,
+      JSON.stringify({ version: 1, entries: { broken: { createdAt: Date.now() } } }, null, 2),
+      "utf8",
+    );
+
+    const store = createStore(stateDir, { logger: { warn } });
+
+    await expect(store.entries()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    await expect(fs.access(storeFile)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("rejects invalid namespaces before any file io", async () => {
     const stateDir = await createTempDir("openclaw-keyed-store-");
 
@@ -224,6 +302,16 @@ describe("createPersistentKeyedStore", () => {
     await expect(fs.access(path.join(stateDir, "lifecycle"))).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  itWithPosixModes("creates the store directory with private permissions", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.lookup("missing");
+
+    const stat = await fs.stat(path.dirname(resolveStoreFile(stateDir)));
+    expect(formatMode(stat.mode)).toBe("700");
   });
 
   it("prunes the oldest live entries when maxEntries is exceeded", async () => {
@@ -284,6 +372,22 @@ describe("createPersistentKeyedStore", () => {
     expect(entries.map((entry) => entry.id).toSorted()).toEqual(
       Array.from({ length: 20 }, (_, index) => `message-${index}`).toSorted(),
     );
+  });
+
+  it("waits long enough for modest cross-process register contention", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-processes-");
+    const workerCount = 12;
+
+    const results = await Promise.all(
+      Array.from({ length: workerCount }, (_, index) =>
+        runRegisterInChildProcess({ stateDir, key: `message-${index}` }),
+      ),
+    );
+
+    const failures = results.filter((result) => result.code !== 0);
+    expect(failures, "child processes should not hit file lock timeouts").toEqual([]);
+    const entries = await createStore(stateDir).entries();
+    expect(entries).toHaveLength(workerCount);
   });
 
   it("keeps only the latest record when overwriting an existing id", async () => {

--- a/src/plugin-sdk/persistent-keyed-store.test.ts
+++ b/src/plugin-sdk/persistent-keyed-store.test.ts
@@ -173,6 +173,9 @@ describe("createPersistentKeyedStore", () => {
     await expect(
       store.register("infinite-number", { value: Number.POSITIVE_INFINITY }),
     ).rejects.toThrow(/JSON/i);
+    const sparseArray: unknown[] = [];
+    sparseArray[1] = "hole";
+    await expect(store.register("sparse-array", sparseArray)).rejects.toThrow(/JSON/i);
     await expect(fs.access(resolveStoreFile(stateDir))).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/src/plugin-sdk/persistent-keyed-store.test.ts
+++ b/src/plugin-sdk/persistent-keyed-store.test.ts
@@ -10,6 +10,7 @@ type DemoRecord = {
 };
 
 const { createTempDir } = createPluginSdkTestHarness();
+const itWithDirectorySymlinks = process.platform === "win32" ? it.skip : it;
 
 function createStore(
   stateDir: string,
@@ -66,6 +67,20 @@ describe("createPersistentKeyedStore", () => {
     await store.register("message-1", { value: "hello" });
 
     await expect(store.lookup("message-1")).resolves.toEqual({ value: "hello" });
+  });
+
+  it("stores prototype-shaped ids as data keys", async () => {
+    const stateDir = await createTempDir("openclaw-keyed-store-");
+    const store = createStore(stateDir);
+
+    await store.register("__proto__", { value: "hello" });
+
+    await expect(store.lookup("__proto__")).resolves.toEqual({ value: "hello" });
+    await expect(store.entries()).resolves.toEqual([
+      expect.objectContaining({ id: "__proto__", record: { value: "hello" } }),
+    ]);
+    const envelope = await readStoreEnvelope(stateDir);
+    expect(Object.hasOwn(envelope.entries, "__proto__")).toBe(true);
   });
 
   it("persists records across new instances", async () => {
@@ -235,6 +250,28 @@ describe("createPersistentKeyedStore", () => {
     const stateDir = await createTempDir("openclaw-keyed-store-");
     const first = createStore(stateDir);
     const second = createStore(stateDir);
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        (index % 2 === 0 ? first : second).register(`message-${index}`, { value: index }),
+      ),
+    );
+
+    const entries = await first.entries();
+    expect(entries).toHaveLength(20);
+    expect(entries.map((entry) => entry.id).toSorted()).toEqual(
+      Array.from({ length: 20 }, (_, index) => `message-${index}`).toSorted(),
+    );
+  });
+
+  itWithDirectorySymlinks("serializes concurrent registers across aliased state dirs", async () => {
+    const parentDir = await createTempDir("openclaw-keyed-store-alias-");
+    const realStateDir = path.join(parentDir, "real");
+    const linkedStateDir = path.join(parentDir, "linked");
+    await fs.mkdir(realStateDir, { recursive: true });
+    await fs.symlink(realStateDir, linkedStateDir, "dir");
+    const first = createStore(realStateDir);
+    const second = createStore(linkedStateDir);
 
     await Promise.all(
       Array.from({ length: 20 }, (_, index) =>

--- a/src/plugin-sdk/persistent-keyed-store.ts
+++ b/src/plugin-sdk/persistent-keyed-store.ts
@@ -1,0 +1,470 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
+import type { FileLockOptions } from "./file-lock.js";
+import { withFileLock } from "./file-lock.js";
+import { writeJsonFileAtomically } from "./json-store.js";
+import { resolveStateDir } from "./state-paths.js";
+
+const STORE_VERSION = 1;
+const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
+const ACCESS_QUEUE_KEY = Symbol.for("openclaw.persistentKeyedStoreAccessQueues");
+const ACCESS_QUEUES = resolveProcessScopedMap<Promise<unknown>>(ACCESS_QUEUE_KEY);
+
+const DEFAULT_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 6,
+    factor: 1.35,
+    minTimeout: 8,
+    maxTimeout: 180,
+    randomize: true,
+  },
+  stale: 60_000,
+};
+
+interface StoredEntry<T> {
+  record: T;
+  createdAt: number;
+  expiresAt?: number;
+}
+
+interface Envelope<T> {
+  version: number;
+  entries: Record<string, StoredEntry<T>>;
+}
+
+type PersistentKeyedStoreLogger = {
+  warn: (message: string, meta?: unknown) => void;
+};
+
+type ReadEnvelopeResult<T> =
+  | { kind: "missing" }
+  | { kind: "ok"; envelope: Envelope<T> }
+  | {
+      kind: "quarantine";
+      versionLabel: string;
+      reason: "corrupt" | "version-mismatch";
+      version?: number;
+    };
+
+export interface PersistentKeyedStoreOptions {
+  namespace: string;
+  stateDir?: string;
+  defaultTtlMs?: number;
+  maxEntries: number;
+  lockOptions?: Partial<FileLockOptions>;
+  logger?: PersistentKeyedStoreLogger;
+}
+
+export interface PersistentKeyedStoreEntry<T> {
+  id: string;
+  record: T;
+  createdAt: number;
+  expiresAt?: number;
+}
+
+export interface PersistentKeyedStore<T> {
+  register(id: string, record: T, options?: { ttlMs?: number }): Promise<void>;
+  lookup(id: string): Promise<T | undefined>;
+  consume(id: string): Promise<T | undefined>;
+  entries(): Promise<PersistentKeyedStoreEntry<T>[]>;
+  clear(): Promise<void>;
+}
+
+function mergeLockOptions(overrides?: Partial<FileLockOptions>): FileLockOptions {
+  return {
+    stale: overrides?.stale ?? DEFAULT_LOCK_OPTIONS.stale,
+    retries: {
+      retries: overrides?.retries?.retries ?? DEFAULT_LOCK_OPTIONS.retries.retries,
+      factor: overrides?.retries?.factor ?? DEFAULT_LOCK_OPTIONS.retries.factor,
+      minTimeout: overrides?.retries?.minTimeout ?? DEFAULT_LOCK_OPTIONS.retries.minTimeout,
+      maxTimeout: overrides?.retries?.maxTimeout ?? DEFAULT_LOCK_OPTIONS.retries.maxTimeout,
+      randomize: overrides?.retries?.randomize ?? DEFAULT_LOCK_OPTIONS.retries.randomize,
+    },
+  };
+}
+
+function createEmptyEnvelope<T>(): Envelope<T> {
+  return {
+    version: STORE_VERSION,
+    entries: {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function validateNamespace(value: string): string {
+  const trimmed = value.trim();
+  if (!NAMESPACE_PATTERN.test(trimmed)) {
+    throw new Error(
+      `persistent-keyed-store namespace must be a single safe path segment: ${value}`,
+    );
+  }
+  return trimmed;
+}
+
+function validateId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("persistent-keyed-store id must not be empty");
+  }
+  return trimmed;
+}
+
+function validateOptionalTtlMs(value: number | undefined, label: string): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`persistent-keyed-store ${label} must be an integer >= 0`);
+  }
+  return value;
+}
+
+function validateMaxEntries(value: number): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error("persistent-keyed-store maxEntries must be an integer >= 1");
+  }
+  return value;
+}
+
+function resolveStoreFilePath(namespace: string, stateDir?: string): string {
+  const trimmedStateDir = stateDir?.trim();
+  if (stateDir != null && !trimmedStateDir) {
+    throw new Error("persistent-keyed-store stateDir must not be empty when provided");
+  }
+  const root = trimmedStateDir ? path.resolve(trimmedStateDir) : resolveStateDir(process.env);
+  return path.resolve(root, "lifecycle", namespace, "store.json");
+}
+
+function serializeEnvelope<T>(envelope: Envelope<T>): string {
+  return JSON.stringify(envelope);
+}
+
+function isExpired<T>(entry: StoredEntry<T>, now: number): boolean {
+  return entry.expiresAt != null && now >= entry.expiresAt;
+}
+
+function pruneExpiredEntries<T>(envelope: Envelope<T>, now: number): boolean {
+  let changed = false;
+  for (const [id, entry] of Object.entries(envelope.entries)) {
+    if (isExpired(entry, now)) {
+      delete envelope.entries[id];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function sortEntries<T>(
+  entries: Array<PersistentKeyedStoreEntry<T>>,
+): Array<PersistentKeyedStoreEntry<T>> {
+  return entries.toSorted(
+    (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
+  );
+}
+
+function toPublicEntry<T>(id: string, entry: StoredEntry<T>): PersistentKeyedStoreEntry<T> {
+  const publicEntry: PersistentKeyedStoreEntry<T> = {
+    id,
+    record: entry.record,
+    createdAt: entry.createdAt,
+  };
+  if (entry.expiresAt != null) {
+    publicEntry.expiresAt = entry.expiresAt;
+  }
+  return publicEntry;
+}
+
+function enforceMaxEntries<T>(envelope: Envelope<T>, maxEntries: number): boolean {
+  const liveEntries = sortEntries(
+    Object.entries(envelope.entries).map(([id, entry]) => toPublicEntry(id, entry)),
+  );
+  const overflow = liveEntries.length - maxEntries;
+  if (overflow <= 0) {
+    return false;
+  }
+  for (const entry of liveEntries.slice(0, overflow)) {
+    delete envelope.entries[entry.id];
+  }
+  return true;
+}
+
+async function readEnvelopeDetailed<T>(filePath: string): Promise<ReadEnvelopeResult<T>> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kind: "missing" };
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      kind: "quarantine",
+      versionLabel: "vunknown",
+      reason: "corrupt",
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      kind: "quarantine",
+      versionLabel: "vunknown",
+      reason: "corrupt",
+    };
+  }
+
+  const rawVersion = parsed.version;
+  const rawEntries = parsed.entries;
+  if (!Number.isInteger(rawVersion)) {
+    return {
+      kind: "quarantine",
+      versionLabel: "vunknown",
+      reason: "corrupt",
+    };
+  }
+  const version = rawVersion as number;
+  if (version > STORE_VERSION) {
+    return {
+      kind: "quarantine",
+      versionLabel: `v${version}`,
+      reason: "version-mismatch",
+      version,
+    };
+  }
+  if (version !== STORE_VERSION || !isRecord(rawEntries)) {
+    return {
+      kind: "quarantine",
+      versionLabel: `v${version}`,
+      reason: "corrupt",
+      version,
+    };
+  }
+
+  const entries = rawEntries;
+  const sanitizedEntries: Record<string, StoredEntry<T>> = {};
+  for (const [id, entry] of Object.entries(entries)) {
+    if (!id || id.trim() !== id || !isRecord(entry) || !isFiniteNumber(entry.createdAt)) {
+      return {
+        kind: "quarantine",
+        versionLabel: `v${version}`,
+        reason: "corrupt",
+        version,
+      };
+    }
+
+    const expiresAt = entry.expiresAt;
+    if (expiresAt != null && !isFiniteNumber(expiresAt)) {
+      return {
+        kind: "quarantine",
+        versionLabel: `v${version}`,
+        reason: "corrupt",
+        version,
+      };
+    }
+
+    sanitizedEntries[id] = {
+      record: (entry as { record: T }).record,
+      createdAt: entry.createdAt,
+      ...(expiresAt != null ? { expiresAt } : {}),
+    };
+  }
+
+  return {
+    kind: "ok",
+    envelope: {
+      version: STORE_VERSION,
+      entries: sanitizedEntries,
+    },
+  };
+}
+
+async function quarantineStoreFile(
+  filePath: string,
+  params: {
+    versionLabel: string;
+    reason: "corrupt" | "version-mismatch";
+    version?: number;
+    logger: PersistentKeyedStoreLogger;
+  },
+): Promise<void> {
+  const extension = path.extname(filePath) || ".json";
+  const baseName = path.basename(filePath, extension);
+  const quarantinePath = path.join(
+    path.dirname(filePath),
+    `${baseName}.${params.versionLabel}.corrupt-${Date.now()}${extension}`,
+  );
+
+  try {
+    await fs.rename(filePath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  params.logger.warn("persistent-keyed-store quarantined store file and started empty", {
+    filePath,
+    quarantinePath,
+    reason: params.reason,
+    ...(params.version != null ? { version: params.version } : {}),
+  });
+}
+
+function runSerializedStoreAccess<R>(filePath: string, fn: () => Promise<R>): Promise<R> {
+  const previous = ACCESS_QUEUES.get(filePath) ?? Promise.resolve();
+  const next = previous.then(fn, fn);
+  ACCESS_QUEUES.set(filePath, next);
+  next
+    .finally(() => {
+      if (ACCESS_QUEUES.get(filePath) === next) {
+        ACCESS_QUEUES.delete(filePath);
+      }
+    })
+    .catch(() => {});
+  return next;
+}
+
+async function loadEnvelopeOrEmpty<T>(
+  filePath: string,
+  logger: PersistentKeyedStoreLogger,
+): Promise<Envelope<T>> {
+  const result = await readEnvelopeDetailed<T>(filePath);
+  if (result.kind === "missing") {
+    return createEmptyEnvelope();
+  }
+  if (result.kind === "ok") {
+    return result.envelope;
+  }
+  await quarantineStoreFile(filePath, {
+    versionLabel: result.versionLabel,
+    reason: result.reason,
+    version: result.version,
+    logger,
+  });
+  return createEmptyEnvelope();
+}
+
+function buildEntriesList<T>(envelope: Envelope<T>): Array<PersistentKeyedStoreEntry<T>> {
+  return sortEntries(
+    Object.entries(envelope.entries).map(([id, entry]) => toPublicEntry(id, entry)),
+  );
+}
+
+export function createPersistentKeyedStore<T>(
+  options: PersistentKeyedStoreOptions,
+): PersistentKeyedStore<T> {
+  const namespace = validateNamespace(options.namespace);
+  const defaultTtlMs = validateOptionalTtlMs(options.defaultTtlMs, "defaultTtlMs");
+  const maxEntries = validateMaxEntries(options.maxEntries);
+  const lockOptions = mergeLockOptions(options.lockOptions);
+  const logger: PersistentKeyedStoreLogger = {
+    warn: options.logger?.warn ?? console.warn.bind(console),
+  };
+  const filePath = resolveStoreFilePath(namespace, options.stateDir);
+
+  async function accessStore<R>(fn: (envelope: Envelope<T>) => Promise<R>): Promise<R> {
+    return runSerializedStoreAccess(filePath, () =>
+      withFileLock(filePath, lockOptions, async () => {
+        const envelope = await loadEnvelopeOrEmpty<T>(filePath, logger);
+        return fn(envelope);
+      }),
+    );
+  }
+
+  async function register(
+    id: string,
+    record: T,
+    registerOptions?: { ttlMs?: number },
+  ): Promise<void> {
+    const normalizedId = validateId(id);
+    const ttlMs = validateOptionalTtlMs(registerOptions?.ttlMs, "ttlMs") ?? defaultTtlMs;
+    const now = Date.now();
+    await accessStore(async (envelope) => {
+      const original = serializeEnvelope(envelope);
+      pruneExpiredEntries(envelope, now);
+      envelope.entries[normalizedId] = {
+        record,
+        createdAt: now,
+        ...(ttlMs != null ? { expiresAt: now + ttlMs } : {}),
+      };
+      pruneExpiredEntries(envelope, now);
+      enforceMaxEntries(envelope, maxEntries);
+      if (serializeEnvelope(envelope) === original) {
+        return;
+      }
+      await writeJsonFileAtomically(filePath, envelope);
+    });
+  }
+
+  async function lookup(id: string): Promise<T | undefined> {
+    const normalizedId = validateId(id);
+    return accessStore(async (envelope) => {
+      const original = serializeEnvelope(envelope);
+      const now = Date.now();
+      pruneExpiredEntries(envelope, now);
+      if (serializeEnvelope(envelope) !== original) {
+        await writeJsonFileAtomically(filePath, envelope);
+      }
+      return envelope.entries[normalizedId]?.record;
+    });
+  }
+
+  async function consume(id: string): Promise<T | undefined> {
+    const normalizedId = validateId(id);
+    return accessStore(async (envelope) => {
+      const now = Date.now();
+      const original = serializeEnvelope(envelope);
+      pruneExpiredEntries(envelope, now);
+      const entry = envelope.entries[normalizedId];
+      if (!entry) {
+        if (serializeEnvelope(envelope) !== original) {
+          await writeJsonFileAtomically(filePath, envelope);
+        }
+        return undefined;
+      }
+      delete envelope.entries[normalizedId];
+      await writeJsonFileAtomically(filePath, envelope);
+      return entry.record;
+    });
+  }
+
+  async function entries(): Promise<PersistentKeyedStoreEntry<T>[]> {
+    return accessStore(async (envelope) => {
+      const original = serializeEnvelope(envelope);
+      pruneExpiredEntries(envelope, Date.now());
+      if (serializeEnvelope(envelope) !== original) {
+        await writeJsonFileAtomically(filePath, envelope);
+      }
+      return buildEntriesList(envelope);
+    });
+  }
+
+  async function clear(): Promise<void> {
+    await runSerializedStoreAccess(filePath, () =>
+      withFileLock(filePath, lockOptions, () =>
+        writeJsonFileAtomically(filePath, createEmptyEnvelope()),
+      ),
+    );
+  }
+
+  return {
+    register,
+    lookup,
+    consume,
+    entries,
+    clear,
+  };
+}

--- a/src/plugin-sdk/persistent-keyed-store.ts
+++ b/src/plugin-sdk/persistent-keyed-store.ts
@@ -124,7 +124,9 @@ function isJsonSerializableValue(value: unknown, seen = new WeakSet<object>()): 
       return false;
     }
     seen.add(value);
-    const valid = value.every((entry) => isJsonSerializableValue(entry, seen));
+    const valid =
+      Object.keys(value).length === value.length &&
+      value.every((entry) => isJsonSerializableValue(entry, seen));
     seen.delete(value);
     return valid;
   }

--- a/src/plugin-sdk/persistent-keyed-store.ts
+++ b/src/plugin-sdk/persistent-keyed-store.ts
@@ -10,13 +10,14 @@ const STORE_VERSION = 1;
 const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
 const ACCESS_QUEUE_KEY = Symbol.for("openclaw.persistentKeyedStoreAccessQueues");
 const ACCESS_QUEUES = resolveProcessScopedMap<Promise<unknown>>(ACCESS_QUEUE_KEY);
+const STORE_DIR_MODE = 0o700;
 
 const DEFAULT_LOCK_OPTIONS: FileLockOptions = {
   retries: {
-    retries: 6,
-    factor: 1.35,
-    minTimeout: 8,
-    maxTimeout: 180,
+    retries: 32,
+    factor: 1.3,
+    minTimeout: 10,
+    maxTimeout: 300,
     randomize: true,
   },
   stale: 60_000,
@@ -103,6 +104,48 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isJsonSerializableValue(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return true;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return false;
+    }
+    seen.add(value);
+    const valid = value.every((entry) => isJsonSerializableValue(entry, seen));
+    seen.delete(value);
+    return valid;
+  }
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  const valid = Object.values(value).every((entry) => isJsonSerializableValue(entry, seen));
+  seen.delete(value);
+  return valid;
+}
+
+function assertJsonSerializableRecord(value: unknown): void {
+  if (!isJsonSerializableValue(value)) {
+    throw new Error("persistent-keyed-store record must be JSON-serializable");
+  }
+}
+
 function validateNamespace(value: string): string {
   const trimmed = value.trim();
   if (!NAMESPACE_PATTERN.test(trimmed)) {
@@ -150,7 +193,8 @@ function resolveStoreFilePath(namespace: string, stateDir?: string): string {
 async function resolveStoreAccessQueueKey(filePath: string): Promise<string> {
   const resolved = path.resolve(filePath);
   const dir = path.dirname(resolved);
-  await fs.mkdir(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true, mode: STORE_DIR_MODE });
+  await fs.chmod(dir, STORE_DIR_MODE).catch(() => undefined);
   try {
     const realDir = await fs.realpath(dir);
     return path.join(realDir, path.basename(resolved));
@@ -272,7 +316,14 @@ async function readEnvelopeDetailed<T>(filePath: string): Promise<ReadEnvelopeRe
   const entries = rawEntries;
   const sanitizedEntries = createEntriesMap<T>();
   for (const [id, entry] of Object.entries(entries)) {
-    if (!id || id.trim() !== id || !isRecord(entry) || !isFiniteNumber(entry.createdAt)) {
+    if (
+      !id ||
+      id.trim() !== id ||
+      !isRecord(entry) ||
+      !isFiniteNumber(entry.createdAt) ||
+      !Object.hasOwn(entry, "record") ||
+      !isJsonSerializableValue(entry.record)
+    ) {
       return {
         kind: "quarantine",
         versionLabel: `v${version}`,
@@ -407,6 +458,7 @@ export function createPersistentKeyedStore<T>(
     registerOptions?: { ttlMs?: number },
   ): Promise<void> {
     const normalizedId = validateId(id);
+    assertJsonSerializableRecord(record);
     const ttlMs = validateOptionalTtlMs(registerOptions?.ttlMs, "ttlMs") ?? defaultTtlMs;
     const now = Date.now();
     await accessStore(async (envelope) => {

--- a/src/plugin-sdk/persistent-keyed-store.ts
+++ b/src/plugin-sdk/persistent-keyed-store.ts
@@ -87,8 +87,12 @@ function mergeLockOptions(overrides?: Partial<FileLockOptions>): FileLockOptions
 function createEmptyEnvelope<T>(): Envelope<T> {
   return {
     version: STORE_VERSION,
-    entries: {},
+    entries: createEntriesMap(),
   };
+}
+
+function createEntriesMap<T>(): Record<string, StoredEntry<T>> {
+  return Object.create(null) as Record<string, StoredEntry<T>>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -141,6 +145,18 @@ function resolveStoreFilePath(namespace: string, stateDir?: string): string {
   }
   const root = trimmedStateDir ? path.resolve(trimmedStateDir) : resolveStateDir(process.env);
   return path.resolve(root, "lifecycle", namespace, "store.json");
+}
+
+async function resolveStoreAccessQueueKey(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  const dir = path.dirname(resolved);
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    const realDir = await fs.realpath(dir);
+    return path.join(realDir, path.basename(resolved));
+  } catch {
+    return resolved;
+  }
 }
 
 function serializeEnvelope<T>(envelope: Envelope<T>): string {
@@ -254,7 +270,7 @@ async function readEnvelopeDetailed<T>(filePath: string): Promise<ReadEnvelopeRe
   }
 
   const entries = rawEntries;
-  const sanitizedEntries: Record<string, StoredEntry<T>> = {};
+  const sanitizedEntries = createEntriesMap<T>();
   for (const [id, entry] of Object.entries(entries)) {
     if (!id || id.trim() !== id || !isRecord(entry) || !isFiniteNumber(entry.createdAt)) {
       return {
@@ -323,14 +339,15 @@ async function quarantineStoreFile(
   });
 }
 
-function runSerializedStoreAccess<R>(filePath: string, fn: () => Promise<R>): Promise<R> {
-  const previous = ACCESS_QUEUES.get(filePath) ?? Promise.resolve();
+async function runSerializedStoreAccess<R>(filePath: string, fn: () => Promise<R>): Promise<R> {
+  const queueKey = await resolveStoreAccessQueueKey(filePath);
+  const previous = ACCESS_QUEUES.get(queueKey) ?? Promise.resolve();
   const next = previous.then(fn, fn);
-  ACCESS_QUEUES.set(filePath, next);
+  ACCESS_QUEUES.set(queueKey, next);
   next
     .finally(() => {
-      if (ACCESS_QUEUES.get(filePath) === next) {
-        ACCESS_QUEUES.delete(filePath);
+      if (ACCESS_QUEUES.get(queueKey) === next) {
+        ACCESS_QUEUES.delete(queueKey);
       }
     })
     .catch(() => {});


### PR DESCRIPTION
## Summary

- Problem: core and plugins do not have one shared SDK primitive for small restart-safe keyed registries, so each consumer would need to re-implement file layout, locking, TTL cleanup, and corrupt-file handling.
- Why it matters: we want to be able to safely restart the gateway and maintain necessary lifecycle state
- What changed: added `openclaw/plugin-sdk/persistent-keyed-store` with `register` / `lookup` / `consume` / `entries` / `clear`, TTL pruning, `maxEntries` eviction, deterministic enumeration, corrupt/higher-version quarantine, and same-process + cross-process serialization.
- What changed: added focused unit coverage for restart survival, TTL/default TTL, consume/clear, deterministic ordering, quarantine behavior, namespace validation, overwrite behavior, and concurrent writes.
- What did NOT change (scope boundary): no consumer migrations, no lifecycle harness changes, and no inbound dedupe changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- Plugins and core can now import `openclaw/plugin-sdk/persistent-keyed-store`.
- The new helper persists small keyed registries under the lifecycle state directory with bounded growth, deterministic enumeration, and quarantine-on-corruption behavior.

## Diagram (if applicable)

```text
Before:
[consumer] -> [custom per-feature persistence / no persistence]

After:
[consumer] -> [persistent-keyed-store]
           -> [same-process serialized access]
           -> [withFileLock(store.json)]
           -> [stateDir/lifecycle/<namespace>/store.json]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temp plugin-sdk state dirs created by test harness

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/plugin-sdk/persistent-keyed-store.test.ts`
  - `pnpm tsgo`
  - `pnpm lint:core`
  - `pnpm plugin-sdk:check-exports`
  - `pnpm plugin-sdk:api:check`
  - `pnpm build`
  - `pnpm check:architecture`
- Edge cases checked:
  - corrupt JSON quarantine
  - higher-version quarantine
  - invalid namespace rejection
  - same-process concurrent register serialization across two instances
  - TTL/default TTL expiry and `maxEntries` pruning
- What you did **not** verify:
  - no consumer integration was wired in this PR
  - no restart lifecycle scenario harness work yet

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: future consumers may need semantics beyond the v1 helper contract.
  - Mitigation: the helper intentionally ships with zero consumer migrations, narrow API surface, and contract tests covering TTL/quarantine/ordering/concurrency semantics first.
