### PR TITLE
fix(qqbot): require auth for /bot-approve command

### DIFF
--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
@@ -746,6 +746,7 @@ export function registerApproveRuntimeGetter(
 registerCommand({
   name: "bot-approve",
   description: "管理命令执行审批配置",
+  requireAuth: true,
   usage: [
     `/bot-approve            查看操作指引`,
     `/bot-approve on         开启审批（白名单模式，推荐）`,


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated users from changing security-critical exec approval settings via the chat command by ensuring `/bot-approve` is handled through the auth-gated command path.

### Description
- Add `requireAuth: true` to the `/bot-approve` registration in `extensions/qqbot/src/engine/commands/slash-commands-impl.ts` so the command is routed through the framework's authenticated command registry instead of the pre-dispatch (unauthenticated) map.

### Testing
- Ran `pnpm test extensions/qqbot/src/engine/commands` and `pnpm test extensions/qqbot/src/api.security.test.ts`, both commands completed successfully in this environment (no matching test files for those targets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b47084948320ba58ca7da818cc34)