### PR TITLE
[codex] Expose agent harness selection decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/subagents: add optional forked context for native `sessions_spawn` runs so agents can let a child inherit the requester transcript when needed, while keeping clean isolated sessions as the default; includes prompt guidance, context-engine hook metadata, docs, and QA coverage.
+- Codex harness: add structured debug logging for embedded harness selection decisions so `/status` stays simple while gateway logs explain auto-selection and Pi fallback reasons. (#70760) Thanks @100yenadmin.
 - Providers/OpenAI: add forward-compatible `gpt-5.5` and `gpt-5.5-pro` support for OpenAI API keys, OpenAI Codex OAuth, and the Codex CLI default model.
 - Providers/OpenAI Codex: add image generation and reference-image editing through Codex OAuth, so `openai-codex/gpt-image-2` works without an `OPENAI_API_KEY`. Fixes #70703.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -49,9 +49,10 @@ compatibility aliases, but new docs/config examples should use `openai/gpt-*`.
 
 Enable debug logging for the `agents/harness` subsystem to inspect the
 structured `agent harness selected` record. It includes the selected harness id,
-policy runtime/fallback values, and the support result for each registered
-plugin harness, which makes prefix mistakes (`openai-codex/*` vs `codex/*`)
-visible without changing runtime behavior.
+policy runtime/fallback values, and, in `auto` mode, support results for each
+registered plugin harness. Forced or pinned runtime paths list candidate
+ids/labels without support probes. This makes prefix mistakes
+(`openai-codex/*` vs `codex/*`) visible without changing runtime behavior.
 
 Harness selection is not a live session control. When an embedded turn runs,
 OpenClaw records the selected harness id on that session and keeps using it for

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -47,6 +47,12 @@ OpenClaw now keeps OpenAI GPT model refs canonical as `openai/*`:
 Legacy `openai-codex/gpt-*` and `codex/gpt-*` refs remain accepted as
 compatibility aliases, but new docs/config examples should use `openai/gpt-*`.
 
+Enable debug logging for the `agents/harness` subsystem to inspect the
+structured `agent harness selected` record. It includes the selected harness id,
+policy runtime/fallback values, and the support result for each registered
+plugin harness, which makes prefix mistakes (`openai-codex/*` vs `codex/*`)
+visible without changing runtime behavior.
+
 Harness selection is not a live session control. When an embedded turn runs,
 OpenClaw records the selected harness id on that session and keeps using it for
 later turns in the same session id. Change `embeddedHarness` config or

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -47,12 +47,11 @@ OpenClaw now keeps OpenAI GPT model refs canonical as `openai/*`:
 Legacy `openai-codex/gpt-*` and `codex/gpt-*` refs remain accepted as
 compatibility aliases, but new docs/config examples should use `openai/gpt-*`.
 
-Enable debug logging for the `agents/harness` subsystem to inspect the
-structured `agent harness selected` record. It includes the selected harness id,
-policy runtime/fallback values, and, in `auto` mode, support results for each
-registered plugin harness. Forced or pinned runtime paths list candidate
-ids/labels without support probes. This makes prefix mistakes
-(`openai-codex/*` vs `codex/*`) visible without changing runtime behavior.
+Use `/status` to confirm the effective harness for the current session. If the
+selection is surprising, enable debug logging for the `agents/harness` subsystem
+and inspect the gateway's structured `agent harness selected` record. It
+includes the selected harness id, selection reason, runtime/fallback policy, and,
+in `auto` mode, each plugin candidate's support result.
 
 Harness selection is not a live session control. When an embedded turn runs,
 OpenClaw records the selected harness id on that session and keeps using it for

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -106,6 +106,11 @@ Legacy sessions created before harness pins are treated as PI-pinned once they
 have transcript history. Use a new/reset session when changing between PI and a
 native plugin harness. `/status` shows non-default harness ids such as `codex`
 next to `Fast`; PI stays hidden because it is the default compatibility path.
+When debug logging is enabled, OpenClaw also emits a structured `agent harness
+selected` record with the resolved runtime policy, PI fallback mode, selected
+harness id, selection reason, and every plugin candidate's support reason. This
+is the safest way to diagnose why a `codex/*` model used the Codex harness while
+an `openai-codex/*` model stayed on the PI compatibility path.
 
 The bundled Codex plugin registers `codex` as its harness id. Core treats that
 as an ordinary plugin harness id; Codex-specific aliases belong in the plugin

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -106,13 +106,10 @@ Legacy sessions created before harness pins are treated as PI-pinned once they
 have transcript history. Use a new/reset session when changing between PI and a
 native plugin harness. `/status` shows non-default harness ids such as `codex`
 next to `Fast`; PI stays hidden because it is the default compatibility path.
-When debug logging is enabled, OpenClaw also emits a structured `agent harness
-selected` record with the resolved runtime policy, PI fallback mode, selected
-harness id, and selection reason. In `auto` mode it also includes each plugin
-candidate's support result; forced or pinned modes list candidate ids/labels
-without probing support. This is the safest way to diagnose why a `codex/*`
-model used the Codex harness while an `openai-codex/*` model stayed on the PI
-compatibility path.
+If the selected harness is surprising, enable `agents/harness` debug logging and
+inspect the gateway's structured `agent harness selected` record. It includes
+the selected harness id, selection reason, runtime/fallback policy, and, in
+`auto` mode, each plugin candidate's support result.
 
 The bundled Codex plugin registers `codex` as its harness id. Core treats that
 as an ordinary plugin harness id; Codex-specific aliases belong in the plugin

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -108,9 +108,11 @@ native plugin harness. `/status` shows non-default harness ids such as `codex`
 next to `Fast`; PI stays hidden because it is the default compatibility path.
 When debug logging is enabled, OpenClaw also emits a structured `agent harness
 selected` record with the resolved runtime policy, PI fallback mode, selected
-harness id, selection reason, and every plugin candidate's support reason. This
-is the safest way to diagnose why a `codex/*` model used the Codex harness while
-an `openai-codex/*` model stayed on the PI compatibility path.
+harness id, and selection reason. In `auto` mode it also includes each plugin
+candidate's support result; forced or pinned modes list candidate ids/labels
+without probing support. This is the safest way to diagnose why a `codex/*`
+model used the Codex harness while an `openai-codex/*` model stayed on the PI
+compatibility path.
 
 The bundled Codex plugin registers `codex` as its harness id. Core treats that
 as an ordinary plugin harness id; Codex-specific aliases belong in the plugin

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -9,7 +9,6 @@ import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
 import {
   maybeCompactAgentHarnessSession,
   runAgentHarnessAttemptWithFallback,
-  resolveAgentHarnessSelection,
   selectAgentHarness,
 } from "./selection.js";
 import type { AgentHarness } from "./types.js";
@@ -153,7 +152,7 @@ describe("runAgentHarnessAttemptWithFallback", () => {
 });
 
 describe("selectAgentHarness", () => {
-  it("exposes an observable auto-selection decision without duplicate support probes", () => {
+  it("auto-selects the highest-priority plugin harness without duplicate support probes", () => {
     process.env.OPENCLAW_AGENT_RUNTIME = "auto";
     const lowPrioritySupports = vi.fn(() => ({
       supported: true as const,
@@ -197,39 +196,18 @@ describe("selectAgentHarness", () => {
       { ownerPluginId: "other" },
     );
 
-    const decision = resolveAgentHarnessSelection({
+    const harness = selectAgentHarness({
       provider: "codex",
       modelId: "gpt-5.4",
     });
 
-    expect(decision.selectedHarnessId).toBe("codex-high");
-    expect(decision.selectedReason).toBe("auto_plugin");
-    expect(decision.policy).toEqual({ runtime: "auto", fallback: "pi" });
-    expect(decision.candidates).toEqual([
-      expect.objectContaining({
-        id: "codex-low",
-        supported: true,
-        priority: 10,
-        reason: "generic codex support",
-      }),
-      expect.objectContaining({
-        id: "codex-high",
-        supported: true,
-        priority: 100,
-        reason: "native codex app-server",
-      }),
-      expect.objectContaining({
-        id: "other",
-        supported: false,
-        reason: "provider mismatch",
-      }),
-    ]);
+    expect(harness.id).toBe("codex-high");
     expect(lowPrioritySupports).toHaveBeenCalledTimes(1);
     expect(highPrioritySupports).toHaveBeenCalledTimes(1);
     expect(unsupportedSupports).toHaveBeenCalledTimes(1);
   });
 
-  it("reports pinned PI selection without probing plugin support", () => {
+  it("keeps pinned PI selection from probing plugin support", () => {
     const supports = vi.fn(() => ({ supported: true as const, priority: 100 }));
     registerAgentHarness({
       id: "codex",
@@ -238,15 +216,13 @@ describe("selectAgentHarness", () => {
       runAttempt: vi.fn(async () => createAttemptResult("codex")),
     });
 
-    const decision = resolveAgentHarnessSelection({
+    const harness = selectAgentHarness({
       provider: "codex",
       modelId: "gpt-5.4",
       agentHarnessId: "pi",
     });
 
-    expect(decision.selectedHarnessId).toBe("pi");
-    expect(decision.selectedReason).toBe("pinned");
-    expect(decision.candidates).toEqual([expect.objectContaining({ id: "codex" })]);
+    expect(harness.id).toBe("pi");
     expect(supports).not.toHaveBeenCalled();
   });
 

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -9,6 +9,7 @@ import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
 import {
   maybeCompactAgentHarnessSession,
   runAgentHarnessAttemptWithFallback,
+  resolveAgentHarnessSelection,
   selectAgentHarness,
 } from "./selection.js";
 import type { AgentHarness } from "./types.js";
@@ -152,6 +153,103 @@ describe("runAgentHarnessAttemptWithFallback", () => {
 });
 
 describe("selectAgentHarness", () => {
+  it("exposes an observable auto-selection decision without duplicate support probes", () => {
+    process.env.OPENCLAW_AGENT_RUNTIME = "auto";
+    const lowPrioritySupports = vi.fn(() => ({
+      supported: true as const,
+      priority: 10,
+      reason: "generic codex support",
+    }));
+    const highPrioritySupports = vi.fn(() => ({
+      supported: true as const,
+      priority: 100,
+      reason: "native codex app-server",
+    }));
+    const unsupportedSupports = vi.fn(() => ({
+      supported: false as const,
+      reason: "provider mismatch",
+    }));
+    registerAgentHarness(
+      {
+        id: "codex-low",
+        label: "Low Codex",
+        supports: lowPrioritySupports,
+        runAttempt: vi.fn(async () => createAttemptResult("codex-low")),
+      },
+      { ownerPluginId: "codex-low" },
+    );
+    registerAgentHarness(
+      {
+        id: "codex-high",
+        label: "High Codex",
+        supports: highPrioritySupports,
+        runAttempt: vi.fn(async () => createAttemptResult("codex-high")),
+      },
+      { ownerPluginId: "codex-high" },
+    );
+    registerAgentHarness(
+      {
+        id: "other",
+        label: "Other Harness",
+        supports: unsupportedSupports,
+        runAttempt: vi.fn(async () => createAttemptResult("other")),
+      },
+      { ownerPluginId: "other" },
+    );
+
+    const decision = resolveAgentHarnessSelection({
+      provider: "codex",
+      modelId: "gpt-5.4",
+    });
+
+    expect(decision.selectedHarnessId).toBe("codex-high");
+    expect(decision.selectedReason).toBe("auto_plugin");
+    expect(decision.policy).toEqual({ runtime: "auto", fallback: "pi" });
+    expect(decision.candidates).toEqual([
+      expect.objectContaining({
+        id: "codex-low",
+        supported: true,
+        priority: 10,
+        reason: "generic codex support",
+      }),
+      expect.objectContaining({
+        id: "codex-high",
+        supported: true,
+        priority: 100,
+        reason: "native codex app-server",
+      }),
+      expect.objectContaining({
+        id: "other",
+        supported: false,
+        reason: "provider mismatch",
+      }),
+    ]);
+    expect(lowPrioritySupports).toHaveBeenCalledTimes(1);
+    expect(highPrioritySupports).toHaveBeenCalledTimes(1);
+    expect(unsupportedSupports).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports pinned PI selection without probing plugin support", () => {
+    const supports = vi.fn(() => ({ supported: true as const, priority: 100 }));
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("codex")),
+    });
+
+    const decision = resolveAgentHarnessSelection({
+      provider: "codex",
+      modelId: "gpt-5.4",
+      agentHarnessId: "pi",
+    });
+
+    expect(decision.selectedHarnessId).toBe("pi");
+    expect(decision.selectedReason).toBe("pinned");
+    expect(decision.candidates).toEqual([expect.objectContaining({ id: "codex" })]);
+    expect(supports).not.toHaveBeenCalled();
+  });
+
   it("fails instead of choosing PI when no plugin harness matches and fallback is none", () => {
     expect(() =>
       selectAgentHarness({

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -28,7 +28,7 @@ type AgentHarnessPolicy = {
   fallback: EmbeddedAgentHarnessFallback;
 };
 
-export type AgentHarnessSelectionCandidate = {
+type AgentHarnessSelectionCandidate = {
   id: string;
   label: string;
   pluginId?: string;
@@ -37,11 +37,10 @@ export type AgentHarnessSelectionCandidate = {
   reason?: string;
 };
 
-export type AgentHarnessSelectionDecision = {
+type AgentHarnessSelectionDecision = {
   harness: AgentHarness;
   policy: AgentHarnessPolicy;
   selectedHarnessId: string;
-  selectedHarnessLabel: string;
   selectedReason:
     | "pinned"
     | "forced_pi"
@@ -75,10 +74,10 @@ export function selectAgentHarness(params: {
   sessionKey?: string;
   agentHarnessId?: string;
 }): AgentHarness {
-  return resolveAgentHarnessSelection(params).harness;
+  return selectAgentHarnessDecision(params).harness;
 }
 
-export function resolveAgentHarnessSelection(params: {
+function selectAgentHarnessDecision(params: {
   provider: string;
   modelId?: string;
   config?: OpenClawConfig;
@@ -171,7 +170,7 @@ export function resolveAgentHarnessSelection(params: {
 export async function runAgentHarnessAttemptWithFallback(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  const selection = resolveAgentHarnessSelection({
+  const selection = selectAgentHarnessDecision({
     provider: params.provider,
     modelId: params.modelId,
     config: params.config,
@@ -237,7 +236,6 @@ function buildSelectionDecision(params: {
     harness: params.harness,
     policy: params.policy,
     selectedHarnessId: params.harness.id,
-    selectedHarnessLabel: params.harness.label,
     selectedReason: params.selectedReason,
     candidates: params.candidates,
   };

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -46,7 +46,9 @@ type AgentHarnessSelectionDecision = {
     | "forced_pi"
     | "forced_plugin"
     | "forced_plugin_fallback_to_pi"
+    // Auto mode chose a registered plugin harness that supports the provider/model.
     | "auto_plugin"
+    // Auto mode found no supporting plugin harness, so PI handled the run.
     | "auto_pi_fallback";
   candidates: AgentHarnessSelectionCandidate[];
 };

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -46,7 +46,7 @@ export type AgentHarnessSelectionDecision = {
     | "pinned"
     | "forced_pi"
     | "forced_plugin"
-    | "forced_plugin_missing_pi_fallback"
+    | "forced_plugin_fallback_to_pi"
     | "auto_plugin"
     | "auto_pi_fallback";
   candidates: AgentHarnessSelectionCandidate[];
@@ -122,7 +122,7 @@ export function resolveAgentHarnessSelection(params: {
     return buildSelectionDecision({
       harness: piHarness,
       policy,
-      selectedReason: "forced_plugin_missing_pi_fallback",
+      selectedReason: "forced_plugin_fallback_to_pi",
       candidates: listHarnessCandidates(pluginHarnesses),
     });
   }
@@ -136,10 +136,6 @@ export function resolveAgentHarnessSelection(params: {
     }),
   }));
   const supported = candidates
-    .map((harness) => ({
-      harness: harness.harness,
-      support: harness.support,
-    }))
     .filter(
       (
         entry,

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -28,6 +28,30 @@ type AgentHarnessPolicy = {
   fallback: EmbeddedAgentHarnessFallback;
 };
 
+export type AgentHarnessSelectionCandidate = {
+  id: string;
+  label: string;
+  pluginId?: string;
+  supported?: boolean;
+  priority?: number;
+  reason?: string;
+};
+
+export type AgentHarnessSelectionDecision = {
+  harness: AgentHarness;
+  policy: AgentHarnessPolicy;
+  selectedHarnessId: string;
+  selectedHarnessLabel: string;
+  selectedReason:
+    | "pinned"
+    | "forced_pi"
+    | "forced_plugin"
+    | "forced_plugin_missing_pi_fallback"
+    | "auto_plugin"
+    | "auto_pi_fallback";
+  candidates: AgentHarnessSelectionCandidate[];
+};
+
 function listPluginAgentHarnesses(): AgentHarness[] {
   return listRegisteredAgentHarnesses().map((entry) => entry.harness);
 }
@@ -51,20 +75,41 @@ export function selectAgentHarness(params: {
   sessionKey?: string;
   agentHarnessId?: string;
 }): AgentHarness {
-  const policy =
-    resolvePinnedAgentHarnessPolicy(params.agentHarnessId) ?? resolveAgentHarnessPolicy(params);
+  return resolveAgentHarnessSelection(params).harness;
+}
+
+export function resolveAgentHarnessSelection(params: {
+  provider: string;
+  modelId?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  agentHarnessId?: string;
+}): AgentHarnessSelectionDecision {
+  const pinnedPolicy = resolvePinnedAgentHarnessPolicy(params.agentHarnessId);
+  const policy = pinnedPolicy ?? resolveAgentHarnessPolicy(params);
   // PI is intentionally not part of the plugin candidate list. It is the legacy
   // fallback path, so `fallback: "none"` can prove that only plugin harnesses run.
   const pluginHarnesses = listPluginAgentHarnesses();
   const piHarness = createPiAgentHarness();
   const runtime = policy.runtime;
   if (runtime === "pi") {
-    return piHarness;
+    return buildSelectionDecision({
+      harness: piHarness,
+      policy,
+      selectedReason: pinnedPolicy ? "pinned" : "forced_pi",
+      candidates: listHarnessCandidates(pluginHarnesses),
+    });
   }
   if (runtime !== "auto") {
     const forced = pluginHarnesses.find((entry) => entry.id === runtime);
     if (forced) {
-      return forced;
+      return buildSelectionDecision({
+        harness: forced,
+        policy,
+        selectedReason: pinnedPolicy ? "pinned" : "forced_plugin",
+        candidates: listHarnessCandidates(pluginHarnesses),
+      });
     }
     if (policy.fallback === "none") {
       throw new Error(
@@ -74,17 +119,26 @@ export function selectAgentHarness(params: {
     log.warn("requested agent harness is not registered; falling back to embedded PI backend", {
       requestedRuntime: runtime,
     });
-    return piHarness;
+    return buildSelectionDecision({
+      harness: piHarness,
+      policy,
+      selectedReason: "forced_plugin_missing_pi_fallback",
+      candidates: listHarnessCandidates(pluginHarnesses),
+    });
   }
 
-  const supported = pluginHarnesses
+  const candidates = pluginHarnesses.map((harness) => ({
+    harness,
+    support: harness.supports({
+      provider: params.provider,
+      modelId: params.modelId,
+      requestedRuntime: runtime,
+    }),
+  }));
+  const supported = candidates
     .map((harness) => ({
-      harness,
-      support: harness.supports({
-        provider: params.provider,
-        modelId: params.modelId,
-        requestedRuntime: runtime,
-      }),
+      harness: harness.harness,
+      support: harness.support,
     }))
     .filter(
       (
@@ -98,26 +152,43 @@ export function selectAgentHarness(params: {
 
   const selected = supported[0]?.harness;
   if (selected) {
-    return selected;
+    return buildSelectionDecision({
+      harness: selected,
+      policy,
+      selectedReason: "auto_plugin",
+      candidates: candidates.map(toSelectionCandidate),
+    });
   }
   if (policy.fallback === "none") {
     throw new Error(
       `No registered agent harness supports ${formatProviderModel(params)} and PI fallback is disabled.`,
     );
   }
-  return piHarness;
+  return buildSelectionDecision({
+    harness: piHarness,
+    policy,
+    selectedReason: "auto_pi_fallback",
+    candidates: candidates.map(toSelectionCandidate),
+  });
 }
 
 export async function runAgentHarnessAttemptWithFallback(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  const harness = selectAgentHarness({
+  const selection = resolveAgentHarnessSelection({
     provider: params.provider,
     modelId: params.modelId,
     config: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     agentHarnessId: params.agentHarnessId,
+  });
+  const harness = selection.harness;
+  logAgentHarnessSelection(selection, {
+    provider: params.provider,
+    modelId: params.modelId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
   });
   if (harness.id === "pi") {
     const result = await harness.runAttempt(params);
@@ -136,6 +207,64 @@ export async function runAgentHarnessAttemptWithFallback(
     });
     throw error;
   }
+}
+
+function listHarnessCandidates(harnesses: AgentHarness[]): AgentHarnessSelectionCandidate[] {
+  return harnesses.map((harness) => ({
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+  }));
+}
+
+function toSelectionCandidate(entry: {
+  harness: AgentHarness;
+  support: AgentHarnessSupport;
+}): AgentHarnessSelectionCandidate {
+  return {
+    id: entry.harness.id,
+    label: entry.harness.label,
+    pluginId: entry.harness.pluginId,
+    supported: entry.support.supported,
+    priority: entry.support.supported ? entry.support.priority : undefined,
+    reason: entry.support.reason,
+  };
+}
+
+function buildSelectionDecision(params: {
+  harness: AgentHarness;
+  policy: AgentHarnessPolicy;
+  selectedReason: AgentHarnessSelectionDecision["selectedReason"];
+  candidates: AgentHarnessSelectionCandidate[];
+}): AgentHarnessSelectionDecision {
+  return {
+    harness: params.harness,
+    policy: params.policy,
+    selectedHarnessId: params.harness.id,
+    selectedHarnessLabel: params.harness.label,
+    selectedReason: params.selectedReason,
+    candidates: params.candidates,
+  };
+}
+
+function logAgentHarnessSelection(
+  selection: AgentHarnessSelectionDecision,
+  params: { provider: string; modelId?: string; sessionKey?: string; agentId?: string },
+) {
+  if (!log.isEnabled("debug")) {
+    return;
+  }
+  log.debug("agent harness selected", {
+    provider: params.provider,
+    modelId: params.modelId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    selectedHarnessId: selection.selectedHarnessId,
+    selectedReason: selection.selectedReason,
+    runtime: selection.policy.runtime,
+    fallback: selection.policy.fallback,
+    candidates: selection.candidates,
+  });
 }
 
 function resolvePinnedAgentHarnessPolicy(


### PR DESCRIPTION
## Summary
- Expose a pure `resolveAgentHarnessSelection(...)` decision object for the existing embedded harness selector.
- Keep the existing `AgentHarness` SPI and runtime behavior unchanged; `selectAgentHarness(...)` now delegates to the decision helper.
- Add structured debug logging from `runAgentHarnessAttemptWithFallback(...)` so operators can see selected harness id, policy runtime/fallback values, selection reason, and candidate support results.
- Document the observability path for diagnosing `codex/*` vs `openai-codex/*` routing without redesigning Pi/Codex harness selection.

## Scope Guard
- This is the follow-up architecture/observability slice after PR #70743. It intentionally does not repeat the GPT-5.4 runtime fixes already implemented there.
- No provider routing, fallback behavior, app-server lifecycle, or public wire format changes.
- This supersedes PR #70750, whose fork branch ref updated correctly but whose PR object remained pinned to its old SHA/check run.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/selection.test.ts`
- `pnpm tsgo:core:test`
- `pnpm exec oxlint src/agents/harness/selection.ts src/agents/harness/selection.test.ts`
- `pnpm exec oxfmt --check src/agents/harness/selection.ts src/agents/harness/selection.test.ts docs/plugins/sdk-agent-harness.md docs/plugins/codex-harness.md`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/lint-suppressions.test.ts`
- `git diff --check`

## Notes
- Current head: `eb82cc910f`.
- The debug record is emitted only when the `agents/harness` logger is debug-enabled.
- Auto-mode tests assert each plugin `supports(...)` method is still called exactly once per candidate.