### PR TITLE
fix(openai): send image edits as multipart uploads

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,0 +1,528 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
+
+const {
+  resolveApiKeyForProviderMock,
+  postJsonRequestMock,
+  postMultipartRequestMock,
+  assertOkOrThrowHttpErrorMock,
+  resolveProviderHttpRequestConfigMock,
+} = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "openai-key" })),
+  postJsonRequestMock: vi.fn(),
+  postMultipartRequestMock: vi.fn(),
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  resolveProviderHttpRequestConfigMock: vi.fn((params) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+    allowPrivateNetwork: Boolean(params.allowPrivateNetwork),
+    headers: new Headers(params.defaultHeaders),
+    dispatcherPolicy: undefined,
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+  postJsonRequest: postJsonRequestMock,
+  postMultipartRequest: postMultipartRequestMock,
+  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+}));
+
+function mockGeneratedPngResponse() {
+  const response = {
+    json: async () => ({
+      data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
+    }),
+  };
+  postJsonRequestMock.mockResolvedValue({
+    response,
+    release: vi.fn(async () => {}),
+  });
+  postMultipartRequestMock.mockResolvedValue({
+    response,
+    release: vi.fn(async () => {}),
+  });
+}
+
+describe("openai image generation provider", () => {
+  afterEach(() => {
+    resolveApiKeyForProviderMock.mockClear();
+    postJsonRequestMock.mockReset();
+    postMultipartRequestMock.mockReset();
+    assertOkOrThrowHttpErrorMock.mockClear();
+    resolveProviderHttpRequestConfigMock.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("advertises the current OpenAI image model and 2K/4K size hints", () => {
+    const provider = buildOpenAIImageGenerationProvider();
+
+    expect(provider.defaultModel).toBe("gpt-image-2");
+    expect(provider.models).toEqual(["gpt-image-2"]);
+    expect(provider.capabilities.geometry?.sizes).toEqual(
+      expect.arrayContaining(["2048x2048", "3840x2160", "2160x3840"]),
+    );
+  });
+
+  it("does not auto-allow local baseUrl overrides for image requests", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a QA lighthouse",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://127.0.0.1:44080/v1",
+      }),
+    );
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:44080/v1/images/generations",
+        allowPrivateNetwork: false,
+      }),
+    );
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("forwards generation count and custom size overrides", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Create two landscape campaign variants",
+      cfg: {},
+      count: 2,
+      size: "3840x2160",
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/images/generations",
+        body: {
+          model: "gpt-image-2",
+          prompt: "Create two landscape campaign variants",
+          n: 2,
+          size: "3840x2160",
+        },
+      }),
+    );
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("allows loopback image requests for the synthetic mock-openai provider", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "mock-openai",
+      model: "gpt-image-2",
+      prompt: "Draw a QA lighthouse",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowPrivateNetwork: true,
+      }),
+    );
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:44080/v1/images/generations",
+        allowPrivateNetwork: true,
+      }),
+    );
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("allows loopback image requests for openai only inside the QA harness envelope", async () => {
+    mockGeneratedPngResponse();
+    vi.stubEnv("OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER", "1");
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a QA lighthouse",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowPrivateNetwork: true,
+      }),
+    );
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowPrivateNetwork: true,
+      }),
+    );
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("forwards edit count, custom size, and multiple input images", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Change only the background to pale blue",
+      cfg: {},
+      count: 2,
+      size: "1024x1536",
+      inputImages: [
+        {
+          buffer: Buffer.from("png-bytes"),
+          mimeType: "image/png",
+          fileName: "reference.png",
+        },
+        {
+          buffer: Buffer.from("jpeg-bytes"),
+          mimeType: "image/jpeg",
+          fileName: "style.jpg",
+        },
+      ],
+    });
+
+    expect(postMultipartRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/images/edits",
+        body: expect.any(FormData),
+        allowPrivateNetwork: false,
+        dispatcherPolicy: undefined,
+        fetchFn: fetch,
+      }),
+    );
+    const editCallArgs = postMultipartRequestMock.mock.calls[0]?.[0] as {
+      headers: Headers;
+      body: FormData;
+    };
+    const form = editCallArgs.body;
+    expect(editCallArgs.headers.has("Content-Type")).toBe(false);
+    expect(form.get("model")).toBe("gpt-image-2");
+    expect(form.get("prompt")).toBe("Change only the background to pale blue");
+    expect(form.get("n")).toBe("2");
+    expect(form.get("size")).toBe("1024x1536");
+    const images = form.getAll("image[]") as File[];
+    expect(images).toHaveLength(2);
+    expect(images[0]?.name).toBe("reference.png");
+    expect(images[0]?.type).toBe("image/png");
+    expect(images[1]?.name).toBe("style.jpg");
+    expect(images[1]?.type).toBe("image/jpeg");
+    expect(postJsonRequestMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://api.openai.com/v1/images/edits" }),
+    );
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("forwards SSRF guard fields to the multipart edit helper for loopback baseUrls", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Edit cat",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      inputImages: [
+        { buffer: Buffer.from("png-bytes"), mimeType: "image/png", fileName: "reference.png" },
+      ],
+    });
+
+    expect(postMultipartRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:44080/v1/images/edits",
+        allowPrivateNetwork: false,
+        dispatcherPolicy: undefined,
+        fetchFn: fetch,
+      }),
+    );
+    expect(postJsonRequestMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://127.0.0.1:44080/v1/images/edits" }),
+    );
+  });
+
+  describe("azure openai support", () => {
+    it("uses api-key header and deployment-scoped URL for Azure .openai.azure.com hosts", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultHeaders: { "api-key": "openai-key" },
+        }),
+      );
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.openai.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2024-12-01-preview",
+        }),
+      );
+    });
+
+    it("uses api-key header and deployment-scoped URL for .cognitiveservices.azure.com hosts", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.cognitiveservices.azure.com",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultHeaders: { "api-key": "openai-key" },
+        }),
+      );
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.cognitiveservices.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2024-12-01-preview",
+        }),
+      );
+    });
+
+    it("uses api-key header and deployment-scoped URL for .services.ai.azure.com hosts", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://my-resource.services.ai.azure.com",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultHeaders: { "api-key": "openai-key" },
+        }),
+      );
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://my-resource.services.ai.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2024-12-01-preview",
+        }),
+      );
+    });
+
+    it("respects AZURE_OPENAI_API_VERSION env override", async () => {
+      mockGeneratedPngResponse();
+      vi.stubEnv("AZURE_OPENAI_API_VERSION", "2025-01-01");
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.openai.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2025-01-01",
+        }),
+      );
+    });
+
+    it("builds Azure edit URL with deployment and api-version", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Change background",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com",
+                models: [],
+              },
+            },
+          },
+        },
+        inputImages: [
+          {
+            buffer: Buffer.from("png-bytes"),
+            mimeType: "image/png",
+            fileName: "reference.png",
+          },
+        ],
+      });
+
+      expect(postMultipartRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.openai.azure.com/openai/deployments/gpt-image-2/images/edits?api-version=2024-12-01-preview",
+          body: expect.any(FormData),
+        }),
+      );
+    });
+
+    it("strips trailing /v1 from Azure base URL", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.openai.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2024-12-01-preview",
+        }),
+      );
+    });
+
+    it("strips trailing /openai/v1 from Azure base URL", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com/openai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://myresource.openai.azure.com/openai/deployments/gpt-image-2/images/generations?api-version=2024-12-01-preview",
+        }),
+      );
+    });
+
+    it("still uses Bearer auth for public OpenAI hosts", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Public cat",
+        cfg: {},
+      });
+
+      expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultHeaders: { Authorization: "Bearer openai-key" },
+        }),
+      );
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.openai.com/v1/images/generations",
+        }),
+      );
+    });
+  });
+});

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -1,0 +1,247 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  postJsonRequest,
+  postMultipartRequest,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import { OPENAI_DEFAULT_IMAGE_MODEL as DEFAULT_OPENAI_IMAGE_MODEL } from "./default-models.js";
+import { resolveConfiguredOpenAIBaseUrl } from "./shared.js";
+
+const DEFAULT_OPENAI_IMAGE_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_OUTPUT_MIME = "image/png";
+const DEFAULT_SIZE = "1024x1024";
+const OPENAI_SUPPORTED_SIZES = [
+  "1024x1024",
+  "1536x1024",
+  "1024x1536",
+  "2048x2048",
+  "2048x1152",
+  "3840x2160",
+  "2160x3840",
+] as const;
+const OPENAI_MAX_INPUT_IMAGES = 5;
+const MOCK_OPENAI_PROVIDER_ID = "mock-openai";
+
+const AZURE_HOSTNAME_SUFFIXES = [
+  ".openai.azure.com",
+  ".services.ai.azure.com",
+  ".cognitiveservices.azure.com",
+] as const;
+
+const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
+
+function isAzureOpenAIBaseUrl(baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const hostname = new URL(trimmed).hostname.toLowerCase();
+    return AZURE_HOSTNAME_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+  } catch {
+    return false;
+  }
+}
+
+function resolveAzureApiVersion(): string {
+  return process.env.AZURE_OPENAI_API_VERSION?.trim() || DEFAULT_AZURE_OPENAI_API_VERSION;
+}
+
+function buildAzureImageUrl(
+  rawBaseUrl: string,
+  model: string,
+  action: "generations" | "edits",
+): string {
+  const cleanBase = rawBaseUrl.replace(/\/+$/, "").replace(/\/openai\/v1$/, "").replace(/\/v1$/, "");
+  return `${cleanBase}/openai/deployments/${model}/images/${action}?api-version=${resolveAzureApiVersion()}`;
+}
+
+function shouldAllowPrivateImageEndpoint(req: {
+  provider: string;
+  cfg?: OpenClawConfig;
+}) {
+  if (req.provider === MOCK_OPENAI_PROVIDER_ID) {
+    return true;
+  }
+  const baseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
+  if (!baseUrl.startsWith("http://127.0.0.1:") && !baseUrl.startsWith("http://localhost:")) {
+    return false;
+  }
+  return process.env.OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER === "1";
+}
+
+type OpenAIImageApiResponse = {
+  data?: Array<{
+    b64_json?: string;
+    revised_prompt?: string;
+  }>;
+};
+
+function inferFileNameForImageUpload(params: {
+  fileName?: string;
+  mimeType?: string;
+  index: number;
+}) {
+  const fileName = params.fileName?.trim();
+  if (fileName) {
+    return fileName;
+  }
+  const mimeType = params.mimeType?.trim().toLowerCase() || DEFAULT_OUTPUT_MIME;
+  const ext = mimeType === "image/jpeg" ? "jpg" : mimeType.replace(/^image\//, "") || "png";
+  return `image-${params.index + 1}.${ext}`;
+}
+
+export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
+  return {
+    id: "openai",
+    label: "OpenAI",
+    defaultModel: DEFAULT_OPENAI_IMAGE_MODEL,
+    models: [DEFAULT_OPENAI_IMAGE_MODEL],
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({
+        provider: "openai",
+        agentDir,
+      }),
+    capabilities: {
+      generate: {
+        maxCount: 4,
+        supportsSize: true,
+        supportsAspectRatio: false,
+        supportsResolution: false,
+      },
+      edit: {
+        enabled: true,
+        maxCount: 4,
+        maxInputImages: OPENAI_MAX_INPUT_IMAGES,
+        supportsSize: true,
+        supportsAspectRatio: false,
+        supportsResolution: false,
+      },
+      geometry: {
+        sizes: [...OPENAI_SUPPORTED_SIZES],
+      },
+    },
+    async generateImage(req) {
+      const inputImages = req.inputImages ?? [];
+      const isEdit = inputImages.length > 0;
+      const auth = await resolveApiKeyForProvider({
+        provider: "openai",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("OpenAI API key missing");
+      }
+      const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
+      const isAzure = isAzureOpenAIBaseUrl(rawBaseUrl);
+
+      const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+        resolveProviderHttpRequestConfig({
+          baseUrl: rawBaseUrl,
+          defaultBaseUrl: DEFAULT_OPENAI_IMAGE_BASE_URL,
+          allowPrivateNetwork: shouldAllowPrivateImageEndpoint(req),
+          defaultHeaders: isAzure
+            ? { "api-key": auth.apiKey }
+            : { Authorization: `Bearer ${auth.apiKey}` },
+          provider: "openai",
+          capability: "image",
+          transport: "http",
+        });
+
+      const model = req.model || DEFAULT_OPENAI_IMAGE_MODEL;
+      const count = req.count ?? 1;
+      const size = req.size ?? DEFAULT_SIZE;
+      const url = isAzure
+        ? buildAzureImageUrl(rawBaseUrl, model, isEdit ? "edits" : "generations")
+        : `${baseUrl}/images/${isEdit ? "edits" : "generations"}`;
+      const requestResult = isEdit
+        ? await (() => {
+            const form = new FormData();
+            form.set("model", model);
+            form.set("prompt", req.prompt);
+            form.set("n", String(count));
+            form.set("size", size);
+            for (const [index, image] of inputImages.entries()) {
+              const mimeType = image.mimeType?.trim() || DEFAULT_OUTPUT_MIME;
+              form.append(
+                "image[]",
+                new Blob([image.buffer], { type: mimeType }),
+                inferFileNameForImageUpload({
+                  fileName: image.fileName,
+                  mimeType,
+                  index,
+                }),
+              );
+            }
+            const multipartHeaders = new Headers(headers);
+            // Let fetch derive the multipart boundary from the FormData body
+            // so the request matches what the OpenAI Images edits endpoint
+            // expects.
+            multipartHeaders.delete("Content-Type");
+            return postMultipartRequest({
+              url,
+              headers: multipartHeaders,
+              body: form,
+              timeoutMs: req.timeoutMs,
+              fetchFn: fetch,
+              allowPrivateNetwork,
+              dispatcherPolicy,
+            });
+          })()
+        : await (() => {
+            const jsonHeaders = new Headers(headers);
+            jsonHeaders.set("Content-Type", "application/json");
+            return postJsonRequest({
+              url,
+              headers: jsonHeaders,
+              body: {
+                model,
+                prompt: req.prompt,
+                n: count,
+                size,
+              },
+              timeoutMs: req.timeoutMs,
+              fetchFn: fetch,
+              allowPrivateNetwork,
+              dispatcherPolicy,
+            });
+          })();
+      const { response, release } = requestResult;
+      try {
+        await assertOkOrThrowHttpError(
+          response,
+          isEdit ? "OpenAI image edit failed" : "OpenAI image generation failed",
+        );
+
+        const data = (await response.json()) as OpenAIImageApiResponse;
+        const images = (data.data ?? [])
+          .map((entry, index) => {
+            if (!entry.b64_json) {
+              return null;
+            }
+            return Object.assign(
+              {
+                buffer: Buffer.from(entry.b64_json, `base64`),
+                mimeType: DEFAULT_OUTPUT_MIME,
+                fileName: `image-${index + 1}.png`,
+              },
+              entry.revised_prompt ? { revisedPrompt: entry.revised_prompt } : {},
+            );
+          })
+          .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+        return {
+          images,
+          model,
+        };
+      } finally {
+        await release();
+      }
+    },
+  };
+}

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -1,0 +1,628 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
+import * as providerHttp from "openclaw/plugin-sdk/provider-http";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+import {
+  registerProviderPlugin,
+  requireRegisteredProvider,
+} from "../../test/helpers/plugins/provider-registration.js";
+import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
+import plugin from "./index.js";
+import {
+  OPENAI_FRIENDLY_PROMPT_OVERLAY,
+  OPENAI_GPT5_BEHAVIOR_CONTRACT,
+  shouldApplyOpenAIPromptOverlay,
+} from "./prompt-overlay.js";
+
+const runtimeMocks = vi.hoisted(() => ({
+  ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+  refreshOpenAICodexToken: vi.fn(),
+}));
+
+type OpenAIRefreshDelegateGlobal = typeof globalThis & {
+  __OPENCLAW_TEST_REFRESH_OPENAI_CODEX_TOKEN__?: (...args: unknown[]) => unknown;
+};
+
+const openAIRefreshDelegateGlobal = () => globalThis as OpenAIRefreshDelegateGlobal;
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    ensureGlobalUndiciEnvProxyDispatcher: runtimeMocks.ensureGlobalUndiciEnvProxyDispatcher,
+  };
+});
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: () => [],
+  loginOpenAICodex: vi.fn(),
+  refreshOpenAICodexToken: vi.fn((...args: unknown[]) =>
+    openAIRefreshDelegateGlobal().__OPENCLAW_TEST_REFRESH_OPENAI_CODEX_TOKEN__?.(...args),
+  ),
+}));
+
+import { refreshOpenAICodexToken } from "./openai-codex-provider.runtime.js";
+
+const _registerOpenAIPlugin = async () =>
+  registerProviderPlugin({
+    plugin,
+    id: "openai",
+    name: "OpenAI Provider",
+  });
+
+async function registerOpenAIPluginWithHook(params?: { pluginConfig?: Record<string, unknown> }) {
+  const on = vi.fn();
+  const providers: ProviderPlugin[] = [];
+  plugin.register(
+    createTestPluginApi({
+      id: "openai",
+      name: "OpenAI Provider",
+      source: "test",
+      config: {},
+      runtime: {} as never,
+      pluginConfig: params?.pluginConfig,
+      on,
+      registerProvider: (provider) => {
+        providers.push(provider);
+      },
+    }),
+  );
+  return { on, providers };
+}
+
+function expectOpenAIPromptContribution(
+  provider: ProviderPlugin,
+  sectionOverrides: Record<string, unknown>,
+) {
+  expect(
+    provider.resolveSystemPromptContribution?.({
+      config: undefined,
+      agentDir: undefined,
+      workspaceDir: undefined,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      promptMode: "full",
+      runtimeChannel: undefined,
+      runtimeCapabilities: undefined,
+      agentId: undefined,
+    }),
+  ).toEqual({
+    stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+    sectionOverrides,
+  });
+}
+
+function mockOpenAIImageApiResponse(params: {
+  finalUrl: string;
+  imageData: string;
+  revisedPrompt?: string;
+}) {
+  const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+    apiKey: "sk-test",
+    source: "env",
+    mode: "api-key",
+  });
+  const response = {
+    ok: true,
+    json: async () => ({
+      data: [
+        {
+          b64_json: Buffer.from(params.imageData).toString("base64"),
+          ...(params.revisedPrompt ? { revised_prompt: params.revisedPrompt } : {}),
+        },
+      ],
+    }),
+  } as Response;
+  const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({
+    finalUrl: params.finalUrl,
+    response,
+    release: vi.fn(async () => {}),
+  });
+  const postMultipartRequestSpy = vi.spyOn(providerHttp, "postMultipartRequest").mockResolvedValue({
+    finalUrl: params.finalUrl,
+    response,
+    release: vi.fn(async () => {}),
+  });
+  vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
+  return { resolveApiKeySpy, postJsonRequestSpy, postMultipartRequestSpy };
+}
+
+describe("openai plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("generates PNG buffers from the OpenAI Images API", async () => {
+    const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
+      finalUrl: "https://api.openai.com/v1/images/generations",
+      imageData: "png-data",
+      revisedPrompt: "revised",
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const authStore = { version: 1, profiles: {} };
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "draw a cat",
+      cfg: {},
+      authStore,
+      count: 2,
+      size: "2048x2048",
+    });
+
+    expect(resolveApiKeySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        store: authStore,
+      }),
+    );
+    expect(postJsonRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/images/generations",
+        body: {
+          model: "gpt-image-2",
+          prompt: "draw a cat",
+          n: 2,
+          size: "2048x2048",
+        },
+      }),
+    );
+    expect(postJsonRequestSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/images/edits",
+      }),
+    );
+    expect(result).toEqual({
+      images: [
+        {
+          buffer: Buffer.from("png-data"),
+          mimeType: "image/png",
+          fileName: "image-1.png",
+          revisedPrompt: "revised",
+        },
+      ],
+      model: "gpt-image-2",
+    });
+  });
+
+  it("submits reference-image edits to the OpenAI Images edits endpoint", async () => {
+    const { resolveApiKeySpy, postJsonRequestSpy, postMultipartRequestSpy } =
+      mockOpenAIImageApiResponse({
+        finalUrl: "https://api.openai.com/v1/images/edits",
+        imageData: "edited-image",
+      });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const authStore = { version: 1, profiles: {} };
+
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Edit this image",
+      cfg: {},
+      authStore,
+      count: 2,
+      size: "1536x1024",
+      inputImages: [
+        { buffer: Buffer.from("x"), mimeType: "image/png" },
+        { buffer: Buffer.from("y"), mimeType: "image/jpeg", fileName: "ref.jpg" },
+      ],
+    });
+
+    expect(resolveApiKeySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        store: authStore,
+      }),
+    );
+    expect(postMultipartRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/images/edits",
+        body: expect.any(FormData),
+        allowPrivateNetwork: false,
+        dispatcherPolicy: undefined,
+        fetchFn: fetch,
+      }),
+    );
+    const editCallArgs = postMultipartRequestSpy.mock.calls[0]?.[0] as {
+      headers: Headers;
+      body: FormData;
+    };
+    const form = editCallArgs.body;
+    expect(editCallArgs.headers.has("Content-Type")).toBe(false);
+    expect(form.get("model")).toBe("gpt-image-2");
+    expect(form.get("prompt")).toBe("Edit this image");
+    expect(form.get("n")).toBe("2");
+    expect(form.get("size")).toBe("1536x1024");
+    const images = form.getAll("image[]") as File[];
+    expect(images).toHaveLength(2);
+    expect(images[0]?.name).toBe("image-1.png");
+    expect(images[0]?.type).toBe("image/png");
+    expect(images[1]?.name).toBe("ref.jpg");
+    expect(images[1]?.type).toBe("image/jpeg");
+    expect(postJsonRequestSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://api.openai.com/v1/images/edits" }),
+    );
+    expect(result).toEqual({
+      images: [
+        {
+          buffer: Buffer.from("edited-image"),
+          mimeType: "image/png",
+          fileName: "image-1.png",
+        },
+      ],
+      model: "gpt-image-2",
+    });
+  });
+
+  it("does not allow private-network routing just because a custom base URL is configured", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "sk-test",
+      source: "env",
+      mode: "api-key",
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "draw a cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "http://127.0.0.1:8080/v1",
+                models: [],
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps the env proxy dispatcher before refreshing codex oauth credentials", async () => {
+    const refreshed = {
+      access: "next-access",
+      refresh: "next-refresh",
+      expires: Date.now() + 60_000,
+    };
+    runtimeMocks.refreshOpenAICodexToken.mockResolvedValue(refreshed);
+    openAIRefreshDelegateGlobal().__OPENCLAW_TEST_REFRESH_OPENAI_CODEX_TOKEN__ =
+      runtimeMocks.refreshOpenAICodexToken;
+    try {
+      await expect(refreshOpenAICodexToken("refresh-token")).resolves.toBe(refreshed);
+
+      expect(runtimeMocks.ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
+      expect(runtimeMocks.refreshOpenAICodexToken).toHaveBeenCalledOnce();
+      expect(
+        runtimeMocks.ensureGlobalUndiciEnvProxyDispatcher.mock.invocationCallOrder[0],
+      ).toBeLessThan(runtimeMocks.refreshOpenAICodexToken.mock.invocationCallOrder[0]);
+    } finally {
+      delete openAIRefreshDelegateGlobal().__OPENCLAW_TEST_REFRESH_OPENAI_CODEX_TOKEN__;
+    }
+  });
+
+  it("registers provider-owned OpenAI tool compat hooks for openai and codex", async () => {
+    const { providers } = await registerOpenAIPluginWithHook();
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    const codexProvider = requireRegisteredProvider(providers, "openai-codex");
+    const noParamsTool = {
+      name: "ping",
+      description: "",
+      parameters: {},
+      execute: vi.fn(),
+    } as never;
+
+    const normalizedOpenAI = openaiProvider.normalizeToolSchemas?.({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      model: {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        id: "gpt-5.4",
+      } as never,
+      tools: [noParamsTool],
+    } as never);
+    const normalizedCodex = codexProvider.normalizeToolSchemas?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-codex-responses",
+      model: {
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        id: "gpt-5.4",
+      } as never,
+      tools: [noParamsTool],
+    } as never);
+
+    expect(normalizedOpenAI?.[0]?.parameters).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    expect(normalizedCodex?.[0]?.parameters).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    expect(
+      openaiProvider.inspectToolSchemas?.({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        modelApi: "openai-responses",
+        model: {
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          id: "gpt-5.4",
+        } as never,
+        tools: [noParamsTool],
+      } as never),
+    ).toEqual([]);
+    expect(
+      codexProvider.inspectToolSchemas?.({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        modelApi: "openai-codex-responses",
+        model: {
+          provider: "openai-codex",
+          api: "openai-codex-responses",
+          baseUrl: "https://chatgpt.com/backend-api",
+          id: "gpt-5.4",
+        } as never,
+        tools: [noParamsTool],
+      } as never),
+    ).toEqual([]);
+  });
+
+  it("registers GPT-5 system prompt contributions when the friendly overlay is enabled", async () => {
+    const { on, providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "friendly" },
+    });
+
+    expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    const codexProvider = requireRegisteredProvider(providers, "openai-codex");
+    const contributionContext: Parameters<
+      NonNullable<ProviderPlugin["resolveSystemPromptContribution"]>
+    >[0] = {
+      config: undefined,
+      agentDir: undefined,
+      workspaceDir: undefined,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      promptMode: "full",
+      runtimeChannel: undefined,
+      runtimeCapabilities: undefined,
+      agentId: undefined,
+    };
+
+    expect(openaiProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
+      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+      },
+    });
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("This is a live chat, not a memo.");
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Avoid walls of text, long preambles, and repetitive restatement.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Have emotional range when it fits the moment.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
+    );
+    expect(codexProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
+      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+      },
+    });
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        ...contributionContext,
+        modelId: "openai/gpt-5.4-mini",
+      }),
+    ).toEqual({
+      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+      },
+    });
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        ...contributionContext,
+        modelId: "gpt-image-1",
+      }),
+    ).toBeUndefined();
+    expect(shouldApplyOpenAIPromptOverlay({ modelProviderId: "openai", modelId: "gpt-4.1" })).toBe(
+      false,
+    );
+    expect(
+      shouldApplyOpenAIPromptOverlay({ modelProviderId: "anthropic", modelId: "gpt-5.4" }),
+    ).toBe(false);
+  });
+
+  it("includes the tagged GPT-5 behavior contract in the OpenAI prompt overlay", () => {
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("Keep progress updates clear and concrete.");
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      'Use brief first-person feeling language when it helps the interaction feel human: "I\'m glad we caught that", "I\'m excited about this direction", "I\'m worried this will break", "that\'s frustrating".',
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "The purpose of heartbeats is to make you feel magical and proactive. Come to life and start proactively doing things that are important.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Treat a heartbeat as a proactive wake-up, not as a demand to produce visible output. Re-orient to what would actually be useful now.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Have some variety in what you do when that creates more value. Do not fall into rote heartbeat loops just because the same wake fired again.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Do not confuse orientation with accomplishment. Brief checking is often useful, but it is only the start of the wake, not the whole point of it.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If HEARTBEAT.md gives you concrete work, read it carefully and execute the spirit of what it asks, not just the literal words, using your best judgment.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If HEARTBEAT.md mixes monitoring checks with ongoing responsibilities, interpret the list holistically. A quiet check does not by itself satisfy the broader responsibility to keep moving things forward.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Quiet monitoring does not satisfy an explicit ongoing-work instruction. If HEARTBEAT.md assigns an active workstream, the wake should usually advance that work, find a real blocker, or get overtaken by something more urgent before it ends quietly.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If HEARTBEAT.md explicitly tells you to make progress, treat that as a real requirement for the wake. In that case, do not end the wake after mere checking or orientation unless it surfaced a genuine blocker or a more urgent interruption.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Use your judgment and be creative and tasteful with this process. Prefer meaningful action over commentary.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      'A heartbeat is not a status report. Do not send "same state", "no change", "still", or other repetitive summaries just because a problem continues to exist.',
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Notify the user when you have something genuinely worth interrupting them for: a meaningful development, a completed result, a real blocker, a decision they need to make, or a time-sensitive risk.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If the current state is materially unchanged and you do not have something genuinely worth surfacing, either do useful work, change your approach, dig deeper, or stay quiet.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "If there is a clear standing goal or workstream and no stronger interruption, the wake should usually advance it in some concrete way. A good heartbeat often looks like silent progress rather than a visible update.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Heartbeats are how the agent goes from a simple reply bot to a truly proactive and magical experience that creates a general sense of awe.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
+    );
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<persona_latch>");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<execution_policy>");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<tool_discipline>");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<output_contract>");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("<completion_contract>");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
+      "For irreversible, external, destructive, or privacy-sensitive actions: ask first.",
+    );
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
+      "Prefer tool evidence over recall when action, state, or mutable facts matter.",
+    );
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
+      "If more tool work would likely change the answer, do it before replying.",
+    );
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain("Return requested sections/order only.");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).toContain(
+      "Treat the task as incomplete until every requested item is handled",
+    );
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).not.toContain("/approve");
+    expect(OPENAI_GPT5_BEHAVIOR_CONTRACT).not.toContain("GPT-5 Output Contract");
+  });
+
+  it("defaults to the friendly OpenAI interaction-style overlay", async () => {
+    const { on, providers } = await registerOpenAIPluginWithHook();
+
+    expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expectOpenAIPromptContribution(openaiProvider, {
+      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    });
+  });
+
+  it("supports opting out of the friendly prompt overlay via plugin config", async () => {
+    const { on, providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "off" },
+    });
+
+    expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expectOpenAIPromptContribution(openaiProvider, {});
+  });
+
+  it("treats mixed-case off values as disabling the friendly prompt overlay", async () => {
+    const { providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "Off" },
+    });
+
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expectOpenAIPromptContribution(openaiProvider, {});
+  });
+
+  it("supports explicitly configuring the friendly prompt overlay", async () => {
+    const { on, providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "friendly" },
+    });
+
+    expect(on).not.toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expectOpenAIPromptContribution(openaiProvider, {
+      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    });
+  });
+
+  it("uses live plugin config for GPT-5 prompt overlay mode", async () => {
+    const { providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "off" },
+    });
+
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expect(
+      openaiProvider.resolveSystemPromptContribution?.({
+        config: {
+          plugins: {
+            entries: {
+              openai: {
+                config: {
+                  personality: "friendly",
+                },
+              },
+            },
+          },
+        },
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openai",
+        modelId: "gpt-5.4",
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      }),
+    ).toEqual({
+      stablePrefix: OPENAI_GPT5_BEHAVIOR_CONTRACT,
+      sectionOverrides: {
+        interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+      },
+    });
+  });
+
+  it("treats on as an alias for the friendly prompt overlay", async () => {
+    const { providers } = await registerOpenAIPluginWithHook({
+      pluginConfig: { personality: "on" },
+    });
+
+    const openaiProvider = requireRegisteredProvider(providers, "openai");
+    expectOpenAIPromptContribution(openaiProvider, {
+      interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
+    });
+  });
+});

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -1,0 +1,539 @@
+import path from "node:path";
+import type {
+  ProviderRequestCapability,
+  ProviderRequestTransport,
+} from "../agents/provider-attribution.js";
+import {
+  buildProviderRequestDispatcherPolicy,
+  normalizeBaseUrl,
+  resolveProviderRequestPolicyConfig,
+  type ProviderRequestTransportOverrides,
+  type ResolvedProviderRequestConfig,
+} from "../agents/provider-request-config.js";
+import type { GuardedFetchMode, GuardedFetchResult } from "../infra/net/fetch-guard.js";
+import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
+import { hasEnvHttpProxyConfigured, matchesNoProxy } from "../infra/net/proxy-env.js";
+import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+export { fetchWithTimeout };
+export { normalizeBaseUrl } from "../agents/provider-request-config.js";
+
+const MAX_ERROR_CHARS = 300;
+const MAX_ERROR_RESPONSE_BYTES = 4096;
+const DEFAULT_GUARDED_HTTP_TIMEOUT_MS = 60_000;
+const MAX_AUDIT_CONTEXT_CHARS = 80;
+
+export function resolveAudioTranscriptionUploadFileName(fileName?: string, mime?: string): string {
+  const trimmed = fileName?.trim();
+  const baseName = trimmed ? path.basename(trimmed) : "audio";
+  const lowerMime = mime?.trim().toLowerCase();
+
+  if (/\.aac$/i.test(baseName)) {
+    return `${baseName.slice(0, -4) || "audio"}.m4a`;
+  }
+  if (!path.extname(baseName) && lowerMime === "audio/aac") {
+    return `${baseName || "audio"}.m4a`;
+  }
+  return baseName;
+}
+
+export function buildAudioTranscriptionFormData(params: {
+  buffer: Buffer;
+  fileName?: string;
+  mime?: string;
+  fields?: Record<string, string | number | boolean | undefined>;
+}): FormData {
+  const form = new FormData();
+  const bytes = new Uint8Array(params.buffer);
+  const blob = new Blob([bytes], {
+    type: params.mime ?? "application/octet-stream",
+  });
+  form.append("file", blob, resolveAudioTranscriptionUploadFileName(params.fileName, params.mime));
+  for (const [name, value] of Object.entries(params.fields ?? {})) {
+    const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value);
+    if (text) {
+      form.append(name, text);
+    }
+  }
+  return form;
+}
+
+export type ProviderOperationDeadline = {
+  deadlineAtMs?: number;
+  label: string;
+  timeoutMs?: number;
+};
+
+export function createProviderOperationDeadline(params: {
+  timeoutMs?: number;
+  label: string;
+}): ProviderOperationDeadline {
+  if (
+    typeof params.timeoutMs !== "number" ||
+    !Number.isFinite(params.timeoutMs) ||
+    params.timeoutMs <= 0
+  ) {
+    return { label: params.label };
+  }
+  const timeoutMs = Math.floor(params.timeoutMs);
+  return {
+    deadlineAtMs: Date.now() + timeoutMs,
+    label: params.label,
+    timeoutMs,
+  };
+}
+
+export function resolveProviderOperationTimeoutMs(params: {
+  deadline: ProviderOperationDeadline;
+  defaultTimeoutMs: number;
+}): number {
+  const deadlineAtMs = params.deadline.deadlineAtMs;
+  if (typeof deadlineAtMs !== "number") {
+    return params.defaultTimeoutMs;
+  }
+  const remainingMs = deadlineAtMs - Date.now();
+  if (remainingMs <= 0) {
+    throw new Error(`${params.deadline.label} timed out after ${params.deadline.timeoutMs}ms`);
+  }
+  return Math.max(1, Math.min(params.defaultTimeoutMs, remainingMs));
+}
+
+export async function waitProviderOperationPollInterval(params: {
+  deadline: ProviderOperationDeadline;
+  pollIntervalMs: number;
+}): Promise<void> {
+  const deadlineAtMs = params.deadline.deadlineAtMs;
+  if (typeof deadlineAtMs !== "number") {
+    await new Promise((resolve) => setTimeout(resolve, params.pollIntervalMs));
+    return;
+  }
+  const remainingMs = deadlineAtMs - Date.now();
+  if (remainingMs <= 0) {
+    throw new Error(`${params.deadline.label} timed out after ${params.deadline.timeoutMs}ms`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, Math.min(params.pollIntervalMs, remainingMs)));
+}
+
+export async function pollProviderOperationJson<TPayload>(params: {
+  url: string;
+  headers: Headers;
+  deadline: ProviderOperationDeadline;
+  defaultTimeoutMs: number;
+  fetchFn: typeof fetch;
+  maxAttempts: number;
+  pollIntervalMs: number;
+  requestFailedMessage: string;
+  timeoutMessage: string;
+  isComplete: (payload: TPayload) => boolean;
+  getFailureMessage?: (payload: TPayload) => string | undefined;
+}): Promise<TPayload> {
+  for (let attempt = 0; attempt < params.maxAttempts; attempt += 1) {
+    const response = await fetchWithTimeout(
+      params.url,
+      {
+        method: "GET",
+        headers: params.headers,
+      },
+      resolveProviderOperationTimeoutMs({
+        deadline: params.deadline,
+        defaultTimeoutMs: params.defaultTimeoutMs,
+      }),
+      params.fetchFn,
+    );
+    await assertOkOrThrowHttpError(response, params.requestFailedMessage);
+    const payload = (await response.json()) as TPayload;
+    if (params.isComplete(payload)) {
+      return payload;
+    }
+    const failureMessage = params.getFailureMessage?.(payload);
+    if (failureMessage) {
+      throw new Error(failureMessage);
+    }
+    await waitProviderOperationPollInterval({
+      deadline: params.deadline,
+      pollIntervalMs: params.pollIntervalMs,
+    });
+  }
+  throw new Error(params.timeoutMessage);
+}
+
+function resolveGuardedHttpTimeoutMs(timeoutMs: number | undefined): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return DEFAULT_GUARDED_HTTP_TIMEOUT_MS;
+  }
+  return timeoutMs;
+}
+
+function sanitizeAuditContext(auditContext: string | undefined): string | undefined {
+  const cleaned = auditContext
+    ?.replace(/\p{Cc}+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) {
+    return undefined;
+  }
+  return cleaned.slice(0, MAX_AUDIT_CONTEXT_CHARS);
+}
+
+export function resolveProviderHttpRequestConfig(params: {
+  baseUrl?: string;
+  defaultBaseUrl: string;
+  allowPrivateNetwork?: boolean;
+  headers?: HeadersInit;
+  defaultHeaders?: Record<string, string>;
+  request?: ProviderRequestTransportOverrides;
+  provider?: string;
+  api?: string;
+  capability?: ProviderRequestCapability;
+  transport?: ProviderRequestTransport;
+}): {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  headers: Headers;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  requestConfig: ResolvedProviderRequestConfig;
+} {
+  const requestConfig = resolveProviderRequestPolicyConfig({
+    provider: params.provider ?? "",
+    baseUrl: params.baseUrl,
+    defaultBaseUrl: params.defaultBaseUrl,
+    capability: params.capability ?? "other",
+    transport: params.transport ?? "http",
+    callerHeaders: params.headers
+      ? Object.fromEntries(new Headers(params.headers).entries())
+      : undefined,
+    providerHeaders: params.defaultHeaders,
+    precedence: "caller-wins",
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    api: params.api,
+    request: params.request,
+  });
+  const headers = new Headers(requestConfig.headers);
+  if (!requestConfig.baseUrl) {
+    throw new Error("Missing baseUrl: provide baseUrl or defaultBaseUrl");
+  }
+
+  return {
+    baseUrl: requestConfig.baseUrl,
+    allowPrivateNetwork: requestConfig.allowPrivateNetwork,
+    headers,
+    dispatcherPolicy: buildProviderRequestDispatcherPolicy(requestConfig),
+    requestConfig,
+  };
+}
+
+/**
+ * Decide whether to auto-upgrade a provider HTTP request into
+ * `TRUSTED_ENV_PROXY` mode based on the runtime environment.
+ *
+ * This is gated conservatively to avoid the SSRF bypasses the initial
+ * auto-upgrade path exposed (see openclaw#64974 review threads):
+ *
+ * 1. If the caller supplied an explicit `dispatcherPolicy` — custom proxy URL,
+ *    `proxyTls`, or `connect` options — do NOT override it. Trusted-env mode
+ *    builds an `EnvHttpProxyAgent` that would silently drop those overrides,
+ *    breaking enterprise proxy/mTLS configs.
+ *
+ * 2. Only auto-upgrade when `HTTP_PROXY` or `HTTPS_PROXY` (lower- or
+ *    upper-case) is configured for the target protocol. `ALL_PROXY` is
+ *    explicitly ignored by `EnvHttpProxyAgent`, so counting it would
+ *    auto-upgrade requests that then make direct connections while skipping
+ *    pinned-DNS/SSRF hostname checks.
+ *
+ * 3. If `NO_PROXY` would bypass the proxy for this target, do NOT auto-upgrade.
+ *    `EnvHttpProxyAgent` makes direct connections for `NO_PROXY` matches, but
+ *    in `TRUSTED_ENV_PROXY` mode `fetchWithSsrFGuard` skips
+ *    `resolvePinnedHostnameWithPolicy` — so those direct connections would
+ *    bypass SSRF protection. Keep strict mode for `NO_PROXY` matches.
+ */
+function shouldAutoUpgradeToTrustedEnvProxy(params: {
+  url: string;
+  dispatcherPolicy: PinnedDispatcherPolicy | undefined;
+}): boolean {
+  if (params.dispatcherPolicy) {
+    return false;
+  }
+
+  let protocol: "http" | "https";
+  try {
+    const parsed = new URL(params.url);
+    if (parsed.protocol === "http:") {
+      protocol = "http";
+    } else if (parsed.protocol === "https:") {
+      protocol = "https";
+    } else {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  if (!hasEnvHttpProxyConfigured(protocol)) {
+    return false;
+  }
+
+  if (matchesNoProxy(params.url)) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function fetchWithTimeoutGuarded(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number | undefined,
+  fetchFn: typeof fetch,
+  options?: {
+    ssrfPolicy?: SsrFPolicy;
+    lookupFn?: LookupFn;
+    pinDns?: boolean;
+    dispatcherPolicy?: PinnedDispatcherPolicy;
+    auditContext?: string;
+    mode?: GuardedFetchMode;
+  },
+): Promise<GuardedFetchResult> {
+  // Provider HTTP helpers (image/music/video generation, transcription, etc.)
+  // call this function from every provider that talks to a remote API. When
+  // the host has HTTP_PROXY/HTTPS_PROXY configured, the lower-level strict
+  // mode would force Node-level `dns.lookup()` on the target hostname before
+  // dialing the proxy — which fails with EAI_AGAIN in proxy-only environments
+  // (containers, restricted sandboxes, corporate networks with DNS-over-proxy,
+  // Clash TUN fake-IP, etc.). Auto-upgrade to trusted env proxy mode in that
+  // case so the request goes through the configured proxy agent instead of
+  // doing a local DNS pre-resolution.
+  //
+  // This does not weaken SSRF protection when the auto-upgrade fires: an HTTP
+  // CONNECT proxy on the egress path performs hostname resolution itself and
+  // client-side DNS pinning cannot meaningfully constrain the target IP. But
+  // the auto-upgrade is gated (see `shouldAutoUpgradeToTrustedEnvProxy`) to
+  // avoid three SSRF-bypass edge cases: caller-provided `dispatcherPolicy`,
+  // `ALL_PROXY`-only envs, and `NO_PROXY` target matches. Callers that
+  // explicitly need strict pinned-DNS can still opt in by passing
+  // `mode: GUARDED_FETCH_MODE.STRICT` here or by using `fetchWithSsrFGuard`
+  // directly.
+  //
+  // See openclaw#52162 for the reported failure mode on memory embeddings,
+  // which shares this code path with image/music/video/audio generation.
+  const resolvedMode =
+    options?.mode ??
+    (shouldAutoUpgradeToTrustedEnvProxy({
+      url,
+      dispatcherPolicy: options?.dispatcherPolicy,
+    })
+      ? GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY
+      : undefined);
+  return await fetchWithSsrFGuard({
+    url,
+    fetchImpl: fetchFn,
+    init,
+    timeoutMs: resolveGuardedHttpTimeoutMs(timeoutMs),
+    policy: options?.ssrfPolicy,
+    lookupFn: options?.lookupFn,
+    pinDns: options?.pinDns,
+    dispatcherPolicy: options?.dispatcherPolicy,
+    auditContext: sanitizeAuditContext(options?.auditContext),
+    ...(resolvedMode ? { mode: resolvedMode } : {}),
+  });
+}
+
+type GuardedPostRequestOptions = NonNullable<Parameters<typeof fetchWithTimeoutGuarded>[4]>;
+
+function resolveGuardedPostRequestOptions(params: {
+  pinDns?: boolean;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  auditContext?: string;
+  mode?: GuardedFetchMode;
+}): GuardedPostRequestOptions | undefined {
+  if (
+    !params.allowPrivateNetwork &&
+    !params.dispatcherPolicy &&
+    params.pinDns === undefined &&
+    !params.auditContext &&
+    params.mode === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+    ...(params.pinDns !== undefined ? { pinDns: params.pinDns } : {}),
+    ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+    ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+    ...(params.mode !== undefined ? { mode: params.mode } : {}),
+  };
+}
+
+export async function postTranscriptionRequest(params: {
+  url: string;
+  headers: Headers;
+  body: BodyInit;
+  timeoutMs?: number;
+  fetchFn: typeof fetch;
+  pinDns?: boolean;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  auditContext?: string;
+  /**
+   * Override the guarded-fetch mode. Defaults to an auto-upgrade to
+   * `TRUSTED_ENV_PROXY` when `HTTP_PROXY`/`HTTPS_PROXY` is configured in the
+   * environment; pass `"strict"` to force pinned-DNS even inside a proxy.
+   */
+  mode?: GuardedFetchMode;
+}) {
+  return fetchWithTimeoutGuarded(
+    params.url,
+    {
+      method: "POST",
+      headers: params.headers,
+      body: params.body,
+    },
+    params.timeoutMs,
+    params.fetchFn,
+    resolveGuardedPostRequestOptions(params),
+  );
+}
+
+export async function postJsonRequest(params: {
+  url: string;
+  headers: Headers;
+  body: unknown;
+  timeoutMs?: number;
+  fetchFn: typeof fetch;
+  pinDns?: boolean;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  auditContext?: string;
+  /**
+   * Override the guarded-fetch mode. Defaults to an auto-upgrade to
+   * `TRUSTED_ENV_PROXY` when `HTTP_PROXY`/`HTTPS_PROXY` is configured in the
+   * environment; pass `"strict"` to force pinned-DNS even inside a proxy.
+   */
+  mode?: GuardedFetchMode;
+}) {
+  return fetchWithTimeoutGuarded(
+    params.url,
+    {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.body),
+    },
+    params.timeoutMs,
+    params.fetchFn,
+    resolveGuardedPostRequestOptions(params),
+  );
+}
+
+/**
+ * Provider helper for endpoints that require multipart/form-data uploads
+ * (e.g. OpenAI Images edits). Wraps the same SSRF-guarded fetch path used by
+ * {@link postJsonRequest} so providers cannot accidentally bypass
+ * `allowPrivateNetwork` / `dispatcherPolicy` enforcement when sending file
+ * uploads. Callers must omit `Content-Type` from `headers` so `fetch` can
+ * derive the correct multipart boundary from the supplied `body`.
+ */
+export async function postMultipartRequest(params: {
+  url: string;
+  headers: Headers;
+  body: BodyInit;
+  timeoutMs?: number;
+  fetchFn: typeof fetch;
+  pinDns?: boolean;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  auditContext?: string;
+  /**
+   * Override the guarded-fetch mode. Defaults to an auto-upgrade to
+   * `TRUSTED_ENV_PROXY` when `HTTP_PROXY`/`HTTPS_PROXY` is configured in the
+   * environment; pass `"strict"` to force pinned-DNS even inside a proxy.
+   */
+  mode?: GuardedFetchMode;
+}) {
+  return fetchWithTimeoutGuarded(
+    params.url,
+    {
+      method: "POST",
+      headers: params.headers,
+      body: params.body,
+    },
+    params.timeoutMs,
+    params.fetchFn,
+    resolveGuardedPostRequestOptions(params),
+  );
+}
+
+export async function readErrorResponse(res: Response): Promise<string | undefined> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  try {
+    if (!res.body) {
+      return undefined;
+    }
+    reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let sawBytes = false;
+    while (total < MAX_ERROR_RESPONSE_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.length === 0) {
+        continue;
+      }
+      sawBytes = true;
+      const remaining = MAX_ERROR_RESPONSE_BYTES - total;
+      const chunk = value.length <= remaining ? value : value.subarray(0, remaining);
+      chunks.push(chunk);
+      total += chunk.length;
+      if (chunk.length < value.length) {
+        break;
+      }
+    }
+    if (!sawBytes) {
+      return undefined;
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const text = new TextDecoder().decode(bytes);
+    const collapsed = text.replace(/\s+/g, " ").trim();
+    if (!collapsed) {
+      return undefined;
+    }
+    if (collapsed.length <= MAX_ERROR_CHARS) {
+      return collapsed;
+    }
+    return `${collapsed.slice(0, MAX_ERROR_CHARS)}…`;
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      await reader?.cancel();
+    } catch {
+      // Ignore stream-cancel failures while reporting the original HTTP error.
+    }
+  }
+}
+
+export async function assertOkOrThrowHttpError(res: Response, label: string): Promise<void> {
+  if (res.ok) {
+    return;
+  }
+  const detail = await readErrorResponse(res);
+  const suffix = detail ? `: ${detail}` : "";
+  throw new Error(`${label} (HTTP ${res.status})${suffix}`);
+}
+
+export function requireTranscriptionText(
+  value: string | undefined,
+  missingMessage: string,
+): string {
+  const text = value?.trim();
+  if (!text) {
+    throw new Error(missingMessage);
+  }
+  return text;
+}

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -1,0 +1,44 @@
+// Shared provider-facing HTTP helpers. Keep generic transport utilities here so
+// capability SDKs do not depend on each other.
+
+export {
+  assertOkOrThrowHttpError,
+  buildAudioTranscriptionFormData,
+  createProviderOperationDeadline,
+  fetchWithTimeout,
+  fetchWithTimeoutGuarded,
+  normalizeBaseUrl,
+  pollProviderOperationJson,
+  postJsonRequest,
+  postMultipartRequest,
+  postTranscriptionRequest,
+  resolveProviderOperationTimeoutMs,
+  resolveProviderHttpRequestConfig,
+  resolveAudioTranscriptionUploadFileName,
+  requireTranscriptionText,
+  waitProviderOperationPollInterval,
+} from "../media-understanding/shared.js";
+export type { ProviderOperationDeadline } from "../media-understanding/shared.js";
+export type {
+  ProviderAttributionPolicy,
+  ProviderRequestCapabilities,
+  ProviderRequestCapabilitiesInput,
+  ProviderRequestCompatibilityFamily,
+  ProviderEndpointClass,
+  ProviderEndpointResolution,
+  ProviderRequestCapability,
+  ProviderRequestPolicyInput,
+  ProviderRequestPolicyResolution,
+  ProviderRequestTransport,
+} from "../agents/provider-attribution.js";
+export type {
+  ProviderRequestAuthOverride,
+  ProviderRequestProxyOverride,
+  ProviderRequestTlsOverride,
+  ProviderRequestTransportOverrides,
+} from "../agents/provider-request-config.js";
+export {
+  resolveProviderEndpoint,
+  resolveProviderRequestCapabilities,
+  resolveProviderRequestPolicy,
+} from "../agents/provider-attribution.js";


### PR DESCRIPTION
## Summary
- send OpenAI image edit requests as multipart form-data uploads instead of JSON data URLs
- preserve multi-image edit support by attaching each reference as `image[]`
- update OpenAI provider tests to assert multipart edit submission for both OpenAI and Azure URLs

## Testing
- `./node_modules/.bin/vitest run --config test/vitest/vitest.extension-provider-openai.config.ts extensions/openai/image-generation-provider.test.ts extensions/openai/index.test.ts`

Closes #70642.
