### PR TITLE
feat(deepseek): add deepseek-v4-pro and deepseek-v4-flash to model catalog [AI-assisted]

### DIFF
--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -30,10 +30,20 @@ describe("deepseek provider plugin", () => {
     expect(catalogProvider.models?.map((model) => model.id)).toEqual([
       "deepseek-chat",
       "deepseek-reasoner",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
     ]);
     expect(
       catalogProvider.models?.find((model) => model.id === "deepseek-reasoner")?.reasoning,
     ).toBe(true);
+    const v4Pro = catalogProvider.models?.find((model) => model.id === "deepseek-v4-pro");
+    expect(v4Pro?.reasoning).toBe(true);
+    expect(v4Pro?.contextWindow).toBe(1_000_000);
+    expect(v4Pro?.maxTokens).toBe(384_000);
+    const v4Flash = catalogProvider.models?.find((model) => model.id === "deepseek-v4-flash");
+    expect(v4Flash?.reasoning).toBe(true);
+    expect(v4Flash?.contextWindow).toBe(1_000_000);
+    expect(v4Flash?.maxTokens).toBe(384_000);
   });
 
   it("publishes configured DeepSeek models through plugin-owned catalog augmentation", async () => {

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -11,6 +11,24 @@ const DEEPSEEK_V3_2_COST = {
   cacheWrite: 0,
 };
 
+// DeepSeek V4 Pro API pricing (per 1M tokens)
+// https://api-docs.deepseek.com/quick_start/pricing
+const DEEPSEEK_V4_PRO_COST = {
+  input: 1.74,
+  output: 3.48,
+  cacheRead: 0.145,
+  cacheWrite: 0,
+};
+
+// DeepSeek V4 Flash API pricing (per 1M tokens)
+// https://api-docs.deepseek.com/quick_start/pricing
+const DEEPSEEK_V4_FLASH_COST = {
+  input: 0.14,
+  output: 0.28,
+  cacheRead: 0.028,
+  cacheWrite: 0,
+};
+
 export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = [
   {
     id: "deepseek-chat",
@@ -30,6 +48,26 @@ export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 131072,
     maxTokens: 65536,
     cost: DEEPSEEK_V3_2_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+  {
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 384_000,
+    cost: DEEPSEEK_V4_PRO_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+  {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 1_000_000,
+    maxTokens: 384_000,
+    cost: DEEPSEEK_V4_FLASH_COST,
     compat: { supportsUsageInStreaming: true },
   },
 ];


### PR DESCRIPTION
## Summary

Adds the two current-generation DeepSeek models to the bundled DeepSeek provider catalog:

- **deepseek-v4-pro** — reasoning model, 1M context window, 384K max output
- **deepseek-v4-flash** — reasoning model, 1M context window, 384K max output

DeepSeek's `/models` endpoint now returns only these two IDs. The legacy `deepseek-chat` and `deepseek-reasoner` entries are kept (backwards compatibility — legacy aliases still resolve on the upstream API), but without this change users cannot select V4 through openclaw (it falls back to `openai/deepseek-v4-pro`, which is not what users want).

## Changes

| Model | Action | reasoning | contextWindow | maxTokens | cost (input / output per 1M) |
|-------|--------|-----------|---------------|-----------|------------------------------|
| `deepseek-v4-pro` | Add | true | 1,000,000 | 384,000 | \$1.74 / \$3.48 |
| `deepseek-v4-flash` | Add | true | 1,000,000 | 384,000 | \$0.14 / \$0.28 |

Pricing source: https://api-docs.deepseek.com/quick_start/pricing

Files changed:
- `extensions/deepseek/models.ts` — add V4 pricing constants and catalog entries
- `extensions/deepseek/index.test.ts` — extend static-catalog assertion with V4 ids and attribute checks

## Validation

### Live API

**`/models` endpoint** confirms the two IDs:
```json
{"object":"list","data":[
  {"id":"deepseek-v4-flash","object":"model","owned_by":"deepseek"},
  {"id":"deepseek-v4-pro","object":"model","owned_by":"deepseek"}
]}
```

**deepseek-v4-pro** — live request/response (returns `reasoning_content`, confirming reasoning: true):
```json
Request:  {"model":"deepseek-v4-pro","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":50}
Response: {"role":"assistant","content":"","reasoning_content":"We are asked: \"What is 2+2?\" ... the answer is \"four\"..."}
usage:    {"prompt_tokens":16,"completion_tokens":50,"completion_tokens_details":{"reasoning_tokens":50}}
system_fingerprint: "fp_9954b31ca7_prod0820_fp8_kvcache_20260402"
```

**deepseek-v4-flash** — live request/response:
```json
Request:  {"model":"deepseek-v4-flash","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":50}
Response: {"role":"assistant","content":"Four","reasoning_content":"We need to answer \"What is 2+2?\" ... The answer is obviously four..."}
usage:    {"prompt_tokens":16,"completion_tokens":33,"completion_tokens_details":{"reasoning_tokens":31}}
system_fingerprint: "fp_058df29938_prod0820_fp8_kvcache_20260402"
```

### Local checks

```
$ pnpm test extensions/deepseek
Test Files  1 passed (1)
Tests  3 passed (3)

$ pnpm format:check extensions/deepseek
All matched files use the correct format.

$ node_modules/.bin/oxlint extensions/deepseek --tsconfig tsconfig.oxlint.extensions.json
Found 0 warnings and 0 errors.

$ pnpm tsgo:extensions / pnpm tsgo:extensions:test
both pass (37s / 123s)
```

`pnpm check:changed` full run also passes the typecheck and conflict-marker gates; the tree-wide oxlint step OOMs on my WSL2 dev box (7.6GB RAM) but is unrelated to this diff.

## Known follow-ups (not part of this PR)

- **Multi-turn sessions**: these V4 models enforce DeepSeek's new \"thinking mode\" contract, which requires `reasoning_content` to be replayed in subsequent assistant turns. openclaw's current `openai-completions` replay path drops that field, so multi-turn sessions fail with `400 The \`reasoning_content\` in the thinking mode must be passed back to the API`. That is tracked in #70931 and needs a separate PR (likely in the transcript → completions message transform for reasoning-capable openai-completions providers). Single-turn requests work against the newly-catalogued models.
- **tieredPricing**: DeepSeek's pricing page does not currently show context-length tiers for V4; leaving `tieredPricing` unset. If V4 gains tiered input rates this should be revisited.

## AI-assisted disclosure

- [x] Mark as AI-assisted: yes, Claude Opus 4.7
- [x] Degree of testing: **fully tested** — local unit tests pass, live API requests/responses captured above, pricing verified against official docs
- [x] Prompts / session logs: happy to share on request
- [x] Confirm understanding of code: yes
- [ ] \`codex review --base origin/main\` — not available in my environment; will address any review-bot comments on this PR

## Test plan

- [x] `pnpm test extensions/deepseek` — passes
- [x] `pnpm format:check extensions/deepseek` — passes
- [x] `oxlint extensions/deepseek` — 0 errors
- [x] `pnpm tsgo:extensions` — passes
- [x] `pnpm tsgo:extensions:test` — passes
- [x] Live `/models` listing + per-model chat completion requests — captured above