### PR TITLE
fix(diagnostics): make otel service restart safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Diagnostics/OTEL: add a lightweight diagnostic trace-context carrier for future span correlation without adding OTEL SDK state to core. Thanks @vincentkoc.
 - Diagnostics/OTEL: attach diagnostic trace context to exported OTEL logs so log records can correlate with future spans without adding retained process state. Thanks @vincentkoc.
 - Diagnostics/OTEL: pass immutable per-run diagnostic trace context through agent and tool hook contexts, and parent exported diagnostic spans from validated context without retaining global trace state. Thanks @vincentkoc.
+- Diagnostics/OTEL: make exporter startup restart-safe so config reloads do not retain stale SDKs, log transports, or diagnostic event listeners. Thanks @vincentkoc.
 - Control UI/chat: add a Steer action on queued messages so a browser follow-up can be injected into the active run without retyping it.
 - Control UI/Talk: add browser WebRTC realtime voice sessions backed by OpenAI Realtime, with Gateway-minted ephemeral client secrets and `openclaw_agent_consult` handoff to the full OpenClaw agent.
 - Agents/tools: add optional per-call `timeoutMs` support for image, video, music, and TTS generation tools so agents can extend provider request timeouts only when a specific generation needs it.

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -166,12 +166,14 @@ function createTraceOnlyContext(endpoint: string): OpenClawPluginServiceContext 
 type RegisteredLogTransport = (logObj: Record<string, unknown>) => void;
 function setupRegisteredTransports() {
   const registeredTransports: RegisteredLogTransport[] = [];
-  const stopTransport = vi.fn();
+  const stopTransports: ReturnType<typeof vi.fn>[] = [];
   registerLogTransportMock.mockImplementation((transport) => {
     registeredTransports.push(transport);
+    const stopTransport = vi.fn();
+    stopTransports.push(stopTransport);
     return stopTransport;
   });
-  return { registeredTransports, stopTransport };
+  return { registeredTransports, stopTransports };
 }
 
 async function emitAndCaptureLog(logObj: Record<string, unknown>) {
@@ -281,6 +283,73 @@ describe("diagnostics-otel service", () => {
     expect(logEmit).toHaveBeenCalled();
 
     await service.stop?.(ctx);
+  });
+
+  test("restarts without retaining prior listeners or log transports", async () => {
+    const { registeredTransports, stopTransports } = setupRegisteredTransports();
+
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
+    await service.start(ctx);
+    await service.start(ctx);
+
+    expect(registerLogTransportMock).toHaveBeenCalledTimes(2);
+    expect(registeredTransports).toHaveLength(2);
+    expect(stopTransports[0]).toHaveBeenCalledTimes(1);
+    expect(logShutdown).toHaveBeenCalledTimes(1);
+    expect(sdkShutdown).toHaveBeenCalledTimes(1);
+
+    telemetryState.tracer.startSpan.mockClear();
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      outcome: "completed",
+      durationMs: 10,
+    });
+    expect(telemetryState.tracer.startSpan).toHaveBeenCalledTimes(1);
+
+    await service.stop?.(ctx);
+    expect(stopTransports[1]).toHaveBeenCalledTimes(1);
+    expect(logShutdown).toHaveBeenCalledTimes(2);
+    expect(sdkShutdown).toHaveBeenCalledTimes(2);
+
+    telemetryState.tracer.startSpan.mockClear();
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      outcome: "completed",
+      durationMs: 10,
+    });
+    expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
+  });
+
+  test("tears down active handles when restarted with diagnostics disabled", async () => {
+    const { stopTransports } = setupRegisteredTransports();
+
+    const service = createDiagnosticsOtelService();
+    const enabledCtx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(enabledCtx);
+    await service.start({
+      ...enabledCtx,
+      config: { diagnostics: { enabled: false } },
+    });
+
+    expect(stopTransports[0]).toHaveBeenCalledTimes(1);
+    expect(logShutdown).toHaveBeenCalledTimes(1);
+    expect(sdkShutdown).toHaveBeenCalledTimes(1);
+
+    telemetryState.tracer.startSpan.mockClear();
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      outcome: "completed",
+      durationMs: 10,
+    });
+    expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
   });
 
   test("appends signal path when endpoint contains non-signal /v1 segment", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -176,9 +176,32 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let stopLogTransport: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
 
+  const stopStarted = async () => {
+    const currentUnsubscribe = unsubscribe;
+    const currentStopLogTransport = stopLogTransport;
+    const currentLogProvider = logProvider;
+    const currentSdk = sdk;
+
+    unsubscribe = null;
+    stopLogTransport = null;
+    logProvider = null;
+    sdk = null;
+
+    currentUnsubscribe?.();
+    currentStopLogTransport?.();
+    if (currentLogProvider) {
+      await currentLogProvider.shutdown().catch(() => undefined);
+    }
+    if (currentSdk) {
+      await currentSdk.shutdown().catch(() => undefined);
+    }
+  };
+
   return {
     id: "diagnostics-otel",
     async start(ctx) {
+      await stopStarted();
+
       const cfg = ctx.config.diagnostics;
       const otel = cfg?.otel;
       if (!cfg?.enabled || !otel?.enabled) {
@@ -251,6 +274,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         try {
           sdk.start();
         } catch (err) {
+          await stopStarted();
           ctx.logger.error(`diagnostics-otel: failed to start SDK: ${formatError(err)}`);
           throw err;
         }
@@ -805,18 +829,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
     },
     async stop() {
-      unsubscribe?.();
-      unsubscribe = null;
-      stopLogTransport?.();
-      stopLogTransport = null;
-      if (logProvider) {
-        await logProvider.shutdown().catch(() => undefined);
-        logProvider = null;
-      }
-      if (sdk) {
-        await sdk.shutdown().catch(() => undefined);
-        sdk = null;
-      }
+      await stopStarted();
     },
   } satisfies OpenClawPluginService;
 }


### PR DESCRIPTION
## Summary

- Problem: restarting or reloading `diagnostics-otel` could overwrite active SDK/log/listener handles without first releasing the previous ones.
- Why it matters: stale diagnostic event listeners and log transports can duplicate exports and retain OTEL resources after config reloads.
- What changed: startup now tears down any active handles before reinitializing, clears handles before async shutdown, and preserves SDK-start failure cleanup.
- What did NOT change (scope boundary): no OTEL schema/config changes, no new exporter behavior, no content capture.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/70980
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `start()` only assigned the newest OTEL SDK/log transport/diagnostic subscription handles; it did not stop previous handles before re-starting.
- Missing detection / guardrail: no test covered repeated `start()` or start-after-disabled config behavior.
- Contributing context (if known): diagnostics exporter lifecycle can be entered through plugin reload/config reload paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/diagnostics-otel/src/service.test.ts`
- Scenario the test should lock in: repeated starts stop the prior log transport/provider/sdk and leave only one active diagnostic event listener; restarting with diagnostics disabled tears down active handles.
- Why this is the smallest reliable guardrail: the service test owns the mocked OTEL SDK, log transport, and diagnostic-event seam.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`diagnostics-otel` is restart-safe during config/plugin reloads; normal export payloads are unchanged.

## Diagram (if applicable)

```text
Before:
start -> handles A
start -> handles B, handles A still active

After:
start -> handles A
start -> stop A -> handles B
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): diagnostics-otel
- Relevant config (redacted): `diagnostics.otel.enabled=true`, traces/metrics/logs enabled in tests

### Steps

1. Start `diagnostics-otel` with traces, metrics, and logs enabled.
2. Start it again with the same context.
3. Emit a diagnostic event.
4. Start it with diagnostics disabled.
5. Emit another diagnostic event.

### Expected

- Old transport/provider/sdk handles are stopped before replacement.
- Only one listener handles events after restart.
- No listener handles events after disabled restart.

### Actual

- Covered by new passing regression tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/diagnostics-otel/src/service.test.ts`
  - `pnpm format:check -- extensions/diagnostics-otel/src/service.ts extensions/diagnostics-otel/src/service.test.ts CHANGELOG.md`
  - `pnpm exec oxlint --tsconfig tsconfig.oxlint.json extensions/diagnostics-otel/src/service.ts extensions/diagnostics-otel/src/service.test.ts`
- Edge cases checked: double start, restart with diagnostics disabled, post-stop listener silence.
- What you did **not** verify: full `pnpm check:changed`; local extension typecheck is blocked by unrelated provider compat errors around `supportsLongCacheRetention` in `extensions/arcee` / `extensions/chutes`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: startup cleanup could shut down handles when `start()` is called with disabled config.
  - Mitigation: this is intentional reload behavior and covered by regression tests.
