### PR TITLE
fix(gateway): remove literal managed env values from install plan

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -194,14 +194,16 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    expect(plan.environment.GOOGLE_API_KEY).toBe("test-key");
-    expect(plan.environment.CUSTOM_VAR).toBe("custom-value");
-    expect(plan.environment.SAFE_KEY).toBe("safe-value");
+    // Managed keys' literal values are removed from the plist so the gateway
+    // loads fresh values from .env at runtime (see #70612).
+    expect(plan.environment.GOOGLE_API_KEY).toBeUndefined();
+    expect(plan.environment.CUSTOM_VAR).toBeUndefined();
+    expect(plan.environment.SAFE_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_PORT).toBeUndefined();
     expect(plan.environment.NODE_OPTIONS).toBeUndefined();
     expect(plan.environment.EMPTY_KEY).toBeUndefined();
     expect(plan.environment.TRIMMED_KEY).toBeUndefined();
     expect(plan.environment.HOME).toBe("/Users/service");
-    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
       "CUSTOM_VAR,GOOGLE_API_KEY,OPENCLAW_PORT,SAFE_KEY",
     );
@@ -250,7 +252,8 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("OPENAI_API_KEY");
     expect(mocks.hasAnyAuthProfileStoreSource).not.toHaveBeenCalled();
     expect(mocks.loadAuthProfileStoreForSecretsRuntime).not.toHaveBeenCalled();
   });
@@ -314,8 +317,11 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.GIT_ASKPASS).toBeUndefined();
     expect(plan.environment["BAD KEY"]).toBeUndefined();
     expect(plan.environment.MISSING_TOKEN).toBeUndefined();
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
-    expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.ANTHROPIC_TOKEN).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
+      "ANTHROPIC_TOKEN,OPENAI_API_KEY",
+    );
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("NODE_OPTIONS"), "Auth profile");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("GIT_ASKPASS"), "Auth profile");
   });
@@ -359,11 +365,14 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       },
     });
 
-    expect(plan.environment.BRAVE_API_KEY).toBe("BSA-from-env");
-    expect(plan.environment.OPENROUTER_API_KEY).toBe("or-key");
-    expect(plan.environment.MY_KEY).toBe("from-config");
+    expect(plan.environment.BRAVE_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENROUTER_API_KEY).toBeUndefined();
+    expect(plan.environment.MY_KEY).toBeUndefined();
     expect(plan.environment.HOME).toBe("/from-service");
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
+      "BRAVE_API_KEY,MY_KEY,OPENROUTER_API_KEY",
+    );
   });
 
   it("works when .env file does not exist", async () => {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -250,6 +250,18 @@ async function buildGatewayInstallEnvironment(params: {
   const managedServiceEnvKeys = formatManagedServiceEnvKeys(managedEnvironment);
   if (managedServiceEnvKeys) {
     environment[MANAGED_SERVICE_ENV_KEYS_VAR] = managedServiceEnvKeys;
+    // Remove literal values for managed keys.  The gateway loads them from
+    // .env at runtime via loadRuntimeDotEnvFile; embedding them in the
+    // plist prevents that load and leaves stale values after .env changes
+    // (see #70612).
+    const managedKeySet = new Set(
+      managedServiceEnvKeys.split(",").map((k) => k.trim().toUpperCase()),
+    );
+    for (const key of Object.keys(environment)) {
+      if (managedKeySet.has(key.toUpperCase())) {
+        delete environment[key];
+      }
+    }
   }
   return environment;
 }


### PR DESCRIPTION
## Summary

- `openclaw gateway install --force` embeds literal secret values (DISCORD_TOKEN, OPENCLAW_GATEWAY_TOKEN, etc.) in the macOS LaunchAgent plist alongside `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`
- At runtime `loadRuntimeDotEnvFile` skips loading `.env` values when `process.env[key] !== undefined`, so stale plist values persist after `.env` changes
- This PR removes literal values of managed keys from the install plan environment — only the `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` passthrough list is kept, so the gateway loads fresh values from `.env` at startup

Fixes #70612

## Test plan

- [x] Updated `daemon-install-helpers.test.ts` — all 4 affected test cases now verify managed keys have no literal values in the plist environment
- [x] `pnpm test src/commands/daemon-install-helpers.test.ts` — 13/13 pass
- [x] `pnpm check` — lint, type-check, import cycle checks all pass