### PR TITLE
fix(webhooks): reload route secrets per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Anthropic Vertex: restore ADC-backed model discovery after the lightweight provider-discovery path by resolving emitted discovery entries, exposing synthetic auth on bootstrap discovery, and honoring copied env snapshots when probing the default GCP ADC path. Fixes #65715. (#65716) Thanks @feiskyer.
 - Codex harness/status: pin embedded harness selection per session, show active non-PI harness ids such as `codex` in `/status`, and keep legacy transcripts on PI until `/new` or `/reset` so config changes cannot hot-switch existing sessions.
 - Gateway/security: fail closed on agent-driven `gateway config.apply`/`config.patch` runtime edits by allowlisting a narrow set of agent-tunable prompt, model, and mention-gating paths (including Telegram topic-level `requireMention`) instead of relying on a hand-maintained denylist of protected subtrees that could miss new sensitive config keys. (#70726) Thanks @drobison00.
+- Webhooks/security: re-resolve `SecretRef`-backed webhook route secrets on each request so `openclaw secrets reload` revokes the previous secret immediately instead of waiting for a gateway restart. (#70727) Thanks @drobison00.
 
 ## 2026.4.22
 

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -158,9 +158,10 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     expect(res.statusCode).toBe(401);
     expect(res.body).toBe("unauthorized");
     expect(target.taskFlow.list()).toEqual([]);
+    expect(hoisted.resolveConfiguredSecretInputStringMock).not.toHaveBeenCalled();
   });
 
-  it("caches SecretRef resolution across requests for the same route", async () => {
+  it("re-resolves SecretRef-backed secrets across requests", async () => {
     const runtime = createRuntimeTaskFlow();
     const target: TaskFlowWebhookTarget = {
       routeId: "cached",
@@ -176,7 +177,10 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         sessionKey: "agent:main:webhook-cached",
       }),
     };
-    hoisted.resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "shared-secret" });
+    hoisted.resolveConfiguredSecretInputStringMock
+      .mockResolvedValueOnce({ value: "shared-secret" })
+      .mockResolvedValueOnce({ value: "rotated-secret" })
+      .mockResolvedValueOnce({ value: "rotated-secret" });
     const handler = createHandlerWithTarget(target);
 
     const first = await dispatchJsonRequest({
@@ -195,10 +199,20 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         action: "list_flows",
       },
     });
+    const third = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret: "rotated-secret",
+      body: {
+        action: "list_flows",
+      },
+    });
 
     expect(first.statusCode).toBe(200);
-    expect(second.statusCode).toBe(200);
-    expect(hoisted.resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(1);
+    expect(second.statusCode).toBe(401);
+    expect(second.body).toBe("unauthorized");
+    expect(third.statusCode).toBe(200);
+    expect(hoisted.resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(3);
   });
 
   it("creates flows through the bound session and scrubs owner metadata from responses", async () => {

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -667,7 +667,6 @@ export function createTaskFlowWebhookRequestHandler(params: {
   targetsByPath: Map<string, TaskFlowWebhookTarget[]>;
   inFlightLimiter?: WebhookInFlightLimiter;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
-  const secretByTarget = new WeakMap<TaskFlowWebhookTarget, Promise<string | undefined>>();
   const rateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
     maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
@@ -679,19 +678,19 @@ export function createTaskFlowWebhookRequestHandler(params: {
       maxInFlightPerKey: WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey,
       maxTrackedKeys: WEBHOOK_IN_FLIGHT_DEFAULTS.maxTrackedKeys,
     });
-  const resolveTargetSecret = (target: TaskFlowWebhookTarget): Promise<string | undefined> => {
-    const cached = secretByTarget.get(target);
-    if (cached) {
-      return cached;
+  const resolveTargetSecret = async (
+    target: TaskFlowWebhookTarget,
+  ): Promise<string | undefined> => {
+    if (typeof target.secretInput === "string") {
+      return target.secretInput;
     }
-    const pending = resolveConfiguredSecretInputString({
+    const resolved = await resolveConfiguredSecretInputString({
       config: params.cfg,
       env: process.env,
       value: target.secretInput,
       path: target.secretConfigPath,
-    }).then((resolved) => resolved.value);
-    secretByTarget.set(target, pending);
-    return pending;
+    });
+    return resolved.value;
   };
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {


### PR DESCRIPTION
# fix(webhooks): reload route secrets per request

## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Webhook routes backed by runtime-resolved secrets kept using an in-memory cached value after the underlying secret rotated.
- Why it matters: After `openclaw secrets reload`, an old leaked webhook secret could still authenticate requests until restart.
- What changed: Removed the per-route resolved-secret cache in the webhook HTTP handler and re-resolve `SecretRef` inputs on each request, while preserving the string-secret fast path.
- What did NOT change (scope boundary): No route config format, reload plumbing, or non-webhook secret handling changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `createTaskFlowWebhookRequestHandler` cached resolved `SecretRef` values in a `WeakMap`, so runtime secret rotation did not affect already-registered webhook routes.
- Missing detection / guardrail: The existing test expected a cached secret to persist across requests instead of asserting revocation after rotation.
- Contributing context (if known): `secrets.reload` refreshes the runtime secret snapshot without rebuilding webhook handlers, so revocation depended on the handler reading the current secret value at request time.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/webhooks/src/http.test.ts`
- Scenario the test should lock in: A request signed with the pre-rotation secret is rejected after the secret source changes, and a request signed with the new secret succeeds.
- Why this is the smallest reliable guardrail: The regression is local to request-time secret resolution in the webhook handler and can be reproduced with the existing mocked secret-resolution helper.
- Existing test that already covers this (if any): `createTaskFlowWebhookRequestHandler > rejects requests with the wrong secret`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Webhook routes using runtime-resolved secrets now honor rotated secrets on the next request after `openclaw secrets reload`; the previous secret is no longer accepted until restart.

## Diagram (if applicable)

```text
Before:
[rotate secret + reload] -> [handler keeps cached old secret] -> [old secret still authenticates]

After:
[rotate secret + reload] -> [handler re-resolves current secret] -> [old secret rejected, new secret accepted]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: Secret-backed webhook authentication now reads the current secret value on each request instead of reusing a stale cached value, which closes the post-rotation acceptance window. Plain string secrets still use the direct fast path.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Codex task workspace container
- Model/provider: Codex GPT-5
- Integration/channel (if any): N/A
- Relevant config (redacted): Default test config with mocked webhook secret resolution

### Steps

1. Configure a webhook route with a runtime-resolved secret.
2. Send one request with the current secret, then rotate the backing secret and refresh the runtime secret snapshot.
3. Retry with the old secret, then with the rotated secret.

### Expected

- The old secret is rejected after rotation and the rotated secret succeeds.

### Actual

- Verified by `pnpm test:extension webhooks -- extensions/webhooks/src/http.test.ts --reporter=verbose` in `/data/state/workspaces/openclaw-project-issue-fix-mob-c2ef4edbee/repo`, which ran `extensions/webhooks/src/http.test.ts` and passed all 9 tests, including `re-resolves SecretRef-backed secrets across requests`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm test:extension webhooks -- extensions/webhooks/src/http.test.ts --reporter=verbose` in the current repo checkout and confirmed all 9 targeted webhook handler tests passed, including wrong-secret rejection and rotated-secret acceptance.
- Edge cases checked: Plain string secrets still bypass runtime resolution; the rotated `SecretRef` path rejects the old secret and accepts the new one.
- What you did **not** verify: I did not run a full gateway process or an end-to-end `openclaw secrets reload` flow outside the targeted extension tests.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Secret-backed webhook routes now perform runtime secret resolution on each authenticated request, which adds some per-request work compared with the previous cache.
  - Mitigation: The change is limited to `SecretRef`-backed routes, plain string secrets still return immediately, and the handler's existing rate/in-flight limiters remain unchanged.