### PR TITLE
build(macos): bump Peekaboo pin to restore source builds on macOS 26.4 SDK

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -43,7 +43,7 @@
       "location" : "https://github.com/steipete/Peekaboo.git",
       "state" : {
         "branch" : "main",
-        "revision" : "bace59f90bb276f1c6fb613acfda3935ec4a7a90"
+        "revision" : "8659b70d386d02f831e277386b3216023ccc707e"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Problem: fresh macOS source builds (`scripts/package-mac-app.sh` / `swift build`) fail on the macOS 26.4 SDK with `'CGWindowListCreateImage' is unavailable in macOS: Please use ScreenCaptureKit instead` inside the Peekaboo SPM checkout.
- Why it matters: contributors on Xcode 26.4+ can't produce a local debug build of the Mac app until the Peekaboo pin moves past this.
- What changed: `apps/macos/Package.resolved` pin for `steipete/Peekaboo` bumped from `bace59f90` to `8659b70d` (current upstream `main` HEAD). That range includes [steipete/Peekaboo@b414c71b](https://github.com/steipete/Peekaboo/commit/b414c71b) which replaces the obsoleted `CGWindowListCreateImage` path with `SCScreenshotManager` / `SCContentFilter`.
- What did NOT change: `apps/macos/Package.swift` (already tracks `branch: "main"` for Peekaboo, matches how other package pins are managed in this repo).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `CGWindowListCreateImage` was marked obsolete in macOS 15.0. Older SDKs emitted a warning; the macOS 26.4 SDK turns it into a hard error. The pinned Peekaboo revision (`bace59f90`, early March) still called it; upstream migrated to ScreenCaptureKit on 2026-03-28 but the `Package.resolved` in this repo was never refreshed.
- Missing detection / guardrail: source-build CI is likely still on an earlier Xcode, so the 26.4 SDK break didn't surface in automation.
- Prior context: steipete/Peekaboo commits b414c71b (ScreenCaptureKit migration) and 1128b568 (refactor of screen-recording permission check) land in this bump range.
- Why this regressed now: dev machines upgrading to Xcode 26.4.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

N/A — this is a lockfile refresh; the guardrail that would catch it is a source-build step on the macOS 26.4 SDK in CI. Not adding one here to keep the PR scoped.

## User-visible / Behavior Changes

None in openclaw's own code. The Peekaboo commits in this range include the following upstream behavior deltas, which any CI build after 2026-03-28 would already pick up:

- Window capture now routes through ScreenCaptureKit (`SCScreenshotManager` / `SCContentFilter`) with display-local cropping; captured pixels/bounds for some windows may shift slightly vs the obsolete `CGWindowList` path.
- Screen-recording permission detection now probes `SCShareableContent.current` as a fallback when `CGPreflightScreenCaptureAccess` reports negative, which can change how permission status is reported.
- Bridge `detectElements` gained an optional `requestTimeoutSec` parameter (default `nil` preserves prior behavior).

## Security Impact (required)

- New permissions/capabilities? No (screen recording entitlement already used)
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.4.x
- Runtime/container: Xcode 26.4 toolchain / Swift 6
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Fresh checkout on a machine with Xcode 26.4 SDK.
2. `cd apps/macos && swift build -c debug --product OpenClaw` (or `scripts/package-mac-app.sh`).

### Expected

- Build completes.

### Actual (before this PR)

- Build fails with `'CGWindowListCreateImage' is unavailable in macOS: Please use ScreenCaptureKit instead` in `Peekaboo/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureService.swift:1605` (and surrounding call sites).

### Actual (after this PR)

- `swift build -c debug --product OpenClaw` completes cleanly (`Build of product 'OpenClaw' complete!`).

## Evidence

- [x] Failing test/log before + passing after

Before:

```
error: 'CGWindowListCreateImage' is unavailable in macOS: Please use ScreenCaptureKit instead.
note: 'CGWindowListCreateImage' was obsoleted in macOS 15.0
```

After:

```
[367/369] Linking OpenClaw
[368/369] Applying OpenClaw
Build of product 'OpenClaw' complete! (14.08s)
```

## Human Verification (required)

- Verified scenarios: `swift package update Peekaboo` produced a one-line `Package.resolved` diff; `swift build -c debug --product OpenClaw` succeeded on macOS 26.4 SDK.
- Edge cases checked: inspected upstream Peekaboo diff across `bace59f90..8659b70d` — no product renames or consumer-facing API removals for the `PeekabooBridge` / `PeekabooAutomationKit` products imported by `apps/macos`.
- What I did **not** verify: full `scripts/package-mac-app.sh` signing/notarization path (unchanged by this diff), runtime behavior of the new SCK-based capture path on every display/window combination.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `Package.resolved` diff.
- Files/config to restore: `apps/macos/Package.resolved` only.
- Known bad symptoms reviewers should watch for: mis-cropped/off-size window screenshots, regressions in screen-recording permission prompts on macOS 26.4+.

## Risks and Mitigations

- Risk: upstream SCK window-capture path has slightly different bounds/shadow handling than the legacy `CGWindowList` path.
  - Mitigation: upstream already shipped and iterated on this since late March; the fallback paths already live in `ScreenCaptureService`.
- Risk: `SCShareableContent` fallback in permission detection may re-prompt or report differently than the prior `CGPreflightScreenCaptureAccess`-only check.
  - Mitigation: behavior change is additive (fallback only when the CG probe says no) and improves reliability for CLI contexts per the upstream commit message.
- Risk: pinning to current upstream HEAD pulls in other incidental changes (bridge timeout plumbing, permissions module refactor, MCP runtime updates).
  - Mitigation: this matches how the Peekaboo pin is already managed (`branch: "main"`); narrower pins have not been used historically for this dep.
