### PR TITLE
fix(agents): suppress Config overwrite log in agents delete --json mode

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -79,6 +79,13 @@ export async function agentsDeleteCommand(
   await replaceConfigFile({
     nextConfig: result.config,
     ...(baseHash !== undefined ? { baseHash } : {}),
+    ...(opts.json
+      ? {
+          writeOptions: {
+            logger: { warn: () => {}, error: () => {} },
+          },
+        }
+      : {}),
   });
   if (!opts.json) {
     logConfigUpdated(runtime);

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -175,4 +175,53 @@ describe("agents delete command", () => {
       });
     });
   });
+
+  it("passes a silent logger to replaceConfigFile in --json mode to suppress Config overwrite output", async () => {
+    await withStateDirEnv("openclaw-agents-delete-json-silent-logger-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      expect(configMocks.replaceConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          writeOptions: expect.objectContaining({
+            logger: expect.objectContaining({
+              warn: expect.any(Function),
+              error: expect.any(Function),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("does not pass a silent logger to replaceConfigFile without --json mode", async () => {
+    await withStateDirEnv("openclaw-agents-delete-no-json-logger-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: false }, runtime);
+
+      expect(configMocks.replaceConfigFile).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          writeOptions: expect.anything(),
+        }),
+      );
+    });
+  });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -168,6 +168,12 @@ export type ConfigWriteOptions = {
    * Normal writers must keep this false so clobbers are rejected before disk commit.
    */
   allowDestructiveWrite?: boolean;
+  /**
+   * Optional logger override for the config write operation.
+   * When provided, this replaces the default console logger within the write path.
+   * Useful for suppressing diagnostics (e.g. `Config overwrite:`) in `--json` CLI modes.
+   */
+  logger?: Pick<typeof console, "error" | "warn">;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -2023,7 +2029,7 @@ export async function writeConfigFile(
   cfg: OpenClawConfig,
   options: ConfigWriteOptions = {},
 ): Promise<void> {
-  const io = createConfigIO();
+  const io = createConfigIO(options.logger ? { logger: options.logger } : undefined);
   let nextCfg = cfg;
   const runtimeConfigSnapshot = getRuntimeConfigSnapshotState();
   const runtimeConfigSourceSnapshot = getRuntimeConfigSourceSnapshotState();


### PR DESCRIPTION
## Summary

`openclaw agents delete <id> --force --json` emits a `Config overwrite: …` diagnostic line before the JSON body, breaking machine-readable JSON parsing (e.g. `| python3 -m json.tool`).

The root cause is that `replaceConfigFile` → `writeConfigFile` logs config overwrite diagnostics via `console.warn` regardless of whether the caller requested JSON output.

## Changes

- Extend `ConfigWriteOptions` with an optional `logger` override (`Pick<typeof console, "error" | "warn">`).
- Pipe the optional `logger` through the global `writeConfigFile` wrapper into `createConfigIO`.
- In `agentsDeleteCommand`, pass a no-op logger via `writeOptions` when `--json` is set.
- Add tests verifying the silent logger is passed in `--json` mode and omitted otherwise.

## Test plan

- [x] `pnpm test src/commands/agents.delete.test.ts` passes (5/5).
- [x] `pnpm test src/config/io.write-config.test.ts` passes (11/11).
- [x] `pnpm lint:core` passes (0 warnings, 0 errors).
- [x] `pnpm tsgo` (core typecheck) passes.


Fixes #70889