### PR TITLE
feat(diagnostics): add trace context carrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Diagnostics/OTEL: add a lightweight diagnostic trace-context carrier for future span correlation without adding OTEL SDK state to core. Thanks @vincentkoc.
 - Control UI/chat: add a Steer action on queued messages so a browser follow-up can be injected into the active run without retyping it.
 - Control UI/Talk: add browser WebRTC realtime voice sessions backed by OpenAI Realtime, with Gateway-minted ephemeral client secrets and `openclaw_agent_consult` handoff to the full OpenClaw agent.
 - Agents/tools: add optional per-call `timeoutMs` support for image, video, music, and TTS generation tools so agents can extend provider request timeouts only when a specific generation needs it.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b9c997ae9dba2c534942c1c79e8285f773ab7481c282e8a981e362e8132f944f  plugin-sdk-api-baseline.json
-c2f8370ae879d4404a9ac7f7aa7f43859e990f04f4872cbd8bc48da05d4bc671  plugin-sdk-api-baseline.jsonl
+3ce0dadfe0cac406051ff95ee8201a508d588e634b98ac22659e6b010c3641f6  plugin-sdk-api-baseline.json
+69c9058277b146196a3a3ef49fe193e42987a3642a233732370c9ddae60ddf62  plugin-sdk-api-baseline.jsonl

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -6,6 +6,7 @@ import {
   resetDiagnosticEventsForTest,
   setDiagnosticsEnabledForProcess,
 } from "./diagnostic-events.js";
+import { createDiagnosticTraceContext } from "./diagnostic-trace-context.js";
 
 describe("diagnostic-events", () => {
   beforeEach(() => {
@@ -86,6 +87,31 @@ describe("diagnostic-events", () => {
       error: "failed",
     });
     expect(seen).toEqual(["webhook.received"]);
+  });
+
+  it("carries explicit trace context without creating retained trace state", () => {
+    const trace = createDiagnosticTraceContext({
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+    });
+    const events: Array<{ trace: typeof trace | undefined; type: string }> = [];
+    const stop = onDiagnosticEvent((event) => {
+      events.push({ trace: event.trace, type: event.type });
+    });
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      source: "telegram",
+      trace,
+    });
+    stop();
+    emitDiagnosticEvent({
+      type: "message.queued",
+      source: "telegram",
+      trace,
+    });
+
+    expect(events).toEqual([{ trace, type: "message.queued" }]);
   });
 
   it("skips event enrichment and subscribers when diagnostics are disabled", () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1,10 +1,12 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { DiagnosticTraceContext } from "./diagnostic-trace-context.js";
 
 export type DiagnosticSessionState = "idle" | "processing" | "waiting";
 
 type DiagnosticBaseEvent = {
   ts: number;
   seq: number;
+  trace?: DiagnosticTraceContext;
 };
 
 export type DiagnosticUsageEvent = DiagnosticBaseEvent & {

--- a/src/infra/diagnostic-trace-context.test.ts
+++ b/src/infra/diagnostic-trace-context.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContext,
+  formatDiagnosticTraceparent,
+  isValidDiagnosticSpanId,
+  isValidDiagnosticTraceFlags,
+  isValidDiagnosticTraceId,
+  parseDiagnosticTraceparent,
+} from "./diagnostic-trace-context.js";
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+const CHILD_SPAN_ID = "7ad6b9a982deb2c9";
+
+describe("diagnostic-trace-context", () => {
+  it("validates W3C trace ids, span ids, and trace flags", () => {
+    expect(isValidDiagnosticTraceId(TRACE_ID)).toBe(true);
+    expect(isValidDiagnosticSpanId(SPAN_ID)).toBe(true);
+    expect(isValidDiagnosticTraceFlags("01")).toBe(true);
+
+    expect(isValidDiagnosticTraceId("0".repeat(32))).toBe(false);
+    expect(isValidDiagnosticTraceId("xyz")).toBe(false);
+    expect(isValidDiagnosticSpanId("0".repeat(16))).toBe(false);
+    expect(isValidDiagnosticSpanId("xyz")).toBe(false);
+    expect(isValidDiagnosticTraceFlags("xyz")).toBe(false);
+  });
+
+  it("parses and formats traceparent values", () => {
+    const traceparent = `00-${TRACE_ID}-${SPAN_ID}-01`;
+
+    expect(parseDiagnosticTraceparent(traceparent)).toEqual({
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: "01",
+    });
+    expect(
+      formatDiagnosticTraceparent({
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        traceFlags: "01",
+      }),
+    ).toBe(traceparent);
+  });
+
+  it("rejects malformed traceparent values", () => {
+    expect(parseDiagnosticTraceparent(undefined)).toBeUndefined();
+    expect(parseDiagnosticTraceparent(`ff-${TRACE_ID}-${SPAN_ID}-01`)).toBeUndefined();
+    expect(parseDiagnosticTraceparent(`00-${"0".repeat(32)}-${SPAN_ID}-01`)).toBeUndefined();
+    expect(parseDiagnosticTraceparent(`00-${TRACE_ID}-${"0".repeat(16)}-01`)).toBeUndefined();
+    expect(parseDiagnosticTraceparent(`00-${TRACE_ID}-${SPAN_ID}-xyz`)).toBeUndefined();
+  });
+
+  it("creates a normalized context from explicit fields or traceparent", () => {
+    expect(
+      createDiagnosticTraceContext({
+        traceId: TRACE_ID.toUpperCase(),
+        spanId: SPAN_ID.toUpperCase(),
+        traceFlags: "00",
+      }),
+    ).toEqual({
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: "00",
+    });
+
+    expect(createDiagnosticTraceContext({ traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` })).toEqual({
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: "01",
+    });
+  });
+
+  it("creates child contexts without retaining parent references or self-parenting", () => {
+    const parent = createDiagnosticTraceContext({
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+    });
+    const child = createChildDiagnosticTraceContext(parent, {
+      spanId: CHILD_SPAN_ID,
+    });
+
+    expect(child).toEqual({
+      traceId: TRACE_ID,
+      spanId: CHILD_SPAN_ID,
+      parentSpanId: SPAN_ID,
+      traceFlags: "01",
+    });
+    expect(
+      createChildDiagnosticTraceContext(parent, { spanId: SPAN_ID }).parentSpanId,
+    ).toBeUndefined();
+  });
+});

--- a/src/infra/diagnostic-trace-context.ts
+++ b/src/infra/diagnostic-trace-context.ts
@@ -1,0 +1,133 @@
+import { randomBytes } from "node:crypto";
+
+const TRACEPARENT_VERSION = "00";
+const DEFAULT_TRACE_FLAGS = "01";
+const TRACE_ID_RE = /^[0-9a-f]{32}$/;
+const SPAN_ID_RE = /^[0-9a-f]{16}$/;
+const TRACE_FLAGS_RE = /^[0-9a-f]{2}$/;
+
+export type DiagnosticTraceContext = {
+  /** W3C trace id, 32 lowercase hex chars. */
+  traceId: string;
+  /** Current span id, 16 lowercase hex chars. */
+  spanId?: string;
+  /** Parent span id, 16 lowercase hex chars. */
+  parentSpanId?: string;
+  /** W3C trace flags, 2 lowercase hex chars. Defaults to sampled. */
+  traceFlags?: string;
+};
+
+export type DiagnosticTraceContextInput = Partial<DiagnosticTraceContext> & {
+  traceparent?: string;
+};
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function isNonZeroHex(value: string): boolean {
+  return !/^0+$/.test(value);
+}
+
+export function isValidDiagnosticTraceId(value: unknown): value is string {
+  return typeof value === "string" && TRACE_ID_RE.test(value) && isNonZeroHex(value);
+}
+
+export function isValidDiagnosticSpanId(value: unknown): value is string {
+  return typeof value === "string" && SPAN_ID_RE.test(value) && isNonZeroHex(value);
+}
+
+export function isValidDiagnosticTraceFlags(value: unknown): value is string {
+  return typeof value === "string" && TRACE_FLAGS_RE.test(value);
+}
+
+function normalizeTraceId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return isValidDiagnosticTraceId(normalized) ? normalized : undefined;
+}
+
+function normalizeSpanId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return isValidDiagnosticSpanId(normalized) ? normalized : undefined;
+}
+
+function normalizeTraceFlags(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return isValidDiagnosticTraceFlags(normalized) ? normalized : undefined;
+}
+
+export function parseDiagnosticTraceparent(
+  traceparent: string | undefined,
+): DiagnosticTraceContext | undefined {
+  const parts = traceparent?.trim().toLowerCase().split("-");
+  if (!parts || parts.length !== 4) {
+    return undefined;
+  }
+  const [version, traceId, spanId, traceFlags] = parts;
+  if (version !== TRACEPARENT_VERSION) {
+    return undefined;
+  }
+  const normalizedTraceId = normalizeTraceId(traceId);
+  const normalizedSpanId = normalizeSpanId(spanId);
+  const normalizedTraceFlags = normalizeTraceFlags(traceFlags);
+  if (!normalizedTraceId || !normalizedSpanId || !normalizedTraceFlags) {
+    return undefined;
+  }
+  return {
+    traceId: normalizedTraceId,
+    spanId: normalizedSpanId,
+    traceFlags: normalizedTraceFlags,
+  };
+}
+
+export function formatDiagnosticTraceparent(
+  context: DiagnosticTraceContext | undefined,
+): string | undefined {
+  if (!context?.spanId) {
+    return undefined;
+  }
+  const traceId = normalizeTraceId(context.traceId);
+  const spanId = normalizeSpanId(context.spanId);
+  const traceFlags = normalizeTraceFlags(context.traceFlags) ?? DEFAULT_TRACE_FLAGS;
+  if (!traceId || !spanId) {
+    return undefined;
+  }
+  return `${TRACEPARENT_VERSION}-${traceId}-${spanId}-${traceFlags}`;
+}
+
+export function createDiagnosticTraceContext(
+  input: DiagnosticTraceContextInput = {},
+): DiagnosticTraceContext {
+  const parsed = parseDiagnosticTraceparent(input.traceparent);
+  const traceId = normalizeTraceId(input.traceId) ?? parsed?.traceId ?? randomHex(16);
+  const spanId = normalizeSpanId(input.spanId) ?? parsed?.spanId ?? randomHex(8);
+  const parentSpanId = normalizeSpanId(input.parentSpanId);
+  return {
+    traceId,
+    spanId,
+    ...(parentSpanId && parentSpanId !== spanId ? { parentSpanId } : {}),
+    traceFlags: normalizeTraceFlags(input.traceFlags) ?? parsed?.traceFlags ?? DEFAULT_TRACE_FLAGS,
+  };
+}
+
+export function createChildDiagnosticTraceContext(
+  parent: DiagnosticTraceContext,
+  input: Omit<DiagnosticTraceContextInput, "traceId" | "traceparent"> = {},
+): DiagnosticTraceContext {
+  const parentSpanId = normalizeSpanId(input.parentSpanId) ?? normalizeSpanId(parent.spanId);
+  return createDiagnosticTraceContext({
+    traceId: parent.traceId,
+    spanId: input.spanId,
+    parentSpanId,
+    traceFlags: input.traceFlags ?? parent.traceFlags,
+  });
+}

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -2,7 +2,17 @@
 // Keep this list additive and scoped to the bundled diagnostics-otel surface.
 
 export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
+export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export { emitDiagnosticEvent, onDiagnosticEvent } from "../infra/diagnostic-events.js";
+export {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContext,
+  formatDiagnosticTraceparent,
+  isValidDiagnosticSpanId,
+  isValidDiagnosticTraceFlags,
+  isValidDiagnosticTraceId,
+  parseDiagnosticTraceparent,
+} from "../infra/diagnostic-trace-context.js";
 export { registerLogTransport } from "../logging/logger.js";
 export { redactSensitiveText } from "../logging/redact.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";


### PR DESCRIPTION
## Summary

- Problem: OTEL-related work needs a shared diagnostic trace carrier before exporter, hook, or log wiring can safely build nested spans.
- Why it matters: Without a lightweight core trace context, later diagnostics-otel changes either flatten spans or pull OpenTelemetry SDK state into core paths too early.
- What changed: Added a pure diagnostic trace context helper, optional `trace` on diagnostic events, plugin-sdk diagnostics exports, focused tests, and the plugin SDK baseline update.
- What did NOT change (scope boundary): No OTEL SDK dependency in core, no global trace registry, no retained per-run maps, no exporter behavior changes, no log transport changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #28166
- Related #50291
- Related #62964
- Related #57653
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/diagnostic-trace-context.test.ts`, `src/infra/diagnostic-events.test.ts`
- Scenario the test should lock in: W3C traceparent parse/format, invalid id rejection, child context creation without self-parenting, and diagnostic event trace pass-through without retained trace state.
- Why this is the smallest reliable guardrail: This PR only adds a core carrier and event field; exporter and runtime hook behavior will land in follow-up slices.
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

Adds plugin-sdk diagnostics helpers that bundled diagnostics-otel and future observability plugins can use for trace correlation. No runtime telemetry behavior changes yet.

## Diagram (if applicable)

```text
Before:
diagnostic event -> seq/ts only -> exporter has no shared parent context

After:
diagnostic event -> seq/ts + optional trace context -> later exporter can parent spans without core OTEL SDK state
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): diagnostics-otel plugin SDK surface
- Relevant config (redacted): N/A

### Steps

1. `pnpm test src/infra/diagnostic-events.test.ts`
2. `pnpm test src/infra/diagnostic-trace-context.test.ts`
3. `pnpm format:check -- CHANGELOG.md docs/.generated/plugin-sdk-api-baseline.sha256 src/infra/diagnostic-trace-context.ts src/infra/diagnostic-trace-context.test.ts src/infra/diagnostic-events.ts src/infra/diagnostic-events.test.ts src/plugin-sdk/diagnostics-otel.ts`
4. `pnpm plugin-sdk:api:check`
5. `pnpm check:changed`
6. On latest `origin/main`: `pnpm tsgo:core`

### Expected

- Focused tests, formatting, and plugin SDK API check pass.
- `check:changed` should get past local change checks; current unrelated main typecheck issue may still fail.

### Actual

- Focused tests passed.
- Formatting passed.
- `pnpm plugin-sdk:api:check` passed.
- `pnpm check:changed` failed at `tsgo:core` with unrelated existing errors in `src/agents/openai-transport-stream.ts` and `src/plugin-sdk/provider-tools.ts`.
- The same `pnpm tsgo:core` failure reproduces on latest `origin/main`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: W3C traceparent parse/format, malformed/zero trace id rejection, child trace context creation, diagnostic event trace pass-through, plugin SDK API baseline.
- Edge cases checked: self-parenting is dropped; malformed traceparent values are rejected; no new global registry or retained trace map is introduced.
- What you did **not** verify: End-to-end OTEL collector export. That is intentionally out of scope for this foundation slice.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Trace ids are accepted from external carriers in later PRs.
  - Mitigation: This slice validates W3C id shape and rejects all-zero ids before context creation.
- Risk: Foundation code grows hidden long-lived trace state.
  - Mitigation: This slice is pure helper/event payload plumbing only; no global trace registry, maps, timers, or OTEL SDK instances are added.
