### PR TITLE
fix(plugins): pin official external channel source

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -18,8 +18,9 @@
           "order": 45
         },
         "install": {
-          "npmSpec": "@wecom/wecom-openclaw-plugin",
-          "defaultChoice": "npm"
+          "npmSpec": "@wecom/wecom-openclaw-plugin@2026.4.23",
+          "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ=="
         }
       }
     }

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -39,6 +39,6 @@ describeOfficialFallbackChannelCatalogContract({
 
 describeChannelCatalogEntryContract({
   channelId: "wecom",
-  npmSpec: "@wecom/wecom-openclaw-plugin",
+  npmSpec: "@wecom/wecom-openclaw-plugin@2026.4.23",
   alias: "wework",
 });

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH,
   writeOfficialChannelCatalog,
 } from "../scripts/write-official-channel-catalog.mjs";
+import { describePluginInstallSource } from "../src/plugins/install-source-info.js";
 import { bundledPluginRoot } from "./helpers/bundled-plugin-paths.js";
 import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "./helpers/temp-repo.js";
 
@@ -78,8 +79,10 @@ describe("buildOfficialChannelCatalog", () => {
               label: "WeCom",
             }),
             install: {
-              npmSpec: "@wecom/wecom-openclaw-plugin",
+              npmSpec: "@wecom/wecom-openclaw-plugin@2026.4.23",
               defaultChoice: "npm",
+              expectedIntegrity:
+                "sha512-bnzfdIEEu1/LFvcdyjaTkyxt27w6c7dqhkPezU62OWaqmcdFsUGR3T55USK/O9pIKsNcnL1Tnu1pqKYCWHFgWQ==",
             },
           }),
         }),
@@ -104,6 +107,20 @@ describe("buildOfficialChannelCatalog", () => {
         },
       ]),
     );
+  });
+
+  it("keeps official external catalog npm sources exactly pinned", () => {
+    const repoRoot = makeRepoRoot("openclaw-official-channel-catalog-policy-");
+    const entries = buildOfficialChannelCatalog({ repoRoot }).entries.filter(
+      (entry) => entry.source === "external",
+    );
+
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      const installSource = describePluginInstallSource(entry.openclaw?.install ?? {});
+      expect(installSource.warnings).toEqual([]);
+      expect(installSource.npm?.pinState).toBe("exact-with-integrity");
+    }
   });
 
   it("writes the official catalog under dist", () => {


### PR DESCRIPTION
## Summary

- pin the shipped official WeCom channel catalog entry to the current npm version and dist integrity
- add coverage that official external channel catalog entries stay exact-version plus integrity pinned
- update the channel catalog contract expectation for the shipped WeCom npm spec

## Why

Phase 1 source-plane work should make official external recommendations explainable and reproducible. External/community catalogs can still use floating specs and surface warnings, but OpenClaw-shipped official external entries should not drift silently.

## Validation

- `pnpm test test/official-channel-catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts src/plugins/install-source-info.test.ts`
- `pnpm format:check scripts/lib/official-external-channel-catalog.json test/official-channel-catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts`

## Notes

- `pnpm check:changed` currently fails in `src/agents/openai-transport-stream.ts` with `TS2339` errors for `supportsStore` / `supportsReasoningEffort`; this branch does not touch that file.
- AI-assisted: yes.
