### PR TITLE
[codex] harden extension-fast memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1344,6 +1344,8 @@ jobs:
       - name: Run changed extension tests
         env:
           OPENCLAW_CHANGED_EXTENSION: ${{ matrix.extension }}
+          NODE_OPTIONS: --max-old-space-size=6144
+          OPENCLAW_VITEST_MAX_WORKERS: 1
         run: pnpm test:extension "$OPENCLAW_CHANGED_EXTENSION"
 
   # Types, lint, and format check shards.


### PR DESCRIPTION
## Summary

- Cap the changed-extension fast Vitest lane to one worker.
- Give that lane a 6144 MB Node heap, matching recent extension shard hardening.

## Why

Recent PR CI runs showed repeated `extension-fast-telegram` failures from Vitest worker heap OOMs across unrelated PRs. The regular extension shard already has similar memory hardening; this applies the same approach to the fast changed-extension lane.

## Validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 NODE_OPTIONS=--max-old-space-size=6144 pnpm test:extension telegram`
- `pnpm check:changed` passed conflict markers, typecheck all, lint, and import-cycle checks; full test sweep then failed with watchdog terminations in broad unrelated shards (`vitest.agents.config.ts`, `vitest.extension-telegram.config.ts`) during local all-lane expansion.
