### PR TITLE
fix: make models list read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - Codex/media understanding: support `codex/*` image models through bounded Codex app-server image turns, while keeping `openai-codex/*` on the OpenAI Codex OAuth route and validating app-server responses against generated protocol contracts. Fixes #70201.
 - Providers/OpenAI Codex: synthesize the `openai-codex/gpt-5.5` OAuth model row when Codex catalog discovery omits it, so cron and subagent runs do not fail with `Unknown model` while the account is authenticated.
+- Models/CLI: keep `openclaw models list` read-only while still showing eligible configured-provider rows, so listing models no longer rewrites per-agent `models.json`. (#70847) Thanks @shakkernerd.
 - Providers/Google: honor the private-network SSRF opt-in for Gemini image generation requests, so trusted proxy setups that resolve Google API hosts to private addresses can use `image_generate`. Fixes #67216.
 - Agents/transport: stop embedded runs from lowering the process-wide undici stream timeouts, so slow Gemini image generation and other long-running provider requests no longer inherit short run-attempt headers timeouts. Fixes #70423. Thanks @giangthb.
 - Providers/OpenRouter: send image-understanding prompts as user text before image parts, restoring non-empty vision responses for OpenRouter multimodal models. Fixes #70410.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -44,6 +44,9 @@ Probe rows can come from auth profiles, env credentials, or `models.json`.
 Notes:
 
 - `models set <model-or-alias>` accepts `provider/model` or an alias.
+- `models list` is read-only: it reads config, auth profiles, existing catalog
+  state, and provider-owned catalog rows, but it does not rewrite
+  `models.json`.
 - `models list --all` includes bundled provider-owned static catalog rows even
   when you have not authenticated with that provider yet. Those rows still show
   as unavailable until matching auth is configured.

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -9,6 +9,7 @@ let findModelInCatalog: typeof import("./model-catalog.js").findModelInCatalog;
 let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
+let ensureOpenClawModelsJsonMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./model-suppression.runtime.js", () => ({
   shouldSuppressBuiltInModel: (params: { provider?: string; id?: string }) =>
@@ -59,8 +60,9 @@ function mockSingleOpenAiCatalogModel() {
 
 describe("loadModelCatalog", () => {
   beforeAll(async () => {
+    ensureOpenClawModelsJsonMock = vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false });
     vi.doMock("./models-config.js", () => ({
-      ensureOpenClawModelsJson: vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false }),
+      ensureOpenClawModelsJson: ensureOpenClawModelsJsonMock,
     }));
     vi.doMock("./agent-paths.js", () => ({
       resolveOpenClawAgentDir: () => "/tmp/openclaw",
@@ -81,6 +83,7 @@ describe("loadModelCatalog", () => {
 
   beforeEach(() => {
     resetModelCatalogCacheForTest();
+    ensureOpenClawModelsJsonMock.mockClear();
   });
 
   afterEach(() => {
@@ -144,6 +147,28 @@ describe("loadModelCatalog", () => {
       setLoggerOverride(null);
       resetLogger();
     }
+  });
+
+  it("does not prepare models.json when loading catalog in read-only mode", async () => {
+    const discoverAuthStorage = vi.fn(() => ({}));
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage,
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+
+    expect(result).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(discoverAuthStorage).toHaveBeenCalledWith("/tmp/openclaw", { readOnly: true });
   });
 
   it("does not synthesize stale openai-codex/gpt-5.3-codex-spark entries from gpt-5.4", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -81,15 +81,17 @@ function instantiatePiModelRegistry(
 export async function loadModelCatalog(params?: {
   config?: OpenClawConfig;
   useCache?: boolean;
+  readOnly?: boolean;
 }): Promise<ModelCatalogEntry[]> {
-  if (params?.useCache === false) {
+  const readOnly = params?.readOnly === true;
+  if (!readOnly && params?.useCache === false) {
     modelCatalogPromise = null;
   }
-  if (modelCatalogPromise) {
+  if (!readOnly && modelCatalogPromise) {
     return modelCatalogPromise;
   }
 
-  modelCatalogPromise = (async () => {
+  const loadCatalog = async () => {
     const models: ModelCatalogEntry[] = [];
     const timingEnabled = shouldLogModelCatalogTiming();
     const startMs = timingEnabled ? Date.now() : 0;
@@ -110,8 +112,10 @@ export async function loadModelCatalog(params?: {
       });
     try {
       const cfg = params?.config ?? loadConfig();
-      await ensureOpenClawModelsJson(cfg);
-      logStage("models-json-ready");
+      if (!readOnly) {
+        await ensureOpenClawModelsJson(cfg);
+        logStage("models-json-ready");
+      }
       // IMPORTANT: keep the dynamic import *inside* the try/catch.
       // If this fails once (e.g. during a pnpm install that temporarily swaps node_modules),
       // we must not poison the cache with a rejected promise (otherwise all channel handlers
@@ -121,7 +125,10 @@ export async function loadModelCatalog(params?: {
       const agentDir = resolveOpenClawAgentDir();
       const { shouldSuppressBuiltInModel } = await loadModelSuppression();
       logStage("catalog-deps-ready");
-      const authStorage = piSdk.discoverAuthStorage(agentDir);
+      const authStorage = piSdk.discoverAuthStorage(
+        agentDir,
+        readOnly ? { readOnly: true } : undefined,
+      );
       logStage("auth-storage-ready");
       const registry = instantiatePiModelRegistry(
         piSdk,
@@ -182,7 +189,9 @@ export async function loadModelCatalog(params?: {
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.
-        modelCatalogPromise = null;
+        if (!readOnly) {
+          modelCatalogPromise = null;
+        }
       }
 
       const sorted = sortModels(models);
@@ -194,14 +203,21 @@ export async function loadModelCatalog(params?: {
         log.warn(`Failed to load model catalog: ${String(error)}`);
       }
       // Don't poison the cache on transient dependency/filesystem issues.
-      modelCatalogPromise = null;
+      if (!readOnly) {
+        modelCatalogPromise = null;
+      }
       if (models.length > 0) {
         return sortModels(models);
       }
       return [];
     }
-  })();
+  };
 
+  if (readOnly) {
+    return loadCatalog();
+  }
+
+  modelCatalogPromise = loadCatalog();
   return modelCatalogPromise;
 }
 

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -15,7 +15,10 @@ import {
 } from "../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import { isRecord } from "../utils.js";
-import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import {
+  ensureAuthProfileStore,
+  loadAuthProfileStoreForSecretsRuntime,
+} from "./auth-profiles/store.js";
 import { resolveProviderEnvApiKeyCandidates } from "./model-auth-env-vars.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
@@ -277,8 +280,18 @@ export function addEnvBackedPiCredentials(
   return next;
 }
 
-export function resolvePiCredentialsForDiscovery(agentDir: string): PiCredentialMap {
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+type DiscoverAuthStorageOptions = {
+  readOnly?: boolean;
+};
+
+export function resolvePiCredentialsForDiscovery(
+  agentDir: string,
+  options?: DiscoverAuthStorageOptions,
+): PiCredentialMap {
+  const store =
+    options?.readOnly === true
+      ? loadAuthProfileStoreForSecretsRuntime(agentDir)
+      : ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
   const credentials = addEnvBackedPiCredentials(resolvePiCredentialMapFromStore(store));
   for (const provider of resolveRuntimeSyntheticAuthProviderRefs()) {
     if (credentials[provider]) {
@@ -305,10 +318,15 @@ export function resolvePiCredentialsForDiscovery(agentDir: string): PiCredential
 }
 
 // Compatibility helpers for pi-coding-agent 0.50+ (discover* helpers removed).
-export function discoverAuthStorage(agentDir: string): PiAuthStorage {
-  const credentials = resolvePiCredentialsForDiscovery(agentDir);
+export function discoverAuthStorage(
+  agentDir: string,
+  options?: DiscoverAuthStorageOptions,
+): PiAuthStorage {
+  const credentials = resolvePiCredentialsForDiscovery(agentDir, options);
   const authPath = path.join(agentDir, "auth.json");
-  scrubLegacyStaticAuthJsonEntriesForDiscovery(authPath);
+  if (options?.readOnly !== true) {
+    scrubLegacyStaticAuthJsonEntriesForDiscovery(authPath);
+  }
   return createAuthStorage(PiAuthStorageClass, authPath, credentials);
 }
 

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -467,26 +467,62 @@ describe("models list/status", () => {
     expect(Array.from(loaded.availableKeys ?? [])).toEqual(["openai/gpt-4.1-mini"]);
   });
 
-  it("modelsListCommand persists using the source snapshot config when provided", async () => {
-    modelRegistryState.models = [OPENAI_MODEL];
-    modelRegistryState.available = [OPENAI_MODEL];
+  it("modelsListCommand lists source snapshot provider models without persisting models.json", async () => {
+    modelRegistryState.models = [];
+    modelRegistryState.available = [];
     const sourceConfig = {
-      models: { providers: { openai: { apiKey: "$OPENAI_API_KEY" } } }, // pragma: allowlist secret
+      models: {
+        providers: {
+          "custom-proxy": {
+            baseUrl: "https://custom.example/v1",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                contextWindow: 128000,
+              },
+            ],
+          },
+        },
+      },
     };
     const resolvedConfig = {
-      models: { providers: { openai: { apiKey: "sk-resolved-runtime-value" } } }, // pragma: allowlist secret
+      models: {
+        providers: {
+          "custom-proxy": {
+            baseUrl: "https://custom.example/v1",
+            apiKey: "sk-resolved-runtime-value", // pragma: allowlist secret
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                contextWindow: 128000,
+              },
+            ],
+          },
+        },
+      },
     };
     readConfigFileSnapshotForWrite.mockResolvedValue({
       snapshot: { valid: true, resolved: resolvedConfig, sourceConfig },
       writeOptions: {},
     });
-    setDefaultModel("openai/gpt-4.1-mini");
+    getRuntimeConfig.mockReturnValue(resolvedConfig);
     const runtime = makeRuntime();
 
-    await modelsListCommand({ all: true, json: true }, runtime);
+    await modelsListCommand({ all: true, provider: "custom-proxy", json: true }, runtime);
 
-    expect(ensureOpenClawModelsJson).toHaveBeenCalled();
-    expect(ensureOpenClawModelsJson.mock.calls[0]?.[0]).toEqual(sourceConfig);
+    expect(ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    const payload = parseJsonLog(runtime);
+    expect(payload.models).toEqual([
+      expect.objectContaining({
+        key: "custom-proxy/custom-model",
+        name: "Custom Model",
+        missing: false,
+      }),
+    ]);
   });
 
   it("toModelRow does not crash without cfg/authStore when availability is undefined", async () => {

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -474,7 +474,9 @@ describe("models list/status", () => {
       models: {
         providers: {
           "custom-proxy": {
+            api: "openai-responses",
             baseUrl: "https://custom.example/v1",
+            apiKey: "$CUSTOM_PROXY_API_KEY",
             models: [
               {
                 id: "custom-model",
@@ -491,6 +493,7 @@ describe("models list/status", () => {
       models: {
         providers: {
           "custom-proxy": {
+            api: "openai-responses",
             baseUrl: "https://custom.example/v1",
             apiKey: "sk-resolved-runtime-value", // pragma: allowlist secret
             models: [
@@ -512,7 +515,7 @@ describe("models list/status", () => {
     getRuntimeConfig.mockReturnValue(resolvedConfig);
     const runtime = makeRuntime();
 
-    await modelsListCommand({ all: true, provider: "custom-proxy", json: true }, runtime);
+    await modelsListCommand({ all: true, json: true }, runtime);
 
     expect(ensureOpenClawModelsJson).not.toHaveBeenCalled();
     const payload = parseJsonLog(runtime);

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -295,14 +295,17 @@ describe("modelsListCommand forward-compat", () => {
       expect(codexPro?.tags).not.toContain("missing");
     });
 
-    it("passes source config to model registry loading for persistence safety", async () => {
+    it("loads model registry without source config persistence input", async () => {
       const runtime = createRuntime();
 
       await modelsListCommand({ json: true }, runtime as never);
 
-      expect(mocks.loadModelRegistry).toHaveBeenCalledWith(mocks.resolvedConfig, {
-        sourceConfig: mocks.sourceConfig,
-      });
+      expect(mocks.loadModelRegistry).toHaveBeenCalledWith(
+        mocks.resolvedConfig,
+        expect.not.objectContaining({
+          sourceConfig: expect.anything(),
+        }),
+      );
     });
 
     it("keeps configured local openai gpt-5.4 entries visible in --local output", async () => {

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -104,13 +104,11 @@ export async function modelsListCommand(
       context: rowContext,
     });
 
-    if (providerFilter) {
-      appendConfiguredProviderRows({
-        rows,
-        context: rowContext,
-        seenKeys,
-      });
-    }
+    appendConfiguredProviderRows({
+      rows,
+      context: rowContext,
+      seenKeys,
+    });
 
     if (modelRegistry) {
       await appendCatalogSupplementRows({

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -6,6 +6,7 @@ import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
 import {
   appendCatalogSupplementRows,
+  appendConfiguredProviderRows,
   appendConfiguredRows,
   appendDiscoveredRows,
   appendProviderCatalogRows,
@@ -47,9 +48,8 @@ export async function modelsListCommand(
   if (providerFilter === null) {
     return;
   }
-  const { ensureAuthProfileStore, ensureOpenClawModelsJson, resolveOpenClawAgentDir } =
-    await import("./list.runtime.js");
-  const { sourceConfig, resolvedConfig: cfg } = await loadModelsConfigWithSource({
+  const { ensureAuthProfileStore, resolveOpenClawAgentDir } = await import("./list.runtime.js");
+  const { resolvedConfig: cfg } = await loadModelsConfigWithSource({
     commandName: "models list",
     runtime,
   });
@@ -62,11 +62,8 @@ export async function modelsListCommand(
   let availabilityErrorMessage: string | undefined;
   const useProviderCatalogFastPath = Boolean(opts.all && providerFilter === "codex");
   try {
-    // Keep command behavior explicit: sync models.json from the source config
-    // before building the read-only model registry view.
     if (!useProviderCatalogFastPath) {
-      await ensureOpenClawModelsJson(sourceConfig ?? cfg);
-      const loaded = await loadListModelRegistry(cfg, { sourceConfig, providerFilter });
+      const loaded = await loadListModelRegistry(cfg, { providerFilter });
       modelRegistry = loaded.registry;
       discoveredKeys = loaded.discoveredKeys;
       availableKeys = loaded.availableKeys;
@@ -106,6 +103,14 @@ export async function modelsListCommand(
       models: modelRegistry?.getAll() ?? [],
       context: rowContext,
     });
+
+    if (providerFilter) {
+      appendConfiguredProviderRows({
+        rows,
+        context: rowContext,
+        seenKeys,
+      });
+    }
 
     if (modelRegistry) {
       await appendCatalogSupplementRows({

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -1,9 +1,17 @@
-import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { modelKey } from "../../agents/model-ref-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isLocalBaseUrl } from "./list.local-url.js";
 import type { ModelRow } from "./list.types.js";
+
+export type ListRowModel = {
+  id: string;
+  name: string;
+  provider: string;
+  input: Array<"text" | "image">;
+  baseUrl?: string;
+  contextWindow?: number | null;
+};
 
 export type ModelAuthAvailabilityResolver = (params: {
   provider: string;
@@ -18,7 +26,7 @@ function authStoreHasProviderProfile(authStore: AuthProfileStore, provider: stri
 }
 
 export function toModelRow(params: {
-  model?: Model<Api>;
+  model?: ListRowModel;
   key: string;
   tags: string[];
   aliases?: string[];
@@ -52,7 +60,7 @@ export function toModelRow(params: {
   }
 
   const input = model.input.join("+") || "text";
-  const local = isLocalBaseUrl(model.baseUrl);
+  const local = isLocalBaseUrl(model.baseUrl ?? "");
   const modelIsAvailable = availableKeys?.has(modelKey(model.provider, model.id)) ?? false;
   // Prefer model-level registry availability when present.
   // Fall back to provider-level auth heuristics only if registry availability isn't available,

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -108,12 +108,9 @@ function loadAvailableModels(registry: ModelRegistry, cfg: OpenClawConfig): Mode
   }
 }
 
-export async function loadModelRegistry(
-  cfg: OpenClawConfig,
-  opts?: { sourceConfig?: OpenClawConfig; providerFilter?: string },
-) {
+export async function loadModelRegistry(cfg: OpenClawConfig, opts?: { providerFilter?: string }) {
   const agentDir = resolveOpenClawAgentDir();
-  const authStorage = discoverAuthStorage(agentDir);
+  const authStorage = discoverAuthStorage(agentDir, { readOnly: true });
   const registry = discoverModels(authStorage, agentDir, {
     providerFilter: opts?.providerFilter,
   });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -193,7 +193,7 @@ export async function appendCatalogSupplementRows(params: {
   context: RowBuilderContext;
   seenKeys: Set<string>;
 }): Promise<void> {
-  const catalog = await loadModelCatalog({ config: params.context.cfg });
+  const catalog = await loadModelCatalog({ config: params.context.cfg, readOnly: true });
   for (const entry of catalog) {
     if (
       params.context.filter.provider &&

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -1,9 +1,12 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { shouldSuppressBuiltInModel } from "../../agents/model-suppression.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ListRowModel } from "./list.model-row.js";
 import { loadModelRegistry, toModelRow } from "./list.registry.js";
 import {
   loadModelCatalog,
@@ -42,7 +45,7 @@ function matchesRowFilter(filter: RowFilter, model: { provider: string; baseUrl?
 }
 
 function buildRow(params: {
-  model: Model<Api>;
+  model: ListRowModel;
   key: string;
   context: RowBuilderContext;
   allowProviderAvailabilityFallback?: boolean;
@@ -75,9 +78,35 @@ function shouldSuppressListModel(params: {
   });
 }
 
+function resolveConfiguredModelInput(params: {
+  model: Partial<ModelDefinitionConfig>;
+}): Array<"text" | "image"> {
+  const input = Array.isArray(params.model.input)
+    ? params.model.input.filter(
+        (item): item is "text" | "image" => item === "text" || item === "image",
+      )
+    : [];
+  return input.length > 0 ? input : ["text"];
+}
+
+function toConfiguredProviderListModel(params: {
+  provider: string;
+  providerConfig: Partial<ModelProviderConfig>;
+  model: Partial<ModelDefinitionConfig> & Pick<ModelDefinitionConfig, "id">;
+}): ListRowModel {
+  return {
+    provider: params.provider,
+    id: params.model.id,
+    name: params.model.name ?? params.model.id,
+    baseUrl: params.model.baseUrl ?? params.providerConfig.baseUrl,
+    input: resolveConfiguredModelInput({ model: params.model }),
+    contextWindow: params.model.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+  };
+}
+
 export async function loadListModelRegistry(
   cfg: OpenClawConfig,
-  opts?: { sourceConfig?: OpenClawConfig; providerFilter?: string },
+  opts?: { providerFilter?: string },
 ) {
   const loaded = await loadModelRegistry(cfg, opts);
   return {
@@ -119,6 +148,43 @@ export function appendDiscoveredRows(params: {
   }
 
   return seenKeys;
+}
+
+export function appendConfiguredProviderRows(params: {
+  rows: ModelRow[];
+  context: RowBuilderContext;
+  seenKeys: Set<string>;
+}): void {
+  for (const [provider, providerConfig] of Object.entries(
+    params.context.cfg.models?.providers ?? {},
+  )) {
+    for (const configuredModel of providerConfig.models ?? []) {
+      const key = modelKey(provider, configuredModel.id);
+      if (params.seenKeys.has(key)) {
+        continue;
+      }
+      const model = toConfiguredProviderListModel({
+        provider,
+        providerConfig,
+        model: configuredModel,
+      });
+      if (!matchesRowFilter(params.context.filter, model)) {
+        continue;
+      }
+      if (shouldSuppressListModel({ model, context: params.context })) {
+        continue;
+      }
+      params.rows.push(
+        buildRow({
+          model,
+          key,
+          context: params.context,
+          allowProviderAvailabilityFallback: !params.context.discoveredKeys.has(key),
+        }),
+      );
+      params.seenKeys.add(key);
+    }
+  }
 }
 
 export async function appendCatalogSupplementRows(params: {

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -104,6 +104,16 @@ function toConfiguredProviderListModel(params: {
   };
 }
 
+function shouldListConfiguredProviderModel(params: {
+  providerConfig: Partial<ModelProviderConfig>;
+  model: Partial<ModelDefinitionConfig>;
+}): boolean {
+  return (
+    params.providerConfig.apiKey !== undefined &&
+    (params.providerConfig.api !== undefined || params.model.api !== undefined)
+  );
+}
+
 export async function loadListModelRegistry(
   cfg: OpenClawConfig,
   opts?: { providerFilter?: string },
@@ -159,6 +169,9 @@ export function appendConfiguredProviderRows(params: {
     params.context.cfg.models?.providers ?? {},
   )) {
     for (const configuredModel of providerConfig.models ?? []) {
+      if (!shouldListConfiguredProviderModel({ providerConfig, model: configuredModel })) {
+        continue;
+      }
       const key = modelKey(provider, configuredModel.id);
       if (params.seenKeys.has(key)) {
         continue;

--- a/src/commands/models/list.runtime.ts
+++ b/src/commands/models/list.runtime.ts
@@ -1,5 +1,4 @@
-export { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
-export { ensureOpenClawModelsJson } from "../../agents/models-config.js";
+export { loadAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 export { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
 export { listProfilesForProvider } from "../../agents/auth-profiles.js";
 export {


### PR DESCRIPTION
## Summary

This PR makes `openclaw models list` a read-only command. Before this change, list paths could call `ensureOpenClawModelsJson()` and rewrite the agent `models.json` file while only displaying available models. That made a read command mutate user state, and it also kept the command tied to heavier write-through catalog preparation.

The new path keeps the visible model-list behavior, but avoids persistence side effects.

## What changed

- Removed the `models list` call path to `ensureOpenClawModelsJson()`.
- Switched model-list auth/profile loading to read-only auth-store loading.
- Changed PI auth discovery so `models list` can pass `readOnly: true` and avoid legacy auth cleanup/mutation.
- Added read-only model catalog loading so supplemental catalog reads do not rewrite `models.json`.
- Preserved the current Codex provider catalog fast path from `main`.
- Preserved config-defined provider model visibility for the previously visible configured-provider shape.
- Added coverage proving:
  - `models list` does not persist `models.json`
  - read-only catalog loading does not call `ensureOpenClawModelsJson`
  - unfiltered `models list --all` still includes eligible config-defined provider rows
- Updated `docs/cli/models.md` to document that `models list` is read-only.

## Before

`openclaw models list --all` could rewrite:

```text
~/.openclaw/agents/<agentId>/agent/models.json
```

That happened through catalog preparation, even though the user only asked to list models.

The old write-through behavior also made some config-defined providers visible indirectly after persistence, so removing the write path required a read-only replacement for the visible configured-provider rows.

## After

`openclaw models list` reads from:

- config
- read-only auth/profile state
- existing registry/catalog data
- provider-owned catalog rows

It does not rewrite `models.json`.

For configured provider rows, the command now preserves the verified existing visible behavior: documented custom provider entries with explicit transport/auth shape still appear in `models list --all`, without relying on `models.json` being rewritten first.

## Verification

- `pnpm test src/commands/models.list.e2e.test.ts src/commands/models/list.list-command.forward-compat.test.ts src/commands/models/list.rows.test.ts`
- `pnpm check:changed`
- `pnpm build`

I also verified the behavior against `origin/main` with isolated config/state directories:

- documented custom provider with `api` + `apiKey` appeared on `origin/main`, and still appears on this branch
- sparse/local no-api-key provider did not appear on `origin/main`, so this PR does not broaden that behavior
- this branch shows the preserved configured-provider row without creating `models.json`
