### PR TITLE
fix: harden realtime voice setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenAI: stop advertising the removed `gpt-5.3-codex-spark` Codex model through fallback catalogs, and suppress stale rows with a GPT-5.5 recovery hint.
 - Plugins/QR: replace legacy `qrcode-terminal` QR rendering with bounded `qrcode-tui` helpers for plugin login/setup flows. (#65969) Thanks @vincentkoc.
 - ACPX/Codex: stop the embedded Codex ACP auth bridge from falling back to raw `~/.codex` file copies; ACPX now only uses OpenClaw's canonical Codex OAuth bridge.
+- Voice-call/realtime: wait for OpenAI session configuration before greeting or forwarding buffered audio, and reject non-allowlisted Twilio callers before stream setup. (#43501) Thanks @forrestblount.
 - Auto-reply/system events: route async exec-event completion replies through the persisted session delivery context, so long-running command results return to the originating channel instead of being dropped when live origin metadata is missing. (#70258) Thanks @wzfukui.
 - OpenAI/image generation: send reference-image edits as guarded multipart uploads instead of JSON data URLs, restoring complex multi-reference `gpt-image-2` edits. Fixes #70642. Thanks @dashhuang.
 - QA channel/security: reject non-HTTP(S) inbound attachment URLs before media fetch, and log rejected schemes so suspicious or misconfigured payloads are visible during debugging. (#70708) Thanks @vincentkoc.

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1,7 +1,72 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
+const { FakeWebSocket } = vi.hoisted(() => {
+  type Listener = (...args: unknown[]) => void;
+
+  class MockWebSocket {
+    static readonly OPEN = 1;
+    static readonly CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    readonly listeners = new Map<string, Listener[]>();
+    readyState = 0;
+    sent: string[] = [];
+    closed = false;
+    terminated = false;
+
+    constructor() {
+      MockWebSocket.instances.push(this);
+    }
+
+    on(event: string, listener: Listener): this {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const listener of this.listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    }
+
+    send(payload: string): void {
+      this.sent.push(payload);
+    }
+
+    close(code?: number, reason?: string): void {
+      this.closed = true;
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit("close", code ?? 1000, Buffer.from(reason ?? ""));
+    }
+
+    terminate(): void {
+      this.terminated = true;
+      this.close(1006, "terminated");
+    }
+  }
+
+  return { FakeWebSocket: MockWebSocket };
+});
+
+vi.mock("ws", () => ({
+  default: FakeWebSocket,
+}));
+
+type FakeWebSocketInstance = InstanceType<typeof FakeWebSocket>;
+type SentRealtimeEvent = { type: string; audio?: string };
+
+function parseSent(socket: FakeWebSocketInstance): SentRealtimeEvent[] {
+  return socket.sent.map((payload: string) => JSON.parse(payload) as SentRealtimeEvent);
+}
+
 describe("buildOpenAIRealtimeVoiceProvider", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+  });
+
   it("normalizes provider-owned voice settings from raw provider config", () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const resolved = provider.resolveConfig?.({
@@ -26,5 +91,65 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       silenceDurationMs: 850,
       vadThreshold: 0.35,
     });
+  });
+
+  it("waits for session.updated before draining audio and firing onReady", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onReady = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      instructions: "Be helpful.",
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onReady,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    await connecting;
+
+    bridge.sendAudio(Buffer.from("before-ready"));
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.created" })));
+
+    expect(onReady).not.toHaveBeenCalled();
+    expect(parseSent(socket).map((event) => event.type)).toEqual(["session.update"]);
+    expect(bridge.isConnected()).toBe(false);
+
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(parseSent(socket).map((event) => event.type)).toEqual([
+      "session.update",
+      "input_audio_buffer.append",
+    ]);
+    expect(bridge.isConnected()).toBe(true);
+  });
+
+  it("settles cleanly when closed before the websocket opens", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    bridge.close();
+
+    await expect(connecting).resolves.toBeUndefined();
+    expect(socket.closed).toBe(true);
+    expect(socket.terminated).toBe(false);
+    expect(onClose).toHaveBeenCalledWith("completed");
   });
 });

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -124,6 +124,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   private ws: WebSocket | null = null;
   private connected = false;
+  private sessionConfigured = false;
   private intentionallyClosed = false;
   private reconnectAttempts = 0;
   private pendingAudio: Buffer[] = [];
@@ -133,6 +134,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private lastAssistantItemId: string | null = null;
   private toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
   private readonly flowId = randomUUID();
+  private sessionReadyFired = false;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {}
 
@@ -143,7 +145,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   sendAudio(audio: Buffer): void {
-    if (!this.connected || this.ws?.readyState !== WebSocket.OPEN) {
+    if (!this.connected || !this.sessionConfigured || this.ws?.readyState !== WebSocket.OPEN) {
       if (this.pendingAudio.length < 320) {
         this.pendingAudio.push(audio);
       }
@@ -172,7 +174,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   triggerGreeting(instructions?: string): void {
-    if (!this.connected || !this.ws) {
+    if (!this.isConnected() || !this.ws) {
       return;
     }
     this.sendEvent({
@@ -209,6 +211,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   close(): void {
     this.intentionallyClosed = true;
     this.connected = false;
+    this.sessionConfigured = false;
     if (this.ws) {
       this.ws.close(1000, "Bridge closed");
       this.ws = null;
@@ -216,11 +219,29 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   isConnected(): boolean {
-    return this.connected;
+    return this.connected && this.sessionConfigured;
   }
 
   private async doConnect(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
+      let connectTimeout: ReturnType<typeof setTimeout>;
+      let settled = false;
+      const settleResolve = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimeout);
+        resolve();
+      };
+      const settleReject = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimeout);
+        reject(error);
+      };
       const { url, headers } = this.resolveConnectionParams();
       const debugProxy = resolveDebugProxySettings();
       const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
@@ -229,13 +250,16 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         ...(proxyAgent ? { agent: proxyAgent } : {}),
       });
 
-      const connectTimeout = setTimeout(() => {
-        reject(new Error("OpenAI realtime connection timeout"));
+      connectTimeout = setTimeout(() => {
+        if (!this.connected && !this.intentionallyClosed) {
+          this.ws?.terminate();
+          settleReject(new Error("OpenAI realtime connection timeout"));
+        }
       }, OpenAIRealtimeVoiceBridge.CONNECT_TIMEOUT_MS);
 
       this.ws.on("open", () => {
-        clearTimeout(connectTimeout);
         this.connected = true;
+        this.sessionConfigured = false;
         this.reconnectAttempts = 0;
         captureWsEvent({
           url,
@@ -248,11 +272,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           },
         });
         this.sendSessionUpdate();
-        for (const chunk of this.pendingAudio.splice(0)) {
-          this.sendAudio(chunk);
-        }
-        this.config.onReady?.();
-        resolve();
+        settleResolve();
       });
 
       this.ws.on("message", (data: Buffer) => {
@@ -287,8 +307,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           },
         });
         if (!this.connected) {
-          clearTimeout(connectTimeout);
-          reject(error);
+          settleReject(error instanceof Error ? error : new Error(String(error)));
         }
         this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
       });
@@ -302,7 +321,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           reasonBuffer,
         });
         this.connected = false;
+        this.sessionConfigured = false;
         if (this.intentionallyClosed) {
+          settleResolve();
           this.config.onClose?.("completed");
           return;
         }
@@ -406,6 +427,20 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   private handleEvent(event: RealtimeEvent): void {
     switch (event.type) {
+      case "session.created":
+        return;
+
+      case "session.updated":
+        this.sessionConfigured = true;
+        for (const chunk of this.pendingAudio.splice(0)) {
+          this.sendAudio(chunk);
+        }
+        if (!this.sessionReadyFired) {
+          this.sessionReadyFired = true;
+          this.config.onReady?.();
+        }
+        return;
+
       case "response.audio.delta": {
         if (!event.delta) {
           return;

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -567,7 +567,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const { manager, processEvent } = createManager([]);
     const config = createConfig({
       provider: "twilio",
-      inboundPolicy: "allowlist",
+      inboundPolicy: "open",
       realtime: {
         enabled: true,
         streamPath: "/voice/stream/realtime",
@@ -601,6 +601,106 @@ describe("VoiceCallWebhookServer replay handling", () => {
       expect(await response.text()).toContain("<Connect><Stream");
       expect(parseWebhookEvent).not.toHaveBeenCalled();
       expect(processEvent).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("rejects non-allowlisted inbound realtime calls before creating a stream token", async () => {
+    const buildTwiMLPayload = vi.fn(() => ({
+      statusCode: 200,
+      headers: { "Content-Type": "text/xml" },
+      body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect></Response>',
+    }));
+    const twilioProvider: VoiceCallProvider = {
+      ...provider,
+      name: "twilio",
+      verifyWebhook: () => ({ ok: true, verifiedRequestKey: "twilio:req:rt-deny" }),
+    };
+    const { manager } = createManager([]);
+    const config = createConfig({
+      provider: "twilio",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15550001111"],
+      realtime: {
+        enabled: true,
+        streamPath: "/voice/stream/realtime",
+        tools: [],
+        providers: {},
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
+    server.setRealtimeHandler({
+      buildTwiMLPayload,
+      getStreamPathPattern: () => "/voice/stream/realtime",
+      handleWebSocketUpgrade: () => {},
+      registerToolHandler: () => {},
+      setPublicUrl: () => {},
+    } as unknown as RealtimeCallHandler);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookFormWithHeaders(
+        server,
+        baseUrl,
+        "CallSid=CA123&Direction=inbound&CallStatus=ringing&From=%2B15550002222",
+        { "x-twilio-signature": "sig" },
+      );
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain("<Reject");
+      expect(buildTwiMLPayload).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("creates a realtime stream only for allowlisted inbound callers", async () => {
+    const buildTwiMLPayload = vi.fn(() => ({
+      statusCode: 200,
+      headers: { "Content-Type": "text/xml" },
+      body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect></Response>',
+    }));
+    const twilioProvider: VoiceCallProvider = {
+      ...provider,
+      name: "twilio",
+      verifyWebhook: () => ({ ok: true, verifiedRequestKey: "twilio:req:rt-allow" }),
+    };
+    const { manager } = createManager([]);
+    const config = createConfig({
+      provider: "twilio",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15550002222"],
+      realtime: {
+        enabled: true,
+        streamPath: "/voice/stream/realtime",
+        tools: [],
+        providers: {},
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
+    server.setRealtimeHandler({
+      buildTwiMLPayload,
+      getStreamPathPattern: () => "/voice/stream/realtime",
+      handleWebSocketUpgrade: () => {},
+      registerToolHandler: () => {},
+      setPublicUrl: () => {},
+    } as unknown as RealtimeCallHandler);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookFormWithHeaders(
+        server,
+        baseUrl,
+        "CallSid=CA123&Direction=inbound&CallStatus=ringing&From=%2B15550002222",
+        { "x-twilio-signature": "sig" },
+      );
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain("<Connect><Stream");
+      expect(buildTwiMLPayload).toHaveBeenCalledTimes(1);
     } finally {
       await server.stop();
     }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -11,6 +11,7 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../api.js";
+import { isAllowlistedCaller, normalizePhoneNumber } from "./allowlist.js";
 import { normalizeVoiceCallConfig, type VoiceCallConfig } from "./config.js";
 import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
 import { getHeader } from "./http-headers.js";
@@ -131,6 +132,14 @@ function normalizeWebhookResponse(parsed: {
     statusCode: parsed.statusCode ?? 200,
     headers: parsed.providerResponseHeaders,
     body: parsed.providerResponseBody ?? "OK",
+  };
+}
+
+function buildRealtimeRejectedTwiML(): WebhookResponsePayload {
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "text/xml" },
+    body: '<?xml version="1.0" encoding="UTF-8"?><Response><Reject reason="rejected" /></Response>',
   };
 }
 
@@ -632,8 +641,13 @@ export class VoiceCallWebhookServer {
         return { statusCode: 401, body: "Unauthorized" };
       }
 
-      if (this.shouldShortCircuitToRealtimeTwiml(ctx)) {
-        return this.realtimeHandler!.buildTwiMLPayload(req, new URLSearchParams(ctx.rawBody));
+      const realtimeParams = this.getRealtimeTwimlParams(ctx);
+      if (realtimeParams) {
+        if (!this.shouldAcceptRealtimeInboundRequest(realtimeParams)) {
+          console.log("[voice-call] Realtime inbound call rejected before stream setup");
+          return buildRealtimeRejectedTwiML();
+        }
+        return this.realtimeHandler!.buildTwiMLPayload(req, realtimeParams);
       }
 
       const parsed = this.provider.parseWebhookEvent(ctx, {
@@ -697,30 +711,46 @@ export class VoiceCallWebhookServer {
     }
   }
 
-  private shouldShortCircuitToRealtimeTwiml(ctx: WebhookContext): boolean {
+  private getRealtimeTwimlParams(ctx: WebhookContext): URLSearchParams | null {
     if (!this.realtimeHandler || this.provider.name !== "twilio") {
-      return false;
+      return null;
     }
 
     const params = new URLSearchParams(ctx.rawBody);
     const direction = params.get("Direction");
     const isInbound = !direction || direction === "inbound";
     if (!isInbound) {
-      return false;
+      return null;
     }
 
     if (ctx.query?.type === "status") {
-      return false;
+      return null;
     }
 
     const callStatus = params.get("CallStatus");
     if (callStatus && isProviderStatusTerminal(callStatus)) {
-      return false;
+      return null;
     }
 
     // Replays must return the same TwiML body so Twilio retries reconnect cleanly.
     // The one-time token still changes, but the behavior stays identical.
-    return !params.get("SpeechResult") && !params.get("Digits");
+    return !params.get("SpeechResult") && !params.get("Digits") ? params : null;
+  }
+
+  private shouldAcceptRealtimeInboundRequest(params: URLSearchParams): boolean {
+    switch (this.config.inboundPolicy) {
+      case "open":
+        return true;
+      case "allowlist":
+      case "pairing":
+        return isAllowlistedCaller(
+          normalizePhoneNumber(params.get("From") ?? undefined),
+          this.config.allowFrom,
+        );
+      case "disabled":
+      default:
+        return false;
+    }
   }
 
   private processParsedEvents(events: NormalizedEvent[]): void {


### PR DESCRIPTION
## Summary
- wait for OpenAI Realtime `session.updated` before marking voice bridges ready, draining buffered audio, or firing the greeting
- reject non-allowlisted inbound Twilio realtime calls before returning `<Connect><Stream>` TwiML
- add regression coverage for provider readiness, early close, and realtime allowlist gating

Supersedes the stale realtime voice work in #43501 with the current provider-based architecture on `main`.

## Verification
- `pnpm check:changed`
- `pnpm check`
- `pnpm test`
- live `.profile` OpenAI Realtime provider smoke: session reached `session.updated`, `isConnected=true`
