### PR TITLE
Route Z.AI vision models to non-coding host on Coding Plan endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Z.AI: route bundled Z.AI vision models (`glm-4.6v`, `glm-4.5v`, `glm-5v-turbo`) to the matching non-coding host when onboarded with a Coding Plan endpoint, so the built-in `image` tool stops returning 404 while keeping text models on the coding route. Fixes #70886.
 - Agents/replay: stop OpenAI/Codex transcript replay from synthesizing missing tool results while still preserving synthetic repair on Anthropic, Gemini, and Bedrock transport-owned sessions. (#61556) Thanks @VictorJeon and @vincentkoc.
 - Telegram/media replies: parse remote markdown image syntax into outbound media payloads on the final reply path, so Telegram group chats stop falling back to plain-text image URLs when the model or a tool emits `![...](...)` instead of a `MEDIA:` token. (#66191) Thanks @apezam and @vincentkoc.
 - Agents/WebChat: surface non-retryable provider failures such as billing, auth, and rate-limit errors from the embedded runner instead of logging `surface_error` and leaving webchat with no rendered error. Fixes #70124. (#70848) Thanks @truffle-dev.

--- a/extensions/zai/model-definitions.ts
+++ b/extensions/zai/model-definitions.ts
@@ -147,6 +147,22 @@ export function resolveZaiBaseUrl(endpoint?: string): string {
   }
 }
 
+export function isZaiCodingBaseUrl(baseUrl: string | undefined): boolean {
+  return baseUrl === ZAI_CODING_GLOBAL_BASE_URL || baseUrl === ZAI_CODING_CN_BASE_URL;
+}
+
+// ZAI vision/image models are not served on the Coding Plan endpoints and
+// respond with 404 there; map coding URLs back to the matching non-coding host.
+export function resolveZaiNonCodingBaseUrl(baseUrl: string | undefined): string | undefined {
+  if (baseUrl === ZAI_CODING_GLOBAL_BASE_URL) {
+    return ZAI_GLOBAL_BASE_URL;
+  }
+  if (baseUrl === ZAI_CODING_CN_BASE_URL) {
+    return ZAI_CN_BASE_URL;
+  }
+  return undefined;
+}
+
 export function buildZaiModelDefinition(params: {
   id: string;
   name?: string;

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -96,6 +96,36 @@ describe("zai onboard", () => {
     expect(byId.get("glm-5v-turbo")?.baseUrl).toBe(ZAI_GLOBAL_BASE_URL);
   });
 
+  it("preserves user-defined custom image-capable zai models during re-onboarding", () => {
+    // A user-added Z.AI model that isn't part of the bundled catalog must keep
+    // its pinned baseUrl across endpoint changes. Only the bundled vision ids
+    // (glm-4.6v / glm-4.5v / glm-5v-turbo) are managed by onboarding.
+    const seed = applyZaiConfig({}, { endpoint: "coding-global" });
+    const zai = seed.models?.providers?.zai;
+    const customModel = {
+      id: "acme-vision-custom",
+      name: "ACME Vision",
+      api: "openai-completions" as const,
+      input: ["text", "image"] as const,
+      output: ["text"] as const,
+      baseUrl: "https://acme.example.com/v1",
+    };
+    const withCustom = {
+      ...seed,
+      models: {
+        ...seed.models,
+        providers: {
+          ...seed.models?.providers,
+          zai: { ...zai, models: [...(zai?.models ?? []), customModel] },
+        },
+      },
+    };
+    const switched = applyZaiConfig(withCustom, { endpoint: "global" });
+    const byId = new Map((switched.models?.providers?.zai?.models ?? []).map((m) => [m.id, m]));
+    expect(byId.get("acme-vision-custom")?.baseUrl).toBe("https://acme.example.com/v1");
+    expect(byId.get("glm-4.6v")?.baseUrl).toBeUndefined();
+  });
+
   it("rewrites stale vision baseUrl when switching between endpoints", () => {
     const first = applyZaiConfig({}, { endpoint: "coding-global" });
     const second = applyZaiConfig(first, { endpoint: "coding-cn" });

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -1,7 +1,12 @@
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
 import { expectProviderOnboardPreservesPrimary } from "../../test/helpers/plugins/provider-onboard.js";
-import { ZAI_CODING_CN_BASE_URL, ZAI_GLOBAL_BASE_URL } from "./model-definitions.js";
+import {
+  ZAI_CN_BASE_URL,
+  ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_GLOBAL_BASE_URL,
+  ZAI_GLOBAL_BASE_URL,
+} from "./model-definitions.js";
 import { applyZaiConfig, applyZaiProviderConfig } from "./onboard.js";
 
 describe("zai onboard", () => {
@@ -32,5 +37,37 @@ describe("zai onboard", () => {
       applyProviderConfig: applyZaiProviderConfig,
       primaryModelRef: "anthropic/claude-opus-4-5",
     });
+  });
+
+  it("routes vision models to the non-coding host when onboarded to a Coding Plan endpoint", () => {
+    // Vision models (glm-4.6v, glm-4.5v, glm-5v-turbo) are unavailable on
+    // the Z.AI Coding Plan endpoints and return 404 there. They must point
+    // at the matching non-coding host so the built-in `image` tool works.
+    for (const [endpoint, provider, vision] of [
+      ["coding-global", ZAI_CODING_GLOBAL_BASE_URL, ZAI_GLOBAL_BASE_URL],
+      ["coding-cn", ZAI_CODING_CN_BASE_URL, ZAI_CN_BASE_URL],
+    ] as const) {
+      const cfg = applyZaiConfig({}, { endpoint });
+      const zai = cfg.models?.providers?.zai;
+      expect(zai?.baseUrl).toBe(provider);
+      const byId = new Map((zai?.models ?? []).map((m) => [m.id, m]));
+      for (const visionId of ["glm-4.6v", "glm-4.5v", "glm-5v-turbo"] as const) {
+        expect(byId.get(visionId)?.baseUrl).toBe(vision);
+      }
+      expect(byId.get("glm-5.1")?.baseUrl).toBeUndefined();
+      expect(byId.get("glm-4.7-flash")?.baseUrl).toBeUndefined();
+    }
+  });
+
+  it("does not override vision model baseUrl when onboarded to non-coding endpoints", () => {
+    for (const endpoint of ["global", "cn"] as const) {
+      const cfg = applyZaiConfig({}, { endpoint });
+      const zai = cfg.models?.providers?.zai;
+      const visionEntries = (zai?.models ?? []).filter((m) => m.input?.includes("image"));
+      expect(visionEntries.length).toBeGreaterThan(0);
+      for (const entry of visionEntries) {
+        expect(entry.baseUrl).toBeUndefined();
+      }
+    }
   });
 });

--- a/extensions/zai/onboard.test.ts
+++ b/extensions/zai/onboard.test.ts
@@ -70,4 +70,44 @@ describe("zai onboard", () => {
       }
     }
   });
+
+  it("backfills vision baseUrl for configs onboarded before the fix", () => {
+    // Simulate a stale config: coding endpoint already configured, vision
+    // models present without baseUrl (the buggy pre-fix shape).
+    const stale = applyZaiConfig({}, { endpoint: "coding-global" });
+    const staleZai = stale.models?.providers?.zai;
+    const stripped = {
+      ...stale,
+      models: {
+        ...stale.models,
+        providers: {
+          ...stale.models?.providers,
+          zai: {
+            ...staleZai,
+            models: (staleZai?.models ?? []).map(({ baseUrl: _drop, ...rest }) => rest),
+          },
+        },
+      },
+    };
+    const cfg = applyZaiConfig(stripped, { endpoint: "coding-global" });
+    const byId = new Map((cfg.models?.providers?.zai?.models ?? []).map((m) => [m.id, m]));
+    expect(byId.get("glm-4.6v")?.baseUrl).toBe(ZAI_GLOBAL_BASE_URL);
+    expect(byId.get("glm-4.5v")?.baseUrl).toBe(ZAI_GLOBAL_BASE_URL);
+    expect(byId.get("glm-5v-turbo")?.baseUrl).toBe(ZAI_GLOBAL_BASE_URL);
+  });
+
+  it("rewrites stale vision baseUrl when switching between endpoints", () => {
+    const first = applyZaiConfig({}, { endpoint: "coding-global" });
+    const second = applyZaiConfig(first, { endpoint: "coding-cn" });
+    const byCodingCn = new Map((second.models?.providers?.zai?.models ?? []).map((m) => [m.id, m]));
+    expect(second.models?.providers?.zai?.baseUrl).toBe(ZAI_CODING_CN_BASE_URL);
+    expect(byCodingCn.get("glm-4.6v")?.baseUrl).toBe(ZAI_CN_BASE_URL);
+    expect(byCodingCn.get("glm-4.5v")?.baseUrl).toBe(ZAI_CN_BASE_URL);
+
+    const third = applyZaiConfig(second, { endpoint: "global" });
+    const byGlobal = new Map((third.models?.providers?.zai?.models ?? []).map((m) => [m.id, m]));
+    expect(third.models?.providers?.zai?.baseUrl).toBe(ZAI_GLOBAL_BASE_URL);
+    expect(byGlobal.get("glm-4.6v")?.baseUrl).toBeUndefined();
+    expect(byGlobal.get("glm-4.5v")?.baseUrl).toBeUndefined();
+  });
 });

--- a/extensions/zai/onboard.ts
+++ b/extensions/zai/onboard.ts
@@ -1,3 +1,4 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyProviderConfigWithModelCatalogPreset,
   type OpenClawConfig,
@@ -5,27 +6,47 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
   buildZaiModelDefinition,
+  isZaiCodingBaseUrl,
   resolveZaiBaseUrl,
+  resolveZaiNonCodingBaseUrl,
   ZAI_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
 
 export const ZAI_DEFAULT_MODEL_REF = `zai/${ZAI_DEFAULT_MODEL_ID}`;
 
-const ZAI_DEFAULT_MODELS = [
-  buildZaiModelDefinition({ id: "glm-5.1" }),
-  buildZaiModelDefinition({ id: "glm-5" }),
-  buildZaiModelDefinition({ id: "glm-5-turbo" }),
-  buildZaiModelDefinition({ id: "glm-5v-turbo" }),
-  buildZaiModelDefinition({ id: "glm-4.7" }),
-  buildZaiModelDefinition({ id: "glm-4.7-flash" }),
-  buildZaiModelDefinition({ id: "glm-4.7-flashx" }),
-  buildZaiModelDefinition({ id: "glm-4.6" }),
-  buildZaiModelDefinition({ id: "glm-4.6v" }),
-  buildZaiModelDefinition({ id: "glm-4.5" }),
-  buildZaiModelDefinition({ id: "glm-4.5-air" }),
-  buildZaiModelDefinition({ id: "glm-4.5-flash" }),
-  buildZaiModelDefinition({ id: "glm-4.5v" }),
-];
+const ZAI_CATALOG_IDS = [
+  "glm-5.1",
+  "glm-5",
+  "glm-5-turbo",
+  "glm-5v-turbo",
+  "glm-4.7",
+  "glm-4.7-flash",
+  "glm-4.7-flashx",
+  "glm-4.6",
+  "glm-4.6v",
+  "glm-4.5",
+  "glm-4.5-air",
+  "glm-4.5-flash",
+  "glm-4.5v",
+] as const;
+
+function buildZaiCatalogModels(providerBaseUrl: string): ModelDefinitionConfig[] {
+  // When the provider is configured to a Coding Plan endpoint, vision models
+  // must target the matching non-coding host; carry a per-model baseUrl so
+  // the image tool stays functional without overriding the text-model path.
+  const visionBaseUrl = isZaiCodingBaseUrl(providerBaseUrl)
+    ? resolveZaiNonCodingBaseUrl(providerBaseUrl)
+    : undefined;
+  const models: ModelDefinitionConfig[] = [];
+  for (const id of ZAI_CATALOG_IDS) {
+    const model = buildZaiModelDefinition({ id });
+    if (visionBaseUrl && model.input.includes("image")) {
+      model.baseUrl = visionBaseUrl;
+    }
+    models.push(model);
+  }
+  return models;
+}
 
 function resolveZaiPresetBaseUrl(cfg: OpenClawConfig, endpoint?: string): string {
   const existingProvider = cfg.models?.providers?.zai;
@@ -40,11 +61,12 @@ function applyZaiPreset(
 ): OpenClawConfig {
   const modelId = normalizeOptionalString(params?.modelId) ?? ZAI_DEFAULT_MODEL_ID;
   const modelRef = `zai/${modelId}`;
+  const baseUrl = resolveZaiPresetBaseUrl(cfg, params?.endpoint);
   return applyProviderConfigWithModelCatalogPreset(cfg, {
     providerId: "zai",
     api: "openai-completions",
-    baseUrl: resolveZaiPresetBaseUrl(cfg, params?.endpoint),
-    catalogModels: ZAI_DEFAULT_MODELS,
+    baseUrl,
+    catalogModels: buildZaiCatalogModels(baseUrl),
     aliases: [{ modelRef, alias: "GLM" }],
     primaryModelRef,
   });

--- a/extensions/zai/onboard.ts
+++ b/extensions/zai/onboard.ts
@@ -30,6 +30,15 @@ const ZAI_CATALOG_IDS = [
   "glm-4.5v",
 ] as const;
 
+// Bundled Z.AI vision ids whose baseUrl is managed by onboarding. User-defined
+// image-capable models are left untouched so custom host overrides survive
+// re-onboarding or endpoint switches.
+const ZAI_BUNDLED_VISION_IDS: ReadonlySet<string> = new Set([
+  "glm-4.6v",
+  "glm-4.5v",
+  "glm-5v-turbo",
+]);
+
 function buildZaiCatalogModels(providerBaseUrl: string): ModelDefinitionConfig[] {
   // When the provider is configured to a Coding Plan endpoint, vision models
   // must target the matching non-coding host; carry a per-model baseUrl so
@@ -68,7 +77,7 @@ function syncZaiVisionBaseUrls(cfg: OpenClawConfig, providerBaseUrl: string): Op
     ? resolveZaiNonCodingBaseUrl(providerBaseUrl)
     : undefined;
   const patched = zai.models.map((model) => {
-    if (!model.input?.includes("image")) {
+    if (!ZAI_BUNDLED_VISION_IDS.has(model.id)) {
       return model;
     }
     if (visionBaseUrl) {

--- a/extensions/zai/onboard.ts
+++ b/extensions/zai/onboard.ts
@@ -54,6 +54,41 @@ function resolveZaiPresetBaseUrl(cfg: OpenClawConfig, endpoint?: string): string
   return endpoint ? resolveZaiBaseUrl(endpoint) : existingBaseUrl || resolveZaiBaseUrl();
 }
 
+function syncZaiVisionBaseUrls(cfg: OpenClawConfig, providerBaseUrl: string): OpenClawConfig {
+  // The shared preset preserves existing model entries by id, so previously
+  // onboarded vision models keep a stale baseUrl when the endpoint changes
+  // (e.g. coding-global -> coding-cn or coding-* -> global). Canonicalize the
+  // vision entries here: coding endpoints get the matching non-coding host,
+  // non-coding endpoints drop any prior override.
+  const zai = cfg.models?.providers?.zai;
+  if (!zai || !Array.isArray(zai.models)) {
+    return cfg;
+  }
+  const visionBaseUrl = isZaiCodingBaseUrl(providerBaseUrl)
+    ? resolveZaiNonCodingBaseUrl(providerBaseUrl)
+    : undefined;
+  const patched = zai.models.map((model) => {
+    if (!model.input?.includes("image")) {
+      return model;
+    }
+    if (visionBaseUrl) {
+      return model.baseUrl === visionBaseUrl ? model : { ...model, baseUrl: visionBaseUrl };
+    }
+    if (model.baseUrl === undefined) {
+      return model;
+    }
+    const { baseUrl: _drop, ...rest } = model;
+    return rest;
+  });
+  return {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      providers: { ...cfg.models?.providers, zai: { ...zai, models: patched } },
+    },
+  };
+}
+
 function applyZaiPreset(
   cfg: OpenClawConfig,
   params?: { endpoint?: string; modelId?: string },
@@ -62,7 +97,7 @@ function applyZaiPreset(
   const modelId = normalizeOptionalString(params?.modelId) ?? ZAI_DEFAULT_MODEL_ID;
   const modelRef = `zai/${modelId}`;
   const baseUrl = resolveZaiPresetBaseUrl(cfg, params?.endpoint);
-  return applyProviderConfigWithModelCatalogPreset(cfg, {
+  const next = applyProviderConfigWithModelCatalogPreset(cfg, {
     providerId: "zai",
     api: "openai-completions",
     baseUrl,
@@ -70,6 +105,7 @@ function applyZaiPreset(
     aliases: [{ modelRef, alias: "GLM" }],
     primaryModelRef,
   });
+  return syncZaiVisionBaseUrls(next, baseUrl);
 }
 
 export function applyZaiProviderConfig(


### PR DESCRIPTION
## Summary

Fixes #70886. The built-in `image` tool returned a 404 whenever `agents.defaults.imageModel` pointed at a Z.AI vision model (for example `zai/glm-4.6v`) and the Z.AI provider had been onboarded with a Coding Plan key. Z.AI's Coding Plan endpoints do not expose vision models, so the shared provider `baseUrl` must not be used for them.

## Root cause

`extensions/zai/onboard.ts` previously applied a single provider-level `baseUrl` to every entry in the Z.AI catalog. When a user onboarded with `--auth-choice zai-coding-global` or `--auth-choice zai-coding-cn`, `https://api.z.ai/api/coding/paas/v4` (or the CN equivalent) became the only route for every model, including `glm-4.6v`, `glm-4.5v`, and `glm-5v-turbo`. Those vision models are only served from the non-coding paths (`…/paas/v4`), so the image tool's `chat/completions` request resolved to a path that does not exist, returning 404.

## Fix

- Add `isZaiCodingBaseUrl` and `resolveZaiNonCodingBaseUrl` helpers in `extensions/zai/model-definitions.ts` that map a coding base URL back to the matching non-coding host on the same origin (`api.z.ai` or `open.bigmodel.cn`).
- While building the Z.AI catalog during onboarding, attach a per-model `baseUrl` to the vision entries (`glm-4.6v`, `glm-4.5v`, `glm-5v-turbo`) when the resolved provider `baseUrl` is a coding endpoint. `pi-coding-agent`'s model registry already prefers per-model `baseUrl` over the provider-level URL, so vision requests go to `…/paas/v4` while text/coding models continue to use the configured coding path.

## Why the fix is safe

- Text and coding models keep the configured provider `baseUrl`; only vision entries gain a per-model override, and only when the provider is already pointed at a Coding Plan endpoint.
- The override maps each coding URL back to the non-coding path on the **same origin** — `api.z.ai` ↔ `api.z.ai` and `open.bigmodel.cn` ↔ `open.bigmodel.cn`. No new hosts, CORS surfaces, or trust boundaries are introduced; all four URLs were already defined and tested in this module.
- Authentication is unchanged: Z.AI uses the same Bearer API key for coding and non-coding paths, and auth choices, env var names, and provider metadata are untouched.

## Security / runtime controls unchanged

- No changes to prompt text, tool catalog, or any policy decision. Routing is enforced at the runtime transport layer via the already-validated `ModelDefinitionConfig.baseUrl` field honored by `@mariozechner/pi-coding-agent`'s `ModelRegistry.parseModels`.
- No changes to `ZAI_API_KEY` / `Z_AI_API_KEY` resolution, auth storage, headers, SSRF posture, or host env allow/deny lists.
- No changes to default onboarding: `openclaw onboard` without an explicit coding choice still lands on `ZAI_GLOBAL_BASE_URL`, so vision entries carry no `baseUrl` override in that path.

## Tests run

- `pnpm vitest run extensions/zai/onboard.test.ts extensions/zai/model-definitions.test.ts` — 10 tests pass, including two new regressions asserting that `coding-global`/`coding-cn` onboard produces vision `baseUrl` overrides to `ZAI_GLOBAL_BASE_URL`/`ZAI_CN_BASE_URL` and that non-coding onboard paths do not add overrides.
- `pnpm test:extension zai` — 4 files / 20 tests pass.
- `pnpm vitest run src/agents/tools/image-tool.test.ts` — 46 tests pass.
- `pnpm test:contracts:plugins` — 51 files / 637 tests pass.
- `pnpm check` — typecheck, lint, and policy guards pass.

Made with [Cursor](https://cursor.com)