### PR TITLE
refactor: split models list row sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: add optional forked context for native `sessions_spawn` runs so agents can let a child inherit the requester transcript when needed, while keeping clean isolated sessions as the default; includes prompt guidance, context-engine hook metadata, docs, and QA coverage.
 - Codex harness: add structured debug logging for embedded harness selection decisions so `/status` stays simple while gateway logs explain auto-selection and Pi fallback reasons. (#70760) Thanks @100yenadmin.
 - Dependencies/Pi: update bundled Pi packages to `0.70.0`, use Pi's upstream `gpt-5.5` catalog metadata for OpenAI and OpenAI Codex, and keep only local `gpt-5.5-pro` forward-compat handling.
+- Models/CLI: split `openclaw models list` row-source orchestration and registry loading into narrower helpers without changing list output behavior. (#70867) Thanks @shakkernerd.
 - Plugins/Google Meet: add a bundled participant plugin with personal Google auth, explicit meeting URL joins, Chrome and Twilio transports, and realtime voice support. (#70765) Thanks @steipete.
 - Providers/OpenAI: add image generation and reference-image editing through Codex OAuth, so `openai/gpt-image-2` works without an `OPENAI_API_KEY`. Fixes #70703.
 - Providers/OpenRouter: add image generation and reference-image editing through `image_generate`, so OpenRouter image models work with `OPENROUTER_API_KEY`. Fixes #55066 via #67668. Thanks @notamicrodose.

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -4,14 +4,8 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
-import {
-  appendCatalogSupplementRows,
-  appendConfiguredProviderRows,
-  appendConfiguredRows,
-  appendDiscoveredRows,
-  appendProviderCatalogRows,
-  loadListModelRegistry,
-} from "./list.rows.js";
+import { loadListModelRegistry } from "./list.registry-load.js";
+import { appendAllModelRowSources, appendConfiguredModelRowSources } from "./list.row-sources.js";
 import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
@@ -98,32 +92,12 @@ export async function modelsListCommand(
   };
 
   if (opts.all) {
-    const seenKeys = appendDiscoveredRows({
-      rows,
-      models: modelRegistry?.getAll() ?? [],
-      context: rowContext,
-    });
-
-    appendConfiguredProviderRows({
+    await appendAllModelRowSources({
       rows,
       context: rowContext,
-      seenKeys,
+      modelRegistry,
+      useProviderCatalogFastPath,
     });
-
-    if (modelRegistry) {
-      await appendCatalogSupplementRows({
-        rows,
-        modelRegistry,
-        context: rowContext,
-        seenKeys,
-      });
-    } else if (useProviderCatalogFastPath) {
-      await appendProviderCatalogRows({
-        rows,
-        context: rowContext,
-        seenKeys,
-      });
-    }
   } else {
     const registry = modelRegistry;
     if (!registry) {
@@ -131,7 +105,7 @@ export async function modelsListCommand(
       process.exitCode = 1;
       return;
     }
-    appendConfiguredRows({
+    appendConfiguredModelRowSources({
       rows,
       entries,
       modelRegistry: registry,

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -5,7 +5,11 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
 import { loadListModelRegistry } from "./list.registry-load.js";
-import { appendAllModelRowSources, appendConfiguredModelRowSources } from "./list.row-sources.js";
+import {
+  appendAllModelRowSources,
+  appendConfiguredModelRowSources,
+  modelRowSourcesRequireRegistry,
+} from "./list.row-sources.js";
 import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
@@ -55,8 +59,12 @@ export async function modelsListCommand(
   let availableKeys: Set<string> | undefined;
   let availabilityErrorMessage: string | undefined;
   const useProviderCatalogFastPath = Boolean(opts.all && providerFilter === "codex");
+  const shouldLoadRegistry = modelRowSourcesRequireRegistry({
+    all: opts.all,
+    useProviderCatalogFastPath,
+  });
   try {
-    if (!useProviderCatalogFastPath) {
+    if (shouldLoadRegistry) {
       const loaded = await loadListModelRegistry(cfg, { providerFilter });
       modelRegistry = loaded.registry;
       discoveredKeys = loaded.discoveredKeys;

--- a/src/commands/models/list.registry-load.ts
+++ b/src/commands/models/list.registry-load.ts
@@ -1,0 +1,14 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadModelRegistry } from "./list.registry.js";
+import { modelKey } from "./shared.js";
+
+export async function loadListModelRegistry(
+  cfg: OpenClawConfig,
+  opts?: { providerFilter?: string },
+) {
+  const loaded = await loadModelRegistry(cfg, opts);
+  return {
+    ...loaded,
+    discoveredKeys: new Set(loaded.models.map((model) => modelKey(model.provider, model.id))),
+  };
+}

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -16,6 +16,13 @@ type AllModelRowSources = {
   useProviderCatalogFastPath: boolean;
 };
 
+export function modelRowSourcesRequireRegistry(params: {
+  all?: boolean;
+  useProviderCatalogFastPath: boolean;
+}): boolean {
+  return !(params.all && params.useProviderCatalogFastPath);
+}
+
 export async function appendAllModelRowSources(params: AllModelRowSources): Promise<void> {
   const seenKeys = appendDiscoveredRows({
     rows: params.rows,

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -1,0 +1,58 @@
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import {
+  appendCatalogSupplementRows,
+  appendConfiguredProviderRows,
+  appendConfiguredRows,
+  appendDiscoveredRows,
+  appendProviderCatalogRows,
+  type RowBuilderContext,
+} from "./list.rows.js";
+import type { ConfiguredEntry, ModelRow } from "./list.types.js";
+
+type AllModelRowSources = {
+  rows: ModelRow[];
+  context: RowBuilderContext;
+  modelRegistry?: ModelRegistry;
+  useProviderCatalogFastPath: boolean;
+};
+
+export async function appendAllModelRowSources(params: AllModelRowSources): Promise<void> {
+  const seenKeys = appendDiscoveredRows({
+    rows: params.rows,
+    models: params.modelRegistry?.getAll() ?? [],
+    context: params.context,
+  });
+
+  appendConfiguredProviderRows({
+    rows: params.rows,
+    context: params.context,
+    seenKeys,
+  });
+
+  if (params.modelRegistry) {
+    await appendCatalogSupplementRows({
+      rows: params.rows,
+      modelRegistry: params.modelRegistry,
+      context: params.context,
+      seenKeys,
+    });
+    return;
+  }
+
+  if (params.useProviderCatalogFastPath) {
+    await appendProviderCatalogRows({
+      rows: params.rows,
+      context: params.context,
+      seenKeys,
+    });
+  }
+}
+
+export function appendConfiguredModelRowSources(params: {
+  rows: ModelRow[];
+  entries: ConfiguredEntry[];
+  modelRegistry: ModelRegistry;
+  context: RowBuilderContext;
+}): void {
+  appendConfiguredRows(params);
+}

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -7,7 +7,7 @@ import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ListRowModel } from "./list.model-row.js";
-import { loadModelRegistry, toModelRow } from "./list.registry.js";
+import { toModelRow } from "./list.registry.js";
 import {
   loadModelCatalog,
   loadProviderCatalogModelsForList,
@@ -23,7 +23,7 @@ type RowFilter = {
   local?: boolean;
 };
 
-type RowBuilderContext = {
+export type RowBuilderContext = {
   cfg: OpenClawConfig;
   agentDir: string;
   authStore: AuthProfileStore;
@@ -112,17 +112,6 @@ function shouldListConfiguredProviderModel(params: {
     params.providerConfig.apiKey !== undefined &&
     (params.providerConfig.api !== undefined || params.model.api !== undefined)
   );
-}
-
-export async function loadListModelRegistry(
-  cfg: OpenClawConfig,
-  opts?: { providerFilter?: string },
-) {
-  const loaded = await loadModelRegistry(cfg, opts);
-  return {
-    ...loaded,
-    discoveredKeys: new Set(loaded.models.map((model) => modelKey(model.provider, model.id))),
-  };
 }
 
 export function appendDiscoveredRows(params: {


### PR DESCRIPTION
## Summary

This PR starts the second `models list` performance slice by separating row-source orchestration from the command body and registry-loading helper code.

There is no intended user-visible behavior change in this PR. The point is to create a clean internal seam so the next optimization can make individual row sources cheaper without mixing that work into command parsing, config loading, or output formatting.

## What changed

- Added `src/commands/models/list.row-sources.ts`.
  - Owns the explicit row-source order for:
    - `models list --all`
    - default/configured `models list`
  - Keeps the current source ordering intact.

- Added `src/commands/models/list.registry-load.ts`.
  - Owns `loadListModelRegistry()`.
  - Keeps registry loading and discovered-key derivation separate from row construction.

- Updated `src/commands/models/list.list-command.ts`.
  - Delegates row assembly to the row-source module.
  - Delegates registry-load requirement checks to `modelRowSourcesRequireRegistry()`.

- Narrowed `src/commands/models/list.rows.ts`.
  - Keeps row construction and append helpers there.
  - Removes registry-loading responsibility from that file.

## Why

After PR #70847, `models list` is read-only, but the command still has too much row-source and registry-loading logic coupled together.

This PR does not try to make the command faster by itself. It makes the next performance changes safer:

- we can optimize configured rows without disturbing `--all`
- we can optimize provider-scoped rows without changing default list behavior
- we can measure and change each source independently
- we avoid another large mixed PR that changes auth, catalog, plugins, and row rendering all at once

## Behavior

Expected behavior is unchanged.

The command still preserves:

- default configured model listing
- `models list --all`
- provider-filtered `--all`
- Codex provider catalog fast path
- configured-provider row visibility from the read-only list PR
- read-only behavior from PR #70847

## Verification

- `pnpm test src/commands/models.list.e2e.test.ts src/commands/models/list.list-command.forward-compat.test.ts src/commands/models/list.rows.test.ts`
- `pnpm check:changed`
- `pnpm build`

Built CLI smoke:

- `node openclaw.mjs models list --json`
- `node openclaw.mjs models list --all --provider moonshot --json`
- `node openclaw.mjs models list --all --provider codex --json`
