### PR TITLE
fix(cron): apply toolsAllow filter to bundled MCP/LSP tools in scheduled runs

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -728,7 +728,10 @@ export async function runEmbeddedAttempt(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
-    const effectiveTools = [...tools, ...filteredBundledTools];
+    const effectiveTools = applyEmbeddedAttemptToolsAllow(
+      [...tools, ...filteredBundledTools],
+      params.toolsAllow,
+    );
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,


### PR DESCRIPTION
## Summary

Scheduled cron `agentTurn` runs correctly applied `toolsAllow` to the base OpenClaw tool registry, but bundled MCP/LSP tools were materialized later and appended to `effectiveTools` without reapplying the allowlist. This caused exec-only cron jobs to still compile with e.g. 45 Atlassian MCP tools, wasting **~370k input tokens/day** across affected deployments.

## Root Cause

In `src/agents/pi-embedded-runner/run/attempt.ts`:

1. Line ~570: `applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow)` filters base tools ✅
2. Line ~710: `applyFinalEffectiveToolPolicy(...)` filters bundled tools by sandbox/policy ✅
3. Line ~731: `const effectiveTools = [...tools, ...filteredBundledTools]` — appends bundled tools **without** re-checking `toolsAllow` ❌

## Fix

Apply `applyEmbeddedAttemptToolsAllow()` to the final combined tool array so `toolsAllow` is authoritative over all tool sources:

```ts
const effectiveTools = applyEmbeddedAttemptToolsAllow(
  [...tools, ...filteredBundledTools],
  params.toolsAllow,
);
```

When `toolsAllow` is empty/undefined, the function is a no-op (returns the full array unchanged).

## Impact

- Cron jobs with `toolsAllow: [\"exec\"]` will now correctly compile with only `exec`
- Saves ~370k input tokens/day for affected deployments (~2.58M/week)
- No behavioral change for cron jobs without `toolsAllow`

## Testing

- All 114 existing tests in `attempt.test.ts` pass ✅
- The existing `applyEmbeddedAttemptToolsAllow` unit test confirms the filter behavior

Fixes #70939