### PR TITLE
fix(gateway): emit final chat resync after live agent run completion

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1660,7 +1660,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchCtx?.CommandBody).toBe("bench update");
   });
 
-  it("emits a user transcript update when chat.send starts an agent run", async () => {
+  it("emits a user transcript update and final resync when chat.send starts an agent run", async () => {
     createTranscriptFixture("openclaw-chat-send-user-transcript-agent-run-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
@@ -1690,6 +1690,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         timestamp: expect.any(Number),
       },
     });
+    const finalBroadcast = (
+      context.broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find((call) => call[0] === "chat")?.[1];
+    expect(finalBroadcast).toMatchObject({
+      runId: "idem-user-transcript-agent-run",
+      sessionKey: "main",
+      state: "final",
+    });
+    expect(finalBroadcast.message).toBeUndefined();
   });
 
   it("adds persisted media paths to the user transcript update", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2665,6 +2665,15 @@ export const chatHandlers: GatewayRequestHandlers = {
             }
           } else {
             void emitUserTranscriptUpdate();
+            // Some harnesses emit live item/tool activity but do not mirror a
+            // terminal assistant/lifecycle event onto the gateway chat stream.
+            // The run still completed and the transcript has been updated, so
+            // send a message-less final event as a UI resync point.
+            broadcastChatFinal({
+              context,
+              runId: clientRunId,
+              sessionKey,
+            });
           }
           setGatewayDedupeEntry({
             dedupe: context.dedupe,


### PR DESCRIPTION
## Summary

On `codex/gpt-5.5` (and any harness using the native Codex app-server path), the TUI spins forever after submitting a prompt. Exit + reopen shows the response was actually produced and persisted in the transcript ... it's purely a live-stream finalization gap.

## Root cause

The Codex app-server path records the final assistant answer and updates the transcript, but unlike the Codex CLI path, it does **not** emit a terminal assistant event plus `lifecycle:end` onto OpenClaw's agent event bus. `chat.send` is still waiting for that finalization signal, so the live WebSocket stream never closes out and the TUI never renders the final event.

## Fix

Conservative fallback in `chat.send`: after the user-transcript update on an agent run, emit a **message-less** `chat.final` broadcast as a UI resync point. The transcript already contains the assistant message, so the client reloads history and goes idle instead of spinning.

Two files, +19 / -1 lines:
- `src/gateway/server-methods/chat.ts` ... emit the resync event
- `src/gateway/server-methods/chat.directive-tags.test.ts` ... regression assertion for the message-less final

## What this does NOT try to do

- Reimplement reasoning streaming (PR #68982 is already aimed at richer reasoning rendering in the Control UI).
- Fix the underlying Codex app-server lifecycle emission (that's the deeper, preferred fix; this is a safety net until that lands).

## Reproduction

1. Configure OpenClaw with `codex/gpt-5.5` (or `codex/gpt-5.4`) as primary, `think: high`.
2. Open TUI, send any prompt.
3. Observe indefinite spinner. Exit TUI, reopen. The answer is there in history.

## Validation

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts \
  src/gateway/server-methods/chat.directive-tags.test.ts
```
Result: 54/54 tests pass.

End-to-end: verified live on a reproducing install ... TUI now renders responses cleanly on `codex/gpt-5.5` without the exit+reopen dance.

## Related

- Similar stall pattern on ACP: #70699
- Complementary (not overlapping): #68982 (reasoning streaming in Control UI)

## Credits

Patch authored primarily by OpenAI Codex CLI (GPT-5.5) during a live debugging session. Co-authored / verified by Parker Todd Brooks, Lēsa, and Claude Opus 4.7.