### PR TITLE
fix(ui): fix synthesis tab button being clipped at certain viewport zoom levels

### DIFF
--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -827,6 +827,8 @@
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
+  position: relative;
+  z-index: 1;
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding-bottom: 2px;


### PR DESCRIPTION
Fix synthesis tab button being clipped/hidden at certain viewport zoom levels.

## Summary

- Problem: At certain browser zoom levels (e.g., 100%), the Memory Palace synthesis tab button row () becomes invisible — its content is rendered behind or clipped by other elements in the flex layout.
- Why it matters: Users cannot switch to the synthesis tab when the tab button is visually hidden at common zoom levels.
- What changed: Added  to . This establishes a new stacking context and lifts the daychips row above subsequent content, ensuring the tab buttons remain visible regardless of zoom level.
- What did NOT change: No overflow properties were modified; no  or  changes were introduced.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Root Cause

- Root cause: The daychips row lacked explicit stacking context (). When cluster content below it grew tall, the row was rendered in the same stacking order as the content and got visually buried at certain viewport/zoom conditions.
- Contributing context: The issue only manifests at certain browser zoom percentages (e.g., 100%) where the flex layout's default stacking causes the row to be covered by subsequent flex items.

## Regression Test Plan

- N/A — purely CSS/layout fix with no logic or behavior change. Manual verification by switching between tabs at various zoom levels is sufficient.

## User-visible / Behavior Changes

- None. Tab buttons for synthesis/entity/concept are now reliably visible regardless of zoom level.

## Diagram



## Security Impact

- No
- No
- No
- No
- No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime: OpenClaw Gateway 2026.3.23+
- Relevant config: Memory Palace tab

### Steps

1. Open Control UI → Memory Palace tab
2. Switch to synthesis tab
3. Observe at 100% zoom: synthesis button should now be visible (alongside entity and concept buttons)

### Expected

All three tab buttons (synthesis, entity, concept) visible at all zoom levels.

### Actual

Buttons were invisible at 100% zoom before fix; visible after.

## Evidence

- [x] Screenshot/recording: Verified in browser (hard refresh after CSS patch)

## Human Verification

- Verified scenarios: Memory Palace synthesis tab at 90%, 100%, 110% zoom levels
- Edge cases checked: entity and concept tabs still function normally
- What you did NOT verify: Behavior on other browsers or mobile viewport sizes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- None