### PR TITLE
fix(approvals): coordinate native handler startup to avoid loopback storms

### DIFF
--- a/src/infra/approval-handler-bootstrap.test.ts
+++ b/src/infra/approval-handler-bootstrap.test.ts
@@ -23,11 +23,14 @@ vi.mock("./approval-handler-runtime.js", async () => {
 });
 
 // Existing tests rely on synchronous handler start; use an instantly-scheduling
-// coordinator unless the test specifically exercises jitter/concurrency.
+// coordinator unless the test specifically exercises jitter/concurrency. The
+// very large hold timeout keeps the slot's force-release watchdog inert
+// unless the test explicitly drives timers past it.
 const createImmediateStartCoordinator = (): ApprovalHandlerStartCoordinator =>
   createApprovalHandlerStartCoordinator({
     jitterMs: 0,
     maxConcurrentStarts: 1_000,
+    startSlotMaxHoldMs: 10 * 60_000,
   });
 
 describe("startChannelApprovalHandlerBootstrap", () => {
@@ -506,6 +509,59 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     expect(startSecond).toHaveBeenCalledTimes(1);
 
     await cleanup();
+  });
+
+  it("force-releases the concurrency slot when handler.start hangs, so queued bootstraps are not starved", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+
+    // First handler: start() never resolves. This simulates the cross-account
+    // deadlock case codex flagged — a handler.start() that blocks on unbounded
+    // post-handshake work (e.g. replaying pending approvals) holding the
+    // semaphore slot and starving every queued bootstrap.
+    const firstStart = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
+    const firstStop = vi.fn().mockResolvedValue(undefined);
+    const secondStart = vi.fn().mockResolvedValue(undefined);
+    const secondStop = vi.fn().mockResolvedValue(undefined);
+
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start: firstStart, stop: firstStop })
+      .mockResolvedValueOnce({ start: secondStart, stop: secondStop });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+      startSlotMaxHoldMs: 500,
+    });
+
+    const firstCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "alpha",
+    });
+    const secondCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "beta",
+    });
+
+    registerApprovalContext(channelRuntime, { ok: "alpha" }, "alpha");
+    registerApprovalContext(channelRuntime, { ok: "beta" }, "beta");
+
+    await flushTransitions();
+    expect(firstStart).toHaveBeenCalledTimes(1);
+    expect(secondStart).not.toHaveBeenCalled();
+
+    // Advance past the hold-timeout. The first start is still hung, but the
+    // watchdog releases its slot and the second bootstrap's slot acquisition
+    // resolves.
+    await vi.advanceTimersByTimeAsync(500);
+    await flushTransitions();
+
+    expect(secondStart).toHaveBeenCalledTimes(1);
+
+    await firstCleanup();
+    await secondCleanup();
   });
 
   it("does not apply startup jitter to retry-after-failure attempts", async () => {

--- a/src/infra/approval-handler-bootstrap.test.ts
+++ b/src/infra/approval-handler-bootstrap.test.ts
@@ -507,4 +507,54 @@ describe("startChannelApprovalHandlerBootstrap", () => {
 
     await cleanup();
   });
+
+  it("does not apply startup jitter to retry-after-failure attempts", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const start = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      child: vi.fn(),
+      isEnabled: vi.fn().mockReturnValue(true),
+      isVerboseEnabled: vi.fn().mockReturnValue(false),
+      verbose: vi.fn(),
+    };
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start, stop })
+      .mockResolvedValueOnce({ start, stop });
+
+    // Long jitter window. If the retry path re-applied jitter, it would
+    // extend the effective retry interval well beyond the configured 1s
+    // timer — exactly the regression codex flagged as P2.
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 10_000,
+      maxConcurrentStarts: 1_000,
+      random: () => 0.5,
+    });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, logger, startCoordinator });
+
+    registerApprovalContext(channelRuntime);
+
+    // Initial attempt: jitter must elapse (5000ms with random=0.5) before start.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushTransitions();
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      "failed to start native approval handler: Error: boom",
+    );
+
+    // Retry must fire on exactly the retry timer (1000ms) with NO extra
+    // jitter on top. Advance to 1000ms since the retry was scheduled and
+    // verify the second start happens, not at 1000 + 5000.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTransitions();
+    expect(start).toHaveBeenCalledTimes(2);
+
+    await cleanup();
+  });
 });

--- a/src/infra/approval-handler-bootstrap.test.ts
+++ b/src/infra/approval-handler-bootstrap.test.ts
@@ -465,4 +465,46 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     await firstCleanup();
     await secondCleanup();
   });
+
+  it("stops the previous handler before the replacement start waits on jitter or a queued slot", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const startFirst = vi.fn().mockResolvedValue(undefined);
+    const stopFirst = vi.fn().mockResolvedValue(undefined);
+    const startSecond = vi.fn().mockResolvedValue(undefined);
+    const stopSecond = vi.fn().mockResolvedValue(undefined);
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start: startFirst, stop: stopFirst })
+      .mockResolvedValueOnce({ start: startSecond, stop: stopSecond });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 5_000,
+      maxConcurrentStarts: 1_000,
+      random: () => 0.5,
+    });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, startCoordinator });
+
+    registerApprovalContext(channelRuntime, { ok: "first" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushTransitions();
+    expect(startFirst).toHaveBeenCalledTimes(1);
+    expect(stopFirst).not.toHaveBeenCalled();
+
+    // Replacement: the new `registered` event fires while jitter is long.
+    registerApprovalContext(channelRuntime, { ok: "second" });
+    await flushTransitions();
+
+    // The previous handler must be stopped ASAP -- NOT after jitter elapses.
+    // Without this guarantee the stale handler would keep processing with
+    // outdated context for up to jitterMs + queue delay.
+    expect(stopFirst).toHaveBeenCalledTimes(1);
+    expect(startSecond).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushTransitions();
+    expect(startSecond).toHaveBeenCalledTimes(1);
+
+    await cleanup();
+  });
 });

--- a/src/infra/approval-handler-bootstrap.test.ts
+++ b/src/infra/approval-handler-bootstrap.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import { startChannelApprovalHandlerBootstrap } from "./approval-handler-bootstrap.js";
+import {
+  _resetDefaultApprovalHandlerStartCoordinatorForTests,
+  createApprovalHandlerStartCoordinator,
+  type ApprovalHandlerStartCoordinator,
+} from "./approval-handler-start-coordinator.js";
 import { createApprovalNativeRuntimeAdapterStubs } from "./approval-handler.test-helpers.js";
 
 const { createChannelApprovalHandlerFromCapability } = vi.hoisted(() => ({
@@ -17,16 +22,32 @@ vi.mock("./approval-handler-runtime.js", async () => {
   };
 });
 
+// Existing tests rely on synchronous handler start; use an instantly-scheduling
+// coordinator unless the test specifically exercises jitter/concurrency.
+const createImmediateStartCoordinator = (): ApprovalHandlerStartCoordinator =>
+  createApprovalHandlerStartCoordinator({
+    jitterMs: 0,
+    maxConcurrentStarts: 1_000,
+  });
+
 describe("startChannelApprovalHandlerBootstrap", () => {
   beforeEach(() => {
     createChannelApprovalHandlerFromCapability.mockReset();
     vi.useRealTimers();
+    _resetDefaultApprovalHandlerStartCoordinatorForTests();
+  });
+
+  afterEach(() => {
+    _resetDefaultApprovalHandlerStartCoordinatorForTests();
   });
 
   const flushTransitions = async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // The bootstrap path chains several awaits (context dispatch, start
+    // coordinator jitter + slot acquisition, stopHandler, handler factory,
+    // handler.start). Flush generously so tests observe terminal state.
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
   };
 
   const createApprovalPlugin = () =>
@@ -41,22 +62,26 @@ describe("startChannelApprovalHandlerBootstrap", () => {
   const startTestBootstrap = (params: {
     channelRuntime: ReturnType<typeof createRuntimeChannel>;
     logger?: unknown;
+    startCoordinator?: ApprovalHandlerStartCoordinator;
+    accountId?: string;
   }) =>
     startChannelApprovalHandlerBootstrap({
       plugin: createApprovalPlugin(),
       cfg: {} as never,
-      accountId: "default",
+      accountId: params.accountId ?? "default",
       channelRuntime: params.channelRuntime,
       logger: params.logger as never,
+      startCoordinator: params.startCoordinator ?? createImmediateStartCoordinator(),
     });
 
   const registerApprovalContext = (
     channelRuntime: ReturnType<typeof createRuntimeChannel>,
     app: unknown = { ok: true },
+    accountId: string = "default",
   ) =>
     channelRuntime.runtimeContexts.register({
       channelId: "slack",
-      accountId: "default",
+      accountId,
       capability: "approval.native",
       context: { app },
     });
@@ -244,5 +269,200 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     expect(secondStop).not.toHaveBeenCalled();
 
     await cleanup();
+  });
+
+  it("delays the first handler start by the configured jitter interval", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const start = vi.fn().mockResolvedValue(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    createChannelApprovalHandlerFromCapability.mockResolvedValue({ start, stop });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 500,
+      maxConcurrentStarts: 1_000,
+      random: () => 0.5,
+    });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, startCoordinator });
+
+    registerApprovalContext(channelRuntime);
+    await flushTransitions();
+
+    expect(createChannelApprovalHandlerFromCapability).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(249);
+    await flushTransitions();
+    expect(createChannelApprovalHandlerFromCapability).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flushTransitions();
+    expect(createChannelApprovalHandlerFromCapability).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+
+    await cleanup();
+  });
+
+  it("does not start a handler if the context is unregistered during the jitter wait", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const start = vi.fn().mockResolvedValue(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    createChannelApprovalHandlerFromCapability.mockResolvedValue({ start, stop });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 1_000,
+      maxConcurrentStarts: 1_000,
+      random: () => 0.9,
+    });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, startCoordinator });
+
+    const lease = registerApprovalContext(channelRuntime);
+    await flushTransitions();
+    expect(createChannelApprovalHandlerFromCapability).not.toHaveBeenCalled();
+
+    lease.dispose();
+    await flushTransitions();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushTransitions();
+
+    expect(createChannelApprovalHandlerFromCapability).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+
+    await cleanup();
+  });
+
+  it("caps concurrent handler starts to the coordinator limit and serves queued bootstraps as slots free", async () => {
+    const channelRuntime = createRuntimeChannel();
+    const firstResolver: { resolve?: () => void } = {};
+    const secondResolver: { resolve?: () => void } = {};
+
+    const firstStart = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          firstResolver.resolve = resolve;
+        }),
+    );
+    const firstStop = vi.fn().mockResolvedValue(undefined);
+    const secondStart = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          secondResolver.resolve = resolve;
+        }),
+    );
+    const secondStop = vi.fn().mockResolvedValue(undefined);
+    const thirdStart = vi.fn().mockResolvedValue(undefined);
+    const thirdStop = vi.fn().mockResolvedValue(undefined);
+
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start: firstStart, stop: firstStop })
+      .mockResolvedValueOnce({ start: secondStart, stop: secondStop })
+      .mockResolvedValueOnce({ start: thirdStart, stop: thirdStop });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+    });
+
+    const firstCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "alpha",
+    });
+    const secondCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "beta",
+    });
+    const thirdCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "gamma",
+    });
+
+    registerApprovalContext(channelRuntime, { ok: "alpha" }, "alpha");
+    registerApprovalContext(channelRuntime, { ok: "beta" }, "beta");
+    registerApprovalContext(channelRuntime, { ok: "gamma" }, "gamma");
+
+    await flushTransitions();
+    await flushTransitions();
+
+    expect(createChannelApprovalHandlerFromCapability).toHaveBeenCalledTimes(1);
+    expect(firstStart).toHaveBeenCalledTimes(1);
+    expect(secondStart).not.toHaveBeenCalled();
+    expect(thirdStart).not.toHaveBeenCalled();
+
+    firstResolver.resolve?.();
+    await flushTransitions();
+    await flushTransitions();
+
+    expect(createChannelApprovalHandlerFromCapability).toHaveBeenCalledTimes(2);
+    expect(secondStart).toHaveBeenCalledTimes(1);
+    expect(thirdStart).not.toHaveBeenCalled();
+
+    secondResolver.resolve?.();
+    await flushTransitions();
+    await flushTransitions();
+
+    expect(createChannelApprovalHandlerFromCapability).toHaveBeenCalledTimes(3);
+    expect(thirdStart).toHaveBeenCalledTimes(1);
+
+    await firstCleanup();
+    await secondCleanup();
+    await thirdCleanup();
+  });
+
+  it("releases a concurrency slot after a handler start failure", async () => {
+    const channelRuntime = createRuntimeChannel();
+    const firstStart = vi.fn().mockRejectedValue(new Error("boom"));
+    const firstStop = vi.fn().mockResolvedValue(undefined);
+    const secondStart = vi.fn().mockResolvedValue(undefined);
+    const secondStop = vi.fn().mockResolvedValue(undefined);
+
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start: firstStart, stop: firstStop })
+      .mockResolvedValueOnce({ start: secondStart, stop: secondStop });
+
+    const startCoordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+    });
+
+    const firstCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "alpha",
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(),
+        isEnabled: vi.fn().mockReturnValue(true),
+        isVerboseEnabled: vi.fn().mockReturnValue(false),
+        verbose: vi.fn(),
+      },
+    });
+    const secondCleanup = await startTestBootstrap({
+      channelRuntime,
+      startCoordinator,
+      accountId: "beta",
+    });
+
+    registerApprovalContext(channelRuntime, { ok: "alpha" }, "alpha");
+    registerApprovalContext(channelRuntime, { ok: "beta" }, "beta");
+
+    await flushTransitions();
+    await flushTransitions();
+    await flushTransitions();
+
+    expect(firstStart).toHaveBeenCalledTimes(1);
+    expect(secondStart).toHaveBeenCalledTimes(1);
+
+    await firstCleanup();
+    await secondCleanup();
   });
 });

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -64,7 +64,11 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     await handler.stop();
   };
 
-  const startHandlerForContext = async (context: unknown, generation: number) => {
+  const startHandlerForContext = async (
+    context: unknown,
+    generation: number,
+    options: { applyJitter: boolean } = { applyJitter: true },
+  ) => {
     if (generation !== activeGeneration) {
       return;
     }
@@ -76,12 +80,15 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     if (generation !== activeGeneration) {
       return;
     }
-    // Jitter before claiming a start slot: spreads the N-account thundering
-    // herd across a small window so the loopback gateway is not asked to
-    // complete N concurrent preauth handshakes at the same tick.
-    await startCoordinator.waitJitter(() => generation !== activeGeneration);
-    if (generation !== activeGeneration) {
-      return;
+    // Jitter is for the initial startup herd only. Retries have their own
+    // timer (APPROVAL_HANDLER_BOOTSTRAP_RETRY_MS) and must not compound an
+    // extra 0-jitterMs delay on top of it, or transient failures translate
+    // into multi-second approval-handler downtime.
+    if (options.applyJitter) {
+      await startCoordinator.waitJitter(() => generation !== activeGeneration);
+      if (generation !== activeGeneration) {
+        return;
+      }
     }
     const releaseSlot = await startCoordinator.acquireStartSlot(
       () => generation !== activeGeneration,
@@ -139,14 +146,18 @@ export async function startChannelApprovalHandlerBootstrap(params: {
       }
       spawn(
         "failed to retry native approval handler",
-        startHandlerForRegisteredContext(context, generation),
+        startHandlerForRegisteredContext(context, generation, { applyJitter: false }),
       );
     }, APPROVAL_HANDLER_BOOTSTRAP_RETRY_MS);
     retryTimer.unref?.();
   };
-  const startHandlerForRegisteredContext = async (context: unknown, generation: number) => {
+  const startHandlerForRegisteredContext = async (
+    context: unknown,
+    generation: number,
+    options: { applyJitter: boolean } = { applyJitter: true },
+  ) => {
     try {
-      await startHandlerForContext(context, generation);
+      await startHandlerForContext(context, generation, options);
     } catch (error) {
       if (generation === activeGeneration) {
         logger.error(`failed to start native approval handler: ${String(error)}`);

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -68,6 +68,14 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     if (generation !== activeGeneration) {
       return;
     }
+    // Stop the previous handler immediately on context replacement, BEFORE
+    // jitter + slot acquisition. Otherwise a stale handler keeps processing
+    // with outdated context for the full jitter + queue wait (potentially
+    // seconds under pressure).
+    await stopHandler();
+    if (generation !== activeGeneration) {
+      return;
+    }
     // Jitter before claiming a start slot: spreads the N-account thundering
     // herd across a small window so the loopback gateway is not asked to
     // complete N concurrent preauth handshakes at the same tick.
@@ -79,10 +87,6 @@ export async function startChannelApprovalHandlerBootstrap(params: {
       () => generation !== activeGeneration,
     );
     try {
-      if (generation !== activeGeneration) {
-        return;
-      }
-      await stopHandler();
       if (generation !== activeGeneration) {
         return;
       }

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -9,6 +9,10 @@ import {
   type ChannelApprovalHandler,
 } from "./approval-handler-runtime.js";
 import {
+  getDefaultApprovalHandlerStartCoordinator,
+  type ApprovalHandlerStartCoordinator,
+} from "./approval-handler-start-coordinator.js";
+import {
   getChannelRuntimeContext,
   watchChannelRuntimeContexts,
 } from "./channel-runtime-context.js";
@@ -16,12 +20,18 @@ import {
 type ApprovalBootstrapHandler = ChannelApprovalHandler;
 const APPROVAL_HANDLER_BOOTSTRAP_RETRY_MS = 1_000;
 
+export type { ApprovalHandlerStartCoordinator };
+
 export async function startChannelApprovalHandlerBootstrap(params: {
   plugin: Pick<ChannelPlugin, "id" | "meta" | "approvalCapability">;
   cfg: OpenClawConfig;
   accountId: string;
   channelRuntime?: ChannelRuntimeSurface;
   logger?: ReturnType<typeof createSubsystemLogger>;
+  // Injected for tests; defaults to a process-scoped singleton that applies
+  // randomized startup jitter and caps concurrent handshakes so multi-account
+  // installs do not stampede the loopback gateway on fresh boot.
+  startCoordinator?: ApprovalHandlerStartCoordinator;
 }): Promise<() => Promise<void>> {
   const capability = resolveChannelApprovalCapability(params.plugin);
   if (!capability?.nativeRuntime || !params.channelRuntime) {
@@ -30,6 +40,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
 
   const channelLabel = params.plugin.meta.label || params.plugin.id;
   const logger = params.logger ?? createSubsystemLogger(`${params.plugin.id}/approval-bootstrap`);
+  const startCoordinator = params.startCoordinator ?? getDefaultApprovalHandlerStartCoordinator();
   let activeGeneration = 0;
   let activeHandler: ApprovalBootstrapHandler | null = null;
   let retryTimer: NodeJS.Timeout | null = null;
@@ -57,36 +68,53 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     if (generation !== activeGeneration) {
       return;
     }
-    await stopHandler();
+    // Jitter before claiming a start slot: spreads the N-account thundering
+    // herd across a small window so the loopback gateway is not asked to
+    // complete N concurrent preauth handshakes at the same tick.
+    await startCoordinator.waitJitter(() => generation !== activeGeneration);
     if (generation !== activeGeneration) {
       return;
     }
-    const handler = await createChannelApprovalHandlerFromCapability({
-      capability,
-      label: `${params.plugin.id}/native-approvals`,
-      clientDisplayName: `${channelLabel} Native Approvals (${params.accountId})`,
-      channel: params.plugin.id,
-      channelLabel,
-      cfg: params.cfg,
-      accountId: params.accountId,
-      context,
-    });
-    if (!handler) {
-      return;
-    }
-    if (generation !== activeGeneration) {
-      await handler.stop().catch(() => {});
-      return;
-    }
-    activeHandler = handler as ApprovalBootstrapHandler;
+    const releaseSlot = await startCoordinator.acquireStartSlot(
+      () => generation !== activeGeneration,
+    );
     try {
-      await handler.start();
-    } catch (error) {
-      if (activeHandler === handler) {
-        activeHandler = null;
+      if (generation !== activeGeneration) {
+        return;
       }
-      await handler.stop().catch(() => {});
-      throw error;
+      await stopHandler();
+      if (generation !== activeGeneration) {
+        return;
+      }
+      const handler = await createChannelApprovalHandlerFromCapability({
+        capability,
+        label: `${params.plugin.id}/native-approvals`,
+        clientDisplayName: `${channelLabel} Native Approvals (${params.accountId})`,
+        channel: params.plugin.id,
+        channelLabel,
+        cfg: params.cfg,
+        accountId: params.accountId,
+        context,
+      });
+      if (!handler) {
+        return;
+      }
+      if (generation !== activeGeneration) {
+        await handler.stop().catch(() => {});
+        return;
+      }
+      activeHandler = handler as ApprovalBootstrapHandler;
+      try {
+        await handler.start();
+      } catch (error) {
+        if (activeHandler === handler) {
+          activeHandler = null;
+        }
+        await handler.stop().catch(() => {});
+        throw error;
+      }
+    } finally {
+      releaseSlot();
     }
   };
 

--- a/src/infra/approval-handler-start-coordinator.test.ts
+++ b/src/infra/approval-handler-start-coordinator.test.ts
@@ -327,6 +327,65 @@ describe("createApprovalHandlerStartCoordinator", () => {
     thirdRelease();
   });
 
+  it("skips canceled waiters when dequeuing so stale generations do not consume FIFO turns", async () => {
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+    });
+
+    const holder = await coordinator.acquireStartSlot(notCanceled);
+
+    // Two waiters queued while the slot is held. Waiter B gets canceled
+    // after enqueueing — its isCanceled returns true only on re-evaluation
+    // at dequeue time, which is the scenario the hand-off logic must cover.
+    let bCanceled = false;
+    let bResolvedAt: number | undefined;
+    let cResolvedAt: number | undefined;
+    const bPromise = coordinator
+      .acquireStartSlot(() => bCanceled)
+      .then((release) => {
+        bResolvedAt = Date.now();
+        return release;
+      });
+    const cPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      cResolvedAt = Date.now();
+      return release;
+    });
+
+    // Both pending; no resolution yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bResolvedAt).toBeUndefined();
+    expect(cResolvedAt).toBeUndefined();
+
+    // Cancel B mid-queue, then release the holder. releaseSlot must skip B
+    // and hand the slot directly to C rather than burning a FIFO turn on B.
+    bCanceled = true;
+    holder();
+
+    const bRelease = await bPromise;
+    const cRelease = await cPromise;
+    expect(bResolvedAt).toBeDefined();
+    expect(cResolvedAt).toBeDefined();
+
+    // C must have acquired the live slot (not queued behind B's
+    // no-op-and-release churn). Queue a fourth acquirer: it should be queued
+    // because C is still holding the one slot.
+    let dResolvedAt: number | undefined;
+    const dPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      dResolvedAt = Date.now();
+      return release;
+    });
+    await Promise.resolve();
+    expect(dResolvedAt).toBeUndefined();
+
+    cRelease();
+    const dRelease = await dPromise;
+    expect(dResolvedAt).toBeDefined();
+    dRelease();
+    bRelease(); // no-op; verifies B's canceled release doesn't corrupt state.
+  });
+
   it("hands back a no-op release and does not consume a slot when canceled up front", async () => {
     const coordinator = createApprovalHandlerStartCoordinator({
       jitterMs: 0,

--- a/src/infra/approval-handler-start-coordinator.test.ts
+++ b/src/infra/approval-handler-start-coordinator.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createApprovalHandlerStartCoordinator,
+  resolveApprovalHandlerMaxConcurrentStarts,
+  resolveApprovalHandlerStartJitterMs,
+} from "./approval-handler-start-coordinator.js";
+
+describe("resolveApprovalHandlerStartJitterMs", () => {
+  it("falls back to the default when the env var is unset", () => {
+    expect(resolveApprovalHandlerStartJitterMs({})).toBe(2_000);
+  });
+
+  it("honors a valid non-negative integer env override", () => {
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "250",
+      } as NodeJS.ProcessEnv),
+    ).toBe(250);
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(0);
+  });
+
+  it("ignores non-numeric and negative env values", () => {
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "nope",
+      } as NodeJS.ProcessEnv),
+    ).toBe(2_000);
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "-100",
+      } as NodeJS.ProcessEnv),
+    ).toBe(2_000);
+  });
+});
+
+describe("resolveApprovalHandlerMaxConcurrentStarts", () => {
+  it("falls back to the default when the env var is unset", () => {
+    expect(resolveApprovalHandlerMaxConcurrentStarts({})).toBe(3);
+  });
+
+  it("honors a valid positive integer env override", () => {
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "7",
+      } as NodeJS.ProcessEnv),
+    ).toBe(7);
+  });
+
+  it("ignores zero, negative, and non-numeric env values", () => {
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3);
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "-3",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3);
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "nope",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3);
+  });
+});
+
+describe("createApprovalHandlerStartCoordinator", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const notCanceled = () => false;
+
+  it("resolves waitJitter immediately when jitter is disabled", async () => {
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 4,
+    });
+    await expect(coordinator.waitJitter(notCanceled)).resolves.toBeUndefined();
+  });
+
+  it("waits up to jitterMs * random() before resolving", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 1_000,
+      maxConcurrentStarts: 4,
+      random: () => 0.25,
+    });
+    let resolved = false;
+    const waitPromise = coordinator.waitJitter(notCanceled).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it("short-circuits waitJitter when canceled up front", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 5_000,
+      maxConcurrentStarts: 4,
+      random: () => 0.9,
+    });
+    const canceled = () => true;
+    // Should resolve on the same tick without advancing timers.
+    await coordinator.waitJitter(canceled);
+  });
+
+  it("serializes acquireStartSlot beyond the concurrency cap and serves waiters FIFO", async () => {
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 2,
+    });
+
+    const first = await coordinator.acquireStartSlot(notCanceled);
+    const second = await coordinator.acquireStartSlot(notCanceled);
+
+    let thirdResolved = false;
+    let fourthResolved = false;
+    const thirdPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      thirdResolved = true;
+      return release;
+    });
+    const fourthPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      fourthResolved = true;
+      return release;
+    });
+
+    // Give the microtask queue a chance to drain without releasing slots.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(thirdResolved).toBe(false);
+    expect(fourthResolved).toBe(false);
+
+    first();
+    const thirdRelease = await thirdPromise;
+    expect(thirdResolved).toBe(true);
+    expect(fourthResolved).toBe(false);
+
+    second();
+    const fourthRelease = await fourthPromise;
+    expect(fourthResolved).toBe(true);
+
+    thirdRelease();
+    fourthRelease();
+  });
+
+  it("treats repeated release() calls as idempotent", async () => {
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+    });
+
+    const first = await coordinator.acquireStartSlot(notCanceled);
+    first();
+    first();
+
+    // The semaphore is not wedged; a fresh acquire resolves immediately.
+    const second = await coordinator.acquireStartSlot(notCanceled);
+    second();
+  });
+
+  it("hands back a no-op release and does not consume a slot when canceled up front", async () => {
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+    });
+
+    const canceledRelease = await coordinator.acquireStartSlot(() => true);
+    canceledRelease();
+
+    // Two concurrent acquisitions should both be available because the
+    // canceled acquire never incremented the active count.
+    const first = await coordinator.acquireStartSlot(notCanceled);
+    // The second call should queue because cap is 1.
+    let secondResolved = false;
+    const secondPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      secondResolved = true;
+      return release;
+    });
+    await Promise.resolve();
+    expect(secondResolved).toBe(false);
+
+    first();
+    const secondRelease = await secondPromise;
+    expect(secondResolved).toBe(true);
+    secondRelease();
+  });
+});

--- a/src/infra/approval-handler-start-coordinator.test.ts
+++ b/src/infra/approval-handler-start-coordinator.test.ts
@@ -35,6 +35,27 @@ describe("resolveApprovalHandlerStartJitterMs", () => {
       } as NodeJS.ProcessEnv),
     ).toBe(2_000);
   });
+
+  it("rejects partial-number env values like '100ms' and '3.5'", () => {
+    // Number.parseInt is lenient and would accept these; we reject anything
+    // that isn't a pure non-negative integer so misconfigurations surface as
+    // "default" instead of a silently-truncated value.
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "100ms",
+      } as NodeJS.ProcessEnv),
+    ).toBe(2_000);
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "3.5",
+      } as NodeJS.ProcessEnv),
+    ).toBe(2_000);
+    expect(
+      resolveApprovalHandlerStartJitterMs({
+        OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS: "  250 ",
+      } as NodeJS.ProcessEnv),
+    ).toBe(2_000);
+  });
 });
 
 describe("resolveApprovalHandlerMaxConcurrentStarts", () => {
@@ -64,6 +85,19 @@ describe("resolveApprovalHandlerMaxConcurrentStarts", () => {
     expect(
       resolveApprovalHandlerMaxConcurrentStarts({
         OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "nope",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3);
+  });
+
+  it("rejects partial-number env values like '7x' and '2.5'", () => {
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "7x",
+      } as NodeJS.ProcessEnv),
+    ).toBe(3);
+    expect(
+      resolveApprovalHandlerMaxConcurrentStarts({
+        OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "2.5",
       } as NodeJS.ProcessEnv),
     ).toBe(3);
   });
@@ -101,6 +135,27 @@ describe("createApprovalHandlerStartCoordinator", () => {
     });
 
     await vi.advanceTimersByTimeAsync(249);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it("clamps jitter sampling to [0, jitterMs) even when random() returns 1", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 1_000,
+      maxConcurrentStarts: 4,
+      random: () => 1,
+    });
+    let resolved = false;
+    const waitPromise = coordinator.waitJitter(notCanceled).then(() => {
+      resolved = true;
+    });
+
+    // With clamp: max sampled delay is jitterMs - 1 = 999ms.
+    await vi.advanceTimersByTimeAsync(998);
     expect(resolved).toBe(false);
 
     await vi.advanceTimersByTimeAsync(1);

--- a/src/infra/approval-handler-start-coordinator.test.ts
+++ b/src/infra/approval-handler-start-coordinator.test.ts
@@ -3,6 +3,7 @@ import {
   createApprovalHandlerStartCoordinator,
   resolveApprovalHandlerMaxConcurrentStarts,
   resolveApprovalHandlerStartJitterMs,
+  resolveApprovalHandlerStartSlotMaxHoldMs,
 } from "./approval-handler-start-coordinator.js";
 
 describe("resolveApprovalHandlerStartJitterMs", () => {
@@ -89,7 +90,7 @@ describe("resolveApprovalHandlerMaxConcurrentStarts", () => {
     ).toBe(3);
   });
 
-  it("rejects partial-number env values like '7x' and '2.5'", () => {
+  it("rejects partial-number env values like '7x' and '2.5' for max-concurrent-starts", () => {
     expect(
       resolveApprovalHandlerMaxConcurrentStarts({
         OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "7x",
@@ -100,6 +101,38 @@ describe("resolveApprovalHandlerMaxConcurrentStarts", () => {
         OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS: "2.5",
       } as NodeJS.ProcessEnv),
     ).toBe(3);
+  });
+});
+
+describe("resolveApprovalHandlerStartSlotMaxHoldMs", () => {
+  it("falls back to the default when the env var is unset", () => {
+    expect(resolveApprovalHandlerStartSlotMaxHoldMs({})).toBe(30_000);
+  });
+
+  it("honors a valid positive integer env override", () => {
+    expect(
+      resolveApprovalHandlerStartSlotMaxHoldMs({
+        OPENCLAW_APPROVAL_HANDLER_START_SLOT_MAX_HOLD_MS: "5000",
+      } as NodeJS.ProcessEnv),
+    ).toBe(5_000);
+  });
+
+  it("ignores zero, negative, non-numeric, and partial-number env values", () => {
+    expect(
+      resolveApprovalHandlerStartSlotMaxHoldMs({
+        OPENCLAW_APPROVAL_HANDLER_START_SLOT_MAX_HOLD_MS: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30_000);
+    expect(
+      resolveApprovalHandlerStartSlotMaxHoldMs({
+        OPENCLAW_APPROVAL_HANDLER_START_SLOT_MAX_HOLD_MS: "-1000",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30_000);
+    expect(
+      resolveApprovalHandlerStartSlotMaxHoldMs({
+        OPENCLAW_APPROVAL_HANDLER_START_SLOT_MAX_HOLD_MS: "5000ms",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30_000);
   });
 });
 
@@ -227,6 +260,71 @@ describe("createApprovalHandlerStartCoordinator", () => {
     // The semaphore is not wedged; a fresh acquire resolves immediately.
     const second = await coordinator.acquireStartSlot(notCanceled);
     second();
+  });
+
+  it("force-releases a start slot after the configured hold timeout so one hung start cannot starve others", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+      startSlotMaxHoldMs: 500,
+    });
+
+    // Acquire a slot and DO NOT release it, simulating a `handler.start()`
+    // that hangs on pending-approval replay or some other unbounded work.
+    await coordinator.acquireStartSlot(notCanceled);
+
+    let secondResolved = false;
+    const secondPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      secondResolved = true;
+      return release;
+    });
+
+    await vi.advanceTimersByTimeAsync(499);
+    await Promise.resolve();
+    expect(secondResolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const secondRelease = await secondPromise;
+    expect(secondResolved).toBe(true);
+
+    secondRelease();
+  });
+
+  it("cancels the hold-timeout watchdog when the caller releases normally", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalHandlerStartCoordinator({
+      jitterMs: 0,
+      maxConcurrentStarts: 1,
+      startSlotMaxHoldMs: 1_000,
+    });
+
+    // Acquire slot 1 and release it immediately. Its hold-timeout watchdog
+    // is still scheduled on the event loop; the contract says the explicit
+    // release must have canceled it.
+    const first = await coordinator.acquireStartSlot(notCanceled);
+    first();
+
+    // Advance the clock past what WOULD have been slot 1's hold deadline.
+    // If the watchdog fired after the explicit release we'd see a double
+    // release: releaseSlot() runs twice, driving `active` negative. That
+    // corruption surfaces in the FIFO check below — a broken watchdog would
+    // let slot 3 acquire immediately even though slot 2 is still holding.
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    const second = await coordinator.acquireStartSlot(notCanceled);
+    let thirdResolved = false;
+    const thirdPromise = coordinator.acquireStartSlot(notCanceled).then((release) => {
+      thirdResolved = true;
+      return release;
+    });
+    await Promise.resolve();
+    expect(thirdResolved).toBe(false); // correctly queued — slot 2 is still holding
+
+    second();
+    const thirdRelease = await thirdPromise;
+    expect(thirdResolved).toBe(true);
+    thirdRelease();
   });
 
   it("hands back a no-op release and does not consume a slot when canceled up front", async () => {

--- a/src/infra/approval-handler-start-coordinator.ts
+++ b/src/infra/approval-handler-start-coordinator.ts
@@ -1,0 +1,168 @@
+// Coordinates the startup of native approval handlers across all channel
+// bootstraps in a single OpenClaw process.
+//
+// Without coordination, an install with many channel accounts — e.g. 11
+// configured Matrix accounts, or 4+ Telegram bots — opens that many loopback
+// gateway websockets on the same tick when channels start. The loopback
+// gateway's preauth pipeline then contends with itself; handshake timers
+// saturate and every one of those connections logs `handshake-timeout` /
+// `gateway closed (1000)`, which each bootstrap then retries. The result is
+// a sustained 1 Hz reconnect storm against the process's own loopback.
+//
+// Two primitives are applied here, both channel-agnostic:
+//
+//   1. Randomized startup jitter. The first handler start on each bootstrap
+//      sleeps for a uniformly-random interval in [0, jitterMs). For a herd
+//      of N accounts, this spreads them across the jitter window instead of
+//      landing at the same millisecond.
+//
+//   2. A process-scoped semaphore that caps how many handler starts may run
+//      their `createChannelApprovalHandlerFromCapability` + `handler.start()`
+//      sequence concurrently. Excess starts queue FIFO and acquire a slot as
+//      earlier starts finish (success OR failure). This is a hard ceiling on
+//      concurrent loopback preauth handshakes from this process regardless of
+//      how many channels are enabled.
+//
+// Both primitives are bypassed cleanly when a bootstrap generation advances
+// (context replaced / unregistered / cleanup), via the `isCanceled` callback.
+// Retry-after-failure backoff is orthogonal and lives in the bootstrap's
+// retry timer.
+
+const DEFAULT_START_JITTER_MS = 2_000;
+const DEFAULT_MAX_CONCURRENT_STARTS = 3;
+const START_JITTER_ENV_VAR = "OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS";
+const MAX_CONCURRENT_STARTS_ENV_VAR = "OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS";
+
+export type ApprovalHandlerStartCoordinator = {
+  waitJitter: (isCanceled: () => boolean) => Promise<void>;
+  acquireStartSlot: (isCanceled: () => boolean) => Promise<() => void>;
+};
+
+export type ApprovalHandlerStartCoordinatorOptions = {
+  jitterMs?: number;
+  maxConcurrentStarts?: number;
+  random?: () => number;
+};
+
+function readNonNegativeIntEnv(name: string, env: NodeJS.ProcessEnv): number | undefined {
+  const raw = env[name];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function readPositiveIntEnv(name: string, env: NodeJS.ProcessEnv): number | undefined {
+  const parsed = readNonNegativeIntEnv(name, env);
+  if (parsed === undefined || parsed < 1) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export function resolveApprovalHandlerStartJitterMs(env: NodeJS.ProcessEnv = process.env): number {
+  return readNonNegativeIntEnv(START_JITTER_ENV_VAR, env) ?? DEFAULT_START_JITTER_MS;
+}
+
+export function resolveApprovalHandlerMaxConcurrentStarts(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return readPositiveIntEnv(MAX_CONCURRENT_STARTS_ENV_VAR, env) ?? DEFAULT_MAX_CONCURRENT_STARTS;
+}
+
+export function createApprovalHandlerStartCoordinator(
+  options: ApprovalHandlerStartCoordinatorOptions = {},
+): ApprovalHandlerStartCoordinator {
+  const jitterMs = Math.max(
+    0,
+    Math.trunc(options.jitterMs ?? resolveApprovalHandlerStartJitterMs()),
+  );
+  const maxConcurrent = Math.max(
+    1,
+    Math.trunc(options.maxConcurrentStarts ?? resolveApprovalHandlerMaxConcurrentStarts()),
+  );
+  const random = options.random ?? Math.random;
+
+  let active = 0;
+  const waiters: Array<(release: () => void) => void> = [];
+
+  const releaseSlot = () => {
+    const next = waiters.shift();
+    if (next) {
+      next(releaseSlot);
+      return;
+    }
+    active -= 1;
+  };
+
+  const waitJitter = (isCanceled: () => boolean): Promise<void> => {
+    if (jitterMs <= 0 || isCanceled()) {
+      return Promise.resolve();
+    }
+    const sampled = Math.floor(random() * jitterMs);
+    if (sampled <= 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        resolve();
+      }, sampled);
+      timer.unref?.();
+    });
+  };
+
+  const acquireStartSlot = (isCanceled: () => boolean): Promise<() => void> => {
+    if (isCanceled()) {
+      // Canceled callers never actually entered the critical section, so hand
+      // back a no-op release and do not bump active count.
+      return Promise.resolve(() => {});
+    }
+    if (active < maxConcurrent) {
+      active += 1;
+      let released = false;
+      return Promise.resolve(() => {
+        if (released) {
+          return;
+        }
+        released = true;
+        releaseSlot();
+      });
+    }
+    return new Promise<() => void>((resolve) => {
+      waiters.push((release) => {
+        let released = false;
+        resolve(() => {
+          if (released) {
+            return;
+          }
+          released = true;
+          release();
+        });
+      });
+    });
+  };
+
+  return {
+    waitJitter,
+    acquireStartSlot,
+  };
+}
+
+let defaultCoordinator: ApprovalHandlerStartCoordinator | null = null;
+
+export function getDefaultApprovalHandlerStartCoordinator(): ApprovalHandlerStartCoordinator {
+  if (!defaultCoordinator) {
+    defaultCoordinator = createApprovalHandlerStartCoordinator();
+  }
+  return defaultCoordinator;
+}
+
+// Test-only: reset the process-wide default coordinator between test cases so
+// one test's queued waiters cannot leak into the next.
+export function _resetDefaultApprovalHandlerStartCoordinatorForTests(): void {
+  defaultCoordinator = null;
+}

--- a/src/infra/approval-handler-start-coordinator.ts
+++ b/src/infra/approval-handler-start-coordinator.ts
@@ -114,13 +114,35 @@ export function createApprovalHandlerStartCoordinator(
   );
   const random = options.random ?? Math.random;
 
-  let active = 0;
-  const waiters: Array<(release: () => void) => void> = [];
+  type Waiter = {
+    isCanceled: () => boolean;
+    // Called when this waiter is handed a live slot; argument is the release
+    // callback to give back to the caller.
+    proceed: (release: () => void) => void;
+    // Called when this waiter is skipped because it was canceled while queued;
+    // the waiter resolves with a no-op release and does not consume a slot.
+    skip: () => void;
+  };
 
+  let active = 0;
+  const waiters: Waiter[] = [];
+
+  // Pick the next non-canceled waiter, skipping any that have been canceled
+  // while queued (e.g. a bootstrap whose generation advanced mid-queue).
+  // Skipped waiters resolve with a no-op release so their caller doesn't
+  // hang, and we keep the slot count unchanged until someone can actually
+  // use it — or release it entirely if the queue is empty.
   const releaseSlot = () => {
-    const next = waiters.shift();
-    if (next) {
-      next(releaseSlot);
+    while (waiters.length > 0) {
+      const next = waiters.shift();
+      if (!next) {
+        break;
+      }
+      if (next.isCanceled()) {
+        next.skip();
+        continue;
+      }
+      next.proceed(releaseSlot);
       return;
     }
     active -= 1;
@@ -181,8 +203,14 @@ export function createApprovalHandlerStartCoordinator(
       return Promise.resolve(wrapWithHoldTimeout(releaseSlot));
     }
     return new Promise<() => void>((resolve) => {
-      waiters.push((release) => {
-        resolve(wrapWithHoldTimeout(release));
+      waiters.push({
+        isCanceled,
+        proceed: (release) => {
+          resolve(wrapWithHoldTimeout(release));
+        },
+        skip: () => {
+          resolve(() => {});
+        },
       });
     });
   };

--- a/src/infra/approval-handler-start-coordinator.ts
+++ b/src/infra/approval-handler-start-coordinator.ts
@@ -30,8 +30,18 @@
 
 const DEFAULT_START_JITTER_MS = 2_000;
 const DEFAULT_MAX_CONCURRENT_STARTS = 3;
+// Hard ceiling on how long a single handler-start may hold its concurrency
+// slot. A well-behaved `handler.start()` only needs the slot for the preauth
+// handshake critical section (single-digit seconds at most), but a handler
+// whose `start()` blocks on unbounded application work — e.g. replaying
+// pending approvals through `exec-approval-channel-runtime` — would otherwise
+// pin the slot and starve every other channel/account waiting for a slot.
+// After this cap the slot is force-released; the original `start()` continues
+// to run in the background but no longer blocks unrelated bootstraps.
+const DEFAULT_START_SLOT_MAX_HOLD_MS = 30_000;
 const START_JITTER_ENV_VAR = "OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS";
 const MAX_CONCURRENT_STARTS_ENV_VAR = "OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS";
+const START_SLOT_MAX_HOLD_ENV_VAR = "OPENCLAW_APPROVAL_HANDLER_START_SLOT_MAX_HOLD_MS";
 
 export type ApprovalHandlerStartCoordinator = {
   waitJitter: (isCanceled: () => boolean) => Promise<void>;
@@ -41,6 +51,7 @@ export type ApprovalHandlerStartCoordinator = {
 export type ApprovalHandlerStartCoordinatorOptions = {
   jitterMs?: number;
   maxConcurrentStarts?: number;
+  startSlotMaxHoldMs?: number;
   random?: () => number;
 };
 
@@ -80,6 +91,12 @@ export function resolveApprovalHandlerMaxConcurrentStarts(
   return readPositiveIntEnv(MAX_CONCURRENT_STARTS_ENV_VAR, env) ?? DEFAULT_MAX_CONCURRENT_STARTS;
 }
 
+export function resolveApprovalHandlerStartSlotMaxHoldMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return readPositiveIntEnv(START_SLOT_MAX_HOLD_ENV_VAR, env) ?? DEFAULT_START_SLOT_MAX_HOLD_MS;
+}
+
 export function createApprovalHandlerStartCoordinator(
   options: ApprovalHandlerStartCoordinatorOptions = {},
 ): ApprovalHandlerStartCoordinator {
@@ -90,6 +107,10 @@ export function createApprovalHandlerStartCoordinator(
   const maxConcurrent = Math.max(
     1,
     Math.trunc(options.maxConcurrentStarts ?? resolveApprovalHandlerMaxConcurrentStarts()),
+  );
+  const startSlotMaxHoldMs = Math.max(
+    1,
+    Math.trunc(options.startSlotMaxHoldMs ?? resolveApprovalHandlerStartSlotMaxHoldMs()),
   );
   const random = options.random ?? Math.random;
 
@@ -103,6 +124,16 @@ export function createApprovalHandlerStartCoordinator(
       return;
     }
     active -= 1;
+  };
+
+  // Schedule a force-release after `startSlotMaxHoldMs`. If the caller's
+  // explicit release fires first, the timer just no-ops. If `handler.start()`
+  // is hung or doing unbounded post-handshake work, the timer releases the
+  // slot so unrelated bootstraps can proceed.
+  const scheduleHoldTimeout = (forceRelease: () => void): (() => void) => {
+    const timer = setTimeout(forceRelease, startSlotMaxHoldMs);
+    timer.unref?.();
+    return () => clearTimeout(timer);
   };
 
   const waitJitter = (isCanceled: () => boolean): Promise<void> => {
@@ -125,6 +156,20 @@ export function createApprovalHandlerStartCoordinator(
     });
   };
 
+  const wrapWithHoldTimeout = (rawRelease: () => void): (() => void) => {
+    let released = false;
+    const safeRelease = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      cancelHoldTimer();
+      rawRelease();
+    };
+    const cancelHoldTimer = scheduleHoldTimeout(safeRelease);
+    return safeRelease;
+  };
+
   const acquireStartSlot = (isCanceled: () => boolean): Promise<() => void> => {
     if (isCanceled()) {
       // Canceled callers never actually entered the critical section, so hand
@@ -133,25 +178,11 @@ export function createApprovalHandlerStartCoordinator(
     }
     if (active < maxConcurrent) {
       active += 1;
-      let released = false;
-      return Promise.resolve(() => {
-        if (released) {
-          return;
-        }
-        released = true;
-        releaseSlot();
-      });
+      return Promise.resolve(wrapWithHoldTimeout(releaseSlot));
     }
     return new Promise<() => void>((resolve) => {
       waiters.push((release) => {
-        let released = false;
-        resolve(() => {
-          if (released) {
-            return;
-          }
-          released = true;
-          release();
-        });
+        resolve(wrapWithHoldTimeout(release));
       });
     });
   };

--- a/src/infra/approval-handler-start-coordinator.ts
+++ b/src/infra/approval-handler-start-coordinator.ts
@@ -49,6 +49,12 @@ function readNonNegativeIntEnv(name: string, env: NodeJS.ProcessEnv): number | u
   if (raw === undefined) {
     return undefined;
   }
+  // Require a pure non-negative integer. Number.parseInt is too lenient — it
+  // happily accepts "100ms", "3.5", "42banana" etc., silently ignoring the
+  // tail. An env var that looks wrong should be rejected, not coerced.
+  if (!/^\d+$/.test(raw)) {
+    return undefined;
+  }
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 0) {
     return undefined;
@@ -103,7 +109,11 @@ export function createApprovalHandlerStartCoordinator(
     if (jitterMs <= 0 || isCanceled()) {
       return Promise.resolve();
     }
-    const sampled = Math.floor(random() * jitterMs);
+    // Clamp to [0, jitterMs). Math.random() is spec'd to return < 1, so the
+    // clamp is belt-and-suspenders against injected RNGs (or exotic runtimes)
+    // that can return exactly 1 — without it, a pathological RNG extends the
+    // wait to the full jitterMs instead of the advertised upper-exclusive bound.
+    const sampled = Math.min(jitterMs - 1, Math.floor(random() * jitterMs));
     if (sampled <= 0) {
       return Promise.resolve();
     }


### PR DESCRIPTION
## Summary

- Problem: on multi-account installs (e.g. 11 Matrix accounts, 4+ Telegram bots, Discord with many servers), every account independently opens a native-approvals gateway client on the same startup tick. The loopback gateway has to complete N concurrent preauth WebSocket handshakes at once, saturates its own handshake timer, fails them all with `handshake-timeout` / `gateway closed (1000)`, and each failure retries at 1 Hz — a sustained self-DoS of the process's own loopback.
- Why it matters: every internal consumer hitting the local gateway (session RPC, tool calls, node messaging, `openclaw status`) pays the latency tax. On the reproducer host (11 Matrix accounts, headless older Intel Mac mini, 2026.4.20) the gateway logged ~157 `handshake-timeout` entries and ~129 `matrix/native-approvals` errors 1:1 correlated in a single 24 h window, with `handshakeMs` spiking to 13–17 s against a nominal 10 s timer — the event loop was falling behind.
- What changed: `startChannelApprovalHandlerBootstrap` now goes through a new process-scoped `approval-handler-start-coordinator` that applies (1) randomized startup jitter and (2) a FIFO concurrency cap on concurrent handler starts. Applied to the initial startup path only — retries keep their existing 1 s retry-timer cadence.
- What did NOT change (scope boundary): approver resolution, `isChannelExecApprovalClientEnabledFromConfig` semantics, the retry-after-failure backoff layer (openclaw#68283 is the in-flight work there), the `ChannelApprovalHandler` runtime contract, or `startChannelApprovalHandlerBootstrap`'s existing signature/cleanup behavior. The `startCoordinator` param is optional and documented as a test seam.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70641
- Related openclaw#68283 (retry-after-failure backoff; complementary)
- Related openclaw#69936 (target-accountId scoping; complementary)
- Related openclaw#70568 (Telegram ambiguous-account fan-out; complementary)
- Related openclaw#68223 (multi-telegram handshake cascade report)
- Related openclaw#69012 (telegram native-approvals handshake timeout on fresh boot)
- Related openclaw#67034 (multi-account polling avalanche)
- Prior art: commit c23ad91a14 `fix(matrix): keep DM allowlist out of room commands` (merged upstream, same "tighten DM allowlist scope" direction, different layer)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: there was no coordination between the N per-account invocations of `startChannelApprovalHandlerBootstrap`. `server-channels.ts:304` fans out accounts via `Promise.all`, each bootstrap awaits `startHandlerForContext` which in turn synchronously constructs a fresh `GatewayClient` and starts its preauth handshake. With jitter = 0 and concurrency = ∞, N accounts produce N near-simultaneous loopback handshakes. Under pressure the handshake timer on the server side misses its deadline, each fails, each retries at 1 Hz, and the thrash stays persistent because there is no jitter and no concurrency ceiling.
- Missing detection / guardrail: no existing test exercised `startChannelApprovalHandlerBootstrap` under N concurrent bootstraps sharing a loopback — the handler-bootstrap unit suite covers single-account lifecycle only.
- Contributing context (if known): the bug is latent regardless of channel; it is most visible on multi-account Matrix/Telegram installs because those channels' approver-resolvers can implicitly activate the handler from `dm.allowFrom` / owner-allowlists. That implicit-activation semantic is a separate discussion — see the `exec-approvals.test.ts` assertion at lines 121–139 of `extensions/matrix/src/exec-approvals.test.ts` which test-enforces the current behavior — and is intentionally out of scope here.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/approval-handler-bootstrap.test.ts` and `src/infra/approval-handler-start-coordinator.test.ts`.
- Scenario the test should lock in: (1) jitter delays first handler start by the configured interval; (2) unregister during jitter cancels cleanly with no handler construction; (3) with `maxConcurrentStarts: 1`, three concurrent bootstraps drain FIFO with only one handler in flight at a time; (4) a slot releases after a thrown `handler.start()`; (5) retry attempts do **not** re-apply jitter; (6) env-var parsing rejects partial-number values like `"100ms"` and `"3.5"`; (7) jitter sampling clamps to `[0, jitterMs)` even when an injected RNG returns 1.
- Why this is the smallest reliable guardrail: the coordinator is a small pure module with a narrow contract (`waitJitter` + `acquireStartSlot`); every failure mode of the storm reduces to one of those two primitives behaving wrong, so unit-level coverage is sufficient. The bootstrap tests cover the threading into `startHandlerForContext` so a regression that accidentally disables the coordinator in production is also caught.
- Existing test that already covers this (if any): none — the pre-existing 6 tests in `approval-handler-bootstrap.test.ts` cover single-account lifecycle and are preserved unchanged.
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes

- On fresh boot, the first native-approvals handler start for each account is delayed by a uniformly-random `[0, 2000)` ms window (configurable). Single-account installs see at most one such delay per channel. Multi-account installs stop self-inflicted handshake storms.
- Two new env vars, both optional with safe defaults: `OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS` (default `2000`, set `0` to restore pre-patch timing) and `OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS` (default `3`, set to a large value to restore pre-patch free-for-all).
- No user-visible config schema change, no UI change, no protocol change.

## Diagram (if applicable)

```text
Before (N=4 accounts, same channel):
  t=0ms   account:a -> handshake
  t=0ms   account:b -> handshake    all N handshakes at t=0
  t=0ms   account:c -> handshake    -> server event loop stalls
  t=0ms   account:d -> handshake    -> all time out -> retry at t=1000ms, repeat

After (same N, jitter=2000ms, maxConcurrentStarts=3):
  t=~400ms    account:a acquires slot, handshake starts
  t=~700ms    account:b acquires slot, handshake starts
  t=~1100ms   account:c acquires slot, handshake starts
  t=~1600ms   account:d jittered; slots 1-2 have finished; d acquires, handshake starts
  -> server event loop keeps up, handshakes complete, no storm
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same connections, just serialized/jittered.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.x, older Intel Mac mini (CPU impact figures are anecdotal to this hardware)
- Runtime/container: Node 22+, launchd-managed headless gateway
- Model/provider: N/A (storm is in gateway preauth layer, no model calls involved)
- Integration/channel (if any): Matrix with 11 configured accounts; each account has `dm.allowFrom` set, no explicit `execApprovals` config
- Relevant config (redacted): `channels.matrix.accounts.*`, `channels.matrix.dm.allowFrom: [<owner-mxid>]`, `channels.matrix.execApprovals` unset, gateway `bind: loopback` `mode: local` token auth

### Steps

1. Configure 6+ Matrix accounts under `channels.matrix.accounts.*`, each with the same owner in `dm.allowFrom` and `execApprovals` unset.
2. Start the gateway and let it run >5 minutes.
3. Tail the gateway log — expect repeating `[matrix/native-approvals] connect error: gateway closed (1000)` plus `[gateway/ws] closed before connect ... cause=handshake-timeout` at ~1 Hz, with `handshakeMs` frequently exceeding the configured/default 10 s timer.

### Expected

- On startup, all account handlers complete their preauth handshake once; no subsequent handshake-timeout entries until a real transient failure occurs.

### Actual (before this PR)

- Persistent 1 Hz loop of handshake-timeout / `gateway closed (1000)` / `failed to start native approval handler`, 1:1 correlated. `openclaw status` hangs intermittently; `sessions_send` times out; gateway-process CPU is artificially elevated for hours.

## Evidence

- [x] Failing test/log before + passing after — see the "Live smoke on 11-account Matrix reproducer" section below for the end-to-end before/after.
- [x] Trace/log snippets — `[matrix/native-approvals] connect error: gateway closed (1000):` + matching `[gateway/ws] closed before connect conn=... cause=handshake-timeout`.
- [ ] Screenshot/recording — N/A (no UI change).
- [x] Perf numbers (if relevant) — `handshakeMs` values of 13–17 s against a nominal 10 s timer before the fix; event loop saturated by self-inflicted preauth churn. Post-fix: zero handshake-timeout / native-approvals errors in 7 minutes of runtime against the same config.

### Live smoke on 11-account Matrix reproducer

Applied on the original affected host on 2026-04-23 14:37 UTC by cherry-picking the three commits (`8270f8322e`, `f4524ad390`, `c4d83d79b2`) onto `v2026.4.20`, running `pnpm install --frozen-lockfile && pnpm build && pnpm ui:build`, and triggering a gateway restart via `kill <pid>` (launchd `KeepAlive=true` auto-respawns).

Pre-restart pattern (representative sample from the host's gateway err log, last ~10 min before SIGTERM):

```
2026-04-23T10:26:09.267  [matrix] connect error: gateway closed (1000):
2026-04-23T10:26:09.268  gateway connect failed: Error: gateway closed (1000):
2026-04-23T10:26:09.302  [matrix] connect error: gateway closed (1000):
2026-04-23T10:26:09.303  gateway connect failed: Error: gateway closed (1000):
2026-04-23T10:26:09.350  [matrix] connect error: gateway closed (1000):
2026-04-23T10:26:09.351  gateway connect failed: Error: gateway closed (1000):
2026-04-23T10:28:07.250  [matrix] connect error: gateway request timeout for connect
2026-04-23T10:28:07.334  [matrix] connect error: gateway request timeout for connect
2026-04-23T10:28:07.383  [matrix] connect error: gateway request timeout for connect
2026-04-23T10:28:07.416  [matrix] connect error: gateway request timeout for connect
```

Post-restart (all err-log entries from SIGTERM through +7 min, unfiltered):

```
2026-04-23T10:39:21.278  [secrets] gateway.auth.token is inactive (env var configured)
2026-04-23T10:40:56.740  [bonjour] watchdog detected non-announced service; attempting re-advertise
2026-04-23T10:43:58.166  [bonjour] restarting advertiser (stuck in probing)
2026-04-23T10:43:58.235  [model-pricing] OpenRouter pricing fetch failed (timeout 15s)
2026-04-23T10:43:58.243  [model-pricing] LiteLLM pricing fetch failed (timeout 15s)
2026-04-23T10:44:07.687  [bonjour] watchdog detected non-announced service; attempting re-advertise
2026-04-23T10:44:19.332  [bonjour] restarting advertiser (stuck in unannounced)
```

All 7 post-restart entries are unrelated to the approvals storm (two benign bonjour advertise cycles, a secrets-config surface hint, two outbound pricing-fetch timeouts to OpenRouter/LiteLLM).

Counts:

| Window | Storm entries (`handshake-timeout` ∪ `gateway closed (1000)` ∪ `[matrix] connect error`) |
| --- | --- |
| Pre-restart, last 90 min (09:00–10:37 local, err log) | **239** |
| Post-restart, full window (10:38–10:45 local, 7 min, err log) | **0** |
| Post-restart, JSON main log (14:38+ UTC, 22 total entries in window) | **0** |

Gateway health post-restart: port 18789 rebound (3:03 boot-to-listen), single live PID `24714` under user `mercury`, `openclaw status` reports `app 2026.4.20`. No crash-loop observed.

## Human Verification (required)

- Verified scenarios:
  - local `pnpm test src/infra/approval-handler-bootstrap.test.ts src/infra/approval-handler-start-coordinator.test.ts` (34/34 passed)
  - pre-commit smart gate `pnpm check:changed` on each commit — 208 files / 2475 tests passed on the most recent commit
  - `pnpm tsgo` + `pnpm tsgo:test` clean; `pnpm lint:core` 0 warnings 0 errors
  - **live smoke on the 11-account Matrix reproducer host: 239 storm entries in the 90 min preceding the cutover → 0 storm entries in the 7 minutes after** (see the "Live smoke" section above for the log samples and counts)
- Edge cases checked: jitter = 0 (regression-safe / opt-out), cancellation during jitter wait, cancellation while queued for a slot, slot release after a thrown `handler.start()`, replacement-during-jitter stops the previous handler immediately (regression test with `jitterMs=5000`), retry path does not re-jitter (regression test with `jitterMs=10000`, retry fires on exact 1 s boundary), env parsing rejection of `"100ms"` / `"3.5"` / `"  250 "` / `"7x"` / `"2.5"`, jitter clamp when injected `random()` returns `1`.
- What I did **not** verify: a multi-hour soak (only 7+ min of live runtime so far); behavior on non-Matrix channels (Telegram/Discord/QQbot) under equivalent multi-account load — reasoning for those is identical at the bootstrap layer, but the live smoke here was Matrix-only.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Codex review on this PR:
- P1 (`discussion_r3131925898`, start slot held through `handler.start()` could block queued bootstraps indefinitely if `start()` hangs on unbounded post-handshake work) — addressed in commit `4fcdeb7a06` by adding a per-acquisition hold-timeout watchdog (`startSlotMaxHoldMs`, default 30 s). Thread resolved.
- P2 (`discussion_r3132157416`, `acquireStartSlot` only checked `isCanceled` pre-enqueue; stale generations could burn FIFO turns) — addressed in commit `0a4f955d51` by re-evaluating `isCanceled` at dequeue time and skipping canceled waiters. Thread resolved.

Prior-iteration codex findings on the fork PR (`lukeboyett/openclaw#2`, now closed) are carried forward in commits `f4524ad390` (stopHandler before jitter/slot wait) and `c4d83d79b2` (limit jitter to initial starts; env-parsing hardening; `[0, jitterMs)` clamp). Those fork threads are not visible on this PR but the fixes are in the commit history here.

## Compatibility / Migration

- Backward compatible? `Yes` — no signature, schema, or protocol change; new optional `startCoordinator` param on `startChannelApprovalHandlerBootstrap` defaults to the process-scoped singleton.
- Config/env changes? `Yes` — two new optional env vars, both with safe defaults, both accept only pure non-negative integers (invalid values fall back to default).
- Migration needed? `No`. Operators who explicitly want pre-patch timing can set `OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS=0` and `OPENCLAW_APPROVAL_HANDLER_MAX_CONCURRENT_STARTS` to a large value.

## Risks and Mitigations

- Risk: startup is slightly slower for installs that were not actually hitting the storm — each account's approval handler may wait up to `jitterMs` (default 2 s) before the first handshake.
  - Mitigation: default is a one-shot per-account delay bounded by `jitterMs`; operators can set `OPENCLAW_APPROVAL_HANDLER_START_JITTER_MS=0` to disable. The delay only applies to the initial start, not to retries.
- Risk: the FIFO slot queue could starve a waiter if preceding slots never release (handler's `start()` / `stop()` never returns).
  - Mitigation: `handler.stop()` is best-effort with `.catch(() => {})` and release happens in a `finally`; a thrown or swallowed `start()` still releases the slot. Tests cover the throw path.
- Risk: process-scoped singleton state could leak between tests.
  - Mitigation: `_resetDefaultApprovalHandlerStartCoordinatorForTests()` is called in `beforeEach`/`afterEach` in the new bootstrap and coordinator test suites.

---

### AI-assisted PR notice

- [x] Mark as AI-assisted — this PR was authored via Claude Code (Claude Opus 4.7, 1M context), iterating against real source, real tests, and GitHub Codex review.
- [x] Degree of testing — fully tested: 34 targeted unit tests (11 bootstrap + 23 coordinator, including regression tests for each codex finding), 2475-test pre-commit smart gate on every commit, typecheck + lint clean. Live smoke on the 11-account Matrix reproducer host also completed (see "Live smoke" and Human Verification sections).
- [x] Confirm I understand what the code does — yes; rationale for every primitive documented in the coordinator header comment and in-line in `startHandlerForContext`.
- [x] GitHub Codex review ran and its P1/P2 findings are addressed (see Review Conversations).

