### PR TITLE
[codex] Expose agent harness selection decisions

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -50,6 +50,11 @@ OpenClaw has separate routes for OpenAI and Codex-shaped access:
 The Codex harness only claims `codex/*` model refs. Existing `openai/*`,
 `openai-codex/*`, Anthropic, Gemini, xAI, local, and custom provider refs keep
 their normal paths.
+Enable debug logging for the `agents/harness` subsystem to inspect the
+structured `agent harness selected` record. It includes the selected harness id,
+policy runtime/fallback values, and the support result for each registered
+plugin harness, which makes prefix mistakes (`openai-codex/*` vs `codex/*`)
+visible without changing runtime behavior.
 
 Harness selection is not a live session control. When an embedded turn runs,
 OpenClaw records the selected harness id on that session and keeps using it for

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -108,6 +108,11 @@ Legacy sessions created before harness pins are treated as PI-pinned once they
 have transcript history. Use a new/reset session when changing between PI and a
 native plugin harness. `/status` shows non-default harness ids such as `codex`
 next to `Fast`; PI stays hidden because it is the default compatibility path.
+When debug logging is enabled, OpenClaw also emits a structured `agent harness
+selected` record with the resolved runtime policy, PI fallback mode, selected
+harness id, selection reason, and every plugin candidate's support reason. This
+is the safest way to diagnose why a `codex/*` model used the Codex harness while
+an `openai-codex/*` model stayed on the PI compatibility path.
 
 The bundled Codex plugin registers `codex` as its harness id. Core treats that
 as an ordinary plugin harness id; Codex-specific aliases belong in the plugin

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -9,6 +9,7 @@ import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
 import {
   maybeCompactAgentHarnessSession,
   runAgentHarnessAttemptWithFallback,
+  resolveAgentHarnessSelection,
   selectAgentHarness,
 } from "./selection.js";
 import type { AgentHarness } from "./types.js";
@@ -152,6 +153,103 @@ describe("runAgentHarnessAttemptWithFallback", () => {
 });
 
 describe("selectAgentHarness", () => {
+  it("exposes an observable auto-selection decision without duplicate support probes", () => {
+    process.env.OPENCLAW_AGENT_RUNTIME = "auto";
+    const lowPrioritySupports = vi.fn(() => ({
+      supported: true as const,
+      priority: 10,
+      reason: "generic codex support",
+    }));
+    const highPrioritySupports = vi.fn(() => ({
+      supported: true as const,
+      priority: 100,
+      reason: "native codex app-server",
+    }));
+    const unsupportedSupports = vi.fn(() => ({
+      supported: false as const,
+      reason: "provider mismatch",
+    }));
+    registerAgentHarness(
+      {
+        id: "codex-low",
+        label: "Low Codex",
+        supports: lowPrioritySupports,
+        runAttempt: vi.fn(async () => createAttemptResult("codex-low")),
+      },
+      { ownerPluginId: "codex-low" },
+    );
+    registerAgentHarness(
+      {
+        id: "codex-high",
+        label: "High Codex",
+        supports: highPrioritySupports,
+        runAttempt: vi.fn(async () => createAttemptResult("codex-high")),
+      },
+      { ownerPluginId: "codex-high" },
+    );
+    registerAgentHarness(
+      {
+        id: "other",
+        label: "Other Harness",
+        supports: unsupportedSupports,
+        runAttempt: vi.fn(async () => createAttemptResult("other")),
+      },
+      { ownerPluginId: "other" },
+    );
+
+    const decision = resolveAgentHarnessSelection({
+      provider: "codex",
+      modelId: "gpt-5.4",
+    });
+
+    expect(decision.selectedHarnessId).toBe("codex-high");
+    expect(decision.selectedReason).toBe("auto_plugin");
+    expect(decision.policy).toEqual({ runtime: "auto", fallback: "pi" });
+    expect(decision.candidates).toEqual([
+      expect.objectContaining({
+        id: "codex-low",
+        supported: true,
+        priority: 10,
+        reason: "generic codex support",
+      }),
+      expect.objectContaining({
+        id: "codex-high",
+        supported: true,
+        priority: 100,
+        reason: "native codex app-server",
+      }),
+      expect.objectContaining({
+        id: "other",
+        supported: false,
+        reason: "provider mismatch",
+      }),
+    ]);
+    expect(lowPrioritySupports).toHaveBeenCalledTimes(1);
+    expect(highPrioritySupports).toHaveBeenCalledTimes(1);
+    expect(unsupportedSupports).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports pinned PI selection without probing plugin support", () => {
+    const supports = vi.fn(() => ({ supported: true as const, priority: 100 }));
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("codex")),
+    });
+
+    const decision = resolveAgentHarnessSelection({
+      provider: "codex",
+      modelId: "gpt-5.4",
+      agentHarnessId: "pi",
+    });
+
+    expect(decision.selectedHarnessId).toBe("pi");
+    expect(decision.selectedReason).toBe("pinned");
+    expect(decision.candidates).toEqual([expect.objectContaining({ id: "codex" })]);
+    expect(supports).not.toHaveBeenCalled();
+  });
+
   it("fails instead of choosing PI when no plugin harness matches and fallback is none", () => {
     expect(() =>
       selectAgentHarness({

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -28,6 +28,30 @@ type AgentHarnessPolicy = {
   fallback: EmbeddedAgentHarnessFallback;
 };
 
+export type AgentHarnessSelectionCandidate = {
+  id: string;
+  label: string;
+  pluginId?: string;
+  supported?: boolean;
+  priority?: number;
+  reason?: string;
+};
+
+export type AgentHarnessSelectionDecision = {
+  harness: AgentHarness;
+  policy: AgentHarnessPolicy;
+  selectedHarnessId: string;
+  selectedHarnessLabel: string;
+  selectedReason:
+    | "pinned"
+    | "forced_pi"
+    | "forced_plugin"
+    | "forced_plugin_missing_pi_fallback"
+    | "auto_plugin"
+    | "auto_pi_fallback";
+  candidates: AgentHarnessSelectionCandidate[];
+};
+
 function listPluginAgentHarnesses(): AgentHarness[] {
   return listRegisteredAgentHarnesses().map((entry) => entry.harness);
 }
@@ -51,20 +75,41 @@ export function selectAgentHarness(params: {
   sessionKey?: string;
   agentHarnessId?: string;
 }): AgentHarness {
-  const policy =
-    resolvePinnedAgentHarnessPolicy(params.agentHarnessId) ?? resolveAgentHarnessPolicy(params);
+  return resolveAgentHarnessSelection(params).harness;
+}
+
+export function resolveAgentHarnessSelection(params: {
+  provider: string;
+  modelId?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  agentHarnessId?: string;
+}): AgentHarnessSelectionDecision {
+  const pinnedPolicy = resolvePinnedAgentHarnessPolicy(params.agentHarnessId);
+  const policy = pinnedPolicy ?? resolveAgentHarnessPolicy(params);
   // PI is intentionally not part of the plugin candidate list. It is the legacy
   // fallback path, so `fallback: "none"` can prove that only plugin harnesses run.
   const pluginHarnesses = listPluginAgentHarnesses();
   const piHarness = createPiAgentHarness();
   const runtime = policy.runtime;
   if (runtime === "pi") {
-    return piHarness;
+    return buildSelectionDecision({
+      harness: piHarness,
+      policy,
+      selectedReason: pinnedPolicy ? "pinned" : "forced_pi",
+      candidates: listHarnessCandidates(pluginHarnesses),
+    });
   }
   if (runtime !== "auto") {
     const forced = pluginHarnesses.find((entry) => entry.id === runtime);
     if (forced) {
-      return forced;
+      return buildSelectionDecision({
+        harness: forced,
+        policy,
+        selectedReason: pinnedPolicy ? "pinned" : "forced_plugin",
+        candidates: listHarnessCandidates(pluginHarnesses),
+      });
     }
     if (policy.fallback === "none") {
       throw new Error(
@@ -74,17 +119,26 @@ export function selectAgentHarness(params: {
     log.warn("requested agent harness is not registered; falling back to embedded PI backend", {
       requestedRuntime: runtime,
     });
-    return piHarness;
+    return buildSelectionDecision({
+      harness: piHarness,
+      policy,
+      selectedReason: "forced_plugin_missing_pi_fallback",
+      candidates: listHarnessCandidates(pluginHarnesses),
+    });
   }
 
-  const supported = pluginHarnesses
+  const candidates = pluginHarnesses.map((harness) => ({
+    harness,
+    support: harness.supports({
+      provider: params.provider,
+      modelId: params.modelId,
+      requestedRuntime: runtime,
+    }),
+  }));
+  const supported = candidates
     .map((harness) => ({
-      harness,
-      support: harness.supports({
-        provider: params.provider,
-        modelId: params.modelId,
-        requestedRuntime: runtime,
-      }),
+      harness: harness.harness,
+      support: harness.support,
     }))
     .filter(
       (
@@ -98,26 +152,43 @@ export function selectAgentHarness(params: {
 
   const selected = supported[0]?.harness;
   if (selected) {
-    return selected;
+    return buildSelectionDecision({
+      harness: selected,
+      policy,
+      selectedReason: "auto_plugin",
+      candidates: candidates.map(toSelectionCandidate),
+    });
   }
   if (policy.fallback === "none") {
     throw new Error(
       `No registered agent harness supports ${formatProviderModel(params)} and PI fallback is disabled.`,
     );
   }
-  return piHarness;
+  return buildSelectionDecision({
+    harness: piHarness,
+    policy,
+    selectedReason: "auto_pi_fallback",
+    candidates: candidates.map(toSelectionCandidate),
+  });
 }
 
 export async function runAgentHarnessAttemptWithFallback(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  const harness = selectAgentHarness({
+  const selection = resolveAgentHarnessSelection({
     provider: params.provider,
     modelId: params.modelId,
     config: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     agentHarnessId: params.agentHarnessId,
+  });
+  const harness = selection.harness;
+  logAgentHarnessSelection(selection, {
+    provider: params.provider,
+    modelId: params.modelId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
   });
   if (harness.id === "pi") {
     const result = await harness.runAttempt(params);
@@ -136,6 +207,64 @@ export async function runAgentHarnessAttemptWithFallback(
     });
     throw error;
   }
+}
+
+function listHarnessCandidates(harnesses: AgentHarness[]): AgentHarnessSelectionCandidate[] {
+  return harnesses.map((harness) => ({
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+  }));
+}
+
+function toSelectionCandidate(entry: {
+  harness: AgentHarness;
+  support: AgentHarnessSupport;
+}): AgentHarnessSelectionCandidate {
+  return {
+    id: entry.harness.id,
+    label: entry.harness.label,
+    pluginId: entry.harness.pluginId,
+    supported: entry.support.supported,
+    priority: entry.support.supported ? entry.support.priority : undefined,
+    reason: entry.support.reason,
+  };
+}
+
+function buildSelectionDecision(params: {
+  harness: AgentHarness;
+  policy: AgentHarnessPolicy;
+  selectedReason: AgentHarnessSelectionDecision["selectedReason"];
+  candidates: AgentHarnessSelectionCandidate[];
+}): AgentHarnessSelectionDecision {
+  return {
+    harness: params.harness,
+    policy: params.policy,
+    selectedHarnessId: params.harness.id,
+    selectedHarnessLabel: params.harness.label,
+    selectedReason: params.selectedReason,
+    candidates: params.candidates,
+  };
+}
+
+function logAgentHarnessSelection(
+  selection: AgentHarnessSelectionDecision,
+  params: { provider: string; modelId?: string; sessionKey?: string; agentId?: string },
+) {
+  if (!log.isEnabled("debug")) {
+    return;
+  }
+  log.debug("agent harness selected", {
+    provider: params.provider,
+    modelId: params.modelId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    selectedHarnessId: selection.selectedHarnessId,
+    selectedReason: selection.selectedReason,
+    runtime: selection.policy.runtime,
+    fallback: selection.policy.fallback,
+    candidates: selection.candidates,
+  });
 }
 
 function resolvePinnedAgentHarnessPolicy(


### PR DESCRIPTION
## Summary
- Expose a pure `resolveAgentHarnessSelection(...)` decision object for the existing embedded harness selector.
- Keep the existing `AgentHarness` SPI and runtime behavior unchanged; `selectAgentHarness(...)` now delegates to the decision helper.
- Add structured debug logging from `runAgentHarnessAttemptWithFallback(...)` so operators can see selected harness id, policy runtime/fallback values, selection reason, and candidate support results.
- Document the observability path for diagnosing `codex/*` vs `openai-codex/*` routing without redesigning Pi/Codex harness selection.

## Scope Guard
- This is the follow-up architecture/observability slice after PR #70743. It intentionally does not repeat the GPT-5.4 runtime fixes already implemented there.
- No provider routing, fallback behavior, app-server lifecycle, or public wire format changes.
- Rebased onto current `upstream/main` to clear the old support-boundary base-drift failure.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/selection.test.ts`
- `pnpm tsgo:core:test`
- `pnpm exec oxlint src/agents/harness/selection.ts src/agents/harness/selection.test.ts`
- `pnpm exec oxfmt --check src/agents/harness/selection.ts src/agents/harness/selection.test.ts docs/plugins/sdk-agent-harness.md docs/plugins/codex-harness.md`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/lint-suppressions.test.ts`
- `git diff --check`

## Notes
- Current head: `eb82cc910f`.
- The debug record is emitted only when the `agents/harness` logger is debug-enabled.
- Auto-mode tests assert each plugin `supports(...)` method is still called exactly once per candidate.