### PR TITLE
fix(agents): break madge import cycle in harness selection path

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,7 +22,7 @@ import {
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
-import type { BuildStatusTextParams } from "../../status/status-text.js";
+import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
 import { loadModelCatalog } from "../model-catalog.js";

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,5 +1,6 @@
 import { logVerbose } from "../../globals.js";
-import { buildStatusText, type BuildStatusTextParams } from "../../status/status-text.js";
+import { buildStatusText } from "../../status/status-text.js";
+import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
 export { buildStatusText } from "../../status/status-text.js";

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -15,20 +15,16 @@ import {
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
 import type {
-  ElevatedLevel,
-  ReasoningLevel,
   ThinkLevel,
-  VerboseLevel,
 } from "../auto-reply/thinking.js";
 import { toAgentModelListLike } from "../config/model-input.js";
-import type { SessionEntry, SessionScope } from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   formatUsageWindowSummary,
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../infra/provider-usage.js";
-import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import {
   listTasksForAgentIdForStatus,
@@ -39,35 +35,8 @@ import {
   formatTaskStatusDetail,
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
-
-export type BuildStatusTextParams = {
-  cfg: OpenClawConfig;
-  sessionEntry?: SessionEntry;
-  sessionKey: string;
-  parentSessionKey?: string;
-  sessionScope?: SessionScope;
-  storePath?: string;
-  statusChannel: string;
-  provider: string;
-  model: string;
-  contextTokens?: number;
-  resolvedThinkLevel?: ThinkLevel;
-  resolvedFastMode?: boolean;
-  resolvedHarness?: string;
-  resolvedVerboseLevel: VerboseLevel;
-  resolvedReasoningLevel: ReasoningLevel;
-  resolvedElevatedLevel?: ElevatedLevel;
-  resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
-  isGroup: boolean;
-  defaultGroupActivation: () => "always" | "mention";
-  mediaDecisions?: MediaUnderstandingDecision[];
-  taskLineOverride?: string;
-  skipDefaultTaskLookup?: boolean;
-  primaryModelLabelOverride?: string;
-  modelAuthOverride?: string;
-  activeModelAuthOverride?: string;
-  includeTranscriptUsage?: boolean;
-};
+import type { BuildStatusTextParams } from "./status-text.types.js";
+export type { BuildStatusTextParams } from "./status-text.types.js";
 
 const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
   "anthropic",

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -1,0 +1,38 @@
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  VerboseLevel,
+} from "../auto-reply/thinking.js";
+import type { SessionEntry, SessionScope } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
+
+export type BuildStatusTextParams = {
+  cfg: OpenClawConfig;
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  parentSessionKey?: string;
+  sessionScope?: SessionScope;
+  storePath?: string;
+  statusChannel: string;
+  provider: string;
+  model: string;
+  contextTokens?: number;
+  resolvedThinkLevel?: ThinkLevel;
+  resolvedFastMode?: boolean;
+  resolvedHarness?: string;
+  resolvedVerboseLevel: VerboseLevel;
+  resolvedReasoningLevel: ReasoningLevel;
+  resolvedElevatedLevel?: ElevatedLevel;
+  resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
+  isGroup: boolean;
+  defaultGroupActivation: () => "always" | "mention";
+  mediaDecisions?: MediaUnderstandingDecision[];
+  taskLineOverride?: string;
+  skipDefaultTaskLookup?: boolean;
+  primaryModelLabelOverride?: string;
+  modelAuthOverride?: string;
+  activeModelAuthOverride?: string;
+  includeTranscriptUsage?: boolean;
+};


### PR DESCRIPTION
Breaks the circular dependency introduced in 1713839288 between builtin-pi → selection → openclaw-tools → attempt → pi-tools → session-status-tool → status-text. The cycle causes check:architecture CI failures on all PRs.