### PR TITLE
Security: require IP/loopback hosts for cleartext mobile pairing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
@@ -63,8 +63,6 @@ internal fun isPrivateLanGatewayHost(
   }
   if (host.isEmpty()) return false
   if (isLoopbackGatewayHost(host, allowEmulatorBridgeAlias = allowEmulatorBridgeAlias)) return true
-  if (host.endsWith(".local")) return true
-  if (!host.contains('.') && !host.contains(':')) return true
 
   parseIpv4Address(host)?.let { ipv4 ->
     val first = ipv4[0].toInt() and 0xff

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -242,7 +242,8 @@ class ConnectionManagerTest {
   @Test
   fun isPrivateLanGatewayHost_acceptsLanHostsButRejectsTailnetHosts() {
     assertTrue(isPrivateLanGatewayHost("192.168.1.20"))
-    assertTrue(isPrivateLanGatewayHost("gateway.local"))
+    assertFalse(isPrivateLanGatewayHost("gateway.local"))
+    assertFalse(isPrivateLanGatewayHost("gateway"))
     assertFalse(isPrivateLanGatewayHost("100.64.0.9"))
     assertFalse(isPrivateLanGatewayHost("gateway.tailnet.ts.net"))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -114,18 +114,17 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
+  fun parseGatewayEndpointRejectsMdnsCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://gateway.local:18789")
 
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "gateway.local",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://gateway.local:18789",
-      ),
-      parsed,
-    )
+    assertNull(parsed)
+  }
+
+  @Test
+  fun parseGatewayEndpointRejectsDotlessCleartextWsUrls() {
+    val parsed = parseGatewayEndpoint("ws://gateway:18789")
+
+    assertNull(parsed)
   }
 
   @Test

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -429,21 +429,6 @@ describe("pairing setup code", () => {
         urlSource: "gateway.bind=custom",
       },
     },
-    {
-      name: "allows mdns hostname cleartext setup urls",
-      config: {
-        gateway: {
-          bind: "custom",
-          customBindHost: "gateway.local",
-          auth: { mode: "token", token: "tok_123" },
-        },
-      } satisfies ResolveSetupConfig,
-      expected: {
-        authLabel: "token",
-        url: "ws://gateway.local:18789",
-        urlSource: "gateway.bind=custom",
-      },
-    },
   ] as const)("$name", async ({ config, options, expected }) => {
     await expectResolvedSetupSuccessCase({
       config,
@@ -459,6 +444,28 @@ describe("pairing setup code", () => {
         gateway: {
           bind: "custom",
           customBindHost: "gateway.example",
+          auth: { mode: "token", token: "tok_123" },
+        },
+      } satisfies ResolveSetupConfig,
+      expectedError: "Tailscale and public mobile pairing require a secure gateway URL",
+    },
+    {
+      name: "rejects custom bind mdns ws setup urls for mobile pairing",
+      config: {
+        gateway: {
+          bind: "custom",
+          customBindHost: "gateway.local",
+          auth: { mode: "token", token: "tok_123" },
+        },
+      } satisfies ResolveSetupConfig,
+      expectedError: "Tailscale and public mobile pairing require a secure gateway URL",
+    },
+    {
+      name: "rejects custom bind dotless ws setup urls for mobile pairing",
+      config: {
+        gateway: {
+          bind: "custom",
+          customBindHost: "gateway",
           auth: { mode: "token", token: "tok_123" },
         },
       } satisfies ResolveSetupConfig,

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -80,14 +80,6 @@ function describeSecureMobilePairingFix(source?: string): string {
   );
 }
 
-function isPrivateLanHostname(host: string): boolean {
-  const normalized = host.trim().toLowerCase().replace(/\.+$/, "");
-  if (!normalized) {
-    return false;
-  }
-  return normalized.endsWith(".local") || (!normalized.includes(".") && !normalized.includes(":"));
-}
-
 function isPrivateLanIpHost(host: string): boolean {
   if (isRfc1918Ipv4Address(host)) {
     return true;
@@ -110,12 +102,7 @@ function isPrivateLanIpHost(host: string): boolean {
 }
 
 function isMobilePairingCleartextAllowedHost(host: string): boolean {
-  return (
-    isLoopbackHost(host) ||
-    host === "10.0.2.2" ||
-    isPrivateLanIpHost(host) ||
-    isPrivateLanHostname(host)
-  );
+  return isLoopbackHost(host) || host === "10.0.2.2" || isPrivateLanIpHost(host);
 }
 
 function validateMobilePairingUrl(url: string, source?: string): string | null {


### PR DESCRIPTION
### Motivation
- A recent change treated single-label hostnames and `.local` names as "private LAN" and allowed `ws://` pairing without verifying the resolved IP, which can leak bootstrap tokens when DNS resolves those names to non-LAN addresses. 
- The intent of this PR is to ensure cleartext (non-TLS) mobile pairing remains limited to addresses that are actually local (loopback, emulator bridge, or private/link-local IP literals) rather than inferred from hostname shape.

### Description
- Stop treating hostname-only values and `.local` mDNS names as sufficient evidence of a private LAN host in the pairing validation logic by removing the hostname-only allowlist from `isMobilePairingCleartextAllowedHost` in `src/pairing/setup-code.ts`.
- Mirror the same hardening in the Android code by removing the early `.local`/dotless hostname check from `isPrivateLanGatewayHost` in `apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt` so that hostnames are only considered private after IP parsing/resolution checks.
- Update unit tests to reflect the tightened policy: `src/pairing/setup-code.test.ts` now rejects `.local` and dotless hosts for cleartext mobile pairing, and Android unit tests `apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt` and `apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt` were updated to assert `.local` and dotless hosts are rejected for cleartext endpoints.
- Files changed: `src/pairing/setup-code.ts`, `src/pairing/setup-code.test.ts`, `apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt`, `apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt`, and `apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt`.

### Testing
- Ran the TypeScript unit tests for the pairing logic with `pnpm test -- src/pairing/setup-code.test.ts`, and the suite passed (`23 tests, 1 file`).
- Ran repo checks (`pnpm check`) as part of the commit hooks and they completed successfully in the environment used for the change.
- Android unit tests were updated but could not be executed in this environment because Gradle failed to resolve the Android Gradle plugin (environment limitation), so those JVM tests remain to be run in a normal Android build environment or CI where Gradle can resolve plugins.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cf8d5d6858832085ded73cae8cbd7e)