### PR TITLE
fix(pi-embedded-runner): make idle-timeout cleanup return before flushing pending tool results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends; \
     fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git gh lsof openssl
+      procps hostname curl git lsof openssl
 
 RUN chown node:node /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends; \
     fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git lsof openssl
+      procps hostname curl git gh lsof openssl
 
 RUN chown node:node /app
 

--- a/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
+++ b/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
@@ -54,11 +54,9 @@ describe("flushPendingToolResultsAfterIdle", () => {
       timeoutMs: 1_000,
     });
 
-    // Flush is waiting for idle; synthetic result must not appear yet.
     await Promise.resolve();
     expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant"]);
 
-    // Tool completes before idle wait finishes.
     appendMessage(toolResult("call_retry_1", "command output here"));
     idle.resolve();
     await flushPromise;
@@ -71,7 +69,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
     );
   });
 
-  it("flushes pending tool call after timeout when idle never resolves", async () => {
+  it("does not synthesize a tool result after timeout when idle never resolves", async () => {
     const sm = guardSessionManager(SessionManager.inMemory());
     const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
     vi.useFakeTimers();
@@ -87,14 +85,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
     await vi.advanceTimersByTimeAsync(30);
     await flushPromise;
 
-    const entries = getMessages(sm);
-
-    expect(entries.length).toBe(2);
-    expect(entries[1].role).toBe("toolResult");
-    expect((entries[1] as { isError?: boolean }).isError).toBe(true);
-    expect((entries[1] as { content?: Array<{ text?: string }> }).content?.[0]?.text).toContain(
-      "missing tool result",
-    );
+    expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant"]);
   });
 
   it("clears pending without synthetic flush when timeout cleanup is requested", async () => {

--- a/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -46,12 +46,14 @@ export async function flushPendingToolResultsAfterIdle(opts: {
   timeoutMs?: number;
   clearPendingOnTimeout?: boolean;
 }): Promise<void> {
-  const timedOut = await waitForAgentIdleBestEffort(
+  const idleState = await waitForAgentIdleBestEffort(
     opts.agent,
     opts.timeoutMs ?? DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS,
   );
-  if (timedOut && opts.clearPendingOnTimeout && opts.sessionManager?.clearPendingToolResults) {
-    opts.sessionManager.clearPendingToolResults();
+  if (idleState.timedOut) {
+    if (opts.clearPendingOnTimeout && opts.sessionManager?.clearPendingToolResults) {
+      opts.sessionManager.clearPendingToolResults();
+    }
     return;
   }
   opts.sessionManager?.flushPendingToolResults?.();

--- a/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -9,13 +9,18 @@ type ToolResultFlushManager = {
 
 export const DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
 
+type AgentIdleWaitState = {
+  timedOut: boolean;
+  resolved: boolean;
+};
+
 async function waitForAgentIdleBestEffort(
   agent: IdleAwareAgent | null | undefined,
   timeoutMs: number,
-): Promise<boolean> {
+): Promise<AgentIdleWaitState> {
   const waitForIdle = agent?.waitForIdle;
   if (typeof waitForIdle !== "function") {
-    return false;
+    return { timedOut: false, resolved: false };
   }
 
   const idleResolved = Symbol("idle");
@@ -29,10 +34,13 @@ async function waitForAgentIdleBestEffort(
         timeoutHandle.unref?.();
       }),
     ]);
-    return outcome === idleTimedOut;
+    return {
+      timedOut: outcome === idleTimedOut,
+      resolved: outcome === idleResolved,
+    };
   } catch {
     // Best-effort during cleanup.
-    return false;
+    return { timedOut: false, resolved: false };
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);


### PR DESCRIPTION
Follow-up to #13746. This patch fixes the timeout branch in `wait-for-idle-before-flush.ts` so an idle wait timeout cannot fall through into a normal pending-tool-result flush path. Without this, the boolean return value obscured the difference between an idle completion and a forced timeout cleanup.