### PR TITLE
OpenAI image generation follow-up

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -10,6 +10,7 @@ const {
   postMultipartRequestMock,
   assertOkOrThrowHttpErrorMock,
   resolveProviderHttpRequestConfigMock,
+  logInfoMock,
 } = vi.hoisted(() => ({
   ensureAuthProfileStoreMock: vi.fn(() => ({ version: 1, profiles: {} })),
   isProviderApiKeyConfiguredMock: vi.fn<
@@ -37,6 +38,16 @@ const {
     headers: new Headers(params.defaultHeaders),
     dispatcherPolicy: undefined,
   })),
+  logInfoMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  createSubsystemLogger: () => ({
+    info: logInfoMock,
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({ info: logInfoMock, warn: vi.fn(), debug: vi.fn() }),
+  }),
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
@@ -98,6 +109,38 @@ function mockCodexImageStream(params: { imageData?: string; revisedPrompt?: stri
   }));
 }
 
+function mockCodexCompletedImageStream(
+  params: { imageData?: string; revisedPrompt?: string } = {},
+) {
+  const image = Buffer.from(params.imageData ?? "codex-completed-png-bytes").toString("base64");
+  const events = [
+    {
+      type: "response.completed",
+      response: {
+        output: [
+          {
+            type: "image_generation_call",
+            result: image,
+            ...(params.revisedPrompt ? { revised_prompt: params.revisedPrompt } : {}),
+          },
+        ],
+      },
+    },
+  ];
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  postJsonRequestMock.mockImplementation(async () => ({
+    response: new Response(body),
+    release: vi.fn(async () => {}),
+  }));
+}
+
+function mockCodexRawStream(body: string) {
+  postJsonRequestMock.mockImplementation(async () => ({
+    response: new Response(body),
+    release: vi.fn(async () => {}),
+  }));
+}
+
 function mockCodexAuthOnly() {
   resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
     if (params?.provider === "openai-codex") {
@@ -135,6 +178,7 @@ describe("openai image generation provider", () => {
     postMultipartRequestMock.mockReset();
     assertOkOrThrowHttpErrorMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
+    logInfoMock.mockClear();
     vi.unstubAllEnvs();
   });
 
@@ -176,6 +220,132 @@ describe("openai image generation provider", () => {
 
     isProviderApiKeyConfiguredMock.mockReturnValue(false);
     expect(provider.isConfigured?.({ agentDir: "/tmp/agent" })).toBe(false);
+  });
+
+  it("does not report Codex OAuth image auth as configured for custom OpenAI endpoints", () => {
+    const provider = buildOpenAIImageGenerationProvider();
+
+    isProviderApiKeyConfiguredMock.mockImplementation(
+      (params: { provider: string }) => params.provider === "openai-codex",
+    );
+
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "http://127.0.0.1:44080/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not report Codex OAuth image auth as configured for non-exact public OpenAI URLs", () => {
+    const provider = buildOpenAIImageGenerationProvider();
+    isProviderApiKeyConfiguredMock.mockImplementation(
+      (params: { provider: string }) => params.provider === "openai-codex",
+    );
+
+    for (const baseUrl of ["https://api.openai.com:444/v1", "https://api.openai.com/v1?x=1"]) {
+      expect(
+        provider.isConfigured?.({
+          agentDir: "/tmp/agent",
+          cfg: {
+            models: {
+              providers: {
+                openai: {
+                  baseUrl,
+                  models: [],
+                },
+              },
+            },
+          },
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does not fall back to Codex OAuth for custom OpenAI-compatible image endpoints", async () => {
+    mockCodexAuthOnly();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a QA lighthouse",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "http://127.0.0.1:44080/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("OpenAI API key missing");
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to Codex OAuth for non-exact public OpenAI URLs", async () => {
+    mockCodexAuthOnly();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a QA lighthouse",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com:444/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("OpenAI API key missing");
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to Codex OAuth when OpenAI auth resolution fails", async () => {
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai") {
+        throw new Error("OpenAI auth profile is corrupt");
+      }
+      if (params?.provider === "openai-codex") {
+        return { apiKey: "codex-key", source: "profile:openai-codex:default", mode: "oauth" };
+      }
+      return {};
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a QA lighthouse",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenAI auth profile is corrupt");
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
   });
 
   it("does not auto-allow local baseUrl overrides for image requests", async () => {
@@ -406,6 +576,7 @@ describe("openai image generation provider", () => {
     expect(postJsonRequestMock).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://chatgpt.com/backend-api/codex/responses",
+        timeoutMs: 180_000,
         body: expect.objectContaining({
           model: "gpt-5.4",
           instructions: "You are an image generation assistant.",
@@ -421,6 +592,9 @@ describe("openai image generation provider", () => {
           tool_choice: { type: "image_generation" },
         }),
       }),
+    );
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "image auth selected: provider=openai-codex mode=oauth transport=codex-responses requestedModel=gpt-image-2 responsesModel=gpt-5.4 timeoutMs=180000",
     );
     expect(postMultipartRequestMock).not.toHaveBeenCalled();
     expect(result.images).toEqual([
@@ -480,6 +654,9 @@ describe("openai image generation provider", () => {
         url: "https://chatgpt.com/backend-api/codex/responses",
       }),
     );
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "image auth selected: provider=openai-codex mode=oauth transport=codex-responses requestedModel=gpt-image-2 responsesModel=gpt-5.4 timeoutMs=180000",
+    );
     expect(result.images[0]?.buffer).toEqual(Buffer.from("codex-image"));
   });
 
@@ -534,6 +711,28 @@ describe("openai image generation provider", () => {
     );
   });
 
+  it("sanitizes Codex OAuth image auth log values", async () => {
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai-codex") {
+        return { apiKey: "codex-key", source: "profile:openai-codex:default", mode: "oauth\nfake" };
+      }
+      return {};
+    });
+    mockCodexImageStream();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2\r\nforged=true",
+      prompt: "Draw a Codex lighthouse",
+      cfg: {},
+    });
+
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "image auth selected: provider=openai-codex mode=oauth fake transport=codex-responses requestedModel=gpt-image-2 forged=true responsesModel=gpt-5.4 timeoutMs=180000",
+    );
+  });
+
   it("sends Codex reference images as Responses input images", async () => {
     mockCodexAuthOnly();
     mockCodexImageStream();
@@ -566,6 +765,31 @@ describe("openai image generation provider", () => {
     expect(postMultipartRequestMock).not.toHaveBeenCalled();
   });
 
+  it("parses Codex Responses completed SSE image output", async () => {
+    mockCodexAuthOnly();
+    mockCodexCompletedImageStream({
+      imageData: "codex-completed-image",
+      revisedPrompt: "completed response prompt",
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a completed Codex image",
+      cfg: {},
+    });
+
+    expect(result.images).toEqual([
+      {
+        buffer: Buffer.from("codex-completed-image"),
+        mimeType: "image/png",
+        fileName: "image-1.png",
+        revisedPrompt: "completed response prompt",
+      },
+    ]);
+  });
+
   it("satisfies Codex count by issuing one Responses request per image", async () => {
     mockCodexAuthOnly();
     mockCodexImageStream({ imageData: "codex-image" });
@@ -589,6 +813,46 @@ describe("openai image generation provider", () => {
       size: "1024x1024",
     });
     expect(result.images.map((image) => image.fileName)).toEqual(["image-1.png", "image-2.png"]);
+  });
+
+  it("caps Codex count to the provider image limit", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageStream({ imageData: "codex-image" });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw several Codex icons",
+      cfg: {},
+      count: 20,
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledTimes(4);
+    expect(result.images.map((image) => image.fileName)).toEqual([
+      "image-1.png",
+      "image-2.png",
+      "image-3.png",
+      "image-4.png",
+    ]);
+  });
+
+  it("rejects Codex SSE responses with too many events", async () => {
+    mockCodexAuthOnly();
+    const event = { type: "response.in_progress" };
+    mockCodexRawStream(
+      Array.from({ length: 513 }, () => `data: ${JSON.stringify(event)}\n\n`).join(""),
+    );
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a Codex icon",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation response has too many events");
   });
 
   it("forwards SSRF guard fields to multipart edit requests", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -5,6 +5,7 @@ import type {
   ImageGenerationResult,
   ImageGenerationSourceImage,
 } from "openclaw/plugin-sdk/image-generation";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
 import {
   ensureAuthProfileStore,
   isProviderApiKeyConfigured,
@@ -21,11 +22,18 @@ import {
 import { OPENAI_DEFAULT_IMAGE_MODEL as DEFAULT_OPENAI_IMAGE_MODEL } from "./default-models.js";
 import { resolveConfiguredOpenAIBaseUrl } from "./shared.js";
 
+const log = createSubsystemLogger("image-generation/openai");
+
 const DEFAULT_OPENAI_IMAGE_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_OPENAI_CODEX_IMAGE_BASE_URL = "https://chatgpt.com/backend-api/codex";
 const OPENAI_CODEX_IMAGE_INSTRUCTIONS = "You are an image generation assistant.";
 const DEFAULT_OUTPUT_MIME = "image/png";
 const DEFAULT_SIZE = "1024x1024";
+const DEFAULT_OPENAI_IMAGE_TIMEOUT_MS = 180_000;
+const MAX_CODEX_IMAGE_SSE_BYTES = 64 * 1024 * 1024;
+const MAX_CODEX_IMAGE_SSE_EVENTS = 512;
+const MAX_CODEX_IMAGE_BASE64_CHARS = 64 * 1024 * 1024;
+const MAX_CODEX_IMAGE_RESULTS = 4;
 const OPENAI_SUPPORTED_SIZES = [
   "1024x1024",
   "1536x1024",
@@ -157,6 +165,59 @@ function hasCodexOAuthProfileConfigured(req: {
   return Boolean(store && listProfilesForProvider(store, "openai-codex").length > 0);
 }
 
+function isPublicOpenAIImageBaseUrl(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl);
+    return (
+      url.protocol === "https:" &&
+      url.hostname.toLowerCase() === "api.openai.com" &&
+      url.port === "" &&
+      url.username === "" &&
+      url.password === "" &&
+      url.search === "" &&
+      url.hash === "" &&
+      url.pathname.replace(/\/+$/, "") === "/v1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function resolveOpenAIImageTimeoutMs(timeoutMs: number | undefined): number {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_OPENAI_IMAGE_TIMEOUT_MS;
+}
+
+function isMissingProviderApiKeyError(error: unknown, provider: string): boolean {
+  return (
+    error instanceof Error &&
+    error.message.startsWith(`No API key found for provider "${provider}".`)
+  );
+}
+
+function sanitizeLogValue(value: unknown): string {
+  const raw =
+    typeof value === "string"
+      ? value
+      : typeof value === "number" || typeof value === "boolean" || typeof value === "bigint"
+        ? value.toString()
+        : "unknown";
+  let sanitized = "";
+  for (const char of raw) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (codePoint < 0x20 || codePoint === 0x7f) {
+      if (!sanitized.endsWith(" ")) {
+        sanitized += " ";
+      }
+      continue;
+    }
+    sanitized += char;
+  }
+  sanitized = sanitized.trim();
+  return sanitized || "unknown";
+}
+
 type OpenAIImageApiResponse = {
   data?: Array<{
     b64_json?: string;
@@ -174,6 +235,11 @@ type OpenAICodexImageGenerationEvent = {
   response?: {
     usage?: unknown;
     tool_usage?: unknown;
+    output?: Array<{
+      type?: string;
+      result?: string;
+      revised_prompt?: string;
+    }>;
   };
   error?: {
     code?: string;
@@ -203,15 +269,24 @@ function toOpenAIDataUrl(image: ImageGenerationSourceImage): string {
 
 async function readResponseBodyText(response: Response): Promise<string> {
   if (!response.body) {
-    return await response.text();
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_CODEX_IMAGE_SSE_BYTES) {
+      throw new Error("OpenAI Codex image generation response too large");
+    }
+    return text;
   }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let text = "";
+  let byteLength = 0;
   try {
     while (true) {
       const { value, done } = await reader.read();
       if (value) {
+        byteLength += value.byteLength;
+        if (byteLength > MAX_CODEX_IMAGE_SSE_BYTES) {
+          throw new Error("OpenAI Codex image generation response too large");
+        }
         text += decoder.decode(value, { stream: !done });
       }
       if (done) {
@@ -240,8 +315,35 @@ function parseCodexImageGenerationEvents(body: string): OpenAICodexImageGenerati
       // Ignore non-JSON SSE payloads from intermediaries; failed HTTP statuses
       // are handled before this parser runs.
     }
+    if (events.length > MAX_CODEX_IMAGE_SSE_EVENTS) {
+      throw new Error("OpenAI Codex image generation response has too many events");
+    }
   }
   return events;
+}
+
+function decodeCodexImagePayload(result: string): Buffer {
+  if (result.length > MAX_CODEX_IMAGE_BASE64_CHARS) {
+    throw new Error("OpenAI Codex image generation payload too large");
+  }
+  return Buffer.from(result, "base64");
+}
+
+function toCodexImage(entry: {
+  result?: string;
+  revised_prompt?: string;
+}): { buffer: Buffer; mimeType: string; fileName: string; revisedPrompt?: string } | null {
+  if (typeof entry.result !== "string" || entry.result.length === 0) {
+    return null;
+  }
+  return Object.assign(
+    {
+      buffer: decodeCodexImagePayload(entry.result),
+      mimeType: DEFAULT_OUTPUT_MIME,
+      fileName: "image-1.png",
+    },
+    entry.revised_prompt ? { revisedPrompt: entry.revised_prompt } : {},
+  );
 }
 
 function extractCodexImageGenerationResult(params: {
@@ -260,7 +362,7 @@ function extractCodexImageGenerationResult(params: {
     throw new Error(message || "OpenAI Codex image generation failed");
   }
   const completedResponse = events.find((event) => event.type === "response.completed");
-  const images = events
+  const outputItemImages = events
     .filter(
       (event) =>
         event.type === "response.output_item.done" &&
@@ -268,16 +370,22 @@ function extractCodexImageGenerationResult(params: {
         typeof event.item.result === "string" &&
         event.item.result.length > 0,
     )
-    .map((event, index) =>
-      Object.assign(
-        {
-          buffer: Buffer.from(event.item?.result ?? "", "base64"),
-          mimeType: DEFAULT_OUTPUT_MIME,
-          fileName: `image-${index + 1}.png`,
-        },
-        event.item?.revised_prompt ? { revisedPrompt: event.item.revised_prompt } : {},
-      ),
-    );
+    .slice(0, MAX_CODEX_IMAGE_RESULTS)
+    .map((event) => toCodexImage(event.item ?? {}))
+    .filter((image): image is NonNullable<typeof image> => image !== null)
+    .map((image, index) => Object.assign({}, image, { fileName: `image-${index + 1}.png` }));
+  const completedResponseImages = (completedResponse?.response?.output ?? [])
+    .filter(
+      (item) =>
+        item.type === "image_generation_call" &&
+        typeof item.result === "string" &&
+        item.result.length > 0,
+    )
+    .slice(0, MAX_CODEX_IMAGE_RESULTS)
+    .map((item) => toCodexImage(item))
+    .filter((image): image is NonNullable<typeof image> => image !== null)
+    .map((image, index) => Object.assign({}, image, { fileName: `image-${index + 1}.png` }));
+  const images = outputItemImages.length > 0 ? outputItemImages : completedResponseImages;
 
   return {
     images,
@@ -333,7 +441,10 @@ async function resolveOptionalApiKeyForProvider(
 ) {
   try {
     return await resolveApiKeyForProvider(params);
-  } catch {
+  } catch (error) {
+    if (!isMissingProviderApiKeyError(error, params.provider)) {
+      throw error;
+    }
     return null;
   }
 }
@@ -358,7 +469,11 @@ async function generateOpenAICodexImage(params: {
     });
 
   const model = req.model || DEFAULT_OPENAI_IMAGE_MODEL;
-  const count = req.count ?? 1;
+  const requestedCount = req.count ?? 1;
+  const count =
+    typeof requestedCount === "number" && Number.isFinite(requestedCount)
+      ? Math.max(1, Math.min(MAX_CODEX_IMAGE_RESULTS, Math.trunc(requestedCount)))
+      : 1;
   const size = req.size ?? DEFAULT_SIZE;
   headers.set("Content-Type", "application/json");
   const content: Array<Record<string, unknown>> = [
@@ -370,6 +485,8 @@ async function generateOpenAICodexImage(params: {
     })),
   ];
   const results: ImageGenerationResult[] = [];
+  // The Codex Responses image tool returns one generated image per request.
+  // Preserve OpenAI Images API count semantics by issuing one bounded request per image.
   for (let index = 0; index < count; index += 1) {
     const requestResult = await postJsonRequest({
       url: `${baseUrl}/responses`,
@@ -394,7 +511,7 @@ async function generateOpenAICodexImage(params: {
         stream: true,
         store: false,
       },
-      timeoutMs: req.timeoutMs,
+      timeoutMs: resolveOpenAIImageTimeoutMs(req.timeoutMs),
       fetchFn: fetch,
       allowPrivateNetwork,
       dispatcherPolicy,
@@ -430,20 +547,24 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
   return createOpenAIImageGenerationProviderBase({
     id: "openai",
     label: "OpenAI",
-    isConfigured: ({ agentDir }) =>
+    isConfigured: ({ cfg, agentDir }) =>
       isProviderApiKeyConfigured({
         provider: "openai",
         agentDir,
       }) ||
-      isProviderApiKeyConfigured({
-        provider: "openai-codex",
-        agentDir,
-      }),
+      (isPublicOpenAIImageBaseUrl(resolveConfiguredOpenAIBaseUrl(cfg)) &&
+        isProviderApiKeyConfigured({
+          provider: "openai-codex",
+          agentDir,
+        })),
     async generateImage(req) {
       const inputImages = req.inputImages ?? [];
       const isEdit = inputImages.length > 0;
+      const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
       const useCodexOAuthRoute =
-        !hasExplicitOpenAIDirectProviderConfig(req.cfg) && hasCodexOAuthProfileConfigured(req);
+        isPublicOpenAIImageBaseUrl(rawBaseUrl) &&
+        !hasExplicitOpenAIDirectProviderConfig(req.cfg) &&
+        hasCodexOAuthProfileConfigured(req);
       if (useCodexOAuthRoute) {
         const codexAuth = await resolveApiKeyForProvider({
           provider: "openai-codex",
@@ -454,6 +575,11 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
         if (!codexAuth.apiKey) {
           throw new Error("OpenAI Codex OAuth missing");
         }
+        const authMode = sanitizeLogValue(codexAuth.mode);
+        const requestedModel = sanitizeLogValue(req.model || DEFAULT_OPENAI_IMAGE_MODEL);
+        log.info(
+          `image auth selected: provider=openai-codex mode=${authMode} transport=codex-responses requestedModel=${requestedModel} responsesModel=gpt-5.4 timeoutMs=${resolveOpenAIImageTimeoutMs(req.timeoutMs)}`,
+        );
         return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
       }
 
@@ -464,6 +590,9 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
         store: req.authStore,
       });
       if (!auth?.apiKey) {
+        if (!isPublicOpenAIImageBaseUrl(rawBaseUrl)) {
+          throw new Error("OpenAI API key missing");
+        }
         const codexAuth = await resolveOptionalApiKeyForProvider({
           provider: "openai-codex",
           cfg: req.cfg,
@@ -471,11 +600,15 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
           store: req.authStore,
         });
         if (codexAuth?.apiKey) {
+          const authMode = sanitizeLogValue(codexAuth.mode);
+          const requestedModel = sanitizeLogValue(req.model || DEFAULT_OPENAI_IMAGE_MODEL);
+          log.info(
+            `image auth selected: provider=openai-codex mode=${authMode} transport=codex-responses requestedModel=${requestedModel} responsesModel=gpt-5.4 timeoutMs=${resolveOpenAIImageTimeoutMs(req.timeoutMs)}`,
+          );
           return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
         }
         throw new Error("OpenAI API key or Codex OAuth missing");
       }
-      const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
       const isAzure = isAzureOpenAIBaseUrl(rawBaseUrl);
 
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
@@ -523,7 +656,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
               url,
               headers: multipartHeaders,
               body: form,
-              timeoutMs: req.timeoutMs,
+              timeoutMs: resolveOpenAIImageTimeoutMs(req.timeoutMs),
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,
@@ -541,7 +674,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
                 n: count,
                 size,
               },
-              timeoutMs: req.timeoutMs,
+              timeoutMs: resolveOpenAIImageTimeoutMs(req.timeoutMs),
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,


### PR DESCRIPTION
## Explanation

`main` now has the baseline OpenAI Codex OAuth image-generation fallback. This PR keeps that upstream implementation and adds the hardening needed for the Telegram/OAuth path to be easier to trust in practice.

The OpenAI image provider still prefers normal `openai` API-key auth. If an API key is available, generation and edits use the public OpenAI Images API path through the existing provider HTTP configuration. That includes the existing SSRF guard, dispatcher policy, Azure URL handling, and multipart upload behavior for image edits.

When an OpenAI API key is not available, Codex OAuth is only considered if the configured OpenAI base URL is exactly the public OpenAI endpoint:

```ts
https://api.openai.com/v1
```

That distinction matters because `openai-codex` credentials are valid for the Codex Responses backend, not for arbitrary OpenAI-compatible, local, proxy, or Azure endpoints. With this PR, a custom `models.providers.openai.baseUrl` plus only Codex OAuth no longer reports OpenAI image generation as configured and no longer attempts the Codex fallback at execution time.

For the OAuth path, the provider sends a Responses request to the Codex backend:

```ts
POST https://chatgpt.com/backend-api/codex/responses
```

It uses the hosted `image_generation` tool with streaming enabled. The generated image arrives as a base64 `image_generation_call.result`, which the provider converts into a PNG image asset.

This PR also makes the stream parser handle completed Responses SSE shapes where the image appears under `response.completed.response.output`, for example:

```json
{
  "type": "response.completed",
  "response": {
    "output": [
      { "type": "image_generation_call", "result": "..." }
    ]
  }
}
```

That prevents a successful streamed response from being treated as an empty provider result.

OpenAI image requests now default to a 180 second timeout when the caller does not provide one. This avoids aborting slower OAuth-backed image generations at the shared guarded HTTP default, while still preserving explicit caller-provided timeout overrides.

The OAuth path logs a token-safe confirmation line when selected:

```text
image auth selected: provider=openai-codex mode=oauth transport=codex-responses requestedModel=gpt-image-2 responsesModel=gpt-5.4 timeoutMs=180000
```

That confirms the selected auth provider and transport without exposing credentials.

## Validation

```bash
pnpm test extensions/openai/image-generation-provider.test.ts
pnpm check:changed
```
