### PR TITLE
fix: strip dev deps from packaged plugin metadata

### DIFF
--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -391,11 +391,16 @@ describe("web session", () => {
 
     await flushCredsUpdate();
 
-    expect(inFlightA).toBe(1);
-    expect(inFlightB).toBe(1);
+    try {
+      await vi.waitFor(() => {
+        expect(inFlightA).toBe(1);
+        expect(inFlightB).toBe(1);
+      });
+    } finally {
+      (releaseA as (() => void) | null)?.();
+      (releaseB as (() => void) | null)?.();
+    }
 
-    (releaseA as (() => void) | null)?.();
-    (releaseB as (() => void) | null)?.();
     await Promise.all([waitForCredsSaveQueue(authDirA), waitForCredsSaveQueue(authDirB)]);
 
     expect(inFlightA).toBe(0);

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -86,6 +86,7 @@ function rewritePackageEntry(entry) {
 function sanitizeBundledPackageJsonForDist(packageJson) {
   const sanitized = { ...packageJson };
   delete sanitized.devDependencies;
+  delete sanitized.optionalDependencies;
   delete sanitized.peerDependencies;
   delete sanitized.peerDependenciesMeta;
   return sanitized;

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -86,7 +86,6 @@ function rewritePackageEntry(entry) {
 function sanitizeBundledPackageJsonForDist(packageJson) {
   const sanitized = { ...packageJson };
   delete sanitized.devDependencies;
-  delete sanitized.optionalDependencies;
   delete sanitized.peerDependencies;
   delete sanitized.peerDependenciesMeta;
   return sanitized;

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -83,6 +83,14 @@ function rewritePackageEntry(entry) {
   return `./${rewritten}`;
 }
 
+function sanitizeBundledPackageJsonForDist(packageJson) {
+  const sanitized = { ...packageJson };
+  delete sanitized.devDependencies;
+  delete sanitized.peerDependencies;
+  delete sanitized.peerDependenciesMeta;
+  return sanitized;
+}
+
 function ensurePathInsideRoot(rootDir, rawPath) {
   const resolved = path.resolve(rootDir, rawPath);
   const relative = path.relative(rootDir, resolved);
@@ -292,17 +300,18 @@ export function copyBundledPluginMetadata(params = {}) {
       removeFileIfExists(distPackageJsonPath);
       continue;
     }
-    if (packageJson.openclaw && "extensions" in packageJson.openclaw) {
-      packageJson.openclaw = {
-        ...packageJson.openclaw,
-        extensions: rewritePackageExtensions(packageJson.openclaw.extensions),
-        ...(typeof packageJson.openclaw.setupEntry === "string"
-          ? { setupEntry: rewritePackageEntry(packageJson.openclaw.setupEntry) }
+    const distPackageJson = sanitizeBundledPackageJsonForDist(packageJson);
+    if (distPackageJson.openclaw && "extensions" in distPackageJson.openclaw) {
+      distPackageJson.openclaw = {
+        ...distPackageJson.openclaw,
+        extensions: rewritePackageExtensions(distPackageJson.openclaw.extensions),
+        ...(typeof distPackageJson.openclaw.setupEntry === "string"
+          ? { setupEntry: rewritePackageEntry(distPackageJson.openclaw.setupEntry) }
           : {}),
       };
     }
 
-    writeTextFileIfChanged(distPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    writeTextFileIfChanged(distPackageJsonPath, `${JSON.stringify(distPackageJson, null, 2)}\n`);
   }
 
   if (!fs.existsSync(distExtensionsRoot)) {

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -162,7 +162,7 @@ describe("copyBundledPluginMetadata", () => {
     const packageJson = readBundledPackageJson(repoRoot, "telegram");
     expect(packageJson.dependencies).toEqual({ grammy: "1.42.0" });
     expect(packageJson.devDependencies).toBeUndefined();
-    expect(packageJson.optionalDependencies).toBeUndefined();
+    expect(packageJson.optionalDependencies).toEqual({ "@openclaw/native-helper": "workspace:*" });
     expect(packageJson.peerDependencies).toBeUndefined();
     expect(packageJson.peerDependenciesMeta).toBeUndefined();
     expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -29,6 +29,10 @@ function createPlugin(
     packageName: string;
     manifest?: Record<string, unknown>;
     packageOpenClaw?: Record<string, unknown>;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, unknown>;
   },
 ) {
   const pluginDir = path.join(repoRoot, "extensions", params.id);
@@ -40,6 +44,10 @@ function createPlugin(
   });
   writeJson(path.join(pluginDir, "package.json"), {
     name: params.packageName,
+    ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+    ...(params.devDependencies ? { devDependencies: params.devDependencies } : {}),
+    ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+    ...(params.peerDependenciesMeta ? { peerDependenciesMeta: params.peerDependenciesMeta } : {}),
     ...(params.packageOpenClaw ? { openclaw: params.packageOpenClaw } : {}),
   });
   return pluginDir;
@@ -57,7 +65,13 @@ function readBundledManifest(repoRoot: string, pluginId: string) {
 function readBundledPackageJson(repoRoot: string, pluginId: string) {
   return JSON.parse(
     fs.readFileSync(path.join(repoRoot, "dist", "extensions", pluginId, "package.json"), "utf8"),
-  ) as { openclaw?: { extensions?: string[] } };
+  ) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, unknown>;
+    openclaw?: { extensions?: string[] };
+  };
 }
 
 function bundledPluginDir(repoRoot: string, pluginId: string) {
@@ -123,6 +137,29 @@ describe("copyBundledPluginMetadata", () => {
     ).toContain("ACP Router");
     expectBundledSkills(repoRoot, "acpx", ["./skills"]);
     const packageJson = readBundledPackageJson(repoRoot, "acpx");
+    expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
+  });
+
+  it("strips development-only dependency groups from dist package metadata", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-meta-sanitized-");
+    createPlugin(repoRoot, {
+      id: "telegram",
+      packageName: "@openclaw/telegram",
+      manifest: {},
+      packageOpenClaw: { extensions: ["./index.ts"], setupEntry: "./setup-entry.ts" },
+      dependencies: { grammy: "1.42.0" },
+      devDependencies: { "@openclaw/plugin-sdk": "workspace:*" },
+      peerDependencies: { openclaw: "workspace:*" },
+      peerDependenciesMeta: { openclaw: { optional: true } },
+    });
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    const packageJson = readBundledPackageJson(repoRoot, "telegram");
+    expect(packageJson.dependencies).toEqual({ grammy: "1.42.0" });
+    expect(packageJson.devDependencies).toBeUndefined();
+    expect(packageJson.peerDependencies).toBeUndefined();
+    expect(packageJson.peerDependenciesMeta).toBeUndefined();
     expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
   });
 

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -31,6 +31,7 @@ function createPlugin(
     packageOpenClaw?: Record<string, unknown>;
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
     peerDependenciesMeta?: Record<string, unknown>;
   },
@@ -46,6 +47,7 @@ function createPlugin(
     name: params.packageName,
     ...(params.dependencies ? { dependencies: params.dependencies } : {}),
     ...(params.devDependencies ? { devDependencies: params.devDependencies } : {}),
+    ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
     ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
     ...(params.peerDependenciesMeta ? { peerDependenciesMeta: params.peerDependenciesMeta } : {}),
     ...(params.packageOpenClaw ? { openclaw: params.packageOpenClaw } : {}),
@@ -68,6 +70,7 @@ function readBundledPackageJson(repoRoot: string, pluginId: string) {
   ) as {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
     peerDependenciesMeta?: Record<string, unknown>;
     openclaw?: { extensions?: string[] };
@@ -149,6 +152,7 @@ describe("copyBundledPluginMetadata", () => {
       packageOpenClaw: { extensions: ["./index.ts"], setupEntry: "./setup-entry.ts" },
       dependencies: { grammy: "1.42.0" },
       devDependencies: { "@openclaw/plugin-sdk": "workspace:*" },
+      optionalDependencies: { "@openclaw/native-helper": "workspace:*" },
       peerDependencies: { openclaw: "workspace:*" },
       peerDependenciesMeta: { openclaw: { optional: true } },
     });
@@ -158,6 +162,7 @@ describe("copyBundledPluginMetadata", () => {
     const packageJson = readBundledPackageJson(repoRoot, "telegram");
     expect(packageJson.dependencies).toEqual({ grammy: "1.42.0" });
     expect(packageJson.devDependencies).toBeUndefined();
+    expect(packageJson.optionalDependencies).toBeUndefined();
     expect(packageJson.peerDependencies).toBeUndefined();
     expect(packageJson.peerDependenciesMeta).toBeUndefined();
     expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);


### PR DESCRIPTION
## Summary

- strip dev-only and peer-only dependency metadata from bundled plugin `package.json` files copied into `dist/extensions`
- preserve runtime `dependencies` and `optionalDependencies` so runtime dependency staging can still install optional plugin runtime packages
- keep existing OpenClaw entry-point rewriting intact
- add regression coverage for `workspace:*` dev/peer metadata not leaking into packaged plugin output while optional runtime dependencies remain available
- stabilize the WhatsApp creds queue test that was blocking the extension shard after the latest upstream rebase

## Why

Packaged bundled plugins should not expose workspace-only development or peer metadata in their dist package metadata. Runtime dependency metadata still has to remain available because the runtime-postbuild staging path reads it before staging bundled plugin runtime dependencies.

## Testing

Tested locally:

- `pnpm test src/plugins/copy-bundled-plugin-metadata.test.ts`
- `pnpm test extensions/whatsapp/src/session.test.ts`
- `pnpm check:changed`
- `pnpm build`

Testing level: fully tested for the touched package-metadata and WhatsApp test surfaces; full GitHub CI is expected to rerun on this latest head.

## AI Assistance

AI-assisted with Codex. I reviewed the generated changes, checked the runtime-postbuild dependency staging path, and understand the package metadata sanitization and WhatsApp test stabilization in this PR. Session logs are not attached; the relevant local validation commands are listed above.
