### PR TITLE
fix(discord): repair thread-bound session spawns

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -489,6 +489,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       },
       actions: discordMessageActions,
       bindings: {
+        selfParentConversationByDefault: true,
         compileConfiguredBinding: ({ conversationId }) =>
           normalizeDiscordAcpConversationId(conversationId),
         matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) =>

--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -193,6 +193,15 @@ describe("discord subagent hook handlers", () => {
 
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledTimes(1);
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        channels: expect.objectContaining({
+          discord: expect.objectContaining({
+            threadBindings: expect.objectContaining({
+              spawnSubagentSessions: true,
+            }),
+          }),
+        }),
+      }),
       accountId: "work",
       channel: "discord",
       to: "channel:123",

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -126,6 +126,7 @@ export async function handleDiscordSubagentSpawning(
   try {
     const agentId = event.agentId?.trim() || "subagent";
     const binding = await autoBindSpawnedDiscordSubagent({
+      cfg: api.config,
       accountId: event.requester?.accountId,
       channel: event.requester?.channel,
       to: event.requester?.to,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -719,6 +719,22 @@ describe("spawnAcpDirect", () => {
   });
 
   it("uses the top-level Discord channel as the parent for child ACP thread spawns", async () => {
+    const discordPlugin = {
+      id: "discord",
+      bindings: {
+        selfParentConversationByDefault: true,
+      },
+      conversationBindings: {
+        defaultTopLevelPlacement: "child" as const,
+      },
+    };
+    hoisted.getLoadedChannelPluginMock.mockImplementation((channelId: string) =>
+      channelId === "discord" ? discordPlugin : undefined,
+    );
+    hoisted.getChannelPluginMock.mockImplementation((channelId: string) =>
+      channelId === "discord" ? discordPlugin : undefined,
+    );
+
     const result = await spawnAcpDirect(
       {
         task: "Investigate flaky tests",
@@ -770,6 +786,10 @@ describe("spawnAcpDirect", () => {
       },
     });
     const discordPlugin = {
+      id: "discord",
+      bindings: {
+        selfParentConversationByDefault: true,
+      },
       config: {
         defaultAccountId: () => "finn",
       },

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -718,6 +718,108 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("uses the top-level Discord channel as the parent for child ACP thread spawns", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    const bindCall = hoisted.sessionBindingBindMock.mock.calls.at(-1)?.[0] as
+      | {
+          placement?: string;
+          conversation?: { conversationId?: string; parentConversationId?: string };
+        }
+      | undefined;
+    expect(bindCall?.placement).toBe("child");
+    expect(bindCall?.conversation?.conversationId).toBeTruthy();
+    expect(bindCall?.conversation?.parentConversationId).toBe(
+      bindCall?.conversation?.conversationId,
+    );
+  });
+
+  it("uses the Discord plugin default account for ACP thread bindings", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      channels: {
+        ...hoisted.state.cfg.channels,
+        discord: {
+          threadBindings: {
+            enabled: true,
+            spawnAcpSessions: true,
+          },
+          accounts: {
+            finn: {
+              threadBindings: {
+                enabled: true,
+                spawnAcpSessions: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    const discordPlugin = {
+      config: {
+        defaultAccountId: () => "finn",
+      },
+      conversationBindings: {
+        defaultTopLevelPlacement: "child" as const,
+      },
+    };
+    hoisted.getLoadedChannelPluginMock.mockImplementation((channelId: string) =>
+      channelId === "discord" ? discordPlugin : undefined,
+    );
+    hoisted.getChannelPluginMock.mockImplementation((channelId: string) =>
+      channelId === "discord" ? discordPlugin : undefined,
+    );
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "finn",
+      capabilities: createSessionBindingCapabilities(),
+      bind: async (input) => await hoisted.sessionBindingBindMock(input),
+      listBySession: (targetSessionKey) =>
+        hoisted.sessionBindingListBySessionMock(targetSessionKey),
+      resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+      unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: expect.objectContaining({
+          channel: "discord",
+          accountId: "finn",
+        }),
+      }),
+    );
+    expect(findAgentGatewayCall()?.params?.accountId).toBe("finn");
+  });
+
   it("passes model override into ACP session initialization", async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -641,12 +641,6 @@ function prepareAcpThreadBinding(params: {
       error: `Could not resolve a ${policy.channel} conversation for ACP thread spawn.`,
     };
   }
-  const parentConversationId =
-    conversationRef.parentConversationId ??
-    (policy.channel === "discord" && placementToUse === "child" && params.threadId == null
-      ? conversationRef.conversationId
-      : undefined);
-
   return {
     ok: true,
     binding: {
@@ -654,7 +648,9 @@ function prepareAcpThreadBinding(params: {
       accountId: policy.accountId,
       placement: placementToUse,
       conversationId: conversationRef.conversationId,
-      ...(parentConversationId ? { parentConversationId } : {}),
+      ...(conversationRef.parentConversationId
+        ? { parentConversationId: conversationRef.parentConversationId }
+        : {}),
     },
   };
 }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -16,6 +16,7 @@ import {
   resolveChannelDefaultBindingPlacement,
   resolveInboundConversationResolution,
 } from "../channels/conversation-resolution.js";
+import { getChannelPlugin, getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import {
   resolveThreadBindingIntroText,
   resolveThreadBindingThreadName,
@@ -546,7 +547,14 @@ function resolveAcpSpawnChannelAccountId(params: {
   }
   const channels = params.cfg.channels as Record<string, { defaultAccount?: unknown } | undefined>;
   const configuredDefaultAccountId = channels?.[channel]?.defaultAccount;
-  return normalizeOptionalString(configuredDefaultAccountId) ?? "default";
+  return (
+    normalizeOptionalString(configuredDefaultAccountId) ??
+    normalizeOptionalString(
+      getLoadedChannelPlugin(channel)?.config.defaultAccountId?.(params.cfg),
+    ) ??
+    normalizeOptionalString(getChannelPlugin(channel)?.config.defaultAccountId?.(params.cfg)) ??
+    "default"
+  );
 }
 
 function prepareAcpThreadBinding(params: {
@@ -633,6 +641,11 @@ function prepareAcpThreadBinding(params: {
       error: `Could not resolve a ${policy.channel} conversation for ACP thread spawn.`,
     };
   }
+  const parentConversationId =
+    conversationRef.parentConversationId ??
+    (policy.channel === "discord" && placementToUse === "child" && params.threadId == null
+      ? conversationRef.conversationId
+      : undefined);
 
   return {
     ok: true,
@@ -641,9 +654,7 @@ function prepareAcpThreadBinding(params: {
       accountId: policy.accountId,
       placement: placementToUse,
       conversationId: conversationRef.conversationId,
-      ...(conversationRef.parentConversationId
-        ? { parentConversationId: conversationRef.parentConversationId }
-        : {}),
+      ...(parentConversationId ? { parentConversationId } : {}),
     },
   };
 }

--- a/src/infra/outbound/session-binding-service.test.ts
+++ b/src/infra/outbound/session-binding-service.test.ts
@@ -143,6 +143,40 @@ describe("session binding service", () => {
     expect(result.conversation.conversationId).toBe("thread-created");
   });
 
+  it("preserves explicit self-parent refs for child placement adapters", async () => {
+    const bind = vi.fn(async (input: SessionBindingBindInput) => createRecord(input));
+    registerSessionBindingAdapter({
+      channel: "demo-binding",
+      accountId: "default",
+      capabilities: { placements: ["child"] },
+      bind,
+      listBySession: () => [],
+      resolveByConversation: () => null,
+    });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:1",
+      targetKind: "session",
+      conversation: {
+        channel: "demo-binding",
+        accountId: "default",
+        conversationId: "channel-parent",
+        parentConversationId: "channel-parent",
+      },
+      placement: "child",
+    });
+
+    expect(bind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "child",
+        conversation: expect.objectContaining({
+          conversationId: "channel-parent",
+          parentConversationId: "channel-parent",
+        }),
+      }),
+    );
+  });
+
   it("returns structured errors when adapter is unavailable", async () => {
     await expect(
       getSessionBindingService().bind({

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -1,4 +1,5 @@
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   __testing as genericCurrentConversationBindingTesting,
   bindGenericCurrentConversation,
@@ -300,9 +301,19 @@ function createDefaultSessionBindingService(): SessionBindingService {
           },
         );
       }
+      const requestedParentConversationId = normalizeOptionalString(
+        input.conversation.parentConversationId,
+      );
+      const conversationForAdapter =
+        placement === "child" && requestedParentConversationId
+          ? {
+              ...normalizedConversation,
+              parentConversationId: requestedParentConversationId,
+            }
+          : normalizedConversation;
       const bound = await adapter.bind({
         ...input,
-        conversation: normalizedConversation,
+        conversation: conversationForAdapter,
         placement,
       });
       if (!bound) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord thread-bound ACP and subagent session spawns can fail before creating a child thread binding.
- Why it matters: `sessions_spawn({ thread: true, mode: "session" })` is the documented path for persistent Discord child-agent lanes.
- What changed: preserve parent conversation/account context for ACP child bindings and pass resolved runtime config into Discord subagent auto-bind.
- What did NOT change (scope boundary): no config default changes, no token storage changes, no new Discord permissions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #38141
- Related #40077
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Discord child thread binding paths dropped context needed by the binding adapter. ACP binding could lose the active/default account or parent conversation, and subagent binding delegated without `api.config`, so Discord channel/thread creation could fail and collapse into the generic session-mode unavailable error.
- Missing detection / guardrail: existing tests covered lower-level binding helpers but not the hook/adapter delegation boundaries that preserve this context.
- Contributing context (if known): ACP and non-ACP thread-bound spawns use different binding paths, so one modality can work while the other still fails.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/acp-spawn.test.ts`, `src/infra/outbound/session-binding-service.test.ts`, `extensions/discord/src/subagent-hooks.test.ts`
- Scenario the test should lock in: child thread bindings preserve account/parent conversation context and subagent hooks pass runtime config into Discord auto-bind.
- Why this is the smallest reliable guardrail: these are the exact seams that dropped the required context before the Discord adapter performed the bind.
- Existing test that already covers this (if any): lower-level lifecycle tests cover direct auto-bind behavior once cfg/context is supplied.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord `sessions_spawn` with `thread: true` should be able to create persistent child session threads when the bot/config already allow thread bindings.

## Diagram (if applicable)

```text
Before:
sessions_spawn(thread=true) -> bind path loses context -> generic thread bind failure

After:
sessions_spawn(thread=true) -> preserve account/config/parent conversation -> Discord thread binding can be created
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw source checkout
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord thread bindings enabled with subagent/ACP spawn enabled

### Steps

1. From a Discord-backed session, spawn a child session with `thread: true`.
2. Exercise ACP child binding and non-ACP subagent hook binding paths.
3. Verify the relevant binding context reaches the Discord binding adapter.

### Expected

- Binding paths preserve account/config/parent conversation data and can create the Discord child thread.

### Actual

- Before this PR, one path could fall back to the wrong/missing context and the subagent hook omitted runtime config.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification:

```text
pnpm test extensions/discord/src/subagent-hooks.test.ts extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts src/agents/acp-spawn.test.ts src/infra/outbound/session-binding-service.test.ts

Test Files  4 passed
Tests       107 passed
```

Commit hook verification:

```text
scripts/committer "fix(discord): pass config to subagent thread binding" ...
check:changed lanes=extensions, extensionTests
Discord extension shard: 121 passed / 1014 tests
```

## Human Verification (required)

- Verified scenarios: targeted binding tests pass after rebasing onto current `origin/main`.
- Edge cases checked: ACP spawn binding tests, session binding service tests, Discord subagent hook tests, and Discord binding lifecycle tests.
- What you did **not** verify: live production Discord gateway roundtrip after install.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: live Discord permissions or concurrency caps can still block a spawn even after binding context is correct.
  - Mitigation: this PR only fixes context propagation; live operators should still check bot permissions and active ACP session limits when diagnosing failures.
