### PR TITLE
fix(gateway): restore runtime-postbuild sync in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,7 +1072,6 @@ Docs: https://docs.openclaw.ai
 - Memory/search: keep sqlite-vec optional in packaged installs and point missing-extension recovery at the valid `agents.defaults.memorySearch.store.vector.extensionPath` setting. Thanks @willemsej and @vincentkoc.
 - Gateway: keep directly requested plugin tools invokable under restrictive tool profiles while preserving explicit deny lists and the HTTP safety deny list, preventing catalog/invoke mismatches that surface as "Tool not available". Thanks @BunsDev.
 - Gateway/update: allow beta binaries to refresh gateway services when the config was last written by the matching stable release version, avoiding false newer-config downgrade blocks during beta channel updates.
-- Gateway/watch mode: detect missing bundled plugin dist and runtime-postbuild outputs before launching, so `pnpm gateway:watch` rebuilds or restages incomplete plugin artifacts instead of trusting stale stamps. Thanks @rubencu.
 - Channels: keep Matrix and Mattermost bundled in the core package instead of advertising external npm installs before those channels are cut over. Thanks @vincentkoc.
 - Bonjour: disable LAN mDNS advertising after a repeated stuck-announcing recovery instead of repeatedly restarting ciao and saturating the Gateway event loop.
 - Channels/setup: label installable channel picker hints as remote npm installs and hide remote install hints for bundled plugins that already ship with OpenClaw.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,6 +1072,7 @@ Docs: https://docs.openclaw.ai
 - Memory/search: keep sqlite-vec optional in packaged installs and point missing-extension recovery at the valid `agents.defaults.memorySearch.store.vector.extensionPath` setting. Thanks @willemsej and @vincentkoc.
 - Gateway: keep directly requested plugin tools invokable under restrictive tool profiles while preserving explicit deny lists and the HTTP safety deny list, preventing catalog/invoke mismatches that surface as "Tool not available". Thanks @BunsDev.
 - Gateway/update: allow beta binaries to refresh gateway services when the config was last written by the matching stable release version, avoiding false newer-config downgrade blocks during beta channel updates.
+- Gateway/watch mode: detect missing bundled plugin dist and runtime-postbuild outputs before launching, so `pnpm gateway:watch` rebuilds or restages incomplete plugin artifacts instead of trusting stale stamps. Thanks @rubencu.
 - Channels: keep Matrix and Mattermost bundled in the core package instead of advertising external npm installs before those channels are cut over. Thanks @vincentkoc.
 - Bonjour: disable LAN mDNS advertising after a repeated stuck-announcing recovery instead of repeatedly restarting ciao and saturating the Gateway event loop.
 - Channels/setup: label installable channel picker hints as remote npm installs and hide remote install hints for bundled plugins that already ship with OpenClaw.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
+- Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.
 - CLI/update: allow restart health probes from the previous gateway protocol during self-update, and make plugin dry-runs report exact npm target versions instead of `unknown` while preserving unchanged status.
 - OpenAI/Codex: point gateway missing-key recovery and wizard docs at the canonical `openai/gpt-5.5` plus Codex OAuth route, and fix trajectory export errors so they suggest the valid `openclaw sessions` command.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` primary, fallback, and model-map refs during config load and unrelated config writes so saved config keeps targeting Gemini 3.1 Pro Preview.

--- a/scripts/lib/static-extension-assets.mjs
+++ b/scripts/lib/static-extension-assets.mjs
@@ -96,6 +96,31 @@ export function copyStaticExtensionAssets(params = {}) {
   }
 }
 
+export function copyStaticExtensionAssetsToRuntimeOverlay(params = {}) {
+  const rootDir = params.rootDir ?? process.cwd();
+  const fsImpl = params.fs ?? fs;
+  const assets = params.assets ?? discoverStaticExtensionAssets({ rootDir, fs: fsImpl });
+  const runtimeExtensionsRoot = path.join(rootDir, "dist-runtime", "extensions");
+  if (!fsImpl.existsSync(runtimeExtensionsRoot)) {
+    return;
+  }
+  const warn = params.warn ?? console.warn;
+  for (const { src, dest } of assets) {
+    const normalizedDest = toPosixPath(dest);
+    if (!normalizedDest.startsWith("dist/extensions/")) {
+      continue;
+    }
+    const srcPath = path.join(rootDir, src);
+    const destPath = path.join(rootDir, "dist-runtime", normalizedDest.slice("dist/".length));
+    if (fsImpl.existsSync(srcPath)) {
+      fsImpl.mkdirSync(path.dirname(destPath), { recursive: true });
+      fsImpl.copyFileSync(srcPath, destPath);
+    } else {
+      warn(`[runtime-postbuild] static asset not found, skipping: ${src}`);
+    }
+  }
+}
+
 export function copyStaticExtensionAssetsForPackage(params) {
   const rootDir = params.rootDir ?? process.cwd();
   const fsImpl = params.fs ?? fs;

--- a/scripts/lib/static-extension-assets.mjs
+++ b/scripts/lib/static-extension-assets.mjs
@@ -34,6 +34,21 @@ function listExtensionPackageDirs(rootDir, fsImpl) {
     .toSorted((left, right) => left.dirName.localeCompare(right.dirName));
 }
 
+function listDistExtensionPackageDirs(rootDir, fsImpl) {
+  const extensionsRoot = path.join(rootDir, "dist", "extensions");
+  if (!fsImpl.existsSync(extensionsRoot)) {
+    return [];
+  }
+  return fsImpl
+    .readdirSync(extensionsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+    .map((entry) => ({
+      dirName: entry.name,
+      packageDir: path.join(extensionsRoot, entry.name),
+    }))
+    .toSorted((left, right) => left.dirName.localeCompare(right.dirName));
+}
+
 function readPackageStaticAssetEntries(packageJson) {
   const entries = packageJson.openclaw?.build?.staticAssets;
   return Array.isArray(entries) ? entries : [];
@@ -63,6 +78,33 @@ export function discoverStaticExtensionAssets(params = {}) {
     }
   }
   return assets.toSorted((left, right) => left.dest.localeCompare(right.dest));
+}
+
+function discoverStaticExtensionRuntimeOverlayAssets(params = {}) {
+  const rootDir = params.rootDir ?? process.cwd();
+  const fsImpl = params.fs ?? fs;
+  const assetsByDest = new Map();
+  for (const asset of params.assets ?? discoverStaticExtensionAssets({ rootDir, fs: fsImpl })) {
+    assetsByDest.set(asset.dest, asset);
+  }
+  for (const { dirName, packageDir } of listDistExtensionPackageDirs(rootDir, fsImpl)) {
+    const packageJsonPath = path.join(packageDir, "package.json");
+    if (!fsImpl.existsSync(packageJsonPath)) {
+      continue;
+    }
+    const packageJson = readJsonFile(packageJsonPath, fsImpl);
+    for (const entry of readPackageStaticAssetEntries(packageJson)) {
+      const output = normalizePackageRelativePath(entry?.output);
+      if (!output) {
+        continue;
+      }
+      const dest = toPosixPath(path.posix.join("dist", "extensions", dirName, output));
+      if (!assetsByDest.has(dest)) {
+        assetsByDest.set(dest, { pluginDir: dirName, src: dest, dest });
+      }
+    }
+  }
+  return [...assetsByDest.values()].toSorted((left, right) => left.dest.localeCompare(right.dest));
 }
 
 export function listStaticExtensionAssetOutputs(params = {}) {
@@ -99,7 +141,7 @@ export function copyStaticExtensionAssets(params = {}) {
 export function copyStaticExtensionAssetsToRuntimeOverlay(params = {}) {
   const rootDir = params.rootDir ?? process.cwd();
   const fsImpl = params.fs ?? fs;
-  const assets = params.assets ?? discoverStaticExtensionAssets({ rootDir, fs: fsImpl });
+  const assets = discoverStaticExtensionRuntimeOverlayAssets({ ...params, rootDir, fs: fsImpl });
   const runtimeExtensionsRoot = path.join(rootDir, "dist-runtime", "extensions");
   if (!fsImpl.existsSync(runtimeExtensionsRoot)) {
     return;
@@ -111,10 +153,12 @@ export function copyStaticExtensionAssetsToRuntimeOverlay(params = {}) {
       continue;
     }
     const srcPath = path.join(rootDir, src);
+    const distPath = path.join(rootDir, dest);
+    const copySourcePath = fsImpl.existsSync(srcPath) ? srcPath : distPath;
     const destPath = path.join(rootDir, "dist-runtime", normalizedDest.slice("dist/".length));
-    if (fsImpl.existsSync(srcPath)) {
+    if (fsImpl.existsSync(copySourcePath)) {
       fsImpl.mkdirSync(path.dirname(destPath), { recursive: true });
-      fsImpl.copyFileSync(srcPath, destPath);
+      fsImpl.copyFileSync(copySourcePath, destPath);
     } else {
       warn(`[runtime-postbuild] static asset not found, skipping: ${src}`);
     }

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -397,9 +397,29 @@ const listRequiredBundledPluginRuntimeOverlayOutputs = (pluginEntries, deps) => 
   return [...new Set(runtimePaths)].toSorted((left, right) => left.localeCompare(right));
 };
 
+const listRequiredOpenClawExtensionAliasOutputs = (deps) => {
+  const distRoot = resolveRuntimePostBuildDistRoot(deps);
+  const pluginSdkDir = path.join(distRoot, "plugin-sdk");
+  let dirents = [];
+  try {
+    dirents = deps.fs.readdirSync(pluginSdkDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const aliasDir = path.join(distRoot, "extensions", "node_modules", "openclaw");
+  return [
+    path.join(aliasDir, "package.json"),
+    ...dirents
+      .filter((dirent) => dirent.isFile() && path.extname(dirent.name) === ".js")
+      .map((dirent) => path.join(aliasDir, "plugin-sdk", dirent.name)),
+  ].toSorted((left, right) => left.localeCompare(right));
+};
+
 const listRequiredRuntimePostBuildOutputs = (deps) => {
   const builtPluginEntries = listBuiltBundledPluginEntries(deps);
   return [
+    ...listRequiredOpenClawExtensionAliasOutputs(deps),
     ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
     ...listRequiredBundledPluginRuntimeOverlayOutputs(builtPluginEntries, deps),
   ];

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -32,7 +32,10 @@ import {
   runNodeSourceRoots,
   runNodeWatchedPaths,
 } from "./run-node-watch-paths.mjs";
-import { runRuntimePostBuild } from "./runtime-postbuild.mjs";
+import {
+  listCoreRuntimePostBuildOutputs,
+  runRuntimePostBuild,
+} from "./runtime-postbuild.mjs";
 
 export { isBuildRelevantRunNodePath, isRestartRelevantRunNodePath, runNodeWatchedPaths };
 
@@ -427,9 +430,15 @@ const listRequiredStaticExtensionAssetOutputs = (deps) => {
     .toSorted((left, right) => left.localeCompare(right));
 };
 
-const listRequiredRuntimePostBuildOutputs = (deps) => {
+const listRequiredCoreRuntimePostBuildOutputs = (deps) =>
+  listCoreRuntimePostBuildOutputs({ rootDir: deps.cwd, fs: deps.fs }).map((relativePath) =>
+    path.join(deps.cwd, normalizePath(relativePath)),
+  );
+
+export const listRequiredRuntimePostBuildOutputs = (deps) => {
   const builtPluginEntries = listBuiltBundledPluginEntries(deps);
   return [
+    ...listRequiredCoreRuntimePostBuildOutputs(deps),
     ...listRequiredOpenClawExtensionAliasOutputs(deps),
     ...listRequiredStaticExtensionAssetOutputs(deps),
     ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -342,6 +342,20 @@ const listBuiltBundledPluginEntries = (deps) => {
     .toSorted((left, right) => left.id.localeCompare(right.id));
 };
 
+const listBuiltBundledPluginRuntimeOverlayDirs = (deps) => {
+  const distExtensionsRoot = path.join(resolveRuntimePostBuildDistRoot(deps), "extensions");
+  let entries = [];
+  try {
+    entries = deps.fs.readdirSync(distExtensionsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+    .map((entry) => entry.name)
+    .toSorted((left, right) => left.localeCompare(right));
+};
+
 const listRequiredBundledPluginMetadataOutputs = (pluginEntries, deps) =>
   pluginEntries.flatMap(({ id, hasManifest, hasPackageJson }) => {
     const builtPluginDir = path.join(resolveRuntimePostBuildDistRoot(deps), "extensions", id);
@@ -386,13 +400,13 @@ const listRuntimeOverlaySourcePaths = (sourceDir, deps) => {
   return paths.toSorted((left, right) => left.localeCompare(right));
 };
 
-const listRequiredBundledPluginRuntimeOverlayOutputs = (pluginEntries, deps) => {
+const listRequiredBundledPluginRuntimeOverlayOutputs = (deps) => {
   const distRoot = resolveRuntimePostBuildDistRoot(deps);
   const runtimeRoot = resolveRuntimePostBuildRuntimeRoot(deps);
   const runtimePaths = [];
-  for (const pluginEntry of pluginEntries) {
-    const distPluginDir = path.join(distRoot, "extensions", pluginEntry.id);
-    const runtimePluginDir = path.join(runtimeRoot, "extensions", pluginEntry.id);
+  for (const pluginId of listBuiltBundledPluginRuntimeOverlayDirs(deps)) {
+    const distPluginDir = path.join(distRoot, "extensions", pluginId);
+    const runtimePluginDir = path.join(runtimeRoot, "extensions", pluginId);
     for (const sourcePath of listRuntimeOverlaySourcePaths(distPluginDir, deps)) {
       runtimePaths.push(path.join(runtimePluginDir, path.relative(distPluginDir, sourcePath)));
     }
@@ -443,7 +457,7 @@ export const listRequiredRuntimePostBuildOutputs = (deps) => {
     ...listRequiredOpenClawExtensionAliasOutputs(deps),
     ...listRequiredStaticExtensionAssetOutputs(deps),
     ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
-    ...listRequiredBundledPluginRuntimeOverlayOutputs(builtPluginEntries, deps),
+    ...listRequiredBundledPluginRuntimeOverlayOutputs(deps),
   ];
 };
 

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -416,10 +416,19 @@ const listRequiredOpenClawExtensionAliasOutputs = (deps) => {
   ].toSorted((left, right) => left.localeCompare(right));
 };
 
+const listRequiredStaticExtensionAssetOutputs = (deps) => {
+  const distRoot = resolveRuntimePostBuildDistRoot(deps);
+  return runtimePostBuildStaticAssets
+    .filter((asset) => deps.fs.existsSync(path.join(deps.cwd, asset.src)))
+    .map((asset) => path.join(distRoot, normalizePath(asset.dest).replace(/^dist\//u, "")))
+    .toSorted((left, right) => left.localeCompare(right));
+};
+
 const listRequiredRuntimePostBuildOutputs = (deps) => {
   const builtPluginEntries = listBuiltBundledPluginEntries(deps);
   return [
     ...listRequiredOpenClawExtensionAliasOutputs(deps),
+    ...listRequiredStaticExtensionAssetOutputs(deps),
     ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
     ...listRequiredBundledPluginRuntimeOverlayOutputs(builtPluginEntries, deps),
   ];

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -5,6 +5,10 @@ import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import {
+  collectBundledPluginBuildEntries,
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
+} from "./lib/bundled-plugin-build-entries.mjs";
+import {
   BUNDLED_PLUGIN_PATH_PREFIX,
   BUNDLED_PLUGIN_ROOT_DIR,
 } from "./lib/bundled-plugin-paths.mjs";
@@ -67,6 +71,11 @@ const resolvePrivateQaRequiredDistEntries = (distRoot) => [
   path.join(distRoot, "plugin-sdk", "qa-lab.js"),
   path.join(distRoot, "plugin-sdk", "qa-runtime.js"),
 ];
+const shouldIncludePrivateQaBundledOutputs = (env = process.env) =>
+  env.OPENCLAW_BUILD_PRIVATE_QA === "1";
+
+const shouldRequireBundledPluginRuntimeOutput = (pluginId, env = process.env) =>
+  shouldIncludePrivateQaBundledOutputs(env) || !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(pluginId);
 
 const isExcludedSource = (filePath, sourceRoot, sourceRootName) => {
   const relativePath = normalizePath(path.relative(sourceRoot, filePath));
@@ -146,7 +155,13 @@ const hasDirtySourceTree = (deps) => {
   if (output === null) {
     return null;
   }
-  return parseGitStatusPaths(output).some((repoPath) => isBuildRelevantRunNodePath(repoPath));
+  return parseGitStatusPaths(output).some((repoPath) => {
+    const normalizedPath = normalizePath(repoPath).replace(/^\.\/+/, "");
+    return (
+      isBuildRelevantRunNodePath(normalizedPath) ||
+      isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs(normalizedPath, deps)
+    );
+  });
 };
 
 const isRuntimePostBuildRelevantPath = (repoPath) => {
@@ -167,7 +182,8 @@ const isRuntimePostBuildRelevantPath = (repoPath) => {
     return false;
   }
   const pluginRelativePath = normalizedPath.slice(BUNDLED_PLUGIN_PATH_PREFIX.length);
-  if (pluginRelativePath.startsWith("skills/")) {
+  const pluginLocalPath = pluginRelativePath.split("/").slice(1).join("/");
+  if (pluginLocalPath === "skills" || pluginLocalPath.startsWith("skills/")) {
     return true;
   }
   return extensionRestartMetadataFiles.has(path.posix.basename(pluginRelativePath));
@@ -257,6 +273,143 @@ const hasRuntimePostBuildInputMtimeChanged = (stampMtime, deps) => {
   return latestInputMtime != null && latestInputMtime > stampMtime;
 };
 
+const resolveRuntimePostBuildDistRoot = (deps) => deps.distRoot ?? path.join(deps.cwd, "dist");
+const resolveRuntimePostBuildRuntimeRoot = (deps) => path.join(deps.cwd, "dist-runtime");
+
+const collectRunNodeBundledPluginBuildEntries = (deps) => {
+  if (!deps.fs.existsSync(path.join(deps.cwd, BUNDLED_PLUGIN_ROOT_DIR))) {
+    return [];
+  }
+  return collectBundledPluginBuildEntries({ cwd: deps.cwd, env: deps.env });
+};
+
+const resolveBuiltBundledPluginRuntimeEntryPath = (distRoot, pluginId, sourceEntry) =>
+  path.join(
+    distRoot,
+    "extensions",
+    pluginId,
+    sourceEntry.replace(/^\.\//, "").replace(/\.[^.]+$/u, ".js"),
+  );
+
+const listBundledPluginRuntimeEntryPaths = (pluginEntry, deps) => {
+  const distRoot = resolveRuntimePostBuildDistRoot(deps);
+  return pluginEntry.sourceEntries
+    .map((sourceEntry) =>
+      resolveBuiltBundledPluginRuntimeEntryPath(distRoot, pluginEntry.id, sourceEntry),
+    )
+    .toSorted((left, right) => left.localeCompare(right));
+};
+
+const isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs = (normalizedPath, deps) => {
+  if (!normalizedPath.startsWith("extensions/") || !normalizedPath.endsWith("/package.json")) {
+    return false;
+  }
+  const [, pluginId] = normalizedPath.split("/");
+  if (!pluginId || !shouldRequireBundledPluginRuntimeOutput(pluginId, deps.env)) {
+    return false;
+  }
+  const pluginEntry = collectRunNodeBundledPluginBuildEntries(deps).find(
+    (entry) => entry.id === pluginId,
+  );
+  if (!pluginEntry) {
+    return false;
+  }
+  return listBundledPluginRuntimeEntryPaths(pluginEntry, deps).some(
+    (filePath) => !deps.fs.existsSync(filePath),
+  );
+};
+
+const hasMissingBuiltBundledPluginRuntimeEntryOutput = (deps) => {
+  return collectRunNodeBundledPluginBuildEntries(deps)
+    .filter(({ id }) => shouldRequireBundledPluginRuntimeOutput(id, deps.env))
+    .some((pluginEntry) => {
+      const entryPaths = listBundledPluginRuntimeEntryPaths(pluginEntry, deps);
+      return entryPaths.some((filePath) => !deps.fs.existsSync(filePath));
+    });
+};
+
+const listBuiltBundledPluginEntries = (deps) => {
+  return collectRunNodeBundledPluginBuildEntries(deps)
+    .filter(({ id }) => shouldRequireBundledPluginRuntimeOutput(id, deps.env))
+    .filter((pluginEntry) =>
+      listBundledPluginRuntimeEntryPaths(pluginEntry, deps).some((filePath) =>
+        deps.fs.existsSync(filePath),
+      ),
+    )
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+};
+
+const listRequiredBundledPluginMetadataOutputs = (pluginEntries, deps) =>
+  pluginEntries.flatMap(({ id, hasManifest, hasPackageJson }) => {
+    const builtPluginDir = path.join(resolveRuntimePostBuildDistRoot(deps), "extensions", id);
+    const requiredPaths = [];
+    if (hasPackageJson) {
+      requiredPaths.push(path.join(builtPluginDir, "package.json"));
+    }
+    if (hasManifest) {
+      requiredPaths.push(path.join(builtPluginDir, "openclaw.plugin.json"));
+    }
+    return requiredPaths;
+  });
+
+const listRuntimeOverlaySourcePaths = (sourceDir, deps) => {
+  const paths = [];
+  const queue = [sourceDir];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    let entries = [];
+    try {
+      entries = deps.fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules") {
+        continue;
+      }
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+        continue;
+      }
+      if (entry.isFile() || entry.isSymbolicLink()) {
+        paths.push(entryPath);
+      }
+    }
+  }
+  return paths.toSorted((left, right) => left.localeCompare(right));
+};
+
+const listRequiredBundledPluginRuntimeOverlayOutputs = (pluginEntries, deps) => {
+  const distRoot = resolveRuntimePostBuildDistRoot(deps);
+  const runtimeRoot = resolveRuntimePostBuildRuntimeRoot(deps);
+  const runtimePaths = [];
+  for (const pluginEntry of pluginEntries) {
+    const distPluginDir = path.join(distRoot, "extensions", pluginEntry.id);
+    const runtimePluginDir = path.join(runtimeRoot, "extensions", pluginEntry.id);
+    for (const sourcePath of listRuntimeOverlaySourcePaths(distPluginDir, deps)) {
+      runtimePaths.push(path.join(runtimePluginDir, path.relative(distPluginDir, sourcePath)));
+    }
+  }
+  return [...new Set(runtimePaths)].toSorted((left, right) => left.localeCompare(right));
+};
+
+const listRequiredRuntimePostBuildOutputs = (deps) => {
+  const builtPluginEntries = listBuiltBundledPluginEntries(deps);
+  return [
+    ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
+    ...listRequiredBundledPluginRuntimeOverlayOutputs(builtPluginEntries, deps),
+  ];
+};
+
+const hasMissingRequiredRuntimePostBuildOutput = (deps) =>
+  listRequiredRuntimePostBuildOutputs(deps).some(
+    (filePath) => statMtime(filePath, deps.fs) == null,
+  );
+
 export const resolveBuildRequirement = (deps) => {
   if (deps.env.OPENCLAW_FORCE_BUILD === "1") {
     return { shouldBuild: true, reason: "force_build" };
@@ -297,8 +450,15 @@ export const resolveBuildRequirement = (deps) => {
       return { shouldBuild: true, reason: "dirty_watched_tree" };
     }
     if (dirty === false) {
+      if (hasMissingBuiltBundledPluginRuntimeEntryOutput(deps)) {
+        return { shouldBuild: true, reason: "missing_bundled_plugin_dist_entry" };
+      }
       return { shouldBuild: false, reason: "clean" };
     }
+  }
+
+  if (hasMissingBuiltBundledPluginRuntimeEntryOutput(deps)) {
+    return { shouldBuild: true, reason: "missing_bundled_plugin_dist_entry" };
   }
 
   if (hasSourceMtimeChanged(stamp.mtime, deps)) {
@@ -338,12 +498,19 @@ export const resolveRuntimePostBuildRequirement = (deps) => {
       return { shouldSync: true, reason: "dirty_runtime_postbuild_inputs" };
     }
     if (dirty === false) {
+      if (hasMissingRequiredRuntimePostBuildOutput(deps)) {
+        return { shouldSync: true, reason: "missing_runtime_postbuild_output" };
+      }
       return { shouldSync: false, reason: "clean" };
     }
   }
 
   if (hasRuntimePostBuildInputMtimeChanged(stamp.mtime, deps)) {
     return { shouldSync: true, reason: "runtime_postbuild_input_mtime_newer" };
+  }
+
+  if (hasMissingRequiredRuntimePostBuildOutput(deps)) {
+    return { shouldSync: true, reason: "missing_runtime_postbuild_output" };
   }
 
   return { shouldSync: false, reason: "clean" };
@@ -357,6 +524,7 @@ const BUILD_REASON_LABELS = {
   build_stamp_missing_head: "build stamp missing git head",
   git_head_changed: "git head changed",
   dirty_watched_tree: "dirty watched source tree",
+  missing_bundled_plugin_dist_entry: "bundled plugin dist entry missing",
   source_mtime_newer: "source mtime newer than build stamp",
   missing_private_qa_dist: "private QA dist entry missing",
   clean: "clean",
@@ -364,6 +532,7 @@ const BUILD_REASON_LABELS = {
 
 const RUNTIME_POSTBUILD_REASON_LABELS = {
   force_runtime_postbuild: "forced by OPENCLAW_FORCE_RUNTIME_POSTBUILD",
+  missing_runtime_postbuild_output: "required runtime postbuild output missing",
   missing_runtime_postbuild_stamp: "runtime postbuild stamp missing",
   missing_build_stamp: "build stamp missing",
   build_stamp_newer: "build stamp newer than runtime postbuild stamp",

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -32,10 +32,7 @@ import {
   runNodeSourceRoots,
   runNodeWatchedPaths,
 } from "./run-node-watch-paths.mjs";
-import {
-  listCoreRuntimePostBuildOutputs,
-  runRuntimePostBuild,
-} from "./runtime-postbuild.mjs";
+import { listCoreRuntimePostBuildOutputs, runRuntimePostBuild } from "./runtime-postbuild.mjs";
 
 export { isBuildRelevantRunNodePath, isRestartRelevantRunNodePath, runNodeWatchedPaths };
 
@@ -405,6 +402,10 @@ const listRequiredBundledPluginRuntimeOverlayOutputs = (pluginEntries, deps) => 
 
 const listRequiredOpenClawExtensionAliasOutputs = (deps) => {
   const distRoot = resolveRuntimePostBuildDistRoot(deps);
+  const distExtensionsRoot = path.join(distRoot, "extensions");
+  if (!deps.fs.existsSync(distExtensionsRoot)) {
+    return [];
+  }
   const pluginSdkDir = path.join(distRoot, "plugin-sdk");
   let dirents = [];
   try {
@@ -1070,7 +1071,8 @@ const writeBuildStamp = (deps) => {
 const shouldSkipWatchRuntimeSync = (deps, requirement) =>
   deps.env.OPENCLAW_WATCH_MODE === "1" &&
   requirement.reason === "missing_runtime_postbuild_stamp" &&
-  hasDirtyRuntimePostBuildInputs(deps) !== true;
+  hasDirtyRuntimePostBuildInputs(deps) !== true &&
+  !hasMissingRequiredRuntimePostBuildOutput(deps);
 
 const isGatewayClientCommand = (args) =>
   args[0] === "gateway" && (args[1] === "call" || args[1] === "status");

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -19,7 +19,10 @@ import {
   writeBuildStamp as writeDistBuildStamp,
   writeRuntimePostBuildStamp as writeDistRuntimePostBuildStamp,
 } from "./lib/local-build-metadata.mjs";
-import { listStaticExtensionAssetSources } from "./lib/static-extension-assets.mjs";
+import {
+  discoverStaticExtensionAssets,
+  listStaticExtensionAssetSources,
+} from "./lib/static-extension-assets.mjs";
 import {
   extensionRestartMetadataFiles,
   isBuildRelevantRunNodePath,
@@ -418,7 +421,7 @@ const listRequiredOpenClawExtensionAliasOutputs = (deps) => {
 
 const listRequiredStaticExtensionAssetOutputs = (deps) => {
   const distRoot = resolveRuntimePostBuildDistRoot(deps);
-  return runtimePostBuildStaticAssets
+  return discoverStaticExtensionAssets({ rootDir: deps.cwd, fs: deps.fs })
     .filter((asset) => deps.fs.existsSync(path.join(deps.cwd, asset.src)))
     .map((asset) => path.join(distRoot, normalizePath(asset.dest).replace(/^dist\//u, "")))
     .toSorted((left, right) => left.localeCompare(right));

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -20,6 +20,8 @@ const ROOT_STABLE_RUNTIME_ALIAS_PATTERN = /^.+\.(?:runtime|contract)\.js$/u;
 const ROOT_RUNTIME_IMPORT_SPECIFIER_PATTERN =
   /(["'])\.\/([^"']+\.(?:runtime|contract)-[A-Za-z0-9_-]+\.js)\1/gu;
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+const PLUGIN_SDK_ROOT_ALIAS_OUTPUT = "dist/plugin-sdk/root-alias.cjs";
+const OFFICIAL_CHANNEL_CATALOG_OUTPUT = "dist/channel-catalog.json";
 const LEGACY_ROOT_RUNTIME_COMPAT_ALIASES = [
   // v2026.4.29 dispatch lazy chunks. Package updates used to replace the
   // dist tree before the live gateway had restarted, so an already-loaded old
@@ -117,7 +119,7 @@ const LEGACY_PLUGIN_INSTALL_RUNTIME_COMPAT_ALIASES = [
   aliasFileName: PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName,
   sourceIncludes: LEGACY_PLUGIN_INSTALL_RUNTIME_MARKERS,
 }));
-const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
+export const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
   {
     dest: "dist/memory-state-CcqRgDZU.js",
     contents: "export function hasMemoryRuntime() {\n  return false;\n}\n",
@@ -128,6 +130,48 @@ const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
   },
 ];
 
+export function listPluginSdkRootAliasOutputs() {
+  return [PLUGIN_SDK_ROOT_ALIAS_OUTPUT];
+}
+
+export function listOfficialChannelCatalogOutputs() {
+  return [OFFICIAL_CHANNEL_CATALOG_OUTPUT];
+}
+
+export function listStableRootRuntimeAliasOutputs(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  let entries = [];
+  try {
+    entries = fsImpl.readdirSync(distDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name.match(ROOT_RUNTIME_ALIAS_PATTERN)?.groups?.base)
+    .filter((base) => typeof base === "string" && base.length > 0)
+    .map((base) => `dist/${base}.js`)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listLegacyCliExitCompatOutputs(params = {}) {
+  const chunks = params.chunks ?? LEGACY_CLI_EXIT_COMPAT_CHUNKS;
+  return chunks
+    .map(({ dest }) => dest.replace(/\\/g, "/"))
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listCoreRuntimePostBuildOutputs(params = {}) {
+  return [
+    ...listPluginSdkRootAliasOutputs(),
+    ...listOfficialChannelCatalogOutputs(),
+    ...listStableRootRuntimeAliasOutputs(params),
+    ...listLegacyCliExitCompatOutputs(params),
+  ].toSorted((left, right) => left.localeCompare(right));
+}
 export function writeStableRootRuntimeAliases(params = {}) {
   const rootDir = params.rootDir ?? ROOT;
   const distDir = path.join(rootDir, "dist");

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -6,6 +6,7 @@ import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
 import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
 import {
   copyStaticExtensionAssets,
+  copyStaticExtensionAssetsToRuntimeOverlay,
   listStaticExtensionAssetOutputs,
 } from "./lib/static-extension-assets.mjs";
 import { writeTextFileIfChanged } from "./runtime-postbuild-shared.mjs";
@@ -459,13 +460,15 @@ export function runRuntimePostBuild(params = {}) {
   runPhase("plugin SDK root alias", () => copyPluginSdkRootAlias(params));
   runPhase("bundled plugin metadata", () => copyBundledPluginMetadata(params));
   runPhase("official channel catalog", () => writeOfficialChannelCatalog(params));
-  runPhase("static extension assets", () =>
-    copyStaticExtensionAssets({
+  runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
+  runPhase("static extension assets", () => {
+    const staticAssetParams = {
       rootDir: ROOT,
       ...params,
-    }),
-  );
-  runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
+    };
+    copyStaticExtensionAssets(staticAssetParams);
+    copyStaticExtensionAssetsToRuntimeOverlay(staticAssetParams);
+  });
   runPhase("stable root runtime imports", () => rewriteRootRuntimeImportsToStableAliases(params));
   runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
   runPhase("legacy root runtime compat aliases", () => writeLegacyRootRuntimeCompatAliases(params));

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -138,49 +138,14 @@ export function listOfficialChannelCatalogOutputs() {
   return [OFFICIAL_CHANNEL_CATALOG_OUTPUT];
 }
 
-export function listStableRootRuntimeAliasOutputs(params = {}) {
-  const rootDir = params.rootDir ?? ROOT;
-  const distDir = path.join(rootDir, "dist");
-  const fsImpl = params.fs ?? fs;
+function collectStableRootRuntimeAliasCandidates(params) {
+  const distDir = params.distDir;
+  const fsImpl = params.fs;
   let entries = [];
   try {
     entries = fsImpl.readdirSync(distDir, { withFileTypes: true });
   } catch {
-    return [];
-  }
-
-  return entries
-    .filter((entry) => entry.isFile())
-    .map((entry) => entry.name.match(ROOT_RUNTIME_ALIAS_PATTERN)?.groups?.base)
-    .filter((base) => typeof base === "string" && base.length > 0)
-    .map((base) => `dist/${base}.js`)
-    .toSorted((left, right) => left.localeCompare(right));
-}
-
-export function listLegacyCliExitCompatOutputs(params = {}) {
-  const chunks = params.chunks ?? LEGACY_CLI_EXIT_COMPAT_CHUNKS;
-  return chunks
-    .map(({ dest }) => dest.replace(/\\/g, "/"))
-    .toSorted((left, right) => left.localeCompare(right));
-}
-
-export function listCoreRuntimePostBuildOutputs(params = {}) {
-  return [
-    ...listPluginSdkRootAliasOutputs(),
-    ...listOfficialChannelCatalogOutputs(),
-    ...listStableRootRuntimeAliasOutputs(params),
-    ...listLegacyCliExitCompatOutputs(params),
-  ].toSorted((left, right) => left.localeCompare(right));
-}
-export function writeStableRootRuntimeAliases(params = {}) {
-  const rootDir = params.rootDir ?? ROOT;
-  const distDir = path.join(rootDir, "dist");
-  const fsImpl = params.fs ?? fs;
-  let entries = [];
-  try {
-    entries = fsImpl.readdirSync(distDir, { withFileTypes: true });
-  } catch {
-    return;
+    return new Map();
   }
 
   const candidatesByAlias = new Map();
@@ -197,42 +162,114 @@ export function writeStableRootRuntimeAliases(params = {}) {
     candidates.push(entry.name);
     candidatesByAlias.set(aliasFileName, candidates);
   }
+  return candidatesByAlias;
+}
 
-  const resolveAliasCandidate = (aliasFileName, candidates) => {
-    if (candidates.length === 1) {
-      return candidates[0];
+function resolveStableRootRuntimeAliasCandidate(params) {
+  const { aliasFileName, candidates, distDir, fsImpl } = params;
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+  if (aliasFileName === PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName) {
+    return resolveRootRuntimeCandidateByMarkers({
+      distDir,
+      fsImpl,
+      aliasFileName,
+      sourceIncludes: PLUGIN_INSTALL_RUNTIME_ALIAS.sourceIncludes,
+    });
+  }
+  const candidateSet = new Set(candidates);
+  const wrappers = candidates.filter((candidate) => {
+    const filePath = path.join(distDir, candidate);
+    let source;
+    try {
+      source = fsImpl.readFileSync(filePath, "utf8");
+    } catch {
+      return false;
     }
-    if (aliasFileName === PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName) {
-      return resolveRootRuntimeCandidateByMarkers({
+    return candidates.some(
+      (target) =>
+        target !== candidate &&
+        candidateSet.has(target) &&
+        source.includes(`"./${target}"`) &&
+        !source.includes("\n//#region "),
+    );
+  });
+  return wrappers.length === 1 ? wrappers[0] : null;
+}
+
+export function listStableRootRuntimeAliasOutputs(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  return [...collectStableRootRuntimeAliasCandidates({ distDir, fs: fsImpl })]
+    .filter(([aliasFileName, candidates]) =>
+      resolveStableRootRuntimeAliasCandidate({
         distDir,
         fsImpl,
         aliasFileName,
-        sourceIncludes: PLUGIN_INSTALL_RUNTIME_ALIAS.sourceIncludes,
-      });
-    }
-    const candidateSet = new Set(candidates);
-    const wrappers = candidates.filter((candidate) => {
-      const filePath = path.join(distDir, candidate);
-      let source;
-      try {
-        source = fsImpl.readFileSync(filePath, "utf8");
-      } catch {
-        return false;
-      }
-      return candidates.some(
-        (target) =>
-          target !== candidate &&
-          candidateSet.has(target) &&
-          source.includes(`"./${target}"`) &&
-          !source.includes("\n//#region "),
-      );
-    });
-    return wrappers.length === 1 ? wrappers[0] : null;
-  };
+        candidates,
+      }),
+    )
+    .map(([aliasFileName]) => `dist/${aliasFileName}`)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listLegacyCliExitCompatOutputs(params = {}) {
+  const chunks = params.chunks ?? LEGACY_CLI_EXIT_COMPAT_CHUNKS;
+  return chunks
+    .map(({ dest }) => dest.replace(/\\/g, "/"))
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listLegacyRootRuntimeCompatOutputs(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  return [
+    ...LEGACY_ROOT_RUNTIME_COMPAT_ALIASES.map(([legacyFileName, aliasFileName]) => ({
+      legacyFileName,
+      aliasFileName,
+    })),
+    ...LEGACY_PLUGIN_INSTALL_RUNTIME_COMPAT_ALIASES,
+  ]
+    .filter((entry) =>
+      resolveLegacyRootRuntimeCompatTarget({
+        distDir,
+        fsImpl,
+        legacyFileName: entry.legacyFileName,
+        aliasFileName: entry.aliasFileName,
+        sourceIncludes: entry.sourceIncludes,
+      }),
+    )
+    .map(({ legacyFileName }) => `dist/${legacyFileName}`)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function listCoreRuntimePostBuildOutputs(params = {}) {
+  return [
+    ...listPluginSdkRootAliasOutputs(),
+    ...listOfficialChannelCatalogOutputs(),
+    ...listStableRootRuntimeAliasOutputs(params),
+    ...listLegacyRootRuntimeCompatOutputs(params),
+    ...listLegacyCliExitCompatOutputs(params),
+  ].toSorted((left, right) => left.localeCompare(right));
+}
+
+export function writeStableRootRuntimeAliases(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  const candidatesByAlias = collectStableRootRuntimeAliasCandidates({ distDir, fs: fsImpl });
 
   for (const [aliasFileName, candidates] of candidatesByAlias) {
     const aliasPath = path.join(distDir, aliasFileName);
-    const candidate = resolveAliasCandidate(aliasFileName, candidates);
+    const candidate = resolveStableRootRuntimeAliasCandidate({
+      distDir,
+      fsImpl,
+      aliasFileName,
+      candidates,
+    });
     if (!candidate) {
       fsImpl.rmSync?.(aliasPath, { force: true });
       continue;

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -459,17 +459,17 @@ export function runRuntimePostBuild(params = {}) {
   runPhase("plugin SDK root alias", () => copyPluginSdkRootAlias(params));
   runPhase("bundled plugin metadata", () => copyBundledPluginMetadata(params));
   runPhase("official channel catalog", () => writeOfficialChannelCatalog(params));
-  runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
-  runPhase("stable root runtime imports", () => rewriteRootRuntimeImportsToStableAliases(params));
-  runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
-  runPhase("legacy root runtime compat aliases", () => writeLegacyRootRuntimeCompatAliases(params));
-  runPhase("legacy CLI exit compat chunks", () => writeLegacyCliExitCompatChunks(params));
   runPhase("static extension assets", () =>
     copyStaticExtensionAssets({
       rootDir: ROOT,
       ...params,
     }),
   );
+  runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
+  runPhase("stable root runtime imports", () => rewriteRootRuntimeImportsToStableAliases(params));
+  runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
+  runPhase("legacy root runtime compat aliases", () => writeLegacyRootRuntimeCompatAliases(params));
+  runPhase("legacy CLI exit compat chunks", () => writeLegacyCliExitCompatChunks(params));
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -30,6 +30,12 @@ const DIST_ENTRY = "dist/entry.js";
 const BUILD_STAMP = `dist/${BUILD_STAMP_FILE}`;
 const RUNTIME_POSTBUILD_STAMP = `dist/${RUNTIME_POSTBUILD_STAMP_FILE}`;
 const DIST_PLUGIN_SDK_INDEX = "dist/plugin-sdk/index.js";
+const DIST_PLUGIN_SDK_ROOT_ALIAS = "dist/plugin-sdk/root-alias.cjs";
+const DIST_CHANNEL_CATALOG = "dist/channel-catalog.json";
+const DIST_LEGACY_CLI_EXIT_COMPAT = "dist/memory-state-CcqRgDZU.js";
+const DIST_LEGACY_CLI_EXIT_COMPAT_ALT = "dist/memory-state-DwGdReW4.js";
+const DIST_STABLE_ROOT_RUNTIME_SOURCE = "dist/model-catalog.runtime-AbCd1234.js";
+const DIST_STABLE_ROOT_RUNTIME_ALIAS = "dist/model-catalog.runtime.js";
 const QA_LAB_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-lab.js";
 const QA_RUNTIME_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-runtime.js";
 const EXTENSION_INDEX = bundledPluginFile("demo", "index.ts");
@@ -126,6 +132,25 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
   await fs.mkdir(path.join(tmp, "extensions"), { recursive: true });
   await fs.writeFile(pluginSdkAliasPath, "module.exports = {};\n", "utf-8");
   await fs.utimes(pluginSdkAliasPath, BUILD_TIME, BUILD_TIME);
+  await writeProjectFiles(tmp, {
+    [DIST_PLUGIN_SDK_ROOT_ALIAS]: "module.exports = {};\n",
+    [DIST_CHANNEL_CATALOG]: '{"entries":[]}\n',
+    [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
+    [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]: "export function hasMemoryRuntime() { return false; }\n",
+    [DIST_OPENCLAW_ALIAS_PACKAGE]:
+      '{"name":"openclaw","type":"module","exports":{"./plugin-sdk":"./plugin-sdk/index.js"}}\n',
+  });
+  await touchProjectFiles(
+    tmp,
+    [
+      DIST_PLUGIN_SDK_ROOT_ALIAS,
+      DIST_CHANNEL_CATALOG,
+      DIST_LEGACY_CLI_EXIT_COMPAT,
+      DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
+      DIST_OPENCLAW_ALIAS_PACKAGE,
+    ],
+    BUILD_TIME,
+  );
 }
 
 function expectedBuildSpawn() {
@@ -1785,6 +1810,48 @@ describe("run-node script", () => {
         reason: "missing_runtime_postbuild_output",
       });
     });
+  });
+
+  it("reports missing core runtime postbuild outputs when runtime stamps match HEAD", async () => {
+    for (const missingPath of [
+      DIST_PLUGIN_SDK_ROOT_ALIAS,
+      DIST_CHANNEL_CATALOG,
+      DIST_LEGACY_CLI_EXIT_COMPAT,
+      DIST_STABLE_ROOT_RUNTIME_ALIAS,
+    ]) {
+      await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+        await setupTrackedProject(tmp, {
+          files: {
+            [ROOT_SRC]: "export const value = 1;\n",
+            [DIST_STABLE_ROOT_RUNTIME_SOURCE]: "export const value = 1;\n",
+            [DIST_STABLE_ROOT_RUNTIME_ALIAS]:
+              "export * from './model-catalog.runtime-AbCd1234.js';\n",
+            [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+          },
+          buildPaths: [
+            ROOT_SRC,
+            DIST_ENTRY,
+            DIST_STABLE_ROOT_RUNTIME_SOURCE,
+            DIST_STABLE_ROOT_RUNTIME_ALIAS,
+            BUILD_STAMP,
+            RUNTIME_POSTBUILD_STAMP,
+          ],
+        });
+        await fs.rm(resolvePath(tmp, missingPath));
+
+        const requirement = resolveRuntimePostBuildRequirement(
+          createBuildRequirementDeps(tmp, {
+            gitHead: "abc123\n",
+            gitStatus: "",
+          }),
+        );
+
+        expect(requirement).toEqual({
+          shouldSync: true,
+          reason: "missing_runtime_postbuild_output",
+        });
+      });
+    }
   });
 
   it("reports missing runtime skill outputs even when stamps match HEAD", async () => {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -29,6 +29,7 @@ const GENERATED_PLUGIN_ASSET_BUNDLE_HASH = "extensions/demo/src/host/assets/.bun
 const DIST_ENTRY = "dist/entry.js";
 const BUILD_STAMP = `dist/${BUILD_STAMP_FILE}`;
 const RUNTIME_POSTBUILD_STAMP = `dist/${RUNTIME_POSTBUILD_STAMP_FILE}`;
+const DIST_PLUGIN_SDK_INDEX = "dist/plugin-sdk/index.js";
 const QA_LAB_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-lab.js";
 const QA_RUNTIME_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-runtime.js";
 const EXTENSION_INDEX = bundledPluginFile("demo", "index.ts");
@@ -46,6 +47,9 @@ const DIST_RUNTIME_EXTENSION_INDEX = "dist-runtime/extensions/demo/index.js";
 const DIST_RUNTIME_EXTENSION_MANIFEST = "dist-runtime/extensions/demo/openclaw.plugin.json";
 const DIST_RUNTIME_EXTENSION_PACKAGE = "dist-runtime/extensions/demo/package.json";
 const DIST_RUNTIME_EXTENSION_SKILL = "dist-runtime/extensions/demo/skills/SKILL.md";
+const DIST_OPENCLAW_ALIAS_PACKAGE = "dist/extensions/node_modules/openclaw/package.json";
+const DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX =
+  "dist/extensions/node_modules/openclaw/plugin-sdk/index.js";
 const DIST_EXTENSION_MANIFEST = bundledDistPluginFile("demo", "openclaw.plugin.json");
 const DIST_EXTENSION_PACKAGE = bundledDistPluginFile("demo", "package.json");
 
@@ -1668,6 +1672,44 @@ describe("run-node script", () => {
         ],
       });
       await fs.rm(resolvePath(tmp, DIST_EXTENSION_PACKAGE));
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
+  it("reports missing OpenClaw SDK alias outputs when runtime stamps match HEAD", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_PLUGIN_SDK_INDEX]: "export * from './core.js';\n",
+          [DIST_OPENCLAW_ALIAS_PACKAGE]:
+            '{"name":"openclaw","type":"module","exports":{"./plugin-sdk":"./plugin-sdk/index.js"}}\n',
+          [DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX]:
+            "export * from '../../../../plugin-sdk/index.js';\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          DIST_ENTRY,
+          DIST_PLUGIN_SDK_INDEX,
+          DIST_OPENCLAW_ALIAS_PACKAGE,
+          DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX));
 
       const requirement = resolveRuntimePostBuildRequirement(
         createBuildRequirementDeps(tmp, {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -35,7 +35,10 @@ const DIST_CHANNEL_CATALOG = "dist/channel-catalog.json";
 const DIST_LEGACY_CLI_EXIT_COMPAT = "dist/memory-state-CcqRgDZU.js";
 const DIST_LEGACY_CLI_EXIT_COMPAT_ALT = "dist/memory-state-DwGdReW4.js";
 const DIST_STABLE_ROOT_RUNTIME_SOURCE = "dist/model-catalog.runtime-AbCd1234.js";
+const DIST_STABLE_ROOT_RUNTIME_SOURCE_ALT = "dist/model-catalog.runtime-EfGh5678.js";
 const DIST_STABLE_ROOT_RUNTIME_ALIAS = "dist/model-catalog.runtime.js";
+const DIST_LEGACY_ROOT_RUNTIME_TARGET = "dist/abort.runtime.js";
+const DIST_LEGACY_ROOT_RUNTIME_COMPAT = "dist/abort.runtime-DX6vo4yJ.js";
 const QA_LAB_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-lab.js";
 const QA_RUNTIME_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-runtime.js";
 const EXTENSION_INDEX = bundledPluginFile("demo", "index.ts");
@@ -1911,6 +1914,7 @@ describe("run-node script", () => {
       DIST_CHANNEL_CATALOG,
       DIST_LEGACY_CLI_EXIT_COMPAT,
       DIST_STABLE_ROOT_RUNTIME_ALIAS,
+      DIST_LEGACY_ROOT_RUNTIME_COMPAT,
     ]) {
       await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
         await setupTrackedProject(tmp, {
@@ -1919,6 +1923,8 @@ describe("run-node script", () => {
             [DIST_STABLE_ROOT_RUNTIME_SOURCE]: "export const value = 1;\n",
             [DIST_STABLE_ROOT_RUNTIME_ALIAS]:
               "export * from './model-catalog.runtime-AbCd1234.js';\n",
+            [DIST_LEGACY_ROOT_RUNTIME_TARGET]: "export const aborted = true;\n",
+            [DIST_LEGACY_ROOT_RUNTIME_COMPAT]: "export * from './abort.runtime.js';\n",
             [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
           },
           buildPaths: [
@@ -1926,6 +1932,8 @@ describe("run-node script", () => {
             DIST_ENTRY,
             DIST_STABLE_ROOT_RUNTIME_SOURCE,
             DIST_STABLE_ROOT_RUNTIME_ALIAS,
+            DIST_LEGACY_ROOT_RUNTIME_TARGET,
+            DIST_LEGACY_ROOT_RUNTIME_COMPAT,
             BUILD_STAMP,
             RUNTIME_POSTBUILD_STAMP,
           ],
@@ -1945,6 +1953,39 @@ describe("run-node script", () => {
         });
       });
     }
+  });
+
+  it("does not require ambiguous stable runtime aliases that postbuild cannot create", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_STABLE_ROOT_RUNTIME_SOURCE]: "export const value = 1;\n",
+          [DIST_STABLE_ROOT_RUNTIME_SOURCE_ALT]: "export const value = 2;\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          DIST_ENTRY,
+          DIST_STABLE_ROOT_RUNTIME_SOURCE,
+          DIST_STABLE_ROOT_RUNTIME_SOURCE_ALT,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: false,
+        reason: "clean",
+      });
+    });
   });
 
   it("reports missing runtime skill outputs even when stamps match HEAD", async () => {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -569,9 +569,21 @@ describe("run-node script", () => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_PLUGIN_SDK_ROOT_ALIAS]: "module.exports = {};\n",
+          [DIST_CHANNEL_CATALOG]: '{"entries":[]}\n',
+          [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
+          [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]:
+            "export function hasMemoryRuntime() { return false; }\n",
         },
         oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
-        buildPaths: [DIST_ENTRY, BUILD_STAMP],
+        buildPaths: [
+          DIST_ENTRY,
+          DIST_PLUGIN_SDK_ROOT_ALIAS,
+          DIST_CHANNEL_CATALOG,
+          DIST_LEGACY_CLI_EXIT_COMPAT,
+          DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
+          BUILD_STAMP,
+        ],
       });
       const profileDir = path.join(tmp, ".artifacts", "profiles");
       const spawnCalls: Array<{ args: string[]; env: Record<string, string | undefined> }> = [];
@@ -898,6 +910,46 @@ describe("run-node script", () => {
       expect(exitCode).toBe(0);
       expect(spawnCalls).toEqual([statusCommandSpawn()]);
       expect(runRuntimePostBuild).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reruns runtime postbuild in watch mode when required outputs are missing with no runtime stamp", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_PLUGIN_SDK_ROOT_ALIAS]: "module.exports = {};\n",
+          [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
+          [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]:
+            "export function hasMemoryRuntime() { return false; }\n",
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+        buildPaths: [
+          DIST_ENTRY,
+          DIST_PLUGIN_SDK_ROOT_ALIAS,
+          DIST_LEGACY_CLI_EXIT_COMPAT,
+          DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
+          BUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, DIST_OPENCLAW_ALIAS_PACKAGE));
+
+      const runRuntimePostBuild = vi.fn();
+      const { spawnCalls, spawn, spawnSync } = createSpawnRecorder({
+        gitHead: "abc123\n",
+        gitStatus: "",
+      });
+      const exitCode = await runStatusCommand({
+        tmp,
+        spawn,
+        spawnSync,
+        env: { OPENCLAW_WATCH_MODE: "1" },
+        runRuntimePostBuild,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(spawnCalls).toEqual([statusCommandSpawn()]);
+      expect(runRuntimePostBuild).toHaveBeenCalledOnce();
     });
   });
 
@@ -1718,6 +1770,47 @@ describe("run-node script", () => {
       expect(requirement).toEqual({
         shouldSync: true,
         reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
+  it("does not require OpenClaw SDK alias outputs when dist extensions are absent", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_PLUGIN_SDK_INDEX]: "export * from './core.js';\n",
+          [DIST_PLUGIN_SDK_ROOT_ALIAS]: "module.exports = {};\n",
+          [DIST_CHANNEL_CATALOG]: '{"entries":[]}\n',
+          [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
+          [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]:
+            "export function hasMemoryRuntime() { return false; }\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          DIST_ENTRY,
+          DIST_PLUGIN_SDK_INDEX,
+          DIST_PLUGIN_SDK_ROOT_ALIAS,
+          DIST_CHANNEL_CATALOG,
+          DIST_LEGACY_CLI_EXIT_COMPAT,
+          DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(path.join(tmp, "dist", "extensions"), { recursive: true, force: true });
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: false,
+        reason: "clean",
       });
     });
   });

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -31,10 +31,21 @@ const BUILD_STAMP = `dist/${BUILD_STAMP_FILE}`;
 const RUNTIME_POSTBUILD_STAMP = `dist/${RUNTIME_POSTBUILD_STAMP_FILE}`;
 const QA_LAB_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-lab.js";
 const QA_RUNTIME_PLUGIN_SDK_ENTRY = "dist/plugin-sdk/qa-runtime.js";
+const EXTENSION_INDEX = bundledPluginFile("demo", "index.ts");
 const EXTENSION_SRC = bundledPluginFile("demo", "src/index.ts");
+const EXTENSION_EXTRA_SRC = bundledPluginFile("demo", "src/extra.ts");
+const EXTENSION_SKILL = bundledPluginFile("demo", "skills/SKILL.md");
 const EXTENSION_MANIFEST = bundledPluginFile("demo", "openclaw.plugin.json");
 const EXTENSION_PACKAGE = bundledPluginFile("demo", "package.json");
 const EXTENSION_README = bundledPluginFile("demo", "README.md");
+const DIST_EXTENSION_INDEX = bundledDistPluginFile("demo", "index.js");
+const DIST_EXTENSION_SRC = bundledDistPluginFile("demo", "src/index.js");
+const DIST_EXTENSION_SKILL = bundledDistPluginFile("demo", "skills/SKILL.md");
+const DIST_EXTENSION_RUNTIME_SRC = "dist-runtime/extensions/demo/src/index.js";
+const DIST_RUNTIME_EXTENSION_INDEX = "dist-runtime/extensions/demo/index.js";
+const DIST_RUNTIME_EXTENSION_MANIFEST = "dist-runtime/extensions/demo/openclaw.plugin.json";
+const DIST_RUNTIME_EXTENSION_PACKAGE = "dist-runtime/extensions/demo/package.json";
+const DIST_RUNTIME_EXTENSION_SKILL = "dist-runtime/extensions/demo/skills/SKILL.md";
 const DIST_EXTENSION_MANIFEST = bundledDistPluginFile("demo", "openclaw.plugin.json");
 const DIST_EXTENSION_PACKAGE = bundledDistPluginFile("demo", "package.json");
 
@@ -1013,12 +1024,16 @@ describe("run-node script", () => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_INDEX]: "export default {};\n",
           [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
           [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
         },
         buildPaths: [
           ROOT_SRC,
+          EXTENSION_INDEX,
           EXTENSION_MANIFEST,
+          DIST_EXTENSION_INDEX,
           ROOT_TSCONFIG,
           ROOT_PACKAGE,
           DIST_ENTRY,
@@ -1285,13 +1300,15 @@ describe("run-node script", () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
         files: {
+          [EXTENSION_INDEX]: "export default {};\n",
           [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
           [EXTENSION_PACKAGE]: '{"name":"demo","openclaw":{"extensions":["./index.ts"]}}\n',
           [ROOT_TSDOWN]: "export default {};\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
           [DIST_EXTENSION_PACKAGE]: '{"name":"demo","openclaw":{"extensions":["./stale.js"]}}\n',
         },
-        oldPaths: [EXTENSION_MANIFEST, ROOT_TSCONFIG, ROOT_PACKAGE, ROOT_TSDOWN],
-        buildPaths: [DIST_ENTRY, BUILD_STAMP, DIST_EXTENSION_PACKAGE],
+        oldPaths: [EXTENSION_INDEX, EXTENSION_MANIFEST, ROOT_TSCONFIG, ROOT_PACKAGE, ROOT_TSDOWN],
+        buildPaths: [DIST_ENTRY, BUILD_STAMP, DIST_EXTENSION_INDEX, DIST_EXTENSION_PACKAGE],
         newPaths: [EXTENSION_PACKAGE],
       });
 
@@ -1341,18 +1358,22 @@ describe("run-node script", () => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_INDEX]: "export default {};\n",
           [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
           [ROOT_TSDOWN]: "export default {};\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
           [DIST_EXTENSION_MANIFEST]: '{"id":"stale","configSchema":{"type":"object"}}\n',
         },
         buildPaths: [
           ROOT_SRC,
+          EXTENSION_INDEX,
           EXTENSION_MANIFEST,
           ROOT_TSCONFIG,
           ROOT_PACKAGE,
           ROOT_TSDOWN,
           DIST_ENTRY,
           BUILD_STAMP,
+          DIST_EXTENSION_INDEX,
           DIST_EXTENSION_MANIFEST,
         ],
       });
@@ -1451,6 +1472,144 @@ describe("run-node script", () => {
     });
   });
 
+  it("reports clean in sparse worktrees without bundled plugin sources", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+        buildPaths: [DIST_ENTRY, BUILD_STAMP],
+      });
+      await fs.rm(resolvePath(tmp, "extensions"), { recursive: true, force: true });
+
+      const requirement = resolveBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldBuild: false,
+        reason: "clean",
+      });
+    });
+  });
+
+  it("rebuilds when dirty bundled package entries point at missing dist outputs", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_SRC]: "export default {};\n",
+          [EXTENSION_EXTRA_SRC]: "export const extra = true;\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.ts","./src/extra.ts"]}}\n',
+          [DIST_EXTENSION_SRC]: "export default {};\n",
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_SRC,
+          EXTENSION_EXTRA_SRC,
+          EXTENSION_MANIFEST,
+          EXTENSION_PACKAGE,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          DIST_EXTENSION_SRC,
+          BUILD_STAMP,
+        ],
+      });
+
+      const requirement = resolveBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: ` M ${EXTENSION_PACKAGE}\n`,
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldBuild: true,
+        reason: "dirty_watched_tree",
+      });
+    });
+  });
+
+  it("rebuilds when clean bundled plugin dist outputs are partially missing", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_SRC]: "export default {};\n",
+          [EXTENSION_EXTRA_SRC]: "export const extra = true;\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.ts","./src/extra.ts"]}}\n',
+          [DIST_EXTENSION_SRC]: "export default {};\n",
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_SRC,
+          EXTENSION_EXTRA_SRC,
+          EXTENSION_MANIFEST,
+          EXTENSION_PACKAGE,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          DIST_EXTENSION_SRC,
+          BUILD_STAMP,
+        ],
+      });
+
+      const requirement = resolveBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldBuild: true,
+        reason: "missing_bundled_plugin_dist_entry",
+      });
+    });
+  });
+
+  it("rebuilds when a clean stamped bundled plugin dist directory is missing", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_SRC]: "export default {};\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.ts"]}}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_SRC,
+          EXTENSION_MANIFEST,
+          EXTENSION_PACKAGE,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          BUILD_STAMP,
+        ],
+      });
+
+      const requirement = resolveBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldBuild: true,
+        reason: "missing_bundled_plugin_dist_entry",
+      });
+    });
+  });
+
   it("reports clean runtime postbuild artifacts when the runtime stamp matches HEAD", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
@@ -1476,17 +1635,117 @@ describe("run-node script", () => {
     });
   });
 
+  it("reports missing runtime postbuild outputs even when stamps match HEAD", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_SRC]: "export default {};\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.ts"]}}\n',
+          [DIST_EXTENSION_SRC]: "export default {};\n",
+          [DIST_EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [DIST_EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.js"]}}\n',
+          [DIST_EXTENSION_RUNTIME_SRC]: "export default {};\n",
+          [DIST_RUNTIME_EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [DIST_RUNTIME_EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./src/index.js"]}}\n',
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_SRC,
+          EXTENSION_MANIFEST,
+          EXTENSION_PACKAGE,
+          DIST_ENTRY,
+          DIST_EXTENSION_SRC,
+          DIST_EXTENSION_MANIFEST,
+          DIST_EXTENSION_PACKAGE,
+          DIST_EXTENSION_RUNTIME_SRC,
+          DIST_RUNTIME_EXTENSION_MANIFEST,
+          DIST_RUNTIME_EXTENSION_PACKAGE,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, DIST_EXTENSION_PACKAGE));
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
+  it("reports missing runtime skill outputs even when stamps match HEAD", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_INDEX]: "export default {};\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","skills":["./skills/SKILL.md"]}\n',
+          [EXTENSION_SKILL]: "# Demo\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_EXTENSION_MANIFEST]: '{"id":"demo","skills":["./skills/SKILL.md"]}\n',
+          [DIST_EXTENSION_SKILL]: "# Demo\n",
+          [DIST_RUNTIME_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_RUNTIME_EXTENSION_MANIFEST]: '{"id":"demo","skills":["./skills/SKILL.md"]}\n',
+          [DIST_RUNTIME_EXTENSION_SKILL]: "# Demo\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_INDEX,
+          EXTENSION_MANIFEST,
+          EXTENSION_SKILL,
+          DIST_ENTRY,
+          DIST_EXTENSION_INDEX,
+          DIST_EXTENSION_MANIFEST,
+          DIST_EXTENSION_SKILL,
+          DIST_RUNTIME_EXTENSION_INDEX,
+          DIST_RUNTIME_EXTENSION_MANIFEST,
+          DIST_RUNTIME_EXTENSION_SKILL,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, DIST_RUNTIME_EXTENSION_SKILL));
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
   it("reports dirty runtime postbuild inputs separately from rebuild inputs", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_INDEX]: "export default {};\n",
           [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
           [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
         },
         buildPaths: [
           ROOT_SRC,
+          EXTENSION_INDEX,
           EXTENSION_MANIFEST,
+          DIST_EXTENSION_INDEX,
           ROOT_TSCONFIG,
           ROOT_PACKAGE,
           DIST_ENTRY,
@@ -1535,21 +1794,58 @@ describe("run-node script", () => {
     });
   });
 
+  it("reports bundled skill edits as runtime postbuild inputs", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_MANIFEST]: '{"id":"demo","skills":["./skills/SKILL.md"]}\n',
+          [EXTENSION_SKILL]: "# Demo\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          EXTENSION_MANIFEST,
+          EXTENSION_SKILL,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+
+      const deps = createBuildRequirementDeps(tmp, {
+        gitHead: "abc123\n",
+        gitStatus: ` M ${EXTENSION_SKILL}\n`,
+      });
+
+      expect(resolveRuntimePostBuildRequirement(deps)).toEqual({
+        shouldSync: true,
+        reason: "dirty_runtime_postbuild_inputs",
+      });
+    });
+  });
+
   it("repairs missing bundled plugin metadata without rerunning tsdown", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [EXTENSION_INDEX]: "export default {};\n",
           [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
           [ROOT_TSDOWN]: "export default {};\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
         },
         buildPaths: [
           ROOT_SRC,
+          EXTENSION_INDEX,
           EXTENSION_MANIFEST,
           ROOT_TSCONFIG,
           ROOT_PACKAGE,
           ROOT_TSDOWN,
           DIST_ENTRY,
+          DIST_EXTENSION_INDEX,
           BUILD_STAMP,
         ],
       });

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1777,6 +1777,49 @@ describe("run-node script", () => {
     });
   });
 
+  it("reports missing runtime overlay outputs from restored dist without plugin sources", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [DIST_EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./index.js"]}}\n',
+          [DIST_RUNTIME_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_RUNTIME_EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
+          [DIST_RUNTIME_EXTENSION_PACKAGE]: '{"openclaw":{"extensions":["./index.js"]}}\n',
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          DIST_ENTRY,
+          DIST_EXTENSION_INDEX,
+          DIST_EXTENSION_MANIFEST,
+          DIST_EXTENSION_PACKAGE,
+          DIST_RUNTIME_EXTENSION_INDEX,
+          DIST_RUNTIME_EXTENSION_MANIFEST,
+          DIST_RUNTIME_EXTENSION_PACKAGE,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, "extensions"), { recursive: true, force: true });
+      await fs.rm(resolvePath(tmp, DIST_RUNTIME_EXTENSION_INDEX));
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
   it("does not require OpenClaw SDK alias outputs when dist extensions are absent", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -59,16 +59,10 @@ const DIST_RUNTIME_EXTENSION_SKILL = "dist-runtime/extensions/demo/skills/SKILL.
 const DIST_OPENCLAW_ALIAS_PACKAGE = "dist/extensions/node_modules/openclaw/package.json";
 const DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX =
   "dist/extensions/node_modules/openclaw/plugin-sdk/index.js";
-const ACPX_PACKAGE = "extensions/acpx/package.json";
-const ACPX_MCP_PROXY_SOURCE = "extensions/acpx/src/runtime-internals/mcp-proxy.mjs";
-const DIST_ACPX_MCP_PROXY = "dist/extensions/acpx/mcp-proxy.mjs";
-const ACPX_ERROR_FORMAT_SOURCE = "extensions/acpx/src/runtime-internals/error-format.mjs";
-const DIST_ACPX_ERROR_FORMAT = "dist/extensions/acpx/error-format.mjs";
-const ACPX_MCP_COMMAND_LINE_SOURCE = "extensions/acpx/src/runtime-internals/mcp-command-line.mjs";
-const DIST_ACPX_MCP_COMMAND_LINE = "dist/extensions/acpx/mcp-command-line.mjs";
 const DIFFS_PACKAGE = "extensions/diffs/package.json";
 const DIFFS_VIEWER_RUNTIME_SOURCE = "extensions/diffs/assets/viewer-runtime.js";
 const DIST_DIFFS_VIEWER_RUNTIME = "dist/extensions/diffs/assets/viewer-runtime.js";
+const DIST_RUNTIME_DIFFS_VIEWER_RUNTIME = "dist-runtime/extensions/diffs/assets/viewer-runtime.js";
 const DIST_EXTENSION_MANIFEST = bundledDistPluginFile("demo", "openclaw.plugin.json");
 const DIST_EXTENSION_PACKAGE = bundledDistPluginFile("demo", "package.json");
 
@@ -1904,38 +1898,25 @@ describe("run-node script", () => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
-          [ACPX_PACKAGE]:
-            '{"openclaw":{"build":{"staticAssets":[{"source":"./src/runtime-internals/mcp-proxy.mjs","output":"mcp-proxy.mjs"},{"source":"./src/runtime-internals/error-format.mjs","output":"error-format.mjs"},{"source":"./src/runtime-internals/mcp-command-line.mjs","output":"mcp-command-line.mjs"}]}}}\n',
-          [ACPX_MCP_PROXY_SOURCE]: "export {};\n",
-          [DIST_ACPX_MCP_PROXY]: "export {};\n",
-          [ACPX_ERROR_FORMAT_SOURCE]: "export {};\n",
-          [DIST_ACPX_ERROR_FORMAT]: "export {};\n",
-          [ACPX_MCP_COMMAND_LINE_SOURCE]: "export {};\n",
-          [DIST_ACPX_MCP_COMMAND_LINE]: "export {};\n",
           [DIFFS_PACKAGE]:
             '{"openclaw":{"build":{"staticAssets":[{"source":"./assets/viewer-runtime.js","output":"assets/viewer-runtime.js"}]}}}\n',
           [DIFFS_VIEWER_RUNTIME_SOURCE]: "export {};\n",
           [DIST_DIFFS_VIEWER_RUNTIME]: "export {};\n",
+          [DIST_RUNTIME_DIFFS_VIEWER_RUNTIME]: "export {};\n",
           [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
         },
         buildPaths: [
           ROOT_SRC,
-          ACPX_PACKAGE,
-          ACPX_MCP_PROXY_SOURCE,
-          DIST_ACPX_MCP_PROXY,
-          ACPX_ERROR_FORMAT_SOURCE,
-          DIST_ACPX_ERROR_FORMAT,
-          ACPX_MCP_COMMAND_LINE_SOURCE,
-          DIST_ACPX_MCP_COMMAND_LINE,
           DIFFS_PACKAGE,
           DIFFS_VIEWER_RUNTIME_SOURCE,
           DIST_DIFFS_VIEWER_RUNTIME,
+          DIST_RUNTIME_DIFFS_VIEWER_RUNTIME,
           DIST_ENTRY,
           BUILD_STAMP,
           RUNTIME_POSTBUILD_STAMP,
         ],
       });
-      await fs.rm(resolvePath(tmp, DIST_ACPX_MCP_COMMAND_LINE));
+      await fs.rm(resolvePath(tmp, DIST_DIFFS_VIEWER_RUNTIME));
 
       const requirement = resolveRuntimePostBuildRequirement(
         createBuildRequirementDeps(tmp, {
@@ -1947,6 +1928,32 @@ describe("run-node script", () => {
       expect(requirement).toEqual({
         shouldSync: true,
         reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
+  it("does not require static asset outputs when the declared source is absent", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [DIFFS_PACKAGE]:
+            '{"openclaw":{"build":{"staticAssets":[{"source":"./assets/viewer-runtime.js","output":"assets/viewer-runtime.js"}]}}}\n',
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [ROOT_SRC, DIFFS_PACKAGE, DIST_ENTRY, BUILD_STAMP, RUNTIME_POSTBUILD_STAMP],
+      });
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: false,
+        reason: "clean",
       });
     });
   });

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -50,8 +50,14 @@ const DIST_RUNTIME_EXTENSION_SKILL = "dist-runtime/extensions/demo/skills/SKILL.
 const DIST_OPENCLAW_ALIAS_PACKAGE = "dist/extensions/node_modules/openclaw/package.json";
 const DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX =
   "dist/extensions/node_modules/openclaw/plugin-sdk/index.js";
+const ACPX_PACKAGE = "extensions/acpx/package.json";
 const ACPX_MCP_PROXY_SOURCE = "extensions/acpx/src/runtime-internals/mcp-proxy.mjs";
 const DIST_ACPX_MCP_PROXY = "dist/extensions/acpx/mcp-proxy.mjs";
+const ACPX_ERROR_FORMAT_SOURCE = "extensions/acpx/src/runtime-internals/error-format.mjs";
+const DIST_ACPX_ERROR_FORMAT = "dist/extensions/acpx/error-format.mjs";
+const ACPX_MCP_COMMAND_LINE_SOURCE = "extensions/acpx/src/runtime-internals/mcp-command-line.mjs";
+const DIST_ACPX_MCP_COMMAND_LINE = "dist/extensions/acpx/mcp-command-line.mjs";
+const DIFFS_PACKAGE = "extensions/diffs/package.json";
 const DIFFS_VIEWER_RUNTIME_SOURCE = "extensions/diffs/assets/viewer-runtime.js";
 const DIST_DIFFS_VIEWER_RUNTIME = "dist/extensions/diffs/assets/viewer-runtime.js";
 const DIST_EXTENSION_MANIFEST = bundledDistPluginFile("demo", "openclaw.plugin.json");
@@ -1734,16 +1740,30 @@ describe("run-node script", () => {
       await setupTrackedProject(tmp, {
         files: {
           [ROOT_SRC]: "export const value = 1;\n",
+          [ACPX_PACKAGE]:
+            '{"openclaw":{"build":{"staticAssets":[{"source":"./src/runtime-internals/mcp-proxy.mjs","output":"mcp-proxy.mjs"},{"source":"./src/runtime-internals/error-format.mjs","output":"error-format.mjs"},{"source":"./src/runtime-internals/mcp-command-line.mjs","output":"mcp-command-line.mjs"}]}}}\n',
           [ACPX_MCP_PROXY_SOURCE]: "export {};\n",
           [DIST_ACPX_MCP_PROXY]: "export {};\n",
+          [ACPX_ERROR_FORMAT_SOURCE]: "export {};\n",
+          [DIST_ACPX_ERROR_FORMAT]: "export {};\n",
+          [ACPX_MCP_COMMAND_LINE_SOURCE]: "export {};\n",
+          [DIST_ACPX_MCP_COMMAND_LINE]: "export {};\n",
+          [DIFFS_PACKAGE]:
+            '{"openclaw":{"build":{"staticAssets":[{"source":"./assets/viewer-runtime.js","output":"assets/viewer-runtime.js"}]}}}\n',
           [DIFFS_VIEWER_RUNTIME_SOURCE]: "export {};\n",
           [DIST_DIFFS_VIEWER_RUNTIME]: "export {};\n",
           [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
         },
         buildPaths: [
           ROOT_SRC,
+          ACPX_PACKAGE,
           ACPX_MCP_PROXY_SOURCE,
           DIST_ACPX_MCP_PROXY,
+          ACPX_ERROR_FORMAT_SOURCE,
+          DIST_ACPX_ERROR_FORMAT,
+          ACPX_MCP_COMMAND_LINE_SOURCE,
+          DIST_ACPX_MCP_COMMAND_LINE,
+          DIFFS_PACKAGE,
           DIFFS_VIEWER_RUNTIME_SOURCE,
           DIST_DIFFS_VIEWER_RUNTIME,
           DIST_ENTRY,
@@ -1751,7 +1771,7 @@ describe("run-node script", () => {
           RUNTIME_POSTBUILD_STAMP,
         ],
       });
-      await fs.rm(resolvePath(tmp, DIST_ACPX_MCP_PROXY));
+      await fs.rm(resolvePath(tmp, DIST_ACPX_MCP_COMMAND_LINE));
 
       const requirement = resolveRuntimePostBuildRequirement(
         createBuildRequirementDeps(tmp, {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -50,6 +50,10 @@ const DIST_RUNTIME_EXTENSION_SKILL = "dist-runtime/extensions/demo/skills/SKILL.
 const DIST_OPENCLAW_ALIAS_PACKAGE = "dist/extensions/node_modules/openclaw/package.json";
 const DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX =
   "dist/extensions/node_modules/openclaw/plugin-sdk/index.js";
+const ACPX_MCP_PROXY_SOURCE = "extensions/acpx/src/runtime-internals/mcp-proxy.mjs";
+const DIST_ACPX_MCP_PROXY = "dist/extensions/acpx/mcp-proxy.mjs";
+const DIFFS_VIEWER_RUNTIME_SOURCE = "extensions/diffs/assets/viewer-runtime.js";
+const DIST_DIFFS_VIEWER_RUNTIME = "dist/extensions/diffs/assets/viewer-runtime.js";
 const DIST_EXTENSION_MANIFEST = bundledDistPluginFile("demo", "openclaw.plugin.json");
 const DIST_EXTENSION_PACKAGE = bundledDistPluginFile("demo", "package.json");
 
@@ -1710,6 +1714,44 @@ describe("run-node script", () => {
         ],
       });
       await fs.rm(resolvePath(tmp, DIST_OPENCLAW_ALIAS_PLUGIN_SDK_INDEX));
+
+      const requirement = resolveRuntimePostBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: "",
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+    });
+  });
+
+  it("reports missing static runtime postbuild asset outputs when runtime stamps match HEAD", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [ACPX_MCP_PROXY_SOURCE]: "export {};\n",
+          [DIST_ACPX_MCP_PROXY]: "export {};\n",
+          [DIFFS_VIEWER_RUNTIME_SOURCE]: "export {};\n",
+          [DIST_DIFFS_VIEWER_RUNTIME]: "export {};\n",
+          [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+        },
+        buildPaths: [
+          ROOT_SRC,
+          ACPX_MCP_PROXY_SOURCE,
+          DIST_ACPX_MCP_PROXY,
+          DIFFS_VIEWER_RUNTIME_SOURCE,
+          DIST_DIFFS_VIEWER_RUNTIME,
+          DIST_ENTRY,
+          BUILD_STAMP,
+          RUNTIME_POSTBUILD_STAMP,
+        ],
+      });
+      await fs.rm(resolvePath(tmp, DIST_ACPX_MCP_PROXY));
 
       const requirement = resolveRuntimePostBuildRequirement(
         createBuildRequirementDeps(tmp, {

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -87,7 +87,7 @@ describe("runtime postbuild static assets", () => {
     expect(await fs.readFile(destPath, "utf8")).toBe("proxy-data\n");
   });
 
-  it("stages copied static assets into the runtime overlay during the same postbuild run", async () => {
+  it("stages copied static assets byte-for-byte during the same postbuild run", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const source = "extensions/diffs/assets/viewer-runtime.js";
     const output = "assets/viewer-runtime.js";
@@ -131,8 +131,8 @@ describe("runtime postbuild static assets", () => {
     await expect(fs.readFile(path.join(rootDir, distAsset), "utf8")).resolves.toBe(
       "export const viewer = true;\n",
     );
-    await expect(fs.readFile(path.join(rootDir, runtimeAsset), "utf8")).resolves.toContain(
-      "dist/extensions/diffs/assets/viewer-runtime.js",
+    await expect(fs.readFile(path.join(rootDir, runtimeAsset), "utf8")).resolves.toBe(
+      "export const viewer = true;\n",
     );
   });
 

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -6,6 +6,7 @@ import {
   copyStaticExtensionAssets,
   listStaticExtensionAssetOutputs,
   rewriteRootRuntimeImportsToStableAliases,
+  runRuntimePostBuild,
   writeLegacyCliExitCompatChunks,
   writeLegacyRootRuntimeCompatAliases,
   writeStableRootRuntimeAliases,
@@ -86,7 +87,56 @@ describe("runtime postbuild static assets", () => {
     expect(await fs.readFile(destPath, "utf8")).toBe("proxy-data\n");
   });
 
-  it("warns when a declared static asset is missing", () => {
+  it("stages copied static assets into the runtime overlay during the same postbuild run", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const source = "extensions/diffs/assets/viewer-runtime.js";
+    const output = "assets/viewer-runtime.js";
+    const distAsset = "dist/extensions/diffs/assets/viewer-runtime.js";
+    const runtimeAsset = "dist-runtime/extensions/diffs/assets/viewer-runtime.js";
+
+    await fs.mkdir(path.join(rootDir, "src", "plugin-sdk"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(rootDir, "extensions", "diffs", "assets"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "extensions", "diffs", "package.json"),
+      JSON.stringify({
+        name: "@openclaw/diffs",
+        openclaw: {
+          extensions: ["./index.ts"],
+          build: {
+            staticAssets: [{ source: `./${output}`, output }],
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "extensions", "diffs", "openclaw.plugin.json"),
+      '{"id":"diffs"}\n',
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, source), "export const viewer = true;\n", "utf8");
+
+    runRuntimePostBuild({
+      cwd: rootDir,
+      repoRoot: rootDir,
+      rootDir,
+      timings: false,
+    });
+
+    await expect(fs.readFile(path.join(rootDir, distAsset), "utf8")).resolves.toBe(
+      "export const viewer = true;\n",
+    );
+    await expect(fs.readFile(path.join(rootDir, runtimeAsset), "utf8")).resolves.toContain(
+      "dist/extensions/diffs/assets/viewer-runtime.js",
+    );
+  });
+
+  it("warns when a declared static asset is missing", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const warn = vi.fn();
 

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -139,6 +139,50 @@ describe("runtime postbuild static assets", () => {
     );
   });
 
+  it("preserves restored dist static assets when plugin sources are absent", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const output = "assets/viewer-runtime.js";
+    const distPluginDir = path.join(rootDir, "dist", "extensions", "diffs");
+    const runtimeAsset = path.join(rootDir, "dist-runtime", "extensions", "diffs", output);
+
+    await fs.mkdir(path.join(rootDir, "src", "plugin-sdk"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(distPluginDir, "assets"), { recursive: true });
+    await fs.writeFile(path.join(distPluginDir, "index.js"), "export default {};\n", "utf8");
+    await fs.writeFile(
+      path.join(distPluginDir, "openclaw.plugin.json"),
+      '{"id":"diffs"}\n',
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distPluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/diffs",
+        openclaw: {
+          extensions: ["./index.js"],
+          build: {
+            staticAssets: [{ source: `./${output}`, output }],
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(distPluginDir, output), "console.log('viewer');\n", "utf8");
+
+    runRuntimePostBuild({
+      cwd: rootDir,
+      repoRoot: rootDir,
+      rootDir,
+      timings: false,
+    });
+
+    await expect(fs.readFile(runtimeAsset, "utf8")).resolves.toBe("console.log('viewer');\n");
+  });
+
   it("skips runtime overlay asset copies when the runtime extension root is absent", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     await fs.mkdir(path.join(rootDir, "extensions", "demo", "assets"), { recursive: true });

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { discoverStaticExtensionAssets } from "../../scripts/lib/static-extension-assets.mjs";
+import {
+  copyStaticExtensionAssetsToRuntimeOverlay,
+  discoverStaticExtensionAssets,
+} from "../../scripts/lib/static-extension-assets.mjs";
 import {
   copyStaticExtensionAssets,
   listStaticExtensionAssetOutputs,
@@ -133,6 +136,75 @@ describe("runtime postbuild static assets", () => {
     );
     await expect(fs.readFile(path.join(rootDir, runtimeAsset), "utf8")).resolves.toBe(
       "export const viewer = true;\n",
+    );
+  });
+
+  it("skips runtime overlay asset copies when the runtime extension root is absent", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    await fs.mkdir(path.join(rootDir, "extensions", "demo", "assets"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "extensions", "demo", "assets", "viewer.js"),
+      "viewer\n",
+      "utf8",
+    );
+
+    copyStaticExtensionAssetsToRuntimeOverlay({
+      rootDir,
+      assets: [
+        {
+          src: "extensions/demo/assets/viewer.js",
+          dest: "dist/extensions/demo/assets/viewer.js",
+        },
+      ],
+    });
+
+    await expectPathMissing(path.join(rootDir, "dist-runtime", "extensions", "demo", "assets"));
+  });
+
+  it("ignores runtime overlay static assets outside dist extensions", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    await fs.mkdir(path.join(rootDir, "dist-runtime", "extensions"), { recursive: true });
+    await fs.mkdir(path.join(rootDir, "extensions", "demo", "assets"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "extensions", "demo", "assets", "viewer.js"),
+      "viewer\n",
+      "utf8",
+    );
+
+    copyStaticExtensionAssetsToRuntimeOverlay({
+      rootDir,
+      assets: [
+        {
+          src: "extensions/demo/assets/viewer.js",
+          dest: "dist/other/demo/assets/viewer.js",
+        },
+      ],
+    });
+
+    await expectPathMissing(path.join(rootDir, "dist-runtime", "other", "demo", "assets"));
+  });
+
+  it("warns when a runtime overlay static asset source is missing", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const warn = vi.fn();
+    await fs.mkdir(path.join(rootDir, "dist-runtime", "extensions"), { recursive: true });
+
+    copyStaticExtensionAssetsToRuntimeOverlay({
+      rootDir,
+      assets: [
+        {
+          src: "extensions/demo/assets/missing.js",
+          dest: "dist/extensions/demo/assets/missing.js",
+        },
+      ],
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[runtime-postbuild] static asset not found, skipping: extensions/demo/assets/missing.js",
+    );
+    await expectPathMissing(
+      path.join(rootDir, "dist-runtime", "extensions", "demo", "assets", "missing.js"),
     );
   });
 


### PR DESCRIPTION
## Summary

- Problem: `pnpm gateway:watch` could trust fresh stamps while required bundled-plugin `dist` files or runtime-postbuild outputs were missing, so the Gateway could launch with an incomplete runtime tree.
- Affected surface: source-checkout Gateway watch launch/relaunch. This is not a Telegram behavior change and not an in-process self-heal for arbitrary artifact deletion after a Gateway child is already running.
- Fix: before launching the Gateway child, `scripts/run-node.mjs` now fails the freshness check when required bundled-plugin dist entries or runtime-postbuild outputs are missing, then rebuilds or restages through the existing watch pipeline.
- Runtime-postbuild scope: `scripts/runtime-postbuild.mjs` now exposes the generated core output set, and declared plugin static assets are copied into both `dist` and `dist-runtime` byte-for-byte after runtime overlay staging.
- Diff-size note: I tested a smaller two-file patch, but local review found it missed static assets and core runtime-postbuild outputs. The current 5-file diff is the smaller correct shape I found; it avoids a new config surface and removes the contributor changelog entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes # N/A (no tracked issue)
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

`gateway:watch` validated source and stamp freshness, but did not prove the generated files it depended on still existed. A partial `dist/` or `dist-runtime/` tree could therefore be considered clean, and the Gateway child could start with missing plugin runtime files.

The observed Telegram startup failure was one symptom of that missing generated-output check:

```text
[telegram] [default] channel exited: Cannot find package 'openclaw' imported from .../dist/extensions/telegram/update-offset-store-*.js
```

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests or files: `src/infra/run-node.test.ts`, `test/scripts/runtime-postbuild.test.ts`
- Scenario the tests lock in: watch/runtime-postbuild freshness now fails closed when required generated outputs are missing, while sparse/restored worktrees do not require unrecoverable source-only outputs.
- Why this is the smallest reliable guardrail: the bug lives at the run-node/runtime-postbuild decision seam, so the tests exercise the same launch decision without requiring a live Telegram token.
- Existing test that already covers this (if any): older run-node tests covered stamp decisions, but not missing generated-output verification.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `pnpm gateway:watch` rebuilds or restages required bundled-plugin/runtime-postbuild artifacts before launching the Gateway when those outputs are missing.
- Declared static plugin assets remain byte-for-byte static files in the runtime overlay instead of being replaced by runtime module wrappers.
- No config, auth, public API, or Telegram product surface changed.

## Diagram (if applicable)

```text
N/A
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw source checkout, Node 22, pnpm
- Integration/channel (if any): Gateway watch; Telegram was the observed symptom, but live proof does not require a Telegram token
- Relevant config (redacted): isolated temp `HOME`/`OPENCLAW_HOME`, Gateway watch with nonessential background services disabled for the proof run

### Steps

1. Start from a stamped source checkout.
2. Remove a required bundled-plugin `dist` entry or a required `dist-runtime` output.
3. Launch the real Gateway through `node scripts/watch-node.mjs gateway --force --allow-unconfigured --port <port> --token watch-proof-token`.
4. Check whether watch mode rebuilds/restages before the Gateway reports ready.

### Expected

The runner rebuilds or restages required outputs before the Gateway child starts with incomplete bundled-plugin/runtime-postbuild artifacts.

### Actual Before Fix

Current `origin/main` could launch the Gateway without rebuilding/restaging and leave the removed artifacts missing.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation on the rebased head (`origin/main` at `e7d5e7eb2b`, PR head `cd9dc83b24`):

- `pnpm docs:list`
- Read relevant docs: `docs/reference/test.md`, `docs/ci.md`, `docs/cli/gateway.md`
- `pnpm exec oxfmt --check --threads=1 scripts/run-node.mjs src/infra/run-node.test.ts scripts/lib/static-extension-assets.mjs scripts/runtime-postbuild.mjs test/scripts/runtime-postbuild.test.ts`
- `pnpm test src/infra/run-node.test.ts test/scripts/runtime-postbuild.test.ts` (`58` run-node tests, `22` runtime-postbuild tests)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/run-node.test.ts --coverage.enabled=true --coverage.include=scripts/run-node.mjs --coverage.reporter=text --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --coverage.thresholds.statements=0`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/runtime-postbuild.test.ts --coverage.enabled=true --coverage.include=scripts/runtime-postbuild.mjs --coverage.include=scripts/lib/static-extension-assets.mjs --coverage.reporter=text --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --coverage.thresholds.statements=0`
- `git diff --check origin/main`
- `codex review --base origin/main` after the final rebase: no actionable regressions found

Live Gateway proof after the final rebase, artifact dir `.artifacts/pr-70805-live-proof-20260509083947`:

```text
PASS missing-plugin-dist reason=missing_bundled_plugin_dist_entry port=64468 log=.artifacts/pr-70805-live-proof-20260509083947/missing-plugin-dist.log
PASS missing-plugin-runtime reason=missing_runtime_postbuild_output port=64480 log=.artifacts/pr-70805-live-proof-20260509083947/missing-plugin-runtime.log
PASS missing-static-runtime reason=missing_runtime_postbuild_output port=64491 log=.artifacts/pr-70805-live-proof-20260509083947/missing-static-runtime.log
static_runtime_byte_match=yes
telegram_dist_restored=yes
telegram_runtime_restored=yes
```

Relevant live log lines:

```text
missing-plugin-dist.log: [openclaw] Building TypeScript (dist is stale: missing_bundled_plugin_dist_entry - bundled plugin dist entry missing).
missing-plugin-dist.log: [gateway] http server listening (0 plugins, 0.6s)
missing-plugin-runtime.log: [openclaw] Syncing runtime artifacts (missing_runtime_postbuild_output - required runtime postbuild output missing).
missing-plugin-runtime.log: [gateway] http server listening (0 plugins, 0.5s)
missing-static-runtime.log: [openclaw] Syncing runtime artifacts (missing_runtime_postbuild_output - required runtime postbuild output missing).
```

## Human Verification (required)

- Verified scenarios: checked the reported Telegram failure path against the watch-mode/runtime-postbuild launch decision, then live-ran the Gateway with missing bundled-plugin dist/runtime artifacts on the rebased PR head.
- Edge cases checked: missing static assets, byte-for-byte static asset staging into `dist-runtime`, missing root runtime compatibility aliases, ambiguous stable runtime aliases, missing bundled skills/runtime overlay files, missing OpenClaw extension alias outputs, and sparse/restored worktrees where plugin sources are absent but `dist/extensions` can restage `dist-runtime`.
- User manual verification: owner performs final manual verification outside this agent run.
- Broad validation: GitHub PR CI on the latest pushed head.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] No unresolved review threads remain.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: runtime-postbuild could trigger more often in watch mode for partially stale bundled-plugin outputs.
- Mitigation: the new checks are constrained to required generated outputs and covered by targeted run-node tests.
- Risk: static JavaScript assets in `dist-runtime` could be treated like runtime modules.
- Mitigation: runtime-postbuild copies declared static assets into the runtime overlay byte-for-byte after staging, and `test/scripts/runtime-postbuild.test.ts` covers that path.


## Real behavior proof

- Behavior or issue addressed: watch-mode runtime-postbuild staging now treats missing bundled-plugin/runtime-postbuild outputs as rebuild/restage blockers instead of launching the Gateway with incomplete plugin runtime artifacts.
- Real environment tested: macOS local OpenClaw source checkout, Node 22, pnpm, live Gateway process, isolated temp HOME and OPENCLAW_HOME, rebased onto origin/main at e7d5e7eb2b with PR head cd9dc83b24.
- Exact steps or command run after this patch: refreshed build/runtime-postbuild stamps, removed required bundled-plugin dist/runtime outputs, then launched the real Gateway with node scripts/watch-node.mjs gateway --force --allow-unconfigured --port <port> --token watch-proof-token under isolated temp state.
- Evidence after fix:

\`\`\`text
PASS missing-plugin-dist reason=missing_bundled_plugin_dist_entry port=64468 log=.artifacts/pr-70805-live-proof-20260509083947/missing-plugin-dist.log
PASS missing-plugin-runtime reason=missing_runtime_postbuild_output port=64480 log=.artifacts/pr-70805-live-proof-20260509083947/missing-plugin-runtime.log
PASS missing-static-runtime reason=missing_runtime_postbuild_output port=64491 log=.artifacts/pr-70805-live-proof-20260509083947/missing-static-runtime.log
static_runtime_byte_match=yes
telegram_dist_restored=yes
telegram_runtime_restored=yes
missing-plugin-dist.log: [openclaw] Building TypeScript (dist is stale: missing_bundled_plugin_dist_entry - bundled plugin dist entry missing).
missing-plugin-dist.log: [gateway] http server listening (0 plugins, 0.6s)
missing-plugin-runtime.log: [openclaw] Syncing runtime artifacts (missing_runtime_postbuild_output - required runtime postbuild output missing).
missing-plugin-runtime.log: [gateway] http server listening (0 plugins, 0.5s)
missing-static-runtime.log: [openclaw] Syncing runtime artifacts (missing_runtime_postbuild_output - required runtime postbuild output missing).
\`\`\`

- Observed result after fix: the PR head rebuilt or restaged before the Gateway launched and restored the removed dist/runtime artifacts; current origin/main reached Gateway ready after the same removals without rebuilding/restaging and left the files missing.
- What was not tested: in-process recovery after arbitrary deletion while an already-running Gateway child keeps serving; the fixed boundary is watch supervisor launch/relaunch artifact freshness.
