### PR TITLE
android: restrict cleartext gateway connections to loopback-only

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -7,7 +7,7 @@ import ai.openclaw.app.gateway.GatewayClientInfo
 import ai.openclaw.app.gateway.GatewayConnectOptions
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayTlsParams
-import ai.openclaw.app.gateway.isPrivateLanGatewayHost
+import ai.openclaw.app.gateway.isLoopbackGatewayHost
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.VoiceWakeMode
 
@@ -34,7 +34,7 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
-      val cleartextAllowedHost = isPrivateLanGatewayHost(endpoint.host)
+      val cleartextAllowedHost = isLoopbackGatewayHost(endpoint.host)
 
       if (isManual) {
         if (!manualTlsEnabled && cleartextAllowedHost) return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -1,6 +1,6 @@
 package ai.openclaw.app.ui
 
-import ai.openclaw.app.gateway.isPrivateLanGatewayHost
+import ai.openclaw.app.gateway.isLoopbackGatewayHost
 import java.util.Base64
 import java.util.Locale
 import java.net.URI
@@ -56,9 +56,9 @@ internal data class GatewayScannedSetupCodeResult(
 
 private val gatewaySetupJson = Json { ignoreUnknownKeys = true }
 private const val remoteGatewaySecurityRule =
-  "Tailscale and public mobile nodes require wss:// or Tailscale Serve. ws:// is allowed for private LAN, localhost, and the Android emulator."
+  "Tailscale and public mobile nodes require wss:// or Tailscale Serve. ws:// is allowed only for localhost and the Android emulator."
 private const val remoteGatewaySecurityFix =
-  "Use a private LAN host/address, or enable Tailscale Serve / expose a wss:// gateway URL."
+  "Use localhost/the Android emulator, or enable Tailscale Serve / expose a wss:// gateway URL."
 
 internal fun resolveGatewayConnectConfig(
   useSetupCode: Boolean,
@@ -143,7 +143,7 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "wss", "https" -> true
       else -> true
     }
-  if (!tls && !isPrivateLanGatewayHost(host)) {
+  if (!tls && !isLoopbackGatewayHost(host)) {
     return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INSECURE_REMOTE_URL)
   }
   val defaultPort =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -49,7 +49,7 @@ internal fun buildGatewayDiagnosticsReport(
     Please:
     - pick one route only: same machine, same LAN, Tailscale, or public URL
     - classify this as pairing/auth, TLS trust, wrong advertised route, wrong address/port, or gateway down
-    - remember: Tailscale/public mobile routes require wss:// or Tailscale Serve; private LAN ws:// is still allowed
+    - remember: Tailscale/public mobile routes require wss:// or Tailscale Serve; ws:// is loopback-only
     - quote the exact app status/error below
     - tell me whether `openclaw devices list` should show a pending pairing request
     - if more signal is needed, ask for `openclaw qr --json`, `openclaw devices list`, and `openclaw nodes status`

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -118,7 +118,9 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertNull(params)
+    assertEquals(true, params?.required)
+    assertNull(params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
   }
 
   @Test
@@ -164,7 +166,9 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertNull(params)
+    assertEquals(true, params?.required)
+    assertNull(params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -99,33 +99,15 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointAllowsPrivateLanCleartextWsUrls() {
+  fun parseGatewayEndpointRejectsPrivateLanCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://192.168.1.20:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "192.168.1.20",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://192.168.1.20:18789",
-      ),
-      parsed,
-    )
+    assertNull(parsed)
   }
 
   @Test
-  fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
+  fun parseGatewayEndpointRejectsMdnsCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://gateway.local:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "gateway.local",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://gateway.local:18789",
-      ),
-      parsed,
-    )
+    assertNull(parsed)
   }
 
   @Test
@@ -163,13 +145,9 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls() {
+  fun parseGatewayEndpointRejectsLinkLocalIpv6ZoneCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://[fe80::1%25eth0]")
-
-    assertEquals("fe80::1%25eth0", parsed?.host)
-    assertEquals(18789, parsed?.port)
-    assertEquals(false, parsed?.tls)
-    assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
+    assertNull(parsed)
   }
 
   @Test
@@ -290,19 +268,10 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointResultAcceptsLanCleartextGateway() {
+  fun parseGatewayEndpointResultFlagsInsecureLanCleartextGateway() {
     val parsed = parseGatewayEndpointResult("ws://192.168.1.20:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "192.168.1.20",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://192.168.1.20:18789",
-      ),
-      parsed.config,
-    )
-    assertNull(parsed.error)
+    assertNull(parsed.config)
+    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, parsed.error)
   }
 
   @Test
@@ -443,7 +412,7 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun resolveGatewayConnectConfigAllowsPrivateLanManualCleartextEndpoint() {
+  fun resolveGatewayConnectConfigRejectsPrivateLanManualCleartextEndpoint() {
     val resolved =
       resolveGatewayConnectConfig(
         useSetupCode = false,
@@ -459,9 +428,7 @@ class GatewayConfigResolverTest {
         fallbackPassword = "",
       )
 
-    assertEquals("192.168.31.100", resolved?.host)
-    assertEquals(18789, resolved?.port)
-    assertEquals(false, resolved?.tls)
+    assertNull(resolved)
   }
 
   private fun encodeSetupCode(payloadJson: String): String {


### PR DESCRIPTION
### Motivation
- Close a security regression that allowed `ws://`/`http://` connections for broad private‑LAN hosts, which exposed bootstrap/shared/operator tokens to LAN MITM. 
- Restore the prior, safer policy that permits cleartext only for loopback/emulator endpoints.

### Description
- Require loopback-only hosts when permitting cleartext by replacing `isPrivateLanGatewayHost(...)` with `isLoopbackGatewayHost(...)` in TLS resolution at `apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt`.
- Tighten gateway URL parsing to reject non‑TLS `ws://`/`http://` for private LAN/mDNS/link‑local hosts by switching to `isLoopbackGatewayHost(...)` and update the diagnostic/help strings in `apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt` and `apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt`.
- Update unit tests to reflect the restored security boundary by changing expectations to require TLS (or reject) for private LAN, mDNS, and link‑local cleartext endpoints in `apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt` and `apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt`.

### Testing
- Attempted to run Android unit tests with `cd apps/android && ./gradlew app:testDebugUnitTest --tests ai.openclaw.app.node.ConnectionManagerTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest`, but the Gradle run failed in this environment because the Android Gradle plugin `com.android.application:9.1.0` could not be resolved.
- The repository-wide pre-commit gate (`pnpm check`) also failed when run by the committer hook due to unrelated TypeScript errors in `src/config/io.write-config.test.ts` that pre-existed this change.
- Committed the change locally with `FAST_COMMIT=1 scripts/committer "android: require loopback-only cleartext gateways" ...` (skipped the full `pnpm check` in the hook) and updated tests to match the tightened behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d07c3431d48320b5f10620f1087fc3)