### PR TITLE
Android: disable auto-send for ASK_OPENCLAW intents

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
@@ -34,7 +34,7 @@ fun parseAssistantLaunchIntent(intent: Intent?): AssistantLaunchRequest? {
       AssistantLaunchRequest(
         source = "app_action",
         prompt = prompt,
-        autoSend = prompt != null,
+        autoSend = false,
       )
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
@@ -33,7 +33,7 @@ class AssistantLaunchTest {
     requireNotNull(parsed)
     assertEquals("app_action", parsed.source)
     assertEquals("summarize my unread texts", parsed.prompt)
-    assertTrue(parsed.autoSend)
+    assertFalse(parsed.autoSend)
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Prevent untrusted apps from injecting and auto-dispatching prompts via the exported `MainActivity` by restoring draft-first behavior for `ai.openclaw.app.action.ASK_OPENCLAW` launches.

### Description
- Change `apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt` to always set `autoSend = false` for `actionAskOpenClaw` while preserving prompt parsing so app-action prompts become drafts.
- Update the corresponding unit test `apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt` to assert `autoSend` is `false` for app-action prompts.

### Testing
- Attempted to run Android unit tests via `./gradlew :app:testDebugUnitTest --tests ai.openclaw.app.AssistantLaunchTest --tests ai.openclaw.app.ui.chat.ChatSheetContentTest`, but the job failed in this environment because the Android Gradle plugin `com.android.application:9.1.0` could not be resolved (build environment limitation).
- Repo verification hooks were run via `scripts/committer` which invoked the repository `pnpm check` pipeline and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ce96fac32083209dc511da33505292)