### PR TITLE
fix(gateway): block webchat session compaction mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Control UI: require authenticated Control UI read access before serving `/__openclaw/control-ui-config.json` when `gateway.auth` is enabled, so unauthenticated callers can no longer read bootstrap metadata. (#70247) Thanks @drobison00.
 - Gateway/restart: default session-scoped restart sentinels to a one-shot agent continuation, so chat-initiated Gateway restarts acknowledge successful boot automatically. (#70269) Thanks @obviyus.
 - Build/npm publish: fail postpublish verification when root `dist/*` files import bundled plugin runtime dependencies without mirroring them in the root package manifest, so Slack-style plugin deps cannot silently ship on the wrong module-resolution path again. (#60112) thanks @medns.
+- Gateway/sessions: extend the webchat session-mutation guard to `sessions.compact` and `sessions.compaction.restore`, so `WEBCHAT_UI` clients are rejected from compaction-side session mutations consistently with the existing patch/delete guards. (#70716) Thanks @drobison00.
 
 ## 2026.4.21
 

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -223,7 +223,7 @@ function emitSessionsChanged(
 }
 
 function rejectWebchatSessionMutation(params: {
-  action: "patch" | "delete";
+  action: "patch" | "delete" | "compact" | "restore";
   client: GatewayClient | null;
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;
@@ -1101,6 +1101,9 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
+    if (rejectWebchatSessionMutation({ action: "restore", client, isWebchatConnect, respond })) {
+      return;
+    }
     const checkpointId =
       typeof p.checkpointId === "string" && p.checkpointId.trim() ? p.checkpointId.trim() : "";
     if (!checkpointId) {
@@ -1493,6 +1496,9 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params;
     const key = requireSessionKey(p.key, respond);
     if (!key) {
+      return;
+    }
+    if (rejectWebchatSessionMutation({ action: "compact", client, isWebchatConnect, respond })) {
       return;
     }
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -3329,14 +3329,40 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  test("webchat clients cannot patch or delete sessions", async () => {
-    await createSessionStoreDir();
+  test("webchat clients cannot patch, delete, compact, or restore sessions", async () => {
+    const { dir } = await createSessionStoreDir();
+    const fixture = await createCheckpointFixture(dir);
 
     await writeSessionStore({
       entries: {
         main: {
-          sessionId: "sess-main",
+          sessionId: fixture.sessionId,
+          sessionFile: fixture.sessionFile,
           updatedAt: Date.now(),
+          compactionCheckpoints: [
+            {
+              checkpointId: "checkpoint-1",
+              sessionKey: "agent:main:main",
+              sessionId: fixture.sessionId,
+              createdAt: Date.now(),
+              reason: "manual",
+              tokensBefore: 123,
+              tokensAfter: 45,
+              summary: "checkpoint summary",
+              firstKeptEntryId: fixture.preCompactionLeafId,
+              preCompaction: {
+                sessionId: fixture.preCompactionSession.getSessionId(),
+                sessionFile: fixture.preCompactionSessionFile,
+                leafId: fixture.preCompactionLeafId,
+              },
+              postCompaction: {
+                sessionId: fixture.sessionId,
+                sessionFile: fixture.sessionFile,
+                leafId: fixture.postCompactionLeafId,
+                entryId: fixture.postCompactionLeafId,
+              },
+            },
+          ],
         },
         "discord:group:dev": {
           sessionId: "sess-group",
@@ -3372,6 +3398,20 @@ describe("gateway server sessions", () => {
     });
     expect(deleted.ok).toBe(false);
     expect(deleted.error?.message ?? "").toMatch(/webchat clients cannot delete sessions/i);
+
+    const compacted = await rpcReq(ws, "sessions.compact", {
+      key: "main",
+      maxLines: 3,
+    });
+    expect(compacted.ok).toBe(false);
+    expect(compacted.error?.message ?? "").toMatch(/webchat clients cannot compact sessions/i);
+
+    const restored = await rpcReq(ws, "sessions.compaction.restore", {
+      key: "main",
+      checkpointId: "checkpoint-1",
+    });
+    expect(restored.ok).toBe(false);
+    expect(restored.error?.message ?? "").toMatch(/webchat clients cannot restore sessions/i);
 
     ws.close();
   });


### PR DESCRIPTION
# fix(gateway): block webchat session compaction mutations

## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `WEBCHAT_UI` clients were blocked from `sessions.patch` and `sessions.delete`, but the sibling mutation handlers `sessions.compact` and `sessions.compaction.restore` still ran.
- Why it matters: Those handlers rewrite or restore persisted session history, so the webchat-specific mutation boundary was incomplete.
- What changed: Applied `rejectWebchatSessionMutation(...)` to `sessions.compact` and `sessions.compaction.restore`, and expanded the existing gateway regression test to cover both handlers.
- What did NOT change (scope boundary): No method-scope changes, no control-ui policy changes, and no changes outside the gateway session handler plus its targeted test.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes <operator to fill>
- Related NVIDIA-dev/openclaw-tracking#501
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The webchat session-mutation helper was only wired into `sessions.patch` and `sessions.delete`, leaving the sibling `compact` and `restore` mutation paths unguarded.
- Missing detection / guardrail: The existing gateway regression coverage only asserted webchat rejection for patch and delete, so the sibling omission was not locked down.
- Contributing context (if known): The affected handlers already live in the same admin-sensitive session-mutation family, which made the missing guard a consistency gap rather than a separate policy design.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- Scenario the test should lock in: A `WEBCHAT_UI` client cannot patch, delete, compact, or restore sessions, even when the client otherwise has admin-scoped access.
- Why this is the smallest reliable guardrail: The gateway test exercises the real RPC handlers and their webchat client classification without requiring broader end-to-end setup.
- Existing test that already covers this (if any): The same file already covered patch and delete rejection for webchat clients.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `WEBCHAT_UI` clients now receive the same invalid-request rejection for `sessions.compact` and `sessions.compaction.restore` that already applied to `sessions.patch` and `sessions.delete`.
- Control UI behavior is unchanged.

## Diagram (if applicable)

```text
Before:
[WEBCHAT_UI client] -> [sessions.compact / sessions.compaction.restore] -> [mutation allowed]

After:
[WEBCHAT_UI client] -> [rejectWebchatSessionMutation] -> [invalid request error]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node.js v22.14.0
- Model/provider: N/A
- Integration/channel (if any): Gateway `WEBCHAT_UI`
- Relevant config (redacted): N/A

### Steps

1. Start the gateway session test harness with a `WEBCHAT_UI` client connection.
2. Issue `sessions.compact` and `sessions.compaction.restore` RPC requests against an existing session and checkpoint.
3. Run `pnpm test:gateway -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts`.

### Expected

- The webchat client is rejected for patch, delete, compact, and restore session mutations.

### Actual

- The targeted gateway test file passed with the new compact and restore rejection assertions in place.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation command run:

```text
pnpm test:gateway -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the handler diff to confirm only `sessions.compact` and `sessions.compaction.restore` gained the existing webchat guard; ran `pnpm test:gateway -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts`; confirmed the branch diff only touches the session handler and its regression test.
- Edge cases checked: Existing patch/delete webchat rejection remains covered in the expanded test; Control UI exemption remains unchanged in the shared helper.
- What you did **not** verify: Manual end-to-end gateway traffic outside the existing automated gateway test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A non-control webchat client that previously relied on compact or restore will now be rejected.
  - Mitigation: This aligns those handlers with the existing webchat restriction already enforced for the sibling patch and delete mutations.