### PR TITLE
fix(infra/restart): verify gateway PIDs via ps argv on Unix, not lsof p_comm

### DIFF
--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -180,12 +180,19 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockReadWindowsProcessArgs.mockReturnValue(null);
     mockReadWindowsProcessArgsResult.mockReturnValue({ ok: true, args: null });
     __testing.setSleepSyncOverride(() => {});
+    // Default: bypass the ps-based gateway-argv verifier. Most tests drive
+    // classification via the lsof `c` (command-name) field they inject into
+    // the mock stdout; the real ps call would land on the same mockSpawnSync
+    // mock that's shaped for lsof and would spuriously mis-verify. Tests that
+    // want to exercise verifyGatewayPidByArgvSync specifically override this.
+    __testing.setVerifyGatewayPidByArgvOverride(() => true);
   });
 
   afterEach(() => {
     __testing.setSleepSyncOverride(null);
     __testing.setDateNowOverride(null);
     __testing.setParentPidOverride(null);
+    __testing.setVerifyGatewayPidByArgvOverride(null);
     vi.restoreAllMocks();
   });
 
@@ -383,7 +390,12 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       },
     );
 
-    it("excludes pids whose command does not include 'openclaw'", () => {
+    it("excludes pids whose argv does not identify them as an openclaw gateway", () => {
+      // The classification is done by verifyGatewayPidByArgvSync, not by the
+      // lsof `c` field (which on macOS reports the kernel p_comm — always
+      // "node" for a node-based gateway — even when argv[0] has been rewritten
+      // to "openclaw-gateway"). Simulate the verifier seeing a non-gateway
+      // argv and correctly excluding the pid.
       const otherPid = process.pid + 2;
       mockSpawnSync.mockReturnValue({
         error: null,
@@ -391,6 +403,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         stdout: lsofOutput([{ pid: otherPid, cmd: "nginx" }]),
         stderr: "",
       });
+      __testing.setVerifyGatewayPidByArgvOverride(() => false);
       expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
     });
 
@@ -503,9 +516,10 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(result).toContain(pid2);
     });
 
-    it("returns [] when status 0 but only non-openclaw pids present", () => {
-      // Port may be bound by an unrelated process. findGatewayPidsOnPortSync
-      // only tracks openclaw processes — non-openclaw listeners are ignored.
+    it("returns [] when status 0 but only non-gateway pids present", () => {
+      // Port may be bound by an unrelated process (caddy, nginx, etc.).
+      // findGatewayPidsOnPortSync only tracks openclaw gateway processes,
+      // classified by verifyGatewayPidByArgvSync.
       const otherPid = process.pid + 50;
       mockSpawnSync.mockReturnValue({
         error: null,
@@ -513,6 +527,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         stdout: lsofOutput([{ pid: otherPid, cmd: "caddy" }]),
         stderr: "",
       });
+      __testing.setVerifyGatewayPidByArgvOverride(() => false);
       expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
     });
   });
@@ -1087,17 +1102,22 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
   // parsePidsFromLsofOutput — branch-coverage for mid-loop && short-circuits
   // -------------------------------------------------------------------------
   describe("parsePidsFromLsofOutput — branch coverage (lines 67-69)", () => {
-    it("skips a mid-loop entry when the command does not include 'openclaw'", () => {
-      // Exercises the false branch of currentCmd.toLowerCase().includes("openclaw")
-      // inside the mid-loop flush: a non-openclaw cmd between two entries must not
-      // be pushed, but the following openclaw entry still must be.
+    it("filters non-gateway listeners via the ps-argv verifier, keeps gateway PIDs", () => {
+      // On macOS the gateway rewrites argv[0] to "openclaw-gateway" after exec,
+      // but lsof's `c` field reports the kernel `p_comm` (the exec'd binary —
+      // "node"), so it cannot be used to classify gateway vs non-gateway.
+      // Classification is delegated to verifyGatewayPidByArgvSync, which ps's
+      // the target pid and matches argv[0] / openclaw entry-file patterns.
+      const nonGatewayPid = process.pid + 699;
       const stalePid = process.pid + 700;
-      // Mixed output: non-openclaw entry first, then openclaw entry
-      const stdout = `p${process.pid + 699}\ncnginx\np${stalePid}\ncopenclaw-gateway\n`;
+      const stdout = `p${nonGatewayPid}\ncnode\np${stalePid}\ncnode\n`;
       mockSpawnSync.mockReturnValue({ error: null, status: 0, stdout, stderr: "" });
+      // Drive the verifier directly: only stalePid is a gateway; the other
+      // listener (nonGatewayPid) is some other "node"-based process.
+      __testing.setVerifyGatewayPidByArgvOverride((pid) => pid === stalePid);
       const result = findGatewayPidsOnPortSync(18789);
       expect(result).toContain(stalePid);
-      expect(result).not.toContain(process.pid + 699);
+      expect(result).not.toContain(nonGatewayPid);
     });
 
     it("skips a mid-loop entry when currentCmd is missing (two consecutive p-lines)", () => {
@@ -1143,20 +1163,27 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
   // pollPortOnce branch — status 1 + non-empty stdout with zero openclaw pids
   // -------------------------------------------------------------------------
   describe("pollPortOnce — status 1 + non-empty non-openclaw stdout (line 145)", () => {
-    it("treats status 1 + non-openclaw stdout as port-free (not an openclaw process)", () => {
-      // status 1 + non-empty stdout where no openclaw pids are present:
-      // the port may be held by an unrelated process. From our perspective
-      // (we only kill openclaw pids) it is effectively free.
+    it("treats status 1 + non-gateway stdout as port-free (not an openclaw process)", () => {
+      // status 1 + non-empty stdout where no openclaw gateway pids are
+      // present: the port is held by an unrelated process. From our
+      // perspective (we only kill openclaw gateway pids) it is effectively
+      // free — pollPortOnce should NOT keep waiting for an unrelated caddy
+      // process to exit.
       const stalePid = process.pid + 800;
+      const unrelatedPid = process.pid + 801;
       const getCallCount = installInitialBusyPoll(stalePid, () => {
-        // status 1 + non-openclaw output — should be treated as free:true for our purposes
+        // status 1 + non-gateway output — should be treated as free:true for our purposes
         return createLsofResult({
           status: 1,
-          stdout: lsofOutput([{ pid: process.pid + 801, cmd: "caddy" }]),
+          stdout: lsofOutput([{ pid: unrelatedPid, cmd: "caddy" }]),
         });
       });
       vi.spyOn(process, "kill").mockReturnValue(true);
-      // Should complete cleanly — no openclaw pids in status-1 output → free
+      // Initial find sees stalePid (gateway); the post-kill polls see
+      // unrelatedPid (caddy, non-gateway). Verifier distinguishes them so
+      // the poll correctly reports the port as free of our-interest listeners.
+      __testing.setVerifyGatewayPidByArgvOverride((pid) => pid === stalePid);
+      // Should complete cleanly — no openclaw gateway pids in status-1 output → free
       expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
       // Completed in exactly 2 calls (initial find + 1 free poll)
       expect(getCallCount()).toBe(2);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -165,40 +165,34 @@ function getSelfAndAncestorPidsSync(): Set<number> {
 }
 
 /**
- * Parse openclaw gateway PIDs from lsof -Fpc stdout, excluding the current
- * process and its ancestors (see `getSelfAndAncestorPidsSync` for the full
- * rationale). On Linux the ancestor lookup reads up to
+ * Parse PIDs listening on the gateway port from lsof -Fpc stdout, excluding
+ * the current process and its ancestors (see `getSelfAndAncestorPidsSync` for
+ * the full rationale). On Linux the ancestor lookup reads up to
  * `MAX_ANCESTOR_WALK_DEPTH` entries from `/proc/<pid>/status`; each read is
  * a virtual-filesystem access (no disk I/O, no external process), wrapped
  * in try/catch and degrades silently. On macOS/Windows the lookup is
  * in-memory via `process.ppid` only.
+ *
+ * NOTE: this parser returns every listening PID; gateway-vs-other
+ * classification is deferred to `verifyGatewayPidByArgvSync` at the
+ * `findGatewayPidsOnPortSync` call site. Previously this function filtered
+ * by the lsof `c` (command-name) field containing "openclaw", but on macOS
+ * the `c` field is the kernel `p_comm` / `BSD_COMM` — the basename of the
+ * exec'd binary (`"node"`) — NOT the rewritten argv[0] (`"openclaw-gateway"`)
+ * that `ps` shows. That filter silently dropped every real gateway PID on
+ * macOS, causing `cleanStaleGatewayProcessesSync` to no-op and
+ * `pollPortOnceUnix` to report busy ports as `{free: true}`, sustaining
+ * launchd EADDRINUSE respawn loops. See issue #70664.
  */
 function parsePidsFromLsofOutput(stdout: string): number[] {
   const pids: number[] = [];
-  let currentPid: number | undefined;
-  let currentCmd: string | undefined;
   for (const line of stdout.split(/\r?\n/).filter(Boolean)) {
     if (line.startsWith("p")) {
-      if (
-        currentPid != null &&
-        currentCmd &&
-        normalizeLowercaseStringOrEmpty(currentCmd).includes("openclaw")
-      ) {
-        pids.push(currentPid);
-      }
       const parsed = Number.parseInt(line.slice(1), 10);
-      currentPid = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-      currentCmd = undefined;
-    } else if (line.startsWith("c")) {
-      currentCmd = line.slice(1);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        pids.push(parsed);
+      }
     }
-  }
-  if (
-    currentPid != null &&
-    currentCmd &&
-    normalizeLowercaseStringOrEmpty(currentCmd).includes("openclaw")
-  ) {
-    pids.push(currentPid);
   }
   // Deduplicate: dual-stack listeners (IPv4 + IPv6) cause lsof to emit the
   // same PID twice. Return each PID at most once to avoid double-killing.
@@ -206,6 +200,57 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
   // caller via the supervisor, recreating the #68451 restart loop.
   const excluded = getSelfAndAncestorPidsSync();
   return [...new Set(pids)].filter((pid) => !excluded.has(pid));
+}
+
+/**
+ * Verify a listening PID is an openclaw gateway by inspecting its argv via
+ * `ps`. On macOS the gateway rewrites argv[0] to "openclaw-gateway" after
+ * exec but the kernel `p_comm` stays "node", so lsof-level classification
+ * is unreliable. `ps` reads the rewritten argv[0], so it sees
+ * "openclaw-gateway" for live gateways. Matches either the argv[0] rewrite
+ * or a recognizable openclaw entry-file pattern (for non-rewritten dev-mode
+ * invocations like `node dist/index.js gateway ...`).
+ *
+ * Returns false on any ps failure so we never mis-attribute a non-gateway
+ * process as a gateway (the cost of a false-negative is at worst one extra
+ * EADDRINUSE retry; the cost of a false-positive is SIGTERM'ing an
+ * unrelated user process).
+ *
+ * Symmetric with the Windows path's `filterVerifiedWindowsGatewayPids` +
+ * `isGatewayArgv`; see also issue #70664.
+ */
+let verifyGatewayPidByArgvOverride: ((pid: number) => boolean) | null = null;
+
+function verifyGatewayPidByArgvSync(pid: number, spawnTimeoutMs = SPAWN_TIMEOUT_MS): boolean {
+  if (verifyGatewayPidByArgvOverride) {
+    return verifyGatewayPidByArgvOverride(pid);
+  }
+  const res = spawnSync("ps", ["-ww", "-p", String(pid), "-o", "command="], {
+    encoding: "utf8",
+    timeout: spawnTimeoutMs,
+  });
+  if (res.error || res.status !== 0) {
+    return false;
+  }
+  const cmd = (res.stdout ?? "").trim();
+  if (!cmd) {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(cmd);
+  if (normalized.includes("openclaw-gateway")) {
+    return true;
+  }
+  // Dev-mode invocations where argv[0] wasn't rewritten (node
+  // dist/index.js gateway, openclaw.mjs gateway, etc.).
+  if (
+    normalized.includes("gateway") &&
+    (normalized.includes("/openclaw/dist/index.js") ||
+      normalized.includes("/openclaw.mjs") ||
+      /(^|\s|\/)openclaw(\s|$)/.test(normalized))
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -297,7 +342,15 @@ export function findGatewayPidsOnPortSync(
     );
     return [];
   }
-  return parsePidsFromLsofOutput(res.stdout);
+  // lsof returns every listening PID on the port (with self + ancestors
+  // already excluded by parsePidsFromLsofOutput). Filter down to PIDs whose
+  // argv identifies them as openclaw gateways — lsof's p_comm is unreliable
+  // on macOS (see verifyGatewayPidByArgvSync). Symmetric with the Windows
+  // path above that runs `filterVerifiedWindowsGatewayPids` on the raw list.
+  // See issue #70664.
+  return parsePidsFromLsofOutput(res.stdout).filter((pid) =>
+    verifyGatewayPidByArgvSync(pid, spawnTimeoutMs),
+  );
 }
 
 /**
@@ -344,7 +397,15 @@ function pollPortOnce(port: number): PollResult {
       // user namespaces), lsof can exit 1 AND still emit some output for the
       // processes it could read. Parse stdout when non-empty to avoid false-free.
       if (res.stdout) {
-        const pids = parsePidsFromLsofOutput(res.stdout);
+        // Only count openclaw-gateway listeners as "busy" — a non-gateway
+        // process (caddy, nginx, etc.) holding the port is not something we
+        // can wait out, and treating it as busy would loop forever. The
+        // subsequent bind will fail with a more informative error. See
+        // verifyGatewayPidByArgvSync for why ps-argv verification is required
+        // instead of the lsof `c` field on macOS.
+        const pids = parsePidsFromLsofOutput(res.stdout).filter((pid) =>
+          verifyGatewayPidByArgvSync(pid),
+        );
         return pids.length === 0 ? { free: true } : { free: false };
       }
       return { free: true };
@@ -356,8 +417,11 @@ function pollPortOnce(port: number): PollResult {
       return { free: null, permanent: false };
     }
     // status === 0: lsof found listeners. Parse pids from the stdout we
-    // already hold — no second lsof spawn, no new failure surface.
-    const pids = parsePidsFromLsofOutput(res.stdout);
+    // already hold — no second lsof spawn, no new failure surface. Same
+    // gateway-only semantics as the status-1-with-stdout branch above.
+    const pids = parsePidsFromLsofOutput(res.stdout).filter((pid) =>
+      verifyGatewayPidByArgvSync(pid),
+    );
     return pids.length === 0 ? { free: true } : { free: false };
   } catch {
     return { free: null, permanent: false };
@@ -560,6 +624,15 @@ export const __testing = {
   },
   setParentPidOverride(fn: (() => number) | null) {
     parentPidOverride = fn;
+  },
+  /**
+   * Override the ps-based gateway-argv verifier used inside
+   * findGatewayPidsOnPortSync. Tests typically provide a single mockSpawnSync
+   * fake that can't distinguish lsof from ps invocations; this override lets
+   * them drive the Unix gateway-vs-other classification directly.
+   */
+  setVerifyGatewayPidByArgvOverride(fn: ((pid: number) => boolean) | null) {
+    verifyGatewayPidByArgvOverride = fn;
   },
   /** Invoke sleepSync directly (bypasses the override) for unit-testing the real Atomics path. */
   callSleepSyncRaw: sleepSync,

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -45,11 +45,16 @@ beforeEach(() => {
     currentTimeMs += ms;
   });
   __testing.setDateNowOverride(() => currentTimeMs);
+  // Default: bypass the ps-based gateway-argv verifier so tests drive
+  // classification via the lsof `c` field (legacy semantics). Tests that
+  // need to exercise verifyGatewayPidByArgvSync override this.
+  __testing.setVerifyGatewayPidByArgvOverride(() => true);
 });
 
 afterEach(() => {
   __testing.setSleepSyncOverride(null);
   __testing.setDateNowOverride(null);
+  __testing.setVerifyGatewayPidByArgvOverride(null);
   vi.restoreAllMocks();
 });
 
@@ -72,6 +77,12 @@ describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => 
         "cOpenClaw",
       ].join("\n"),
     });
+    // Simulate the ps-argv verifier seeing openclaw-gateway argv on gatewayPidA/B
+    // and a non-gateway argv on foreignPid. (On real macOS, lsof reports "node"
+    // for both gatewayPidA and foreignPid — classification requires ps.)
+    __testing.setVerifyGatewayPidByArgvOverride(
+      (pid) => pid === gatewayPidA || pid === gatewayPidB,
+    );
 
     const pids = findGatewayPidsOnPortSync(18789);
 


### PR DESCRIPTION
## Summary

Fixes #70664. On macOS, `lsof -Fpc` reports the kernel `p_comm` field (the exec'd binary basename — `"node"`) rather than the rewritten argv[0] (`"openclaw-gateway"`). The `.includes("openclaw")` filter in `parsePidsFromLsofOutput` therefore silently dropped every real gateway PID, making `cleanStaleGatewayProcessesSync` no-op and `pollPortOnceUnix` report busy ports as `{free: true}`. With `KeepAlive=true` in the LaunchAgent plist this manifests as a self-sustaining launchd respawn loop.

Reproduction and full impact analysis in #70664.

## Change

- **`parsePidsFromLsofOutput`** — dropped the broken comm filter; now returns every listening PID. The self+ancestor exclusion from 8aadca4c3e is preserved (the invariant that `cleanStaleGatewayProcessesSync` must never terminate an ancestor of its caller is unchanged).
- **`verifyGatewayPidByArgvSync(pid)`** — new Unix-side verifier. Calls `ps -ww -p <pid> -o command=` (which reads the rewritten argv[0]) and matches against `"openclaw-gateway"` plus common entry-file patterns (`/dist/index.js gateway`, `/openclaw.mjs gateway`, `openclaw gateway`). Returns `false` on any ps failure so we never mis-attribute a non-gateway process as a gateway.
- **`findGatewayPidsOnPortSync`** (Unix path) — now runs lsof, then filters the returned PIDs through `verifyGatewayPidByArgvSync`. Symmetric with the Windows path's existing `filterVerifiedWindowsGatewayPids` + `isGatewayArgv` structure.
- **`pollPortOnceUnix`** — both the `status === 0` and the `status === 1 + non-empty stdout` branches that previously relied on the comm filter now apply the same verifier. Without this, a non-gateway listener on the port (caddy/nginx) would loop the port-free wait forever; with it, the port is reported as free-from-our-perspective and the downstream bind fails with a more informative error.

## Tests

- Added `__testing.setVerifyGatewayPidByArgvOverride` hook so tests can drive the Unix gateway-vs-other classification directly. Most existing tests use a single `mockSpawnSync` fake that can't distinguish lsof from ps invocations; the default bypass in `beforeEach` preserves legacy test semantics.
- Replaced the obsolete `parsePidsFromLsofOutput — branch coverage (lines 67-69) > skips a mid-loop entry when the command does not include 'openclaw'` test that specifically asserted the removed comm filter's behavior, with a new test exercising the verifier-driven classification.
- Updated the two `findGatewayPidsOnPortSync` tests that exercised non-gateway filtering (`excludes pids whose argv does not identify them as an openclaw gateway`, `returns [] when status 0 but only non-gateway pids present`) to drive the verifier override matching the intended behavior.
- Updated the one `pollPortOnce` test (`treats status 1 + non-gateway stdout as port-free`) to use a pid-specific verifier override so the post-kill polling correctly sees the unrelated caddy listener as "free-from-our-perspective".
- Updated `restart.test.ts` to add the override hook reset and a verifier override for its `parses lsof output and filters non-openclaw/current processes` test.

## Test plan

- [x] `pnpm vitest run --project infra src/infra/restart-stale-pids.test.ts` — 46 passed / 2 skipped (Windows-only)
- [x] `pnpm vitest run --project infra src/infra/restart.test.ts src/infra/gateway-processes.test.ts` — all green
- [x] `pnpm vitest run --project cli src/cli/gateway-cli/` — all green (no regressions in consumers of `findGatewayPidsOnPortSync`)
- [x] `node scripts/tsdown-build.mjs` — clean build
- [x] Manual reproduction on macOS: before this patch, `gateway.err.log` grew with one `Gateway failed to start: another gateway instance is already listening` cycle every ~18 s. After this patch, `service-mode: cleared N stale gateway pid(s) before bind on port 18789` appears correctly in `/tmp/openclaw/openclaw-*.log` when stale gateway PIDs are found, and the cleanup proceeds as intended.

## What's deliberately out of scope

- The `PORT_FREE_TIMEOUT_MS` bump (2 s → 30 s) that #70664 lists as "optional hardening". Discovered mid-test-update that the existing test suite assumes ≤ 2 s of port-free polling (`beforeEach` doesn't install a `setDateNowOverride`, so a longer timeout let some tests run long enough to hit OOM on a 4 GB V8 heap). Left as a separate follow-up — the core correctness fix in this PR is the comm filter.
- A `run.ts` service-mode "yield-if-peer-exists" behavior change I tested locally: when launchd respawns the gateway but an openclaw-gateway is already listening, exit 0 quickly instead of kill-and-take-over. That's a behavior change (not just a bug fix) so I pulled it out to keep this PR purely corrective; happy to open a follow-up issue/PR if maintainers want to discuss it.

## Notes for reviewers

- The pair of tests that look like "we expected them to not hit spawnSync / ps at all" now do — this is because the code path is correct. The override hook keeps the tests deterministic without needing each test to track its lsof-vs-ps call order through a multi-call mock.
- The implementation of `verifyGatewayPidByArgvSync` uses a `ps` call per PID. In the typical steady-state (a single listener on the port) this is one extra ~5 ms call per `findGatewayPidsOnPortSync` invocation — well inside the existing `SPAWN_TIMEOUT_MS = 2000`. If this ever gets called for many PIDs, a short-circuit on first non-gateway match could be added; current behavior is the safe default.
