### PR TITLE
fix(memory-core): harden singleton cache recovery

### DIFF
--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -46,6 +46,25 @@ describe("manager cache", () => {
     );
   });
 
+  it("repairs an invalid singleton cache shape", async () => {
+    const cacheKey = Symbol("openclaw.manager-cache.corrupt-test");
+    (globalThis as Record<PropertyKey, unknown>)[cacheKey] = {};
+
+    const cache = resolveSingletonManagedCache<TestEntry>(cacheKey);
+    cachesForCleanup.push(cache);
+    const entry = await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      key: "same",
+      create: async () => createEntry("repaired"),
+    });
+
+    expect(entry.id).toBe("repaired");
+    expect(cache.cache).toBeInstanceOf(Map);
+    expect(cache.pending).toBeInstanceOf(Map);
+    delete (globalThis as Record<PropertyKey, unknown>)[cacheKey];
+  });
+
   it("deduplicates concurrent creation for the same cache key", async () => {
     const cache = createTestCache();
     cachesForCleanup.push(cache);

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -9,22 +9,18 @@ export type ManagedCache<T> = {
   pending: Map<string, Promise<T>>;
 };
 
-function isManagedCache<T>(value: unknown): value is ManagedCache<T> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as Partial<ManagedCache<T>>).cache instanceof Map &&
-    (value as Partial<ManagedCache<T>>).pending instanceof Map
-  );
-}
-
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
   const resolved = resolveGlobalSingleton<unknown>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
   }));
-  if (isManagedCache<T>(resolved)) {
-    return resolved;
+  if (
+    typeof resolved === "object" &&
+    resolved !== null &&
+    (resolved as Partial<ManagedCache<T>>).cache instanceof Map &&
+    (resolved as Partial<ManagedCache<T>>).pending instanceof Map
+  ) {
+    return resolved as ManagedCache<T>;
   }
   const repaired: ManagedCache<T> = {
     cache: new Map<string, T>(),

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -9,11 +9,29 @@ export type ManagedCache<T> = {
   pending: Map<string, Promise<T>>;
 };
 
+function isManagedCache<T>(value: unknown): value is ManagedCache<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<ManagedCache<T>>).cache instanceof Map &&
+    (value as Partial<ManagedCache<T>>).pending instanceof Map
+  );
+}
+
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
-  return resolveGlobalSingleton<ManagedCache<T>>(cacheKey, () => ({
+  const resolved = resolveGlobalSingleton<unknown>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
   }));
+  if (isManagedCache<T>(resolved)) {
+    return resolved;
+  }
+  const repaired: ManagedCache<T> = {
+    cache: new Map<string, T>(),
+    pending: new Map<string, Promise<T>>(),
+  };
+  (globalThis as Record<PropertyKey, unknown>)[cacheKey] = repaired;
+  return repaired;
 }
 
 export async function getOrCreateManagedCacheEntry<T>(params: {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -214,6 +214,25 @@ beforeEach(async () => {
 });
 
 describe("getMemorySearchManager caching", () => {
+  it("repairs an invalid shared singleton cache shape before using qmd cache maps", async () => {
+    await closeAllMemorySearchManagers();
+    vi.resetModules();
+    const cacheKey = Symbol.for("openclaw.memorySearchManagerCache");
+    (globalThis as Record<PropertyKey, unknown>)[cacheKey] = {};
+
+    const freshModule = await import("./search-manager.js");
+    try {
+      const result = await freshModule.getMemorySearchManager({
+        cfg: createQmdCfg("corrupt-cache-agent"),
+        agentId: "corrupt-cache-agent",
+      });
+      requireManager(result);
+    } finally {
+      await freshModule.closeAllMemorySearchManagers();
+      delete (globalThis as Record<PropertyKey, unknown>)[cacheKey];
+    }
+  });
+
   it("reuses the same QMD manager instance for repeated calls", async () => {
     const cfg = createQmdCfg("main");
 

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -42,15 +42,34 @@ type MemorySearchManagerCacheStore = {
   pendingQmdManagerCreates: Map<string, PendingQmdManagerCreate>;
 };
 
+function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
+  return {
+    qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
+    pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
+  };
+}
+
+function isMemorySearchManagerCacheStore(value: unknown): value is MemorySearchManagerCacheStore {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<MemorySearchManagerCacheStore>).qmdManagerCache instanceof Map &&
+    (value as Partial<MemorySearchManagerCacheStore>).pendingQmdManagerCreates instanceof Map
+  );
+}
+
 function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   // Keep caches reachable across `vi.resetModules()` so later cleanup can close older instances.
-  return resolveGlobalSingleton<MemorySearchManagerCacheStore>(
+  const resolved = resolveGlobalSingleton<unknown>(
     MEMORY_SEARCH_MANAGER_CACHE_KEY,
-    () => ({
-      qmdManagerCache: new Map<string, CachedQmdManagerEntry>(),
-      pendingQmdManagerCreates: new Map<string, PendingQmdManagerCreate>(),
-    }),
+    createMemorySearchManagerCacheStore,
   );
+  if (isMemorySearchManagerCacheStore(resolved)) {
+    return resolved;
+  }
+  const repaired = createMemorySearchManagerCacheStore();
+  (globalThis as Record<PropertyKey, unknown>)[MEMORY_SEARCH_MANAGER_CACHE_KEY] = repaired;
+  return repaired;
 }
 
 const log = createSubsystemLogger("memory");

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -49,23 +49,19 @@ function createMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   };
 }
 
-function isMemorySearchManagerCacheStore(value: unknown): value is MemorySearchManagerCacheStore {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as Partial<MemorySearchManagerCacheStore>).qmdManagerCache instanceof Map &&
-    (value as Partial<MemorySearchManagerCacheStore>).pendingQmdManagerCreates instanceof Map
-  );
-}
-
 function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   // Keep caches reachable across `vi.resetModules()` so later cleanup can close older instances.
   const resolved = resolveGlobalSingleton<unknown>(
     MEMORY_SEARCH_MANAGER_CACHE_KEY,
     createMemorySearchManagerCacheStore,
   );
-  if (isMemorySearchManagerCacheStore(resolved)) {
-    return resolved;
+  if (
+    typeof resolved === "object" &&
+    resolved !== null &&
+    (resolved as Partial<MemorySearchManagerCacheStore>).qmdManagerCache instanceof Map &&
+    (resolved as Partial<MemorySearchManagerCacheStore>).pendingQmdManagerCreates instanceof Map
+  ) {
+    return resolved as MemorySearchManagerCacheStore;
   }
   const repaired = createMemorySearchManagerCacheStore();
   (globalThis as Record<PropertyKey, unknown>)[MEMORY_SEARCH_MANAGER_CACHE_KEY] = repaired;


### PR DESCRIPTION
Resolves #70527.

## Summary
- Validate memory singleton cache shapes before use
- Rebuild corrupted search and index manager cache stores
- Add regressions for corrupted global cache state

## Validation
- `pnpm test extensions/memory-core/src/memory/search-manager.test.ts`
- `pnpm test extensions/memory-core/src/memory/manager-cache.test.ts`
- `scripts/committer` scoped pre-commit checks
