### PR TITLE
fix: block owner-only tools from MCP plugin handlers

### DIFF
--- a/src/mcp/openclaw-tools-serve.test.ts
+++ b/src/mcp/openclaw-tools-serve.test.ts
@@ -3,18 +3,20 @@ import { resolveOpenClawToolsForMcp } from "./openclaw-tools-serve.js";
 import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
 
 describe("OpenClaw tools MCP server", () => {
-  it("exposes cron", async () => {
+  it("does not expose owner-only cron", async () => {
     const handlers = createPluginToolsMcpHandlers(resolveOpenClawToolsForMcp());
 
     const listed = await handlers.listTools();
-    expect(listed).toEqual({
-      tools: [
-        expect.objectContaining({
-          name: "cron",
-          description: expect.stringContaining("Manage Gateway cron jobs"),
-          inputSchema: expect.objectContaining({ type: "object" }),
-        }),
-      ],
+    expect(listed).toEqual({ tools: [] });
+  });
+
+  it("blocks owner-only cron invocation", async () => {
+    const handlers = createPluginToolsMcpHandlers(resolveOpenClawToolsForMcp());
+
+    const result = await handlers.callTool({ name: "cron", arguments: { action: "status" } });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Unknown tool: cron" }],
+      isError: true,
     });
   });
 });

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -19,7 +19,8 @@ function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
 }
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
-  const wrappedTools = tools.map((tool) => {
+  const allowedTools = tools.filter((tool) => !tool.ownerOnly);
+  const wrappedTools = allowedTools.map((tool) => {
     if (isToolWrappedWithBeforeToolCallHook(tool)) {
       return tool;
     }


### PR DESCRIPTION
### Motivation
- The MCP bridge exposed owner-only control-plane tools (notably `cron`) without applying owner-only or sender policy checks, creating a privilege-escalation path for ACPX sessions.
- The change aims to prevent owner-only tools from being listed or invoked via the MCP handlers while preserving normal tool behavior elsewhere.

### Description
- Filter MCP-exposed tools in `createPluginToolsMcpHandlers` to exclude tools with `ownerOnly` by adding `const allowedTools = tools.filter((tool) => !tool.ownerOnly)` and wrapping only those tools. (edited: `src/mcp/plugin-tools-handlers.ts`)
- Update MCP server tests to assert that owner-only `cron` is not listed and that direct MCP invocation returns `Unknown tool: cron`. (edited: `src/mcp/openclaw-tools-serve.test.ts`)

### Testing
- Ran the targeted unit test with `pnpm test src/mcp/openclaw-tools-serve.test.ts` and the test suite passed. 
- Ran the repository pre-commit checks via `scripts/committer` (which includes `pnpm check:changed --staged`, typecheck, lint, import-cycle checks and the test shards) and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94fa24f00832081ac4dcf5867be00)