### PR TITLE
fix(cron): clear stale lifecycle fields on isolated run session seed

### DIFF
--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -32,12 +32,16 @@ export function createPersistCronSessionEntry(params: {
     }
     params.cronSession.store[params.agentSessionKey] = params.cronSession.sessionEntry;
     if (params.runSessionKey !== params.agentSessionKey) {
-      params.cronSession.store[params.runSessionKey] = params.cronSession.sessionEntry;
+      // Use a shallow copy so the run-scoped row does not share a mutable
+      // reference with the base agent key. Sharing the same object causes
+      // subsequent runs to inherit stale lifecycle fields (status/startedAt/
+      // endedAt) written into the entry after the run completes (issue #70619).
+      params.cronSession.store[params.runSessionKey] = { ...params.cronSession.sessionEntry };
     }
     await params.updateSessionStore(params.cronSession.storePath, (store) => {
       store[params.agentSessionKey] = params.cronSession.sessionEntry;
       if (params.runSessionKey !== params.agentSessionKey) {
-        store[params.runSessionKey] = params.cronSession.sessionEntry;
+        store[params.runSessionKey] = { ...params.cronSession.sessionEntry };
       }
     });
   };

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -170,6 +170,50 @@ describe("resolveCronSession", () => {
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
     });
 
+    it("clears stale lifecycle fields (status/startedAt/endedAt) when forceNew is true (issue #70619)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-prev",
+          updatedAt: NOW_MS - 1000,
+          status: "done",
+          startedAt: NOW_MS - 5000,
+          endedAt: NOW_MS - 1000,
+          modelOverride: "sonnet-4",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.sessionEntry.sessionId).not.toBe("existing-session-id-prev");
+      expect(result.isNewSession).toBe(true);
+      // Lifecycle fields from the prior run must be cleared
+      expect(result.sessionEntry.status).toBeUndefined();
+      expect(result.sessionEntry.startedAt).toBeUndefined();
+      expect(result.sessionEntry.endedAt).toBeUndefined();
+      // Per-session overrides should still be preserved
+      expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
+    });
+
+    it("clears stale lifecycle fields (status/startedAt/endedAt) when session is stale", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id-prev",
+          updatedAt: NOW_MS - 86_400_000,
+          status: "failed",
+          startedAt: NOW_MS - 90_000_000,
+          endedAt: NOW_MS - 86_400_000,
+          modelOverride: "gpt-4.1",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.status).toBeUndefined();
+      expect(result.sessionEntry.startedAt).toBeUndefined();
+      expect(result.sessionEntry.endedAt).toBeUndefined();
+      expect(result.sessionEntry.modelOverride).toBe("gpt-4.1");
+    });
+
     it("clears stale sessionFile when forceNew rolls to a fresh session", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -78,6 +78,8 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
+    // Lifecycle fields (status/startedAt/endedAt) are also cleared so that each
+    // isolated cron run starts with fresh state (issue #70619).
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
@@ -85,6 +87,9 @@ export function resolveCronSession(params: {
       lastThreadId: undefined,
       deliveryContext: undefined,
       sessionFile: undefined,
+      status: undefined,
+      startedAt: undefined,
+      endedAt: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession, previousSessionId };


### PR DESCRIPTION
## Summary

Fixes #70619 — Isolated cron run session rows inherit stale `status`/`startedAt`/`endedAt` from prior runs.

Two root causes fixed:

1. **`session.ts`** — When `isNewSession` is true, the spread block cleared delivery routing fields but NOT lifecycle fields. Added explicit `status: undefined`, `startedAt: undefined`, `endedAt: undefined` to the reset.

2. **`run-session-state.ts`** — Per-run key (`cron:<jobId>:run:<sessionId>`) was assigned the same object reference as the base agent key. Post-run mutations to the base key silently polluted the shared object. Changed to shallow copy (`{ ...sessionEntry }`) so keys are independent.

## Files changed

- `src/cron/isolated-agent/session.ts` (5 lines) — clear lifecycle fields on new session
- `src/cron/isolated-agent/run-session-state.ts` (8 lines) — break shared mutable reference
- `src/cron/isolated-agent/session.test.ts` (44 lines) — two regression tests

## Test plan

- [ ] Run isolated cron job twice, verify second run has fresh `startedAt` and `status=running`
- [ ] Verify per-run rows don't carry prior run's `endedAt`
- [ ] Run new regression tests: `npm test -- --grep "stale lifecycle"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)