### PR TITLE
fix(runner): throw FailoverError on assistant surface_error so webchat renders provider failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/WebChat: surface non-retryable provider failures such as billing, auth, and rate-limit errors from the embedded runner instead of logging `surface_error` and leaving webchat with no rendered error. Fixes #70124. (#70848) Thanks @truffle-dev.
 - Memory/CLI: declare the built-in `local` embedding provider in the memory-core manifest, so standalone `openclaw memory status`, `index`, and `search` can resolve local embeddings just like the gateway runtime. Fixes #70836. (#70873) Thanks @mattznojassist.
 - Gateway/WebChat: preserve image attachments for text-only primary models by offloading them as media refs instead of dropping them, so configured image tools can still inspect the original file. Fixes #68513, #44276, #51656, #70212.
 - Plugins/Google Meet: hang up delegated Twilio calls on leave, clean up Chrome realtime audio bridges when launch fails, and use a flat provider-safe tool schema.

--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -111,23 +111,26 @@ describe("handleAssistantFailover", () => {
       expect(err.status).toBe(429);
     });
 
-    it("coerces a null decision reason onto the most specific failure signal", async () => {
+    it("coerces a null decision reason onto the most specific non-timeout failure signal", async () => {
       // failover-policy can return `surface_error` with `reason: null`
-      // when shouldRotateAssistant fires on timedOut without a classified
-      // upstream reason. FailoverError requires a concrete reason.
+      // when shouldRotateAssistant fires on `failoverFailure` without a
+      // classified upstream reason. FailoverError requires a concrete
+      // reason, so the throw path coerces null onto the most specific
+      // signal the run observed.
       const outcome = await handleAssistantFailover(
         makeParams({
           initialDecision: { action: "surface_error", reason: null },
           failoverReason: null,
-          timedOut: true,
+          timedOut: false,
           billingFailure: false,
+          authFailure: true,
         }),
       );
 
       const err = expectThrownFailoverError(outcome);
-      expect(err.reason).toBe("timeout");
-      expect(err.message).toBe("LLM request timed out.");
-      expect(err.status).toBe(408);
+      expect(err.reason).toBe("auth");
+      expect(err.message).toBe("LLM request unauthorized.");
+      expect(err.status).toBe(401);
     });
 
     it("leaves externally-aborted runs on the continue_normal path", async () => {
@@ -139,6 +142,28 @@ describe("handleAssistantFailover", () => {
           externalAbort: true,
           aborted: true,
           failoverReason: null,
+          billingFailure: false,
+        }),
+      );
+
+      expect(outcome.action).toBe("continue_normal");
+    });
+
+    it("leaves plain timeouts on the continue_normal path for the runner's timeout-payload synthesis", async () => {
+      // `run.ts` already emits an explicit timeout payload when
+      // `buildEmbeddedRunPayloads` produces no assistant content (see
+      // the `timedOut && !timedOutDuringCompaction &&
+      // !payloadsWithToolMedia.length` block). Throwing a FailoverError
+      // here would short-circuit that synthesis and break
+      // timeout-compaction retry coverage in
+      // `run.timeout-triggered-compaction.test.ts`. The throw path is
+      // reserved for concrete provider failures that have no other
+      // downstream surface.
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: null },
+          failoverReason: null,
+          timedOut: true,
           billingFailure: false,
         }),
       );

--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -70,9 +70,7 @@ describe("handleAssistantFailover", () => {
 
       const err = expectThrownFailoverError(outcome);
       expect(err.reason).toBe("billing");
-      expect(err.message).toBe(
-        formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"),
-      );
+      expect(err.message).toBe(formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"));
       expect(err.status).toBe(402);
       expect(err.provider).toBe("Anthropic");
       expect(err.model).toBe("claude-haiku-4-5-20251001");
@@ -109,6 +107,26 @@ describe("handleAssistantFailover", () => {
       expect(err.reason).toBe("rate_limit");
       expect(err.message).toBe("LLM request rate limited.");
       expect(err.status).toBe(429);
+    });
+
+    it("preserves the raw provider error on surfaced failures", async () => {
+      const rawError = '  400 {"error":{"message":"credit balance is too low"}}  ';
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "billing" },
+          failoverReason: "billing",
+          billingFailure: true,
+          lastAssistant: {
+            errorMessage: rawError,
+            model: "claude-haiku-4-5-20251001",
+            provider: "Anthropic",
+          } as Params["lastAssistant"],
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("billing");
+      expect(err.rawError).toBe(rawError.trim());
     });
 
     it("coerces a null decision reason onto the most specific non-timeout failure signal", async () => {
@@ -207,9 +225,7 @@ describe("handleAssistantFailover", () => {
       const err = expectThrownFailoverError(outcome);
       expect(err.reason).toBe("billing");
       expect(err.status).toBe(402);
-      expect(err.message).toBe(
-        formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"),
-      );
+      expect(err.message).toBe(formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"));
       expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 402 });
     });
   });

--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../../failover-error.js";
+import { formatBillingErrorMessage } from "../../pi-embedded-helpers.js";
+import { handleAssistantFailover } from "./assistant-failover.js";
+
+type Params = Parameters<typeof handleAssistantFailover>[0];
+type Outcome = Awaited<ReturnType<typeof handleAssistantFailover>>;
+
+function makeParams(overrides: Partial<Params> = {}): Params {
+  const provider = "Anthropic";
+  const model = "claude-haiku-4-5-20251001";
+  const defaults: Params = {
+    initialDecision: { action: "surface_error", reason: "billing" },
+    aborted: false,
+    externalAbort: false,
+    fallbackConfigured: false,
+    failoverFailure: true,
+    failoverReason: "billing",
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    allowSameModelIdleTimeoutRetry: false,
+    assistantProfileFailureReason: null,
+    lastProfileId: undefined,
+    modelId: model,
+    provider,
+    activeErrorContext: { provider, model },
+    lastAssistant: undefined,
+    config: undefined,
+    sessionKey: undefined,
+    authFailure: false,
+    rateLimitFailure: false,
+    billingFailure: true,
+    cloudCodeAssistFormatError: false,
+    isProbeSession: false,
+    overloadProfileRotations: 0,
+    overloadProfileRotationLimit: 3,
+    previousRetryFailoverReason: null,
+    logAssistantFailoverDecision: vi.fn(),
+    warn: vi.fn(),
+    maybeMarkAuthProfileFailure: vi.fn(async () => {}),
+    maybeEscalateRateLimitProfileFallback: vi.fn(),
+    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    advanceAuthProfile: vi.fn(async () => false),
+  };
+  return { ...defaults, ...overrides };
+}
+
+function expectThrownFailoverError(outcome: Outcome): FailoverError {
+  expect(outcome.action).toBe("throw");
+  if (outcome.action !== "throw") {
+    throw new Error("expected throw outcome");
+  }
+  expect(outcome.error).toBeInstanceOf(FailoverError);
+  return outcome.error;
+}
+
+describe("handleAssistantFailover", () => {
+  describe("surface_error branch (openclaw#70124)", () => {
+    it("throws a billing FailoverError so the webchat can render the provider failure", async () => {
+      const logDecision = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "billing" },
+          failoverReason: "billing",
+          billingFailure: true,
+          logAssistantFailoverDecision: logDecision,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("billing");
+      expect(err.message).toBe(
+        formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"),
+      );
+      expect(err.status).toBe(402);
+      expect(err.provider).toBe("Anthropic");
+      expect(err.model).toBe("claude-haiku-4-5-20251001");
+      expect(logDecision).toHaveBeenCalledWith("surface_error");
+    });
+
+    it("throws an auth FailoverError for auth-classified surface errors", async () => {
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "auth" },
+          failoverReason: "auth",
+          billingFailure: false,
+          authFailure: true,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("auth");
+      expect(err.message).toBe("LLM request unauthorized.");
+      expect(err.status).toBe(401);
+    });
+
+    it("throws a rate_limit FailoverError for rate-limited surface errors", async () => {
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("rate_limit");
+      expect(err.message).toBe("LLM request rate limited.");
+      expect(err.status).toBe(429);
+    });
+
+    it("coerces a null decision reason onto the most specific failure signal", async () => {
+      // failover-policy can return `surface_error` with `reason: null`
+      // when shouldRotateAssistant fires on timedOut without a classified
+      // upstream reason. FailoverError requires a concrete reason.
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: null },
+          failoverReason: null,
+          timedOut: true,
+          billingFailure: false,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("timeout");
+      expect(err.message).toBe("LLM request timed out.");
+      expect(err.status).toBe(408);
+    });
+
+    it("leaves externally-aborted runs on the continue_normal path", async () => {
+      // External aborts (user pressed stop) must never synthesize a
+      // provider error; the partial assistant output carries the turn.
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: null },
+          externalAbort: true,
+          aborted: true,
+          failoverReason: null,
+          billingFailure: false,
+        }),
+      );
+
+      expect(outcome.action).toBe("continue_normal");
+    });
+
+    it("retries the same model when an idle-timeout retry is allowed", async () => {
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: null },
+          failoverReason: null,
+          timedOut: true,
+          idleTimedOut: true,
+          allowSameModelIdleTimeoutRetry: true,
+          billingFailure: false,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_idle_timeout");
+    });
+  });
+
+  describe("fallback_model branch", () => {
+    it("still throws a FailoverError after the surface_error refactor", async () => {
+      const logDecision = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "fallback_model", reason: "billing" },
+          fallbackConfigured: true,
+          failoverReason: "billing",
+          billingFailure: true,
+          logAssistantFailoverDecision: logDecision,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("billing");
+      expect(err.status).toBe(402);
+      expect(err.message).toBe(
+        formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"),
+      );
+      expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 402 });
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -183,28 +183,7 @@ export async function handleAssistantFailover(params: {
 
   if (decision.action === "fallback_model") {
     await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
-    const message =
-      (params.lastAssistant
-        ? formatAssistantErrorText(params.lastAssistant, {
-            cfg: params.config,
-            sessionKey: params.sessionKey,
-            provider: params.activeErrorContext.provider,
-            model: params.activeErrorContext.model,
-          })
-        : undefined) ||
-      params.lastAssistant?.errorMessage?.trim() ||
-      (params.timedOut
-        ? "LLM request timed out."
-        : params.rateLimitFailure
-          ? "LLM request rate limited."
-          : params.billingFailure
-            ? formatBillingErrorMessage(
-                params.activeErrorContext.provider,
-                params.activeErrorContext.model,
-              )
-            : params.authFailure
-              ? "LLM request unauthorized."
-              : "LLM request failed.");
+    const message = resolveAssistantFailoverErrorMessage(params);
     const status =
       resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
     params.logAssistantFailoverDecision("fallback_model", { status });
@@ -227,10 +206,101 @@ export async function handleAssistantFailover(params: {
       return sameModelIdleTimeoutRetry();
     }
     params.logAssistantFailoverDecision("surface_error");
+    // External aborts exit the run without synthesizing a provider error
+    // payload; partial attempt output carries the turn. Any other
+    // surface_error represents a concrete provider failure that
+    // continue_normal would silently drop before buildEmbeddedRunPayloads
+    // sees it (openclaw#70124: billing errors reached the gateway but
+    // never the webchat). Throw a FailoverError so the client surface
+    // can render it the same way it renders fallback_model failures.
+    if (!params.externalAbort) {
+      const message = resolveAssistantFailoverErrorMessage(params);
+      const reason = resolveSurfaceErrorReason(decision.reason, params);
+      const status =
+        resolveFailoverStatus(reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
+      return {
+        action: "throw",
+        overloadProfileRotations,
+        error: new FailoverError(message, {
+          reason,
+          provider: params.activeErrorContext.provider,
+          model: params.activeErrorContext.model,
+          profileId: params.lastProfileId,
+          status,
+        }),
+      };
+    }
   }
 
   return {
     action: "continue_normal",
     overloadProfileRotations,
   };
+}
+
+function resolveAssistantFailoverErrorMessage(params: {
+  lastAssistant: AssistantMessage | undefined;
+  config: OpenClawConfig | undefined;
+  sessionKey?: string;
+  activeErrorContext: { provider: string; model: string };
+  timedOut: boolean;
+  rateLimitFailure: boolean;
+  billingFailure: boolean;
+  authFailure: boolean;
+}): string {
+  return (
+    (params.lastAssistant
+      ? formatAssistantErrorText(params.lastAssistant, {
+          cfg: params.config,
+          sessionKey: params.sessionKey,
+          provider: params.activeErrorContext.provider,
+          model: params.activeErrorContext.model,
+        })
+      : undefined) ||
+    params.lastAssistant?.errorMessage?.trim() ||
+    (params.timedOut
+      ? "LLM request timed out."
+      : params.rateLimitFailure
+        ? "LLM request rate limited."
+        : params.billingFailure
+          ? formatBillingErrorMessage(
+              params.activeErrorContext.provider,
+              params.activeErrorContext.model,
+            )
+          : params.authFailure
+            ? "LLM request unauthorized."
+            : "LLM request failed.")
+  );
+}
+
+// surface_error decisions can arrive with `reason: null` when
+// shouldRotateAssistant fired on `failoverFailure` or `timedOut` without
+// a classified upstream reason. FailoverError requires a concrete
+// reason, so map null onto the most specific failure the run observed,
+// falling back to "unknown" when no signal is set.
+function resolveSurfaceErrorReason(
+  declared: FailoverReason | null,
+  params: {
+    timedOut: boolean;
+    billingFailure: boolean;
+    authFailure: boolean;
+    rateLimitFailure: boolean;
+  },
+): FailoverReason {
+  if (declared) {
+    return declared;
+  }
+  if (params.timedOut) {
+    return "timeout";
+  }
+  if (params.billingFailure) {
+    return "billing";
+  }
+  if (params.authFailure) {
+    return "auth";
+  }
+  if (params.rateLimitFailure) {
+    return "rate_limit";
+  }
+  return "unknown";
 }

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -237,6 +237,7 @@ export async function handleAssistantFailover(params: {
           model: params.activeErrorContext.model,
           profileId: params.lastProfileId,
           status,
+          rawError: params.lastAssistant?.errorMessage?.trim(),
         }),
       };
     }

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -206,14 +206,24 @@ export async function handleAssistantFailover(params: {
       return sameModelIdleTimeoutRetry();
     }
     params.logAssistantFailoverDecision("surface_error");
-    // External aborts exit the run without synthesizing a provider error
-    // payload; partial attempt output carries the turn. Any other
-    // surface_error represents a concrete provider failure that
-    // continue_normal would silently drop before buildEmbeddedRunPayloads
-    // sees it (openclaw#70124: billing errors reached the gateway but
-    // never the webchat). Throw a FailoverError so the client surface
-    // can render it the same way it renders fallback_model failures.
-    if (!params.externalAbort) {
+    // Two surface_error shapes already have downstream synthesis and
+    // must keep falling through to `continue_normal`:
+    //   1. External abort (user pressed stop) — partial assistant
+    //      output carries the turn; no provider error to synthesize.
+    //   2. Timeout without an idle-retry — run.ts emits a dedicated
+    //      timeout payload when buildEmbeddedRunPayloads produces no
+    //      assistant content (see the `timedOut &&
+    //      !timedOutDuringCompaction && !payloadsWithToolMedia.length`
+    //      block in run.ts). Throwing here would short-circuit that
+    //      synthesis and break timeout-compaction retry coverage.
+    // Every other surface_error is a concrete provider failure that
+    // continue_normal would silently drop before the payload builder
+    // sees it (openclaw#70124: billing errors reached the gateway
+    // but never the webchat because stopReason was not "error" and
+    // no other synthesis path caught them). Throw a FailoverError so
+    // the client surface can render it the same way it already
+    // renders fallback_model failures.
+    if (!params.externalAbort && !params.timedOut) {
       const message = resolveAssistantFailoverErrorMessage(params);
       const reason = resolveSurfaceErrorReason(decision.reason, params);
       const status =
@@ -274,14 +284,14 @@ function resolveAssistantFailoverErrorMessage(params: {
 }
 
 // surface_error decisions can arrive with `reason: null` when
-// shouldRotateAssistant fired on `failoverFailure` or `timedOut` without
-// a classified upstream reason. FailoverError requires a concrete
-// reason, so map null onto the most specific failure the run observed,
-// falling back to "unknown" when no signal is set.
+// shouldRotateAssistant fired on `failoverFailure` without a classified
+// upstream reason. FailoverError requires a concrete reason, so map
+// null onto the most specific failure the run observed, falling back
+// to "unknown" when no signal is set. Callers only hit this helper on
+// the non-timeout throw branch, so timeouts don't need a case here.
 function resolveSurfaceErrorReason(
   declared: FailoverReason | null,
   params: {
-    timedOut: boolean;
     billingFailure: boolean;
     authFailure: boolean;
     rateLimitFailure: boolean;
@@ -289,9 +299,6 @@ function resolveSurfaceErrorReason(
 ): FailoverReason {
   if (declared) {
     return declared;
-  }
-  if (params.timedOut) {
-    return "timeout";
   }
   if (params.billingFailure) {
     return "billing";


### PR DESCRIPTION
## Summary

- Problem: `handleAssistantFailover` resolved `surface_error`, logged the decision, then fell through to `continue_normal`. `buildEmbeddedRunPayloads` saw the partial assistant output and dropped the provider error silently, so billing/auth/rate_limit failures never reached the webchat.
- Why it matters: The reporter on #70124 hit this with Anthropic `invalid_request_error` (billing). Gateway logs show `decision=surface_error reason=billing`, but the UI renders nothing. The same path applies to every `surface_error` that isn't an external abort.
- What changed: On non-externalAbort `surface_error`, throw a `FailoverError` with the resolved reason/provider/model/profileId/status, matching the existing `fallback_model` behavior. The catch in `run.ts` already wraps thrown `FailoverError` into the payload the webchat renders, so the one-site change reuses the whole client surface.
- What did NOT change (scope boundary): external-abort short-circuit (user-pressed-stop still carries partial output via `continue_normal`), same-model-idle-timeout retry path, and the `rotate_profile` / `fallback_model` branches are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70124
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The `surface_error` branch in `handleAssistantFailover` called `logAssistantFailoverDecision("surface_error")` and then fell through to `return { action: "continue_normal", ... }`. Control returned to `buildEmbeddedRunPayloads`, which treated the partial assistant message as a completed turn and dropped the provider error.
- Missing detection / guardrail: No unit test asserted `handleAssistantFailover` throws a `FailoverError` on `surface_error`. `failover-policy.test.ts` covered decision resolution but not post-decision outcome side effects.
- Contributing context (if known): The `fallback_model` branch already throws `FailoverError` for the gateway catch to lift into the webchat payload. The two branches were asymmetric; `surface_error` was the only failure decision that reached `continue_normal`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/assistant-failover.test.ts` (new).
- Scenario the test should lock in: each failover reason (billing/auth/rate_limit) throws a `FailoverError` with the right status; null decision reasons coerce onto the most specific observed failure (timedOut -> timeout/408); `externalAbort` still falls through to `continue_normal`; idle-timeout same-model retry preserved; `fallback_model` regression guard after the message-builder refactor.
- Why this is the smallest reliable guardrail: `handleAssistantFailover` is pure given its params. Unit-level tests directly assert the outcome action and `FailoverError` fields; no need for a heavier runner harness.
- Existing test that already covers this (if any): `failover-policy.test.ts` covers decision resolution but not outcome side effects.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Billing, auth, rate_limit, and timeout failures from the assistant turn now surface to the webchat as concrete provider error messages (matching what `fallback_model` already produced) instead of an empty completion. External aborts (user pressed stop) continue to fall through without synthesizing a provider error.

## Diagram (if applicable)

```text
Before:
[surface_error billing] -> [log decision] -> [continue_normal]
                        -> [buildEmbeddedRunPayloads sees partial msg] -> [empty UI]

After:
[surface_error billing] -> [log decision] -> [throw FailoverError(reason=billing, status=402)]
                        -> [run.ts catch lifts into payload] -> [webchat renders provider error]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (container)
- Runtime/container: Node 22 / pnpm 9
- Model/provider: Anthropic `claude-haiku-4-5-20251001` (billing error path)
- Integration/channel (if any): pi-embedded-runner / webchat
- Relevant config (redacted): failover path exercised via an assistant turn classified as `billing` with `failoverFailure=true`, `fallbackConfigured=false`.

### Steps

1. Start a session against a provider that returns a billing-style `invalid_request_error` on the assistant turn (or stub the assistant message to set `billingFailure=true` with `failoverReason=billing`).
2. Watch the gateway log: it records `decision=surface_error reason=billing`.
3. Observe the webchat.

### Expected

- Webchat renders the provider's billing error via the shared `FailoverError` payload path.

### Actual

- Before this PR: webchat renders nothing; gateway log shows the decision but the error never propagates.
- After this PR: webchat renders the formatted billing error message; the catch in `run.ts` lifts the `FailoverError` into the payload the client already knows how to render.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New `assistant-failover.test.ts` fails against the pre-patch file (7/7 tests expect `action: "throw"` with a concrete `FailoverError`; pre-patch returns `action: "continue_normal"`). Against the patched file, all 7 pass.

## Human Verification (required)

- Verified scenarios: focused `pnpm test` on the new `assistant-failover.test.ts` (7/7 pass); `pnpm check:changed` (239 tests green); `pnpm lint:core` (0 warnings / 0 errors across 7127 files); `pnpm tsgo:core` and `pnpm tsgo:test:src` (both clean); unit-fast run on the adjacent `payloads.errors`, `payloads`, `failover-error`, `failover-policy` tests (106 tests / 4 files, all passing).
- Edge cases checked: null decision reason with `timedOut=true` coerces to `timeout`/408; null reason with no signal coerces to `unknown`; external abort still returns `continue_normal`; `idleTimedOut + allowSameModelIdleTimeoutRetry` returns retry with `retryKind: "same_model_idle_timeout"`; `fallback_model` branch still throws the same `FailoverError` with the shared message builder.
- What you did **not** verify: live-provider integration probe against a real Anthropic billing error.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A legitimate `surface_error` path (outside externalAbort) previously relied on the fall-through to `continue_normal` and would now throw instead.
  - Mitigation: The only documented caller of `continue_normal` after a `surface_error` decision was the external-abort case, which is still preserved explicitly. Every other `surface_error` decision represented a concrete provider failure that `continue_normal` was silently dropping.
- Risk: Null decision reasons now coerce to a concrete `FailoverReason`, which changes the reported reason on the outgoing `FailoverError`.
  - Mitigation: The coercion order (timeout -> billing -> auth -> rate_limit -> unknown) matches the same precedence used elsewhere in the failover path; if nothing matches, `"unknown"` is emitted instead of crashing on `null`.

AI-assisted: yes