### PR TITLE
fix(webchat): support non-image file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/restart: default session-scoped restart sentinels to a one-shot agent continuation, so chat-initiated Gateway restarts acknowledge successful boot automatically. (#70269) Thanks @obviyus.
 - Build/npm publish: fail postpublish verification when root `dist/*` files import bundled plugin runtime dependencies without mirroring them in the root package manifest, so Slack-style plugin deps cannot silently ship on the wrong module-resolution path again. (#60112) thanks @medns.
 - Gateway/sessions: extend the webchat session-mutation guard to `sessions.compact` and `sessions.compaction.restore`, so `WEBCHAT_UI` clients are rejected from compaction-side session mutations consistently with the existing patch/delete guards. (#70716) Thanks @drobison00.
+- Control UI/chat: accept and persist non-image webchat attachments such as PDFs and documents instead of silently dropping them in the web UI + gateway path, render generic file badges in previews/history, and preserve buffered OOXML MIME when the original filename is known. Closes #69447.
 
 ## 2026.4.21
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2167,6 +2167,79 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchImageOrder).toEqual(["inline"]);
   });
 
+  it("persists non-image attachments for text-only session models without image-drop warnings", async () => {
+    createTranscriptFixture("openclaw-chat-send-text-only-files-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      modelProvider: "test-provider",
+      model: "text-only",
+    };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "text-only",
+        name: "Text only",
+        input: ["text"],
+      },
+    ];
+    mockState.savedMediaResults = [
+      { path: "/tmp/chat-send-brief.pdf", contentType: "application/pdf" },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-text-only-files",
+      message: "review the file",
+      requestParams: {
+        attachments: [
+          {
+            type: "file",
+            mimeType: "application/pdf",
+            fileName: "brief.pdf",
+            content: Buffer.from("%PDF-1.4\n").toString("base64"),
+          },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    const warnMock = context.logGateway.warn as unknown as ReturnType<typeof vi.fn>;
+    const userUpdate = mockState.emittedTranscriptUpdates.find(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "user",
+    );
+    const userMessage = userUpdate?.message as
+      | {
+          MediaPath?: string;
+          MediaPaths?: string[];
+          MediaType?: string;
+          MediaTypes?: string[];
+        }
+      | undefined;
+
+    expect(mockState.savedMediaCalls).toEqual([
+      expect.objectContaining({ contentType: "application/pdf", subdir: "inbound" }),
+    ]);
+    expect(mockState.lastDispatchImages).toBeUndefined();
+    expect(mockState.lastDispatchImageOrder).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe("/tmp/chat-send-brief.pdf");
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual(["/tmp/chat-send-brief.pdf"]);
+    expect(mockState.lastDispatchCtx?.MediaType).toBe("application/pdf");
+    expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["application/pdf"]);
+    expect(userMessage?.MediaPath).toBe("/tmp/chat-send-brief.pdf");
+    expect(userMessage?.MediaPaths).toEqual(["/tmp/chat-send-brief.pdf"]);
+    expect(userMessage?.MediaType).toBe("application/pdf");
+    expect(userMessage?.MediaTypes).toEqual(["application/pdf"]);
+    expect(
+      warnMock.mock.calls.some(([message]) => String(message).includes("detected non-image")),
+    ).toBe(false);
+  });
+
   it("resolves attachment image support from the session agent model", async () => {
     createTranscriptFixture("openclaw-chat-send-agent-scoped-text-only-attachments-");
     mockState.finalText = "ok";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -122,6 +122,8 @@ type AbortedPartialSnapshot = {
   abortOrigin: AbortOrigin;
 };
 
+const CHAT_SEND_ATTACHMENT_MAX_BYTES = 5_000_000;
+
 type ChatAbortRequester = {
   connId?: string;
   deviceId?: string;
@@ -738,12 +740,62 @@ async function persistChatSendImages(params: {
   return saved;
 }
 
+function isImageChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
+  return typeof mimeType === "string" && mimeType.trim().toLowerCase().startsWith("image/");
+}
+
+function stripChatAttachmentDataUrlPrefix(content: string): string {
+  const trimmed = content.trim();
+  const match = /^data:[^;]+;base64,(.*)$/.exec(trimmed);
+  return match ? match[1] : trimmed;
+}
+
+async function persistChatSendNonImageAttachments(params: {
+  attachments: Array<{ content?: unknown; mimeType?: string; fileName?: string; type?: string }>;
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: GatewayRequestContext["logGateway"];
+}): Promise<SavedMedia[]> {
+  if (params.attachments.length === 0 || isAcpBridgeClient(params.client)) {
+    return [];
+  }
+  const saved: SavedMedia[] = [];
+  for (const att of params.attachments) {
+    if (typeof att.content !== "string") {
+      continue;
+    }
+    const mimeType =
+      typeof att.mimeType === "string" && att.mimeType.trim()
+        ? att.mimeType.trim()
+        : "application/octet-stream";
+    if (isImageChatAttachmentMimeType(mimeType)) {
+      continue;
+    }
+    try {
+      saved.push(
+        await saveMediaBuffer(
+          Buffer.from(stripChatAttachmentDataUrlPrefix(att.content), "base64"),
+          mimeType,
+          "inbound",
+          CHAT_SEND_ATTACHMENT_MAX_BYTES,
+          att.fileName,
+        ),
+      );
+    } catch (err) {
+      const label = att.fileName ?? att.type ?? "attachment";
+      params.logGateway.warn(
+        `chat.send: failed to persist inbound attachment ${label} (${mimeType}): ${formatForLog(err)}`,
+      );
+    }
+  }
+  return saved;
+}
+
 function buildChatSendTranscriptMessage(params: {
   message: string;
-  savedImages: SavedMedia[];
+  savedMedia: SavedMedia[];
   timestamp: number;
 }) {
-  const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
+  const mediaFields = resolveChatSendTranscriptMediaFields(params.savedMedia);
   return {
     role: "user" as const,
     content: params.message,
@@ -752,12 +804,12 @@ function buildChatSendTranscriptMessage(params: {
   };
 }
 
-function resolveChatSendTranscriptMediaFields(savedImages: SavedMedia[]) {
-  const mediaPaths = savedImages.map((entry) => entry.path);
+function resolveChatSendTranscriptMediaFields(savedMedia: SavedMedia[]) {
+  const mediaPaths = savedMedia.map((entry) => entry.path);
   if (mediaPaths.length === 0) {
     return {};
   }
-  const mediaTypes = savedImages.map((entry) => entry.contentType ?? "application/octet-stream");
+  const mediaTypes = savedMedia.map((entry) => entry.contentType ?? "application/octet-stream");
   return {
     MediaPath: mediaPaths[0],
     MediaPaths: mediaPaths,
@@ -785,9 +837,9 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
   transcriptPath: string;
   sessionKey: string;
   message: string;
-  savedImages: SavedMedia[];
+  savedMedia: SavedMedia[];
 }) {
-  const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
+  const mediaFields = resolveChatSendTranscriptMediaFields(params.savedMedia);
   if (!("MediaPath" in mediaFields)) {
     return;
   }
@@ -2201,7 +2253,13 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
-    if (normalizedAttachments.length > 0) {
+    const imageCandidateAttachments = normalizedAttachments.filter((attachment) =>
+      isImageChatAttachmentMimeType(attachment.mimeType),
+    );
+    const hasNonImageAttachments = normalizedAttachments.some(
+      (attachment) => !isImageChatAttachmentMimeType(attachment.mimeType),
+    );
+    if (imageCandidateAttachments.length > 0) {
       const modelRef = resolveSessionModelRef(cfg, entry, agentId);
       const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
@@ -2215,11 +2273,15 @@ export const chatHandlers: GatewayRequestHandlers = {
         explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
         explicitOriginTargetsPlugin;
       try {
-        const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
-          maxBytes: 5_000_000,
-          log: context.logGateway,
-          supportsImages,
-        });
+        const parsed = await parseMessageWithAttachments(
+          inboundMessage,
+          imageCandidateAttachments,
+          {
+            maxBytes: CHAT_SEND_ATTACHMENT_MAX_BYTES,
+            log: context.logGateway,
+            supportsImages,
+          },
+        );
         parsedMessage = parsed.message;
         parsedImages = parsed.images;
         imageOrder = parsed.imageOrder;
@@ -2260,10 +2322,21 @@ export const chatHandlers: GatewayRequestHandlers = {
         client,
         logGateway: context.logGateway,
       });
-      const pluginBoundMediaFields =
-        explicitOriginTargetsPlugin && parsedImages.length > 0
-          ? resolveChatSendTranscriptMediaFields(await persistedImagesPromise)
-          : {};
+      const persistedNonImageAttachmentsPromise = hasNonImageAttachments
+        ? persistChatSendNonImageAttachments({
+            attachments: normalizedAttachments,
+            client,
+            logGateway: context.logGateway,
+          })
+        : Promise.resolve([]);
+      const persistedTranscriptMediaPromise = hasNonImageAttachments
+        ? Promise.all([persistedImagesPromise, persistedNonImageAttachmentsPromise]).then(
+            ([persistedImages, persistedNonImageAttachments]) => [
+              ...persistedImages,
+              ...persistedNonImageAttachments,
+            ],
+          )
+        : persistedImagesPromise;
 
       const trimmedMessage = parsedMessage.trim();
       const injectThinking = Boolean(
@@ -2293,6 +2366,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658
       const stampedMessage = injectTimestamp(messageForAgent, timestampOptsFromConfig(cfg));
+      const chatContextMediaFields = explicitOriginTargetsPlugin || hasNonImageAttachments
+        ? resolveChatSendTranscriptMediaFields(await persistedTranscriptMediaPromise)
+        : {};
 
       const ctx: MsgContext = {
         Body: messageForAgent,
@@ -2316,7 +2392,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         SenderName: clientInfo?.displayName,
         SenderUsername: clientInfo?.displayName,
         GatewayClientScopes: client?.connect?.scopes ?? [],
-        ...pluginBoundMediaFields,
+        ...chatContextMediaFields,
       };
 
       const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
@@ -2347,13 +2423,13 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!transcriptPath) {
             return;
           }
-          const persistedImages = await persistedImagesPromise;
+          const persistedMedia = await persistedTranscriptMediaPromise;
           emitSessionTranscriptUpdate({
             sessionFile: transcriptPath,
             sessionKey,
             message: buildChatSendTranscriptMessage({
               message: parsedMessage,
-              savedImages: persistedImages,
+              savedMedia: persistedMedia,
               timestamp: now,
             }),
           });
@@ -2384,7 +2460,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           transcriptPath,
           sessionKey,
           message: parsedMessage,
-          savedImages: await persistedImagesPromise,
+          savedMedia: await persistedTranscriptMediaPromise,
         });
       };
       const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -567,6 +567,31 @@ describe("media store", () => {
     });
   });
 
+  it("preserves OOXML mime for buffered docx uploads when the original filename is known", async () => {
+    await withTempStore(async (store) => {
+      const zip = new JSZip();
+      zip.file(
+        "[Content_Types].xml",
+        '<Types><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+      );
+      zip.file("word/document.xml", "<w:document/>");
+      const buffer = await zip.generateAsync({ type: "nodebuffer" });
+
+      const saved = await store.saveMediaBuffer(
+        buffer,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "inbound",
+        5 * 1024 * 1024,
+        "report.docx",
+      );
+
+      expect(saved.contentType).toBe(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      );
+      expect(path.extname(saved.path)).toBe(".docx");
+    });
+  });
+
   it("prefers header mime extension when sniffed mime lacks mapping", async () => {
     await withTempStore(async (_store, home) => {
       vi.doMock("./mime.js", async () => {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -418,7 +418,7 @@ export async function saveMediaBuffer(
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const uuid = crypto.randomUUID();
   const headerExt = extensionForMime(normalizeOptionalString(contentType?.split(";")[0]));
-  const mime = await detectMime({ buffer, headerMime: contentType });
+  const mime = await detectMime({ buffer, headerMime: contentType, filePath: originalFilename });
   const ext = headerExt ?? extensionForMime(mime) ?? "";
   const id = buildSavedMediaId({ baseId: uuid, ext, originalFilename });
   await writeSavedMediaBuffer({ dir, id, buffer });

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -282,6 +282,13 @@
   margin-bottom: 8px;
 }
 
+.chat-message-files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .chat-message-image {
   max-width: 300px;
   max-height: 200px;
@@ -298,6 +305,38 @@
 /* User message images align right */
 .chat-group.user .chat-message-images {
   justify-content: flex-end;
+}
+
+.chat-group.user .chat-message-files {
+  justify-content: flex-end;
+}
+
+.chat-message-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  background: var(--surface-secondary, rgba(128, 128, 128, 0.1));
+  border: 1px solid var(--border);
+  max-width: 280px;
+}
+
+.chat-message-file__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.chat-message-file__name,
+.chat-message-file__type {
+  font-size: 13px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.8;
 }
 
 .chat-assistant-attachments {
@@ -902,6 +941,45 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.chat-attachment-thumb--file {
+  width: auto;
+  min-width: 60px;
+  max-width: 140px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-secondary, #f0f0f0);
+  padding: 4px 8px;
+  box-sizing: border-box;
+}
+
+.chat-attachment-file-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.chat-attachment-file-icon svg {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.chat-attachment-file-name {
+  font-size: 10px;
+  line-height: 1.2;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  opacity: 0.7;
 }
 
 .chat-attachment-remove {

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -1,5 +1,11 @@
-export const CHAT_ATTACHMENT_ACCEPT = "image/*";
+export const CHAT_ATTACHMENT_ACCEPT = "*/*";
+
+const UNSUPPORTED_MIME_PREFIXES = ["video/"];
 
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && mimeType.startsWith("image/");
+  if (typeof mimeType !== "string") {
+    return false;
+  }
+  const normalizedMimeType = mimeType.trim().toLowerCase();
+  return !UNSUPPORTED_MIME_PREFIXES.some((prefix) => normalizedMimeType.startsWith(prefix));
 }

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -587,7 +587,7 @@ describe("grouped chat rendering", () => {
     expect(container.textContent).not.toContain("MEDIA:https://example.com/photo.png");
   });
 
-  it("renders allowed transcript images and skips blocked/non-image media", () => {
+  it("renders allowed transcript images and generic file badges while skipping blocked media", () => {
     const renderUserMedia = (message: unknown) => {
       const container = document.createElement("div");
       renderGroupedMessage(container, message, "user", {
@@ -663,6 +663,9 @@ describe("grouped chat rendering", () => {
       timestamp: Date.now(),
     });
     expect(container.querySelector(".chat-message-image")).toBeNull();
+    expect(container.querySelector(".chat-message-file__name")?.textContent).toBe(
+      "user-upload.pdf",
+    );
   });
 
   it("renders legacy input_image image_url blocks", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -67,6 +67,12 @@ type ImageBlock = {
   height?: number;
 };
 
+type FileBlock = {
+  fileName?: string;
+  mimeType: string;
+  source?: string;
+};
+
 type ImageRenderOptions = {
   localMediaPreviewRoots?: readonly string[];
   basePath?: string;
@@ -82,9 +88,26 @@ const managedImageBlobUrlResolvedCache = new Map<string, string>();
 const managedImageBlobUrlMissCache = new Map<string, number>();
 const MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS = 5_000;
 
+type RenderableFileBlock = FileBlock & {
+  displayName: string;
+};
+
 function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
   if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
     images.push(block);
+  }
+}
+
+function appendFileBlock(files: FileBlock[], block: FileBlock) {
+  if (
+    !files.some(
+      (entry) =>
+        entry.source === block.source &&
+        entry.fileName === block.fileName &&
+        entry.mimeType === block.mimeType,
+    )
+  ) {
+    files.push(block);
   }
 }
 
@@ -109,6 +132,25 @@ function getFileExtension(url: string): string | undefined {
   const fileName = source.split(/[\\/]/).pop() ?? source;
   const match = /\.([a-zA-Z0-9]+)$/.exec(fileName);
   return match?.[1]?.toLowerCase();
+}
+
+function getDisplayFileName(source: string): string | undefined {
+  const candidate = (() => {
+    try {
+      const trimmed = source.trim();
+      if (/^https?:\/\//i.test(trimmed)) {
+        return new URL(trimmed).pathname;
+      }
+      if (/^file:\/\//i.test(trimmed)) {
+        return decodeURIComponent(trimmed.replace(/^file:\/+/, "/"));
+      }
+    } catch {
+      // Fall back to the raw source when decoding fails.
+    }
+    return source;
+  })();
+  const fileName = candidate.split(/[\\/]/).pop()?.trim();
+  return fileName || undefined;
 }
 
 function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
@@ -209,6 +251,55 @@ function extractImages(message: unknown): ImageBlock[] {
   }
 
   return images;
+}
+
+function extractFiles(message: unknown): FileBlock[] {
+  const m = message as Record<string, unknown>;
+  const content = m.content;
+  const files: FileBlock[] = [];
+
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (typeof block !== "object" || block === null) {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (b.type !== "file") {
+        continue;
+      }
+      appendFileBlock(files, {
+        fileName: typeof b.fileName === "string" ? b.fileName : undefined,
+        mimeType: typeof b.mimeType === "string" ? b.mimeType : "application/octet-stream",
+      });
+    }
+  }
+
+  const transcriptMediaPaths = Array.isArray(m.MediaPaths)
+    ? m.MediaPaths.filter((value): value is string => typeof value === "string")
+    : typeof m.MediaPath === "string"
+      ? [m.MediaPath]
+      : [];
+  const transcriptMediaTypes = Array.isArray(m.MediaTypes)
+    ? m.MediaTypes
+    : typeof m.MediaType === "string"
+      ? [m.MediaType]
+      : [];
+  for (const [index, mediaPath] of transcriptMediaPaths.entries()) {
+    const mediaType =
+      typeof transcriptMediaTypes[index] === "string" && transcriptMediaTypes[index].trim()
+        ? transcriptMediaTypes[index].trim()
+        : "application/octet-stream";
+    if (isImageTranscriptMediaPath(mediaPath, mediaType)) {
+      continue;
+    }
+    appendFileBlock(files, {
+      fileName: getDisplayFileName(mediaPath),
+      mimeType: mediaType,
+      source: mediaPath,
+    });
+  }
+
+  return files;
 }
 
 export function renderReadingIndicatorGroup(
@@ -754,6 +845,30 @@ function resolveRenderableMessageImages(
   });
 }
 
+function resolveRenderableMessageFiles(
+  files: FileBlock[],
+  opts?: ImageRenderOptions,
+): RenderableFileBlock[] {
+  return files.flatMap((file) => {
+    const isLocalFile =
+      typeof file.source === "string" && isLocalAssistantAttachmentSource(file.source);
+    if (
+      isLocalFile &&
+      !isLocalAttachmentPreviewAllowed(file.source!, opts?.localMediaPreviewRoots ?? [])
+    ) {
+      return [];
+    }
+    const displayName =
+      file.fileName?.trim() || (file.source ? getDisplayFileName(file.source) : "");
+    return [
+      {
+        ...file,
+        displayName: displayName || file.mimeType,
+      },
+    ];
+  });
+}
+
 function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderOptions) {
   if (images.length === 0) {
     return nothing;
@@ -788,6 +903,41 @@ function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderO
   };
 
   return html` <div class="chat-message-images">${images.map((img) => renderImage(img))}</div> `;
+}
+
+function renderMessageFiles(files: RenderableFileBlock[]) {
+  if (files.length === 0) {
+    return nothing;
+  }
+
+  return html`
+    <div class="chat-message-files">
+      ${files.map(
+        (file) => html`
+          <div class="chat-message-file">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="chat-message-file__icon"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="16" y1="13" x2="8" y2="13" />
+              <line x1="16" y1="17" x2="8" y2="17" />
+              <polyline points="10 9 9 9 8 9" />
+            </svg>
+            ${file.displayName
+              ? html`<span class="chat-message-file__name">${file.displayName}</span>`
+              : html`<span class="chat-message-file__type">${file.mimeType}</span>`}
+          </div>
+        `,
+      )}
+    </div>
+  `;
 }
 
 function renderReplyPill(replyTarget: NormalizedMessage["replyTarget"]) {
@@ -1347,6 +1497,10 @@ function renderGroupedMessage(
   };
   const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
   const hasImages = images.length > 0;
+  const files = resolveRenderableMessageFiles(extractFiles(message), {
+    localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
+  });
+  const hasFiles = files.length > 0;
 
   const normalizedMessage = normalizeMessage(message);
   const extractedText = normalizedMessage.content
@@ -1386,6 +1540,7 @@ function renderGroupedMessage(
     !markdown &&
     !visibleToolCards &&
     !hasImages &&
+    !hasFiles &&
     assistantAttachments.length === 0 &&
     assistantViewBlocks.length === 0 &&
     !normalizedMessage.replyTarget
@@ -1405,7 +1560,7 @@ function renderGroupedMessage(
     markdown && !toolSummaryLabel ? markdown.trim().replace(/\s+/g, " ").slice(0, 120) : "";
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
   const toolMessageLabel =
-    singleToolCard && !markdown && !hasImages
+    singleToolCard && !markdown && !hasImages && !hasFiles
       ? singleToolCard.outputText?.trim()
         ? "Tool output"
         : "Tool call"
@@ -1447,6 +1602,7 @@ function renderGroupedMessage(
                 ? html`
                     <div class="chat-tool-msg-body">
                       ${renderMessageImages(images, imageRenderOptions)}
+                      ${renderMessageFiles(files)}
                       ${renderAssistantAttachments(
                         assistantAttachments,
                         opts.localMediaPreviewRoots ?? [],
@@ -1478,7 +1634,7 @@ function renderGroupedMessage(
                             </div>`
                           : nothing}
                       ${hasToolCards
-                        ? singleToolCard && !markdown && !hasImages
+                        ? singleToolCard && !markdown && !hasImages && !hasFiles
                           ? renderExpandedToolCardContent(
                               singleToolCard,
                               onOpenSidebar,
@@ -1503,6 +1659,7 @@ function renderGroupedMessage(
           `
         : html`
             ${renderMessageImages(images, imageRenderOptions)}
+            ${renderMessageFiles(files)}
             ${renderAssistantAttachments(
               assistantAttachments,
               opts.localMediaPreviewRoots ?? [],

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -651,6 +651,46 @@ describe("sendChatMessage", () => {
       ],
     });
   });
+
+  it("sends non-image attachments as generic files and keeps the local badge payload", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "review this", [
+      {
+        id: "att-1",
+        dataUrl: "data:application/pdf;base64,JVBERi0xLjQK",
+        mimeType: "application/pdf",
+        fileName: "brief.pdf",
+      },
+    ]);
+
+    expect(result).toBeTypeOf("string");
+    expect(request).toHaveBeenCalledWith("chat.send", {
+      sessionKey: "main",
+      message: "review this",
+      deliver: false,
+      idempotencyKey: result,
+      attachments: [
+        {
+          type: "file",
+          mimeType: "application/pdf",
+          content: "JVBERi0xLjQK",
+          fileName: "brief.pdf",
+        },
+      ],
+    });
+    expect(state.chatMessages.at(-1)).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "review this" },
+        { type: "file", mimeType: "application/pdf", fileName: "brief.pdf" },
+      ],
+    });
+  });
 });
 
 describe("abortChatRun", () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -203,7 +203,7 @@ export async function loadChatHistory(state: ChatState) {
 }
 
 function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+  const match = /^data:([^;]*);base64,(.+)$/.exec(dataUrl);
   if (!match) {
     return null;
   }
@@ -219,10 +219,12 @@ function buildApiAttachments(attachments?: ChatAttachment[]) {
           if (!parsed) {
             return null;
           }
+          const mimeType = parsed.mimeType || att.mimeType || "application/octet-stream";
           return {
-            type: "image",
-            mimeType: parsed.mimeType,
+            type: mimeType.startsWith("image/") ? "image" : "file",
+            mimeType,
             content: parsed.content,
+            ...(att.fileName ? { fileName: att.fileName } : {}),
           };
         })
         .filter((a): a is NonNullable<typeof a> => a !== null)
@@ -308,16 +310,25 @@ export async function sendChatMessage(
   const now = Date.now();
 
   // Build user message content blocks
-  const contentBlocks: Array<{ type: string; text?: string; source?: unknown }> = [];
+  const contentBlocks: Array<Record<string, unknown>> = [];
   if (msg) {
     contentBlocks.push({ type: "text", text: msg });
   }
-  // Add image previews to the message for display
+  // Preserve local attachment rendering for both images and generic files.
   if (hasAttachments) {
     for (const att of attachments) {
+      const mimeType = att.mimeType || "application/octet-stream";
+      if (mimeType.startsWith("image/")) {
+        contentBlocks.push({
+          type: "image",
+          source: { type: "base64", media_type: mimeType, data: att.dataUrl },
+        });
+        continue;
+      }
       contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+        type: "file",
+        fileName: att.fileName,
+        mimeType,
       });
     }
   }

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -2,6 +2,7 @@ export type ChatAttachment = {
   id: string;
   dataUrl: string;
   mimeType: string;
+  fileName?: string;
 };
 
 export type ChatQueueItem = {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -231,6 +231,7 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl,
         mimeType: file.type,
+        fileName: file.name,
       };
       const current = props.attachments ?? [];
       props.onAttachmentsChange?.([...current, newAttachment]);
@@ -258,6 +259,7 @@ function handleFileSelect(e: Event, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl: reader.result as string,
         mimeType: file.type,
+        fileName: file.name,
       });
       pending--;
       if (pending === 0) {
@@ -289,6 +291,7 @@ function handleDrop(e: DragEvent, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl: reader.result as string,
         mimeType: file.type,
+        fileName: file.name,
       });
       pending--;
       if (pending === 0) {
@@ -297,6 +300,10 @@ function handleDrop(e: DragEvent, props: ChatProps) {
     });
     reader.readAsDataURL(file);
   }
+}
+
+function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
 }
 
 function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof nothing {
@@ -308,8 +315,32 @@ function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof noth
     <div class="chat-attachments-preview">
       ${attachments.map(
         (att) => html`
-          <div class="chat-attachment-thumb">
-            <img src=${att.dataUrl} alt="Attachment preview" />
+          <div
+            class="chat-attachment-thumb ${isImageMimeType(att.mimeType)
+              ? ""
+              : "chat-attachment-thumb--file"}"
+          >
+            ${isImageMimeType(att.mimeType)
+              ? html`<img src=${att.dataUrl} alt="Attachment preview" />`
+              : html`<div class="chat-attachment-file-icon">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="16" y1="13" x2="8" y2="13" />
+                    <line x1="16" y1="17" x2="8" y2="17" />
+                    <polyline points="10 9 9 9 8 9" />
+                  </svg>
+                  ${att.fileName
+                    ? html`<span class="chat-attachment-file-name">${att.fileName}</span>`
+                    : nothing}
+                </div>`}
             <button
               class="chat-attachment-remove"
               type="button"
@@ -771,7 +802,7 @@ export function renderChat(props: ChatProps) {
 
   const placeholder = props.connected
     ? hasAttachments
-      ? "Add a message or paste more images..."
+      ? "Add a message or attach more files..."
       : `Message ${props.assistantName || "agent"} (Enter to send)`
     : "Connect to the gateway to start chatting...";
 
@@ -1149,7 +1180,9 @@ export function renderChat(props: ChatProps) {
                           : nothing}
                         <div class="chat-queue__text">
                           ${item.text ||
-                          (item.attachments?.length ? `Image (${item.attachments.length})` : "")}
+                          (item.attachments?.length
+                            ? `Attachment${item.attachments.length === 1 ? "" : "s"} (${item.attachments.length})`
+                            : "")}
                         </div>
                       </div>
                       <div class="chat-queue__actions">


### PR DESCRIPTION
## Summary

- Intent: fix the end-to-end webchat attachment path so non-image files are not blocked in the Control UI or silently dropped by the gateway.
- Goal: accept, persist, render, and forward generic files such as PDFs and office documents through webchat while keeping current image behavior unchanged.
- Requirements considered:
  - fix both layers, not just the picker
  - keep the existing image path intact
  - keep the change generic and upstream-safe
  - add regression coverage plus human verification on current `main`

Describe the problem and fix in 2–5 bullets:

- Problem: webchat still treated attachments as image-only in both the UI serializer and the gateway attachment path, so non-image files were either blocked or dropped before they reached the agent/media-understanding flow.
- Why it matters: users could not share PDFs, text files, or office documents through Control UI chat even though OpenClaw already has transcript/media infrastructure for persisted inbound files.
- What changed: the UI now accepts non-video files, preserves `fileName`, sends non-image attachments as `type: "file"`, and renders generic file badges in previews/history; the gateway now filters only image candidates through the image parser, persists non-image attachments separately, and bridges them into transcript/media fields for the text-only model lane.
- What did NOT change (scope boundary): the existing image path stays intact, image-only text-model behavior is unchanged, and this PR does not add provider-specific document blocks or rich file previews.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69447
- Related #57707
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `ui/src/ui/chat/attachment-support.ts` and `ui/src/ui/controllers/chat.ts` still assumed attachments were image-only, while `src/gateway/server-methods/chat.ts` only routed image-compatible attachments through the existing persistence/context path.
- Missing detection / guardrail: there was no regression coverage for a text-only webchat send with a non-image attachment, and the UI did not preserve/render generic file metadata locally.
- Contributing context (if known): #57707 identified the same gap earlier, but that branch is no longer mergeable on current `main`; this PR refreshes that fix shape on the current codebase and keeps the scope tight.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-methods/chat.directive-tags.test.ts`
  - `ui/src/ui/controllers/chat.test.ts`
  - `ui/src/ui/chat/grouped-render.test.ts`
  - `src/media/store.test.ts`
- Scenario the test should lock in: webchat non-image attachments are serialized as files, persisted into inbound media storage for the text-only model lane, rendered back as generic file badges, and OOXML buffered saves preserve their document MIME when the filename is known.
- Why this is the smallest reliable guardrail: the regression spans UI payload creation, gateway transcript/media bridging, and renderer output, so seam tests at those boundaries catch the break without introducing a larger browser-only suite.
- Existing test that already covers this (if any): image-only attachment behavior already had existing coverage and remains unchanged.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Control UI chat now accepts generic non-video file attachments instead of image-only files.
- Non-image attachments show generic file badges with filenames in both the composer preview and sent-message history.
- Non-image attachments are now persisted into inbound media storage and forwarded through the transcript/media path instead of being silently dropped.
- Buffered OOXML saves such as `.docx` preserve the document MIME when the original filename is available.

## Diagram (if applicable)

```text
Before:
[user selects PDF/docx in Control UI] -> [UI blocks or serializes as image] -> [gateway drops non-image path] -> [agent never sees file]

After:
[user selects PDF/docx in Control UI] -> [UI sends file block + filename] -> [gateway persists non-image media] -> [transcript/media fields populated] -> [agent sees persisted file path]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev machine
- Runtime/container: local repo dev runtime
- Model/provider: `openai-codex/gpt-5.4` for the live Control UI smoke; targeted Vitest lanes for regression coverage
- Integration/channel (if any): Control UI webchat / gateway `chat.send`
- Relevant config (redacted): text-only model lane for the gateway regression case

### Steps

1. Open Control UI chat.
2. Attach a PDF or office document.
3. Send the message through webchat on the text-only model lane.

### Expected

- The file is attachable in the UI, renders as a generic file badge locally, persists through the gateway, and shows up in the transcript/media context instead of being dropped.

### Actual

- Before this fix, non-image files were blocked or silently dropped by the webchat/gateway path.
- After this fix, non-image files follow the generic file path and reach the agent/media context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests passed; `pnpm build` passed; Control UI drag/drop + send with a PDF and DOCX rendered both filenames before send and after send; gateway persisted both inbound files; the model request snapshot included both persisted file paths.
- Edge cases checked: non-image attachments no longer trigger the old `detected non-image` warning path; `data:`-URL attachment content is normalized before buffer decode; buffered `.docx` saves preserve document MIME when the filename is known.
- What you did **not** verify: remote deployment packaging; direct update of the existing #57707 branch; full `pnpm check:changed` still routes to `lanes=all` in this tree and the repo-wide Vitest sweep hit a worker OOM (`ERR_WORKER_OUT_OF_MEMORY`) after the targeted attachment tests and `pnpm build` had already passed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: browsers sometimes report unknown file MIME values as empty strings.
  - Mitigation: the UI now permits generic files and the send/gateway path normalizes missing MIME to `application/octet-stream` while still preserving the original filename for downstream detection.
- Risk: this path could regress existing image behavior if the new file handling crossed into the image parser.
  - Mitigation: the gateway still filters image candidates into the existing image path and the existing text-only image-drop behavior remains covered and unchanged.
