### PR TITLE
test(agents): cover cache snapshot usage reporting

### DIFF
--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -191,4 +191,49 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     // If the bug exists, it will likely be 350
     expect(usage?.total).toBe(200);
   });
+
+  it("keeps cache snapshot totals from inflating the reported current-turn total", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Tool call 1", "Tool call 2", "Final answer"],
+        lastAssistant: makeAssistantMessage({
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: {
+            input: 1,
+            output: 190,
+            cacheRead: 22_595,
+            cacheWrite: 1_086,
+            total: 23_872,
+          } as unknown as AssistantMessage["usage"],
+        }),
+        attemptUsage: {
+          input: 5,
+          output: 570,
+          cacheRead: 61_490,
+          cacheWrite: 4_309,
+          total: 66_374,
+        },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "anthropic-session",
+      sessionKey: "anthropic-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-anthropic-cache-snapshot",
+    });
+
+    expect(result.meta.agentMeta?.usage?.total).toBe(23_872);
+    expect(result.meta.agentMeta?.lastCallUsage).toEqual({
+      input: 1,
+      output: 190,
+      cacheRead: 22_595,
+      cacheWrite: 1_086,
+      total: 23_872,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add regression coverage for cache-snapshot usage reporting in the embedded runner
- verify the reported current-turn total comes from the final call snapshot instead of inflated accumulated tool-loop totals
- assert `lastCallUsage` preserves the final cache snapshot used for session accounting

Refs #70679

## Testing
- pnpm exec vitest run src/agents/pi-embedded-runner/usage-reporting.test.ts
- pnpm exec vitest run src/agents/usage.test.ts
- pnpm exec oxfmt --check src/agents/pi-embedded-runner/usage-reporting.test.ts