### PR TITLE
fix(gateway): disarm wrapper timeout before teardown

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -875,6 +875,61 @@ describe("callGateway error details", () => {
     expect(callResolved).toBe(true);
   });
 
+  it("clears the wrapper timeout before awaiting gateway teardown", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    vi.useFakeTimers();
+    let releaseStop!: () => void;
+    let stopStarted = false;
+
+    __testing.setDepsForTests({
+      createGatewayClient: (opts) =>
+        ({
+          async request(
+            method: string,
+            params: unknown,
+            requestOpts?: { expectFinal?: boolean; timeoutMs?: number | null },
+          ) {
+            lastRequestOptions = { method, params, opts: requestOpts };
+            return { ok: true };
+          },
+          start() {
+            opts.onHelloOk?.({
+              features: {
+                methods: helloMethods ?? [],
+                events: [],
+              },
+            } as unknown as Parameters<NonNullable<typeof opts.onHelloOk>>[0]);
+          },
+          stop() {},
+          async stopAndWait() {
+            stopStarted = true;
+            await new Promise<void>((resolve) => {
+              releaseStop = resolve;
+            });
+          },
+        }) as never,
+      loadConfig: loadConfig as unknown as () => OpenClawConfig,
+      loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      resolveGatewayPort: resolveGatewayPort as unknown as (
+        cfg?: OpenClawConfig,
+        env?: NodeJS.ProcessEnv,
+      ) => number,
+    });
+
+    const promise = callGateway<{ ok: true }>({ method: "health", timeoutMs: 5 });
+
+    await vi.waitFor(() => {
+      expect(stopStarted).toBe(true);
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+
+    releaseStop();
+
+    await expect(promise).resolves.toEqual({ ok: true });
+  });
+
   it("fails fast when remote mode is missing remote url", async () => {
     loadConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -490,11 +490,13 @@ async function executeGatewayRequestWithScopes<T>(params: {
       }
       settled = true;
       clearTimeout(timer);
-      if (err) {
-        reject(err);
-      } else {
-        resolve(value as T);
-      }
+      void stopGatewayClient(client).finally(() => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(value as T);
+        }
+      });
     };
 
     const client = gatewayCallDeps.createGatewayClient({
@@ -528,11 +530,9 @@ async function executeGatewayRequestWithScopes<T>(params: {
             timeoutMs: opts.timeoutMs,
           });
           ignoreClose = true;
-          await stopGatewayClient(client);
           stop(undefined, result);
         } catch (err) {
           ignoreClose = true;
-          await stopGatewayClient(client);
           stop(err as Error);
         }
       },
@@ -541,17 +541,13 @@ async function executeGatewayRequestWithScopes<T>(params: {
           return;
         }
         ignoreClose = true;
-        void stopGatewayClient(client).finally(() => {
-          stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
-        });
+        stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
       },
     });
 
     const timer = setTimeout(() => {
       ignoreClose = true;
-      void stopGatewayClient(client).finally(() => {
-        stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
-      });
+      stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
     }, safeTimerTimeoutMs);
 
     client.start();


### PR DESCRIPTION
The previous gateway teardown fix changed settlement ordering so one-shot CLI calls waited for `stopAndWait()`, but it still left the wrapper timeout armed until teardown completed. That introduced a race: if `client.request()` succeeded or failed with a real RPC error near `timeoutMs`, and teardown took slightly longer, the wrapper timer could fire first and replace the real outcome with a synthetic timeout.

Example of the bad sequence:

```ts
const result = await client.request(...); // succeeds near timeout
await stopGatewayClient(client);          // teardown still running
// wrapper timeout fires here and wins incorrectly
```

This follow-up fixes the ordering by claiming the outcome and clearing the wrapper timeout before awaiting teardown, while still delaying final resolve/reject until teardown completes:

```ts
const stop = (err?: Error, value?: T) => {
  if (settled) return;
  settled = true;
  clearTimeout(timer);
  void stopGatewayClient(client).finally(() => {
    if (err) reject(err);
    else resolve(value as T);
  });
};
```

It also adds a regression test that blocks `stopAndWait()`, advances fake timers past `timeoutMs`, and verifies a successful RPC still resolves with the real result instead of timing out.

Verified:
- `pnpm test src/gateway/call.test.ts`
- staged repo checks from the commit hook, including `check:changed`, typechecks, lint, import-cycle guards, and gateway tests
