### PR TITLE
fix(plugins): share bundled runtime SDK alias prep

### DIFF
--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareBundledPluginRuntimeRoot } from "./bundled-runtime-root.js";
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-runtime-root-"));
+}
+
+function writeMirroredRuntimeFixture(params: {
+  packageRoot: string;
+  pluginRoot: string;
+  pluginSdkDir: string;
+}) {
+  fs.mkdirSync(params.pluginRoot, { recursive: true });
+  fs.mkdirSync(params.pluginSdkDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(params.packageRoot, "package.json"),
+    JSON.stringify({ name: "openclaw", type: "module" }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(params.pluginRoot, "monitor-polling.runtime.js"),
+    [
+      'import { sentinelValue } from "openclaw/plugin-sdk/text-runtime";',
+      "export const mirroredSentinel = sentinelValue;",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(params.pluginRoot, "package.json"), JSON.stringify({}), "utf8");
+  fs.writeFileSync(
+    path.join(params.pluginSdkDir, "text-runtime.js"),
+    'export const sentinelValue = "runtime-alias-ok";\n',
+    "utf8",
+  );
+  fs.writeFileSync(path.join(params.pluginSdkDir, "index.js"), "export {};\n", "utf8");
+}
+
+describe("bundled runtime root mirroring", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves openclaw/plugin-sdk imports for mirrored staged dist roots", async () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    tempDirs.push(packageRoot, stageDir);
+
+    const pluginRoot = path.join(packageRoot, "dist", "extensions", "telegram");
+    const pluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
+    writeMirroredRuntimeFixture({ packageRoot, pluginRoot, pluginSdkDir });
+
+    const prepared = prepareBundledPluginRuntimeRoot({
+      pluginId: "telegram",
+      pluginRoot,
+      modulePath: path.join(pluginRoot, "monitor-polling.runtime.js"),
+      env: {
+        ...process.env,
+        OPENCLAW_PLUGIN_STAGE_DIR: stageDir,
+      },
+    });
+
+    expect(prepared.pluginRoot).not.toBe(pluginRoot);
+    const stagedPackageRoot = path.join(stageDir, fs.readdirSync(stageDir)[0] ?? "");
+    expect(
+      fs.existsSync(
+        path.join(
+          stagedPackageRoot,
+          "dist",
+          "extensions",
+          "node_modules",
+          "openclaw",
+          "plugin-sdk",
+          "text-runtime.js",
+        ),
+      ),
+    ).toBe(true);
+
+    await expect(import(pathToFileURL(prepared.modulePath).href)).resolves.toBeTruthy();
+  });
+
+  it("preserves openclaw/plugin-sdk imports for mirrored staged dist-runtime roots", async () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    tempDirs.push(packageRoot, stageDir);
+
+    const pluginRoot = path.join(packageRoot, "dist-runtime", "extensions", "telegram");
+    const pluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
+    writeMirroredRuntimeFixture({ packageRoot, pluginRoot, pluginSdkDir });
+
+    const prepared = prepareBundledPluginRuntimeRoot({
+      pluginId: "telegram",
+      pluginRoot,
+      modulePath: path.join(pluginRoot, "monitor-polling.runtime.js"),
+      env: {
+        ...process.env,
+        OPENCLAW_PLUGIN_STAGE_DIR: stageDir,
+      },
+    });
+
+    const stagedPackageRoot = path.join(stageDir, fs.readdirSync(stageDir)[0] ?? "");
+    expect(
+      fs.existsSync(
+        path.join(
+          stagedPackageRoot,
+          "dist-runtime",
+          "extensions",
+          "node_modules",
+          "openclaw",
+          "plugin-sdk",
+          "text-runtime.js",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(stagedPackageRoot, "dist", "plugin-sdk", "text-runtime.js")),
+    ).toBe(true);
+
+    await expect(import(pathToFileURL(prepared.modulePath).href)).resolves.toBeTruthy();
+  });
+});

--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { prepareBundledPluginRuntimeRoot } from "./bundled-runtime-root.js";
+import { ensureOpenClawPluginSdkAlias } from "./runtime-sdk-alias.js";
 
 function makeTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-runtime-root-"));
@@ -124,5 +125,23 @@ describe("bundled runtime root mirroring", () => {
     ).toBe(true);
 
     await expect(import(pathToFileURL(prepared.modulePath).href)).resolves.toBeTruthy();
+  });
+
+  it("refuses to write runtime aliases through symlinked alias paths", () => {
+    const packageRoot = makeTempDir();
+    tempDirs.push(packageRoot);
+    const aliasDistRoot = path.join(packageRoot, "dist");
+    const sdkDistRoot = path.join(packageRoot, "sdk");
+    fs.mkdirSync(path.join(aliasDistRoot, "extensions", "node_modules"), { recursive: true });
+    fs.mkdirSync(path.join(sdkDistRoot, "plugin-sdk"), { recursive: true });
+    fs.writeFileSync(path.join(sdkDistRoot, "plugin-sdk", "index.js"), "export {};\n", "utf8");
+    fs.symlinkSync(packageRoot, path.join(aliasDistRoot, "extensions", "node_modules", "openclaw"));
+
+    expect(() =>
+      ensureOpenClawPluginSdkAlias({
+        aliasDistRoot,
+        sdkDistRoot,
+      }),
+    ).toThrow(/refusing to prepare runtime alias directory via symlinked path/u);
   });
 });

--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -144,4 +144,27 @@ describe("bundled runtime root mirroring", () => {
       }),
     ).toThrow(/refusing to prepare runtime alias directory via symlinked path/u);
   });
+
+  it("refuses to mirror symlinked runtime entries", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    tempDirs.push(packageRoot, stageDir);
+
+    const pluginRoot = path.join(packageRoot, "dist", "extensions", "telegram");
+    const pluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
+    writeMirroredRuntimeFixture({ packageRoot, pluginRoot, pluginSdkDir });
+    fs.symlinkSync("../package.json", path.join(pluginRoot, "symlinked.js"));
+
+    expect(() =>
+      prepareBundledPluginRuntimeRoot({
+        pluginId: "telegram",
+        pluginRoot,
+        modulePath: path.join(pluginRoot, "monitor-polling.runtime.js"),
+        env: {
+          ...process.env,
+          OPENCLAW_PLUGIN_STAGE_DIR: stageDir,
+        },
+      }),
+    ).toThrow(/refusing to mirror symlinked runtime entry/u);
+  });
 });

--- a/src/plugins/bundled-runtime-root.ts
+++ b/src/plugins/bundled-runtime-root.ts
@@ -4,6 +4,7 @@ import {
   ensureBundledPluginRuntimeDeps,
   resolveBundledRuntimeDependencyInstallRoot,
 } from "./bundled-runtime-deps.js";
+import { ensureOpenClawPluginSdkAlias } from "./runtime-sdk-alias.js";
 
 const bundledRuntimeDepsRetainSpecsByInstallRoot = new Map<string, readonly string[]>();
 
@@ -112,7 +113,8 @@ function prepareBundledPluginRuntimeDistMirror(params: {
 }): string {
   const sourceExtensionsRoot = path.dirname(params.pluginRoot);
   const sourceDistRoot = path.dirname(sourceExtensionsRoot);
-  const mirrorDistRoot = path.join(params.installRoot, "dist");
+  const sourceDistRootName = path.basename(sourceDistRoot);
+  const mirrorDistRoot = path.join(params.installRoot, sourceDistRootName);
   const mirrorExtensionsRoot = path.join(mirrorDistRoot, "extensions");
   fs.mkdirSync(mirrorExtensionsRoot, { recursive: true, mode: 0o755 });
   for (const entry of fs.readdirSync(sourceDistRoot, { withFileTypes: true })) {
@@ -134,6 +136,30 @@ function prepareBundledPluginRuntimeDistMirror(params: {
       }
     }
   }
+  let sdkAliasSourceRoot = mirrorDistRoot;
+  if (sourceDistRootName === "dist-runtime") {
+    const sourceCanonicalDistRoot = path.join(path.dirname(sourceDistRoot), "dist");
+    const targetCanonicalDistRoot = path.join(params.installRoot, "dist");
+    if (fs.existsSync(sourceCanonicalDistRoot)) {
+      const targetMatchesSource =
+        fs.existsSync(targetCanonicalDistRoot) &&
+        safeRealpathOrResolve(targetCanonicalDistRoot) ===
+          safeRealpathOrResolve(sourceCanonicalDistRoot);
+      if (!targetMatchesSource) {
+        fs.rmSync(targetCanonicalDistRoot, { recursive: true, force: true });
+        try {
+          fs.symlinkSync(sourceCanonicalDistRoot, targetCanonicalDistRoot, "junction");
+        } catch {
+          copyBundledPluginRuntimeRoot(sourceCanonicalDistRoot, targetCanonicalDistRoot);
+        }
+      }
+      sdkAliasSourceRoot = targetCanonicalDistRoot;
+    }
+  }
+  ensureOpenClawPluginSdkAlias({
+    aliasDistRoot: mirrorDistRoot,
+    sdkDistRoot: sdkAliasSourceRoot,
+  });
   return mirrorExtensionsRoot;
 }
 
@@ -163,5 +189,13 @@ function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): v
     } catch {
       // Readable copied files are enough for plugin loading.
     }
+  }
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
   }
 }

--- a/src/plugins/bundled-runtime-root.ts
+++ b/src/plugins/bundled-runtime-root.ts
@@ -146,11 +146,13 @@ function prepareBundledPluginRuntimeDistMirror(params: {
         safeRealpathOrResolve(targetCanonicalDistRoot) ===
           safeRealpathOrResolve(sourceCanonicalDistRoot);
       if (!targetMatchesSource) {
-        fs.rmSync(targetCanonicalDistRoot, { recursive: true, force: true });
         try {
           fs.symlinkSync(sourceCanonicalDistRoot, targetCanonicalDistRoot, "junction");
         } catch {
-          copyBundledPluginRuntimeRoot(sourceCanonicalDistRoot, targetCanonicalDistRoot);
+          replaceDirWithCopiedTree({
+            sourceRoot: sourceCanonicalDistRoot,
+            targetRoot: targetCanonicalDistRoot,
+          });
         }
       }
       sdkAliasSourceRoot = targetCanonicalDistRoot;
@@ -164,6 +166,7 @@ function prepareBundledPluginRuntimeDistMirror(params: {
 }
 
 function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): void {
+  assertPathIsNotSymlink(targetRoot, "prepare mirrored runtime root");
   fs.mkdirSync(targetRoot, { recursive: true, mode: 0o755 });
   for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
     if (entry.name === "node_modules") {
@@ -172,16 +175,19 @@ function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): v
     const sourcePath = path.join(sourceRoot, entry.name);
     const targetPath = path.join(targetRoot, entry.name);
     if (entry.isDirectory()) {
+      assertPathIsNotSymlink(targetPath, "copy mirrored runtime directory");
       copyBundledPluginRuntimeRoot(sourcePath, targetPath);
       continue;
     }
     if (entry.isSymbolicLink()) {
+      assertPathIsNotSymlink(targetPath, "copy mirrored runtime symlink");
       fs.symlinkSync(fs.readlinkSync(sourcePath), targetPath);
       continue;
     }
     if (!entry.isFile()) {
       continue;
     }
+    assertPathIsNotSymlink(targetPath, "copy mirrored runtime file");
     fs.copyFileSync(sourcePath, targetPath);
     try {
       const sourceMode = fs.statSync(sourcePath).mode;
@@ -189,6 +195,34 @@ function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): v
     } catch {
       // Readable copied files are enough for plugin loading.
     }
+  }
+}
+
+function assertPathIsNotSymlink(targetPath: string, label: string): void {
+  try {
+    if (fs.lstatSync(targetPath).isSymbolicLink()) {
+      throw new Error(`refusing to ${label} via symlinked path: ${targetPath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+function replaceDirWithCopiedTree(params: { sourceRoot: string; targetRoot: string }): void {
+  assertPathIsNotSymlink(params.targetRoot, "replace mirrored runtime directory");
+  const targetParentDir = path.dirname(params.targetRoot);
+  fs.mkdirSync(targetParentDir, { recursive: true });
+  const tempDir = fs.mkdtempSync(path.join(targetParentDir, ".openclaw-runtime-copy-"));
+  const stagedRoot = path.join(tempDir, "tree");
+  try {
+    copyBundledPluginRuntimeRoot(params.sourceRoot, stagedRoot);
+    fs.rmSync(params.targetRoot, { recursive: true, force: true });
+    fs.renameSync(stagedRoot, params.targetRoot);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 

--- a/src/plugins/bundled-runtime-root.ts
+++ b/src/plugins/bundled-runtime-root.ts
@@ -121,6 +121,11 @@ function prepareBundledPluginRuntimeDistMirror(params: {
     if (entry.name === "extensions") {
       continue;
     }
+    if (entry.isSymbolicLink()) {
+      throw new Error(
+        `refusing to mirror symlinked dist entry: ${path.join(sourceDistRoot, entry.name)}`,
+      );
+    }
     const sourcePath = path.join(sourceDistRoot, entry.name);
     const targetPath = path.join(mirrorDistRoot, entry.name);
     if (fs.existsSync(targetPath)) {
@@ -180,9 +185,7 @@ function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): v
       continue;
     }
     if (entry.isSymbolicLink()) {
-      assertPathIsNotSymlink(targetPath, "copy mirrored runtime symlink");
-      fs.symlinkSync(fs.readlinkSync(sourcePath), targetPath);
-      continue;
+      throw new Error(`refusing to mirror symlinked runtime entry: ${sourcePath}`);
     }
     if (!entry.isFile()) {
       continue;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -87,6 +87,7 @@ import {
 } from "./plugin-scope.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { resolvePluginCacheInputs } from "./roots.js";
+import { ensureOpenClawPluginSdkAlias } from "./runtime-sdk-alias.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
@@ -599,7 +600,13 @@ function prepareBundledPluginRuntimeDistMirror(params: {
       }
     }
   }
-  ensureOpenClawPluginSdkAlias(mirrorDistRoot);
+  ensureOpenClawPluginSdkAlias({
+    aliasDistRoot: mirrorDistRoot,
+    sdkDistRoot:
+      sourceDistRootName === "dist-runtime"
+        ? path.join(params.installRoot, "dist")
+        : mirrorDistRoot,
+  });
   return mirrorExtensionsRoot;
 }
 
@@ -629,76 +636,6 @@ function copyBundledPluginRuntimeRoot(sourceRoot: string, targetRoot: string): v
     } catch {
       // Readable copied files are enough for plugin loading.
     }
-  }
-}
-
-function writeRuntimeJsonFile(targetPath: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-function hasRuntimeDefaultExport(sourcePath: string): boolean {
-  const text = fs.readFileSync(sourcePath, "utf8");
-  return /\bexport\s+default\b/u.test(text) || /\bas\s+default\b/u.test(text);
-}
-
-function writeRuntimeModuleWrapper(sourcePath: string, targetPath: string): void {
-  const specifier = path.relative(path.dirname(targetPath), sourcePath).replaceAll(path.sep, "/");
-  const normalizedSpecifier = specifier.startsWith(".") ? specifier : `./${specifier}`;
-  const defaultForwarder = hasRuntimeDefaultExport(sourcePath)
-    ? [
-        `import defaultModule from ${JSON.stringify(normalizedSpecifier)};`,
-        `let defaultExport = defaultModule;`,
-        `for (let index = 0; index < 4 && defaultExport && typeof defaultExport === "object" && "default" in defaultExport; index += 1) {`,
-        `  defaultExport = defaultExport.default;`,
-        `}`,
-      ]
-    : [
-        `import * as module from ${JSON.stringify(normalizedSpecifier)};`,
-        `let defaultExport = "default" in module ? module.default : module;`,
-        `for (let index = 0; index < 4 && defaultExport && typeof defaultExport === "object" && "default" in defaultExport; index += 1) {`,
-        `  defaultExport = defaultExport.default;`,
-        `}`,
-      ];
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(
-    targetPath,
-    [
-      `export * from ${JSON.stringify(normalizedSpecifier)};`,
-      ...defaultForwarder,
-      "export { defaultExport as default };",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-}
-
-function ensureOpenClawPluginSdkAlias(distRoot: string): void {
-  const pluginSdkDir = path.join(distRoot, "plugin-sdk");
-  if (!fs.existsSync(pluginSdkDir)) {
-    return;
-  }
-
-  const aliasDir = path.join(distRoot, "extensions", "node_modules", "openclaw");
-  const pluginSdkAliasDir = path.join(aliasDir, "plugin-sdk");
-  writeRuntimeJsonFile(path.join(aliasDir, "package.json"), {
-    name: "openclaw",
-    type: "module",
-    exports: {
-      "./plugin-sdk": "./plugin-sdk/index.js",
-      "./plugin-sdk/*": "./plugin-sdk/*.js",
-    },
-  });
-  fs.rmSync(pluginSdkAliasDir, { recursive: true, force: true });
-  fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
-  for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
-    if (!entry.isFile() || path.extname(entry.name) !== ".js") {
-      continue;
-    }
-    writeRuntimeModuleWrapper(
-      path.join(pluginSdkDir, entry.name),
-      path.join(pluginSdkAliasDir, entry.name),
-    );
   }
 }
 
@@ -2208,7 +2145,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               );
             }
           }
-          ensureOpenClawPluginSdkAlias(path.dirname(path.dirname(pluginRoot)));
+          ensureOpenClawPluginSdkAlias({
+            aliasDistRoot: path.dirname(path.dirname(pluginRoot)),
+          });
           if (path.resolve(installRoot) !== path.resolve(pluginRoot)) {
             registerBundledRuntimeDependencyNodePath(installRoot);
             runtimePluginRoot = mirrorBundledPluginRuntimeRoot({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -600,12 +600,16 @@ function prepareBundledPluginRuntimeDistMirror(params: {
       }
     }
   }
+  let sdkDistRoot = mirrorDistRoot;
+  if (sourceDistRootName === "dist-runtime") {
+    const targetCanonicalDistRoot = path.join(params.installRoot, "dist");
+    if (fs.existsSync(path.join(targetCanonicalDistRoot, "plugin-sdk"))) {
+      sdkDistRoot = targetCanonicalDistRoot;
+    }
+  }
   ensureOpenClawPluginSdkAlias({
     aliasDistRoot: mirrorDistRoot,
-    sdkDistRoot:
-      sourceDistRootName === "dist-runtime"
-        ? path.join(params.installRoot, "dist")
-        : mirrorDistRoot,
+    sdkDistRoot,
   });
   return mirrorExtensionsRoot;
 }

--- a/src/plugins/runtime-sdk-alias.ts
+++ b/src/plugins/runtime-sdk-alias.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function writeRuntimeJsonFile(targetPath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function hasRuntimeDefaultExport(sourcePath: string): boolean {
+  const text = fs.readFileSync(sourcePath, "utf8");
+  return /\bexport\s+default\b/u.test(text) || /\bas\s+default\b/u.test(text);
+}
+
+function writeRuntimeModuleWrapper(sourcePath: string, targetPath: string): void {
+  const specifier = path.relative(path.dirname(targetPath), sourcePath).replaceAll(path.sep, "/");
+  const normalizedSpecifier = specifier.startsWith(".") ? specifier : `./${specifier}`;
+  const defaultForwarder = hasRuntimeDefaultExport(sourcePath)
+    ? [
+        `import defaultModule from ${JSON.stringify(normalizedSpecifier)};`,
+        "let defaultExport = defaultModule;",
+        `for (let index = 0; index < 4 && defaultExport && typeof defaultExport === "object" && "default" in defaultExport; index += 1) {`,
+        "  defaultExport = defaultExport.default;",
+        "}",
+      ]
+    : [
+        `import * as module from ${JSON.stringify(normalizedSpecifier)};`,
+        `let defaultExport = "default" in module ? module.default : module;`,
+        `for (let index = 0; index < 4 && defaultExport && typeof defaultExport === "object" && "default" in defaultExport; index += 1) {`,
+        "  defaultExport = defaultExport.default;",
+        "}",
+      ];
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(
+    targetPath,
+    [
+      `export * from ${JSON.stringify(normalizedSpecifier)};`,
+      ...defaultForwarder,
+      "export { defaultExport as default };",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+export function ensureOpenClawPluginSdkAlias(params: {
+  aliasDistRoot: string;
+  sdkDistRoot?: string;
+}): void {
+  const pluginSdkDir = path.join(params.sdkDistRoot ?? params.aliasDistRoot, "plugin-sdk");
+  if (!fs.existsSync(pluginSdkDir)) {
+    return;
+  }
+
+  const aliasDir = path.join(params.aliasDistRoot, "extensions", "node_modules", "openclaw");
+  const pluginSdkAliasDir = path.join(aliasDir, "plugin-sdk");
+  writeRuntimeJsonFile(path.join(aliasDir, "package.json"), {
+    name: "openclaw",
+    type: "module",
+    exports: {
+      "./plugin-sdk": "./plugin-sdk/index.js",
+      "./plugin-sdk/*": "./plugin-sdk/*.js",
+    },
+  });
+  fs.rmSync(pluginSdkAliasDir, { recursive: true, force: true });
+  fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
+  for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
+    if (!entry.isFile() || path.extname(entry.name) !== ".js") {
+      continue;
+    }
+    writeRuntimeModuleWrapper(
+      path.join(pluginSdkDir, entry.name),
+      path.join(pluginSdkAliasDir, entry.name),
+    );
+  }
+}

--- a/src/plugins/runtime-sdk-alias.ts
+++ b/src/plugins/runtime-sdk-alias.ts
@@ -1,8 +1,38 @@
 import fs from "node:fs";
 import path from "node:path";
 
+function assertPathIsNotSymlink(targetPath: string, label: string): void {
+  try {
+    if (fs.lstatSync(targetPath).isSymbolicLink()) {
+      throw new Error(`refusing to ${label} via symlinked path: ${targetPath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+function ensureDirectoryPathSegments(params: {
+  rootDir: string;
+  relativeSegments: readonly string[];
+  label: string;
+}): string {
+  let cursor = params.rootDir;
+  assertPathIsNotSymlink(cursor, params.label);
+  for (const segment of params.relativeSegments) {
+    cursor = path.join(cursor, segment);
+    assertPathIsNotSymlink(cursor, params.label);
+    if (!fs.existsSync(cursor)) {
+      fs.mkdirSync(cursor);
+    }
+  }
+  return cursor;
+}
+
 function writeRuntimeJsonFile(targetPath: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  assertPathIsNotSymlink(targetPath, "write runtime alias file");
   fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
@@ -51,7 +81,11 @@ export function ensureOpenClawPluginSdkAlias(params: {
     return;
   }
 
-  const aliasDir = path.join(params.aliasDistRoot, "extensions", "node_modules", "openclaw");
+  const aliasDir = ensureDirectoryPathSegments({
+    rootDir: params.aliasDistRoot,
+    relativeSegments: ["extensions", "node_modules", "openclaw"],
+    label: "prepare runtime alias directory",
+  });
   const pluginSdkAliasDir = path.join(aliasDir, "plugin-sdk");
   writeRuntimeJsonFile(path.join(aliasDir, "package.json"), {
     name: "openclaw",
@@ -61,6 +95,7 @@ export function ensureOpenClawPluginSdkAlias(params: {
       "./plugin-sdk/*": "./plugin-sdk/*.js",
     },
   });
+  assertPathIsNotSymlink(pluginSdkAliasDir, "replace runtime alias directory");
   fs.rmSync(pluginSdkAliasDir, { recursive: true, force: true });
   fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
   for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {

--- a/src/plugins/runtime-sdk-alias.ts
+++ b/src/plugins/runtime-sdk-alias.ts
@@ -72,6 +72,25 @@ function writeRuntimeModuleWrapper(sourcePath: string, targetPath: string): void
   );
 }
 
+function replaceDirWithGeneratedTree(params: {
+  targetRoot: string;
+  populate: (stagedRoot: string) => void;
+}): void {
+  assertPathIsNotSymlink(params.targetRoot, "replace runtime alias directory");
+  const parentDir = path.dirname(params.targetRoot);
+  fs.mkdirSync(parentDir, { recursive: true });
+  const tempDir = fs.mkdtempSync(path.join(parentDir, ".openclaw-runtime-alias-"));
+  const stagedRoot = path.join(tempDir, "plugin-sdk");
+  try {
+    params.populate(stagedRoot);
+    assertPathIsNotSymlink(params.targetRoot, "replace runtime alias directory");
+    fs.rmSync(params.targetRoot, { recursive: true, force: true });
+    fs.renameSync(stagedRoot, params.targetRoot);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 export function ensureOpenClawPluginSdkAlias(params: {
   aliasDistRoot: string;
   sdkDistRoot?: string;
@@ -95,16 +114,19 @@ export function ensureOpenClawPluginSdkAlias(params: {
       "./plugin-sdk/*": "./plugin-sdk/*.js",
     },
   });
-  assertPathIsNotSymlink(pluginSdkAliasDir, "replace runtime alias directory");
-  fs.rmSync(pluginSdkAliasDir, { recursive: true, force: true });
-  fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
-  for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
-    if (!entry.isFile() || path.extname(entry.name) !== ".js") {
-      continue;
-    }
-    writeRuntimeModuleWrapper(
-      path.join(pluginSdkDir, entry.name),
-      path.join(pluginSdkAliasDir, entry.name),
-    );
-  }
+  replaceDirWithGeneratedTree({
+    targetRoot: pluginSdkAliasDir,
+    populate: (stagedRoot) => {
+      fs.mkdirSync(stagedRoot, { recursive: true });
+      for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
+        if (!entry.isFile() || path.extname(entry.name) !== ".js") {
+          continue;
+        }
+        writeRuntimeModuleWrapper(
+          path.join(pluginSdkDir, entry.name),
+          path.join(stagedRoot, entry.name),
+        );
+      }
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- share bundled runtime SDK alias generation in a dedicated helper instead of duplicating it in two loaders
- fix staged bundled runtime mirroring for both `dist` and `dist-runtime` roots
- add focused regression coverage for mirrored runtime imports and keep existing loader coverage green

## Validation
- `pnpm test src/plugins/bundled-runtime-root.test.ts`
- `pnpm test src/plugins/loader.test.ts -- --testNamePattern "loads bundled plugins with plugin-sdk imports from an external stage dir|loads dist-runtime wrappers from an external stage dir"`
- `pnpm build` currently fails on latest `origin/main` due to unrelated type resolution errors in `src/media/qr-runtime.ts` for `@vincentkoc/qrcode-tui`
