### PR TITLE
fix(gateway-install): refresh install when loaded service embeds stale OPENCLAW_GATEWAY_TOKEN (#70752)

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -15,6 +15,7 @@ import {
   normalizeEnvVarKey,
 } from "../../infra/host-env-security.js";
 import { defaultRuntime } from "../../runtime.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { formatCliCommand } from "../command-format.js";
 import { buildDaemonServiceSnapshot, installDaemonServiceAndEmit } from "./response.js";
 import {
@@ -115,6 +116,19 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         } else {
           defaultRuntime.log(message);
         }
+      } else if (
+        gatewayServiceEmbedsStaleGatewayToken({
+          existingServiceEnv,
+          env: process.env,
+        })
+      ) {
+        const message =
+          "Gateway service embeds a stale OPENCLAW_GATEWAY_TOKEN; refreshing the install.";
+        if (json) {
+          warnings.push(message);
+        } else {
+          defaultRuntime.log(message);
+        }
       } else {
         emit({
           ok: true,
@@ -185,6 +199,27 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       });
     },
   });
+}
+
+// Detect the drift scenario from #70752: the loaded LaunchAgent / systemd unit
+// still embeds a previously-installed OPENCLAW_GATEWAY_TOKEN, but the operator's
+// current shell env has a different value (e.g. post-rotation). Without
+// refreshing the install, the gateway keeps running under the stale token and
+// every CLI call gets rejected with token_mismatch until the operator
+// remembers to run `openclaw gateway install --force`.
+function gatewayServiceEmbedsStaleGatewayToken(params: {
+  existingServiceEnv: Record<string, string> | undefined;
+  env: Record<string, string | undefined>;
+}): boolean {
+  const embedded = params.existingServiceEnv?.OPENCLAW_GATEWAY_TOKEN?.trim();
+  if (!embedded) {
+    return false;
+  }
+  const currentInvocation = normalizeOptionalString(params.env.OPENCLAW_GATEWAY_TOKEN);
+  if (!currentInvocation) {
+    return false;
+  }
+  return embedded !== currentInvocation;
 }
 
 async function gatewayServiceNeedsAutoNodeExtraCaCertsRefresh(params: {


### PR DESCRIPTION
## Summary

Closes #70752.

After a token rotation (e.g. post-upgrade), the loaded LaunchAgent / systemd unit still embeds the old \`OPENCLAW_GATEWAY_TOKEN\`. Plain \`openclaw gateway install\` then returns \`already-installed\` and the machine is stuck in a \`token_mismatch\` loop until the operator remembers to re-run with \`--force\`.

## Change

Mirror the existing NODE_EXTRA_CA_CERTS drift branch in \`src/cli/daemon-cli/install.ts\`. When:
1. The service is loaded
2. \`--force\` is not set
3. The loaded service definition has an embedded \`OPENCLAW_GATEWAY_TOKEN\`
4. The operator's current invocation environment has a different \`OPENCLAW_GATEWAY_TOKEN\`

...log \`Gateway service embeds a stale OPENCLAW_GATEWAY_TOKEN; refreshing the install.\` and fall through to the full install path instead of returning early.

## Scope

Intentionally narrow:
- Only fires when \`process.env.OPENCLAW_GATEWAY_TOKEN\` is set **and** differs from the embedded one. Absent or matching tokens keep the existing early-return — we don't want plain \`openclaw gateway install\` to silently rewrite the plist on every invocation.
- \`--force\` path is untouched.
- No changes to configure-time token resolution or to the systemd side (the same helper runs on both).

## Test plan

- \`pnpm oxlint src/cli/daemon-cli/install.ts\` → 0 warnings, 0 errors
- Manual (macOS LaunchAgent): install with token A → rotate config to token B, set \`OPENCLAW_GATEWAY_TOKEN=<B>\` in shell, re-run \`openclaw gateway install\` → now sees the drift message + refreshes, instead of returning \`already-installed\`. With \`OPENCLAW_GATEWAY_TOKEN\` unset, behavior unchanged from main.