### PR TITLE
feat(plugins): expose install source facts

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -884,12 +884,14 @@ Or point `OPENCLAW_PLUGIN_CATALOG_PATHS` (or `OPENCLAW_MPM_CATALOG_PATHS`) at
 one or more JSON files (comma/semicolon/`PATH`-delimited). Each file should
 contain `{ "entries": [ { "name": "@scope/pkg", "openclaw": { "channel": {...}, "install": {...} } } ] }`. The parser also accepts `"packages"` or `"plugins"` as legacy aliases for the `"entries"` key.
 
-Channel catalog entries and provider install catalog entries expose normalized
-install-source facts next to the raw `openclaw.install` block. The normalized
-facts identify whether the npm spec is an exact version or floating selector,
-whether expected integrity metadata is present, and whether a local source path
-is also available. This lets onboarding and diagnostics explain source-plane
-state without importing plugin runtime.
+Generated channel catalog entries and provider install catalog entries expose
+normalized install-source facts next to the raw `openclaw.install` block. The
+normalized facts identify whether the npm spec is an exact version or floating
+selector, whether expected integrity metadata is present, and whether a local
+source path is also available. Consumers should treat `installSource` as an
+additive optional field so older hand-built entries and compatibility shims do
+not have to synthesize it. This lets onboarding and diagnostics explain
+source-plane state without importing plugin runtime.
 
 Official external npm entries should prefer an exact `npmSpec` plus
 `expectedIntegrity`. Bare package names and dist-tags still work for

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -884,6 +884,18 @@ Or point `OPENCLAW_PLUGIN_CATALOG_PATHS` (or `OPENCLAW_MPM_CATALOG_PATHS`) at
 one or more JSON files (comma/semicolon/`PATH`-delimited). Each file should
 contain `{ "entries": [ { "name": "@scope/pkg", "openclaw": { "channel": {...}, "install": {...} } } ] }`. The parser also accepts `"packages"` or `"plugins"` as legacy aliases for the `"entries"` key.
 
+Channel catalog entries and provider install catalog entries expose normalized
+install-source facts next to the raw `openclaw.install` block. The normalized
+facts identify whether the npm spec is an exact version or floating selector,
+whether expected integrity metadata is present, and whether a local source path
+is also available. This lets onboarding and diagnostics explain source-plane
+state without importing plugin runtime.
+
+Official external npm entries should prefer an exact `npmSpec` plus
+`expectedIntegrity`. Bare package names and dist-tags still work for
+compatibility, but they surface source-plane warnings so the catalog can move
+toward pinned, integrity-checked installs without breaking existing plugins.
+
 ## Context engine plugins
 
 Context engine plugins own session context orchestration for ingest, assembly,

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -591,10 +591,12 @@ registry loading. Invalid values are rejected; newer-but-valid values skip the
 plugin on older hosts.
 
 Exact npm version pinning already lives in `npmSpec`, for example
-`"npmSpec": "@wecom/wecom-openclaw-plugin@1.2.3"`. Pair that with
-`expectedIntegrity` when you want update flows to fail closed if the fetched
-npm artifact no longer matches the pinned release. Interactive onboarding
-offers trusted registry npm specs, including bare package names and dist-tags.
+`"npmSpec": "@wecom/wecom-openclaw-plugin@1.2.3"`. Official external catalog
+entries should pair exact specs with `expectedIntegrity` so update flows fail
+closed if the fetched npm artifact no longer matches the pinned release.
+Interactive onboarding still offers trusted registry npm specs, including bare
+package names and dist-tags, for compatibility. Catalog diagnostics can
+distinguish exact, floating, integrity-pinned, and missing-integrity sources.
 When `expectedIntegrity` is present, install/update flows enforce it; when it
 is omitted, the registry resolution is recorded without an integrity pin.
 

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -40,7 +40,7 @@ export type ChannelPluginCatalogEntry = {
   install: PluginPackageInstall & {
     npmSpec: string;
   };
-  installSource: PluginInstallSourceInfo;
+  installSource?: PluginInstallSourceInfo;
 };
 
 type CatalogOptions = {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -4,6 +4,10 @@ import officialExternalChannelCatalog from "../../../scripts/lib/official-extern
 import { MANIFEST_KEY } from "../../compat/legacy-names.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { listChannelCatalogEntries } from "../../plugins/channel-catalog-registry.js";
+import {
+  describePluginInstallSource,
+  type PluginInstallSourceInfo,
+} from "../../plugins/install-source-info.js";
 import type { OpenClawPackageManifest } from "../../plugins/manifest.js";
 import type { PluginPackageChannel, PluginPackageInstall } from "../../plugins/manifest.js";
 import type { PluginOrigin } from "../../plugins/plugin-origin.types.js";
@@ -36,6 +40,7 @@ export type ChannelPluginCatalogEntry = {
   install: PluginPackageInstall & {
     npmSpec: string;
   };
+  installSource: PluginInstallSourceInfo;
 };
 
 type CatalogOptions = {
@@ -264,6 +269,7 @@ function buildCatalogEntryFromManifest(params: {
     ...(params.origin ? { origin: params.origin } : {}),
     meta,
     install,
+    installSource: describePluginInstallSource(install),
   };
 }
 

--- a/src/plugins/install-source-info.test.ts
+++ b/src/plugins/install-source-info.test.ts
@@ -6,7 +6,7 @@ describe("describePluginInstallSource", () => {
     expect(
       describePluginInstallSource({
         npmSpec: "@vendor/demo@1.2.3",
-        expectedIntegrity: "sha512-demo",
+        expectedIntegrity: " sha512-demo ",
         defaultChoice: "npm",
       }),
     ).toEqual({
@@ -24,7 +24,64 @@ describe("describePluginInstallSource", () => {
     });
   });
 
-  it("surfaces floating or missing-integrity npm metadata without rejecting it", () => {
+  it("marks exact npm specs without integrity as version-pinned only", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@1.2.3",
+      }),
+    ).toEqual({
+      npm: {
+        spec: "@vendor/demo@1.2.3",
+        packageName: "@vendor/demo",
+        selector: "1.2.3",
+        selectorKind: "exact-version",
+        exactVersion: true,
+        pinState: "exact-without-integrity",
+      },
+      warnings: ["npm-spec-missing-integrity"],
+    });
+  });
+
+  it("omits whitespace-only integrity from npm source facts", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@1.2.3",
+        expectedIntegrity: "   ",
+      }),
+    ).toEqual({
+      npm: {
+        spec: "@vendor/demo@1.2.3",
+        packageName: "@vendor/demo",
+        selector: "1.2.3",
+        selectorKind: "exact-version",
+        exactVersion: true,
+        pinState: "exact-without-integrity",
+      },
+      warnings: ["npm-spec-missing-integrity"],
+    });
+  });
+
+  it("surfaces floating specs with integrity without rejecting them", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@beta",
+        expectedIntegrity: "sha512-demo",
+      }),
+    ).toEqual({
+      npm: {
+        spec: "@vendor/demo@beta",
+        packageName: "@vendor/demo",
+        selector: "beta",
+        selectorKind: "tag",
+        exactVersion: false,
+        expectedIntegrity: "sha512-demo",
+        pinState: "floating-with-integrity",
+      },
+      warnings: ["npm-spec-floating"],
+    });
+  });
+
+  it("surfaces floating specs without integrity without rejecting them", () => {
     expect(
       describePluginInstallSource({
         npmSpec: "@vendor/demo@beta",

--- a/src/plugins/install-source-info.test.ts
+++ b/src/plugins/install-source-info.test.ts
@@ -61,6 +61,25 @@ describe("describePluginInstallSource", () => {
     });
   });
 
+  it("treats non-string integrity metadata as missing", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@1.2.3",
+        expectedIntegrity: 123,
+      } as never),
+    ).toEqual({
+      npm: {
+        spec: "@vendor/demo@1.2.3",
+        packageName: "@vendor/demo",
+        selector: "1.2.3",
+        selectorKind: "exact-version",
+        exactVersion: true,
+        pinState: "exact-without-integrity",
+      },
+      warnings: ["npm-spec-missing-integrity"],
+    });
+  });
+
   it("surfaces floating specs with integrity without rejecting them", () => {
     expect(
       describePluginInstallSource({

--- a/src/plugins/install-source-info.test.ts
+++ b/src/plugins/install-source-info.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { describePluginInstallSource } from "./install-source-info.js";
+
+describe("describePluginInstallSource", () => {
+  it("marks exact npm specs with integrity as fully pinned", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@1.2.3",
+        expectedIntegrity: "sha512-demo",
+        defaultChoice: "npm",
+      }),
+    ).toEqual({
+      defaultChoice: "npm",
+      npm: {
+        spec: "@vendor/demo@1.2.3",
+        packageName: "@vendor/demo",
+        selector: "1.2.3",
+        selectorKind: "exact-version",
+        exactVersion: true,
+        expectedIntegrity: "sha512-demo",
+        pinState: "exact-with-integrity",
+      },
+      warnings: [],
+    });
+  });
+
+  it("surfaces floating or missing-integrity npm metadata without rejecting it", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "@vendor/demo@beta",
+      }),
+    ).toEqual({
+      npm: {
+        spec: "@vendor/demo@beta",
+        packageName: "@vendor/demo",
+        selector: "beta",
+        selectorKind: "tag",
+        exactVersion: false,
+        pinState: "floating-without-integrity",
+      },
+      warnings: ["npm-spec-floating", "npm-spec-missing-integrity"],
+    });
+  });
+
+  it("reports invalid npm specs while preserving local source metadata", () => {
+    expect(
+      describePluginInstallSource({
+        npmSpec: "github:vendor/demo",
+        localPath: "extensions/demo",
+      }),
+    ).toEqual({
+      local: {
+        path: "extensions/demo",
+      },
+      warnings: ["invalid-npm-spec"],
+    });
+  });
+});

--- a/src/plugins/install-source-info.ts
+++ b/src/plugins/install-source-info.ts
@@ -1,0 +1,85 @@
+import { parseRegistryNpmSpec, type ParsedRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import type { PluginPackageInstall } from "./manifest.js";
+
+export type PluginInstallSourceWarning =
+  | "invalid-npm-spec"
+  | "npm-spec-floating"
+  | "npm-spec-missing-integrity";
+
+export type PluginInstallNpmPinState =
+  | "exact-with-integrity"
+  | "exact-without-integrity"
+  | "floating-with-integrity"
+  | "floating-without-integrity";
+
+export type PluginInstallNpmSourceInfo = {
+  spec: string;
+  packageName: string;
+  selector?: string;
+  selectorKind: ParsedRegistryNpmSpec["selectorKind"];
+  exactVersion: boolean;
+  expectedIntegrity?: string;
+  pinState: PluginInstallNpmPinState;
+};
+
+export type PluginInstallLocalSourceInfo = {
+  path: string;
+};
+
+export type PluginInstallSourceInfo = {
+  defaultChoice?: PluginPackageInstall["defaultChoice"];
+  npm?: PluginInstallNpmSourceInfo;
+  local?: PluginInstallLocalSourceInfo;
+  warnings: readonly PluginInstallSourceWarning[];
+};
+
+function resolveNpmPinState(params: {
+  exactVersion: boolean;
+  hasIntegrity: boolean;
+}): PluginInstallNpmPinState {
+  if (params.exactVersion) {
+    return params.hasIntegrity ? "exact-with-integrity" : "exact-without-integrity";
+  }
+  return params.hasIntegrity ? "floating-with-integrity" : "floating-without-integrity";
+}
+
+export function describePluginInstallSource(
+  install: PluginPackageInstall,
+): PluginInstallSourceInfo {
+  const npmSpec = install.npmSpec?.trim();
+  const localPath = install.localPath?.trim();
+  const warnings: PluginInstallSourceWarning[] = [];
+  let npm: PluginInstallNpmSourceInfo | undefined;
+
+  if (npmSpec) {
+    const parsed = parseRegistryNpmSpec(npmSpec);
+    if (parsed) {
+      const exactVersion = parsed.selectorKind === "exact-version";
+      const hasIntegrity = Boolean(install.expectedIntegrity?.trim());
+      if (!exactVersion) {
+        warnings.push("npm-spec-floating");
+      }
+      if (!hasIntegrity) {
+        warnings.push("npm-spec-missing-integrity");
+      }
+      npm = {
+        spec: parsed.raw,
+        packageName: parsed.name,
+        selectorKind: parsed.selectorKind,
+        exactVersion,
+        pinState: resolveNpmPinState({ exactVersion, hasIntegrity }),
+        ...(parsed.selector ? { selector: parsed.selector } : {}),
+        ...(install.expectedIntegrity ? { expectedIntegrity: install.expectedIntegrity } : {}),
+      };
+    } else {
+      warnings.push("invalid-npm-spec");
+    }
+  }
+
+  return {
+    ...(install.defaultChoice ? { defaultChoice: install.defaultChoice } : {}),
+    ...(npm ? { npm } : {}),
+    ...(localPath ? { local: { path: localPath } } : {}),
+    warnings,
+  };
+}

--- a/src/plugins/install-source-info.ts
+++ b/src/plugins/install-source-info.ts
@@ -1,4 +1,5 @@
 import { parseRegistryNpmSpec, type ParsedRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { PluginPackageInstall } from "./manifest.js";
 
 export type PluginInstallSourceWarning =
@@ -46,8 +47,12 @@ function resolveNpmPinState(params: {
 export function describePluginInstallSource(
   install: PluginPackageInstall,
 ): PluginInstallSourceInfo {
-  const npmSpec = install.npmSpec?.trim();
-  const localPath = install.localPath?.trim();
+  const npmSpec = normalizeOptionalString(install.npmSpec);
+  const localPath = normalizeOptionalString(install.localPath);
+  const defaultChoice =
+    install.defaultChoice === "npm" || install.defaultChoice === "local"
+      ? install.defaultChoice
+      : undefined;
   const warnings: PluginInstallSourceWarning[] = [];
   let npm: PluginInstallNpmSourceInfo | undefined;
 
@@ -55,7 +60,7 @@ export function describePluginInstallSource(
     const parsed = parseRegistryNpmSpec(npmSpec);
     if (parsed) {
       const exactVersion = parsed.selectorKind === "exact-version";
-      const expectedIntegrity = install.expectedIntegrity?.trim();
+      const expectedIntegrity = normalizeOptionalString(install.expectedIntegrity);
       const hasIntegrity = Boolean(expectedIntegrity);
       if (!exactVersion) {
         warnings.push("npm-spec-floating");
@@ -78,7 +83,7 @@ export function describePluginInstallSource(
   }
 
   return {
-    ...(install.defaultChoice ? { defaultChoice: install.defaultChoice } : {}),
+    ...(defaultChoice ? { defaultChoice } : {}),
     ...(npm ? { npm } : {}),
     ...(localPath ? { local: { path: localPath } } : {}),
     warnings,

--- a/src/plugins/install-source-info.ts
+++ b/src/plugins/install-source-info.ts
@@ -55,7 +55,8 @@ export function describePluginInstallSource(
     const parsed = parseRegistryNpmSpec(npmSpec);
     if (parsed) {
       const exactVersion = parsed.selectorKind === "exact-version";
-      const hasIntegrity = Boolean(install.expectedIntegrity?.trim());
+      const expectedIntegrity = install.expectedIntegrity?.trim();
+      const hasIntegrity = Boolean(expectedIntegrity);
       if (!exactVersion) {
         warnings.push("npm-spec-floating");
       }
@@ -69,7 +70,7 @@ export function describePluginInstallSource(
         exactVersion,
         pinState: resolveNpmPinState({ exactVersion, hasIntegrity }),
         ...(parsed.selector ? { selector: parsed.selector } : {}),
-        ...(install.expectedIntegrity ? { expectedIntegrity: install.expectedIntegrity } : {}),
+        ...(expectedIntegrity ? { expectedIntegrity } : {}),
       };
     } else {
       warnings.push("invalid-npm-spec");

--- a/src/plugins/provider-install-catalog.test.ts
+++ b/src/plugins/provider-install-catalog.test.ts
@@ -104,6 +104,22 @@ describe("provider install catalog", () => {
           defaultChoice: "npm",
           expectedIntegrity: "sha512-openai",
         },
+        installSource: {
+          defaultChoice: "npm",
+          npm: {
+            spec: "@openclaw/openai@1.2.3",
+            packageName: "@openclaw/openai",
+            selector: "1.2.3",
+            selectorKind: "exact-version",
+            exactVersion: true,
+            expectedIntegrity: "sha512-openai",
+            pinState: "exact-with-integrity",
+          },
+          local: {
+            path: "extensions/openai",
+          },
+          warnings: [],
+        },
       },
     ]);
   });
@@ -156,6 +172,13 @@ describe("provider install catalog", () => {
         install: {
           localPath: "extensions/demo-provider",
           defaultChoice: "local",
+        },
+        installSource: {
+          defaultChoice: "local",
+          local: {
+            path: "extensions/demo-provider",
+          },
+          warnings: [],
         },
       },
     ]);
@@ -216,6 +239,19 @@ describe("provider install catalog", () => {
         expectedIntegrity: "sha512-vllm",
         defaultChoice: "npm",
       },
+      installSource: {
+        defaultChoice: "npm",
+        npm: {
+          spec: "@openclaw/vllm@2.0.0",
+          packageName: "@openclaw/vllm",
+          selector: "2.0.0",
+          selectorKind: "exact-version",
+          exactVersion: true,
+          expectedIntegrity: "sha512-vllm",
+          pinState: "exact-with-integrity",
+        },
+        warnings: [],
+      },
     });
   });
 
@@ -269,6 +305,17 @@ describe("provider install catalog", () => {
       install: {
         npmSpec: "@openclaw/vllm",
         defaultChoice: "npm",
+      },
+      installSource: {
+        defaultChoice: "npm",
+        npm: {
+          spec: "@openclaw/vllm",
+          packageName: "@openclaw/vllm",
+          selectorKind: "none",
+          exactVersion: false,
+          pinState: "floating-without-integrity",
+        },
+        warnings: ["npm-spec-floating", "npm-spec-missing-integrity"],
       },
     });
   });

--- a/src/plugins/provider-install-catalog.ts
+++ b/src/plugins/provider-install-catalog.ts
@@ -21,7 +21,7 @@ export type ProviderInstallCatalogEntry = ProviderAuthChoiceMetadata & {
   label: string;
   origin: PluginOrigin;
   install: PluginPackageInstall;
-  installSource: PluginInstallSourceInfo;
+  installSource?: PluginInstallSourceInfo;
 };
 
 type ProviderInstallCatalogParams = {

--- a/src/plugins/provider-install-catalog.ts
+++ b/src/plugins/provider-install-catalog.ts
@@ -3,6 +3,10 @@ import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import {
+  describePluginInstallSource,
+  type PluginInstallSourceInfo,
+} from "./install-source-info.js";
+import {
   loadPluginManifest,
   type PluginPackageInstall,
   type PluginManifestLoadResult,
@@ -17,6 +21,7 @@ export type ProviderInstallCatalogEntry = ProviderAuthChoiceMetadata & {
   label: string;
   origin: PluginOrigin;
   install: PluginPackageInstall;
+  installSource: PluginInstallSourceInfo;
 };
 
 type ProviderInstallCatalogParams = {
@@ -179,6 +184,7 @@ export function resolveProviderInstallCatalogEntries(
           label: choice.groupLabel ?? choice.choiceLabel,
           origin: install.origin,
           install: install.install,
+          installSource: describePluginInstallSource(install.install),
         } satisfies ProviderInstallCatalogEntry,
       ];
     })

--- a/test/helpers/channels/channel-plugin-catalog-contract-suites.ts
+++ b/test/helpers/channels/channel-plugin-catalog-contract-suites.ts
@@ -264,6 +264,19 @@ export function describeChannelPluginCatalogEntriesContract() {
                 minHostVersion: ">=2026.4.10",
                 expectedIntegrity: "sha512-wecom",
               },
+              installSource: {
+                defaultChoice: "npm",
+                npm: {
+                  spec: "@wecom/wecom-openclaw-plugin@1.2.3",
+                  packageName: "@wecom/wecom-openclaw-plugin",
+                  selector: "1.2.3",
+                  selectorKind: "exact-version",
+                  exactVersion: true,
+                  expectedIntegrity: "sha512-wecom",
+                  pinState: "exact-with-integrity",
+                },
+                warnings: [],
+              },
             },
           };
         },


### PR DESCRIPTION
## Summary
- add normalized install-source facts for provider and channel install catalog entries
- classify npm specs by selector type, exact-version status, integrity presence, and pin state
- surface warnings for floating npm specs, missing integrity pins, and invalid npm specs
- document Phase 1 source-plane behavior and the preferred exact spec + integrity shape for official external npm entries

## Validation
- `pnpm test src/plugins/install-source-info.test.ts src/plugins/provider-install-catalog.test.ts src/channels/plugins/contracts/plugins-core.catalog.entries.contract.test.ts`
- `pnpm format:check src/plugins/install-source-info.ts src/plugins/install-source-info.test.ts src/plugins/provider-install-catalog.ts src/plugins/provider-install-catalog.test.ts src/channels/plugins/catalog.ts test/helpers/channels/channel-plugin-catalog-contract-suites.ts docs/plugins/architecture-internals.md docs/plugins/manifest.md`
- `pnpm test:contracts:channels`
- `pnpm test:contracts:plugins`
- filtered `pnpm tsgo:core` check found no touched-file errors

## Known failures
- `pnpm check:changed` fails in `src/agents/openai-transport-stream.ts` / `src/plugin-sdk/provider-tools.ts` on existing OpenAI compat type errors
- `pnpm build` reaches `build:plugin-sdk:dts` and fails on the same unrelated OpenAI compat type errors

## Notes
- AI-assisted: yes
