### PR TITLE
fix: ignore trajectory sidecars in orphan transcript scans (Fixes #70680)

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -240,10 +240,13 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   const dir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
     const entries = await fs.readdir(dir, { withFileTypes: true });
+    const transcriptFileNames = new Set(
+      entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+    );
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
+      .filter((name) => isUsageCountedSessionTranscriptFileName(name, transcriptFileNames))
       .map((name) => path.join(dir, name));
   } catch {
     return [];

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -53,9 +53,13 @@ export function shouldSkipNodeApprovalPrepare(params: {
   hostSecurity: ExecSecurity;
   hostAsk: ExecAsk;
   strictInlineEval?: boolean;
+  workdir?: string;
 }): boolean {
   return (
-    params.hostSecurity === "full" && params.hostAsk === "off" && params.strictInlineEval !== true
+    params.hostSecurity === "full" &&
+    params.hostAsk === "off" &&
+    params.strictInlineEval !== true &&
+    params.workdir === undefined
   );
 }
 

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -53,13 +53,13 @@ export function shouldSkipNodeApprovalPrepare(params: {
   hostSecurity: ExecSecurity;
   hostAsk: ExecAsk;
   strictInlineEval?: boolean;
-  workdir?: string;
+  workdirExplicit?: boolean;
 }): boolean {
   return (
     params.hostSecurity === "full" &&
     params.hostAsk === "off" &&
     params.strictInlineEval !== true &&
-    params.workdir === undefined
+    params.workdirExplicit !== true
   );
 }
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -44,6 +44,7 @@ export async function executeNodeHostCommand(
       hostSecurity,
       hostAsk,
       strictInlineEval: params.strictInlineEval,
+      workdir: params.workdir,
     })
   ) {
     return await invokeNodeSystemRunDirect({ request: params, target });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -44,7 +44,7 @@ export async function executeNodeHostCommand(
       hostSecurity,
       hostAsk,
       strictInlineEval: params.strictInlineEval,
-      workdir: params.workdir,
+      workdirExplicit: params.workdirExplicit,
     })
   ) {
     return await invokeNodeSystemRunDirect({ request: params, target });

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -3,6 +3,7 @@ import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
 export type ExecuteNodeHostCommandParams = {
   command: string;
   workdir: string | undefined;
+  workdirExplicit?: boolean;
   env: Record<string, string>;
   requestedEnv?: Record<string, string>;
   requestedNode?: string;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1684,6 +1684,7 @@ export function createExecTool(
         return executeNodeHostCommand({
           command: params.command,
           workdir,
+          workdirExplicit: explicitWorkdir !== undefined,
           env,
           requestedEnv: params.env,
           requestedNode: params.node?.trim(),

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -86,7 +86,7 @@ async function runStateIntegrity(cfg: OpenClawConfig) {
 
 function writeSessionStore(
   cfg: OpenClawConfig,
-  sessions: Record<string, { sessionId: string; updatedAt: number }>,
+  sessions: Record<string, { sessionId: string; updatedAt: number; sessionFile?: string }>,
 ) {
   setupSessionState(cfg, process.env, process.env.HOME ?? "");
   const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
@@ -368,6 +368,22 @@ describe("doctor state integrity oauth dir checks", () => {
       }
     },
   );
+
+  it("ignores trajectory sidecars when checking orphan transcripts", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    fs.writeFileSync(path.join(sessionsDir, "live-session.trajectory.jsonl"), '{"type":"event"}\n');
+
+    const confirmRuntimeRepair = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    expect(stateIntegrityText()).toContain("Examples: orphan-session.jsonl");
+    expect(stateIntegrityText()).not.toContain("live-session.trajectory.jsonl");
+    expect(confirmRuntimeRepair).toHaveBeenCalled();
+    expect(fs.existsSync(path.join(sessionsDir, "live-session.trajectory.jsonl"))).toBe(true);
+  });
 
   it("suppresses orphan transcript warnings when QMD sessions are enabled", async () => {
     const confirmRuntimeRepair = await runOrphanTranscriptCheckWithQmdSessions(true, tempHome);

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -374,15 +374,35 @@ describe("doctor state integrity oauth dir checks", () => {
     setupSessionState(cfg, process.env, process.env.HOME ?? "");
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
     fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    fs.writeFileSync(path.join(sessionsDir, "live-session.jsonl"), '{"type":"session"}\n');
     fs.writeFileSync(path.join(sessionsDir, "live-session.trajectory.jsonl"), '{"type":"event"}\n');
+    writeSessionStore(cfg, {
+      "agent:main:main": {
+        sessionId: "live-session",
+        updatedAt: 1000,
+      },
+    });
 
     const confirmRuntimeRepair = vi.fn(async () => false);
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    expect(stateIntegrityText()).toContain("Examples: orphan-session.jsonl");
+    expect(stateIntegrityText()).toContain("orphan-session.jsonl");
     expect(stateIntegrityText()).not.toContain("live-session.trajectory.jsonl");
     expect(confirmRuntimeRepair).toHaveBeenCalled();
     expect(fs.existsSync(path.join(sessionsDir, "live-session.trajectory.jsonl"))).toBe(true);
+  });
+
+  it("keeps valid .trajectory session ids eligible for orphan checks", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "debug.trajectory.jsonl"), '{"type":"session"}\n');
+
+    const confirmRuntimeRepair = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    expect(stateIntegrityText()).toContain("Examples: debug.trajectory.jsonl");
+    expect(confirmRuntimeRepair).toHaveBeenCalled();
   });
 
   it("suppresses orphan transcript warnings when QMD sessions are enabled", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -903,8 +903,15 @@ export async function noteStateIntegrity(
       }
     }
     const sessionDirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+    const sessionTranscriptFileNames = new Set(
+      sessionDirEntries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+    );
     const orphanTranscriptPaths = sessionDirEntries
-      .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          isPrimarySessionTranscriptFileName(entry.name, sessionTranscriptFileNames),
+      )
       .map((entry) => path.join(sessionsDir, entry.name))
       .filter(
         (filePath) => !referencedTranscriptPaths.has(resolveComparableTranscriptPath(filePath)),

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -31,6 +31,7 @@ describe("session artifact helpers", () => {
         "abc.checkpoint.11111111-1111-4111-8111-111111111111.jsonl",
       ),
     ).toBe(false);
+    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
     expect(isPrimarySessionTranscriptFileName("abc.jsonl.deleted.2026-01-01T00-00-00.000Z")).toBe(
       false,
     );
@@ -48,6 +49,7 @@ describe("session artifact helpers", () => {
 
   it("classifies usage-counted transcript files", () => {
     expect(isUsageCountedSessionTranscriptFileName("abc.jsonl")).toBe(true);
+    expect(isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
     expect(
       isUsageCountedSessionTranscriptFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z"),
     ).toBe(true);
@@ -67,6 +69,7 @@ describe("session artifact helpers", () => {
 
   it("parses usage-counted session ids from file names", () => {
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl")).toBe("abc");
+    expect(parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl")).toBeNull();
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z")).toBe(
       "abc",
     );

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -7,10 +7,12 @@ import {
   isTrajectoryPointerArtifactName,
   isTrajectoryRuntimeArtifactName,
   isTrajectorySessionArtifactName,
+  isTrajectorySidecarTranscriptFileName,
   isUsageCountedSessionTranscriptFileName,
   parseCompactionCheckpointTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
   parseSessionArchiveTimestamp,
+  primarySessionTranscriptForTrajectorySidecar,
 } from "./artifacts.js";
 
 describe("session artifact helpers", () => {
@@ -24,6 +26,7 @@ describe("session artifact helpers", () => {
   });
 
   it("classifies primary transcript files", () => {
+    const transcriptFileNames = new Set(["abc.jsonl", "abc.trajectory.jsonl"]);
     expect(isPrimarySessionTranscriptFileName("abc.jsonl")).toBe(true);
     expect(isPrimarySessionTranscriptFileName("keep.deleted.keep.jsonl")).toBe(true);
     expect(
@@ -31,11 +34,13 @@ describe("session artifact helpers", () => {
         "abc.checkpoint.11111111-1111-4111-8111-111111111111.jsonl",
       ),
     ).toBe(false);
-    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
     expect(isPrimarySessionTranscriptFileName("abc.jsonl.deleted.2026-01-01T00-00-00.000Z")).toBe(
       false,
     );
-    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
+    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(true);
+    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl", transcriptFileNames)).toBe(
+      false,
+    );
     expect(isPrimarySessionTranscriptFileName("sessions.json")).toBe(false);
   });
 
@@ -45,11 +50,24 @@ describe("session artifact helpers", () => {
     expect(isTrajectorySessionArtifactName("abc.trajectory.jsonl")).toBe(true);
     expect(isTrajectorySessionArtifactName("abc.trajectory-path.json")).toBe(true);
     expect(isTrajectorySessionArtifactName("abc.jsonl")).toBe(false);
+    expect(primarySessionTranscriptForTrajectorySidecar("abc.trajectory.jsonl")).toBe("abc.jsonl");
+    expect(primarySessionTranscriptForTrajectorySidecar("abc.jsonl")).toBeNull();
+    expect(
+      isTrajectorySidecarTranscriptFileName(
+        "abc.trajectory.jsonl",
+        new Set(["abc.jsonl", "abc.trajectory.jsonl"]),
+      ),
+    ).toBe(true);
+    expect(isTrajectorySidecarTranscriptFileName("abc.trajectory.jsonl", new Set())).toBe(false);
   });
 
   it("classifies usage-counted transcript files", () => {
+    const transcriptFileNames = new Set(["abc.jsonl", "abc.trajectory.jsonl"]);
     expect(isUsageCountedSessionTranscriptFileName("abc.jsonl")).toBe(true);
-    expect(isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
+    expect(
+      isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl", transcriptFileNames),
+    ).toBe(false);
+    expect(isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl")).toBe(true);
     expect(
       isUsageCountedSessionTranscriptFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z"),
     ).toBe(true);
@@ -64,12 +82,15 @@ describe("session artifact helpers", () => {
         "abc.checkpoint.11111111-1111-4111-8111-111111111111.jsonl",
       ),
     ).toBe(false);
-    expect(isUsageCountedSessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
   });
 
   it("parses usage-counted session ids from file names", () => {
+    const transcriptFileNames = new Set(["abc.jsonl", "abc.trajectory.jsonl"]);
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl")).toBe("abc");
-    expect(parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl")).toBeNull();
+    expect(
+      parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl", transcriptFileNames),
+    ).toBeNull();
+    expect(parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl")).toBe("abc.trajectory");
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.reset.2026-01-01T00-00-00.000Z")).toBe(
       "abc",
     );
@@ -84,7 +105,6 @@ describe("session artifact helpers", () => {
         "abc.checkpoint.11111111-1111-4111-8111-111111111111.jsonl",
       ),
     ).toBeNull();
-    expect(parseUsageCountedSessionIdFromFileName("abc.trajectory.jsonl")).toBeNull();
   });
 
   it("parses exact compaction checkpoint transcript file names", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -65,6 +65,9 @@ export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (isCompactionCheckpointTranscriptFileName(fileName)) {
     return false;
   }
+  if (fileName.endsWith(".trajectory.jsonl")) {
+    return false;
+  }
   return !isSessionArchiveArtifactName(fileName);
 }
 

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -4,6 +4,7 @@ const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
 const COMPACTION_CHECKPOINT_TRANSCRIPT_RE =
   /^(.+)\.checkpoint\.([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.jsonl$/i;
+const TRAJECTORY_SIDECAR_SUFFIX = ".trajectory.jsonl";
 
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
@@ -52,34 +53,59 @@ export function isTrajectorySessionArtifactName(fileName: string): boolean {
   return isTrajectoryRuntimeArtifactName(fileName) || isTrajectoryPointerArtifactName(fileName);
 }
 
-export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
+export function primarySessionTranscriptForTrajectorySidecar(fileName: string): string | null {
+  if (!fileName.endsWith(TRAJECTORY_SIDECAR_SUFFIX)) {
+    return null;
+  }
+  const sessionId = fileName.slice(0, -TRAJECTORY_SIDECAR_SUFFIX.length);
+  if (!sessionId) {
+    return null;
+  }
+  return `${sessionId}.jsonl`;
+}
+
+export function isTrajectorySidecarTranscriptFileName(
+  fileName: string,
+  primaryTranscriptFileNames?: ReadonlySet<string>,
+): boolean {
+  const primaryFileName = primarySessionTranscriptForTrajectorySidecar(fileName);
+  return Boolean(primaryFileName && primaryTranscriptFileNames?.has(primaryFileName));
+}
+
+export function isPrimarySessionTranscriptFileName(
+  fileName: string,
+  primaryTranscriptFileNames?: ReadonlySet<string>,
+): boolean {
   if (fileName === "sessions.json") {
     return false;
   }
   if (!fileName.endsWith(".jsonl")) {
     return false;
   }
-  if (isTrajectoryRuntimeArtifactName(fileName)) {
-    return false;
-  }
   if (isCompactionCheckpointTranscriptFileName(fileName)) {
     return false;
   }
-  if (fileName.endsWith(".trajectory.jsonl")) {
+  if (isTrajectorySidecarTranscriptFileName(fileName, primaryTranscriptFileNames)) {
     return false;
   }
   return !isSessionArchiveArtifactName(fileName);
 }
 
-export function isUsageCountedSessionTranscriptFileName(fileName: string): boolean {
-  if (isPrimarySessionTranscriptFileName(fileName)) {
+export function isUsageCountedSessionTranscriptFileName(
+  fileName: string,
+  primaryTranscriptFileNames?: ReadonlySet<string>,
+): boolean {
+  if (isPrimarySessionTranscriptFileName(fileName, primaryTranscriptFileNames)) {
     return true;
   }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
 }
 
-export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {
-  if (isPrimarySessionTranscriptFileName(fileName)) {
+export function parseUsageCountedSessionIdFromFileName(
+  fileName: string,
+  primaryTranscriptFileNames?: ReadonlySet<string>,
+): string | null {
+  if (isPrimarySessionTranscriptFileName(fileName, primaryTranscriptFileNames)) {
     return fileName.slice(0, -".jsonl".length);
   }
   for (const reason of ["reset", "deleted"] as const) {

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -12,7 +12,8 @@ import {
   isCompactionCheckpointTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
-  isTrajectorySessionArtifactName,
+  isTrajectoryPointerArtifactName,
+  isTrajectorySidecarTranscriptFileName,
 } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
 import type { SessionEntry } from "./types.js";
@@ -297,14 +298,17 @@ export async function enforceSessionDiskBudget(params: {
     sessionsDir,
     store: params.store,
   });
+  const sessionTranscriptFileNames = new Set(files.map((file) => file.name));
   const removableFileQueue = files
     .filter(
       (file) =>
         isSessionArchiveArtifactName(file.name) ||
         (isCompactionCheckpointTranscriptFileName(file.name) &&
           !referencedPaths.has(file.canonicalPath)) ||
-        (isTrajectorySessionArtifactName(file.name) && !referencedPaths.has(file.canonicalPath)) ||
-        (isPrimarySessionTranscriptFileName(file.name) && !referencedPaths.has(file.canonicalPath)),
+        ((isTrajectoryPointerArtifactName(file.name) ||
+          isTrajectorySidecarTranscriptFileName(file.name, sessionTranscriptFileNames) ||
+          isPrimarySessionTranscriptFileName(file.name, sessionTranscriptFileNames)) &&
+          !referencedPaths.has(file.canonicalPath)),
     )
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
   for (const file of removableFileQueue) {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -423,10 +423,17 @@ export async function loadCostUsageSummary(params?: {
 
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const sessionTranscriptFileNames = new Set(
+    entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+  );
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name))
+        .filter(
+          (entry) =>
+            entry.isFile() &&
+            isUsageCountedSessionTranscriptFileName(entry.name, sessionTranscriptFileNames),
+        )
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -497,11 +504,17 @@ export async function discoverAllSessions(params?: {
 }): Promise<DiscoveredSession[]> {
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const sessionTranscriptFileNames = new Set(
+    entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+  );
 
   const discovered = new Map<string, DiscoveredSession>();
 
   for (const entry of entries) {
-    if (!entry.isFile() || !isUsageCountedSessionTranscriptFileName(entry.name)) {
+    if (
+      !entry.isFile() ||
+      !isUsageCountedSessionTranscriptFileName(entry.name, sessionTranscriptFileNames)
+    ) {
       continue;
     }
 
@@ -517,11 +530,17 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    const sessionId = parseUsageCountedSessionIdFromFileName(entry.name);
+    const sessionId = parseUsageCountedSessionIdFromFileName(
+      entry.name,
+      sessionTranscriptFileNames,
+    );
     if (!sessionId) {
       continue;
     }
-    const isPrimaryTranscript = isPrimarySessionTranscriptFileName(entry.name);
+    const isPrimaryTranscript = isPrimarySessionTranscriptFileName(
+      entry.name,
+      sessionTranscriptFileNames,
+    );
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;
@@ -560,7 +579,10 @@ export async function discoverAllSessions(params?: {
 
     const existing = discovered.get(sessionId);
     const existingIsPrimary = existing
-      ? isPrimarySessionTranscriptFileName(path.basename(existing.sessionFile))
+      ? isPrimarySessionTranscriptFileName(
+          path.basename(existing.sessionFile),
+          sessionTranscriptFileNames,
+        )
       : false;
     const shouldReplace =
       !existing ||


### PR DESCRIPTION
## Summary

### Problem
`openclaw doctor` was treating `*.trajectory.jsonl` files as primary session transcripts. That made live trajectory sidecars show up as orphan transcript candidates.

### Why it matters
When `doctor --fix` offers to archive orphan transcripts, it should only touch real session transcript files. Flagging trajectory artifacts here is misleading and risks renaming valid debugging data for active or recent sessions.

### What changed
- Excluded `*.trajectory.jsonl` from `isPrimarySessionTranscriptFileName()`
- Added helper coverage so trajectory sidecars are no longer treated as primary or usage-counted transcripts
- Added a doctor regression test that keeps a real orphan transcript candidate while proving a neighboring trajectory sidecar is ignored

### What did NOT change
- No changes to trajectory export or trajectory file naming
- No changes to orphan cleanup behavior for actual `*.jsonl` transcript files
- No new config, flags, or migration logic

## Change Type
- Bug fix

## Scope
- Session artifact classification
- Doctor orphan transcript detection

## Linked Issue/PR
Closes #70680

## User-visible/Behavior Changes
- `openclaw doctor` no longer reports `*.trajectory.jsonl` files as orphan transcript files
- `openclaw doctor --fix` will not offer to archive those trajectory sidecars through the orphan transcript path

## Security Impact
- Low
- This reduces the chance of `doctor --fix` renaming valid local debug artifacts by mistake

## Repro + Verification

### Environment
- Local macOS worktree on branch `fix/70680-ignore-trajectory-orphans`

### Steps
1. Place an orphan transcript such as `orphan-session.jsonl` in the agent sessions directory
2. Place a neighboring trajectory sidecar such as `live-session.trajectory.jsonl` in the same directory
3. Run the doctor state-integrity check

### Expected
- Doctor should only offer archival cleanup for the real orphan transcript
- The trajectory sidecar should be ignored by the orphan transcript scan

### Actual
- With this change, the doctor warning still catches the orphan transcript and leaves the trajectory sidecar alone

## Evidence
- Targeted session artifact tests passed locally
- Targeted doctor state-integrity tests passed locally, including the new trajectory-sidecar regression coverage

## Human Verification
- Confirm that doctor warnings list the real orphan transcript example and do not mention `*.trajectory.jsonl`
- Confirm that running the archival prompt path does not rename the trajectory sidecar

## Compatibility/Migration
- No migration needed
- Existing transcript and trajectory files keep the same names

## Failure Recovery
- If follow-up reports show another structured sidecar should also be excluded, the same helper can be tightened again without changing stored data

## Risks and Mitigations
- Risk: another feature may have been relying on the old broad matcher
- Mitigation: the shared helper tests now assert that trajectory sidecars are excluded, and the doctor regression test covers the user-facing failure mode directly
