### PR TITLE
fix(codex): require final two-phase approval decisions

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -390,6 +390,39 @@ describe("Codex app-server approval bridge", () => {
     expect(result).toEqual({ decision: "accept" });
   });
 
+  it("does not fail when request-time decision descriptors throw", async () => {
+    const params = createParams();
+    const requestResult = new Proxy(
+      { id: "plugin:approval-proxy", status: "accepted" },
+      {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "decision") {
+            throw new Error("descriptor trap must not fail approval");
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      },
+    );
+    mockCallGatewayTool
+      .mockResolvedValueOnce(requestResult)
+      .mockResolvedValueOnce({ id: "plugin:approval-proxy", decision: "allow-once" });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-proxy",
+        command: "pnpm test",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ decision: "accept" });
+  });
+
   it("fails closed when no approval route is available", async () => {
     const params = createParams();
     mockCallGatewayTool.mockResolvedValueOnce({

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -81,10 +81,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("describes command approvals from parsed command actions when available", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-actions",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-actions", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-actions", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -121,10 +120,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("sanitizes command previews before forwarding approval text and events", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-sanitized-command",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-sanitized-command", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-sanitized-command", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -159,10 +157,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("preserves visible OSC-8 link labels in command previews", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-osc",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-osc", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-osc", decision: "allow-once" });
     const esc = "\u001b";
 
     await handleCodexAppServerApprovalRequest({
@@ -194,10 +191,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("strips bidi and invisible formatting controls from command previews", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-bidi",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-bidi", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-bidi", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -228,10 +224,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("marks oversized unsafe command previews as omitted", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-omitted-command",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-omitted-command", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-omitted-command", decision: "allow-once" });
     const esc = "\u001b";
     const oversizedPrefix = `${esc}]8;;https://example.com${esc}\\`.repeat(300);
 
@@ -267,10 +262,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("marks clipped command previews even when a safe prefix remains", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-clipped-command",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-clipped-command", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-clipped-command", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -296,6 +290,104 @@ describe("Codex app-server approval bridge", () => {
         }),
       }),
     );
+  });
+
+  it("does not trust request-time decisions for two-phase command approvals", async () => {
+    const params = createParams();
+    mockCallGatewayTool
+      .mockResolvedValueOnce({
+        id: "plugin:approval-untrusted",
+        status: "accepted",
+        decision: "allow-always",
+      })
+      .mockResolvedValueOnce({ id: "plugin:approval-untrusted", decision: "deny" });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-untrusted",
+        command: "pnpm test",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ decision: "decline" });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+    expect(params.onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "approval",
+        data: expect.objectContaining({
+          status: "denied",
+          approvalId: "plugin:approval-untrusted",
+        }),
+      }),
+    );
+  });
+
+  it("only treats own null data-property request decisions as no-route", async () => {
+    const params = createParams();
+    const inheritedDecisionResult = Object.assign(Object.create({ decision: null }), {
+      id: "plugin:approval-inherited",
+      status: "accepted",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce(inheritedDecisionResult)
+      .mockResolvedValueOnce({ id: "plugin:approval-inherited", decision: "allow-once" });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-inherited",
+        command: "pnpm test",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ decision: "accept" });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+  });
+
+  it("does not invoke request-time decision accessors", async () => {
+    const params = createParams();
+    const requestResult = {
+      id: "plugin:approval-accessor",
+      status: "accepted",
+      get decision() {
+        throw new Error("decision getter must not run");
+      },
+    };
+    mockCallGatewayTool
+      .mockResolvedValueOnce(requestResult)
+      .mockResolvedValueOnce({ id: "plugin:approval-accessor", decision: "allow-once" });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-accessor",
+        command: "pnpm test",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ decision: "accept" });
   });
 
   it("fails closed when no approval route is available", async () => {
@@ -389,10 +481,9 @@ describe("Codex app-server approval bridge", () => {
   });
   it("labels permission approvals explicitly with sanitized permission detail", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-3",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-3", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-3", decision: "allow-once" });
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
@@ -443,10 +534,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("keeps permission detail bounded with truncated and redacted target samples", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-4",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-4", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-4", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
@@ -495,10 +585,9 @@ describe("Codex app-server approval bridge", () => {
 
   it("strips terminal and invisible controls from permission descriptions", async () => {
     const params = createParams();
-    mockCallGatewayTool.mockResolvedValueOnce({
-      id: "plugin:approval-permission-controls",
-      decision: "allow-once",
-    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-permission-controls", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-permission-controls", decision: "allow-once" });
 
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -3,6 +3,7 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
+  approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
   requestPluginApproval,
   type AppServerApprovalOutcome,
@@ -99,8 +100,8 @@ export async function handleCodexAppServerApprovalRequest(params: {
       message: "Codex app-server approval requested.",
     });
 
-    const decision = Object.prototype.hasOwnProperty.call(requestResult, "decision")
-      ? requestResult.decision
+    const decision = approvalRequestExplicitlyUnavailable(requestResult)
+      ? null
       : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
     const outcome = mapExecDecisionToOutcome(decision);
 

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -104,6 +104,58 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
+  it("does not trust request-time decisions for two-phase MCP approvals", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({
+        id: "plugin:approval-untrusted",
+        status: "accepted",
+        decision: "allow-always",
+      })
+      .mockResolvedValueOnce({ id: "plugin:approval-untrusted", decision: "deny" });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildApprovalElicitation(),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+  });
+
+  it("does not treat inherited request-time MCP decisions as final", async () => {
+    const inheritedDecisionResult = Object.assign(Object.create({ decision: null }), {
+      id: "plugin:approval-inherited",
+      status: "accepted",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce(inheritedDecisionResult)
+      .mockResolvedValueOnce({ id: "plugin:approval-inherited", decision: "allow-once" });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildApprovalElicitation(),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({
+      action: "accept",
+      content: {
+        approve: true,
+      },
+      _meta: null,
+    });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+  });
+
   it("accepts current Codex MCP approval elicitations with an empty form schema", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-current", status: "accepted" })

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -3,6 +3,7 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
+  approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
   requestPluginApproval,
   type AppServerApprovalOutcome,
@@ -198,8 +199,8 @@ async function requestPluginApprovalOutcome(params: {
       return "unavailable";
     }
 
-    const decision = Object.prototype.hasOwnProperty.call(requestResult, "decision")
-      ? requestResult.decision
+    const decision = approvalRequestExplicitlyUnavailable(requestResult)
+      ? null
       : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
     return mapExecDecisionToOutcome(decision);
   } catch {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -58,6 +58,14 @@ export async function requestPluginApproval(params: {
   ) as Promise<ApprovalRequestResult | undefined>;
 }
 
+export function approvalRequestExplicitlyUnavailable(result: unknown): boolean {
+  if (result === null || result === undefined || typeof result !== "object") {
+    return false;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(result, "decision");
+  return descriptor !== undefined && "value" in descriptor && descriptor.value === null;
+}
+
 export async function waitForPluginApprovalDecision(params: {
   approvalId: string;
   signal?: AbortSignal;

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -62,7 +62,12 @@ export function approvalRequestExplicitlyUnavailable(result: unknown): boolean {
   if (result === null || result === undefined || typeof result !== "object") {
     return false;
   }
-  const descriptor = Object.getOwnPropertyDescriptor(result, "decision");
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(result, "decision");
+  } catch {
+    return false;
+  }
   return descriptor !== undefined && "value" in descriptor && descriptor.value === null;
 }
 


### PR DESCRIPTION
## Summary

- Problem: Codex app-server approval bridges trusted a `decision` field returned by the initial `plugin.approval.request` call.
- Why it matters: `plugin.approval.request` is a two-phase registration step; granting from that response can bypass the final `plugin.approval.waitDecision` confirmation path.
- What changed: command/file/permission approvals and MCP approval elicitations now wait for `plugin.approval.waitDecision` whenever an approval route exists.
- What did NOT change (scope boundary): `decision: null` from the request response still fails closed immediately for the existing no-approval-route case; approval payload shape and granted permission mapping are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Codex bridge treated the registration response from `plugin.approval.request` as potentially final even though it always requests `twoPhase: true`.
- Missing detection / guardrail: Tests covered the normal two-call path but did not assert that an eager request-time `allow-always` is ignored.
- Contributing context (if known): The gateway uses `decision: null` on the request response to report no approval route, which made the request response look decision-shaped.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/approval-bridge.test.ts`, `extensions/codex/src/app-server/elicitation-bridge.test.ts`
- Scenario the test should lock in: A request-time `allow-always` is ignored and the final `waitDecision` result controls the outcome.
- Why this is the smallest reliable guardrail: The behavior is isolated in the two Codex bridge helpers that consume plugin approval decisions.
- Existing test that already covers this (if any): Existing route tests covered normal accepted flows and no-route `decision: null`, but not conflicting request-time decisions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex approval prompts still look the same, but final approval decisions now always come from the two-phase wait endpoint when an approval route exists.

## Diagram (if applicable)

```text
Before:
plugin.approval.request -> response.decision=allow-always -> approved-session

After:
plugin.approval.request -> status/id -> plugin.approval.waitDecision -> final outcome
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: This reduces the command/tool approval surface by preventing request-time approval decisions from granting Codex native command/file/permission approvals or MCP tool approval elicitations.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: Codex app-server bridge tests
- Integration/channel (if any): Codex extension
- Relevant config (redacted): default test config

### Steps

1. Return `{ id, status: "accepted", decision: "allow-always" }` from `plugin.approval.request`.
2. Return `{ id, decision: "deny" }` from `plugin.approval.waitDecision`.
3. Run Codex approval and MCP elicitation bridge tests.

### Expected

- The bridge ignores request-time `allow-always` and returns the denied final outcome.

### Actual

- Before this PR, request-time decisions could be consumed directly.
- After this PR, final `waitDecision` controls the outcome.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: command approval bridge and MCP elicitation bridge ignore request-time `allow-always`; no-route `decision: null` still fails closed without waiting.
- Edge cases checked: permission approval tests still preserve granted permission response mapping after moving to final decisions.
- What you did **not** verify: Live Codex app-server approval flow against a real UI approval client.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: If a future non-two-phase caller reused this helper, request-time decisions would be ignored.
  - Mitigation: `requestPluginApproval` always sends `twoPhase: true`; tests assert the expected two-call contract.

