### PR TITLE
perf: avoid broad registry enumeration for default models list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: add optional forked context for native `sessions_spawn` runs so agents can let a child inherit the requester transcript when needed, while keeping clean isolated sessions as the default; includes prompt guidance, context-engine hook metadata, docs, and QA coverage.
 - Codex harness: add structured debug logging for embedded harness selection decisions so `/status` stays simple while gateway logs explain auto-selection and Pi fallback reasons. (#70760) Thanks @100yenadmin.
 - Dependencies/Pi: update bundled Pi packages to `0.70.0`, use Pi's upstream `gpt-5.5` catalog metadata for OpenAI and OpenAI Codex, and keep only local `gpt-5.5-pro` forward-compat handling.
+- Models/CLI: avoid broad registry enumeration for default `openclaw models list`, reducing default listing latency while preserving configured-row output. (#70883) Thanks @shakkernerd.
 - Models/CLI: split `openclaw models list` row-source orchestration and registry loading into narrower helpers without changing list output behavior. (#70867) Thanks @shakkernerd.
 - Plugins/Google Meet: add a bundled participant plugin with personal Google auth, explicit meeting URL joins, Chrome and Twilio transports, and realtime voice support. (#70765) Thanks @steipete.
 - Plugins/Google Meet: default Chrome realtime sessions to OpenAI plus SoX `rec`/`play` audio bridge commands, so the usual setup only needs the plugin enabled and `OPENAI_API_KEY`.

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -27,6 +27,7 @@ const modelRegistryState = {
   available: [] as Array<Record<string, unknown>>,
   getAllError: undefined as unknown,
   getAvailableError: undefined as unknown,
+  findError: undefined as unknown,
 };
 let previousExitCode: typeof process.exitCode;
 
@@ -46,6 +47,9 @@ vi.mock("./models/load-config.js", () => ({
 vi.mock("./models/list.runtime.js", () => {
   class MockModelRegistry {
     find(provider: string, id: string) {
+      if (modelRegistryState.findError !== undefined) {
+        throw modelRegistryState.findError;
+      }
       return (
         modelRegistryState.models.find((model) => model.provider === provider && model.id === id) ??
         null
@@ -64,6 +68,12 @@ vi.mock("./models/list.runtime.js", () => {
         throw modelRegistryState.getAvailableError;
       }
       return modelRegistryState.available;
+    }
+
+    hasConfiguredAuth(model: { provider: string; id: string }) {
+      return modelRegistryState.available.some(
+        (available) => available.provider === model.provider && available.id === model.id,
+      );
     }
   }
 
@@ -133,6 +143,7 @@ beforeEach(() => {
   process.exitCode = undefined;
   modelRegistryState.getAllError = undefined;
   modelRegistryState.getAvailableError = undefined;
+  modelRegistryState.findError = undefined;
   getRuntimeConfig.mockReset();
   getRuntimeConfig.mockReturnValue({});
   listProfilesForProvider.mockReturnValue([]);
@@ -390,22 +401,27 @@ describe("models list/status", () => {
     expect(loadProviderCatalogModelsForList).not.toHaveBeenCalled();
   });
 
-  it("models list does not treat availability-unavailable code as discovery fallback", async () => {
+  it("models list default does not enumerate all registry models", async () => {
     configureGoogleAntigravityModel("claude-opus-4-6-thinking");
+    modelRegistryState.models = [
+      makeGoogleAntigravityTemplate("claude-opus-4-6-thinking", "Claude Opus 4.6 Thinking"),
+    ];
+    modelRegistryState.available = modelRegistryState.models;
     modelRegistryState.getAllError = Object.assign(new Error("model discovery failed"), {
       code: "MODEL_AVAILABILITY_UNAVAILABLE",
     });
     const runtime = makeRuntime();
     await modelsListCommand({ json: true }, runtime);
 
-    expectModelRegistryUnavailable(runtime, "model discovery failed");
-    expect(runtime.error.mock.calls[0]?.[0]).not.toContain("configured models may appear missing");
+    expect(runtime.error).not.toHaveBeenCalled();
+    const payload = parseJsonLog(runtime);
+    expect(payload.models[0]?.key).toBe("google-antigravity/claude-opus-4-6-thinking");
   });
 
-  it("models list fails fast when registry model discovery is unavailable", async () => {
+  it("models list fails fast when configured registry lookup is unavailable", async () => {
     configureGoogleAntigravityModel("claude-opus-4-6-thinking");
     enableGoogleAntigravityAuthProfile();
-    modelRegistryState.getAllError = Object.assign(new Error("model discovery unavailable"), {
+    modelRegistryState.findError = Object.assign(new Error("model discovery unavailable"), {
       code: "MODEL_DISCOVERY_UNAVAILABLE",
     });
     const runtime = makeRuntime();

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -141,6 +141,43 @@ function installModelsListCommandForwardCompatMocks() {
     printModelTable: mocks.printModelTable,
   }));
 
+  vi.doMock("./list.registry-load.js", () => ({
+    loadListModelRegistry: async (
+      cfg: unknown,
+      opts?: { providerFilter?: string },
+    ): Promise<{
+      models: Array<{ provider: string; id: string }>;
+      availableKeys?: Set<string>;
+      registry?: unknown;
+      discoveredKeys: Set<string>;
+    }> => {
+      const loaded = await mocks.loadModelRegistry(cfg, opts);
+      return {
+        ...loaded,
+        discoveredKeys: new Set(
+          loaded.models.map(
+            (model: { provider: string; id: string }) => `${model.provider}/${model.id}`,
+          ),
+        ),
+      };
+    },
+    loadConfiguredListModelRegistry: (
+      _cfg: unknown,
+      _entries: unknown,
+      opts?: { providerFilter?: string },
+    ) => {
+      mocks.loadModelRegistry(mocks.resolvedConfig, opts);
+      return {
+        registry: {
+          find: () => undefined,
+          hasConfiguredAuth: () => false,
+        },
+        discoveredKeys: new Set(),
+        availableKeys: new Set(),
+      };
+    },
+  }));
+
   vi.doMock("./list.runtime.js", () => ({
     ensureOpenClawModelsJson: mocks.ensureOpenClawModelsJson,
     ensureAuthProfileStore: mocks.ensureAuthProfileStore,
@@ -363,7 +400,7 @@ describe("modelsListCommand forward-compat", () => {
       );
     });
 
-    it("exits with an error when configured-mode listing has no model registry", async () => {
+    it("does not require the all-model registry result for configured-mode listing", async () => {
       const previousExitCode = process.exitCode;
       process.exitCode = undefined;
       mocks.loadModelRegistry.mockResolvedValueOnce({
@@ -381,9 +418,9 @@ describe("modelsListCommand forward-compat", () => {
         process.exitCode = previousExitCode;
       }
 
-      expect(runtime.error).toHaveBeenCalledWith("Model registry unavailable.");
-      expect(observedExitCode).toBe(1);
-      expect(mocks.printModelTable).not.toHaveBeenCalled();
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(observedExitCode).toBeUndefined();
+      expect(mocks.printModelTable).toHaveBeenCalled();
     });
   });
 

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -4,7 +4,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
-import { loadListModelRegistry } from "./list.registry-load.js";
+import { loadConfiguredListModelRegistry, loadListModelRegistry } from "./list.registry-load.js";
 import {
   appendAllModelRowSources,
   appendConfiguredModelRowSources,
@@ -59,6 +59,8 @@ export async function modelsListCommand(
   let availableKeys: Set<string> | undefined;
   let availabilityErrorMessage: string | undefined;
   const useProviderCatalogFastPath = Boolean(opts.all && providerFilter === "codex");
+  const { entries } = resolveConfiguredEntries(cfg);
+  const configuredByKey = new Map(entries.map((entry) => [entry.key, entry]));
   const shouldLoadRegistry = modelRowSourcesRequireRegistry({
     all: opts.all,
     useProviderCatalogFastPath,
@@ -70,6 +72,11 @@ export async function modelsListCommand(
       discoveredKeys = loaded.discoveredKeys;
       availableKeys = loaded.availableKeys;
       availabilityErrorMessage = loaded.availabilityErrorMessage;
+    } else if (!opts.all) {
+      const loaded = loadConfiguredListModelRegistry(cfg, entries, { providerFilter });
+      modelRegistry = loaded.registry;
+      discoveredKeys = loaded.discoveredKeys;
+      availableKeys = loaded.availableKeys;
     }
   } catch (err) {
     runtime.error(`Model registry unavailable:\n${formatErrorWithStack(err)}`);
@@ -81,8 +88,6 @@ export async function modelsListCommand(
       `Model availability lookup failed; falling back to auth heuristics for discovered models: ${availabilityErrorMessage}`,
     );
   }
-  const { entries } = resolveConfiguredEntries(cfg);
-  const configuredByKey = new Map(entries.map((entry) => [entry.key, entry]));
 
   const rows: ModelRow[] = [];
   const rowContext = {

--- a/src/commands/models/list.registry-load.ts
+++ b/src/commands/models/list.registry-load.ts
@@ -1,5 +1,10 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { shouldSuppressBuiltInModel } from "../../agents/model-suppression.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadModelRegistry } from "./list.registry.js";
+import { discoverAuthStorage, discoverModels, resolveOpenClawAgentDir } from "./list.runtime.js";
+import type { ConfiguredEntry } from "./list.types.js";
 import { modelKey } from "./shared.js";
 
 export async function loadListModelRegistry(
@@ -10,5 +15,59 @@ export async function loadListModelRegistry(
   return {
     ...loaded,
     discoveredKeys: new Set(loaded.models.map((model) => modelKey(model.provider, model.id))),
+  };
+}
+
+function findConfiguredRegistryModel(params: {
+  registry: ModelRegistry;
+  entry: ConfiguredEntry;
+  cfg: OpenClawConfig;
+}): Model<Api> | undefined {
+  const model = params.registry.find(params.entry.ref.provider, params.entry.ref.model);
+  if (!model) {
+    return undefined;
+  }
+  if (
+    shouldSuppressBuiltInModel({
+      provider: model.provider,
+      id: model.id,
+      baseUrl: model.baseUrl,
+      config: params.cfg,
+    })
+  ) {
+    return undefined;
+  }
+  return model;
+}
+
+export function loadConfiguredListModelRegistry(
+  cfg: OpenClawConfig,
+  entries: ConfiguredEntry[],
+  opts?: { providerFilter?: string },
+) {
+  const agentDir = resolveOpenClawAgentDir();
+  const authStorage = discoverAuthStorage(agentDir, { readOnly: true });
+  const registry = discoverModels(authStorage, agentDir, {
+    providerFilter: opts?.providerFilter,
+  });
+  const discoveredKeys = new Set<string>();
+  const availableKeys = new Set<string>();
+
+  for (const entry of entries) {
+    const model = findConfiguredRegistryModel({ registry, entry, cfg });
+    if (!model) {
+      continue;
+    }
+    const key = modelKey(model.provider, model.id);
+    discoveredKeys.add(key);
+    if (registry.hasConfiguredAuth(model)) {
+      availableKeys.add(key);
+    }
+  }
+
+  return {
+    registry,
+    discoveredKeys,
+    availableKeys,
   };
 }

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -20,7 +20,10 @@ export function modelRowSourcesRequireRegistry(params: {
   all?: boolean;
   useProviderCatalogFastPath: boolean;
 }): boolean {
-  return !(params.all && params.useProviderCatalogFastPath);
+  if (!params.all) {
+    return false;
+  }
+  return !params.useProviderCatalogFastPath;
 }
 
 export async function appendAllModelRowSources(params: AllModelRowSources): Promise<void> {


### PR DESCRIPTION
## What changed

Default `openclaw models list` now resolves configured/default model rows without enumerating the full model registry.

Before this change, the default list path still paid for broad registry work even though it only needed configured rows. That meant `models list` could spend several seconds in all-model discovery before printing a single configured/default model.

This PR keeps the broad registry path for `models list --all`, but narrows the default path to:

- resolve configured entries from config
- look up only those configured models with `registry.find()`
- check exact configured availability with `registry.hasConfiguredAuth(model)`
- preserve the existing configured-row fallback for missing or forward-compatible models

## Before

Measured against `origin/main` after build:

```sh
node openclaw.mjs models list --json
```

Warm runs:

- `9.31s`
- `8.24s`

Local output:

```json
{
  "count": 1,
  "models": [
    {
      "key": "openai/gpt-5.5"
    }
  ]
}
```

## After

Measured on this branch after build:

```sh
node openclaw.mjs models list --json
```

Warm runs:

- `4.15s`
- `2.97s`

Local output remains the same configured row:

```json
{
  "count": 1,
  "models": [
    {
      "key": "openai/gpt-5.5"
    }
  ]
}
```

## Behavior notes

- `models list --all` still uses the broad registry path.
- Default `models list` still hydrates configured rows through the registry.
- Missing configured models still flow through the existing fallback path.
- This does not introduce new manifest/plugin catalog behavior.

## Verification

- `pnpm check:changed`
- `node openclaw.mjs models list --json`
