### PR TITLE
fix(doctor): enable codex when openai plugin is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Docs: https://docs.openclaw.ai
 - Plugins/QR: replace legacy `qrcode-terminal` QR rendering with bounded `qrcode-tui` helpers for plugin login/setup flows. (#65969) Thanks @vincentkoc.
 - Voice-call/realtime: wait for OpenAI session configuration before greeting or forwarding buffered audio, and reject non-allowlisted Twilio callers before stream setup. (#43501) Thanks @forrestblount.
 - ACPX/Codex: stop materializing `auth.json` bridge files for Codex ACP, Codex app-server, and Codex CLI runs; Codex-owned runtimes now use their normal `CODEX_HOME`/`~/.codex` auth path directly.
+- Doctor/Codex: enable the bundled Codex plugin from `openclaw doctor --fix` when the OpenAI plugin is explicitly enabled but Codex is still off, restoring `codex/*` model availability after plugin config drift.
+
 - Auto-reply/system events: route async exec-event completion replies through the persisted session delivery context, so long-running command results return to the originating channel instead of being dropped when live origin metadata is missing. (#70258) Thanks @wzfukui.
 - OpenAI/image generation: send reference-image edits as guarded multipart uploads instead of JSON data URLs, restoring complex multi-reference `gpt-image-2` edits. Fixes #70642. Thanks @dashhuang.
 - QA channel/security: reject non-HTTP(S) inbound attachment URLs before media fetch, and log rejected schemes so suspicious or misconfigured payloads are visible during debugging. (#70708) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/QR: replace legacy `qrcode-terminal` QR rendering with bounded `qrcode-tui` helpers for plugin login/setup flows. (#65969) Thanks @vincentkoc.
 - Voice-call/realtime: wait for OpenAI session configuration before greeting or forwarding buffered audio, and reject non-allowlisted Twilio callers before stream setup. (#43501) Thanks @forrestblount.
 - ACPX/Codex: stop materializing `auth.json` bridge files for Codex ACP, Codex app-server, and Codex CLI runs; Codex-owned runtimes now use their normal `CODEX_HOME`/`~/.codex` auth path directly.
-- Doctor/Codex: enable the bundled Codex plugin from `openclaw doctor --fix` when the OpenAI plugin is explicitly enabled but Codex is still off, restoring `codex/*` model availability after plugin config drift.
+- Doctor/Codex: enable the bundled Codex plugin from `openclaw doctor --fix` when the OpenAI plugin is explicitly enabled but Codex is still off, restoring `codex/*` model availability after plugin config drift. (#70767) Thanks @ngutman.
 
 - Auto-reply/system events: route async exec-event completion replies through the persisted session delivery context, so long-running command results return to the originating channel instead of being dropped when live origin metadata is missing. (#70258) Thanks @wzfukui.
 - OpenAI/image generation: send reference-image edits as guarded multipart uploads instead of JSON data URLs, restoring complex multi-reference `gpt-image-2` edits. Fixes #70642. Thanks @dashhuang.

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -9,6 +9,7 @@ import {
   applyDoctorConfigMutation,
   type DoctorConfigMutationState,
 } from "./shared/config-mutation-state.js";
+import { maybeRepairConfiguredPluginAutoEnableBlockers } from "./shared/configured-plugin-auto-enable-blockers.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.js";
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
 import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sender.js";
@@ -58,6 +59,12 @@ export async function runDoctorRepairSequence(params: {
   applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
   applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
   applyMutation(maybeRepairStalePluginConfig(state.candidate, env));
+  applyMutation(
+    maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg: state.candidate,
+      env,
+    }),
+  );
   applyMutation(await maybeRepairAllowlistPolicyAllowFrom(state.candidate));
 
   const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(state.candidate, {

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
@@ -52,7 +52,7 @@ describe("configured plugin auto-enable blockers", () => {
     expect(repaired.warnings).toEqual([]);
   });
 
-  it("warns instead of expanding a restrictive allowlist for OpenAI companion enablement", () => {
+  it("adds Codex to a restrictive allowlist when OpenAI is explicitly allowlisted", () => {
     const cfg: OpenClawConfig = {
       plugins: {
         allow: ["openai"],
@@ -65,20 +65,29 @@ describe("configured plugin auto-enable blockers", () => {
       manifestRegistry: registry,
     });
 
-    expect(repaired.config).toBe(cfg);
-    expect(repaired.changes).toEqual([]);
-    expect(repaired.warnings).toEqual([
-      '- plugins.allow: plugin "codex" is not allowlisted, but OpenAI plugin enabled. Add "codex" to plugins.allow before relying on that configuration.',
+    expect(repaired.config.plugins?.entries?.codex).toEqual({ enabled: true });
+    expect(repaired.config.plugins?.allow).toEqual(["openai", "codex"]);
+    expect(repaired.changes).toEqual([
+      "plugins.entries.codex.enabled: enabled plugin because OpenAI plugin enabled.",
+      'plugins.allow: added "codex" because OpenAI plugin enabled.',
     ]);
+    expect(repaired.warnings).toEqual([]);
   });
 
-  it("keeps restrictive allowlist blocking OpenAI companion repair even when Codex is disabled", () => {
+  it("preserves existing Codex plugin config while enabling it", () => {
     const cfg: OpenClawConfig = {
       plugins: {
-        allow: ["openai"],
         entries: {
+          openai: {
+            enabled: true,
+          },
           codex: {
             enabled: false,
+            config: {
+              appServer: {
+                enabled: true,
+              },
+            },
           },
         },
       },
@@ -90,11 +99,14 @@ describe("configured plugin auto-enable blockers", () => {
       manifestRegistry: registry,
     });
 
-    expect(repaired.config).toBe(cfg);
-    expect(repaired.changes).toEqual([]);
-    expect(repaired.warnings).toEqual([
-      '- plugins.allow: plugin "codex" is not allowlisted, but OpenAI plugin enabled. Add "codex" to plugins.allow before relying on that configuration. Also enable plugins.entries.codex.enabled before relying on that configuration.',
-    ]);
+    expect(repaired.config.plugins?.entries?.codex).toEqual({
+      enabled: true,
+      config: {
+        appServer: {
+          enabled: true,
+        },
+      },
+    });
   });
 
   it("does not enable Codex when the plugin is unavailable", () => {
@@ -131,23 +143,16 @@ describe("configured plugin auto-enable blockers", () => {
     expect(repaired.warnings).toEqual([]);
   });
 
-  it("enables a disabled plugin when configured model refs require it", () => {
+  it("warns instead of removing a Codex denylist blocker", () => {
     const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          model: "codex/gpt-5.5",
-        },
-      },
       plugins: {
-        allow: ["telegram"],
+        deny: ["codex"],
         entries: {
+          openai: {
+            enabled: true,
+          },
           codex: {
             enabled: false,
-            config: {
-              discovery: {
-                enabled: true,
-              },
-            },
           },
         },
       },
@@ -159,48 +164,33 @@ describe("configured plugin auto-enable blockers", () => {
       manifestRegistry: registry,
     });
 
-    expect(repaired.config.plugins?.entries?.codex).toEqual({
-      enabled: true,
-      config: {
-        discovery: {
-          enabled: true,
-        },
-      },
-    });
-    expect(repaired.config.plugins?.allow).toEqual(["telegram", "codex"]);
-    expect(repaired.changes).toEqual([
-      "plugins.entries.codex.enabled: enabled plugin because codex/gpt-5.5 model configured.",
-      'plugins.allow: added "codex" because codex/gpt-5.5 model configured.',
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([
+      '- plugins.deny: plugin "codex" is denied, but OpenAI plugin enabled. Remove it from plugins.deny before relying on that configuration.',
     ]);
-    expect(repaired.warnings).toEqual([]);
   });
 
-  it("detects disabled plugins required by embedded harness runtime", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          embeddedHarness: {
-            runtime: "codex",
-            fallback: "none",
+  it("reports preview warnings for OpenAI-enabled configs before repair", () => {
+    const hits = scanConfiguredPluginAutoEnableBlockers({
+      cfg: {
+        plugins: {
+          entries: {
+            openai: {
+              enabled: true,
+            },
           },
         },
-      },
-      plugins: {
-        entries: {
-          codex: {
-            enabled: false,
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const hits = scanConfiguredPluginAutoEnableBlockers({ cfg, env, manifestRegistry: registry });
+      } as OpenClawConfig,
+      env,
+      manifestRegistry: registry,
+    });
 
     expect(hits).toEqual([
       {
         pluginId: "codex",
-        blocker: "disabled-in-config",
-        reasons: ["codex agent harness runtime configured"],
+        reasons: ["OpenAI plugin enabled"],
+        blocker: "not-enabled",
       },
     ]);
     expect(
@@ -209,106 +199,7 @@ describe("configured plugin auto-enable blockers", () => {
         doctorFixCommand: "openclaw doctor --fix",
       }),
     ).toEqual([
-      '- plugins.entries.codex.enabled: plugin is disabled, but codex agent harness runtime configured. Run "openclaw doctor --fix" to enable it.',
-    ]);
-  });
-
-  it("sanitizes config-derived reasons in warnings and changes", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          model: "codex/gpt-5.5\u001B[31m\r\nforged",
-        },
-      },
-      plugins: {
-        entries: {
-          codex: {
-            enabled: false,
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
-      cfg,
-      env,
-      manifestRegistry: registry,
-    });
-
-    expect(repaired.changes.join("\n")).toContain(
-      "plugins.entries.codex.enabled: enabled plugin because codex/gpt-5.5forged model configured.",
-    );
-    expect(repaired.changes.join("\n")).not.toContain("\u001B");
-    expect(repaired.changes.join("\n")).not.toContain("\r");
-    expect(repaired.changes.join("\n")).not.toContain("\nforged");
-  });
-
-  it("warns instead of repairing reserved plugin ids", () => {
-    const reservedPluginId = ["__", "proto__"].join("");
-    const entries = Object.create(null) as Record<string, { enabled: false }>;
-    entries[reservedPluginId] = { enabled: false };
-    const cfg: OpenClawConfig = {
-      auth: {
-        profiles: {
-          dangerous: {
-            provider: "danger",
-            mode: "api_key",
-          },
-        },
-      },
-      plugins: {
-        entries,
-      },
-    } as OpenClawConfig;
-
-    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
-      cfg,
-      env,
-      manifestRegistry: makeRegistry([
-        {
-          id: reservedPluginId,
-          channels: [],
-          providers: ["danger"],
-          autoEnableWhenConfiguredProviders: ["danger"],
-        },
-      ]),
-    });
-
-    expect(repaired.config).toBe(cfg);
-    expect(repaired.changes).toEqual([]);
-    expect(repaired.warnings).toEqual([
-      `- plugins.entries.${reservedPluginId}.enabled: plugin id is reserved and cannot be auto-repaired, but danger auth configured. Use a non-reserved plugin id before relying on that configuration.`,
-    ]);
-    expect(Object.prototype).not.toHaveProperty("enabled");
-  });
-
-  it("warns instead of removing denylist blockers", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          model: "codex/gpt-5.5",
-        },
-      },
-      plugins: {
-        deny: ["codex"],
-        entries: {
-          codex: {
-            enabled: false,
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
-      cfg,
-      env,
-      manifestRegistry: registry,
-    });
-
-    expect(repaired.config).toBe(cfg);
-    expect(repaired.changes).toEqual([]);
-    expect(repaired.warnings).toEqual([
-      '- plugins.deny: plugin "codex" is denied, but codex/gpt-5.5 model configured. Remove it from plugins.deny before relying on that configuration.',
+      '- plugins.entries.codex.enabled: plugin is not enabled, but OpenAI plugin enabled. Run "openclaw doctor --fix" to enable it.',
     ]);
   });
 });

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
@@ -12,16 +12,22 @@ import {
 } from "./configured-plugin-auto-enable-blockers.js";
 
 const env = makeIsolatedEnv();
-const registry = makeRegistry([
-  {
-    id: "codex",
-    channels: [],
-    providers: ["codex"],
-    activation: {
-      onAgentHarnesses: ["codex"],
+function makeCodexRegistry(origin: "bundled" | "config" | "workspace" = "bundled") {
+  const registry = makeRegistry([
+    {
+      id: "codex",
+      channels: [],
+      providers: ["codex"],
+      activation: {
+        onAgentHarnesses: ["codex"],
+      },
     },
-  },
-]);
+  ]);
+  registry.plugins[0].origin = origin;
+  return registry;
+}
+
+const registry = makeCodexRegistry();
 
 afterAll(() => {
   resetPluginAutoEnableTestState();
@@ -109,6 +115,49 @@ describe("configured plugin auto-enable blockers", () => {
     });
   });
 
+  it("does not carry blocked keys while preserving existing Codex plugin config", () => {
+    const blockedKey = ["__", "proto__"].join("");
+    const codexEntry = Object.create(null) as Record<string, unknown>;
+    codexEntry.enabled = false;
+    codexEntry.config = {
+      appServer: {
+        enabled: true,
+      },
+    };
+    codexEntry[blockedKey] = { polluted: true };
+    const entries = Object.create(null) as Record<string, unknown>;
+    entries.openai = { enabled: true };
+    entries.codex = codexEntry;
+    entries[blockedKey] = { enabled: true };
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries,
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(repaired.config.plugins?.entries, blockedKey)).toBe(
+      false,
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(repaired.config.plugins?.entries?.codex, blockedKey),
+    ).toBe(false);
+    expect(repaired.config.plugins?.entries?.codex).toEqual({
+      enabled: true,
+      config: {
+        appServer: {
+          enabled: true,
+        },
+      },
+    });
+    expect(Object.prototype).not.toHaveProperty("polluted");
+  });
+
   it("does not enable Codex when the plugin is unavailable", () => {
     const cfg: OpenClawConfig = {
       plugins: {
@@ -141,6 +190,47 @@ describe("configured plugin auto-enable blockers", () => {
     expect(repaired.config).toEqual({});
     expect(repaired.changes).toEqual([]);
     expect(repaired.warnings).toEqual([]);
+  });
+
+  it("does not inspect plugin manifests when OpenAI is not explicitly enabled", () => {
+    const manifestRegistry = {
+      get plugins(): never {
+        throw new Error("manifest registry should not be inspected");
+      },
+      diagnostics: [],
+    };
+
+    expect(
+      scanConfiguredPluginAutoEnableBlockers({
+        cfg: {},
+        env,
+        manifestRegistry,
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not auto-enable non-bundled Codex manifests", () => {
+    for (const origin of ["config", "workspace"] as const) {
+      const cfg: OpenClawConfig = {
+        plugins: {
+          entries: {
+            openai: {
+              enabled: true,
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+        cfg,
+        env,
+        manifestRegistry: makeCodexRegistry(origin),
+      });
+
+      expect(repaired.config).toBe(cfg);
+      expect(repaired.changes).toEqual([]);
+      expect(repaired.warnings).toEqual([]);
+    }
   });
 
   it("warns instead of removing a Codex denylist blocker", () => {

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
@@ -1,0 +1,199 @@
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  makeIsolatedEnv,
+  makeRegistry,
+  resetPluginAutoEnableTestState,
+} from "../../../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  collectConfiguredPluginAutoEnableBlockerWarnings,
+  maybeRepairConfiguredPluginAutoEnableBlockers,
+  scanConfiguredPluginAutoEnableBlockers,
+} from "./configured-plugin-auto-enable-blockers.js";
+
+const env = makeIsolatedEnv();
+const registry = makeRegistry([
+  {
+    id: "codex",
+    channels: [],
+    providers: ["codex"],
+    activation: {
+      onAgentHarnesses: ["codex"],
+    },
+  },
+]);
+
+afterAll(() => {
+  resetPluginAutoEnableTestState();
+});
+
+describe("configured plugin auto-enable blockers", () => {
+  it("enables Codex when OpenAI is explicitly enabled and Codex is off", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          openai: {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config.plugins?.entries?.codex).toEqual({ enabled: true });
+    expect(repaired.changes).toEqual([
+      "plugins.entries.codex.enabled: enabled plugin because OpenAI plugin enabled.",
+    ]);
+    expect(repaired.warnings).toEqual([]);
+  });
+
+  it("adds Codex to a restrictive allowlist when OpenAI is explicitly allowed", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        allow: ["openai"],
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config.plugins?.entries?.codex).toEqual({ enabled: true });
+    expect(repaired.config.plugins?.allow).toEqual(["openai", "codex"]);
+    expect(repaired.changes).toEqual([
+      "plugins.entries.codex.enabled: enabled plugin because OpenAI plugin enabled.",
+      'plugins.allow: added "codex" because OpenAI plugin enabled.',
+    ]);
+  });
+
+  it("does not enable Codex just because OpenAI is enabled by default", () => {
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg: {},
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config).toEqual({});
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([]);
+  });
+
+  it("enables a disabled plugin when configured model refs require it", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "codex/gpt-5.5",
+        },
+      },
+      plugins: {
+        allow: ["telegram"],
+        entries: {
+          codex: {
+            enabled: false,
+            config: {
+              discovery: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config.plugins?.entries?.codex).toEqual({
+      enabled: true,
+      config: {
+        discovery: {
+          enabled: true,
+        },
+      },
+    });
+    expect(repaired.config.plugins?.allow).toEqual(["telegram", "codex"]);
+    expect(repaired.changes).toEqual([
+      "plugins.entries.codex.enabled: enabled plugin because codex/gpt-5.5 model configured.",
+      'plugins.allow: added "codex" because codex/gpt-5.5 model configured.',
+    ]);
+    expect(repaired.warnings).toEqual([]);
+  });
+
+  it("detects disabled plugins required by embedded harness runtime", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          embeddedHarness: {
+            runtime: "codex",
+            fallback: "none",
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          codex: {
+            enabled: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const hits = scanConfiguredPluginAutoEnableBlockers({ cfg, env, manifestRegistry: registry });
+
+    expect(hits).toEqual([
+      {
+        pluginId: "codex",
+        blocker: "disabled-in-config",
+        reasons: ["codex agent harness runtime configured"],
+      },
+    ]);
+    expect(
+      collectConfiguredPluginAutoEnableBlockerWarnings({
+        hits,
+        doctorFixCommand: "openclaw doctor --fix",
+      }),
+    ).toEqual([
+      '- plugins.entries.codex.enabled: plugin is disabled, but codex agent harness runtime configured. Run "openclaw doctor --fix" to enable it.',
+    ]);
+  });
+
+  it("warns instead of removing denylist blockers", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "codex/gpt-5.5",
+        },
+      },
+      plugins: {
+        deny: ["codex"],
+        entries: {
+          codex: {
+            enabled: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([
+      '- plugins.deny: plugin "codex" is denied, but codex/gpt-5.5 model configured. Remove it from plugins.deny before relying on that configuration.',
+    ]);
+  });
+});

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
@@ -52,7 +52,7 @@ describe("configured plugin auto-enable blockers", () => {
     expect(repaired.warnings).toEqual([]);
   });
 
-  it("adds Codex to a restrictive allowlist when OpenAI is explicitly allowed", () => {
+  it("warns instead of expanding a restrictive allowlist for OpenAI companion enablement", () => {
     const cfg: OpenClawConfig = {
       plugins: {
         allow: ["openai"],
@@ -65,12 +65,33 @@ describe("configured plugin auto-enable blockers", () => {
       manifestRegistry: registry,
     });
 
-    expect(repaired.config.plugins?.entries?.codex).toEqual({ enabled: true });
-    expect(repaired.config.plugins?.allow).toEqual(["openai", "codex"]);
-    expect(repaired.changes).toEqual([
-      "plugins.entries.codex.enabled: enabled plugin because OpenAI plugin enabled.",
-      'plugins.allow: added "codex" because OpenAI plugin enabled.',
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([
+      '- plugins.allow: plugin "codex" is not allowlisted, but OpenAI plugin enabled. Add "codex" to plugins.allow before relying on that configuration.',
     ]);
+  });
+
+  it("does not enable Codex when the plugin is unavailable", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          openai: {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: makeRegistry([]),
+    });
+
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([]);
   });
 
   it("does not enable Codex just because OpenAI is enabled by default", () => {
@@ -165,6 +186,36 @@ describe("configured plugin auto-enable blockers", () => {
     ).toEqual([
       '- plugins.entries.codex.enabled: plugin is disabled, but codex agent harness runtime configured. Run "openclaw doctor --fix" to enable it.',
     ]);
+  });
+
+  it("sanitizes config-derived reasons in warnings and changes", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "codex/gpt-5.5\u001B[31m\r\nforged",
+        },
+      },
+      plugins: {
+        entries: {
+          codex: {
+            enabled: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.changes.join("\n")).toContain(
+      "plugins.entries.codex.enabled: enabled plugin because codex/gpt-5.5forged model configured.",
+    );
+    expect(repaired.changes.join("\n")).not.toContain("\u001B");
+    expect(repaired.changes.join("\n")).not.toContain("\r");
+    expect(repaired.changes.join("\n")).not.toContain("\nforged");
   });
 
   it("warns instead of removing denylist blockers", () => {

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts
@@ -72,6 +72,31 @@ describe("configured plugin auto-enable blockers", () => {
     ]);
   });
 
+  it("keeps restrictive allowlist blocking OpenAI companion repair even when Codex is disabled", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        allow: ["openai"],
+        entries: {
+          codex: {
+            enabled: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: registry,
+    });
+
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([
+      '- plugins.allow: plugin "codex" is not allowlisted, but OpenAI plugin enabled. Add "codex" to plugins.allow before relying on that configuration. Also enable plugins.entries.codex.enabled before relying on that configuration.',
+    ]);
+  });
+
   it("does not enable Codex when the plugin is unavailable", () => {
     const cfg: OpenClawConfig = {
       plugins: {
@@ -216,6 +241,45 @@ describe("configured plugin auto-enable blockers", () => {
     expect(repaired.changes.join("\n")).not.toContain("\u001B");
     expect(repaired.changes.join("\n")).not.toContain("\r");
     expect(repaired.changes.join("\n")).not.toContain("\nforged");
+  });
+
+  it("warns instead of repairing reserved plugin ids", () => {
+    const reservedPluginId = ["__", "proto__"].join("");
+    const entries = Object.create(null) as Record<string, { enabled: false }>;
+    entries[reservedPluginId] = { enabled: false };
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          dangerous: {
+            provider: "danger",
+            mode: "api_key",
+          },
+        },
+      },
+      plugins: {
+        entries,
+      },
+    } as OpenClawConfig;
+
+    const repaired = maybeRepairConfiguredPluginAutoEnableBlockers({
+      cfg,
+      env,
+      manifestRegistry: makeRegistry([
+        {
+          id: reservedPluginId,
+          channels: [],
+          providers: ["danger"],
+          autoEnableWhenConfiguredProviders: ["danger"],
+        },
+      ]),
+    });
+
+    expect(repaired.config).toBe(cfg);
+    expect(repaired.changes).toEqual([]);
+    expect(repaired.warnings).toEqual([
+      `- plugins.entries.${reservedPluginId}.enabled: plugin id is reserved and cannot be auto-repaired, but danger auth configured. Use a non-reserved plugin id before relying on that configuration.`,
+    ]);
+    expect(Object.prototype).not.toHaveProperty("enabled");
   });
 
   it("warns instead of removing denylist blockers", () => {

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
@@ -1,45 +1,24 @@
-import {
-  detectPluginAutoEnableCandidates,
-  resolvePluginAutoEnableCandidateReason,
-  type PluginAutoEnableCandidate,
-} from "../../../config/plugin-auto-enable.js";
 import { ensurePluginAllowlisted } from "../../../config/plugins-allowlist.js";
-import { isBlockedObjectKey } from "../../../config/prototype-keys.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadPluginManifestRegistry,
   type PluginManifestRegistry,
 } from "../../../plugins/manifest-registry.js";
-import { sanitizeForLog } from "../../../terminal/ansi.js";
 
-const REPAIRABLE_CANDIDATE_KINDS = new Set<PluginAutoEnableCandidate["kind"]>([
-  "provider-auth-configured",
-  "provider-model-configured",
-  "agent-harness-runtime-configured",
-]);
+const CODEX_PLUGIN_ID = "codex";
+const OPENAI_PLUGIN_ID = "openai";
 const OPENAI_ENABLED_CODEX_REASON = "OpenAI plugin enabled";
 
-export type ConfiguredPluginAutoEnableBlockerReason =
-  | "disabled-in-config"
-  | "blocked-by-denylist"
-  | "blocked-by-allowlist"
-  | "plugins-disabled"
-  | "invalid-plugin-id"
-  | "not-enabled";
+export type ConfiguredPluginAutoEnableBlockerReason = "blocked-by-denylist" | "not-enabled";
 
 export type ConfiguredPluginAutoEnableBlockerHit = {
-  pluginId: string;
-  reasons: string[];
+  pluginId: typeof CODEX_PLUGIN_ID;
+  reasons: [typeof OPENAI_ENABLED_CODEX_REASON];
   blocker: ConfiguredPluginAutoEnableBlockerReason;
-  entryDisabled?: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
-function isRepairableCandidate(candidate: PluginAutoEnableCandidate): boolean {
-  return REPAIRABLE_CANDIDATE_KINDS.has(candidate.kind);
 }
 
 function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
@@ -59,23 +38,29 @@ function isPluginAllowMissing(cfg: OpenClawConfig, pluginId: string): boolean {
 }
 
 function isOpenAiExplicitlyEnabled(cfg: OpenClawConfig): boolean {
-  if (cfg.plugins?.enabled === false || isPluginDenied(cfg, "openai")) {
+  if (cfg.plugins?.enabled === false || isPluginDenied(cfg, OPENAI_PLUGIN_ID)) {
     return false;
   }
-  if (isPluginEntryDisabled(cfg, "openai")) {
+  if (isPluginEntryDisabled(cfg, OPENAI_PLUGIN_ID)) {
     return false;
   }
-  if (isPluginAllowMissing(cfg, "openai")) {
+  if (isPluginAllowMissing(cfg, OPENAI_PLUGIN_ID)) {
     return false;
   }
-  return isPluginEntryEnabled(cfg, "openai") || cfg.plugins?.allow?.includes("openai") === true;
+  return (
+    isPluginEntryEnabled(cfg, OPENAI_PLUGIN_ID) ||
+    cfg.plugins?.allow?.includes(OPENAI_PLUGIN_ID) === true
+  );
 }
 
-function isCodexAlreadyEnabled(cfg: OpenClawConfig): boolean {
-  if (!isPluginEntryEnabled(cfg, "codex")) {
+function isCodexEnabled(cfg: OpenClawConfig): boolean {
+  if (isPluginDenied(cfg, CODEX_PLUGIN_ID)) {
     return false;
   }
-  return !isPluginAllowMissing(cfg, "codex");
+  if (!isPluginEntryEnabled(cfg, CODEX_PLUGIN_ID)) {
+    return false;
+  }
+  return !isPluginAllowMissing(cfg, CODEX_PLUGIN_ID);
 }
 
 function resolveRegistry(params: {
@@ -92,26 +77,19 @@ function resolveRegistry(params: {
   );
 }
 
-function hasManifestPlugin(registry: PluginManifestRegistry, pluginId: string): boolean {
-  return registry.plugins.some((plugin) => plugin.id === pluginId);
+function hasCodexManifest(registry: PluginManifestRegistry): boolean {
+  return registry.plugins.some((plugin) => plugin.id === CODEX_PLUGIN_ID);
 }
 
 function shouldEnableCodexForOpenAi(
   cfg: OpenClawConfig,
   registry: PluginManifestRegistry,
 ): boolean {
-  return (
-    isOpenAiExplicitlyEnabled(cfg) &&
-    !isCodexAlreadyEnabled(cfg) &&
-    hasManifestPlugin(registry, "codex")
-  );
+  return isOpenAiExplicitlyEnabled(cfg) && !isCodexEnabled(cfg) && hasCodexManifest(registry);
 }
 
-function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
-  if (isBlockedObjectKey(pluginId)) {
-    return cfg;
-  }
-  const entry = cfg.plugins?.entries?.[pluginId];
+function setCodexEntryEnabled(cfg: OpenClawConfig): OpenClawConfig {
+  const entry = cfg.plugins?.entries?.[CODEX_PLUGIN_ID];
   const existingEntry = isRecord(entry) ? entry : {};
   return {
     ...cfg,
@@ -119,7 +97,7 @@ function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawC
       ...cfg.plugins,
       entries: {
         ...cfg.plugins?.entries,
-        [pluginId]: {
+        [CODEX_PLUGIN_ID]: {
           ...existingEntry,
           enabled: true,
         },
@@ -128,100 +106,22 @@ function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawC
   };
 }
 
-function joinReasons(reasons: readonly string[]): string {
-  return reasons.join("; ");
-}
-
-function sanitizeOutput(value: string): string {
-  return sanitizeForLog(value);
-}
-
-function isOpenAiCompanionOnlyReason(reasons: readonly string[]): boolean {
-  return reasons.length === 1 && reasons[0] === OPENAI_ENABLED_CODEX_REASON;
-}
-
-function isOpenAiCompanionAllowlistBlocked(
-  cfg: OpenClawConfig,
-  pluginId: string,
-  reasons: readonly string[],
-): boolean {
-  return (
-    pluginId === "codex" &&
-    isOpenAiCompanionOnlyReason(reasons) &&
-    isPluginAllowMissing(cfg, pluginId)
-  );
-}
-
-function addReason(reasonsByPlugin: Map<string, string[]>, pluginId: string, reason: string): void {
-  const reasons = reasonsByPlugin.get(pluginId) ?? [];
-  if (!reasons.includes(reason)) {
-    reasons.push(reason);
-  }
-  reasonsByPlugin.set(pluginId, reasons);
-}
-
 export function scanConfiguredPluginAutoEnableBlockers(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
 }): ConfiguredPluginAutoEnableBlockerHit[] {
   const registry = resolveRegistry(params);
-  const candidates = detectPluginAutoEnableCandidates({
-    config: params.cfg,
-    env: params.env,
-    manifestRegistry: registry,
-  }).filter(isRepairableCandidate);
-
-  const reasonsByPlugin = new Map<string, string[]>();
-  for (const candidate of candidates) {
-    addReason(
-      reasonsByPlugin,
-      candidate.pluginId,
-      resolvePluginAutoEnableCandidateReason(candidate),
-    );
-  }
-  if (shouldEnableCodexForOpenAi(params.cfg, registry)) {
-    addReason(reasonsByPlugin, "codex", OPENAI_ENABLED_CODEX_REASON);
-  }
-  if (reasonsByPlugin.size === 0) {
+  if (!shouldEnableCodexForOpenAi(params.cfg, registry)) {
     return [];
   }
-
-  const hits: ConfiguredPluginAutoEnableBlockerHit[] = [];
-  for (const pluginId of [...reasonsByPlugin.keys()].toSorted((left, right) =>
-    left.localeCompare(right),
-  )) {
-    const reasons = reasonsByPlugin.get(pluginId) ?? [];
-    if (isBlockedObjectKey(pluginId)) {
-      hits.push({ pluginId, reasons, blocker: "invalid-plugin-id" });
-      continue;
-    }
-    if (params.cfg.plugins?.enabled === false) {
-      hits.push({ pluginId, reasons, blocker: "plugins-disabled" });
-      continue;
-    }
-    if (isPluginDenied(params.cfg, pluginId)) {
-      hits.push({ pluginId, reasons, blocker: "blocked-by-denylist" });
-      continue;
-    }
-    if (isOpenAiCompanionAllowlistBlocked(params.cfg, pluginId, reasons)) {
-      hits.push({
-        pluginId,
-        reasons,
-        blocker: "blocked-by-allowlist",
-        entryDisabled: isPluginEntryDisabled(params.cfg, pluginId),
-      });
-      continue;
-    }
-    if (isPluginEntryDisabled(params.cfg, pluginId)) {
-      hits.push({ pluginId, reasons, blocker: "disabled-in-config" });
-      continue;
-    }
-    if (pluginId === "codex" && reasons.includes(OPENAI_ENABLED_CODEX_REASON)) {
-      hits.push({ pluginId, reasons, blocker: "not-enabled" });
-    }
-  }
-  return hits;
+  return [
+    {
+      pluginId: CODEX_PLUGIN_ID,
+      reasons: [OPENAI_ENABLED_CODEX_REASON],
+      blocker: isPluginDenied(params.cfg, CODEX_PLUGIN_ID) ? "blocked-by-denylist" : "not-enabled",
+    },
+  ];
 }
 
 export function collectConfiguredPluginAutoEnableBlockerWarnings(params: {
@@ -229,33 +129,13 @@ export function collectConfiguredPluginAutoEnableBlockerWarnings(params: {
   doctorFixCommand?: string;
 }): string[] {
   return params.hits.map((hit) => {
-    const pluginId = sanitizeOutput(hit.pluginId);
-    const reason = sanitizeOutput(joinReasons(hit.reasons));
-    if (hit.blocker === "disabled-in-config") {
-      const suffix = params.doctorFixCommand
-        ? ` Run "${params.doctorFixCommand}" to enable it.`
-        : " Enable the plugin before relying on that configuration.";
-      return `- plugins.entries.${pluginId}.enabled: plugin is disabled, but ${reason}.${suffix}`;
-    }
-    if (hit.blocker === "not-enabled") {
-      const suffix = params.doctorFixCommand
-        ? ` Run "${params.doctorFixCommand}" to enable it.`
-        : " Enable the plugin before relying on that configuration.";
-      return `- plugins.entries.${pluginId}.enabled: plugin is not enabled, but ${reason}.${suffix}`;
-    }
-    if (hit.blocker === "blocked-by-allowlist") {
-      const disabledSuffix = hit.entryDisabled
-        ? ` Also enable plugins.entries.${pluginId}.enabled before relying on that configuration.`
-        : "";
-      return `- plugins.allow: plugin "${pluginId}" is not allowlisted, but ${reason}. Add "${pluginId}" to plugins.allow before relying on that configuration.${disabledSuffix}`;
-    }
     if (hit.blocker === "blocked-by-denylist") {
-      return `- plugins.deny: plugin "${pluginId}" is denied, but ${reason}. Remove it from plugins.deny before relying on that configuration.`;
+      return `- plugins.deny: plugin "${hit.pluginId}" is denied, but ${hit.reasons[0]}. Remove it from plugins.deny before relying on that configuration.`;
     }
-    if (hit.blocker === "invalid-plugin-id") {
-      return `- plugins.entries.${pluginId}.enabled: plugin id is reserved and cannot be auto-repaired, but ${reason}. Use a non-reserved plugin id before relying on that configuration.`;
-    }
-    return `- plugins.enabled: plugins are disabled globally, but plugin "${pluginId}" is needed because ${reason}. Enable plugins before relying on that configuration.`;
+    const suffix = params.doctorFixCommand
+      ? ` Run "${params.doctorFixCommand}" to enable it.`
+      : " Enable the plugin before relying on that configuration.";
+    return `- plugins.entries.${hit.pluginId}.enabled: plugin is not enabled, but ${hit.reasons[0]}.${suffix}`;
   });
 }
 
@@ -268,27 +148,28 @@ export function maybeRepairConfiguredPluginAutoEnableBlockers(params: {
   changes: string[];
   warnings: string[];
 } {
-  let next = params.cfg;
-  const changes: string[] = [];
-  const warnings: string[] = [];
   const hits = scanConfiguredPluginAutoEnableBlockers(params);
-
-  for (const hit of hits) {
-    if (hit.blocker !== "disabled-in-config" && hit.blocker !== "not-enabled") {
-      warnings.push(...collectConfiguredPluginAutoEnableBlockerWarnings({ hits: [hit] }));
-      continue;
-    }
-
-    const hadAllowlistMissing = isPluginAllowMissing(next, hit.pluginId);
-    next = setPluginEntryEnabled(next, hit.pluginId);
-    next = ensurePluginAllowlisted(next, hit.pluginId);
-    const pluginId = sanitizeOutput(hit.pluginId);
-    const reason = sanitizeOutput(joinReasons(hit.reasons));
-    changes.push(`plugins.entries.${pluginId}.enabled: enabled plugin because ${reason}.`);
-    if (hadAllowlistMissing) {
-      changes.push(`plugins.allow: added "${pluginId}" because ${reason}.`);
-    }
+  if (hits.length === 0) {
+    return { config: params.cfg, changes: [], warnings: [] };
+  }
+  const hit = hits[0];
+  if (hit.blocker === "blocked-by-denylist") {
+    return {
+      config: params.cfg,
+      changes: [],
+      warnings: collectConfiguredPluginAutoEnableBlockerWarnings({ hits }),
+    };
   }
 
-  return { config: next, changes, warnings };
+  const hadAllowlistMissing = isPluginAllowMissing(params.cfg, CODEX_PLUGIN_ID);
+  const config = ensurePluginAllowlisted(setCodexEntryEnabled(params.cfg), CODEX_PLUGIN_ID);
+  const changes = [
+    `plugins.entries.${CODEX_PLUGIN_ID}.enabled: enabled plugin because ${OPENAI_ENABLED_CODEX_REASON}.`,
+  ];
+  if (hadAllowlistMissing) {
+    changes.push(
+      `plugins.allow: added "${CODEX_PLUGIN_ID}" because ${OPENAI_ENABLED_CODEX_REASON}.`,
+    );
+  }
+  return { config, changes, warnings: [] };
 }

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
@@ -1,4 +1,5 @@
 import { ensurePluginAllowlisted } from "../../../config/plugins-allowlist.js";
+import { isBlockedObjectKey } from "../../../config/prototype-keys.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadPluginManifestRegistry,
@@ -77,26 +78,38 @@ function resolveRegistry(params: {
   );
 }
 
-function hasCodexManifest(registry: PluginManifestRegistry): boolean {
-  return registry.plugins.some((plugin) => plugin.id === CODEX_PLUGIN_ID);
+function hasBundledCodexManifest(registry: PluginManifestRegistry): boolean {
+  return registry.plugins.some(
+    (plugin) => plugin.id === CODEX_PLUGIN_ID && plugin.origin === "bundled",
+  );
 }
 
-function shouldEnableCodexForOpenAi(
-  cfg: OpenClawConfig,
-  registry: PluginManifestRegistry,
-): boolean {
-  return isOpenAiExplicitlyEnabled(cfg) && !isCodexEnabled(cfg) && hasCodexManifest(registry);
+function shouldCheckCodexForOpenAi(cfg: OpenClawConfig): boolean {
+  return isOpenAiExplicitlyEnabled(cfg) && !isCodexEnabled(cfg);
+}
+
+function copyConfigRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const copy: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!isBlockedObjectKey(key)) {
+      copy[key] = entry;
+    }
+  }
+  return copy;
 }
 
 function setCodexEntryEnabled(cfg: OpenClawConfig): OpenClawConfig {
-  const entry = cfg.plugins?.entries?.[CODEX_PLUGIN_ID];
-  const existingEntry = isRecord(entry) ? entry : {};
+  const entries = copyConfigRecord(cfg.plugins?.entries);
+  const existingEntry = copyConfigRecord(entries[CODEX_PLUGIN_ID]);
   return {
     ...cfg,
     plugins: {
       ...cfg.plugins,
       entries: {
-        ...cfg.plugins?.entries,
+        ...entries,
         [CODEX_PLUGIN_ID]: {
           ...existingEntry,
           enabled: true,
@@ -111,8 +124,11 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
 }): ConfiguredPluginAutoEnableBlockerHit[] {
+  if (!shouldCheckCodexForOpenAi(params.cfg)) {
+    return [];
+  }
   const registry = resolveRegistry(params);
-  if (!shouldEnableCodexForOpenAi(params.cfg, registry)) {
+  if (!hasBundledCodexManifest(registry)) {
     return [];
   }
   return [

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
@@ -5,7 +5,11 @@ import {
 } from "../../../config/plugin-auto-enable.js";
 import { ensurePluginAllowlisted } from "../../../config/plugins-allowlist.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type { PluginManifestRegistry } from "../../../plugins/manifest-registry.js";
+import {
+  loadPluginManifestRegistry,
+  type PluginManifestRegistry,
+} from "../../../plugins/manifest-registry.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
 
 const REPAIRABLE_CANDIDATE_KINDS = new Set<PluginAutoEnableCandidate["kind"]>([
   "provider-auth-configured",
@@ -17,6 +21,7 @@ const OPENAI_ENABLED_CODEX_REASON = "OpenAI plugin enabled";
 export type ConfiguredPluginAutoEnableBlockerReason =
   | "disabled-in-config"
   | "blocked-by-denylist"
+  | "blocked-by-allowlist"
   | "plugins-disabled"
   | "not-enabled";
 
@@ -70,8 +75,33 @@ function isCodexAlreadyEnabled(cfg: OpenClawConfig): boolean {
   return !isPluginAllowMissing(cfg, "codex");
 }
 
-function shouldEnableCodexForOpenAi(cfg: OpenClawConfig): boolean {
-  return isOpenAiExplicitlyEnabled(cfg) && !isCodexAlreadyEnabled(cfg);
+function resolveRegistry(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRegistry?: PluginManifestRegistry;
+}): PluginManifestRegistry {
+  return (
+    params.manifestRegistry ??
+    loadPluginManifestRegistry({
+      config: params.cfg,
+      env: params.env,
+    })
+  );
+}
+
+function hasManifestPlugin(registry: PluginManifestRegistry, pluginId: string): boolean {
+  return registry.plugins.some((plugin) => plugin.id === pluginId);
+}
+
+function shouldEnableCodexForOpenAi(
+  cfg: OpenClawConfig,
+  registry: PluginManifestRegistry,
+): boolean {
+  return (
+    isOpenAiExplicitlyEnabled(cfg) &&
+    !isCodexAlreadyEnabled(cfg) &&
+    hasManifestPlugin(registry, "codex")
+  );
 }
 
 function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
@@ -96,6 +126,14 @@ function joinReasons(reasons: readonly string[]): string {
   return reasons.join("; ");
 }
 
+function sanitizeOutput(value: string): string {
+  return sanitizeForLog(value);
+}
+
+function isOpenAiCompanionOnlyReason(reasons: readonly string[]): boolean {
+  return reasons.length === 1 && reasons[0] === OPENAI_ENABLED_CODEX_REASON;
+}
+
 function addReason(reasonsByPlugin: Map<string, string[]>, pluginId: string, reason: string): void {
   const reasons = reasonsByPlugin.get(pluginId) ?? [];
   if (!reasons.includes(reason)) {
@@ -109,10 +147,11 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
 }): ConfiguredPluginAutoEnableBlockerHit[] {
+  const registry = resolveRegistry(params);
   const candidates = detectPluginAutoEnableCandidates({
     config: params.cfg,
     env: params.env,
-    manifestRegistry: params.manifestRegistry,
+    manifestRegistry: registry,
   }).filter(isRepairableCandidate);
 
   const reasonsByPlugin = new Map<string, string[]>();
@@ -123,7 +162,7 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
       resolvePluginAutoEnableCandidateReason(candidate),
     );
   }
-  if (shouldEnableCodexForOpenAi(params.cfg)) {
+  if (shouldEnableCodexForOpenAi(params.cfg, registry)) {
     addReason(reasonsByPlugin, "codex", OPENAI_ENABLED_CODEX_REASON);
   }
   if (reasonsByPlugin.size === 0) {
@@ -143,6 +182,14 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
       hits.push({ pluginId, reasons, blocker: "blocked-by-denylist" });
       continue;
     }
+    if (
+      pluginId === "codex" &&
+      isOpenAiCompanionOnlyReason(reasons) &&
+      isPluginAllowMissing(params.cfg, pluginId)
+    ) {
+      hits.push({ pluginId, reasons, blocker: "blocked-by-allowlist" });
+      continue;
+    }
     if (isPluginEntryDisabled(params.cfg, pluginId)) {
       hits.push({ pluginId, reasons, blocker: "disabled-in-config" });
       continue;
@@ -159,23 +206,27 @@ export function collectConfiguredPluginAutoEnableBlockerWarnings(params: {
   doctorFixCommand?: string;
 }): string[] {
   return params.hits.map((hit) => {
-    const reason = joinReasons(hit.reasons);
+    const pluginId = sanitizeOutput(hit.pluginId);
+    const reason = sanitizeOutput(joinReasons(hit.reasons));
     if (hit.blocker === "disabled-in-config") {
       const suffix = params.doctorFixCommand
         ? ` Run "${params.doctorFixCommand}" to enable it.`
         : " Enable the plugin before relying on that configuration.";
-      return `- plugins.entries.${hit.pluginId}.enabled: plugin is disabled, but ${reason}.${suffix}`;
+      return `- plugins.entries.${pluginId}.enabled: plugin is disabled, but ${reason}.${suffix}`;
     }
     if (hit.blocker === "not-enabled") {
       const suffix = params.doctorFixCommand
         ? ` Run "${params.doctorFixCommand}" to enable it.`
         : " Enable the plugin before relying on that configuration.";
-      return `- plugins.entries.${hit.pluginId}.enabled: plugin is not enabled, but ${reason}.${suffix}`;
+      return `- plugins.entries.${pluginId}.enabled: plugin is not enabled, but ${reason}.${suffix}`;
+    }
+    if (hit.blocker === "blocked-by-allowlist") {
+      return `- plugins.allow: plugin "${pluginId}" is not allowlisted, but ${reason}. Add "${pluginId}" to plugins.allow before relying on that configuration.`;
     }
     if (hit.blocker === "blocked-by-denylist") {
-      return `- plugins.deny: plugin "${hit.pluginId}" is denied, but ${reason}. Remove it from plugins.deny before relying on that configuration.`;
+      return `- plugins.deny: plugin "${pluginId}" is denied, but ${reason}. Remove it from plugins.deny before relying on that configuration.`;
     }
-    return `- plugins.enabled: plugins are disabled globally, but plugin "${hit.pluginId}" is needed because ${reason}. Enable plugins before relying on that configuration.`;
+    return `- plugins.enabled: plugins are disabled globally, but plugin "${pluginId}" is needed because ${reason}. Enable plugins before relying on that configuration.`;
   });
 }
 
@@ -202,10 +253,11 @@ export function maybeRepairConfiguredPluginAutoEnableBlockers(params: {
     const hadAllowlistMissing = isPluginAllowMissing(next, hit.pluginId);
     next = setPluginEntryEnabled(next, hit.pluginId);
     next = ensurePluginAllowlisted(next, hit.pluginId);
-    const reason = joinReasons(hit.reasons);
-    changes.push(`plugins.entries.${hit.pluginId}.enabled: enabled plugin because ${reason}.`);
+    const pluginId = sanitizeOutput(hit.pluginId);
+    const reason = sanitizeOutput(joinReasons(hit.reasons));
+    changes.push(`plugins.entries.${pluginId}.enabled: enabled plugin because ${reason}.`);
     if (hadAllowlistMissing) {
-      changes.push(`plugins.allow: added "${hit.pluginId}" because ${reason}.`);
+      changes.push(`plugins.allow: added "${pluginId}" because ${reason}.`);
     }
   }
 

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
@@ -4,6 +4,7 @@ import {
   type PluginAutoEnableCandidate,
 } from "../../../config/plugin-auto-enable.js";
 import { ensurePluginAllowlisted } from "../../../config/plugins-allowlist.js";
+import { isBlockedObjectKey } from "../../../config/prototype-keys.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadPluginManifestRegistry,
@@ -23,12 +24,14 @@ export type ConfiguredPluginAutoEnableBlockerReason =
   | "blocked-by-denylist"
   | "blocked-by-allowlist"
   | "plugins-disabled"
+  | "invalid-plugin-id"
   | "not-enabled";
 
 export type ConfiguredPluginAutoEnableBlockerHit = {
   pluginId: string;
   reasons: string[];
   blocker: ConfiguredPluginAutoEnableBlockerReason;
+  entryDisabled?: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -105,6 +108,9 @@ function shouldEnableCodexForOpenAi(
 }
 
 function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
+  if (isBlockedObjectKey(pluginId)) {
+    return cfg;
+  }
   const entry = cfg.plugins?.entries?.[pluginId];
   const existingEntry = isRecord(entry) ? entry : {};
   return {
@@ -132,6 +138,18 @@ function sanitizeOutput(value: string): string {
 
 function isOpenAiCompanionOnlyReason(reasons: readonly string[]): boolean {
   return reasons.length === 1 && reasons[0] === OPENAI_ENABLED_CODEX_REASON;
+}
+
+function isOpenAiCompanionAllowlistBlocked(
+  cfg: OpenClawConfig,
+  pluginId: string,
+  reasons: readonly string[],
+): boolean {
+  return (
+    pluginId === "codex" &&
+    isOpenAiCompanionOnlyReason(reasons) &&
+    isPluginAllowMissing(cfg, pluginId)
+  );
 }
 
 function addReason(reasonsByPlugin: Map<string, string[]>, pluginId: string, reason: string): void {
@@ -174,6 +192,10 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
     left.localeCompare(right),
   )) {
     const reasons = reasonsByPlugin.get(pluginId) ?? [];
+    if (isBlockedObjectKey(pluginId)) {
+      hits.push({ pluginId, reasons, blocker: "invalid-plugin-id" });
+      continue;
+    }
     if (params.cfg.plugins?.enabled === false) {
       hits.push({ pluginId, reasons, blocker: "plugins-disabled" });
       continue;
@@ -182,12 +204,13 @@ export function scanConfiguredPluginAutoEnableBlockers(params: {
       hits.push({ pluginId, reasons, blocker: "blocked-by-denylist" });
       continue;
     }
-    if (
-      pluginId === "codex" &&
-      isOpenAiCompanionOnlyReason(reasons) &&
-      isPluginAllowMissing(params.cfg, pluginId)
-    ) {
-      hits.push({ pluginId, reasons, blocker: "blocked-by-allowlist" });
+    if (isOpenAiCompanionAllowlistBlocked(params.cfg, pluginId, reasons)) {
+      hits.push({
+        pluginId,
+        reasons,
+        blocker: "blocked-by-allowlist",
+        entryDisabled: isPluginEntryDisabled(params.cfg, pluginId),
+      });
       continue;
     }
     if (isPluginEntryDisabled(params.cfg, pluginId)) {
@@ -221,10 +244,16 @@ export function collectConfiguredPluginAutoEnableBlockerWarnings(params: {
       return `- plugins.entries.${pluginId}.enabled: plugin is not enabled, but ${reason}.${suffix}`;
     }
     if (hit.blocker === "blocked-by-allowlist") {
-      return `- plugins.allow: plugin "${pluginId}" is not allowlisted, but ${reason}. Add "${pluginId}" to plugins.allow before relying on that configuration.`;
+      const disabledSuffix = hit.entryDisabled
+        ? ` Also enable plugins.entries.${pluginId}.enabled before relying on that configuration.`
+        : "";
+      return `- plugins.allow: plugin "${pluginId}" is not allowlisted, but ${reason}. Add "${pluginId}" to plugins.allow before relying on that configuration.${disabledSuffix}`;
     }
     if (hit.blocker === "blocked-by-denylist") {
       return `- plugins.deny: plugin "${pluginId}" is denied, but ${reason}. Remove it from plugins.deny before relying on that configuration.`;
+    }
+    if (hit.blocker === "invalid-plugin-id") {
+      return `- plugins.entries.${pluginId}.enabled: plugin id is reserved and cannot be auto-repaired, but ${reason}. Use a non-reserved plugin id before relying on that configuration.`;
     }
     return `- plugins.enabled: plugins are disabled globally, but plugin "${pluginId}" is needed because ${reason}. Enable plugins before relying on that configuration.`;
   });

--- a/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
+++ b/src/commands/doctor/shared/configured-plugin-auto-enable-blockers.ts
@@ -1,0 +1,213 @@
+import {
+  detectPluginAutoEnableCandidates,
+  resolvePluginAutoEnableCandidateReason,
+  type PluginAutoEnableCandidate,
+} from "../../../config/plugin-auto-enable.js";
+import { ensurePluginAllowlisted } from "../../../config/plugins-allowlist.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { PluginManifestRegistry } from "../../../plugins/manifest-registry.js";
+
+const REPAIRABLE_CANDIDATE_KINDS = new Set<PluginAutoEnableCandidate["kind"]>([
+  "provider-auth-configured",
+  "provider-model-configured",
+  "agent-harness-runtime-configured",
+]);
+const OPENAI_ENABLED_CODEX_REASON = "OpenAI plugin enabled";
+
+export type ConfiguredPluginAutoEnableBlockerReason =
+  | "disabled-in-config"
+  | "blocked-by-denylist"
+  | "plugins-disabled"
+  | "not-enabled";
+
+export type ConfiguredPluginAutoEnableBlockerHit = {
+  pluginId: string;
+  reasons: string[];
+  blocker: ConfiguredPluginAutoEnableBlockerReason;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isRepairableCandidate(candidate: PluginAutoEnableCandidate): boolean {
+  return REPAIRABLE_CANDIDATE_KINDS.has(candidate.kind);
+}
+
+function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
+  return Array.isArray(cfg.plugins?.deny) && cfg.plugins.deny.includes(pluginId);
+}
+
+function isPluginEntryDisabled(cfg: OpenClawConfig, pluginId: string): boolean {
+  return cfg.plugins?.entries?.[pluginId]?.enabled === false;
+}
+
+function isPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): boolean {
+  return cfg.plugins?.entries?.[pluginId]?.enabled === true;
+}
+
+function isPluginAllowMissing(cfg: OpenClawConfig, pluginId: string): boolean {
+  return Array.isArray(cfg.plugins?.allow) && !cfg.plugins.allow.includes(pluginId);
+}
+
+function isOpenAiExplicitlyEnabled(cfg: OpenClawConfig): boolean {
+  if (cfg.plugins?.enabled === false || isPluginDenied(cfg, "openai")) {
+    return false;
+  }
+  if (isPluginEntryDisabled(cfg, "openai")) {
+    return false;
+  }
+  if (isPluginAllowMissing(cfg, "openai")) {
+    return false;
+  }
+  return isPluginEntryEnabled(cfg, "openai") || cfg.plugins?.allow?.includes("openai") === true;
+}
+
+function isCodexAlreadyEnabled(cfg: OpenClawConfig): boolean {
+  if (!isPluginEntryEnabled(cfg, "codex")) {
+    return false;
+  }
+  return !isPluginAllowMissing(cfg, "codex");
+}
+
+function shouldEnableCodexForOpenAi(cfg: OpenClawConfig): boolean {
+  return isOpenAiExplicitlyEnabled(cfg) && !isCodexAlreadyEnabled(cfg);
+}
+
+function setPluginEntryEnabled(cfg: OpenClawConfig, pluginId: string): OpenClawConfig {
+  const entry = cfg.plugins?.entries?.[pluginId];
+  const existingEntry = isRecord(entry) ? entry : {};
+  return {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      entries: {
+        ...cfg.plugins?.entries,
+        [pluginId]: {
+          ...existingEntry,
+          enabled: true,
+        },
+      },
+    },
+  };
+}
+
+function joinReasons(reasons: readonly string[]): string {
+  return reasons.join("; ");
+}
+
+function addReason(reasonsByPlugin: Map<string, string[]>, pluginId: string, reason: string): void {
+  const reasons = reasonsByPlugin.get(pluginId) ?? [];
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+  reasonsByPlugin.set(pluginId, reasons);
+}
+
+export function scanConfiguredPluginAutoEnableBlockers(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRegistry?: PluginManifestRegistry;
+}): ConfiguredPluginAutoEnableBlockerHit[] {
+  const candidates = detectPluginAutoEnableCandidates({
+    config: params.cfg,
+    env: params.env,
+    manifestRegistry: params.manifestRegistry,
+  }).filter(isRepairableCandidate);
+
+  const reasonsByPlugin = new Map<string, string[]>();
+  for (const candidate of candidates) {
+    addReason(
+      reasonsByPlugin,
+      candidate.pluginId,
+      resolvePluginAutoEnableCandidateReason(candidate),
+    );
+  }
+  if (shouldEnableCodexForOpenAi(params.cfg)) {
+    addReason(reasonsByPlugin, "codex", OPENAI_ENABLED_CODEX_REASON);
+  }
+  if (reasonsByPlugin.size === 0) {
+    return [];
+  }
+
+  const hits: ConfiguredPluginAutoEnableBlockerHit[] = [];
+  for (const pluginId of [...reasonsByPlugin.keys()].toSorted((left, right) =>
+    left.localeCompare(right),
+  )) {
+    const reasons = reasonsByPlugin.get(pluginId) ?? [];
+    if (params.cfg.plugins?.enabled === false) {
+      hits.push({ pluginId, reasons, blocker: "plugins-disabled" });
+      continue;
+    }
+    if (isPluginDenied(params.cfg, pluginId)) {
+      hits.push({ pluginId, reasons, blocker: "blocked-by-denylist" });
+      continue;
+    }
+    if (isPluginEntryDisabled(params.cfg, pluginId)) {
+      hits.push({ pluginId, reasons, blocker: "disabled-in-config" });
+      continue;
+    }
+    if (pluginId === "codex" && reasons.includes(OPENAI_ENABLED_CODEX_REASON)) {
+      hits.push({ pluginId, reasons, blocker: "not-enabled" });
+    }
+  }
+  return hits;
+}
+
+export function collectConfiguredPluginAutoEnableBlockerWarnings(params: {
+  hits: readonly ConfiguredPluginAutoEnableBlockerHit[];
+  doctorFixCommand?: string;
+}): string[] {
+  return params.hits.map((hit) => {
+    const reason = joinReasons(hit.reasons);
+    if (hit.blocker === "disabled-in-config") {
+      const suffix = params.doctorFixCommand
+        ? ` Run "${params.doctorFixCommand}" to enable it.`
+        : " Enable the plugin before relying on that configuration.";
+      return `- plugins.entries.${hit.pluginId}.enabled: plugin is disabled, but ${reason}.${suffix}`;
+    }
+    if (hit.blocker === "not-enabled") {
+      const suffix = params.doctorFixCommand
+        ? ` Run "${params.doctorFixCommand}" to enable it.`
+        : " Enable the plugin before relying on that configuration.";
+      return `- plugins.entries.${hit.pluginId}.enabled: plugin is not enabled, but ${reason}.${suffix}`;
+    }
+    if (hit.blocker === "blocked-by-denylist") {
+      return `- plugins.deny: plugin "${hit.pluginId}" is denied, but ${reason}. Remove it from plugins.deny before relying on that configuration.`;
+    }
+    return `- plugins.enabled: plugins are disabled globally, but plugin "${hit.pluginId}" is needed because ${reason}. Enable plugins before relying on that configuration.`;
+  });
+}
+
+export function maybeRepairConfiguredPluginAutoEnableBlockers(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRegistry?: PluginManifestRegistry;
+}): {
+  config: OpenClawConfig;
+  changes: string[];
+  warnings: string[];
+} {
+  let next = params.cfg;
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const hits = scanConfiguredPluginAutoEnableBlockers(params);
+
+  for (const hit of hits) {
+    if (hit.blocker !== "disabled-in-config" && hit.blocker !== "not-enabled") {
+      warnings.push(...collectConfiguredPluginAutoEnableBlockerWarnings({ hits: [hit] }));
+      continue;
+    }
+
+    const hadAllowlistMissing = isPluginAllowMissing(next, hit.pluginId);
+    next = setPluginEntryEnabled(next, hit.pluginId);
+    next = ensurePluginAllowlisted(next, hit.pluginId);
+    const reason = joinReasons(hit.reasons);
+    changes.push(`plugins.entries.${hit.pluginId}.enabled: enabled plugin because ${reason}.`);
+    if (hadAllowlistMissing) {
+      changes.push(`plugins.allow: added "${hit.pluginId}" because ${reason}.`);
+    }
+  }
+
+  return { config: next, changes, warnings };
+}

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -125,6 +125,23 @@ export async function collectDoctorPreviewWarnings(params: {
 
   if (hasPluginConfig) {
     const {
+      collectConfiguredPluginAutoEnableBlockerWarnings,
+      scanConfiguredPluginAutoEnableBlockers,
+    } = await import("./configured-plugin-auto-enable-blockers.js");
+    const configuredPluginBlockerHits = scanConfiguredPluginAutoEnableBlockers({
+      cfg: params.cfg,
+      env,
+    });
+    if (configuredPluginBlockerHits.length > 0) {
+      warnings.push(
+        collectConfiguredPluginAutoEnableBlockerWarnings({
+          hits: configuredPluginBlockerHits,
+          doctorFixCommand: params.doctorFixCommand,
+        }).join("\n"),
+      );
+    }
+
+    const {
       collectStalePluginConfigWarnings,
       isStalePluginAutoRepairBlocked,
       scanStalePluginConfig,


### PR DESCRIPTION
## Summary
- add a doctor repair that enables the bundled Codex plugin when OpenAI is explicitly enabled and Codex is off
- add preview warnings for Codex/OpenAI plugin drift and preserve deny/global-disable blockers as warnings
- add focused doctor repair tests and changelog entry

## Tests
- pnpm test src/commands/doctor/shared/configured-plugin-auto-enable-blockers.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/preview-warnings.test.ts
- pnpm check:changed