### PR TITLE
Security: remove claude-cli permission bypass defaults

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -26,8 +26,6 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--verbose",
         "--setting-sources",
         "user",
-        "--permission-mode",
-        "bypassPermissions",
       ],
       resumeArgs: [
         "-p",
@@ -37,8 +35,6 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--verbose",
         "--setting-sources",
         "user",
-        "--permission-mode",
-        "bypassPermissions",
         "--resume",
         "{sessionId}",
       ],

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -9,23 +9,16 @@ import {
 } from "./cli-shared.js";
 
 describe("normalizeClaudePermissionArgs", () => {
-  it("injects bypassPermissions when args omit permission flags", () => {
+  it("does not inject permission-mode when args omit permission flags", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--output-format", "stream-json", "--verbose"]),
-    ).toEqual([
-      "-p",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--permission-mode",
-      "bypassPermissions",
-    ]);
+    ).toEqual(["-p", "--output-format", "stream-json", "--verbose"]);
   });
 
-  it("removes legacy skip-permissions and injects bypassPermissions", () => {
+  it("removes legacy skip-permissions", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--dangerously-skip-permissions", "--verbose"]),
-    ).toEqual(["-p", "--verbose", "--permission-mode", "bypassPermissions"]);
+    ).toEqual(["-p", "--verbose"]);
   });
 
   it("keeps explicit permission-mode overrides", () => {
@@ -40,10 +33,10 @@ describe("normalizeClaudePermissionArgs", () => {
     ]);
   });
 
-  it("treats a bare permission-mode flag as malformed and falls back to bypassPermissions", () => {
+  it("treats a bare permission-mode flag as malformed and drops it", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--permission-mode", "--output-format", "stream-json"]),
-    ).toEqual(["-p", "--output-format", "stream-json", "--permission-mode", "bypassPermissions"]);
+    ).toEqual(["-p", "--output-format", "stream-json"]);
   });
 });
 
@@ -93,8 +86,6 @@ describe("normalizeClaudeBackendConfig", () => {
       "--verbose",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(normalized.resumeArgs).toEqual([
       "-p",
@@ -105,8 +96,6 @@ describe("normalizeClaudeBackendConfig", () => {
       "{sessionId}",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
   });
 
@@ -122,12 +111,8 @@ describe("normalizeClaudeBackendConfig", () => {
       resumeArgs: ["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"],
     });
 
-    expect(normalized?.args).toContain("--permission-mode");
-    expect(normalized?.args).toContain("bypassPermissions");
     expect(normalized?.args).toContain("--setting-sources");
     expect(normalized?.args).toContain("user");
-    expect(normalized?.resumeArgs).toContain("--permission-mode");
-    expect(normalized?.resumeArgs).toContain("bypassPermissions");
     expect(normalized?.resumeArgs).toContain("--setting-sources");
     expect(normalized?.resumeArgs).toContain("user");
   });

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -87,7 +87,6 @@ export const CLAUDE_CLI_CLEAR_ENV = [
 
 const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";
 const CLAUDE_PERMISSION_MODE_ARG = "--permission-mode";
-const CLAUDE_BYPASS_PERMISSIONS_MODE = "bypassPermissions";
 const CLAUDE_SETTING_SOURCES_ARG = "--setting-sources";
 const CLAUDE_SAFE_SETTING_SOURCES = "user";
 
@@ -100,7 +99,6 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
     return args;
   }
   const normalized: string[] = [];
-  let hasPermissionMode = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG) {
@@ -113,20 +111,13 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
         maybeValue.trim().length > 0 &&
         !maybeValue.startsWith("-")
       ) {
-        hasPermissionMode = true;
         normalized.push(arg);
         normalized.push(maybeValue);
         i += 1;
       }
       continue;
     }
-    if (arg.startsWith(`${CLAUDE_PERMISSION_MODE_ARG}=`)) {
-      hasPermissionMode = true;
-    }
     normalized.push(arg);
-  }
-  if (!hasPermissionMode) {
-    normalized.push(CLAUDE_PERMISSION_MODE_ARG, CLAUDE_BYPASS_PERMISSIONS_MODE);
   }
   return normalized;
 }

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -38,8 +38,6 @@ beforeEach(() => {
           "--verbose",
           "--setting-sources",
           "user",
-          "--permission-mode",
-          "bypassPermissions",
         ],
         resumeArgs: [
           "stream-json",
@@ -47,8 +45,6 @@ beforeEach(() => {
           "--verbose",
           "--setting-sources",
           "user",
-          "--permission-mode",
-          "bypassPermissions",
           "--resume",
           "{sessionId}",
         ],
@@ -198,7 +194,7 @@ describe("resolveCliBackendConfig reliability merge", () => {
 });
 
 describe("resolveCliBackendConfig claude-cli defaults", () => {
-  it("uses non-interactive permission-mode defaults for fresh and resume args", () => {
+  it("uses hardened claude-cli defaults for fresh and resume args", () => {
     const resolved = resolveCliBackendConfig("claude-cli");
 
     expect(resolved).not.toBeNull();
@@ -208,8 +204,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.args).toContain("--verbose");
     expect(resolved?.config.args).toContain("--setting-sources");
     expect(resolved?.config.args).toContain("user");
-    expect(resolved?.config.args).toContain("--permission-mode");
-    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.args).not.toContain("--permission-mode");
     expect(resolved?.config.args).not.toContain("--dangerously-skip-permissions");
     expect(resolved?.config.input).toBe("stdin");
     expect(resolved?.config.resumeArgs).toContain("stream-json");
@@ -217,8 +212,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.resumeArgs).toContain("--verbose");
     expect(resolved?.config.resumeArgs).toContain("--setting-sources");
     expect(resolved?.config.resumeArgs).toContain("user");
-    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
-    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).not.toContain("--permission-mode");
     expect(resolved?.config.resumeArgs).not.toContain("--dangerously-skip-permissions");
   });
 
@@ -241,12 +235,10 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.command).toBe("/usr/local/bin/claude");
     expect(resolved?.config.args).toContain("--setting-sources");
     expect(resolved?.config.args).toContain("user");
-    expect(resolved?.config.args).toContain("--permission-mode");
-    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.args).not.toContain("--permission-mode");
     expect(resolved?.config.resumeArgs).toContain("--setting-sources");
     expect(resolved?.config.resumeArgs).toContain("user");
-    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
-    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).not.toContain("--permission-mode");
     expect(resolved?.config.env).toEqual({ CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: "1" });
     expect(resolved?.config.clearEnv).toContain("ANTHROPIC_BASE_URL");
     expect(resolved?.config.clearEnv).toContain("CLAUDE_CONFIG_DIR");
@@ -257,7 +249,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.clearEnv).toContain("CLAUDE_CODE_USE_COWORK_PLUGINS");
   });
 
-  it("normalizes legacy skip-permissions overrides to permission-mode bypassPermissions", () => {
+  it("normalizes legacy skip-permissions overrides by removing the legacy flag", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -283,11 +275,9 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
 
     expect(resolved).not.toBeNull();
     expect(resolved?.config.args).not.toContain("--dangerously-skip-permissions");
-    expect(resolved?.config.args).toContain("--permission-mode");
-    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.args).not.toContain("--permission-mode");
     expect(resolved?.config.resumeArgs).not.toContain("--dangerously-skip-permissions");
-    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
-    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).not.toContain("--permission-mode");
   });
 
   it("keeps explicit permission-mode overrides while removing legacy skip flag", () => {
@@ -399,8 +389,6 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "stream-json",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(resolved?.config.resumeArgs).toEqual([
       "-p",
@@ -408,12 +396,10 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "{sessionId}",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
   });
 
-  it("falls back to bypassPermissions when a custom override leaves permission-mode without a value", () => {
+  it("drops malformed permission-mode values while keeping setting-source hardening", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -437,8 +423,6 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "stream-json",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(resolved?.config.resumeArgs).toEqual([
       "-p",
@@ -446,12 +430,10 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "{sessionId}",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
   });
 
-  it("injects bypassPermissions when custom args omit any permission flag", () => {
+  it("does not inject permission-mode when custom args omit permission flags", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -478,12 +460,10 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved).not.toBeNull();
     expect(resolved?.config.args).toContain("--setting-sources");
     expect(resolved?.config.args).toContain("user");
-    expect(resolved?.config.args).toContain("--permission-mode");
-    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.args).not.toContain("--permission-mode");
     expect(resolved?.config.resumeArgs).toContain("--setting-sources");
     expect(resolved?.config.resumeArgs).toContain("user");
-    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
-    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).not.toContain("--permission-mode");
   });
 
   it("keeps hardened clearEnv defaults when custom claude env overrides are merged", () => {
@@ -548,8 +528,6 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "json",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(resolved?.config.resumeArgs).toEqual([
       "-p",
@@ -559,8 +537,6 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "{sessionId}",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(resolved?.config.systemPromptArg).toBe("--append-system-prompt");
     expect(resolved?.config.systemPromptWhen).toBe("first");


### PR DESCRIPTION
### Motivation

- Prevent the Anthropic Claude CLI backend from disabling Claude CLI permission prompts by default, which allowed untrusted inputs to trigger local actions outside OpenClaw's tool/sandbox guardrails.

### Description

- Remove the hard-coded `--permission-mode bypassPermissions` defaults from the Anthropic backend `args` and `resumeArgs` in `extensions/anthropic/cli-backend.ts` so the backend no longer launches Claude CLI in bypass mode by default. 
- Stop auto-injecting a bypass permission mode in `normalizeClaudePermissionArgs` by removing the fallback injection while preserving sanitization of legacy `--dangerously-skip-permissions` and keeping valid explicit `--permission-mode` overrides in `extensions/anthropic/cli-shared.ts`.
- Update unit tests to reflect the new safe defaults and normalization behavior in `extensions/anthropic/cli-shared.test.ts` and `src/agents/cli-backends.test.ts`.

### Testing

- Ran `pnpm test extensions/anthropic/cli-shared.test.ts src/agents/cli-backends.test.ts`, and both test files passed.
- The targeted unit tests validate that defaults no longer include `--permission-mode` or `bypassPermissions`, legacy skip flags are removed, malformed `--permission-mode` flags are dropped, and setting-source hardening (`--setting-sources user`) is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d3b534ab4c8320a1915924733ba94a)