### PR TITLE
fix(slack): wire message_sending plugin hook into reply delivery path

### DIFF
--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -5,6 +5,14 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
+const messageHookRunner = {
+  hasHooks: vi.fn(),
+  runMessageSending: vi.fn(),
+};
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: () => messageHookRunner,
+}));
+
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveSlackThreadTs: typeof import("./replies.js").resolveSlackThreadTs;
@@ -33,6 +41,10 @@ describe("deliverReplies identity passthrough", () => {
 
   beforeEach(() => {
     sendMock.mockReset();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.runMessageSending.mockReset();
+    // Default: no hooks registered
+    messageHookRunner.hasHooks.mockReturnValue(false);
   });
   it("passes identity to sendMessageSlack for text replies", async () => {
     sendMock.mockResolvedValue(undefined);
@@ -256,5 +268,73 @@ describe("deliverSlackSlashReplies chunking", () => {
       text,
       response_type: "ephemeral",
     });
+  });
+});
+
+describe("deliverReplies message_sending hook", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue(undefined);
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.runMessageSending.mockReset();
+  });
+
+  it("fires message_sending hook before sending a text reply", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(true);
+    messageHookRunner.runMessageSending.mockResolvedValue(undefined);
+
+    await deliverReplies(baseParams({ accountId: "default" }));
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledTimes(1);
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "C123",
+        content: "hello",
+      }),
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "default",
+        conversationId: "C123",
+      }),
+    );
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels delivery when hook returns cancel: true", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(true);
+    messageHookRunner.runMessageSending.mockResolvedValue({ cancel: true });
+
+    await deliverReplies(baseParams());
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledTimes(1);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("applies modified content from hook", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(true);
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: "modified" });
+
+    await deliverReplies(baseParams());
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][1]).toBe("modified");
+  });
+
+  it("skips hook when no message_sending hooks are registered", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(false);
+
+    await deliverReplies(baseParams());
+
+    expect(messageHookRunner.runMessageSending).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers normally when hook throws", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(true);
+    messageHookRunner.runMessageSending.mockRejectedValue(new Error("plugin crash"));
+
+    await deliverReplies(baseParams());
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,4 +1,5 @@
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   deliverTextOrMediaReply,
   resolveSendableOutboundReplyParts,
@@ -6,6 +7,7 @@ import {
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackReplyBlocks } from "../reply-blocks.js";
@@ -33,15 +35,53 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
 }) {
+  const hookRunner = getGlobalHookRunner();
+  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
+
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
     // must not force threading.
     const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;
     const threadTs = inlineReplyToId ?? params.replyThreadTs;
-    const reply = resolveSendableOutboundReplyParts(payload);
+    let reply = resolveSendableOutboundReplyParts(payload);
     const slackBlocks = readSlackReplyBlocks(payload);
     if (!reply.hasContent && !slackBlocks?.length) {
       continue;
+    }
+
+    // Run message_sending plugin hooks before delivery (content filtering, cancel).
+    let activePayload = payload;
+    if (hasMessageSendingHooks) {
+      try {
+        const hookResult = await hookRunner?.runMessageSending(
+          {
+            to: params.target,
+            content: reply.text ?? "",
+            replyToId: inlineReplyToId ?? undefined,
+            threadId: threadTs,
+            metadata: {
+              channel: "slack",
+              accountId: params.accountId,
+              mediaUrls: reply.hasMedia ? payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []) : [],
+            },
+          },
+          {
+            channelId: "slack",
+            accountId: params.accountId ?? undefined,
+            conversationId: params.target,
+          },
+        );
+        if (hookResult?.cancel) {
+          logVerbose("slack reply: message_sending hook cancelled delivery");
+          continue;
+        }
+        if (typeof hookResult?.content === "string" && hookResult.content !== (reply.text ?? "")) {
+          activePayload = { ...payload, text: hookResult.content };
+          reply = resolveSendableOutboundReplyParts(activePayload);
+        }
+      } catch {
+        // Don't block delivery on hook failure.
+      }
     }
 
     if (!reply.hasMedia && slackBlocks?.length) {
@@ -65,7 +105,7 @@ export async function deliverReplies(params: {
     }
 
     const delivered = await deliverTextOrMediaReply({
-      payload,
+      payload: activePayload,
       text: reply.text,
       chunkText: !reply.hasMedia
         ? (value) => {


### PR DESCRIPTION
## Summary

The Slack reply delivery path (`deliverReplies` → `sendMessageSlack`) bypasses `deliverOutboundPayloads` entirely, so `message_sending` plugin hooks **never fire for same-channel agent replies** — only for proactive sends (notifications, cron, message tool).

This wires `runMessageSending()` into `deliverReplies()` before each `sendMessageSlack` call, following the same pattern already used by Telegram's `delivery.replies.ts`.

## Changes

### `extensions/slack/src/monitor/replies.ts`
- Import `getGlobalHookRunner` from `openclaw/plugin-sdk/plugin-runtime`
- Resolve the hook runner once per `deliverReplies` call (zero overhead when no hooks registered)
- Run `runMessageSending()` per reply before delivery
- Support `cancel` (skip delivery) and content modification (`{ content: "..." }`)
- Fail-open on hook errors (don't block delivery on plugin bugs)

### `extensions/slack/src/monitor/replies.test.ts`
- Add mock for the global hook runner
- 5 new tests: hook fires, cancel respected, content modification applied, no-op when no hooks, fail-open on error

## Motivation — Production Impact

We hit this bug building a content-filtering plugin for our Slack-based OpenClaw deployment. Our journey:

1. **Regex output guard** on `message_sending` → hooks never fired for replies
2. **Opus classifier** on `message_sending` → same result, $0.02/msg wasted
3. **Discovered root cause**: `deliverReplies` calls `sendMessageSlack` directly, bypassing `deliverOutboundPayloads` and all hooks
4. **Workaround**: `before_prompt_build` hook to inject anti-narration rules into the system prompt (soft guard, ~99% effective)
5. **This PR**: fixes the root cause so `message_sending` works as documented

The `before_prompt_build` workaround is a soft guard — the model can still ignore prompt instructions under complex tool chains. `message_sending` is the only reliable hard gate for output filtering, and it was silently broken for the primary conversational path.

## Approach: Focused Fix

This is a **Slack-only fix** — small, reviewable, and testable. The same bug exists across other channels (Discord, WhatsApp, Line, etc.), but a single focused PR is more likely to land than a sprawling multi-channel change.

## Related Issues & PRs

- Fixes #69606 — Fire `message_sending` hook in reply dispatch path
- Related: #59350 — Discord reply delivery bypasses hooks
- Related: #69807 — Telegram agent-reply path bypasses hooks  
- Related: #61550 — `message_sending` hooks bypassed when streaming is enabled
- Related: #56349 — Unbypassable outbound policy enforcement
- See also: PR #48408 — comprehensive multi-channel fix (stalled)

## Test Results

All 15 tests pass (10 existing + 5 new):

```
✓ deliverReplies identity passthrough (6 tests)
✓ resolveSlackThreadTs fallback classification (2 tests)
✓ createSlackReplyDeliveryPlan (1 test)
✓ deliverSlackSlashReplies chunking (1 test)
✓ deliverReplies message_sending hook (5 tests)
```