### PR TITLE
fix(googlechat): resolve domexception startup crash and prevent silent text loss

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -110,7 +110,7 @@ jobs:
             openclaw-ext-smoke:local
           load: true
           push: false
-          provenance: false
+          provenance: false # zizmor: ignore[no-provenance]
 
       - name: Run root Dockerfile CLI smoke
         run: |
@@ -205,7 +205,7 @@ jobs:
             openclaw-ext-smoke:local
           load: true
           push: false
-          provenance: false
+          provenance: false # zizmor: ignore[no-provenance]
 
       - name: Run root Dockerfile CLI smoke
         run: |
@@ -270,7 +270,7 @@ jobs:
           tags: openclaw-install-smoke:local
           load: true
           push: false
-          provenance: false
+          provenance: false # zizmor: ignore[no-provenance]
 
       - name: Build installer non-root image
         uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2
@@ -280,7 +280,7 @@ jobs:
           tags: openclaw-install-nonroot:local
           load: true
           push: false
-          provenance: false
+          provenance: false # zizmor: ignore[no-provenance]
 
       - name: Setup Node environment for installer smoke
         uses: ./.github/actions/setup-node-env

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -346,8 +346,11 @@ async function deliverGoogleChatReply(params: {
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
 }): Promise<void> {
-  const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
-    params;
+  const { payload, account, spaceId, runtime, core, config, statusSink } = params;
+  // Use let so we can clear it after a successful delete — if we leave it set, sendText
+  // would try to updateGoogleChatMessage on an already-deleted message and silently drop
+  // all text content (the update error is caught before firstTextChunk flips to false).
+  let typingMessageName = params.typingMessageName;
   const reply = resolveSendableOutboundReplyParts(payload);
   const mediaCount = reply.mediaCount;
   const hasMedia = reply.hasMedia;
@@ -362,22 +365,32 @@ async function deliverGoogleChatReply(params: {
           account,
           messageName: typingMessageName,
         });
+        // Clear after successful delete so the sendText path below does not attempt to
+        // update a message that no longer exists.
+        typingMessageName = undefined;
       } catch (err) {
         runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
-        const fallbackText = reply.hasText
-          ? text
-          : mediaCount > 1
-            ? "Sent attachments."
-            : "Sent attachment.";
-        try {
-          await updateGoogleChatMessage({
-            account,
-            messageName: typingMessageName,
-            text: fallbackText,
-          });
-          suppressCaption = Boolean(text.trim());
-        } catch (updateErr) {
-          runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+        // typingMessageName is still set here: the delete threw before the reset ran.
+        // The guard below satisfies TypeScript's conservative catch-block narrowing.
+        if (typingMessageName) {
+          const fallbackText = reply.hasText
+            ? text
+            : mediaCount > 1
+              ? "Sent attachments."
+              : "Sent attachment.";
+          try {
+            await updateGoogleChatMessage({
+              account,
+              messageName: typingMessageName,
+              text: fallbackText,
+            });
+            suppressCaption = Boolean(text.trim());
+          } catch (updateErr) {
+            runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+            // Also clear here so sendText falls through to sendGoogleChatMessage
+            // instead of repeatedly retrying the unavailable message and dropping text.
+            typingMessageName = undefined;
+          }
         }
       }
     }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -422,6 +422,14 @@ async function deliverGoogleChatReply(params: {
         statusSink?.({ lastOutboundAt: Date.now() });
       } catch (err) {
         runtime.error?.(`Google Chat message send failed: ${String(err)}`);
+        if (firstTextChunk && typingMessageName) {
+          // The updateGoogleChatMessage call failed. Clear both flags so
+          // subsequent chunks fall through to sendGoogleChatMessage instead of
+          // retrying the unavailable typing-indicator message and silently
+          // dropping all remaining text.
+          typingMessageName = undefined;
+          firstTextChunk = false;
+        }
       }
     },
     sendMedia: async ({ mediaUrl, caption }) => {


### PR DESCRIPTION
Fixes silent text loss when Google Chat replies contain both media and text with typing indicators enabled.

**Root cause:** After deleting the typing indicator message (`hasMedia=true`), `typingMessageName` was left set. The `sendText` callback then tried to `updateGoogleChatMessage` on the already-deleted message, caught the error before `firstTextChunk` flipped to `false`, and silently dropped all subsequent text chunks.

**Fix:**
- Set `typingMessageName = undefined` immediately after a successful delete
- Add `if (typingMessageName)` guard in the catch block (satisfies TypeScript narrowing)
- Also clear `typingMessageName` in the inner `catch (updateErr)` block to handle the double-failure path

Also suppresses pre-existing `zizmor no-provenance` warnings in `install-smoke.yml` (these builds use `load: true`/`push: false` and are never published to a registry).

Closes #33117
Closes #38800

This is a rebase of #65570 onto current main.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>