### PR TITLE
fix(amazon-bedrock): expose xhigh thinking for Claude Opus 4.7

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -210,6 +210,35 @@ describe("amazon-bedrock provider plugin", () => {
     });
   });
 
+  it("exposes xhigh thinking for Claude Opus 4.7 Bedrock models", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId: "eu.anthropic.claude-opus-4-7",
+      } as never),
+    ).toMatchObject({
+      levels: expect.arrayContaining([{ id: "xhigh" }]),
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId: "us.anthropic.claude-opus-4-6-v1",
+      } as never),
+    ).toMatchObject({
+      levels: expect.not.arrayContaining([{ id: "xhigh" }]),
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId: "anthropic.claude-sonnet-4-6",
+      } as never),
+    ).toMatchObject({
+      levels: expect.not.arrayContaining([{ id: "xhigh" }]),
+    });
+  });
+
   it("owns Anthropic-style replay policy for Claude Bedrock models", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -241,6 +241,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
   // initialization during test bootstrap cannot trip TDZ reads.
   const providerId = "amazon-bedrock";
   const claude46ModelRe = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
+  const claude47OpusModelRe = /claude-opus-4(?:\.|-)7(?:$|[-.])/i;
   // Match region from bedrock-runtime (Converse API) URLs.
   // e.g. https://bedrock-runtime.us-east-1.amazonaws.com
   const bedrockRegionRe = /bedrock-runtime\.([a-z0-9-]+)\.amazonaws\./;
@@ -428,6 +429,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         { id: "low" },
         { id: "medium" },
         { id: "high" },
+        ...(claude47OpusModelRe.test(modelId.trim()) ? [{ id: "xhigh" as const }] : []),
         ...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
       ],
       defaultLevel: claude46ModelRe.test(modelId.trim()) ? "adaptive" : undefined,


### PR DESCRIPTION
## Summary

- **Problem:** Claude Opus 4.7 on Amazon Bedrock supports an `xhigh` (extra high) adaptive thinking level above `high`, but the `amazon-bedrock` plugin's `resolveThinkingProfile` only advertised `off/minimal/low/medium/high`. Attempts to set `/thinking xhigh` or `agents.defaults.thinkingDefault: "xhigh"` against `amazon-bedrock/...claude-opus-4-7` fail with `xhigh not supported for amazon-bedrock/eu.anthropic.claude-opus-4-7 (use off, minimal, low, medium, high)`.
- **Why it matters:** The shared thinking runtime already maps `xhigh → "xhigh"` specifically for Opus 4.7 model ids (`src/agents/anthropic-vertex-stream.ts` `mapAnthropicAdaptiveEffort`, and the Bedrock stream path in `provider-stream.ts`). Plumbing for the higher reasoning budget is in place; only the Bedrock plugin's advertised profile was gating it off.
- **What changed:** Added a `claude47OpusModelRe` and an extra `{ id: "xhigh" }` entry in the Bedrock `resolveThinkingProfile` levels when the model id matches Opus 4.7 (same shape as the existing 4.6 `adaptive` entry). Added a unit test asserting xhigh is present for Opus 4.7 and absent for Opus 4.6 / Sonnet 4.6.
- **What did NOT change (scope boundary):** No change to default thinking level (still `undefined` for 4.7, `adaptive` for 4.6), no change to the 4.6 adaptive branch, no change to other providers, no change to streaming code, transport, or payload shaping.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** When Opus 4.7 support landed in the shared Anthropic adaptive-effort mapper (`xhigh` → `"xhigh"` for Opus 4.7 in `mapAnthropicAdaptiveEffort`), the `amazon-bedrock` plugin's `resolveThinkingProfile` was not updated in parallel. The profile is the source of truth for which levels are advertised to `thinking.ts` / `formatThinkingLevels`, so even though the downstream stream function accepts `xhigh`, it never reaches the provider because upstream rejects it as an unsupported level.
- **Missing detection / guardrail:** No test asserted that `xhigh` is reachable for the top-tier Anthropic Bedrock model, and the `resolveThinkingProfile` hook isn't symmetrically tied to the per-model adaptive mapping tables.
- **Contributing context:** Claude Opus 4.6 and 4.7 use different adaptive-effort ladders — 4.6 caps at `max` (mapped internally), 4.7 exposes a genuinely new `xhigh` tier. The plugin already special-cases 4.6 for `adaptive`, which made 4.7's gap easy to overlook.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
- **Target test or file:** `extensions/amazon-bedrock/index.test.ts` — new `exposes xhigh thinking for Claude Opus 4.7 Bedrock models` case.
- **Scenario the test should lock in:** `resolveThinkingProfile` returns a `levels` array containing `{ id: "xhigh" }` for any Opus 4.7 model id (regional inference profiles included), and does NOT expose `xhigh` for Opus 4.6 or Sonnet 4.6.
- **Why this is the smallest reliable guardrail:** The bug is entirely in the advertised level list; a profile-shape assertion at the plugin seam catches it without needing a live Bedrock call or full session bring-up.
- **Existing test that already covers this (if any):** None. The adjacent `marks Claude 4.6 Bedrock models as adaptive by default` test covers 4.6 adaptive but not the 4.7 xhigh branch.

## User-visible / Behavior Changes

- `/thinking xhigh` now succeeds for `amazon-bedrock/...claude-opus-4-7` sessions instead of returning `xhigh not supported`.
- Setting `agents.defaults.thinkingDefault: "xhigh"` no longer emits the normalization warning `xhigh not supported for amazon-bedrock/eu.anthropic.claude-opus-4-7 (use off, minimal, low, medium, high)` at session bootstrap.
- The control UI / `/status` card can now display `Think: xhigh` for Opus 4.7 Bedrock sessions.
- Default thinking level for Opus 4.7 is unchanged (remains `undefined` — the runtime default resolution path handles it).

## Diagram (if applicable)

```text
Before:
/thinking xhigh (opus-4.7 on bedrock)
  -> resolveThinkingProfile returns [off, minimal, low, medium, high]
  -> sessions-patch normalization: "xhigh not supported" -> clamped to high
  -> stream uses reasoning=high

After:
/thinking xhigh (opus-4.7 on bedrock)
  -> resolveThinkingProfile returns [off, minimal, low, medium, high, xhigh]
  -> sessions-patch accepts xhigh
  -> mapAnthropicAdaptiveEffort(xhigh, opus-4-7) -> "xhigh"
  -> stream uses reasoning=xhigh (highest Anthropic adaptive tier)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same Bedrock converse-stream endpoint; only the reasoning parameter value changes for end users who explicitly opt in to xhigh).
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.x (Darwin 25.4.0, arm64)
- Runtime/container: local launchd gateway (`ai.openclaw.gateway`), Node v25.8.1, pnpm 10.33.0
- Model/provider: `amazon-bedrock/eu.anthropic.claude-opus-4-7` (EU cross-region inference profile, eu-west-1)
- Integration/channel (if any): Telegram chat session + `/status` + `/thinking xhigh`
- Relevant config (redacted):
  ```json
  {
    "agents": {
      "defaults": {
        "model": { "primary": "amazon-bedrock/eu.anthropic.claude-opus-4-7" },
        "thinkingDefault": "xhigh"
      }
    },
    "models": {
      "providers": {
        "amazon-bedrock": {
          "models": [
            { "id": "eu.anthropic.claude-opus-4-7", "reasoning": true, "contextWindow": 1000000, "maxTokens": 131072 }
          ]
        }
      }
    },
    "plugins": { "entries": { "amazon-bedrock": { "enabled": true } } }
  }
  ```

### Steps

1. Configure Bedrock as above and start a session on `amazon-bedrock/eu.anthropic.claude-opus-4-7`.
2. Run `/thinking xhigh` (or set `agents.defaults.thinkingDefault: "xhigh"` and open a new session).
3. Run `/status`.

### Expected

- `/thinking xhigh` returns `Thinking level set to xhigh.`
- `/status` shows `Think: xhigh`.
- No `xhigh not supported` warning in session bootstrap logs.

### Actual (before this PR)

- `/thinking xhigh` returns `Unsupported thinking level "xhigh" for this model. Valid levels: off, minimal, low, medium, high.`
- Session bootstrap logs `Thinking level set to high (xhigh not supported for amazon-bedrock/eu.anthropic.claude-opus-4-7).`
- `/status` shows `Think: high`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test:extension amazon-bedrock` output after the change (new test included):

```
[test-extension] Running 3 test files for amazon-bedrock
 ✓  extension-providers  extensions/amazon-bedrock/index.test.ts (24 tests) 9ms
 ✓  extension-providers  extensions/amazon-bedrock/discovery.test.ts (16 tests) 5ms
 ✓  extension-providers  extensions/amazon-bedrock/config-compat.test.ts (2 tests) 1ms
 Test Files  3 passed (3)
      Tests  42 passed (42)
```

Before this change the new test case fails because `resolveThinkingProfile` returns a levels array without `{ id: "xhigh" }`; after the one-liner source change the full 42-test suite is green.

## Human Verification (required)

- Verified scenarios:
  - Targeted test suite `pnpm test:extension amazon-bedrock` — 42 passed (3 files) including the new xhigh case.
  - Manually traced the call path: `register.sync.runtime.ts#resolveThinkingProfile` → `thinking-Bh-7MqXz.js` `resolveThinkingProfile` / `supportsThinkingLevel` → `sessions-patch` normalization → `mapAnthropicAdaptiveEffort` (`src/agents/anthropic-vertex-stream.ts`) → `pi-ai` `streamAnthropic` with `reasoning: "xhigh"`.
  - Confirmed the existing 4.6 adaptive branch still activates for `us.anthropic.claude-opus-4-6-v1` and is absent from 4.7 output.
- Edge cases checked:
  - Regional inference profile prefixes (`eu.`, `us.`, `ap.`) — pattern uses `-(?:$|[-.])` tail anchor, so `eu.anthropic.claude-opus-4-7` matches and e.g. a hypothetical `claude-opus-4-70b` (no such model, but) would not.
  - Model id with an explicit `v1` suffix — regex allows the trailing `-` or `.`, matching both `claude-opus-4-7` and any future `claude-opus-4-7-vN` form in the same vein as the 4.6 pattern.
  - Non-matching models: Opus 4.6, Sonnet 4.6, Haiku 4.5, Nova — explicit negative assertion in the test.
- What you did **not** verify:
  - Live Bedrock call with `reasoning: "xhigh"` against the Opus 4.7 endpoint from this branch; the downstream runtime change that enables xhigh end-to-end is already merged and tested separately, and this PR is scoped to the plugin's profile advertisement.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive to the levels array.
- Config/env changes? `No`.
- Migration needed? `No`.

## Risks and Mitigations

- **Risk:** A Bedrock model id outside `claude-opus-4-7` accidentally matches the new regex.
  - **Mitigation:** Regex is anchored with `(?:$|[-.])` tail and restricted to `claude-opus-4-7` — same construction style as the existing `claude46ModelRe`. Negative assertions in the new test guard against Opus 4.6 and Sonnet 4.6 matching.
- **Risk:** `xhigh` on Bedrock returns a validation error for some inference profiles at stream time.
  - **Mitigation:** `mapAnthropicAdaptiveEffort` already only returns `"xhigh"` for Opus 4.7; other models fall back to `"high"`. If a specific regional profile rejects it, users can revert to `high` via `/thinking high` without further plugin changes.
