### PR TITLE
fix(discord): pass config to subagent thread binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/subagents: pass runtime config into thread-bound native subagent binding and require it at the helper boundary so Discord channel resolution keeps account-aware config. Fixes #71054. (#70945) Thanks @jai.
 - Agents/failover: stop body-less HTTP 400/422 proxy failures from defaulting to `"format"` classification, so embedded retries surface the opaque provider failure instead of falling into a compaction loop. Fixes #66462. (#67024) Thanks @altaywtf and @HongzhuLiu.
 
 ## 2026.4.24

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -398,6 +398,30 @@ function createGatewayPlugin(params: {
   return new SafeGatewayPlugin();
 }
 
+async function fetchDiscordGatewayMetadataDirect(
+  input: string,
+  init?: DiscordGatewayFetchInit,
+  capture?: false | { flowId: string; meta: Record<string, unknown> },
+): Promise<Response> {
+  const runtimeFetch = globalThis.fetch;
+  if (typeof runtimeFetch !== "function") {
+    throw new Error("fetch is not available");
+  }
+  const response = await runtimeFetch(input, init as RequestInit);
+  if (capture) {
+    captureHttpExchange({
+      url: input,
+      method: (init?.method as string | undefined) ?? "GET",
+      requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+      requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+      response,
+      flowId: capture.flowId,
+      meta: capture.meta,
+    });
+  }
+  return response;
+}
+
 export function waitForDiscordGatewayPluginRegistration(
   plugin: unknown,
 ): Promise<void> | undefined {
@@ -434,19 +458,16 @@ export function createDiscordGatewayPlugin(params: {
     return createGatewayPlugin({
       options,
       fetchImpl: async (input, init) => {
-        const response = await fetch(input, init as RequestInit);
-        if (!debugProxySettings.enabled) {
-          captureHttpExchange({
-            url: input,
-            method: (init?.method as string | undefined) ?? "GET",
-            requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
-            requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
-            response,
-            flowId: randomUUID(),
-            meta: { subsystem: "discord-gateway-metadata" },
-          });
-        }
-        return response;
+        return await fetchDiscordGatewayMetadataDirect(
+          input,
+          init,
+          debugProxySettings.enabled
+            ? false
+            : {
+                flowId: randomUUID(),
+                meta: { subsystem: "discord-gateway-metadata" },
+              },
+        );
       },
       runtime: params.runtime,
       testing: params.__testing
@@ -500,7 +521,7 @@ export function createDiscordGatewayPlugin(params: {
     params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));
     return createGatewayPlugin({
       options,
-      fetchImpl: (input, init) => fetch(input, init as RequestInit),
+      fetchImpl: (input, init) => fetchDiscordGatewayMetadataDirect(input, init, false),
       runtime: params.runtime,
       testing: params.__testing
         ? {

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -775,6 +775,7 @@ describe("thread binding lifecycle", () => {
     hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-2" });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
+      cfg: {} as OpenClawConfig,
       accountId: "default",
       channel: "discord",
       to: "channel:thread-1",
@@ -815,6 +816,7 @@ describe("thread binding lifecycle", () => {
     hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-lookup" });
 
     const childBinding = await autoBindSpawnedDiscordSubagent({
+      cfg: {} as OpenClawConfig,
       accountId: "default",
       channel: "discord",
       to: "channel:thread-lookup",

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.ts
@@ -98,7 +98,7 @@ export function listThreadBindingsBySessionKey(params: {
 }
 
 export async function autoBindSpawnedDiscordSubagent(params: {
-  cfg?: OpenClawConfig;
+  cfg: OpenClawConfig;
   accountId?: string;
   channel?: string;
   to?: string;

--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -193,6 +193,15 @@ describe("discord subagent hook handlers", () => {
 
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledTimes(1);
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledWith({
+      cfg: expect.objectContaining({
+        channels: expect.objectContaining({
+          discord: expect.objectContaining({
+            threadBindings: expect.objectContaining({
+              spawnSubagentSessions: true,
+            }),
+          }),
+        }),
+      }),
       accountId: "work",
       channel: "discord",
       to: "channel:123",

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -126,6 +126,7 @@ export async function handleDiscordSubagentSpawning(
   try {
     const agentId = event.agentId?.trim() || "subagent";
     const binding = await autoBindSpawnedDiscordSubagent({
+      cfg: api.config,
       accountId: event.requester?.accountId,
       channel: event.requester?.channel,
       to: event.requester?.to,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord thread-bound subagent spawning can fail before child startup because the subagent hook calls `autoBindSpawnedDiscordSubagent` without the resolved runtime config.
- Why it matters: the pre-bind channel resolution path may need config for Discord REST/proxy/account context, so it silently returns null and surfaces a generic “Unable to create or bind…” error.
- What changed: forward `api.config` into `autoBindSpawnedDiscordSubagent` and update the hook regression test to assert that config is passed.
- What did NOT change (scope boundary): no Discord permission/webhook behavior, no thread-binding defaults, and no ACP binding logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71054
- Related #38141, #40077
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Discord `subagent_spawning` hook omitted `cfg: api.config` when delegating to `autoBindSpawnedDiscordSubagent`, while downstream channel resolution can require runtime config even when a token is available.
- Missing detection / guardrail: existing lifecycle tests passed cfg directly into `autoBindSpawnedDiscordSubagent`, and the hook test asserted the old delegated call shape without cfg.
- Contributing context (if known): thread-bound spawning fails before provisional child session startup, so failures surface as generic session-mode unavailable errors.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/subagent-hooks.test.ts`
- Scenario the test should lock in: `subagent_spawning` forwards the resolved Discord runtime config into `autoBindSpawnedDiscordSubagent`.
- Why this is the smallest reliable guardrail: this bug was specifically at the hook delegation boundary; lifecycle tests already cover direct cfg usage.
- Existing test that already covers this (if any): lifecycle tests cover direct auto-bind config/token behavior, but not hook forwarding.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord thread-bound subagent sessions should be able to use the runtime config during auto-bind channel resolution instead of failing with the generic bind error when config is required.

## Diagram (if applicable)

```text
Before:
subagent_spawning -> autoBindSpawnedDiscordSubagent(no cfg) -> channel resolution can return null

After:
subagent_spawning -> autoBindSpawnedDiscordSubagent(cfg) -> channel resolution has runtime context
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw source checkout
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord thread bindings enabled with `spawnSubagentSessions=true`

### Steps

1. Trigger a Discord `subagent_spawning` hook for a thread-requested subagent session.
2. Mock `autoBindSpawnedDiscordSubagent` and inspect the delegated arguments.
3. Confirm the hook passes `api.config` to auto-bind.

### Expected

- Hook delegates with `cfg: api.config`.

### Actual

- Before this PR, hook delegated without cfg.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification:

```text
npm test -- --run extensions/discord/src/subagent-hooks.test.ts extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts

Test Files  2 passed (2)
Tests       44 passed (44)
```

## Human Verification (required)

- Verified scenarios: targeted Discord hook test and lifecycle auto-bind tests pass locally; live gateway restart and live Discord thread-bound native subagent spawn were verified on the jai-work/finn production runtime after applying this one-line runtime patch.
- Edge cases checked: direct lifecycle auto-bind tests still pass with cfg/token scenarios; the same patch was also applied to jai-personal and the Mac mini LaunchDaemon restart was verified.
- What you did **not** verify: full live coverage across every Discord account/channel, every managed runtime, or unrelated ACP thread-binding paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: cfg forwarding could expose unintended config dependency in tests.
  - Mitigation: the callee already accepts optional cfg and direct lifecycle tests already exercise cfg-aware behavior.