### PR TITLE
qa-channel: reject non-http inbound attachment URLs

### DIFF
--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isHttpMediaUrl } from "./inbound.js";
+
+describe("isHttpMediaUrl", () => {
+  it("accepts only http and https urls", () => {
+    expect(isHttpMediaUrl("https://example.com/image.png")).toBe(true);
+    expect(isHttpMediaUrl("http://example.com/image.png")).toBe(true);
+    expect(isHttpMediaUrl("file:///etc/passwd")).toBe(false);
+    expect(isHttpMediaUrl("/etc/passwd")).toBe(false);
+    expect(isHttpMediaUrl("data:text/plain;base64,SGVsbG8=")).toBe(false);
+  });
+});

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -9,6 +9,15 @@ import { buildQaTarget, sendQaBusMessage, type QaBusMessage } from "./bus-client
 import { getQaChannelRuntime } from "./runtime.js";
 import type { CoreConfig, ResolvedQaChannelAccount } from "./types.js";
 
+export function isHttpMediaUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 async function resolveQaInboundMediaPayload(attachments: QaBusMessage["attachments"]) {
   if (!Array.isArray(attachments) || attachments.length === 0) {
     return {};
@@ -33,6 +42,9 @@ async function resolveQaInboundMediaPayload(attachments: QaBusMessage["attachmen
       continue;
     }
     if (typeof attachment.url === "string" && attachment.url.trim()) {
+      if (!isHttpMediaUrl(attachment.url)) {
+        continue;
+      }
       const saved = await saveMediaSource(attachment.url, undefined, "inbound");
       mediaList.push({
         path: saved.path,


### PR DESCRIPTION
### Motivation
- Prevent local file disclosure by ensuring QA inbound attachment `url` values are not treated as local filesystem paths when passed to media staging.
- The previous code forwarded untrusted `attachment.url` values directly to `saveMediaSource`, which treats non-HTTP(S) sources as local files and can cause sensitive host reads.

### Description
- Add `isHttpMediaUrl(value: string)` exported helper in `extensions/qa-channel/src/inbound.ts` that returns `true` only for `http:` or `https:` URLs and `false` otherwise.
- Gate media staging so `resolveQaInboundMediaPayload` skips any `attachment.url` that is not an HTTP(S) URL and only calls `saveMediaSource` for allowed schemes; existing `contentBase64` handling is unchanged.
- Add a focused unit test `extensions/qa-channel/src/inbound.test.ts` that asserts `http(s)` URLs are accepted and `file:`, absolute local paths, and `data:` URIs are rejected.

### Testing
- Ran `pnpm test extensions/qa-channel/src/inbound.test.ts` and it passed.
- Attempted to run the broader integration spec `pnpm test extensions/qa-channel/src/channel.test.ts` and a run in this environment timed out / hit a `qa-bus` wait timeout; this appears to be an environment-specific integration timing issue and not a regression in the URL-scheme guard itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc69d6cf94832085903ed4e300e15a)