### PR TITLE
Approvals: require explicit chat exec enablement

### DIFF
--- a/extensions/discord/src/exec-approvals.test.ts
+++ b/extensions/discord/src/exec-approvals.test.ts
@@ -22,7 +22,7 @@ function buildConfig(
 }
 
 describe("discord exec approvals", () => {
-  it("auto-enables when owner approvers resolve and disables only when forced off", () => {
+  it("requires explicit enablement even when owner approvers resolve", () => {
     expect(isDiscordExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
     expect(
       isDiscordExecApprovalClientEnabled({
@@ -33,11 +33,24 @@ describe("discord exec approvals", () => {
       isDiscordExecApprovalClientEnabled({
         cfg: buildConfig({ approvers: ["123"] }),
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isDiscordExecApprovalClientEnabled({
         cfg: {
           ...buildConfig(),
+          commands: { ownerAllowFrom: ["discord:789"] },
+        } as OpenClawConfig,
+      }),
+    ).toBe(false);
+    expect(
+      isDiscordExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: true, approvers: ["123"] }),
+      }),
+    ).toBe(true);
+    expect(
+      isDiscordExecApprovalClientEnabled({
+        cfg: {
+          ...buildConfig({ enabled: "auto" }),
           commands: { ownerAllowFrom: ["discord:789"] },
         } as OpenClawConfig,
       }),

--- a/extensions/slack/src/exec-approvals.test.ts
+++ b/extensions/slack/src/exec-approvals.test.ts
@@ -29,7 +29,7 @@ function buildConfig(
 }
 
 describe("slack exec approvals", () => {
-  it("auto-enables when owner approvers resolve and disables only when forced off", () => {
+  it("requires explicit enablement even when owner approvers resolve", () => {
     expect(isSlackExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
     expect(
       isSlackExecApprovalClientEnabled({
@@ -40,11 +40,24 @@ describe("slack exec approvals", () => {
       isSlackExecApprovalClientEnabled({
         cfg: buildConfig({ approvers: ["U123"] }),
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isSlackExecApprovalClientEnabled({
         cfg: {
           ...buildConfig(),
+          commands: { ownerAllowFrom: ["slack:U123OWNER"] },
+        } as OpenClawConfig,
+      }),
+    ).toBe(false);
+    expect(
+      isSlackExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: true, approvers: ["U123"] }),
+      }),
+    ).toBe(true);
+    expect(
+      isSlackExecApprovalClientEnabled({
+        cfg: {
+          ...buildConfig({ enabled: "auto" }),
           commands: { ownerAllowFrom: ["slack:U123OWNER"] },
         } as OpenClawConfig,
       }),

--- a/extensions/telegram/src/exec-approvals.test.ts
+++ b/extensions/telegram/src/exec-approvals.test.ts
@@ -28,7 +28,7 @@ function buildConfig(
 }
 
 describe("telegram exec approvals", () => {
-  it("auto-enables when approvers resolve and disables only when forced off", () => {
+  it("requires explicit enablement even when approvers resolve", () => {
     expect(isTelegramExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
     expect(
       isTelegramExecApprovalClientEnabled({
@@ -39,10 +39,20 @@ describe("telegram exec approvals", () => {
       isTelegramExecApprovalClientEnabled({
         cfg: buildConfig(undefined, { allowFrom: ["123"] }),
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isTelegramExecApprovalClientEnabled({
         cfg: buildConfig({ approvers: ["123"] }),
+      }),
+    ).toBe(false);
+    expect(
+      isTelegramExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: true, approvers: ["123"] }),
+      }),
+    ).toBe(true);
+    expect(
+      isTelegramExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: "auto", approvers: ["123"] }),
       }),
     ).toBe(true);
     expect(

--- a/src/plugin-sdk/approval-client-helpers.test.ts
+++ b/src/plugin-sdk/approval-client-helpers.test.ts
@@ -77,12 +77,12 @@ describe("createChannelExecApprovalProfile", () => {
     matchesRequestAccount: ({ accountId }) => accountId !== "other",
   });
 
-  it("treats unset enabled as auto and false as disabled", () => {
+  it("requires explicit enablement and still honors auto", () => {
     expect(
       isChannelExecApprovalClientEnabledFromConfig({
         approverCount: 1,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isChannelExecApprovalClientEnabledFromConfig({
         enabled: "auto",

--- a/src/plugin-sdk/approval-client-helpers.ts
+++ b/src/plugin-sdk/approval-client-helpers.ts
@@ -43,7 +43,7 @@ export function isChannelExecApprovalClientEnabledFromConfig(params: {
   if (params.approverCount <= 0) {
     return false;
   }
-  return params.enabled !== false;
+  return params.enabled === true || params.enabled === "auto";
 }
 
 export function isChannelExecApprovalTargetRecipient(params: {


### PR DESCRIPTION
### Motivation
- Prevent chat allowlists or inferred approvers from implicitly enabling exec approvals when `execApprovals.enabled` is omitted, restoring the previous explicit opt-in semantics.
- Keep the `"auto"` and explicit `true` values as supported enablement modes while requiring at least one approver to be present.

### Description
- Change `isChannelExecApprovalClientEnabledFromConfig` to return `true` only when `enabled === true` or `enabled === "auto"` and `approverCount > 0`, instead of treating unset `enabled` as enabled whenever approvers exist (`src/plugin-sdk/approval-client-helpers.ts`).
- Update unit tests for the shared helper to assert unset `enabled` stays disabled and that `"auto"`/`true` still enable the client (`src/plugin-sdk/approval-client-helpers.test.ts`).
- Update Telegram, Discord, and Slack exec-approval tests to require explicit enablement even when approvers resolve from allowlists or owner allowlists, and to keep behavior for explicit `true` and `"auto"` (`extensions/telegram/src/exec-approvals.test.ts`, `extensions/discord/src/exec-approvals.test.ts`, `extensions/slack/src/exec-approvals.test.ts`).

### Testing
- Ran focused unit tests: `pnpm test -- src/plugin-sdk/approval-client-helpers.test.ts extensions/telegram/src/exec-approvals.test.ts extensions/discord/src/exec-approvals.test.ts extensions/slack/src/exec-approvals.test.ts`, and all targeted tests passed. 
- Preflight checks were exercised via the committer flow which ran `pnpm check` (type/lint/build gates) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cea5e75620832083568b34f57d6f54)