### PR TITLE
feat(openai): add Codex OAuth image generation provider

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -470,4 +470,38 @@ describe("openai image generation provider", () => {
       );
     });
   });
+
+  it.each([
+    {
+      name: "generation",
+      inputImages: undefined,
+      expectedMessage: "OpenAI Codex image generation failed",
+    },
+    {
+      name: "edit",
+      inputImages: [{ buffer: Buffer.from("x"), mimeType: "image/png" }],
+      expectedMessage: "OpenAI Codex image edit failed",
+    },
+  ])("uses the codex provider label in $name failure messages", async ({ inputImages, expectedMessage }) => {
+    postJsonRequestMock.mockResolvedValue({
+      response: {} as Response,
+      release: vi.fn(async () => {}),
+    });
+    assertOkOrThrowHttpErrorMock.mockRejectedValueOnce(new Error(expectedMessage));
+
+    const provider = buildOpenAIImageGenerationProvider("openai-codex");
+
+    await expect(
+      provider.generateImage({
+        provider: "openai-codex",
+        model: "gpt-image-2",
+        prompt: "draw a cat",
+        cfg: {},
+        authStore: { version: 1, profiles: {} },
+        inputImages,
+      }),
+    ).rejects.toThrow(expectedMessage);
+
+    expect(assertOkOrThrowHttpErrorMock).toHaveBeenCalledWith(expect.anything(), expectedMessage);
+  });
 });

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -11,6 +11,7 @@ import { OPENAI_DEFAULT_IMAGE_MODEL as DEFAULT_OPENAI_IMAGE_MODEL } from "./defa
 import { resolveConfiguredOpenAIBaseUrl, toOpenAIDataUrl } from "./shared.js";
 
 const DEFAULT_OPENAI_IMAGE_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_OPENAI_CODEX_IMAGE_BASE_URL = "https://chatgpt.com/backend-api";
 const DEFAULT_OUTPUT_MIME = "image/png";
 const DEFAULT_SIZE = "1024x1024";
 const OPENAI_SUPPORTED_SIZES = [
@@ -24,6 +25,9 @@ const OPENAI_SUPPORTED_SIZES = [
 ] as const;
 const OPENAI_MAX_INPUT_IMAGES = 5;
 const MOCK_OPENAI_PROVIDER_ID = "mock-openai";
+const OPENAI_IMAGE_PROVIDER_IDS = ["openai", "openai-codex"] as const;
+
+type OpenAIImageProviderId = (typeof OPENAI_IMAGE_PROVIDER_IDS)[number];
 
 const AZURE_HOSTNAME_SUFFIXES = [
   ".openai.azure.com",
@@ -80,17 +84,36 @@ type OpenAIImageApiResponse = {
   }>;
 };
 
-export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
+function getProviderLabel(provider: OpenAIImageProviderId): string {
+  return provider === "openai-codex" ? "OpenAI Codex" : "OpenAI";
+}
+
+function resolveOpenAIImageBaseUrl(
+  provider: OpenAIImageProviderId,
+  cfg: OpenClawConfig | undefined,
+): string {
+  if (provider === "openai") {
+    return resolveConfiguredOpenAIBaseUrl(cfg);
+  }
+  return cfg?.models?.providers?.["openai-codex"]?.baseUrl?.trim() || DEFAULT_OPENAI_CODEX_IMAGE_BASE_URL;
+}
+
+function isConfiguredForProvider(provider: OpenAIImageProviderId, agentDir?: string): boolean {
+  return isProviderApiKeyConfigured({
+    provider,
+    agentDir,
+  });
+}
+
+export function buildOpenAIImageGenerationProvider(
+  provider: OpenAIImageProviderId = "openai",
+): ImageGenerationProvider {
   return {
-    id: "openai",
-    label: "OpenAI",
+    id: provider,
+    label: getProviderLabel(provider),
     defaultModel: DEFAULT_OPENAI_IMAGE_MODEL,
     models: [DEFAULT_OPENAI_IMAGE_MODEL],
-    isConfigured: ({ agentDir }) =>
-      isProviderApiKeyConfigured({
-        provider: "openai",
-        agentDir,
-      }),
+    isConfigured: ({ agentDir }) => isConfiguredForProvider(provider, agentDir),
     capabilities: {
       generate: {
         maxCount: 4,
@@ -114,26 +137,34 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
       const inputImages = req.inputImages ?? [];
       const isEdit = inputImages.length > 0;
       const auth = await resolveApiKeyForProvider({
-        provider: "openai",
+        provider,
         cfg: req.cfg,
         agentDir: req.agentDir,
         store: req.authStore,
       });
       if (!auth.apiKey) {
-        throw new Error("OpenAI API key missing");
+        throw new Error(
+          provider === "openai-codex"
+            ? "OpenAI Codex OAuth token missing"
+            : "OpenAI API key missing",
+        );
       }
-      const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
-      const isAzure = isAzureOpenAIBaseUrl(rawBaseUrl);
+      const rawBaseUrl = resolveOpenAIImageBaseUrl(provider, req.cfg);
+      const isAzure = provider === "openai" && isAzureOpenAIBaseUrl(rawBaseUrl);
 
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
         resolveProviderHttpRequestConfig({
           baseUrl: rawBaseUrl,
-          defaultBaseUrl: DEFAULT_OPENAI_IMAGE_BASE_URL,
-          allowPrivateNetwork: shouldAllowPrivateImageEndpoint(req),
+          defaultBaseUrl:
+            provider === "openai-codex"
+              ? DEFAULT_OPENAI_CODEX_IMAGE_BASE_URL
+              : DEFAULT_OPENAI_IMAGE_BASE_URL,
+          allowPrivateNetwork:
+            provider === "openai" ? shouldAllowPrivateImageEndpoint(req) : false,
           defaultHeaders: isAzure
             ? { "api-key": auth.apiKey }
             : { Authorization: `Bearer ${auth.apiKey}` },
-          provider: "openai",
+          provider,
           capability: "image",
           transport: "http",
         });
@@ -191,7 +222,9 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
       try {
         await assertOkOrThrowHttpError(
           response,
-          isEdit ? "OpenAI image edit failed" : "OpenAI image generation failed",
+          isEdit
+            ? `${getProviderLabel(provider)} image edit failed`
+            : `${getProviderLabel(provider)} image generation failed`,
         );
 
         const data = (await response.json()) as OpenAIImageApiResponse;
@@ -202,7 +235,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
             }
             return Object.assign(
               {
-                buffer: Buffer.from(entry.b64_json, `base64`),
+                buffer: Buffer.from(entry.b64_json, "base64"),
                 mimeType: DEFAULT_OUTPUT_MIME,
                 fileName: `image-${index + 1}.png`,
               },

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -97,31 +97,48 @@ function expectOpenAIPromptContribution(
   });
 }
 
-function mockOpenAIImageApiResponse(params: {
-  finalUrl: string;
-  imageData: string;
-  revisedPrompt?: string;
+function mockOpenAIImageApiResponses(params: {
+  authValue: string;
+  authMode: "api-key" | "oauth";
+  generationFinalUrl: string;
+  editFinalUrl: string;
 }) {
   const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-    apiKey: "sk-test",
+    apiKey: params.authValue,
     source: "env",
-    mode: "api-key",
+    mode: params.authMode,
   });
-  const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({
-    finalUrl: params.finalUrl,
-    response: {
-      ok: true,
-      json: async () => ({
-        data: [
-          {
-            b64_json: Buffer.from(params.imageData).toString("base64"),
-            ...(params.revisedPrompt ? { revised_prompt: params.revisedPrompt } : {}),
-          },
-        ],
-      }),
-    } as Response,
-    release: vi.fn(async () => {}),
-  });
+  const postJsonRequestSpy = vi
+    .spyOn(providerHttp, "postJsonRequest")
+    .mockResolvedValueOnce({
+      finalUrl: params.generationFinalUrl,
+      response: {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              b64_json: Buffer.from("png-data").toString("base64"),
+              revised_prompt: "revised",
+            },
+          ],
+        }),
+      } as Response,
+      release: vi.fn(async () => {}),
+    })
+    .mockResolvedValueOnce({
+      finalUrl: params.editFinalUrl,
+      response: {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              b64_json: Buffer.from("edited-image").toString("base64"),
+            },
+          ],
+        }),
+      } as Response,
+      release: vi.fn(async () => {}),
+    });
   vi.spyOn(providerHttp, "assertOkOrThrowHttpError").mockResolvedValue(undefined);
   return { resolveApiKeySpy, postJsonRequestSpy };
 }
@@ -135,118 +152,140 @@ describe("openai plugin", () => {
     vi.restoreAllMocks();
   });
 
-  it("generates PNG buffers from the OpenAI Images API", async () => {
-    const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
-      finalUrl: "https://api.openai.com/v1/images/generations",
-      imageData: "png-data",
-      revisedPrompt: "revised",
-    });
+  it.each<{
+    providerId: "openai" | "openai-codex";
+    authValue: string;
+    authMode: "api-key" | "oauth";
+    generationEndpoint: string;
+    editEndpoint: string;
+  }>([
+    {
+      providerId: "openai",
+      authValue: "sk-test",
+      authMode: "api-key" as const,
+      generationEndpoint: "https://api.openai.com/v1/images/generations",
+      editEndpoint: "https://api.openai.com/v1/images/edits",
+    },
+    {
+      providerId: "openai-codex",
+      authValue: "oauth-token",
+      authMode: "oauth" as const,
+      generationEndpoint: "https://chatgpt.com/backend-api/images/generations",
+      editEndpoint: "https://chatgpt.com/backend-api/images/edits",
+    },
+  ])(
+    "supports image generation and edits for $providerId",
+    async ({ providerId, authValue, authMode, generationEndpoint, editEndpoint }) => {
+      const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponses({
+        authValue,
+        authMode,
+        generationFinalUrl: generationEndpoint,
+        editFinalUrl: editEndpoint,
+      });
 
-    const provider = buildOpenAIImageGenerationProvider();
-    const authStore = { version: 1, profiles: {} };
-    const result = await provider.generateImage({
-      provider: "openai",
-      model: "gpt-image-2",
-      prompt: "draw a cat",
-      cfg: {},
-      authStore,
-      count: 2,
-      size: "2048x2048",
-    });
+      const provider = buildOpenAIImageGenerationProvider(providerId);
+      const authStore = { version: 1, profiles: {} };
+      const generated = await provider.generateImage({
+        provider: providerId,
+        model: "gpt-image-2",
+        prompt: "draw a cat",
+        cfg: {},
+        authStore,
+        count: 2,
+        size: "2048x2048",
+      });
 
-    expect(resolveApiKeySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "openai",
-        store: authStore,
-      }),
+      expect(resolveApiKeySpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          provider: providerId,
+          store: authStore,
+        }),
+      );
+      expect(postJsonRequestSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          url: generationEndpoint,
+          body: {
+            model: "gpt-image-2",
+            prompt: "draw a cat",
+            n: 2,
+            size: "2048x2048",
+          },
+        }),
+      );
+      expect(generated).toEqual({
+        images: [
+          {
+            buffer: Buffer.from("png-data"),
+            mimeType: "image/png",
+            fileName: "image-1.png",
+            revisedPrompt: "revised",
+          },
+        ],
+        model: "gpt-image-2",
+      });
+
+      const edited = await provider.generateImage({
+        provider: providerId,
+        model: "gpt-image-2",
+        prompt: "Edit this image",
+        cfg: {},
+        authStore,
+        count: 2,
+        size: "1536x1024",
+        inputImages: [
+          { buffer: Buffer.from("x"), mimeType: "image/png" },
+          { buffer: Buffer.from("y"), mimeType: "image/jpeg", fileName: "ref.jpg" },
+        ],
+      });
+
+      expect(resolveApiKeySpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: providerId,
+          store: authStore,
+        }),
+      );
+      expect(postJsonRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          url: editEndpoint,
+          body: {
+            model: "gpt-image-2",
+            prompt: "Edit this image",
+            n: 2,
+            size: "1536x1024",
+            images: [
+              {
+                image_url: "data:image/png;base64,eA==",
+              },
+              {
+                image_url: "data:image/jpeg;base64,eQ==",
+              },
+            ],
+          },
+        }),
+      );
+      expect(edited).toEqual({
+        images: [
+          {
+            buffer: Buffer.from("edited-image"),
+            mimeType: "image/png",
+            fileName: "image-1.png",
+          },
+        ],
+        model: "gpt-image-2",
+      });
+    },
+  );
+
+  it("registers openai-codex as an image generation provider in the plugin runtime", async () => {
+    const providers = await registerOpenAIPlugin();
+
+    expect(providers.imageProviders.map((provider) => provider.id)).toEqual(
+      expect.arrayContaining(["openai", "openai-codex"]),
     );
-    expect(postJsonRequestSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: "https://api.openai.com/v1/images/generations",
-        body: {
-          model: "gpt-image-2",
-          prompt: "draw a cat",
-          n: 2,
-          size: "2048x2048",
-        },
-      }),
-    );
-    expect(postJsonRequestSpy).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: "https://api.openai.com/v1/images/edits",
-      }),
-    );
-    expect(result).toEqual({
-      images: [
-        {
-          buffer: Buffer.from("png-data"),
-          mimeType: "image/png",
-          fileName: "image-1.png",
-          revisedPrompt: "revised",
-        },
-      ],
-      model: "gpt-image-2",
-    });
-  });
-
-  it("submits reference-image edits to the OpenAI Images edits endpoint", async () => {
-    const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
-      finalUrl: "https://api.openai.com/v1/images/edits",
-      imageData: "edited-image",
-    });
-
-    const provider = buildOpenAIImageGenerationProvider();
-    const authStore = { version: 1, profiles: {} };
-
-    const result = await provider.generateImage({
-      provider: "openai",
-      model: "gpt-image-2",
-      prompt: "Edit this image",
-      cfg: {},
-      authStore,
-      count: 2,
-      size: "1536x1024",
-      inputImages: [
-        { buffer: Buffer.from("x"), mimeType: "image/png" },
-        { buffer: Buffer.from("y"), mimeType: "image/jpeg", fileName: "ref.jpg" },
-      ],
-    });
-
-    expect(resolveApiKeySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "openai",
-        store: authStore,
-      }),
-    );
-    expect(postJsonRequestSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: "https://api.openai.com/v1/images/edits",
-        body: {
-          model: "gpt-image-2",
-          prompt: "Edit this image",
-          n: 2,
-          size: "1536x1024",
-          images: [
-            {
-              image_url: "data:image/png;base64,eA==",
-            },
-            {
-              image_url: "data:image/jpeg;base64,eQ==",
-            },
-          ],
-        },
-      }),
-    );
-    expect(result).toEqual({
-      images: [
-        {
-          buffer: Buffer.from("edited-image"),
-          mimeType: "image/png",
-          fileName: "image-1.png",
-        },
-      ],
-      model: "gpt-image-2",
-    });
   });
 
   it("does not allow private-network routing just because a custom base URL is configured", async () => {

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -48,7 +48,7 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 
 import { refreshOpenAICodexToken } from "./openai-codex-provider.runtime.js";
 
-const _registerOpenAIPlugin = async () =>
+const registerOpenAIPlugin = async () =>
   registerProviderPlugin({
     plugin,
     id: "openai",

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -48,7 +48,8 @@ export default definePluginEntry({
     api.registerProvider(buildProviderWithPromptContribution(buildOpenAIProvider()));
     api.registerProvider(buildProviderWithPromptContribution(buildOpenAICodexProviderPlugin()));
     api.registerMemoryEmbeddingProvider(openAiMemoryEmbeddingProviderAdapter);
-    api.registerImageGenerationProvider(buildOpenAIImageGenerationProvider());
+    api.registerImageGenerationProvider(buildOpenAIImageGenerationProvider("openai"));
+    api.registerImageGenerationProvider(buildOpenAIImageGenerationProvider("openai-codex"));
     api.registerRealtimeTranscriptionProvider(buildOpenAIRealtimeTranscriptionProvider());
     api.registerRealtimeVoiceProvider(buildOpenAIRealtimeVoiceProvider());
     api.registerSpeechProvider(buildOpenAISpeechProvider());

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -54,7 +54,7 @@
     "realtimeVoiceProviders": ["openai"],
     "memoryEmbeddingProviders": ["openai"],
     "mediaUnderstandingProviders": ["openai", "openai-codex"],
-    "imageGenerationProviders": ["openai"],
+    "imageGenerationProviders": ["openai", "openai-codex"],
     "videoGenerationProviders": ["openai"]
   },
   "mediaUnderstandingProviderMetadata": {

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -104,7 +104,7 @@ export const pluginRegistrationContractCases = {
     realtimeTranscriptionProviderIds: ["openai"],
     realtimeVoiceProviderIds: ["openai"],
     mediaUnderstandingProviderIds: ["openai", "openai-codex"],
-    imageGenerationProviderIds: ["openai"],
+    imageGenerationProviderIds: ["openai", "openai-codex"],
     requireSpeechVoices: true,
     requireDescribeImages: true,
     requireGenerateImage: true,


### PR DESCRIPTION
## Summary
- add `openai-codex` as a native image generation provider in the bundled OpenAI extension
- reuse existing OpenClaw Codex OAuth credential resolution for `gpt-image-2`
- exercise both API-key and Codex OAuth image generation paths in extension tests

## Why
OpenClaw already had most of the Codex OAuth plumbing, but `openai-codex` was not registered as an image generation provider. This closes that gap so Codex-authenticated setups can use native image generation without requiring `OPENAI_API_KEY`.

## Testing
- AI-assisted: yes
- Testing level: lightly tested + live smoke tested locally
- `node scripts/run-vitest.mjs run --config vitest.config.ts extensions/openai/index.test.ts`
- local live smoke test through `image_generate` with `openai-codex/gpt-image-2`

## Notes
- kept the change focused to the bundled OpenAI extension only
- left unrelated local `pnpm-lock.yaml` workspace noise out of the commit
