### PR TITLE
fix(msteams): require app binding for global Bot Framework audience tokens

### DIFF
--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -16,6 +16,10 @@ const jwtState = vi.hoisted(() => ({
   verifyBehavior: "success" as "success" | "throw",
   decodedHeader: { kid: "key-1" } as { kid?: string } | null,
   decodedPayload: { iss: "https://api.botframework.com" } as { iss?: string } | null,
+  verifyResult: {
+    aud: "https://api.botframework.com",
+    appid: "app-id",
+  } as Record<string, unknown>,
   verifyCalls: [] as Array<{ token: string; options: unknown }>,
 }));
 
@@ -31,7 +35,7 @@ const jwtMockImpl = {
     if (jwtState.verifyBehavior === "throw") {
       throw new Error("invalid signature");
     }
-    return { sub: "ok" };
+    return jwtState.verifyResult;
   },
 };
 
@@ -57,6 +61,10 @@ afterEach(() => {
   jwtState.verifyBehavior = "success";
   jwtState.decodedHeader = { kid: "key-1" };
   jwtState.decodedPayload = { iss: "https://api.botframework.com" };
+  jwtState.verifyResult = {
+    aud: "https://api.botframework.com",
+    appid: "app-id",
+  };
   vi.restoreAllMocks();
 });
 
@@ -213,6 +221,10 @@ describe("createBotFrameworkJwtValidator", () => {
   it("accepts tokens with aud: https://api.botframework.com (#58249)", async () => {
     // This is the critical fix: the old JwtValidator rejected this audience.
     jwtState.decodedPayload = { iss: "https://api.botframework.com" };
+    jwtState.verifyResult = {
+      aud: "https://api.botframework.com",
+      appid: "app-id",
+    };
 
     const validator = await createBotFrameworkJwtValidator(creds);
     await expect(validator.validate("Bearer botfw-token")).resolves.toBe(true);
@@ -223,6 +235,7 @@ describe("createBotFrameworkJwtValidator", () => {
 
   it("validates a token with Entra issuer", async () => {
     jwtState.decodedPayload = { iss: `https://login.microsoftonline.com/tenant-id/v2.0` };
+    jwtState.verifyResult = { aud: "app-id" };
 
     const validator = await createBotFrameworkJwtValidator(creds);
     await expect(validator.validate("Bearer token-entra")).resolves.toBe(true);
@@ -236,6 +249,7 @@ describe("createBotFrameworkJwtValidator", () => {
     jwtState.decodedPayload = {
       iss: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
     };
+    jwtState.verifyResult = { aud: "app-id" };
 
     const validator = await createBotFrameworkJwtValidator(creds);
     await expect(validator.validate("Bearer token-sts")).resolves.toBe(true);
@@ -260,6 +274,17 @@ describe("createBotFrameworkJwtValidator", () => {
 
     const validator = await createBotFrameworkJwtValidator(creds);
     await expect(validator.validate("Bearer token-bad")).resolves.toBe(false);
+  });
+
+  it("rejects global Bot Framework audience token for another bot app", async () => {
+    jwtState.decodedPayload = { iss: "https://api.botframework.com" };
+    jwtState.verifyResult = {
+      aud: "https://api.botframework.com",
+      azp: "different-app-id",
+    };
+
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer token-other-bot")).resolves.toBe(false);
   });
 
   it("returns false for empty bearer token", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -470,11 +470,12 @@ export async function createBotFrameworkJwtValidator(creds: MSTeamsCredentials):
 }> {
   const jwt = await import("jsonwebtoken");
   const { JwksClient } = await import("jwks-rsa");
+  const BOT_FRAMEWORK_GLOBAL_AUDIENCE = "https://api.botframework.com";
 
   const allowedAudiences: [string, ...string[]] = [
     creds.appId,
     `api://${creds.appId}`,
-    "https://api.botframework.com",
+    BOT_FRAMEWORK_GLOBAL_AUDIENCE,
   ];
 
   const allowedIssuers = BOT_FRAMEWORK_ISSUERS.map((entry) =>
@@ -515,6 +516,25 @@ export async function createBotFrameworkJwtValidator(creds: MSTeamsCredentials):
     });
   }
 
+  function getAudienceClaims(payload: unknown): ReadonlyArray<string> {
+    if (!payload || typeof payload !== "object") {
+      return [];
+    }
+    const aud = (payload as { aud?: string | string[] }).aud;
+    if (Array.isArray(aud)) {
+      return aud.filter((value): value is string => typeof value === "string");
+    }
+    return typeof aud === "string" ? [aud] : [];
+  }
+
+  function hasExpectedBotIdentity(payload: unknown): boolean {
+    if (!payload || typeof payload !== "object") {
+      return false;
+    }
+    const { appid, azp } = payload as { appid?: string; azp?: string };
+    return appid === creds.appId || azp === creds.appId;
+  }
+
   return {
     async validate(authHeader: string, _serviceUrl?: string): Promise<boolean> {
       const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : authHeader;
@@ -539,12 +559,19 @@ export async function createBotFrameworkJwtValidator(creds: MSTeamsCredentials):
       try {
         const signingKey = await client.getSigningKey(header.kid);
         const publicKey = signingKey.getPublicKey();
-        jwt.verify(token, publicKey, {
+        const verifiedPayload = jwt.verify(token, publicKey, {
           audience: allowedAudiences,
           issuer: allowedIssuers,
           algorithms: ["RS256"],
           clockTolerance: 300,
         });
+        const audiences = getAudienceClaims(verifiedPayload);
+        if (
+          audiences.includes(BOT_FRAMEWORK_GLOBAL_AUDIENCE) &&
+          !hasExpectedBotIdentity(verifiedPayload)
+        ) {
+          return false;
+        }
         return true;
       } catch {
         return false;


### PR DESCRIPTION
### Motivation
- The Teams JWT validator previously accepted tokens with the global Bot Framework audience (`https://api.botframework.com`) without ensuring the token was actually intended for the configured bot, enabling cross‑bot token replay.

### Description
- Add a guard that preserves acceptance of the global Bot Framework audience but requires the verified JWT payload to contain `appid` or `azp` matching the configured bot `appId` when the global audience is present (changes in `extensions/msteams/src/sdk.ts`).
- Introduce helper functions `getAudienceClaims` and `hasExpectedBotIdentity` and a `BOT_FRAMEWORK_GLOBAL_AUDIENCE` constant to implement the post‑signature check (`extensions/msteams/src/sdk.ts`).
- Update the unit test harness to return a verified payload from the `jsonwebtoken` mock and add a regression test that rejects a global‑audience token issued for a different app id (`extensions/msteams/src/sdk.test.ts`).

### Testing
- Ran the targeted unit tests with `pnpm test extensions/msteams/src/sdk.test.ts`, which passed (13 tests).
- Ran repository checks with `pnpm check`, which failed due to a pre‑existing unrelated TypeScript error in `extensions/msteams/src/attachments.test.ts` (`TS2493`), and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87287dfe0832098970e25c0623f93)