### PR TITLE
fix(qwen): stop filtering qwen3.6-plus from Coding Plan endpoints

### DIFF
--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -123,16 +123,19 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
+/**
+ * @deprecated qwen3.6-plus is now supported on all DashScope endpoints
+ * including the Coding Plan (coding.dashscope.aliyuncs.com). Kept for
+ * backward compatibility; always returns true.
+ */
+export function isQwen36PlusSupportedBaseUrl(_baseUrl: string | undefined): boolean {
+  return true;
 }
 
 export function buildQwenModelCatalogForBaseUrl(
-  baseUrl: string | undefined,
+  _baseUrl: string | undefined,
 ): ReadonlyArray<ModelDefinitionConfig> {
-  return isQwen36PlusSupportedBaseUrl(baseUrl)
-    ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+  return QWEN_MODEL_CATALOG;
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -15,14 +15,14 @@ describe("qwen provider catalog", () => {
     expect(provider.api).toBe("openai-completions");
     expect(provider.models?.length).toBeGreaterThan(0);
     expect(provider.models?.find((model) => model.id === QWEN_DEFAULT_MODEL_ID)).toBeTruthy();
-    expect(provider.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
+    expect(provider.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
   });
 
-  it("only advertises qwen3.6-plus on Standard endpoints", () => {
+  it("advertises qwen3.6-plus on all DashScope endpoints including Coding Plan", () => {
     const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
     const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
 
-    expect(coding.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
+    expect(coding.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
     expect(standard.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

`qwen3.6-plus` is now supported on all DashScope endpoints including the Coding Plan (`coding.dashscope.aliyuncs.com`). This PR removes the filter that excluded it from the model catalog when a Coding Plan base URL was configured.

## Root Cause

`buildQwenModelCatalogForBaseUrl()` in `extensions/qwen/models.ts` called `isQwen36PlusSupportedBaseUrl()` which returned `false` for Coding Plan URLs, filtering out `qwen3.6-plus`. This was originally added when the Coding Plan endpoint didn't support the model, but Alibaba Cloud has since added support.

## Fix

- `isQwen36PlusSupportedBaseUrl()` now always returns `true` (kept for backward compat, marked deprecated)
- `buildQwenModelCatalogForBaseUrl()` always returns the full `QWEN_MODEL_CATALOG`
- Updated tests to verify qwen3.6-plus is available on all endpoints

## Testing

- 3/3 tests pass in `provider-catalog.test.ts` ✅

Fixes #70927