### PR TITLE
fix #70640: graceful ACL fallback on Windows + strip UTF-8 BOM in secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/chat: queue Stop-button aborts across Gateway reconnects so a disconnected active run is canceled on reconnect instead of only clearing local UI state. (#70673) Thanks @chinar-amrutkar.
+- Secrets/Windows: strip UTF-8 BOMs from file-backed secrets and keep unavailable ACL checks fail-closed unless trusted file or exec providers explicitly opt into `allowInsecurePath`. (#70662) Thanks @zhanggpcsu.
 - QQBot/security: require framework auth for `/bot-approve` so unauthorized QQ senders cannot change exec approval settings through the unauthenticated pre-dispatch slash-command path. (#70706) Thanks @vincentkoc.
 - MCP/tools: stop the ACPX OpenClaw tools bridge from listing or invoking owner-only tools such as `cron`, closing a privilege-escalation path for non-owner MCP callers. (#70698) Thanks @vincentkoc.
 - Feishu/onboarding: load Feishu setup surfaces through a setup-only barrel so first-run setup no longer imports Feishu's Lark SDK before bundled runtime deps are staged. (#70339) Thanks @andrejtr.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -203,6 +203,7 @@ File provider (`--provider-source file`):
 - `--provider-path <path>` (required)
 - `--provider-mode <singleValue|json>`
 - `--provider-max-bytes <bytes>`
+- `--provider-allow-insecure-path`
 
 Exec provider (`--provider-source exec`):
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -3473,6 +3473,7 @@ Validation:
 Notes:
 
 - `file` provider supports `mode: "json"` and `mode: "singleValue"` (`id` must be `"value"` in singleValue mode).
+- File and exec provider paths fail closed when Windows ACL verification is unavailable. Set `allowInsecurePath: true` only for trusted paths that cannot be verified.
 - `exec` provider requires an absolute `command` path and uses protocol payloads on stdin/stdout.
 - By default, symlink command paths are rejected. Set `allowSymlinkCommand: true` to allow symlink paths while validating the resolved target path.
 - If `trustedDirs` is configured, the trusted-dir check applies to the resolved target path.

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -318,79 +318,79 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
     <Accordion title="Projects, shards, and scoped lanes"> - Untargeted `pnpm test` runs twelve smaller shard configs (`core-unit-fast`, `core-unit-src`, `core-unit-security`, `core-unit-ui`, `core-unit-support`, `core-support-boundary`, `core-contracts`, `core-bundled`, `core-runtime`, `agentic`, `auto-reply`, `extensions`) instead of one giant native root-project process. This cuts peak RSS on loaded machines and avoids auto-reply/extension work starving unrelated suites. - `pnpm test --watch` still uses the native root `vitest.config.ts` project graph, because a multi-shard watch loop is not practical. - `pnpm test`, `pnpm test:watch`, and `pnpm test:perf:imports` route explicit file/directory targets through scoped lanes first, so `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts` avoids paying the full root project startup tax. - `pnpm test:changed` expands changed git paths into the same scoped lanes when the diff only touches routable source/test files; config/setup edits still fall back to the broad root-project rerun. - `pnpm check:changed` is the normal smart local gate for narrow work. It classifies the diff into core, core tests, extensions, extension tests, apps, docs, release metadata, and tooling, then runs the matching typecheck/lint/test lanes. Public Plugin SDK and plugin-contract changes include extension validation because extensions depend on those core contracts. Release metadata-only version bumps run targeted version/config/root-dependency checks instead of the full suite, with a guard that rejects package changes outside the top-level version field. - Import-light unit tests from agents, commands, plugins, auto-reply helpers, `plugin-sdk`, and similar pure utility areas route through the `unit-fast` lane, which skips `test/setup-openclaw-runtime.ts`; stateful/runtime-heavy files stay on the existing lanes. - Selected `plugin-sdk` and `commands` helper source files also map changed-mode runs to explicit sibling tests in those light lanes, so helper edits avoid rerunning the full heavy suite for that directory. - `auto-reply` has three dedicated buckets: top-level core helpers, top-level `reply.*` integration tests, and the `src/auto-reply/reply/**` subtree. This keeps the heaviest reply harness work off the cheap status/chunk/token tests.
     </Accordion>
 
-    <Accordion title="Embedded runner coverage">
-      - When you change message-tool discovery inputs or compaction runtime
-        context, keep both levels of coverage.
-      - Add focused helper regressions for pure routing and normalization
-        boundaries.
-      - Keep the embedded runner integration suites healthy:
-        `src/agents/pi-embedded-runner/compact.hooks.test.ts`,
-        `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`, and
-        `src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`.
-      - Those suites verify that scoped ids and compaction behavior still flow
-        through the real `run.ts` / `compact.ts` paths; helper-only tests are
-        not a sufficient substitute for those integration paths.
-    </Accordion>
+      <Accordion title="Embedded runner coverage">
+        - When you change message-tool discovery inputs or compaction runtime
+          context, keep both levels of coverage.
+        - Add focused helper regressions for pure routing and normalization
+          boundaries.
+        - Keep the embedded runner integration suites healthy:
+          `src/agents/pi-embedded-runner/compact.hooks.test.ts`,
+          `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`, and
+          `src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`.
+        - Those suites verify that scoped ids and compaction behavior still flow
+          through the real `run.ts` / `compact.ts` paths; helper-only tests are
+          not a sufficient substitute for those integration paths.
+      </Accordion>
 
-    <Accordion title="Vitest pool and isolation defaults">
-      - Base Vitest config defaults to `threads`.
-      - The shared Vitest config fixes `isolate: false` and uses the
-        non-isolated runner across the root projects, e2e, and live configs.
-      - The root UI lane keeps its `jsdom` setup and optimizer, but runs on the
-        shared non-isolated runner too.
-      - Each `pnpm test` shard inherits the same `threads` + `isolate: false`
-        defaults from the shared Vitest config.
-      - `scripts/run-vitest.mjs` adds `--no-maglev` for Vitest child Node
-        processes by default to reduce V8 compile churn during big local runs.
-        Set `OPENCLAW_VITEST_ENABLE_MAGLEV=1` to compare against stock V8
-        behavior.
-    </Accordion>
+      <Accordion title="Vitest pool and isolation defaults">
+        - Base Vitest config defaults to `threads`.
+        - The shared Vitest config fixes `isolate: false` and uses the
+          non-isolated runner across the root projects, e2e, and live configs.
+        - The root UI lane keeps its `jsdom` setup and optimizer, but runs on the
+          shared non-isolated runner too.
+        - Each `pnpm test` shard inherits the same `threads` + `isolate: false`
+          defaults from the shared Vitest config.
+        - `scripts/run-vitest.mjs` adds `--no-maglev` for Vitest child Node
+          processes by default to reduce V8 compile churn during big local runs.
+          Set `OPENCLAW_VITEST_ENABLE_MAGLEV=1` to compare against stock V8
+          behavior.
+      </Accordion>
 
-    <Accordion title="Fast local iteration">
-      - `pnpm changed:lanes` shows which architectural lanes a diff triggers.
-      - The pre-commit hook runs `pnpm check:changed --staged` after staged
-        formatting/linting, so core-only commits do not pay extension test cost
-        unless they touch public extension-facing contracts. Release
-        metadata-only commits stay on the targeted
-        version/config/root-dependency lane.
-      - If the exact staged change set was already validated with
-        equal-or-stronger gates, use
-        `scripts/committer --fast "<message>" <files...>` to skip only the
-        changed-scope hook rerun. Staged format/lint still run. Mention the
-        completed gates in your handoff. This is also acceptable after an
-        isolated flaky hook failure is rerun and passes with scoped proof.
-      - `pnpm test:changed` routes through scoped lanes when the changed paths
-        map cleanly to a smaller suite.
-      - `pnpm test:max` and `pnpm test:changed:max` keep the same routing
-        behavior, just with a higher worker cap.
-      - Local worker auto-scaling is intentionally conservative and backs off
-        when the host load average is already high, so multiple concurrent
-        Vitest runs do less damage by default.
-      - The base Vitest config marks the projects/config files as
-        `forceRerunTriggers` so changed-mode reruns stay correct when test
-        wiring changes.
-      - The config keeps `OPENCLAW_VITEST_FS_MODULE_CACHE` enabled on supported
-        hosts; set `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/abs/path` if you want
-        one explicit cache location for direct profiling.
-    </Accordion>
+      <Accordion title="Fast local iteration">
+        - `pnpm changed:lanes` shows which architectural lanes a diff triggers.
+        - The pre-commit hook runs `pnpm check:changed --staged` after staged
+          formatting/linting, so core-only commits do not pay extension test cost
+          unless they touch public extension-facing contracts. Release
+          metadata-only commits stay on the targeted
+          version/config/root-dependency lane.
+        - If the exact staged change set was already validated with
+          equal-or-stronger gates, use
+          `scripts/committer --fast "<message>" <files...>` to skip only the
+          changed-scope hook rerun. Staged format/lint still run. Mention the
+          completed gates in your handoff. This is also acceptable after an
+          isolated flaky hook failure is rerun and passes with scoped proof.
+        - `pnpm test:changed` routes through scoped lanes when the changed paths
+          map cleanly to a smaller suite.
+        - `pnpm test:max` and `pnpm test:changed:max` keep the same routing
+          behavior, just with a higher worker cap.
+        - Local worker auto-scaling is intentionally conservative and backs off
+          when the host load average is already high, so multiple concurrent
+          Vitest runs do less damage by default.
+        - The base Vitest config marks the projects/config files as
+          `forceRerunTriggers` so changed-mode reruns stay correct when test
+          wiring changes.
+        - The config keeps `OPENCLAW_VITEST_FS_MODULE_CACHE` enabled on supported
+          hosts; set `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/abs/path` if you want
+          one explicit cache location for direct profiling.
+      </Accordion>
 
-    <Accordion title="Perf debugging">
-      - `pnpm test:perf:imports` enables Vitest import-duration reporting plus
-        import-breakdown output.
-      - `pnpm test:perf:imports:changed` scopes the same profiling view to
-        files changed since `origin/main`.
-      - `pnpm test:perf:changed:bench -- --ref <git-ref>` compares routed
-        `test:changed` against the native root-project path for that committed
-        diff and prints wall time plus macOS max RSS.
-      - `pnpm test:perf:changed:bench -- --worktree` benchmarks the current
-        dirty tree by routing the changed file list through
-        `scripts/test-projects.mjs` and the root Vitest config.
-      - `pnpm test:perf:profile:main` writes a main-thread CPU profile for
-        Vitest/Vite startup and transform overhead.
-      - `pnpm test:perf:profile:runner` writes runner CPU+heap profiles for the
-        unit suite with file parallelism disabled.
-    </Accordion>
-  </AccordionGroup>
+      <Accordion title="Perf debugging">
+        - `pnpm test:perf:imports` enables Vitest import-duration reporting plus
+          import-breakdown output.
+        - `pnpm test:perf:imports:changed` scopes the same profiling view to
+          files changed since `origin/main`.
+        - `pnpm test:perf:changed:bench -- --ref <git-ref>` compares routed
+          `test:changed` against the native root-project path for that committed
+          diff and prints wall time plus macOS max RSS.
+        - `pnpm test:perf:changed:bench -- --worktree` benchmarks the current
+          dirty tree by routing the changed file list through
+          `scripts/test-projects.mjs` and the root Vitest config.
+        - `pnpm test:perf:profile:main` writes a main-thread CPU profile for
+          Vitest/Vite startup and transform overhead.
+        - `pnpm test:perf:profile:runner` writes runner CPU+heap profiles for the
+          unit suite with file parallelism disabled.
+      </Accordion>
+    </AccordionGroup>
 
 ### Stability (gateway)
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -885,6 +885,7 @@ describe("config cli", () => {
         "/tmp/vault.json",
         "--provider-mode",
         "json",
+        "--provider-allow-insecure-path",
       ]);
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
@@ -893,6 +894,7 @@ describe("config cli", () => {
         source: "file",
         path: "/tmp/vault.json",
         mode: "json",
+        allowInsecurePath: true,
       });
     });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -712,6 +712,7 @@ function buildProviderFromBuilder(opts: ConfigSetOptions): SecretProviderConfig 
       ...(mode ? { mode } : {}),
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(maxBytes !== undefined ? { maxBytes } : {}),
+      ...(opts.providerAllowInsecurePath ? { allowInsecurePath: true } : {}),
     };
   } else {
     const command = opts.providerCommand?.trim();
@@ -1599,7 +1600,7 @@ export function registerConfigCli(program: Command) {
     )
     .option(
       "--provider-allow-insecure-path",
-      "Provider builder (exec): bypass strict path permission checks",
+      "Provider builder (file|exec): bypass strict path permission checks",
       false,
     )
     .option(

--- a/src/config/config.secrets-schema.test.ts
+++ b/src/config/config.secrets-schema.test.ts
@@ -30,6 +30,7 @@ describe("config secret refs schema", () => {
             path: "~/.openclaw/secrets.json",
             mode: "json",
             timeoutMs: 10_000,
+            allowInsecurePath: true,
           },
           vault: {
             source: "exec",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -824,6 +824,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       exclusiveMinimum: 0,
                       maximum: 20971520,
                     },
+                    allowInsecurePath: {
+                      type: "boolean",
+                    },
                   },
                   required: ["source", "path"],
                   additionalProperties: false,

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -233,6 +233,7 @@ export type FileSecretProviderConfig = {
   mode?: FileSecretProviderMode;
   timeoutMs?: number;
   maxBytes?: number;
+  allowInsecurePath?: boolean;
 };
 
 export type ExecSecretProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -102,6 +102,7 @@ const SecretsFileProviderSchema = z
       .positive()
       .max(20 * 1024 * 1024)
       .optional(),
+    allowInsecurePath: z.boolean().optional(),
   })
   .strict();
 

--- a/src/secrets/configure.ts
+++ b/src/secrets/configure.ts
@@ -446,6 +446,13 @@ async function promptFileProvider(
     initialValue: base?.maxBytes,
     max: 20 * 1024 * 1024,
   });
+  const allowInsecurePath = assertNoCancel(
+    await confirm({
+      message: "Allow insecure file path checks?",
+      initialValue: base?.allowInsecurePath ?? false,
+    }),
+    "Secrets configure cancelled.",
+  );
 
   return {
     source: "file",
@@ -453,6 +460,7 @@ async function promptFileProvider(
     mode,
     ...(timeoutMs ? { timeoutMs } : {}),
     ...(maxBytes ? { maxBytes } : {}),
+    ...(allowInsecurePath ? { allowInsecurePath: true } : {}),
   };
 }
 

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -54,6 +54,7 @@ describe("secret ref resolver", () => {
     path: string;
     mode: "json" | "singleValue";
     timeoutMs?: number;
+    allowInsecurePath?: boolean;
   };
 
   function createExecProviderConfig(
@@ -498,32 +499,66 @@ describe("secret ref resolver", () => {
     expect(value).toBe("my-secret-value");
   });
 
-  it("warns instead of crashing on Windows when ACL source is unknown", async () => {
-    // Mock process.platform to simulate Windows
+  it("fails closed on Windows when file provider ACL source is unknown", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32" as unknown as NodeJS.Platform);
-    const { getLogger } = await import("../logging/logger.js");
-    const warnSpy = vi.spyOn(getLogger(), "warn");
 
     try {
       const dir = await createCaseDir("win-acl");
       const filePath = path.join(dir, "secrets.json");
       await writeSecureFile(filePath, '{"token":"abc123"}');
 
-      // This should NOT throw even on Windows with unknown ACL source
+      await expect(
+        resolveSecretRefString(
+          { source: "file", provider: "filemain", id: "/token" },
+          {
+            config: {
+              secrets: {
+                providers: {
+                  filemain: createFileProviderConfig(filePath),
+                },
+              },
+            },
+          },
+        ),
+      ).rejects.toThrow(/ACL verification unavailable on Windows/);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("allows trusted file provider opt-out when Windows ACL source is unknown", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32" as unknown as NodeJS.Platform);
+
+    try {
+      const dir = await createCaseDir("win-acl-opt-out");
+      const filePath = path.join(dir, "secrets.json");
+      await writeSecureFile(filePath, '{"token":"abc123"}');
+
       const value = await resolveSecretRefString(
         { source: "file", provider: "filemain", id: "/token" },
         {
           config: {
             secrets: {
               providers: {
-                filemain: createFileProviderConfig(filePath),
+                filemain: createFileProviderConfig(filePath, { allowInsecurePath: true }),
               },
             },
           },
         },
       );
       expect(value).toBe("abc123");
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ACL verification unavailable"));
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("fails closed on Windows when exec provider ACL source is unknown", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32" as unknown as NodeJS.Platform);
+
+    try {
+      await expect(resolveExecSecret(execProtocolV1ScriptPath)).rejects.toThrow(
+        /ACL verification unavailable on Windows/,
+      );
     } finally {
       vi.restoreAllMocks();
     }

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -454,4 +454,75 @@ describe("secret ref resolver", () => {
       ).rejects.toThrow(/Exec secret reference id must match|Secret reference id is empty/);
     }
   });
+
+  it("strips UTF-8 BOM from file provider payload before JSON parse", async () => {
+    const dir = await createCaseDir("bom-file");
+    const filePath = path.join(dir, "secrets-with-bom.json");
+    // Write JSON with UTF-8 BOM prefix (EF BB BF)
+    const bom = "\uFEFF";
+    await writeSecureFile(filePath, `${bom}{"apiKey":"sk-test-123"}`);
+
+    const value = await resolveSecretRefString(
+      { source: "file", provider: "filemain", id: "/apiKey" },
+      {
+        config: {
+          secrets: {
+            providers: {
+              filemain: createFileProviderConfig(filePath),
+            },
+          },
+        },
+      },
+    );
+    expect(value).toBe("sk-test-123");
+  });
+
+  it("strips UTF-8 BOM from file provider singleValue mode", async () => {
+    const dir = await createCaseDir("bom-single");
+    const filePath = path.join(dir, "secret-with-bom.txt");
+    const bom = "\uFEFF";
+    await writeSecureFile(filePath, `${bom}my-secret-value\n`);
+
+    const value = await resolveSecretRefString(
+      { source: "file", provider: "filemain", id: "value" },
+      {
+        config: {
+          secrets: {
+            providers: {
+              filemain: createFileProviderConfig(filePath, { mode: "singleValue" }),
+            },
+          },
+        },
+      },
+    );
+    expect(value).toBe("my-secret-value");
+  });
+
+  it("warns instead of crashing on Windows when ACL source is unknown", async () => {
+    // Mock process.platform to simulate Windows
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32" as unknown as NodeJS.Platform);
+
+    try {
+      const dir = await createCaseDir("win-acl");
+      const filePath = path.join(dir, "secrets.json");
+      await writeSecureFile(filePath, '{"token":"abc123"}');
+
+      // This should NOT throw even on Windows with unknown ACL source
+      const value = await resolveSecretRefString(
+        { source: "file", provider: "filemain", id: "/token" },
+        {
+          config: {
+            secrets: {
+              providers: {
+                filemain: createFileProviderConfig(filePath),
+              },
+            },
+          },
+        },
+      );
+      expect(value).toBe("abc123");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -501,6 +501,8 @@ describe("secret ref resolver", () => {
   it("warns instead of crashing on Windows when ACL source is unknown", async () => {
     // Mock process.platform to simulate Windows
     vi.spyOn(process, "platform", "get").mockReturnValue("win32" as unknown as NodeJS.Platform);
+    const { getLogger } = await import("../logging/logger.js");
+    const warnSpy = vi.spyOn(getLogger(), "warn");
 
     try {
       const dir = await createCaseDir("win-acl");
@@ -521,6 +523,7 @@ describe("secret ref resolver", () => {
         },
       );
       expect(value).toBe("abc123");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ACL verification unavailable"));
     } finally {
       vi.restoreAllMocks();
     }

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -207,6 +207,7 @@ async function assertSecurePath(params: {
   allowInsecurePath?: boolean;
   allowReadableByOthers?: boolean;
   allowSymlinkPath?: boolean;
+  isExecPath?: boolean;
 }): Promise<string> {
   if (!isAbsolutePathname(params.targetPath)) {
     throw new Error(`${params.label} must be an absolute path.`);
@@ -254,6 +255,11 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
+    if (params.isExecPath) {
+      throw new Error(
+        `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this check when the path is trusted.`,
+      );
+    }
     getLogger().warn(
       `${params.label} ACL verification unavailable on Windows for ${effectivePath}, skipping permission check.`,
     );
@@ -672,6 +678,7 @@ async function resolveExecRefs(params: {
       allowInsecurePath: params.providerConfig.allowInsecurePath,
       allowReadableByOthers: true,
       allowSymlinkPath: params.providerConfig.allowSymlinkCommand,
+      isExecPath: true,
     });
   } catch (err) {
     throwUnknownProviderResolutionError({

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -10,7 +10,6 @@ import type {
   SecretRefSource,
 } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { getLogger } from "../logging/logger.js";
 import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { resolveUserPath } from "../utils.js";
@@ -207,7 +206,6 @@ async function assertSecurePath(params: {
   allowInsecurePath?: boolean;
   allowReadableByOthers?: boolean;
   allowSymlinkPath?: boolean;
-  isExecPath?: boolean;
 }): Promise<string> {
   if (!isAbsolutePathname(params.targetPath)) {
     throw new Error(`${params.label} must be an absolute path.`);
@@ -255,15 +253,9 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
-    if (params.isExecPath) {
-      throw new Error(
-        `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this check when the path is trusted.`,
-      );
-    }
-    getLogger().warn(
-      `${params.label} ACL verification unavailable on Windows for ${effectivePath}, skipping permission check.`,
+    throw new Error(
+      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this check when the path is trusted.`,
     );
-    return effectivePath;
   }
 
   if (process.platform !== "win32" && typeof process.getuid === "function" && stat.uid != null) {
@@ -294,6 +286,7 @@ async function readFileProviderPayload(params: {
     const secureFilePath = await assertSecurePath({
       targetPath: filePath,
       label: `secrets.providers.${params.providerName}.path`,
+      allowInsecurePath: params.providerConfig.allowInsecurePath,
     });
     const timeoutMs = normalizePositiveInt(
       params.providerConfig.timeoutMs,
@@ -678,7 +671,6 @@ async function resolveExecRefs(params: {
       allowInsecurePath: params.providerConfig.allowInsecurePath,
       allowReadableByOthers: true,
       allowSymlinkPath: params.providerConfig.allowSymlinkCommand,
-      isExecPath: true,
     });
   } catch (err) {
     throwUnknownProviderResolutionError({

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -10,6 +10,7 @@ import type {
   SecretRefSource,
 } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { getLogger } from "../logging/logger.js";
 import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { resolveUserPath } from "../utils.js";
@@ -253,9 +254,10 @@ async function assertSecurePath(params: {
   }
 
   if (process.platform === "win32" && perms.source === "unknown") {
-    throw new Error(
-      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this provider to bypass this check when the path is trusted.`,
+    getLogger().warn(
+      `${params.label} ACL verification unavailable on Windows for ${effectivePath}, skipping permission check.`,
     );
+    return effectivePath;
   }
 
   if (process.platform !== "win32" && typeof process.getuid === "function" && stat.uid != null) {
@@ -309,7 +311,7 @@ async function readFileProviderPayload(params: {
       if (payload.byteLength > maxBytes) {
         throw new Error(`File provider "${params.providerName}" exceeded maxBytes (${maxBytes}).`);
       }
-      const text = payload.toString("utf8");
+      const text = payload.toString("utf8").replace(/^\uFEFF/, "");
       if (params.providerConfig.mode === "singleValue") {
         return text.replace(/\r?\n$/, "");
       }

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -440,7 +440,7 @@ Successfully processed 1 files`;
       expectInspectSuccess(result, 2);
       // /sid is passed so that account names are printed as SIDs, making the
       // audit locale-independent (fixes #35834).
-      expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt", "/sid"]);
+      expect(mockExec).toHaveBeenCalledWith("icacls.exe", ["C:\\test\\file.txt", "/sid"]);
     });
 
     it("classifies *S-1-5-18 (SID form of SYSTEM from /sid) as trusted", async () => {
@@ -485,8 +485,8 @@ Successfully processed 1 files`;
       expectInspectSuccess(result, 2);
       expect(result.trusted).toHaveLength(2);
       expect(result.untrustedGroup).toHaveLength(0);
-      expect(mockExec).toHaveBeenNthCalledWith(1, "icacls", ["C:\\test\\file.txt", "/sid"]);
-      expect(mockExec).toHaveBeenNthCalledWith(2, "whoami", ["/user", "/fo", "csv", "/nh"]);
+      expect(mockExec).toHaveBeenNthCalledWith(1, "icacls.exe", ["C:\\test\\file.txt", "/sid"]);
+      expect(mockExec).toHaveBeenNthCalledWith(2, "whoami.exe", ["/user", "/fo", "csv", "/nh"]);
     });
 
     it("returns error state on exec failure", async () => {
@@ -533,6 +533,36 @@ Successfully processed 1 files`;
       // Unknown SID stays in untrustedGroup (resolveCurrentUserSid returned null)
       expect(result.untrustedGroup).toHaveLength(1);
       expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses SystemRoot for Windows system commands when available", async () => {
+      const mockExec = vi
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "C:\\test\\file.txt *S-1-5-21-111-222-333-1001:(F)",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: '"mock-host\\\\MockUser","S-1-5-21-111-222-333-1001"\r\n',
+          stderr: "",
+        });
+
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+        env: { SystemRoot: "C:\\Windows" },
+      });
+
+      expectInspectSuccess(result, 1);
+      expect(mockExec).toHaveBeenNthCalledWith(1, "C:\\Windows\\System32\\icacls.exe", [
+        "C:\\test\\file.txt",
+        "/sid",
+      ]);
+      expect(mockExec).toHaveBeenNthCalledWith(2, "C:\\Windows\\System32\\whoami.exe", [
+        "/user",
+        "/fo",
+        "csv",
+        "/nh",
+      ]);
     });
   });
 

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import path from "node:path";
 import { runExec } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
@@ -98,6 +99,15 @@ function buildTrustedPrincipals(env?: NodeJS.ProcessEnv): Set<string> {
     trusted.add(userSid);
   }
   return trusted;
+}
+
+function resolveWindowsSystemCommand(command: string, env?: NodeJS.ProcessEnv): string {
+  const root =
+    env?.SystemRoot?.trim() ||
+    env?.SYSTEMROOT?.trim() ||
+    env?.windir?.trim() ||
+    env?.WINDIR?.trim();
+  return root ? path.win32.join(root, "System32", command) : command;
 }
 
 function classifyPrincipal(
@@ -270,9 +280,17 @@ export function summarizeWindowsAcl(
   return { trusted, untrustedWorld, untrustedGroup };
 }
 
-async function resolveCurrentUserSid(exec: ExecFn): Promise<string | null> {
+async function resolveCurrentUserSid(
+  exec: ExecFn,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | null> {
   try {
-    const { stdout, stderr } = await exec("whoami", ["/user", "/fo", "csv", "/nh"]);
+    const { stdout, stderr } = await exec(resolveWindowsSystemCommand("whoami.exe", env), [
+      "/user",
+      "/fo",
+      "csv",
+      "/nh",
+    ]);
     const match = `${stdout}\n${stderr}`.match(/\*?S-\d+-\d+(?:-\d+)+/i);
     return match ? normalizeSid(match[0]) : null;
   } catch (err) {
@@ -297,7 +315,10 @@ export async function inspectWindowsAcl(
     // Windows (Russian, Chinese, etc.) where icacls prints Cyrillic / CJK
     // characters that may be garbled when Node reads them in the wrong code
     // page.  Fixes #35834.
-    const { stdout, stderr } = await exec("icacls", [targetPath, "/sid"]);
+    const { stdout, stderr } = await exec(resolveWindowsSystemCommand("icacls.exe", opts?.env), [
+      targetPath,
+      "/sid",
+    ]);
     const output = `${stdout}\n${stderr}`.trim();
     const entries = parseIcaclsOutput(output, targetPath);
     let effectiveEnv = opts?.env;
@@ -307,7 +328,7 @@ export async function inspectWindowsAcl(
       !effectiveEnv?.USERSID &&
       untrustedGroup.some((entry) => SID_RE.test(normalize(entry.principal)));
     if (needsUserSidResolution) {
-      const currentUserSid = await resolveCurrentUserSid(exec);
+      const currentUserSid = await resolveCurrentUserSid(exec, effectiveEnv);
       if (currentUserSid) {
         effectiveEnv = { ...effectiveEnv, USERSID: currentUserSid };
         ({ trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, effectiveEnv));


### PR DESCRIPTION
## Summary
Fixes #70640

### Issue
OpenClaw v2026.4.21 crashes on Windows due to two issues:
1. ACL verification throws when `perms.source` is `"unknown"` on Windows
2. `secrets.json` with UTF-8 BOM cannot be parsed

### Changes
1. **Windows ACL graceful degradation**: Changed `assertSecurePath()` to log a warning and continue (instead of throwing) when `perms.source === "unknown"` on Windows. This prevents the gateway from crashing on Windows where ACL info is often unavailable.

2. **UTF-8 BOM stripping**: Added `.replace(/^\uFEFF/, "")` when reading file provider payloads to strip UTF-8 BOM before `JSON.parse()`. This handles `secrets.json` files created by Windows editors that add BOM.

### Fix Before vs After
| | Before | After |
|---|---|---|
| Windows ACL | `throw new Error(...)` → gateway crash | `logger.warn(...)` → graceful continue |
| BOM in secrets.json | `JSON.parse` fails with syntax error | BOM stripped before parse |

### Testing
- 3 new test cases added to `resolve.test.ts`:
  - UTF-8 BOM stripping in JSON mode
  - UTF-8 BOM stripping in singleValue mode
  - Windows ACL unknown source graceful handling

---
*This PR was generated by the daily Issue→PR automation task.*