### PR TITLE
Improve compat timeout handling and Ollama runtime support

### DIFF
--- a/scripts/ollama-bridge.py
+++ b/scripts/ollama-bridge.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""User-space TCP forwarder so docker bridge containers can reach host Ollama.
+
+Listens on the docker bridge IP and forwards to 127.0.0.1:11435 (Ollama).
+"""
+import socket
+import sys
+import threading
+
+LISTEN_HOST = "172.18.0.1"
+LISTEN_PORT = 11436
+TARGET_HOST = "127.0.0.1"
+TARGET_PORT = 11435
+
+
+def pipe(src: socket.socket, dst: socket.socket) -> None:
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def handle(client: socket.socket) -> None:
+    upstream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        upstream.connect((TARGET_HOST, TARGET_PORT))
+    except OSError as exc:
+        print(f"upstream connect failed: {exc}", file=sys.stderr)
+        client.close()
+        return
+    threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
+    threading.Thread(target=pipe, args=(upstream, client), daemon=True).start()
+
+
+def main() -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((LISTEN_HOST, LISTEN_PORT))
+    server.listen(64)
+    print(f"ollama-bridge listening on {LISTEN_HOST}:{LISTEN_PORT} -> {TARGET_HOST}:{TARGET_PORT}", flush=True)
+    while True:
+        client, _ = server.accept()
+        threading.Thread(target=handle, args=(client,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ollama-keepwarm.sh
+++ b/scripts/ollama-keepwarm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Keep ollama models pinned in RAM (keep_alive=-1) so user-facing requests
+# never hit cold-start. Pings before ollama's default 5-minute unload window.
+set -u
+OLLAMA="${OLLAMA:-http://127.0.0.1:11435}"
+MODELS=("qwen3.6:latest")
+
+for m in "${MODELS[@]}"; do
+  # Pre-load with the same num_ctx openclaw uses so ollama doesn't unload+reload
+  # when the first real chat request arrives (which would re-trigger cold start).
+  curl -sS --max-time 120 -X POST "$OLLAMA/api/generate" \
+    -H 'Content-Type: application/json' \
+    -d "{\"model\":\"$m\",\"keep_alive\":-1,\"prompt\":\"\",\"options\":{\"num_ctx\":131072}}" >/dev/null \
+    || echo "ollama-keepwarm: failed for $m" >&2
+done

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -237,6 +237,11 @@ export type GatewayHttpChatCompletionsConfig = {
   maxTotalImageBytes?: number;
   /** Image input controls for `image_url` parts. */
   images?: GatewayHttpChatCompletionsImagesConfig;
+  /**
+   * Runtime-only override injected by the gateway so compat HTTP requests use
+   * the active agent timeout instead of falling back to a stale process snapshot.
+   */
+  agentTimeoutSeconds?: number;
 };
 
 export type GatewayHttpChatCompletionsImagesConfig = {

--- a/src/gateway/openai-http.timeout-propagation.test.ts
+++ b/src/gateway/openai-http.timeout-propagation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { __testOnlyOpenAiHttp } from "./openai-http.js";
+
+describe("openai compat timeout propagation", () => {
+  it("serializes timeout from gateway runtime config into ingress command input", () => {
+    const input = __testOnlyOpenAiHttp.buildAgentCommandInput({
+      prompt: { message: "hello" },
+      modelOverride: "ollama/qwen3.6:latest",
+      sessionKey: "agent:main:openai:test",
+      runId: "run-1",
+      messageChannel: "webchat",
+      senderIsOwner: false,
+      timeoutSeconds: 300,
+    });
+
+    expect(input.timeout).toBe("300");
+  });
+
+  it("clamps negative timeout to zero-style no-timeout semantics", () => {
+    const input = __testOnlyOpenAiHttp.buildAgentCommandInput({
+      prompt: { message: "hello" },
+      sessionKey: "agent:main:openai:test",
+      runId: "run-2",
+      messageChannel: "webchat",
+      senderIsOwner: false,
+      timeoutSeconds: -25,
+    });
+
+    expect(input.timeout).toBe("0");
+  });
+
+  it("omits timeout override when gateway runtime did not provide one", () => {
+    const input = __testOnlyOpenAiHttp.buildAgentCommandInput({
+      prompt: { message: "hello" },
+      sessionKey: "agent:main:openai:test",
+      runId: "run-3",
+      messageChannel: "webchat",
+      senderIsOwner: false,
+    });
+
+    expect(input).not.toHaveProperty("timeout");
+  });
+});

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -119,6 +119,7 @@ function buildAgentCommandInput(params: {
   runId: string;
   messageChannel: string;
   senderIsOwner: boolean;
+  timeoutSeconds?: number;
   abortSignal?: AbortSignal;
 }) {
   return {
@@ -133,6 +134,9 @@ function buildAgentCommandInput(params: {
     bestEffortDeliver: false as const,
     senderIsOwner: params.senderIsOwner,
     allowModelOverride: true as const,
+    ...(typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+      ? { timeout: String(Math.max(0, Math.floor(params.timeoutSeconds))) }
+      : {}),
     abortSignal: params.abortSignal,
   };
 }
@@ -369,6 +373,7 @@ async function resolveImagesForRequest(
 export const __testOnlyOpenAiHttp = {
   resolveImagesForRequest,
   resolveOpenAiChatCompletionsLimits,
+  buildAgentCommandInput,
 };
 
 function buildAgentPrompt(
@@ -590,6 +595,7 @@ export async function handleOpenAiHttpRequest(
     messageChannel,
     abortSignal: abortController.signal,
     senderIsOwner,
+    timeoutSeconds: opts.config?.agentTimeoutSeconds,
   });
 
   if (!stream) {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -167,7 +167,11 @@ export async function resolveGatewayRuntimeConfig(params: {
     controlUiEnabled,
     openAiChatCompletionsEnabled,
     openAiChatCompletionsConfig: openAiChatCompletionsConfig
-      ? { ...openAiChatCompletionsConfig, enabled: openAiChatCompletionsEnabled }
+      ? {
+          ...openAiChatCompletionsConfig,
+          enabled: openAiChatCompletionsEnabled,
+          agentTimeoutSeconds: params.cfg.agents?.defaults?.timeoutSeconds,
+        }
       : undefined,
     openResponsesEnabled,
     openResponsesConfig: openResponsesConfig

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -320,7 +320,7 @@ describe("fetchWithTimeoutGuarded", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://example.com",
-        timeoutMs: 60_000,
+        timeoutMs: 300_000,
       }),
     );
   });

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -19,7 +19,7 @@ export { normalizeBaseUrl } from "../agents/provider-request-config.js";
 
 const MAX_ERROR_CHARS = 300;
 const MAX_ERROR_RESPONSE_BYTES = 4096;
-const DEFAULT_GUARDED_HTTP_TIMEOUT_MS = 60_000;
+const DEFAULT_GUARDED_HTTP_TIMEOUT_MS = 300_000; // 5 minutes — covers Ollama cold-start (30–90s model load)
 const MAX_AUDIT_CONTEXT_CHARS = 80;
 
 export type ProviderOperationDeadline = {


### PR DESCRIPTION
## Summary

This change improves long-running request handling for OpenClaw's OpenAI-compatible path and adds supporting Ollama runtime tooling.

### What changed

1. **Gateway timeout propagation**: Propagate the active agent timeout into the OpenAI-compatible chat completions flow so compat requests are no longer limited to the old 60-second boundary.
2. **Regression test**: Add coverage to prevent the compat path from falling back to short timeout behavior.
3. **Media provider timeout**: Increase the guarded provider HTTP timeout for media-understanding flows that may legitimately run longer (300s instead of 60s).
4. **Ollama ops tooling**: Add bridge and keepwarm scripts for local Ollama runtime support and cold-start optimization.

## Commits

- `ad96421d36` **fix(gateway): propagate compat chat timeout from runtime config**
  - Thread `agentTimeoutSeconds` from runtime config into `openai-http.ts` handler
  - Update `GatewayHttpChatCompletionsConfig` type to include runtime timeout override
  - Add focused regression test `openai-http.timeout-propagation.test.ts`

- `2925d57dfc` **refactor(media): widen guarded provider http timeout**
  - Increase `DEFAULT_GUARDED_HTTP_TIMEOUT_MS` from 60s to 300s
  - Update related tests to match new timeout expectation

- `ba60445ec3` **chore(ops): add Ollama bridge and keepwarm tooling**
  - `scripts/ollama-bridge.py`: TCP bridge from Docker containers to host Ollama
  - `scripts/ollama-keepwarm.sh`: Keep models resident to reduce cold-start latency

## Validation

✓ Gateway timeout propagation regression test passes (3/3)
✓ Repository commit hooks and staged validation passed
✓ Media-understanding tests passed after timeout update
✓ Runtime verification confirmed compat endpoint no longer fails at 60-second boundary

## Design notes

- The gateway timeout fix is kept isolated from the media timeout change for clear scope separation
- Ollama operational scripts are committed as tooling changes and can be used independently
- All three commits are backward-compatible and focus on improving timeout handling for long-running flows