### PR TITLE
fix(tasks): stop cron audit noise from 1ms startedAt/createdAt skew (#70887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tasks/audit: anchor `createdAt` to a caller-supplied `startedAt` when the wall clock ticks between the two `Date.now()` reads, so cron-runtime task ledger records no longer flood `openclaw tasks audit` with `inconsistent_timestamps` warnings for every successful run. Fixes #70887.
 - Memory/CLI: declare the built-in `local` embedding provider in the memory-core manifest, so standalone `openclaw memory status`, `index`, and `search` can resolve local embeddings just like the gateway runtime. Fixes #70836. (#70873) Thanks @mattznojassist.
 - Gateway/WebChat: preserve image attachments for text-only primary models by offloading them as media refs instead of dropping them, so configured image tools can still inspect the original file. Fixes #68513, #44276, #51656, #70212.
 - Plugins/Google Meet: hang up delegated Twilio calls on leave, clean up Chrome realtime audio bridges when launch fails, and use a flat provider-safe tool schema.

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -16,6 +16,7 @@ import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
 import { configureTaskFlowRegistryRuntime } from "./task-flow-registry.store.js";
+import { listTaskAuditFindings } from "./task-registry.audit.js";
 import {
   cancelTaskById,
   createTaskRecord,
@@ -279,6 +280,41 @@ describe("task-registry", () => {
         status: "succeeded",
         endedAt: 250,
       });
+    });
+  });
+
+  it("anchors createdAt to caller-supplied startedAt when the wall clock ticks between reads", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const startedAt = 1_800_000_000_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(startedAt + 1);
+      try {
+        const task = createTaskRecord({
+          runtime: "cron",
+          ownerKey: "",
+          scopeKind: "system",
+          childSessionKey: "agent:main:cron:nightly",
+          runId: "run-cron-race",
+          task: "nightly trading cycle",
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          startedAt,
+          lastEventAt: startedAt,
+        });
+
+        expect(task.createdAt).toBe(startedAt);
+        expect(task.startedAt).toBe(startedAt);
+        const findings = listTaskAuditFindings({
+          tasks: [task],
+          now: startedAt + 1,
+        });
+        expect(findings.filter((f) => f.code === "inconsistent_timestamps")).toEqual([]);
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1452,6 +1452,13 @@ export function createTaskRecord(params: {
     ownerKey,
     scopeKind,
   });
+  // Callers such as the cron runner capture `startedAt = Date.now()` just before
+  // creating the task record, so the `now` read above can land 1-4ms later when
+  // the wall clock ticks between the two reads. Anchor `createdAt` to the earlier
+  // caller-supplied `startedAt` in that case so audits do not flag the 1ms skew
+  // as `inconsistent_timestamps` for every successful cron run.
+  const createdAt =
+    typeof params.startedAt === "number" && params.startedAt < now ? params.startedAt : now;
   const lastEventAt = params.lastEventAt ?? params.startedAt ?? now;
   const record: TaskRecord = {
     taskId,
@@ -1471,7 +1478,7 @@ export function createTaskRecord(params: {
     status,
     deliveryStatus,
     notifyPolicy,
-    createdAt: now,
+    createdAt,
     startedAt: params.startedAt,
     lastEventAt,
     cleanupAfter: params.cleanupAfter,


### PR DESCRIPTION
## Summary

`openclaw tasks audit` was producing 700+ `inconsistent_timestamps` warnings per run, 99% of them `startedAt` exactly 1ms before `createdAt` on cron-runtime tasks. Root cause is two separate `Date.now()` reads: the cron runner captures `startedAt = Date.now()` just before invoking `createRunningTaskRun(...)`, and `createTaskRecord` reads `Date.now()` again for `createdAt`. When the wall clock ticks between the two reads (very common under load), the audit's `startedAt < createdAt` check fires for every successful cron run, drowning out real warnings.

Fix is a one-branch monotonicity clamp inside `createTaskRecord`: when a caller supplies a `startedAt` that is strictly earlier than the registry's own `Date.now()`, anchor `createdAt` to that `startedAt`. This also keeps the natural semantics for retroactive records (task was started before the ledger row was persisted). Callers that do not supply `startedAt` (the common subagent/ACP/queued paths) are unchanged — `createdAt` still comes from `Date.now()`.

Fixes #70887.

## Root cause

```
// src/cron/service/timer.ts
const startedAt = state.deps.nowMs();          // first Date.now()
...
createRunningTaskRun({ ..., startedAt, lastEventAt: startedAt });
  -> createTaskRecord(...)
       const now = Date.now();                  // second Date.now(), 1-4ms later
       ...
       createdAt: now,
       startedAt: params.startedAt,             // < now on any ms tick
```

`src/cron/service/ops.ts` (manual cron runs) has the same shape, and is covered by the same single fix since both paths funnel through `createTaskRecord`.

## Why this is safe

- Only affects the branch where `params.startedAt` is explicitly supplied **and** strictly earlier than the in-function `Date.now()`; every other call site keeps the existing `createdAt = now` behavior.
- `cleanupAfter` computation uses `endedAt ?? lastEventAt ?? createdAt`, and `lastEventAt` already defaulted to `params.startedAt ?? now`, so retention math stays consistent with the pre-fix behavior on the caller-supplied `startedAt` path.
- No change to the audit check, to `mergeExistingTaskForCreate`, to persistence schema, or to the `TaskRecord` type shape.
- Existing `src/tasks/task-registry.test.ts` (43 tests including the terminal-task prune test that passes `startedAt: Date.now() - 9 * 24 * 60 * 60_000`) continues to pass.

## Security / runtime controls unchanged

- No changes to owner/scope enforcement, delivery status, notify policy, or any permission/approval surface.
- `inconsistent_timestamps` is an observability/debug aid in `openclaw tasks audit`, not a runtime security gate.
- No prompt/text-level behavior was relied on; the fix is a pure write-time data-consistency clamp.
- No CODEOWNERS-protected paths touched.

## Testing

- Added focused regression: `src/tasks/task-registry.test.ts` - \"anchors createdAt to caller-supplied startedAt when the wall clock ticks between reads\". Uses `vi.spyOn(Date, 'now')` to deterministically simulate the 1ms race, verifies (a) `task.createdAt === startedAt`, and (b) `listTaskAuditFindings` returns no `inconsistent_timestamps` findings for the record.
- `pnpm test src/tasks/task-registry.test.ts` - 43/43 pass.
- `pnpm test src/tasks/task-registry.audit.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/detached-task-runtime.test.ts` - 13/13 pass.
- `pnpm test:changed` (origin/main base) - 116/116 pass across the tasks lane.
- `npx oxlint src/tasks/task-registry.ts src/tasks/task-registry.test.ts` - 0 warnings, 0 errors.
- `pnpm format src/tasks/task-registry.ts src/tasks/task-registry.test.ts` applied.
- `pnpm tsgo` shows no new errors in the touched files; the remaining `tsgo`/`lint:core` failures (`typebox` module, `plugin-sdk/*`, `gateway/server-methods/*`, `ui/*`) reproduce on an unmodified `origin/main` checkout and are unrelated to this change.

## Notes for reviewers

- AI-assisted PR.
- Lightly tested (unit-level regression + adjacent lanes green). Not exercised against a live cron runtime.
- One changelog entry added under `## Unreleased` > `### Fixes`.

Made with [Cursor](https://cursor.com)