### PR TITLE
fix: exclude compaction checkpoint files from usage cost calculation

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -25,6 +25,23 @@ describe("session artifact helpers", () => {
       false,
     );
     expect(isPrimarySessionTranscriptFileName("sessions.json")).toBe(false);
+    // Compaction checkpoint files must not be counted as primary transcripts
+    expect(
+      isPrimarySessionTranscriptFileName(
+        "8534ecd0-1234-5678-abcd-ef0123456789.checkpoint.b8d30d3b-dead-beef-cafe-123456789abc.jsonl",
+      ),
+    ).toBe(false);
+    expect(
+      isPrimarySessionTranscriptFileName("abc.checkpoint.00000000-0000-0000-0000-000000000000.jsonl"),
+    ).toBe(false);
+  });
+
+  it("excludes checkpoint files from usage-counted transcripts", () => {
+    expect(
+      isUsageCountedSessionTranscriptFileName(
+        "8534ecd0-1234-5678-abcd-ef0123456789.checkpoint.b8d30d3b-dead-beef-cafe-123456789abc.jsonl",
+      ),
+    ).toBe(false);
   });
 
   it("classifies usage-counted transcript files", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -24,11 +24,16 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
   );
 }
 
+const CHECKPOINT_SUFFIX_RE = /\.checkpoint\.[0-9a-f-]+\.jsonl$/i;
+
 export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (fileName === "sessions.json") {
     return false;
   }
   if (!fileName.endsWith(".jsonl")) {
+    return false;
+  }
+  if (CHECKPOINT_SUFFIX_RE.test(fileName)) {
     return false;
   }
   return !isSessionArchiveArtifactName(fileName);


### PR DESCRIPTION
Closes #70686

## Summary

The Usage dashboard reported roughly **2× the actual cost** in sessions with compaction checkpoints enabled.

**Root cause:** Checkpoint files are named `{sessionId}.checkpoint.{uuid}.jsonl` and live in the same `sessions/` directory as primary session files. They contain full snapshots of the session — including identical `usage.cost` records — but `isPrimarySessionTranscriptFileName` had no exclusion for the `.checkpoint.` suffix, so `loadCostUsageSummary` processed them as independent sessions and counted every assistant turn twice.

**Fix:** Add `CHECKPOINT_SUFFIX_RE` (`/\.checkpoint\.[0-9a-f-]+\.jsonl$/i`) to `isPrimarySessionTranscriptFileName`. Checkpoint files now return `false` from both `isPrimarySessionTranscriptFileName` and `isUsageCountedSessionTranscriptFileName`, matching the existing treatment of `.deleted.*` and `.reset.*` archive files.

## Files changed

**`src/config/sessions/artifacts.ts`**
- Add `CHECKPOINT_SUFFIX_RE` constant
- Exit early in `isPrimarySessionTranscriptFileName` when the file name matches the checkpoint pattern

**`src/config/sessions/artifacts.test.ts`**
- Add two new test cases: `isPrimarySessionTranscriptFileName` rejects checkpoint files
- Add a dedicated test block: `isUsageCountedSessionTranscriptFileName` rejects checkpoint files

## Test plan

- [ ] `pnpm test src/config/sessions/artifacts.test.ts` — all cases pass including the new checkpoint assertions
- [ ] Open Usage dashboard after a session with auto-compaction — total cost matches provider billing
- [ ] Confirm non-checkpoint `.jsonl` files (primary sessions, reset/deleted archives) are still counted correctly