### PR TITLE
ci: add manual npm Telegram beta E2E

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const allowed = new Set(["admin", "maintain", "write"]);
+            const allowed = new Set(["admin", "write"]);
             const { owner, repo } = context.repo;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner,
@@ -63,7 +63,7 @@ jobs:
             core.info(`Actor ${context.actor} permission: ${permission}`);
             if (!allowed.has(permission)) {
               core.setFailed(
-                `Workflow requires write/maintain/admin access. Actor "${context.actor}" has "${permission}".`,
+                `Workflow requires write/admin access. Actor "${context.actor}" has "${permission}".`,
               );
             }
 

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -52,18 +52,18 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const allowed = new Set(["admin", "write"]);
+            const allowedRoles = new Set(["admin", "maintain"]);
             const { owner, repo } = context.repo;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner,
               repo,
               username: context.actor,
             });
-            const permission = data.permission;
-            core.info(`Actor ${context.actor} permission: ${permission}`);
-            if (!allowed.has(permission)) {
+            const role = data.role_name ?? data.permission;
+            core.info(`Actor ${context.actor} role: ${role}`);
+            if (!allowedRoles.has(role)) {
               core.setFailed(
-                `Workflow requires write/admin access. Actor "${context.actor}" has "${permission}".`,
+                `Workflow requires maintainer/admin access. Actor "${context.actor}" has "${role}".`,
               );
             }
 

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -48,22 +48,22 @@ jobs:
             exit 1
           fi
 
-      - name: Require maintainer-level repository access
+      - name: Require release manager team membership
         uses: actions/github-script@v8
         with:
           script: |
-            const allowedRoles = new Set(["admin", "maintain"]);
-            const { owner, repo } = context.repo;
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner,
-              repo,
-              username: context.actor,
+            const { owner } = context.repo;
+            const teamSlug = "openclaw-release-managers";
+            const members = await github.paginate(github.rest.teams.listMembersInOrg, {
+              org: owner,
+              team_slug: teamSlug,
+              per_page: 100,
             });
-            const role = data.role_name ?? data.permission;
-            core.info(`Actor ${context.actor} role: ${role}`);
-            if (!allowedRoles.has(role)) {
+            const memberLogins = new Set(members.map((member) => member.login));
+            core.info(`${teamSlug} members loaded: ${memberLogins.size}`);
+            if (!memberLogins.has(context.actor)) {
               core.setFailed(
-                `Workflow requires maintainer/admin access. Actor "${context.actor}" has "${role}".`,
+                `Workflow requires active ${teamSlug} membership. Actor "${context.actor}" is not a member of ${owner}/${teamSlug}.`,
               );
             }
 

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -1,0 +1,153 @@
+name: NPM Telegram Beta E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_spec:
+        description: Published OpenClaw package spec to test
+        required: true
+        default: openclaw@beta
+        type: string
+      provider_mode:
+        description: QA provider mode
+        required: true
+        default: mock-openai
+        type: choice
+        options:
+          - mock-openai
+          - live-frontier
+      scenario:
+        description: Optional comma-separated Telegram scenario ids
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-telegram-beta-e2e-${{ github.run_id }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.33.0"
+
+jobs:
+  authorize_actor:
+    name: Authorize workflow actor
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    steps:
+      - name: Require main workflow ref
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "NPM Telegram beta E2E must be dispatched from main so workflow logic stays controlled." >&2
+            exit 1
+          fi
+
+      - name: Require maintainer-level repository access
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const allowed = new Set(["admin", "maintain", "write"]);
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: context.actor,
+            });
+            const permission = data.permission;
+            core.info(`Actor ${context.actor} permission: ${permission}`);
+            if (!allowed.has(permission)) {
+              core.setFailed(
+                `Workflow requires write/maintain/admin access. Actor "${context.actor}" has "${permission}".`,
+              );
+            }
+
+  run_npm_telegram_beta_e2e:
+    name: Run published npm Telegram E2E
+    needs: authorize_actor
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 60
+    environment: qa-live-shared
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "true"
+
+      - name: Validate inputs and secrets
+        env:
+          PACKAGE_SPEC: ${{ inputs.package_spec }}
+          PROVIDER_MODE: ${{ inputs.provider_mode }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${PACKAGE_SPEC}" =~ ^openclaw@(beta|latest|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*|-beta\.[1-9][0-9]*)?)$ ]]; then
+            echo "package_spec must be openclaw@beta, openclaw@latest, or an exact OpenClaw release version; got: ${PACKAGE_SPEC}" >&2
+            exit 1
+          fi
+
+          require_var() {
+            local key="$1"
+            if [[ -z "${!key:-}" ]]; then
+              echo "Missing required ${key}." >&2
+              exit 1
+            fi
+          }
+
+          require_var OPENCLAW_QA_CONVEX_SITE_URL
+          require_var OPENCLAW_QA_CONVEX_SECRET_CI
+          if [[ "${PROVIDER_MODE}" == "live-frontier" ]]; then
+            require_var OPENAI_API_KEY
+          fi
+
+      - name: Run npm Telegram beta E2E
+        id: run_lane
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC: ${{ inputs.package_spec }}
+          OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE: ${{ inputs.provider_mode }}
+          OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE: convex
+          OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE: ci
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
+          INPUT_SCENARIO: ${{ inputs.scenario }}
+        run: |
+          set -euo pipefail
+
+          output_dir=".artifacts/qa-e2e/npm-telegram-beta-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
+          export OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR="${output_dir}"
+
+          if [[ -n "${INPUT_SCENARIO// }" ]]; then
+            export OPENCLAW_NPM_TELEGRAM_SCENARIOS="${INPUT_SCENARIO}"
+          fi
+
+          pnpm test:docker:npm-telegram-live
+
+      - name: Upload npm Telegram E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-telegram-beta-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.run_lane.outputs.output_dir }}
+          retention-days: 14
+          if-no-files-found: warn

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -119,6 +119,9 @@ runs the same lanes before release approval.
     the Docker wrapper selects Convex automatically.
   - `OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE=ci|maintainer` overrides the shared
     `OPENCLAW_QA_CREDENTIAL_ROLE` for this lane only.
+  - GitHub Actions exposes this lane as the manual maintainer workflow
+    `NPM Telegram Beta E2E`. It does not run on merge. The workflow uses the
+    `qa-live-shared` environment and Convex CI credential leases.
 - `pnpm test:docker:bundled-channel-deps`
   - Packs and installs the current OpenClaw build in Docker, starts the Gateway
     with OpenAI configured, then enables bundled channel/plugins via config

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -112,7 +112,13 @@ runs the same lanes before release approval.
     live Telegram QA lane with that installed package as the SUT Gateway.
   - Defaults to `OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC=openclaw@beta`.
   - Uses the same Telegram env credentials or Convex credential source as
-    `pnpm openclaw qa telegram`.
+    `pnpm openclaw qa telegram`. For CI/release automation, set
+    `OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE=convex` plus
+    `OPENCLAW_QA_CONVEX_SITE_URL` and the role secret. If
+    `OPENCLAW_QA_CONVEX_SITE_URL` and a Convex role secret are present in CI,
+    the Docker wrapper selects Convex automatically.
+  - `OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE=ci|maintainer` overrides the shared
+    `OPENCLAW_QA_CREDENTIAL_ROLE` for this lane only.
 - `pnpm test:docker:bundled-channel-deps`
   - Packs and installs the current OpenClaw build in Docker, starts the Gateway
     with OpenAI configured, then enables bundled channel/plugins via config

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -93,6 +93,9 @@ OpenClaw has three public release lanes:
   against the published npm package using the shared leased Telegram credential
   pool. Local maintainer one-offs may omit the Convex vars and pass the three
   `OPENCLAW_QA_TELEGRAM_*` env credentials directly.
+- Maintainers can run the same post-publish check from GitHub Actions via the
+  manual `NPM Telegram Beta E2E` workflow. It is intentionally manual-only and
+  does not run on every merge.
 - Maintainer release automation now uses preflight-then-promote:
   - real npm publish must pass a successful npm `preflight_run_id`
   - the real npm publish must be dispatched from the same `main` or

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -88,9 +88,11 @@ OpenClaw has three public release lanes:
   `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.D`
   (or the matching beta/correction version) to verify the published registry
   install path in a fresh temp prefix
-- After a beta publish, run `OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC=openclaw@YYYY.M.D-beta.N pnpm test:docker:npm-telegram-live`
+- After a beta publish, run `OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC=openclaw@YYYY.M.D-beta.N OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE=convex OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE=ci pnpm test:docker:npm-telegram-live`
   to verify installed-package onboarding, Telegram setup, and real Telegram E2E
-  against the published npm package.
+  against the published npm package using the shared leased Telegram credential
+  pool. Local maintainer one-offs may omit the Convex vars and pass the three
+  `OPENCLAW_QA_TELEGRAM_*` env credentials directly.
 - Maintainer release automation now uses preflight-then-promote:
   - real npm publish must pass a successful npm `preflight_run_id`
   - the real npm publish must be dispatched from the same `main` or

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -50,8 +50,12 @@ docker_e2e_build_or_reuse "$IMAGE_NAME" npm-telegram-live "$ROOT_DIR/scripts/e2e
 
 mkdir -p "$ROOT_DIR/.artifacts/qa-e2e"
 run_log="$(mktemp "${TMPDIR:-/tmp}/openclaw-npm-telegram-live.XXXXXX")"
+npm_prefix_host="$(mktemp -d "$ROOT_DIR/.artifacts/qa-e2e/npm-telegram-live-prefix.XXXXXX")"
 credential_source="$(resolve_credential_source)"
 credential_role="$(resolve_credential_role)"
+if [ -z "$credential_role" ] && [ -n "${CI:-}" ] && [ "$credential_source" = "convex" ]; then
+  credential_role="ci"
+fi
 
 docker_env=(
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0
@@ -109,15 +113,15 @@ done
 
 echo "Running published npm Telegram live Docker E2E ($PACKAGE_SPEC)..."
 if ! docker run --rm \
-  "${docker_env[@]}" \
-  -v "$ROOT_DIR/.artifacts:/app/.artifacts" \
+  -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  -e OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC="$PACKAGE_SPEC" \
+  -v "$npm_prefix_host:/npm-global" \
   -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'
 set -euo pipefail
 
-export HOME="$(mktemp -d "/tmp/openclaw-npm-telegram-live.XXXXXX")"
-export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+export HOME="$(mktemp -d "/tmp/openclaw-npm-telegram-install.XXXXXX")"
+export NPM_CONFIG_PREFIX="/npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
-export OPENCLAW_NPM_TELEGRAM_REPO_ROOT="/app"
 
 package_spec="${OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC:?missing OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC}"
 if [[ ! "$package_spec" =~ ^openclaw@(beta|latest|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*|-beta\.[1-9][0-9]*)?)$ ]]; then
@@ -129,6 +133,31 @@ npm install -g "$package_spec" --no-fund --no-audit
 
 command -v openclaw
 openclaw --version
+EOF
+then
+  cat "$run_log"
+  rm -f "$run_log"
+  rm -rf "$npm_prefix_host"
+  exit 1
+fi
+
+cat "$run_log"
+>"$run_log"
+
+if ! docker run --rm \
+  "${docker_env[@]}" \
+  -v "$ROOT_DIR/.artifacts:/app/.artifacts" \
+  -v "$npm_prefix_host:/npm-global" \
+  -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'
+set -euo pipefail
+
+export HOME="$(mktemp -d "/tmp/openclaw-npm-telegram-runtime.XXXXXX")"
+export NPM_CONFIG_PREFIX="/npm-global"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+export OPENCLAW_NPM_TELEGRAM_REPO_ROOT="/app"
+
+command -v openclaw
+openclaw --version
 
 export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$(command -v openclaw)"
 node --import tsx scripts/e2e/npm-telegram-live-runner.ts
@@ -136,9 +165,11 @@ EOF
 then
   cat "$run_log"
   rm -f "$run_log"
+  rm -rf "$npm_prefix_host"
   exit 1
 fi
 
 cat "$run_log"
 rm -f "$run_log"
+rm -rf "$npm_prefix_host"
 echo "published npm Telegram live Docker E2E passed ($PACKAGE_SPEC)"

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -9,6 +9,32 @@ DOCKER_TARGET="${OPENCLAW_NPM_TELEGRAM_DOCKER_TARGET:-build}"
 PACKAGE_SPEC="${OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC:-openclaw@beta}"
 OUTPUT_DIR="${OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR:-.artifacts/qa-e2e/npm-telegram-live}"
 
+resolve_credential_source() {
+  if [ -n "${OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE:-}" ]; then
+    printf "%s" "$OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE"
+    return 0
+  fi
+  if [ -n "${OPENCLAW_QA_CREDENTIAL_SOURCE:-}" ]; then
+    printf "%s" "$OPENCLAW_QA_CREDENTIAL_SOURCE"
+    return 0
+  fi
+  if [ -n "${CI:-}" ] && [ -n "${OPENCLAW_QA_CONVEX_SITE_URL:-}" ]; then
+    if [ -n "${OPENCLAW_QA_CONVEX_SECRET_CI:-}" ] || [ -n "${OPENCLAW_QA_CONVEX_SECRET_MAINTAINER:-}" ]; then
+      printf "convex"
+    fi
+  fi
+}
+
+resolve_credential_role() {
+  if [ -n "${OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE:-}" ]; then
+    printf "%s" "$OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE"
+    return 0
+  fi
+  if [ -n "${OPENCLAW_QA_CREDENTIAL_ROLE:-}" ]; then
+    printf "%s" "$OPENCLAW_QA_CREDENTIAL_ROLE"
+  fi
+}
+
 validate_openclaw_package_spec() {
   local spec="$1"
   if [[ "$spec" =~ ^openclaw@(beta|latest|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*|-beta\.[1-9][0-9]*)?)$ ]]; then
@@ -24,6 +50,8 @@ docker_e2e_build_or_reuse "$IMAGE_NAME" npm-telegram-live "$ROOT_DIR/scripts/e2e
 
 mkdir -p "$ROOT_DIR/.artifacts/qa-e2e"
 run_log="$(mktemp "${TMPDIR:-/tmp}/openclaw-npm-telegram-live.XXXXXX")"
+credential_source="$(resolve_credential_source)"
+credential_role="$(resolve_credential_role)"
 
 docker_env=(
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0
@@ -39,6 +67,13 @@ forward_env_if_set() {
   fi
 }
 
+if [ -n "$credential_source" ]; then
+  docker_env+=(-e OPENCLAW_QA_CREDENTIAL_SOURCE="$credential_source")
+fi
+if [ -n "$credential_role" ]; then
+  docker_env+=(-e OPENCLAW_QA_CREDENTIAL_ROLE="$credential_role")
+fi
+
 for key in \
   OPENAI_API_KEY \
   ANTHROPIC_API_KEY \
@@ -50,8 +85,6 @@ for key in \
   OPENCLAW_QA_TELEGRAM_GROUP_ID \
   OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN \
   OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN \
-  OPENCLAW_QA_CREDENTIAL_SOURCE \
-  OPENCLAW_QA_CREDENTIAL_ROLE \
   OPENCLAW_QA_CONVEX_SITE_URL \
   OPENCLAW_QA_CONVEX_SECRET_CI \
   OPENCLAW_QA_CONVEX_SECRET_MAINTAINER \

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -51,6 +51,7 @@ docker_e2e_build_or_reuse "$IMAGE_NAME" npm-telegram-live "$ROOT_DIR/scripts/e2e
 mkdir -p "$ROOT_DIR/.artifacts/qa-e2e"
 run_log="$(mktemp "${TMPDIR:-/tmp}/openclaw-npm-telegram-live.XXXXXX")"
 npm_prefix_host="$(mktemp -d "$ROOT_DIR/.artifacts/qa-e2e/npm-telegram-live-prefix.XXXXXX")"
+trap 'rm -f "$run_log"; rm -rf "$npm_prefix_host"' EXIT
 credential_source="$(resolve_credential_source)"
 credential_role="$(resolve_credential_role)"
 if [ -z "$credential_role" ] && [ -n "${CI:-}" ] && [ "$credential_source" = "convex" ]; then
@@ -111,12 +112,21 @@ for key in \
   forward_env_if_set "$key"
 done
 
+run_logged() {
+  if ! "$@" >"$run_log" 2>&1; then
+    cat "$run_log"
+    exit 1
+  fi
+  cat "$run_log"
+  >"$run_log"
+}
+
 echo "Running published npm Telegram live Docker E2E ($PACKAGE_SPEC)..."
-if ! docker run --rm \
+run_logged docker run --rm \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC="$PACKAGE_SPEC" \
   -v "$npm_prefix_host:/npm-global" \
-  -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'
+  -i "$IMAGE_NAME" bash -s <<'EOF'
 set -euo pipefail
 
 export HOME="$(mktemp -d "/tmp/openclaw-npm-telegram-install.XXXXXX")"
@@ -124,31 +134,18 @@ export NPM_CONFIG_PREFIX="/npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 
 package_spec="${OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC:?missing OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC}"
-if [[ ! "$package_spec" =~ ^openclaw@(beta|latest|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*|-beta\.[1-9][0-9]*)?)$ ]]; then
-  echo "OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC must be openclaw@beta, openclaw@latest, or an exact OpenClaw release version; got: $package_spec" >&2
-  exit 1
-fi
 echo "Installing ${package_spec}..."
 npm install -g "$package_spec" --no-fund --no-audit
 
 command -v openclaw
 openclaw --version
 EOF
-then
-  cat "$run_log"
-  rm -f "$run_log"
-  rm -rf "$npm_prefix_host"
-  exit 1
-fi
 
-cat "$run_log"
->"$run_log"
-
-if ! docker run --rm \
+run_logged docker run --rm \
   "${docker_env[@]}" \
   -v "$ROOT_DIR/.artifacts:/app/.artifacts" \
   -v "$npm_prefix_host:/npm-global" \
-  -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'
+  -i "$IMAGE_NAME" bash -s <<'EOF'
 set -euo pipefail
 
 export HOME="$(mktemp -d "/tmp/openclaw-npm-telegram-runtime.XXXXXX")"
@@ -162,14 +159,5 @@ openclaw --version
 export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$(command -v openclaw)"
 node --import tsx scripts/e2e/npm-telegram-live-runner.ts
 EOF
-then
-  cat "$run_log"
-  rm -f "$run_log"
-  rm -rf "$npm_prefix_host"
-  exit 1
-fi
 
-cat "$run_log"
-rm -f "$run_log"
-rm -rf "$npm_prefix_host"
 echo "published npm Telegram live Docker E2E passed ($PACKAGE_SPEC)"

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -63,7 +63,7 @@ docker_env=(
 forward_env_if_set() {
   local key="$1"
   if [ -n "${!key:-}" ]; then
-    docker_env+=(-e "$key=${!key}")
+    docker_env+=(-e "$key")
   fi
 }
 

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { runTelegramQaLive } from "../../extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts";
 import { formatErrorMessage } from "../../src/infra/errors.ts";
 
@@ -15,6 +16,14 @@ function splitCsv(value: string | undefined) {
     .split(",")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+}
+
+function resolveCredentialSource(env: NodeJS.ProcessEnv) {
+  return env.OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE ?? env.OPENCLAW_QA_CREDENTIAL_SOURCE;
+}
+
+function resolveCredentialRole(env: NodeJS.ProcessEnv) {
+  return env.OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE ?? env.OPENCLAW_QA_CREDENTIAL_ROLE;
 }
 
 async function resolveTrustedOpenClawCommand(rawCommand: string) {
@@ -63,8 +72,8 @@ async function main() {
     fastMode: parseBoolean(process.env.OPENCLAW_NPM_TELEGRAM_FAST),
     scenarioIds: splitCsv(process.env.OPENCLAW_NPM_TELEGRAM_SCENARIOS),
     sutAccountId: process.env.OPENCLAW_NPM_TELEGRAM_SUT_ACCOUNT,
-    credentialSource: process.env.OPENCLAW_QA_CREDENTIAL_SOURCE,
-    credentialRole: process.env.OPENCLAW_QA_CREDENTIAL_ROLE,
+    credentialSource: resolveCredentialSource(process.env),
+    credentialRole: resolveCredentialRole(process.env),
   });
 
   process.stdout.write(`NPM Telegram QA report: ${result.reportPath}\n`);
@@ -78,7 +87,14 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(`npm telegram live e2e failed: ${formatErrorMessage(error)}\n`);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`npm telegram live e2e failed: ${formatErrorMessage(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export const __testing = {
+  resolveCredentialRole,
+  resolveCredentialSource,
+};

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -31,10 +31,9 @@ describe("npm Telegram live Docker E2E", () => {
 
   it("installs the npm package before forwarding runtime secrets", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-    const installRun = script.slice(
-      script.indexOf('echo "Running published npm Telegram live Docker E2E'),
-      script.indexOf('cat "$run_log"\n>"$run_log"'),
-    );
+    const installRunStart = script.indexOf('echo "Running published npm Telegram live Docker E2E');
+    const installRunEnd = script.indexOf('run_logged docker run --rm \\\n  "${docker_env[@]}"');
+    const installRun = script.slice(installRunStart, installRunEnd);
 
     expect(installRun).toContain('npm install -g "$package_spec" --no-fund --no-audit');
     expect(installRun).not.toContain('"${docker_env[@]}"');

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -42,12 +42,15 @@ describe("npm Telegram live Docker E2E", () => {
     expect(script).toContain('credential_role="ci"');
   });
 
-  it("limits the manual npm beta workflow to maintainer-level actors", () => {
+  it("limits the manual npm beta workflow to release managers", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
-    expect(workflow).toContain('const allowedRoles = new Set(["admin", "maintain"]);');
-    expect(workflow).toContain("const role = data.role_name ?? data.permission;");
+    expect(workflow).toContain('const teamSlug = "openclaw-release-managers";');
+    expect(workflow).toContain("github.rest.teams.listMembersInOrg");
+    expect(workflow).toContain("memberLogins.has(context.actor)");
     expect(workflow).not.toContain('new Set(["admin", "write"])');
+    expect(workflow).not.toContain("data.role_name");
+    expect(workflow).not.toContain("getMembershipForUserInOrg");
   });
 
   it("lets npm-specific credential aliases override shared QA env", () => {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { __testing } from "../../scripts/e2e/npm-telegram-live-runner.ts";
+
+const DOCKER_SCRIPT_PATH = "scripts/e2e/npm-telegram-live-docker.sh";
+
+describe("npm Telegram live Docker E2E", () => {
+  it("supports npm-specific Convex credential aliases", () => {
+    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE");
+    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE");
+    expect(script).toContain('docker_env+=(-e OPENCLAW_QA_CREDENTIAL_SOURCE="$credential_source")');
+    expect(script).toContain('docker_env+=(-e OPENCLAW_QA_CREDENTIAL_ROLE="$credential_role")');
+  });
+
+  it("defaults CI runs to Convex when broker credentials are present", () => {
+    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain(
+      'if [ -n "${CI:-}" ] && [ -n "${OPENCLAW_QA_CONVEX_SITE_URL:-}" ]; then',
+    );
+    expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_CI");
+    expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER");
+    expect(script).toContain('printf "convex"');
+  });
+
+  it("lets npm-specific credential aliases override shared QA env", () => {
+    expect(
+      __testing.resolveCredentialSource({
+        OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE: "convex",
+        OPENCLAW_QA_CREDENTIAL_SOURCE: "env",
+      }),
+    ).toBe("convex");
+    expect(
+      __testing.resolveCredentialRole({
+        OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE: "ci",
+        OPENCLAW_QA_CREDENTIAL_ROLE: "maintainer",
+      }),
+    ).toBe("ci");
+  });
+});

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { __testing } from "../../scripts/e2e/npm-telegram-live-runner.ts";
 
-const DOCKER_SCRIPT_PATH = "scripts/e2e/npm-telegram-live-docker.sh";
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DOCKER_SCRIPT_PATH = path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegram-live-docker.sh");
 
 describe("npm Telegram live Docker E2E", () => {
   it("supports npm-specific Convex credential aliases", () => {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -6,6 +6,7 @@ import { __testing } from "../../scripts/e2e/npm-telegram-live-runner.ts";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DOCKER_SCRIPT_PATH = path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegram-live-docker.sh");
+const WORKFLOW_PATH = path.resolve(TEST_DIR, "../../.github/workflows/npm-telegram-beta-e2e.yml");
 
 describe("npm Telegram live Docker E2E", () => {
   it("supports npm-specific Convex credential aliases", () => {
@@ -26,6 +27,27 @@ describe("npm Telegram live Docker E2E", () => {
     expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_CI");
     expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER");
     expect(script).toContain('printf "convex"');
+  });
+
+  it("installs the npm package before forwarding runtime secrets", () => {
+    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+    const installRun = script.slice(
+      script.indexOf('echo "Running published npm Telegram live Docker E2E'),
+      script.indexOf('cat "$run_log"\n>"$run_log"'),
+    );
+
+    expect(installRun).toContain('npm install -g "$package_spec" --no-fund --no-audit');
+    expect(installRun).not.toContain('"${docker_env[@]}"');
+    expect(script).toContain('if [ -z "$credential_role" ] && [ -n "${CI:-}" ]');
+    expect(script).toContain('credential_role="ci"');
+  });
+
+  it("limits the manual npm beta workflow to maintainer-level actors", () => {
+    const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain('const allowedRoles = new Set(["admin", "maintain"]);');
+    expect(workflow).toContain("const role = data.role_name ?? data.permission;");
+    expect(workflow).not.toContain('new Set(["admin", "write"])');
   });
 
   it("lets npm-specific credential aliases override shared QA env", () => {


### PR DESCRIPTION
## Summary

- add Convex credential support for the npm Telegram E2E lane
- add a manual maintainer-only GitHub workflow for testing published npm beta packages
- document the release/QA usage path

## Validation

- `pnpm check:changed`
- local Convex-backed npm Telegram run passed: 8/8 scenarios
