### PR TITLE
feat: update NVIDIA provider to NIM with Llama/Mistral models

### DIFF
--- a/extensions/nvidia/api.ts
+++ b/extensions/nvidia/api.ts
@@ -1,1 +1,1 @@
-export { buildNvidiaProvider } from "./provider-catalog.js";
+export { buildNimProvider } from "./provider-catalog.js";

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -1,19 +1,19 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { buildNimProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
-  name: "NVIDIA Provider",
-  description: "Bundled NVIDIA provider plugin",
+  name: "NVIDIA NIM Provider",
+  description: "Bundled NVIDIA NIM provider plugin for inference microservices",
   provider: {
-    label: "NVIDIA",
+    label: "NVIDIA NIM",
     docsPath: "/providers/nvidia",
     envVars: ["NVIDIA_API_KEY"],
     auth: [],
     catalog: {
-      buildProvider: buildNvidiaProvider,
+      buildProvider: buildNimProvider,
     },
   },
 });

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { buildNimProvider } from "./provider-catalog.js";
 
-describe("nvidia provider catalog", () => {
-  it("builds the bundled NVIDIA provider defaults", () => {
-    const provider = buildNvidiaProvider();
+describe("nvidia nim provider catalog", () => {
+  it("builds the bundled NVIDIA NIM provider defaults", () => {
+    const provider = buildNimProvider();
 
     expect(provider.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
     expect(provider.api).toBe("openai-completions");
     expect(provider.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "nvidia/llama-3.1-nemotron-70b-instruct",
+      "meta/llama-3.1-405b-instruct",
+      "meta/llama-3.1-70b-instruct",
+      "mistralai/mixtral-8x22b-instruct-v0.1",
     ]);
   });
 });

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -1,55 +1,54 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
-const NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1";
-const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-super-120b-a12b";
-const NVIDIA_DEFAULT_MAX_TOKENS = 8192;
-const NVIDIA_DEFAULT_COST = {
+const NIM_BASE_URL = "https://integrate.api.nvidia.com/v1";
+const NIM_DEFAULT_MAX_TOKENS = 4096;
+const NIM_DEFAULT_COST = {
   input: 0,
   output: 0,
   cacheRead: 0,
   cacheWrite: 0,
 };
 
-export function buildNvidiaProvider(): ModelProviderConfig {
+export function buildNimProvider(): ModelProviderConfig {
   return {
-    baseUrl: NVIDIA_BASE_URL,
+    baseUrl: NIM_BASE_URL,
     api: "openai-completions",
     models: [
       {
-        id: NVIDIA_DEFAULT_MODEL_ID,
-        name: "NVIDIA Nemotron 3 Super 120B",
+        id: "nvidia/llama-3.1-nemotron-70b-instruct",
+        name: "Llama 3.1 Nemotron 70B",
         reasoning: false,
         input: ["text"],
-        cost: NVIDIA_DEFAULT_COST,
-        contextWindow: 262144,
-        maxTokens: NVIDIA_DEFAULT_MAX_TOKENS,
+        cost: NIM_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: NIM_DEFAULT_MAX_TOKENS,
       },
       {
-        id: "moonshotai/kimi-k2.5",
-        name: "Kimi K2.5",
+        id: "meta/llama-3.1-405b-instruct",
+        name: "Meta Llama 3.1 405B Instruct",
         reasoning: false,
         input: ["text"],
-        cost: NVIDIA_DEFAULT_COST,
-        contextWindow: 262144,
-        maxTokens: NVIDIA_DEFAULT_MAX_TOKENS,
+        cost: NIM_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: NIM_DEFAULT_MAX_TOKENS,
       },
       {
-        id: "minimaxai/minimax-m2.5",
-        name: "MiniMax M2.5",
+        id: "meta/llama-3.1-70b-instruct",
+        name: "Meta Llama 3.1 70B Instruct",
         reasoning: false,
         input: ["text"],
-        cost: NVIDIA_DEFAULT_COST,
-        contextWindow: 196608,
-        maxTokens: NVIDIA_DEFAULT_MAX_TOKENS,
+        cost: NIM_DEFAULT_COST,
+        contextWindow: 131072,
+        maxTokens: NIM_DEFAULT_MAX_TOKENS,
       },
       {
-        id: "z-ai/glm5",
-        name: "GLM-5",
+        id: "mistralai/mixtral-8x22b-instruct-v0.1",
+        name: "Mistral Mixtral 8x22B",
         reasoning: false,
         input: ["text"],
-        cost: NVIDIA_DEFAULT_COST,
-        contextWindow: 202752,
-        maxTokens: NVIDIA_DEFAULT_MAX_TOKENS,
+        cost: NIM_DEFAULT_COST,
+        contextWindow: 65536,
+        maxTokens: NIM_DEFAULT_MAX_TOKENS,
       },
     ],
   };


### PR DESCRIPTION
Replace the previous NVIDIA provider catalog with NVIDIA NIM (Inference Microservices) models that are actually available via the NIM API:

- nvidia/llama-3.1-nemotron-70b-instruct
- meta/llama-3.1-405b-instruct
- meta/llama-3.1-70b-instruct
- mistralai/mixtral-8x22b-instruct-v0.1

Removes models not directly served by NVIDIA NIM (Kimi, MiniMax, GLM).

The provider still uses openai-completions API and NVIDIA_API_KEY auth.