### PR TITLE
fix(ui): skip history reload when final event carries assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: stop `final` chat events from always triggering a full history reload; when the final payload already carries an assistant message, the inline append is authoritative and an extra `chat.history` fetch can race with server persistence and wipe the just-rendered reply. Restores the original skip-reload behavior from #20588 that #64104 unintentionally removed.
 - Codex harness: route native `request_user_input` prompts back to the originating chat, preserve queued follow-up answers, and honor newer app-server command approval amendment decisions.
 - Codex harness/context-engine: redact context-engine assembly failures before logging, so fallback warnings do not serialize raw error objects. (#70809) Thanks @jalehman.
 - Block streaming: suppress final assembled text after partial block-delivery aborts when the already-sent text chunks exactly cover the final reply, preventing duplicate replies without dropping unrelated short messages. Fixes #70921.

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -23,7 +23,7 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(true);
   });
 
-  it("returns true when final event includes assistant payload", () => {
+  it("returns false when final event includes assistant payload", () => {
     expect(
       shouldReloadHistoryForFinalEvent({
         runId: "run-1",
@@ -31,7 +31,18 @@ describe("shouldReloadHistoryForFinalEvent", () => {
         state: "final",
         message: { role: "assistant", content: [{ type: "text", text: "done" }] },
       }),
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  it("returns false when final event message role is missing (defaults to assistant)", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent({
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: { content: [{ type: "text", text: "done" }] },
+      }),
+    ).toBe(false);
   });
 
   it("returns true when final event message role is non-assistant", () => {

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -1,5 +1,32 @@
 import type { ChatEventPayload } from "./controllers/chat.ts";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
+// Decide whether a chat `final` event should trigger a full history reload.
+//
+// Final events normally carry the authoritative assistant message inline.
+// `handleChatEvent` appends it to `state.chatMessages`, so a subsequent
+// reload is redundant — and, because the server may not have flushed the
+// message to the history store yet, the reload can race and wipe the
+// just-appended assistant card from the UI (symptom: sent/replied message
+// renders briefly, then disappears until hard refresh).
+//
+// Reload only when the payload lacks a usable assistant message:
+//   - missing/invalid message object  → reload (nothing to append)
+//   - role is explicitly non-assistant → reload (e.g. tool/system)
+// When the payload is an assistant message (or role is omitted and the
+// message is treated as assistant by `normalizeFinalAssistantMessage`),
+// trust the inline payload and skip the reload.
 export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): boolean {
-  return Boolean(payload && payload.state === "final");
+  if (!payload || payload.state !== "final") {
+    return false;
+  }
+  if (!payload.message || typeof payload.message !== "object") {
+    return true;
+  }
+  const message = payload.message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(message.role);
+  if (role && role !== "assistant") {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

In the control-UI webchat, assistant replies render briefly and then disappear from view until the user hard-refreshes (data is persisted server-side). Root cause is a race introduced by #64104:

- `shouldReloadHistoryForFinalEvent` used to skip the reload when the `final` event payload already contained a usable assistant message (#20588 behavior).
- #64104 simplified the helper to `return Boolean(payload && payload.state === \"final\")`, so **every** final event now kicks off a full `chat.history` fetch in parallel with the inline append done by \`handleChatEvent\`.
- If the server hasn't flushed the just-finalized assistant message to the history store when \`chat.history\` responds, the reload returns the prior transcript and \`state.chatMessages\` gets reassigned without the new reply, wiping the card the user just saw.

Restoring the original skip-when-assistant-final check fixes the race. The final event's payload is authoritative for that assistant turn; reload is still performed when the payload is missing or when the role is explicitly non-assistant.

Files:
- \`ui/src/ui/chat-event-reload.ts\` — restore the smart check, document the race in a comment so a future cleanup doesn't re-flatten it.
- \`ui/src/ui/chat-event-reload.test.ts\` — flip the two cases that were updated in #64104 and add a guard for role-missing payloads.
- \`CHANGELOG.md\` — note under Unreleased/Fixes.

Tool-event-driven reloads are unaffected — \`handleTerminalChatEvent\` still calls \`loadChatHistory\` when \`hadToolEvents\` is true so persisted tool results replace the streaming state.

## Test plan

- [x] \`pnpm test ui/src/ui/chat-event-reload.test.ts\` — 5/5 pass
- [x] \`pnpm tsgo\` — clean (after a fresh \`pnpm install\` to refresh \`@mariozechner/pi-ai\`)
- [x] \`pnpm build\` — clean
- [x] \`oxlint\` on the two changed UI files — 0 errors
- [ ] Manual verification in openclaw-control-ui: send a message, confirm the reply stays visible without hard-refresh (I couldn't reproduce locally without a live session — pending reporter confirmation)

Scoped proof (unrelated \`pnpm check:changed\` failures on \`origin/main\`):
- \`src/gateway/server.cron.test.ts\` has 3 pre-existing oxlint errors (\`no-unnecessary-type-parameters\`, \`no-unnecessary-type-assertion\`, \`no-unnecessary-type-conversion\`). Reproducible on a clean \`upstream/main\` checkout; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)