### PR TITLE
fix(cli): wait for gateway client teardown before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Gateway: wait for one-shot gateway RPC clients to finish WebSocket teardown before the CLI process exits, reducing hangs where commands like `openclaw status` or `openclaw version` could finish their work but stay alive until an external timeout killed them.
 - Thinking defaults/status: raise the implicit default thinking level for reasoning-capable models from legacy `off`/`low` fallback behavior to a safe provider-supported `medium` equivalent when no explicit config default is set, preserve configured-model reasoning metadata when runtime catalog loading is empty, and make `/status` report the same resolved default as runtime.
 - Gateway/model pricing: fetch OpenRouter and LiteLLM pricing asynchronously at startup and extend catalog fetch timeouts to 30 seconds, reducing noisy timeout warnings during slow upstream responses.
 - Plugins/install: add newly installed plugin ids to an existing `plugins.allow` list before enabling them, so allowlisted configs load installed plugins after restart.

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -124,6 +124,7 @@ class StubGatewayClient {
     }
   }
   stop() {}
+  async stopAndWait() {}
 }
 
 function resetGatewayCallMocks() {
@@ -810,6 +811,68 @@ describe("callGateway error details", () => {
     expect(lastRequestOptions?.method).toBe("health");
     expect(lastRequestOptions?.opts?.expectFinal).toBe(true);
     expect(lastRequestOptions?.opts?.timeoutMs).toBeUndefined();
+  });
+
+  it("waits for gateway client teardown before resolving", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    let releaseStop!: () => void;
+    let stopStarted = false;
+    let stopFinished = false;
+    let callResolved = false;
+
+    __testing.setDepsForTests({
+      createGatewayClient: (opts) =>
+        ({
+          async request(
+            method: string,
+            params: unknown,
+            requestOpts?: { expectFinal?: boolean; timeoutMs?: number | null },
+          ) {
+            lastRequestOptions = { method, params, opts: requestOpts };
+            return { ok: true };
+          },
+          start() {
+            opts.onHelloOk?.({
+              features: {
+                methods: helloMethods ?? [],
+                events: [],
+              },
+            } as unknown as Parameters<NonNullable<typeof opts.onHelloOk>>[0]);
+          },
+          stop() {},
+          async stopAndWait() {
+            stopStarted = true;
+            await new Promise<void>((resolve) => {
+              releaseStop = () => {
+                stopFinished = true;
+                resolve();
+              };
+            });
+          },
+        }) as never,
+      loadConfig: loadConfig as unknown as () => OpenClawConfig,
+      loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      resolveGatewayPort: resolveGatewayPort as unknown as (
+        cfg?: OpenClawConfig,
+        env?: NodeJS.ProcessEnv,
+      ) => number,
+    });
+
+    const promise = callGateway({ method: "health" }).then(() => {
+      callResolved = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(stopStarted).toBe(true);
+    });
+    expect(callResolved).toBe(false);
+
+    releaseStop();
+    await promise;
+
+    expect(stopFinished).toBe(true);
+    expect(callResolved).toBe(true);
   });
 
   it("fails fast when remote mode is missing remote url", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -92,6 +92,14 @@ const gatewayCallDeps = {
   ...defaultGatewayCallDeps,
 };
 
+async function stopGatewayClient(client: GatewayClient): Promise<void> {
+  try {
+    await client.stopAndWait({ timeoutMs: 1_000 });
+  } catch {
+    client.stop();
+  }
+}
+
 function resolveGatewayClientDisplayName(opts: CallGatewayBaseOptions): string | undefined {
   if (opts.clientDisplayName) {
     return opts.clientDisplayName;
@@ -520,11 +528,11 @@ async function executeGatewayRequestWithScopes<T>(params: {
             timeoutMs: opts.timeoutMs,
           });
           ignoreClose = true;
+          await stopGatewayClient(client);
           stop(undefined, result);
-          client.stop();
         } catch (err) {
           ignoreClose = true;
-          client.stop();
+          await stopGatewayClient(client);
           stop(err as Error);
         }
       },
@@ -533,15 +541,17 @@ async function executeGatewayRequestWithScopes<T>(params: {
           return;
         }
         ignoreClose = true;
-        client.stop();
-        stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
+        void stopGatewayClient(client).finally(() => {
+          stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
+        });
       },
     });
 
     const timer = setTimeout(() => {
       ignoreClose = true;
-      client.stop();
-      stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
+      void stopGatewayClient(client).finally(() => {
+        stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
+      });
     }, safeTimerTimeoutMs);
 
     client.start();


### PR DESCRIPTION
## Summary

Before this patch, `executeGatewayRequestWithScopes()` would get the RPC result and then call `client.stop()` as fire-and-forget. That meant the outer `callGateway()` promise could resolve while the `GatewayClient` still had a live WebSocket or teardown timer keeping the Node process alive. In a one-shot CLI subprocess, that is exactly the failure mode reported in #63609: the command appears done, but the process never exits and the caller eventually kills it.

This change fixes that by switching settlement ordering. `src/gateway/call.ts` now funnels all teardown through `stopGatewayClient()` and prefers `await client.stopAndWait({ timeoutMs: 1000 })`, which uses the existing `GatewayClient.stopAndWait()` contract in `src/gateway/client.ts` to wait for socket close or terminate fallback before returning. The key effect is that success, request-error, close, and timeout paths in `src/gateway/call.ts` no longer resolve or reject the outer promise until teardown has actually finished or been force-stopped.

I also added a regression in `src/gateway/call.test.ts` that proves the success path now blocks resolution until `stopAndWait()` completes, and a changelog entry describing the user-visible CLI/Gateway hang fix.

## Validation

- `pnpm test src/gateway/call.test.ts`
- `scripts/committer "fix(cli): wait for gateway client teardown before exit" CHANGELOG.md src/gateway/call.ts src/gateway/call.test.ts`
  - includes `pnpm check:changed --staged`
