### PR TITLE
fix(ui): show agent display name for channel-prefixed session keys in switcher

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -25,6 +25,7 @@ import {
   parseSessionKey,
   resolveAssistantAttachmentAuthToken,
   resolveSessionDisplayName,
+  resolveSessionOptionGroups,
   switchChatSession,
 } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -409,5 +410,109 @@ describe("switchChatSession", () => {
       includeGlobal: true,
       includeUnknown: true,
     });
+  });
+});
+
+describe("resolveSessionOptionGroups — channel agent key fallback (#70610)", () => {
+  function makeState(agentsList: Array<{ id: string; identity?: { name: string } }>): AppViewState {
+    return {
+      agentsList: {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "local",
+        agents: agentsList,
+      },
+      sessionsResult: null,
+      sessionsHideCron: true,
+    } as unknown as AppViewState;
+  }
+
+  it("routes webchat:g-agent-{id}-{rest} key to the correct agent group", () => {
+    const state = makeState([{ id: "lottery", identity: { name: "旺财" } }]);
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {} as any,
+      sessions: [
+        {
+          key: "webchat:g-agent-lottery-main",
+          kind: "global",
+          updatedAt: null,
+        } as any,
+      ],
+    };
+
+    const groups = resolveSessionOptionGroups(
+      state,
+      "webchat:g-agent-lottery-main",
+      state.sessionsResult,
+    );
+
+    // Should NOT fall into "other" group with the raw key as label
+    const otherGroup = groups.find((g) => g.id === "other");
+    expect(otherGroup).toBeUndefined();
+
+    // Should be in the lottery agent group
+    const agentGroup = groups.find((g) => g.id === "agent:lottery");
+    expect(agentGroup).toBeDefined();
+    expect(agentGroup!.label).toBe("旺财 (lottery)");
+
+    // The option label should be the rest segment, not the raw key
+    const option = agentGroup!.options[0];
+    expect(option).toBeDefined();
+    expect(option.label).not.toBe("webchat:g-agent-lottery-main");
+    expect(option.key).toBe("webchat:g-agent-lottery-main");
+  });
+
+  it("leaves unmatched channel keys in Other Sessions", () => {
+    const state = makeState([{ id: "lottery" }]);
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {} as any,
+      sessions: [
+        {
+          key: "webchat:g-agent-unknown-agent-main",
+          kind: "global",
+          updatedAt: null,
+        } as any,
+      ],
+    };
+
+    const groups = resolveSessionOptionGroups(
+      state,
+      "webchat:g-agent-unknown-agent-main",
+      state.sessionsResult,
+    );
+
+    const otherGroup = groups.find((g) => g.id === "other");
+    expect(otherGroup).toBeDefined();
+    expect(otherGroup!.options[0].key).toBe("webchat:g-agent-unknown-agent-main");
+  });
+
+  it("prefers canonical agent: key over fallback parsing", () => {
+    const state = makeState([{ id: "lottery", identity: { name: "旺财" } }]);
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {} as any,
+      sessions: [
+        {
+          key: "agent:lottery:main",
+          kind: "direct",
+          updatedAt: null,
+        } as any,
+      ],
+    };
+
+    const groups = resolveSessionOptionGroups(state, "agent:lottery:main", state.sessionsResult);
+
+    const agentGroup = groups.find((g) => g.id === "agent:lottery");
+    expect(agentGroup).toBeDefined();
+    expect(agentGroup!.label).toBe("旺财 (lottery)");
+    expect(agentGroup!.options[0].key).toBe("agent:lottery:main");
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -14,7 +14,7 @@ import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
-import { parseAgentSessionKey } from "./session-key.ts";
+import { parseAgentSessionKey, type ParsedAgentSessionKey } from "./session-key.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import type { ThemeMode } from "./theme.ts";
 import {
@@ -967,7 +967,8 @@ export function resolveSessionOptionGroups(
     }
     seenKeys.add(key);
     const row = byKey.get(key);
-    const parsed = parseAgentSessionKey(key);
+    const parsed =
+      parseAgentSessionKey(key) ?? tryParseChannelAgentKey(key, state.agentsList?.agents ?? []);
     const group = parsed
       ? ensureGroup(
           `agent:${normalizeLowercaseStringOrEmpty(parsed.agentId)}`,
@@ -1081,6 +1082,46 @@ function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResul
   }
   // Don't count the currently active session even if it's a cron.
   return sessions.sessions.filter((s) => isCronSessionKey(s.key) && s.key !== sessionKey).length;
+}
+
+/**
+ * Attempt to decode a legacy channel-prefixed session key of the form
+ * `{channel}:g-agent-{agentId}-{mainKey}` into an agent identity.
+ *
+ * Channel plugins (webchat, bluebubbles, etc.) may store sessions under a
+ * channel-local group key before normalization.  When such a key appears in
+ * the session switcher we want to route it to the correct agent group and
+ * show the configured display name instead of the raw key.
+ *
+ * Resolution uses the known agents list (longest agentId first) to avoid
+ * prefix collisions (e.g. agents "foo" and "foo-bar" both present).
+ */
+function tryParseChannelAgentKey(
+  key: string,
+  agents: Array<{ id?: string | null }>,
+): ParsedAgentSessionKey | null {
+  // Require the form: {anything}:g-agent-{suffix}
+  const match = key.match(/^[^:]+:g-agent-(.+)$/);
+  if (!match) {
+    return null;
+  }
+  const suffix = match[1]; // e.g. "lottery-main" or "main-main"
+
+  // Sort by descending length so a longer agentId wins over its own prefix.
+  const knownIds = agents
+    .map((a) => normalizeLowercaseStringOrEmpty(a.id))
+    .filter(Boolean)
+    .toSorted((a, b) => b.length - a.length);
+
+  for (const agentId of knownIds) {
+    if (suffix === agentId) {
+      return { agentId, rest: "main" };
+    }
+    if (suffix.startsWith(`${agentId}-`)) {
+      return { agentId, rest: suffix.slice(agentId.length + 1) };
+    }
+  }
+  return null;
 }
 
 function resolveAgentGroupLabel(state: AppViewState, agentIdRaw: string): string {


### PR DESCRIPTION
## Problem

Closes #70610

Non-default agents accessed via channel plugins (e.g. webchat) appear in the session list under a legacy channel-prefixed key like `webchat:g-agent-lottery-main` instead of the canonical `agent:lottery:main` format. `parseAgentSessionKey` returns `null` for these keys, so the session switcher placed them in the **"Other Sessions"** group and used the raw key as the label:

| | |
|---|---|
| **Expected** | `旺财(lottery)/main` |
| **Actual** | `webchat:g-agent-lottery-main` |

## Root Cause

In `resolveSessionOptionGroups → addOption`:

```typescript
// Before — single parse attempt
const parsed = parseAgentSessionKey(key);
// null for webchat:g-agent-lottery-main → raw key used as label
```

## Fix

Add `tryParseChannelAgentKey(key, agents)` that matches the `{channel}:g-agent-{agentId}-{rest}` pattern against the known agents list (sorted longest-first to avoid prefix collisions), returning a `ParsedAgentSessionKey` when a match is found.

`addOption` falls back to this function when `parseAgentSessionKey` returns `null`:

```typescript
// After — fallback for channel-prefixed keys
const parsed =
  parseAgentSessionKey(key) ??
  tryParseChannelAgentKey(key, state.agentsList?.agents ?? []);
```

The **original key is preserved** as the option value so session switching continues to work. Only the display routing changes: the session is now placed in the correct agent group with the configured name (`旺财 (lottery)`) and the rest segment (`main`) as the option label.

## Tests Added

`resolveSessionOptionGroups — channel agent key fallback (#70610)`:
- routes `webchat:g-agent-{id}-{rest}` to the correct agent group
- leaves unmatched channel keys in Other Sessions (safe fallback)
- prefers canonical `agent:` key over fallback parsing (no regression)