### PR TITLE
fix(plugins): ignore cwd setup-api fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Anthropic/CLI security: stop Claude CLI backend defaults from forcing `bypassPermissions`, and strip malformed permission-mode overrides instead of silently falling back to a bypass. (#70723) Thanks @vincentkoc.
 - Android/security: require loopback-only cleartext gateway connections on Android manual and scanned routes, so private-LAN and link-local `ws://` endpoints now fail closed unless TLS is enabled. (#70722) Thanks @vincentkoc.
 - Pairing/security: require private-IP or loopback hosts for cleartext mobile pairing, and stop treating `.local` or dotless hostnames as safe cleartext endpoints. (#70721) Thanks @vincentkoc.
+- Plugins/security: stop setup-api lookup from falling back to the launch directory, so workspace-local `extensions/<plugin>/setup-api.*` files cannot be executed during provider setup resolution. (#70718) Thanks @drobison00.
 - Approvals/security: require explicit chat exec-approval enablement instead of auto-enabling approval clients just because approvers resolve from config or owner allowlists. (#70715) Thanks @vincentkoc.
 - Discord/security: keep native slash-command channel policy from bypassing configured owner or member restrictions, while preserving channel-policy fallback when no stricter access rule exists. (#70711) Thanks @vincentkoc.
 - Android/security: stop `ASK_OPENCLAW` intents from auto-sending injected prompts, so external app actions only prefill the draft instead of dispatching it immediately. (#70714) Thanks @vincentkoc.

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -349,6 +349,39 @@ describe("setup-registry getJiti", () => {
     expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(path.join(pluginRoot, "setup-api.js"));
   });
 
+  it("does not load setup-api modules from the current working directory", () => {
+    const pluginRoot = makeTempDir();
+    const workspaceRoot = makeTempDir();
+    const maliciousExtensionRoot = path.join(workspaceRoot, "extensions", "workspace-shadow");
+    fs.mkdirSync(maliciousExtensionRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(maliciousExtensionRoot, "setup-api.js"),
+      "export default { register(api) { api.registerProvider({ id: 'openai', label: 'OpenAI', auth: [] }); } };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-shadow",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "openai" }],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(workspaceRoot);
+    try {
+      expect(resolvePluginSetupProvider({ provider: "openai", env: {} })).toBeUndefined();
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(mocks.createJiti).not.toHaveBeenCalled();
+  });
+
   it("resolves setup cli backends from descriptors without loading every setup-api", () => {
     const openaiRoot = makeTempDir();
     const anthropicRoot = makeTempDir();

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -352,7 +352,14 @@ describe("setup-registry getJiti", () => {
   it("does not load setup-api modules from the current working directory", () => {
     const pluginRoot = makeTempDir();
     const workspaceRoot = makeTempDir();
-    const maliciousExtensionRoot = path.join(workspaceRoot, "extensions", "workspace-shadow");
+    // The old cwd-fallback derived the lookup subdirectory from
+    // `path.basename(pluginRoot)`, so the malicious file must live at
+    // `<workspaceRoot>/extensions/<basename(pluginRoot)>/setup-api.js` to
+    // actually reproduce the pre-fix behavior. Without this, the old code
+    // would have failed to resolve the shadow module too, and the
+    // assertion below would pass vacuously.
+    const shadowDirName = path.basename(pluginRoot);
+    const maliciousExtensionRoot = path.join(workspaceRoot, "extensions", shadowDirName);
     fs.mkdirSync(maliciousExtensionRoot, { recursive: true });
     fs.writeFileSync(
       path.join(maliciousExtensionRoot, "setup-api.js"),

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -195,10 +195,7 @@ function resolveSetupApiPath(rootDir: string): string | null {
   }
 
   const bundledExtensionDir = path.basename(rootDir);
-  const repoRootCandidates = [
-    path.resolve(path.dirname(CURRENT_MODULE_PATH), "..", ".."),
-    process.cwd(),
-  ];
+  const repoRootCandidates = [path.resolve(path.dirname(CURRENT_MODULE_PATH), "..", "..")];
   for (const repoRoot of repoRootCandidates) {
     const sourceExtensionRoot = path.join(repoRoot, "extensions", bundledExtensionDir);
     if (sourceExtensionRoot === rootDir) {


### PR DESCRIPTION
# fix(plugins): ignore cwd setup-api fallback

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `resolveSetupApiPath()` treated `process.cwd()` as a trusted repo root and could load `extensions/<plugin>/setup-api.*` from the current workspace.
- Why it matters: ordinary provider-setup resolution could execute attacker-controlled JavaScript from untrusted repository content.
- What changed: removed the `process.cwd()` fallback so setup module discovery only checks the plugin root and the canonical bundled source root, and added a regression test for a malicious cwd shadow path.
- What did NOT change (scope boundary): no plugin manifest format changes, no broader setup loading refactor, and no CI or workflow changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes <operator to fill>
- Related NVIDIA-dev/openclaw-tracking#515
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `resolveSetupApiPath()` included `process.cwd()` in its repo-root candidates, so bundled plugin setup lookup could fall through to attacker-controlled workspace content.
- Missing detection / guardrail: there was no regression test asserting that cwd `extensions/<plugin>/setup-api.js` content must never be loaded.
- Contributing context (if known): the bundled source fallback exists to support canonical source checkouts, but the cwd fallback widened that trust boundary beyond the actual plugin package roots.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/setup-registry.test.ts`
- Scenario the test should lock in: when a workspace contains `extensions/workspace-shadow/setup-api.js`, provider resolution must not load it just because `process.cwd()` points at that workspace.
- Why this is the smallest reliable guardrail: the vulnerability lives in path selection inside `resolveSetupApiPath()`, and the unit test exercises that exact decision without requiring a full CLI repro harness.
- Existing test that already covers this (if any): none found for cwd shadowing.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Running OpenClaw from a workspace that contains a shadow `extensions/<plugin>/setup-api.*` file no longer affects plugin setup resolution. Canonical bundled source-root fallback behavior remains intact.

## Diagram (if applicable)

```text
Before:
[provider setup lookup]
  -> [plugin root miss]
  -> [cwd/extensions/<plugin>/setup-api.js]
  -> [module executes]

After:
[provider setup lookup]
  -> [plugin root miss]
  -> [canonical bundled source root only]
  -> [no cwd execution]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this narrows the setup-module execution surface by removing cwd-based loading. Only the plugin root and canonical bundled source root remain eligible, which blocks untrusted workspace content from being executed through provider setup resolution.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic
- Runtime/container: Codex task workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): None

### Steps

1. Create a workspace containing `extensions/workspace-shadow/setup-api.js`.
2. Resolve a provider through `resolvePluginSetupProvider()` for a plugin record whose real root has no setup file while `process.cwd()` points at that workspace.
3. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/plugins/setup-registry.test.ts`.

### Expected

- Cwd shadow setup files are ignored, and the targeted setup-registry test file passes.

### Actual

- The new regression test passed, `mocks.createJiti` was not called for the cwd shadow path, and the targeted Vitest command exited successfully.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation command:
`node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/plugins/setup-registry.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: audited the final diff to confirm only `src/plugins/setup-registry.ts` and `src/plugins/setup-registry.test.ts` changed; ran the targeted setup-registry Vitest file and confirmed successful completion; confirmed the new test asserts cwd shadow modules are not loaded.
- Edge cases checked: provider resolution still searches the plugin root first; canonical bundled source-root fallback remains in place; no forbidden `.github` or CI paths are present in the branch diff.
- What you did **not** verify: full CLI end-to-end reproduction commands such as `openclaw models list` from a malicious workspace.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: local workflows that accidentally relied on cwd shadow setup files will stop loading those files.
  - Mitigation: canonical plugin-root and bundled-source-root lookup paths are unchanged; only the untrusted cwd fallback was removed.