### PR TITLE
fix(ui): render assistant identity avatars in chat

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1115,6 +1115,19 @@
   overflow: hidden;
 }
 
+.agent-chat__avatar--text {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-lg);
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  font-weight: 700;
+}
+
 .agent-chat__avatar--logo img {
   width: 32px;
   height: 32px;

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -2,18 +2,30 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-describe("chat steer styles", () => {
+function readLayoutCss(): string {
+  const cssPath = [
+    resolve(process.cwd(), "src/styles/chat/layout.css"),
+    resolve(process.cwd(), "ui/src/styles/chat/layout.css"),
+  ].find((candidate) => existsSync(candidate));
+  expect(cssPath).toBeTruthy();
+  return readFileSync(cssPath!, "utf8");
+}
+
+describe("chat layout styles", () => {
   it("styles queued-message steering controls and pending indicators", () => {
-    const cssPath = [
-      resolve(process.cwd(), "src/styles/chat/layout.css"),
-      resolve(process.cwd(), "ui/src/styles/chat/layout.css"),
-    ].find((candidate) => existsSync(candidate));
-    expect(cssPath).toBeTruthy();
-    const css = readFileSync(cssPath!, "utf8");
+    const css = readLayoutCss();
 
     expect(css).toContain(".chat-queue__steer");
     expect(css).toContain(".chat-queue__actions");
     expect(css).toContain(".chat-queue__item--steered");
     expect(css).toContain(".chat-queue__badge");
+  });
+
+  it("includes assistant text avatar styles for configured IDENTITY avatars", () => {
+    const css = readLayoutCss();
+
+    expect(css).toContain(".agent-chat__avatar--text");
+    expect(css).toContain("font-size: 20px;");
+    expect(css).toContain("place-items: center;");
   });
 });

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -6,6 +6,7 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import {
   renderMessageGroup,
+  resolveAssistantTextAvatar,
   resetAssistantAttachmentAvailabilityCacheForTest,
 } from "./grouped-render.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
@@ -258,6 +259,33 @@ describe("grouped chat rendering", () => {
     const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.assistant");
     expect(avatar).not.toBeNull();
     expect(avatar?.getAttribute("src")).toBe("/openclaw-logo.svg");
+  });
+
+  it("renders a configured assistant text avatar", () => {
+    const container = document.createElement("div");
+
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "hello",
+        timestamp: 1000,
+      },
+      { assistantAvatar: "VC", assistantName: "Val" },
+    );
+
+    const avatar = container.querySelector<HTMLElement>(".chat-avatar.assistant");
+    expect(avatar).not.toBeNull();
+    expect(avatar?.tagName).toBe("DIV");
+    expect(avatar?.textContent).toContain("VC");
+    expect(avatar?.getAttribute("aria-label")).toBe("Val");
+  });
+
+  it("rejects unsafe invisible controls in assistant text avatars", () => {
+    expect(resolveAssistantTextAvatar("VC")).toBe("VC");
+    expect(resolveAssistantTextAvatar("\u{1F43E}")).toBe("\u{1F43E}");
+    expect(resolveAssistantTextAvatar("V\u202eC")).toBeNull();
+    expect(resolveAssistantTextAvatar("V\u200bC")).toBeNull();
   });
 
   it("includes cache tokens when rendering assistant context usage", () => {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -261,6 +261,25 @@ describe("grouped chat rendering", () => {
     expect(avatar?.getAttribute("src")).toBe("/openclaw-logo.svg");
   });
 
+  it("renders a blob: assistant avatar as an image", () => {
+    const container = document.createElement("div");
+
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "hello",
+        timestamp: 1000,
+      },
+      { assistantAvatar: "blob:managed-image", assistantName: "Val" },
+    );
+
+    const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.assistant");
+    expect(avatar).not.toBeNull();
+    expect(avatar?.tagName).toBe("IMG");
+    expect(avatar?.getAttribute("src")).toBe("blob:managed-image");
+  });
+
   it("renders a configured assistant text avatar", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { until } from "lit/directives/until.js";
 import { getSafeLocalStorage } from "../../local-storage.ts";
-import type { AssistantIdentity } from "../assistant-identity.ts";
+import { DEFAULT_ASSISTANT_AVATAR, type AssistantIdentity } from "../assistant-identity.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
@@ -638,6 +638,7 @@ function renderAvatar(
   const normalized = normalizeRoleForGrouping(role);
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
+  const assistantAvatarText = resolveAssistantTextAvatar(assistantAvatar);
   const userName = resolveLocalUserName(user);
   const userAvatarUrl = resolveLocalUserAvatarUrl(user);
   const userAvatarText = resolveLocalUserAvatarText(user);
@@ -712,6 +713,11 @@ function renderAvatar(
         alt="${assistantName}"
       />`;
     }
+    if (assistantAvatarText) {
+      return html`<div class="chat-avatar ${className}" aria-label="${assistantName}">
+        ${assistantAvatarText}
+      </div>`;
+    }
     return html`<img
       class="chat-avatar ${className} chat-avatar--logo"
       src="${agentLogoUrl(basePath ?? "")}"
@@ -733,7 +739,29 @@ function renderAvatar(
 }
 
 function isAvatarUrl(value: string): boolean {
-  return isRenderableControlUiAvatarUrl(value);
+  const trimmed = value.trim();
+  return trimmed.startsWith("blob:") || isRenderableControlUiAvatarUrl(trimmed);
+}
+
+const UNSAFE_ASSISTANT_TEXT_AVATAR_CHARS = /[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/u;
+
+export function resolveAssistantTextAvatar(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === DEFAULT_ASSISTANT_AVATAR) {
+    return null;
+  }
+  if (isAvatarUrl(trimmed)) {
+    return null;
+  }
+  if (
+    trimmed.length > 8 ||
+    /\s/.test(trimmed) ||
+    /[\\/.:]/.test(trimmed) ||
+    UNSAFE_ASSISTANT_TEXT_AVATAR_CHARS.test(trimmed)
+  ) {
+    return null;
+  }
+  return trimmed;
 }
 
 function resolveRenderableMessageImages(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -105,3 +105,33 @@ describe("chat view queue steering", () => {
     expect(container.querySelector(".chat-queue__steer")).toBeNull();
   });
 });
+
+describe("renderChat", () => {
+  afterEach(() => {
+    cleanupChatModuleState();
+  });
+
+  it("renders configured assistant text avatars in transcript groups", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Val",
+          assistantAvatar: "VC",
+          assistantAvatarUrl: null,
+          messages: [{ role: "assistant", content: "hello", timestamp: 1000 }],
+          stream: null,
+          streamStartedAt: null,
+        }),
+      ),
+      container,
+    );
+
+    const avatar = container.querySelector<HTMLElement>(".chat-group.assistant .chat-avatar");
+    expect(avatar).not.toBeNull();
+    expect(avatar?.tagName).toBe("DIV");
+    expect(avatar?.textContent).toContain("VC");
+    expect(avatar?.getAttribute("aria-label")).toBe("Val");
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -14,6 +14,7 @@ import {
   renderMessageGroup,
   renderReadingIndicatorGroup,
   renderStreamingGroup,
+  resolveAssistantTextAvatar,
 } from "../chat/grouped-render.ts";
 import { InputHistory } from "../chat/input-history.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
@@ -475,12 +476,8 @@ const WELCOME_SUGGESTIONS = [
 
 function renderWelcomeState(props: ChatProps): TemplateResult {
   const name = props.assistantName || "Assistant";
-  const avatar = resolveChatAvatarRenderUrl(props.assistantAvatarUrl, {
-    identity: {
-      avatar: props.assistantAvatar ?? undefined,
-      avatarUrl: props.assistantAvatarUrl ?? undefined,
-    },
-  });
+  const avatar = resolveAssistantAvatarUrl(props);
+  const avatarText = avatar ? null : resolveAssistantTextAvatar(props.assistantAvatar);
   const logoUrl = agentLogoUrl(props.basePath ?? "");
 
   return html`
@@ -492,9 +489,13 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
             alt=${name}
             style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
           />`
-        : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
-            <img src=${logoUrl} alt="OpenClaw" />
-          </div>`}
+        : avatarText
+          ? html`<div class="agent-chat__avatar agent-chat__avatar--text" aria-label=${name}>
+              ${avatarText}
+            </div>`
+          : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
+              <img src=${logoUrl} alt="OpenClaw" />
+            </div>`}
       <h2>${name}</h2>
       <div class="agent-chat__badges">
         <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Ready to chat</span>
@@ -518,6 +519,23 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
       </div>
     </div>
   `;
+}
+
+function resolveAssistantAvatarUrl(
+  props: Pick<ChatProps, "assistantAvatar" | "assistantAvatarUrl">,
+): string | null {
+  return resolveChatAvatarRenderUrl(props.assistantAvatarUrl, {
+    identity: {
+      avatar: props.assistantAvatar ?? undefined,
+      avatarUrl: props.assistantAvatarUrl ?? undefined,
+    },
+  });
+}
+
+function resolveAssistantDisplayAvatar(
+  props: Pick<ChatProps, "assistantAvatar" | "assistantAvatarUrl">,
+): string | null {
+  return resolveAssistantAvatarUrl(props) ?? resolveAssistantTextAvatar(props.assistantAvatar);
 }
 
 function renderSearchBar(requestUpdate: () => void): TemplateResult | typeof nothing {
@@ -755,13 +773,7 @@ export function renderChat(props: ChatProps) {
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
     name: props.assistantName,
-    avatar:
-      resolveChatAvatarRenderUrl(props.assistantAvatarUrl, {
-        identity: {
-          avatar: props.assistantAvatar ?? undefined,
-          avatarUrl: props.assistantAvatarUrl ?? undefined,
-        },
-      }) ?? null,
+    avatar: resolveAssistantDisplayAvatar(props),
   };
   const pinned = getPinnedMessages(props.sessionKey);
   const deleted = getDeletedMessages(props.sessionKey);


### PR DESCRIPTION
## Summary

- Problem: Control UI chat already received assistant identity from the gateway, but short text/emoji avatars from `IDENTITY.md` fell back to the OpenClaw logo instead of rendering as the agent avatar.
- Why it matters: Agents with an `Avatar:` identity value should look consistent in the chat welcome state and message groups.
- What changed: Added assistant text-avatar rendering, reused it in the welcome state, and added focused renderer/style tests.
- What did NOT change (scope boundary): No avatar source resolution, auth, remote-image CSP, or gateway protocol behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Assistant avatar values were normalized by the gateway, but the chat renderer only treated same-origin/data image URLs as renderable assistant avatars. Non-image short text/emoji values therefore dropped to the logo fallback.
- Missing detection / guardrail: Grouped chat rendering did not have coverage for assistant text avatars.
- Contributing context (if known): User/operator identity already supported text/data avatars, but assistant chat rendering did not mirror that behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/chat/grouped-render.test.ts`, `ui/src/styles/chat/layout.test.ts`
- Scenario the test should lock in: assistant avatar value `VC` renders as a text avatar in chat groups instead of falling back to the logo.
- Why this is the smallest reliable guardrail: the behavior is decided entirely in the Lit chat renderer and CSS class surface.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Agents with a short text/emoji `Avatar:` in `IDENTITY.md` now show that avatar in Control UI chat bubbles and the empty welcome state.

## Diagram (if applicable)

```text
Before:
IDENTITY.md Avatar: VC -> gateway assistant identity -> chat renderer -> OpenClaw logo fallback

After:
IDENTITY.md Avatar: VC -> gateway assistant identity -> chat renderer -> text avatar "VC"
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.13.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): agent workspace `IDENTITY.md` with `Avatar: VC`

### Steps

1. Configure an agent identity with a short text avatar such as `Avatar: VC`.
2. Open Control UI chat for that agent.
3. Inspect the welcome state or an assistant message group.

### Expected

- The configured avatar text renders as the assistant avatar.

### Actual

- Before this fix, the chat UI fell back to the OpenClaw logo.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check:changed` on the rebased branch; focused renderer test via `pnpm test ui/src/ui/chat/grouped-render.test.ts`.
- Edge cases checked: default fallback avatar `A` still resolves to the logo; remote avatar URLs still fall back rather than rendering.
- What you did **not** verify: manual browser screenshot against a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist yet at PR creation time.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Short path-like avatar strings could accidentally render as text.
  - Mitigation: text avatars reject whitespace, slash, backslash, dot, and colon characters; image/path values keep the existing image/logo behavior.
