### PR TITLE
fix(diagnostics): harden trace context parsing

### DIFF
--- a/src/infra/diagnostic-trace-context.test.ts
+++ b/src/infra/diagnostic-trace-context.test.ts
@@ -45,10 +45,25 @@ describe("diagnostic-trace-context", () => {
 
   it("rejects malformed traceparent values", () => {
     expect(parseDiagnosticTraceparent(undefined)).toBeUndefined();
+    expect(parseDiagnosticTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-extra`)).toBeUndefined();
     expect(parseDiagnosticTraceparent(`ff-${TRACE_ID}-${SPAN_ID}-01`)).toBeUndefined();
     expect(parseDiagnosticTraceparent(`00-${"0".repeat(32)}-${SPAN_ID}-01`)).toBeUndefined();
     expect(parseDiagnosticTraceparent(`00-${TRACE_ID}-${"0".repeat(16)}-01`)).toBeUndefined();
     expect(parseDiagnosticTraceparent(`00-${TRACE_ID}-${SPAN_ID}-xyz`)).toBeUndefined();
+  });
+
+  it("rejects oversized traceparent values before parsing", () => {
+    expect(
+      parseDiagnosticTraceparent(`00-${TRACE_ID}-${SPAN_ID}-01-${"a".repeat(128)}`),
+    ).toBeUndefined();
+  });
+
+  it("continues future-version traceparents from the first four fields", () => {
+    expect(parseDiagnosticTraceparent(`01-${TRACE_ID}-${SPAN_ID}-01-extra`)).toEqual({
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: "01",
+    });
   });
 
   it("creates a normalized context from explicit fields or traceparent", () => {
@@ -69,6 +84,14 @@ describe("diagnostic-trace-context", () => {
       spanId: SPAN_ID,
       traceFlags: "01",
     });
+  });
+
+  it("generates valid non-zero ids for fallback contexts", () => {
+    const context = createDiagnosticTraceContext();
+
+    expect(isValidDiagnosticTraceId(context.traceId)).toBe(true);
+    expect(isValidDiagnosticSpanId(context.spanId)).toBe(true);
+    expect(formatDiagnosticTraceparent(context)).toBeDefined();
   });
 
   it("creates child contexts without retaining parent references or self-parenting", () => {

--- a/src/infra/diagnostic-trace-context.ts
+++ b/src/infra/diagnostic-trace-context.ts
@@ -2,9 +2,11 @@ import { randomBytes } from "node:crypto";
 
 const TRACEPARENT_VERSION = "00";
 const DEFAULT_TRACE_FLAGS = "01";
+const MAX_TRACEPARENT_LENGTH = 128;
 const TRACE_ID_RE = /^[0-9a-f]{32}$/;
 const SPAN_ID_RE = /^[0-9a-f]{16}$/;
 const TRACE_FLAGS_RE = /^[0-9a-f]{2}$/;
+const TRACEPARENT_VERSION_RE = /^[0-9a-f]{2}$/;
 
 export type DiagnosticTraceContext = {
   /** W3C trace id, 32 lowercase hex chars. */
@@ -27,6 +29,22 @@ function randomHex(bytes: number): string {
 
 function isNonZeroHex(value: string): boolean {
   return !/^0+$/.test(value);
+}
+
+function randomTraceId(): string {
+  let traceId = randomHex(16);
+  while (!isNonZeroHex(traceId)) {
+    traceId = randomHex(16);
+  }
+  return traceId;
+}
+
+function randomSpanId(): string {
+  let spanId = randomHex(8);
+  while (!isNonZeroHex(spanId)) {
+    spanId = randomHex(8);
+  }
+  return spanId;
 }
 
 export function isValidDiagnosticTraceId(value: unknown): value is string {
@@ -68,12 +86,19 @@ function normalizeTraceFlags(value: unknown): string | undefined {
 export function parseDiagnosticTraceparent(
   traceparent: string | undefined,
 ): DiagnosticTraceContext | undefined {
-  const parts = traceparent?.trim().toLowerCase().split("-");
-  if (!parts || parts.length !== 4) {
+  if (typeof traceparent !== "string" || traceparent.length > MAX_TRACEPARENT_LENGTH) {
+    return undefined;
+  }
+  const parts = traceparent.trim().toLowerCase().split("-");
+  if (!parts || parts.length < 4) {
     return undefined;
   }
   const [version, traceId, spanId, traceFlags] = parts;
-  if (version !== TRACEPARENT_VERSION) {
+  if (
+    !TRACEPARENT_VERSION_RE.test(version) ||
+    version === "ff" ||
+    (version === TRACEPARENT_VERSION && parts.length !== 4)
+  ) {
     return undefined;
   }
   const normalizedTraceId = normalizeTraceId(traceId);
@@ -108,8 +133,8 @@ export function createDiagnosticTraceContext(
   input: DiagnosticTraceContextInput = {},
 ): DiagnosticTraceContext {
   const parsed = parseDiagnosticTraceparent(input.traceparent);
-  const traceId = normalizeTraceId(input.traceId) ?? parsed?.traceId ?? randomHex(16);
-  const spanId = normalizeSpanId(input.spanId) ?? parsed?.spanId ?? randomHex(8);
+  const traceId = normalizeTraceId(input.traceId) ?? parsed?.traceId ?? randomTraceId();
+  const spanId = normalizeSpanId(input.spanId) ?? parsed?.spanId ?? randomSpanId();
   const parentSpanId = normalizeSpanId(input.parentSpanId);
   return {
     traceId,


### PR DESCRIPTION
## Summary

- Problem: follow-up review on the diagnostic trace context carrier found two edge cases: random fallback ids did not make the non-zero invariant explicit, and future-version traceparents were dropped.
- Why it matters: invalid fallback ids could break later traceparent formatting in the impossible all-zero RNG case, and future W3C traceparent versions should still preserve correlation where possible.
- What changed: added non-zero random trace/span id wrappers; parse future non-`ff` traceparent versions from the first four fields while keeping version `00` strict.
- What did NOT change (scope boundary): no OTEL SDK wiring, no global state, no log/hook/event fanout changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/70924
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: generated fallback ids came directly from `randomBytes().toString("hex")`, bypassing the same non-zero validation path used for inbound ids; parsing also treated all non-`00` traceparent versions as invalid instead of preserving the first four fields for future versions.
- Missing detection / guardrail: trace context tests did not assert generated fallback ids validate, or future-version traceparent continuation.
- Contributing context (if known): initial foundation slice was intentionally small and internal-only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/diagnostic-trace-context.test.ts`
- Scenario the test should lock in: fallback contexts generate valid non-zero ids, version `00` remains strict, and future non-`ff` versions continue from the first four fields.
- Why this is the smallest reliable guardrail: the behavior is fully contained in the pure trace-context helper.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo worktree
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/infra/diagnostic-trace-context.test.ts`.
2. Run `pnpm format:check -- src/infra/diagnostic-trace-context.ts src/infra/diagnostic-trace-context.test.ts`.
3. Run `pnpm exec oxlint src/infra/diagnostic-trace-context.ts src/infra/diagnostic-trace-context.test.ts`.

### Expected

- Trace context tests pass.
- Formatting passes.
- Oxlint reports no warnings or errors.

### Actual

- All listed checks passed locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: future traceparent parsing, strict version `00` extra-field rejection, generated fallback ids validate and format.
- Edge cases checked: invalid `ff` version, all-zero inbound trace/span ids, invalid trace flags.
- What you did **not** verify: full repo-wide CI locally; PR CI will cover broader lanes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting future traceparent versions could preserve malformed future fields.
  - Mitigation: only non-`ff` two-hex versions are accepted, `traceId`, `spanId`, and `traceFlags` still use the existing validators, and version `00` remains strict at exactly four fields.
