### PR TITLE
fix: enable claude-cli 1m context override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ Docs: https://docs.openclaw.ai
 - Codex media understanding: require approval-checked app-server image turns while explicitly declining tool, file, permission, and elicitation approval requests for the bounded image worker. (#71703) Thanks @vincentkoc.
 - Agents/Claude CLI: allow large live `stream-json` JSONL lines up to the existing per-turn raw limit, preventing large Telegram, WebChat, MCP, and image turns from aborting on the old stdout buffer cap. Fixes #71793, #71080, and #70766. (#71897) Thanks @chacher86, @shivamgrover21, and @tpjordan.
 - Agents/Claude CLI: unwrap nested Claude result envelopes in CLI JSON output so delegated agent responses surface as final text instead of raw result JSON. (#66819) Thanks @mraleko.
+- Agents/Claude CLI: apply the configured 1M context window override to eligible Claude CLI Opus and Sonnet models when `context1m` is enabled. (#70863) Thanks @bidadh.
 
 ## 2026.4.24
 

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -240,6 +240,58 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
+  it("does not force 1M context when claude-cli context1m is enabled", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            "claude-cli": {
+              baseUrl: "https://api.anthropic.com",
+              models: [testModelContextWindow("claude-opus-4-7", 200_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "claude-cli/claude-opus-4-7": {
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
+  });
+
+  it("does not force 1M context for claude-cli aliases when context1m is enabled", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "claude-cli/sonnet": {
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "sonnet",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
+  });
+
   it("does not force 1M context when context1m is not enabled", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -240,13 +240,12 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("does not force 1M context when claude-cli context1m is enabled", () => {
+  it("returns 1M context when claude-cli context1m is enabled for opus/sonnet", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
           providers: {
             "claude-cli": {
-              baseUrl: "https://api.anthropic.com",
               models: [testModelContextWindow("claude-opus-4-7", 200_000)],
             },
           },
@@ -267,29 +266,7 @@ describe("resolveContextTokensForModel", () => {
       allowAsyncLoad: false,
     });
 
-    expect(result).toBe(200_000);
-  });
-
-  it("does not force 1M context for claude-cli aliases when context1m is enabled", () => {
-    const result = resolveContextTokensForModel({
-      cfg: {
-        agents: {
-          defaults: {
-            models: {
-              "claude-cli/sonnet": {
-                params: { context1m: true },
-              },
-            },
-          },
-        },
-      },
-      provider: "claude-cli",
-      model: "sonnet",
-      fallbackContextTokens: 200_000,
-      allowAsyncLoad: false,
-    });
-
-    expect(result).toBe(200_000);
+    expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
   it("does not force 1M context when context1m is not enabled", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -246,6 +246,7 @@ describe("resolveContextTokensForModel", () => {
         models: {
           providers: {
             "claude-cli": {
+              baseUrl: "https://api.anthropic.com",
               models: [testModelContextWindow("claude-opus-4-7", 200_000)],
             },
           },

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -375,7 +375,7 @@ function resolveConfiguredProviderContextTokens(
 }
 
 function isAnthropic1MModel(provider: string, model: string): boolean {
-  if (provider !== "anthropic") {
+  if (provider !== "anthropic" && provider !== "claude-cli") {
     return false;
   }
   const modelId = resolveModelFamilyId(model);


### PR DESCRIPTION
## Summary

- Problem: `claude-cli` models in OpenClaw were not receiving the 1M context-window override for supported Claude Opus/Sonnet models when `params.context1m: true` was configured.
- Why it matters: Claude Code subscription users on the `claude-cli/*` path should get the same long-context behavior OpenClaw already exposes through model config for supported Anthropic-family models.
- What changed: extend the `context1m` context-window resolution logic to include `claude-cli` model refs, and add regression coverage for that path.
- Scope boundary: this PR is specifically about OpenClaw’s `claude-cli/*` context-window resolution, not the direct `anthropic/*` API-key flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/context.ts` only treated `anthropic` as eligible for the `context1m` 1M window override, so the `claude-cli` subscription-backed model path was excluded.
- Impacted behavior: `claude-cli/*` models with `params.context1m: true` stayed on the standard context window even for supported Opus/Sonnet models.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/context.test.ts`
- Scenario the test locks in: `claude-cli` model refs with `params.context1m: true` resolve to `ANTHROPIC_CONTEXT_1M_TOKENS`.

## User-visible / Behavior Changes

- `claude-cli/*` Opus/Sonnet models now resolve the 1M context window when `params.context1m: true` is enabled.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: `claude-cli`
- Relevant config (redacted): `agents.defaults.models["claude-cli/..."].params.context1m = true`

### Steps

1. Configure a `claude-cli` Opus or Sonnet model with `params.context1m: true`.
2. Resolve context tokens for that model in OpenClaw.
3. Confirm the resolved context window is `ANTHROPIC_CONTEXT_1M_TOKENS`.

### Expected

- `claude-cli` resolves the 1M context window for supported models when `context1m` is enabled.

### Actual

- This PR makes that behavior explicit and covered by unit tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm test src/agents/context.test.ts
```