### PR TITLE
fix(whatsapp): normalize hosted LID targets

### DIFF
--- a/extensions/whatsapp/src/normalize-target.ts
+++ b/extensions/whatsapp/src/normalize-target.ts
@@ -3,7 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 
 const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
 const WHATSAPP_LEGACY_USER_JID_RE = /^(\d+)@c\.us$/i;
-const WHATSAPP_LID_RE = /^(\d+)@lid$/i;
+const WHATSAPP_LID_RE = /^(\d+)@(lid|hosted\.lid)$/i;
 
 function stripWhatsAppTargetPrefixes(value: string): string {
   let candidate = value.trim();

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -29,6 +29,8 @@ describe("normalizeWhatsAppTarget", () => {
   it("normalizes LID JIDs to E.164", () => {
     expect(normalizeWhatsAppTarget("123456789@lid")).toBe("+123456789");
     expect(normalizeWhatsAppTarget("123456789@LID")).toBe("+123456789");
+    expect(normalizeWhatsAppTarget("123456789@hosted.lid")).toBe("+123456789");
+    expect(normalizeWhatsAppTarget("123456789@HOSTED.LID")).toBe("+123456789");
   });
 
   it("rejects invalid targets", () => {
@@ -54,6 +56,8 @@ describe("isWhatsAppUserTarget", () => {
     expect(isWhatsAppUserTarget("1234567890@s.whatsapp.net")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@lid")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@LID")).toBe(true);
+    expect(isWhatsAppUserTarget("123456789@hosted.lid")).toBe(true);
+    expect(isWhatsAppUserTarget("123456789@HOSTED.LID")).toBe(true);
     expect(isWhatsAppUserTarget("123@lid:0")).toBe(false);
     expect(isWhatsAppUserTarget("abc@s.whatsapp.net")).toBe(false);
     expect(isWhatsAppUserTarget("123456789-987654321@g.us")).toBe(false);


### PR DESCRIPTION
## Summary

- Problem: WhatsApp hosted LID JIDs (`@hosted.lid`) were accepted by the runtime JID-to-E.164 path but rejected by target normalization.
- Why it matters: the same user identifier form could behave differently depending on the code path, causing valid hosted LID targets to be missed.
- What changed: `normalizeWhatsAppTarget` and `isWhatsAppUserTarget` now recognize `@hosted.lid`, with regression coverage for lower/upper case forms.
- What did NOT change (scope boundary): no routing, auth, network, or message-send behavior changed beyond target normalization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: hosted LID support was added in one WhatsApp JID conversion path but not mirrored in the shared target normalizer.
- Missing detection / guardrail: target normalization tests covered `@lid` but not `@hosted.lid`.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/resolve-target.test.ts`
- Scenario the test should lock in: hosted LID JIDs normalize to E.164 and are detected as user targets.
- Why this is the smallest reliable guardrail: the bug is isolated to target parsing/normalization.
- Existing test that already covers this (if any): existing LID tests covered only `@lid`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Valid WhatsApp hosted LID user targets are now accepted consistently by target normalization.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.21.1, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): N/A

### Steps

1. Normalize `123456789@hosted.lid` with `normalizeWhatsAppTarget`.
2. Check `isWhatsAppUserTarget("123456789@hosted.lid")`.
3. Run the targeted WhatsApp normalization test.

### Expected

- Hosted LID targets are normalized and detected as user targets.

### Actual

- Before this PR they were rejected by the normalizer; after this PR they pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: lower/upper case `@hosted.lid` normalization and user-target detection.
- Edge cases checked: existing invalid LID suffix case remains rejected.
- What you did **not** verify: live WhatsApp delivery.

Commands run:

```shell
pnpm -s vitest --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/resolve-target.test.ts --run
pnpm -s exec oxlint extensions/whatsapp/src/normalize-target.ts extensions/whatsapp/src/resolve-target.test.ts
git diff --check
```

Note: the local commit hook's broad `tsgo:extensions` check could not complete in this worktree because local dependencies such as `typebox` and `@tencent-connect/qqbot-connector` were not installed. The targeted test and lint above passed.

## Review Conversations

- [x] No bot review conversations were present or addressed at PR creation.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.