### PR TITLE
[codex] Add Pi/Codex runtime contract tests

### DIFF
--- a/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
@@ -1,6 +1,8 @@
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { wrapToolWithBeforeToolCallHook } from "../../../../src/agents/pi-tools.before-tool-call.js";
 import {
+  installCodexToolResultMiddleware,
   installOpenClawOwnedToolHooks,
   resetOpenClawOwnedToolHooks,
   textToolResult,
@@ -93,6 +95,72 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
     });
   });
 
+  it("runs tool_result middleware before after_tool_call observes the result", async () => {
+    const adjustedParams = { command: "status", mode: "safe" };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const middleware = installCodexToolResultMiddleware((event) => {
+      expect(event).toMatchObject({
+        toolName: "exec",
+        toolCallId: "call-middleware",
+        args: { command: "status" },
+        result: {
+          content: [{ type: "text", text: "raw output" }],
+          details: { stage: "execute" },
+        },
+      });
+      return textToolResult("compacted output", { stage: "middleware" });
+    });
+    const execute = vi.fn(async () => textToolResult("raw output", { stage: "execute" }));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "exec", execute })],
+      signal: new AbortController().signal,
+      hookContext: {
+        agentId: "agent-1",
+        sessionId: "session-1",
+        sessionKey: "agent:agent-1:session-1",
+        runId: "run-middleware",
+      },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-middleware",
+      namespace: null,
+      tool: "exec",
+      arguments: { command: "status" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "compacted output" }],
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "call-middleware",
+      adjustedParams,
+      expect.any(AbortSignal),
+      undefined,
+    );
+    expect(middleware.middleware).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          toolCallId: "call-middleware",
+          params: adjustedParams,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "compacted output" }],
+            details: { stage: "middleware" },
+          }),
+        }),
+        expect.objectContaining({
+          runId: "run-middleware",
+          toolCallId: "call-middleware",
+        }),
+      );
+    });
+  });
+
   it("fails closed when before_tool_call blocks a dynamic tool", async () => {
     const hooks = installOpenClawOwnedToolHooks({ blockReason: "blocked by policy" });
     const execute = vi.fn(async () => textToolResult("should not run"));
@@ -141,5 +209,87 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
         }),
       );
     });
+  });
+
+  it("reports dynamic tool execution errors through after_tool_call", async () => {
+    const adjustedParams = { command: "false", timeoutSec: 1 };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const execute = vi.fn(async () => {
+      throw new Error("tool failed");
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "exec", execute })],
+      signal: new AbortController().signal,
+      hookContext: { runId: "run-error" },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-error",
+      namespace: null,
+      tool: "exec",
+      arguments: { command: "false" },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      contentItems: [{ type: "inputText", text: "tool failed" }],
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "call-error",
+      adjustedParams,
+      expect.any(AbortSignal),
+      undefined,
+    );
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          toolCallId: "call-error",
+          params: adjustedParams,
+          error: "tool failed",
+        }),
+        expect.objectContaining({
+          runId: "run-error",
+          toolCallId: "call-error",
+        }),
+      );
+    });
+  });
+
+  it("does not double-wrap dynamic tools that already have before_tool_call", async () => {
+    const adjustedParams = { command: "pwd", mode: "safe" };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const execute = vi.fn(async () => textToolResult("done"));
+    const tool = wrapToolWithBeforeToolCallHook(createContractTool({ name: "exec", execute }), {
+      runId: "run-wrapped",
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+      hookContext: { runId: "run-wrapped" },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-wrapped",
+      namespace: null,
+      tool: "exec",
+      arguments: { command: "pwd" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "done" }],
+    });
+    expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(
+      "call-wrapped",
+      adjustedParams,
+      expect.any(AbortSignal),
+      undefined,
+    );
   });
 });

--- a/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
@@ -25,7 +25,8 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
   });
 
   it("wraps unwrapped dynamic tools with before/after tool hooks", async () => {
-    const adjustedParams = { command: "pwd", mode: "safe" };
+    const adjustedParams = { mode: "safe" };
+    const mergedParams = { command: "pwd", mode: "safe" };
     const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
     const execute = vi.fn(async () => textToolResult("done", { ok: true }));
     const bridge = createCodexDynamicToolBridge({
@@ -69,7 +70,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
     );
     expect(execute).toHaveBeenCalledWith(
       "call-contract",
-      adjustedParams,
+      mergedParams,
       expect.any(AbortSignal),
       undefined,
     );
@@ -78,7 +79,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
         expect.objectContaining({
           toolName: "exec",
           toolCallId: "call-contract",
-          params: adjustedParams,
+          params: mergedParams,
           result: expect.objectContaining({
             content: [{ type: "text", text: "done" }],
             details: { ok: true },
@@ -96,7 +97,8 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
   });
 
   it("runs tool_result middleware before after_tool_call observes the result", async () => {
-    const adjustedParams = { command: "status", mode: "safe" };
+    const adjustedParams = { mode: "safe" };
+    const mergedParams = { command: "status", mode: "safe" };
     const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
     const middleware = installCodexToolResultMiddleware((event) => {
       expect(event).toMatchObject({
@@ -137,7 +139,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
     });
     expect(execute).toHaveBeenCalledWith(
       "call-middleware",
-      adjustedParams,
+      mergedParams,
       expect.any(AbortSignal),
       undefined,
     );
@@ -147,7 +149,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
         expect.objectContaining({
           toolName: "exec",
           toolCallId: "call-middleware",
-          params: adjustedParams,
+          params: mergedParams,
           result: expect.objectContaining({
             content: [{ type: "text", text: "compacted output" }],
             details: { stage: "middleware" },
@@ -212,7 +214,8 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
   });
 
   it("reports dynamic tool execution errors through after_tool_call", async () => {
-    const adjustedParams = { command: "false", timeoutSec: 1 };
+    const adjustedParams = { timeoutSec: 1 };
+    const mergedParams = { command: "false", timeoutSec: 1 };
     const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
     const execute = vi.fn(async () => {
       throw new Error("tool failed");
@@ -238,7 +241,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
     });
     expect(execute).toHaveBeenCalledWith(
       "call-error",
-      adjustedParams,
+      mergedParams,
       expect.any(AbortSignal),
       undefined,
     );
@@ -247,7 +250,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
         expect.objectContaining({
           toolName: "exec",
           toolCallId: "call-error",
-          params: adjustedParams,
+          params: mergedParams,
           error: "tool failed",
         }),
         expect.objectContaining({
@@ -259,7 +262,8 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
   });
 
   it("does not double-wrap dynamic tools that already have before_tool_call", async () => {
-    const adjustedParams = { command: "pwd", mode: "safe" };
+    const adjustedParams = { mode: "safe" };
+    const mergedParams = { command: "pwd", mode: "safe" };
     const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
     const execute = vi.fn(async () => textToolResult("done"));
     const tool = wrapToolWithBeforeToolCallHook(createContractTool({ name: "exec", execute }), {
@@ -287,7 +291,7 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
     expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
     expect(execute).toHaveBeenCalledWith(
       "call-wrapped",
-      adjustedParams,
+      mergedParams,
       expect.any(AbortSignal),
       undefined,
     );

--- a/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
@@ -4,6 +4,7 @@ import { wrapToolWithBeforeToolCallHook } from "../../../../src/agents/pi-tools.
 import {
   installCodexToolResultMiddleware,
   installOpenClawOwnedToolHooks,
+  mediaToolResult,
   resetOpenClawOwnedToolHooks,
   textToolResult,
 } from "../../../../test/helpers/agents/openclaw-owned-tool-runtime-contract.js";
@@ -256,6 +257,114 @@ describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", ()
         expect.objectContaining({
           runId: "run-error",
           toolCallId: "call-error",
+        }),
+      );
+    });
+  });
+
+  it("records successful Codex messaging text, media, and target telemetry", async () => {
+    const hooks = installOpenClawOwnedToolHooks();
+    const execute = vi.fn(async () => textToolResult("Sent."));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "message", execute })],
+      signal: new AbortController().signal,
+      hookContext: { runId: "run-message" },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-message",
+      namespace: null,
+      tool: "message",
+      arguments: {
+        action: "send",
+        text: "hello from Codex",
+        mediaUrl: "/tmp/codex-reply.png",
+        provider: "telegram",
+        to: "chat-1",
+        threadId: "thread-ts-1",
+      },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "Sent." }],
+    });
+    expect(bridge.telemetry).toMatchObject({
+      didSendViaMessagingTool: true,
+      messagingToolSentTexts: ["hello from Codex"],
+      messagingToolSentMediaUrls: ["/tmp/codex-reply.png"],
+      messagingToolSentTargets: [
+        {
+          tool: "message",
+          provider: "telegram",
+          to: "chat-1",
+          threadId: "thread-ts-1",
+        },
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "message",
+          toolCallId: "call-message",
+          params: expect.objectContaining({
+            text: "hello from Codex",
+            mediaUrl: "/tmp/codex-reply.png",
+          }),
+        }),
+        expect.objectContaining({
+          runId: "run-message",
+          toolCallId: "call-message",
+        }),
+      );
+    });
+  });
+
+  it("records successful Codex media artifacts from tool results", async () => {
+    const hooks = installOpenClawOwnedToolHooks();
+    const execute = vi.fn(async () =>
+      mediaToolResult("Generated media reply.", "/tmp/reply.opus", true),
+    );
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "tts", execute })],
+      signal: new AbortController().signal,
+      hookContext: { runId: "run-media" },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-media",
+      namespace: null,
+      tool: "tts",
+      arguments: { text: "hello" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "Generated media reply." }],
+    });
+    expect(bridge.telemetry.toolMediaUrls).toEqual(["/tmp/reply.opus"]);
+    expect(bridge.telemetry.toolAudioAsVoice).toBe(true);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "tts",
+          toolCallId: "call-media",
+          result: expect.objectContaining({
+            details: {
+              media: {
+                mediaUrl: "/tmp/reply.opus",
+                audioAsVoice: true,
+              },
+            },
+          }),
+        }),
+        expect.objectContaining({
+          runId: "run-media",
+          toolCallId: "call-media",
         }),
       );
     });

--- a/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts
@@ -1,0 +1,145 @@
+import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  installOpenClawOwnedToolHooks,
+  resetOpenClawOwnedToolHooks,
+  textToolResult,
+} from "../../../../test/helpers/agents/openclaw-owned-tool-runtime-contract.js";
+import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
+
+function createContractTool(overrides: Partial<AnyAgentTool>): AnyAgentTool {
+  return {
+    name: "exec",
+    description: "Run a command.",
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(),
+    ...overrides,
+  } as unknown as AnyAgentTool;
+}
+
+describe("OpenClaw-owned tool runtime contract — Codex app-server adapter", () => {
+  afterEach(() => {
+    resetOpenClawOwnedToolHooks();
+  });
+
+  it("wraps unwrapped dynamic tools with before/after tool hooks", async () => {
+    const adjustedParams = { command: "pwd", mode: "safe" };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const execute = vi.fn(async () => textToolResult("done", { ok: true }));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "exec", execute })],
+      signal: new AbortController().signal,
+      hookContext: {
+        agentId: "agent-1",
+        sessionId: "session-1",
+        sessionKey: "agent:agent-1:session-1",
+        runId: "run-contract",
+      },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-contract",
+      namespace: null,
+      tool: "exec",
+      arguments: { command: "pwd" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "done" }],
+    });
+    expect(hooks.beforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "exec",
+        toolCallId: "call-contract",
+        runId: "run-contract",
+        params: { command: "pwd" },
+      }),
+      expect.objectContaining({
+        agentId: "agent-1",
+        sessionId: "session-1",
+        sessionKey: "agent:agent-1:session-1",
+        runId: "run-contract",
+        toolCallId: "call-contract",
+      }),
+    );
+    expect(execute).toHaveBeenCalledWith(
+      "call-contract",
+      adjustedParams,
+      expect.any(AbortSignal),
+      undefined,
+    );
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          toolCallId: "call-contract",
+          params: adjustedParams,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "done" }],
+            details: { ok: true },
+          }),
+        }),
+        expect.objectContaining({
+          agentId: "agent-1",
+          sessionId: "session-1",
+          sessionKey: "agent:agent-1:session-1",
+          runId: "run-contract",
+          toolCallId: "call-contract",
+        }),
+      );
+    });
+  });
+
+  it("fails closed when before_tool_call blocks a dynamic tool", async () => {
+    const hooks = installOpenClawOwnedToolHooks({ blockReason: "blocked by policy" });
+    const execute = vi.fn(async () => textToolResult("should not run"));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createContractTool({ name: "message", execute })],
+      signal: new AbortController().signal,
+      hookContext: { runId: "run-blocked" },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-blocked",
+      namespace: null,
+      tool: "message",
+      arguments: {
+        action: "send",
+        text: "blocked",
+        provider: "telegram",
+        to: "chat-1",
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      contentItems: [{ type: "inputText", text: "blocked by policy" }],
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(bridge.telemetry.didSendViaMessagingTool).toBe(false);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "message",
+          toolCallId: "call-blocked",
+          params: {
+            action: "send",
+            text: "blocked",
+            provider: "telegram",
+            to: "chat-1",
+          },
+          error: "blocked by policy",
+        }),
+        expect.objectContaining({
+          runId: "run-blocked",
+          toolCallId: "call-blocked",
+        }),
+      );
+    });
+  });
+});

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -235,6 +235,82 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     });
   });
 
+  it("commits successful Pi messaging text, media, and target telemetry", async () => {
+    const hooks = installOpenClawOwnedToolHooks();
+    const execute = vi.fn(async () => textToolResult("sent"));
+    const tool = wrapToolWithBeforeToolCallHook(createContractTool("message", execute), {
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+      runId: "run-message",
+    });
+    const definition = toToolDefinitions([tool])[0];
+    if (!definition) {
+      throw new Error("missing Pi tool definition");
+    }
+    const ctx = createToolHandlerCtx();
+    ctx.params.runId = "run-message";
+    const toolCallId = "call-message";
+    const originalParams = {
+      action: "send",
+      content: "hello from Pi",
+      mediaUrl: "/tmp/pi-reply.png",
+      provider: "telegram",
+      to: "chat-1",
+    };
+
+    await handleToolExecutionStart(
+      ctx,
+      toolExecutionStartEvent({
+        toolName: "message",
+        toolCallId,
+        args: originalParams,
+      }),
+    );
+    const result = await definition.execute(
+      toolCallId,
+      originalParams,
+      undefined,
+      undefined,
+      createToolExtensionContext(),
+    );
+    await handleToolExecutionEnd(
+      ctx,
+      toolExecutionEndEvent({
+        toolName: "message",
+        toolCallId,
+        isError: false,
+        result,
+      }),
+    );
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["hello from Pi"]);
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/pi-reply.png"]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([
+      expect.objectContaining({
+        tool: "message",
+        provider: "telegram",
+        to: "chat-1",
+      }),
+    ]);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "message",
+          toolCallId,
+          params: originalParams,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "sent" }],
+          }),
+        }),
+        expect.objectContaining({
+          runId: "run-message",
+          toolCallId,
+        }),
+      );
+    });
+  });
+
   it("fails closed when before_tool_call blocks a Pi dynamic tool", async () => {
     const hooks = installOpenClawOwnedToolHooks({ blockReason: "blocked by policy" });
     const execute = vi.fn(async () => textToolResult("should not run"));

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -51,8 +51,9 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     resetOpenClawOwnedToolHooks();
   });
 
-  it("preserves adjusted before_tool_call params through execution and after_tool_call", async () => {
-    const adjustedParams = { command: "pwd", mode: "safe" };
+  it("preserves partially adjusted before_tool_call params through execution and after_tool_call", async () => {
+    const adjustedParams = { mode: "safe" };
+    const mergedParams = { command: "pwd", mode: "safe" };
     const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
     const execute = vi.fn(async () => textToolResult("done", { ok: true }));
     const tool = wrapToolWithBeforeToolCallHook(createContractTool("exec", execute), {
@@ -91,13 +92,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     );
 
     expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
-    expect(execute).toHaveBeenCalledWith(toolCallId, adjustedParams, undefined, undefined);
+    expect(execute).toHaveBeenCalledWith(toolCallId, mergedParams, undefined, undefined);
     await vi.waitFor(() => {
       expect(hooks.afterToolCall).toHaveBeenCalledWith(
         expect.objectContaining({
           toolName: "exec",
           toolCallId,
-          params: adjustedParams,
+          params: mergedParams,
           result: expect.objectContaining({
             content: [{ type: "text", text: "done" }],
             details: { ok: true },
@@ -108,6 +109,75 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
           sessionId: "session-1",
           sessionKey: "agent:agent-1:session-1",
           runId: "run-contract",
+          toolCallId,
+        }),
+      );
+    });
+  });
+
+  it("reports Pi dynamic tool execution errors through after_tool_call", async () => {
+    const adjustedParams = { timeoutSec: 1 };
+    const mergedParams = { command: "false", timeoutSec: 1 };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const execute = vi.fn(async () => {
+      throw new Error("tool failed");
+    });
+    const tool = wrapToolWithBeforeToolCallHook(createContractTool("exec", execute), {
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+      runId: "run-error",
+    });
+    const definition = toToolDefinitions([tool])[0];
+    if (!definition) {
+      throw new Error("missing Pi tool definition");
+    }
+    const ctx = createToolHandlerCtx();
+    ctx.params.runId = "run-error";
+    const toolCallId = "call-error";
+    const originalParams = { command: "false" };
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId,
+        args: originalParams,
+      } as never,
+    );
+    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          status: "error",
+          error: "tool failed",
+        }),
+      }),
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId,
+        isError: true,
+        result,
+      } as never,
+    );
+
+    expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(toolCallId, mergedParams, undefined, undefined);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          toolCallId,
+          params: mergedParams,
+          error: "tool failed",
+        }),
+        expect.objectContaining({
+          runId: "run-error",
           toolCallId,
         }),
       );

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -1,0 +1,116 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  installOpenClawOwnedToolHooks,
+  resetOpenClawOwnedToolHooks,
+  textToolResult,
+} from "../../test/helpers/agents/openclaw-owned-tool-runtime-contract.js";
+import {
+  handleToolExecutionEnd,
+  handleToolExecutionStart,
+} from "./pi-embedded-subscribe.handlers.tools.js";
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import { createBaseToolHandlerState } from "./pi-tool-handler-state.test-helpers.js";
+import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+
+function createContractTool(name: string, execute: AgentTool["execute"]): AgentTool {
+  return {
+    name,
+    label: name,
+    description: `contract tool: ${name}`,
+    parameters: { type: "object", properties: {} },
+    execute,
+  } as AgentTool;
+}
+
+function createToolHandlerCtx() {
+  return {
+    params: {
+      runId: "run-contract",
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+      session: { messages: [] },
+    },
+    state: {
+      ...createBaseToolHandlerState(),
+      successfulCronAdds: 0,
+    },
+    log: { debug: vi.fn(), warn: vi.fn() },
+    flushBlockReplyBuffer: vi.fn(),
+    shouldEmitToolResult: () => false,
+    shouldEmitToolOutput: () => false,
+    emitToolSummary: vi.fn(),
+    emitToolOutput: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+  };
+}
+
+describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
+  afterEach(() => {
+    resetOpenClawOwnedToolHooks();
+  });
+
+  it("preserves adjusted before_tool_call params through execution and after_tool_call", async () => {
+    const adjustedParams = { command: "pwd", mode: "safe" };
+    const hooks = installOpenClawOwnedToolHooks({ adjustedParams });
+    const execute = vi.fn(async () => textToolResult("done", { ok: true }));
+    const tool = wrapToolWithBeforeToolCallHook(createContractTool("exec", execute), {
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+      runId: "run-contract",
+    });
+    const definition = toToolDefinitions([tool])[0];
+    if (!definition) {
+      throw new Error("missing Pi tool definition");
+    }
+    const ctx = createToolHandlerCtx();
+    const toolCallId = "call-contract";
+    const originalParams = { command: "pwd" };
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId,
+        args: originalParams,
+      } as never,
+    );
+    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId,
+        isError: false,
+        result,
+      } as never,
+    );
+
+    expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(toolCallId, adjustedParams, undefined, undefined);
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          toolCallId,
+          params: adjustedParams,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "done" }],
+            details: { ok: true },
+          }),
+        }),
+        expect.objectContaining({
+          agentId: "agent-1",
+          sessionId: "session-1",
+          sessionKey: "agent:agent-1:session-1",
+          runId: "run-contract",
+          toolCallId,
+        }),
+      );
+    });
+  });
+});

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -9,6 +9,7 @@ import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
 } from "./pi-embedded-subscribe.handlers.tools.js";
+import type { ToolHandlerContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
 import { createBaseToolHandlerState } from "./pi-tool-handler-state.test-helpers.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
@@ -23,7 +24,10 @@ function createContractTool(name: string, execute: AgentTool["execute"]): AgentT
   } as AgentTool;
 }
 
-function createToolHandlerCtx() {
+type ToolExecutionStartEvent = Parameters<typeof handleToolExecutionStart>[1];
+type ToolExecutionEndEvent = Parameters<typeof handleToolExecutionEnd>[1];
+
+function createToolHandlerCtx(): ToolHandlerContext {
   return {
     params: {
       runId: "run-contract",
@@ -44,6 +48,34 @@ function createToolHandlerCtx() {
     emitToolOutput: vi.fn(),
     trimMessagingToolSent: vi.fn(),
   };
+}
+
+function toolExecutionStartEvent(params: {
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+}): ToolExecutionStartEvent {
+  return {
+    type: "tool_execution_start",
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    args: params.args,
+  } as ToolExecutionStartEvent;
+}
+
+function toolExecutionEndEvent(params: {
+  toolName: string;
+  toolCallId: string;
+  isError: boolean;
+  result: unknown;
+}): ToolExecutionEndEvent {
+  return {
+    type: "tool_execution_end",
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    isError: params.isError,
+    result: params.result,
+  } as ToolExecutionEndEvent;
 }
 
 describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
@@ -71,24 +103,22 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     const originalParams = { command: "pwd" };
 
     await handleToolExecutionStart(
-      ctx as never,
-      {
-        type: "tool_execution_start",
+      ctx,
+      toolExecutionStartEvent({
         toolName: "exec",
         toolCallId,
         args: originalParams,
-      } as never,
+      }),
     );
     const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
     await handleToolExecutionEnd(
-      ctx as never,
-      {
-        type: "tool_execution_end",
+      ctx,
+      toolExecutionEndEvent({
         toolName: "exec",
         toolCallId,
         isError: false,
         result,
-      } as never,
+      }),
     );
 
     expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
@@ -138,13 +168,12 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     const originalParams = { command: "false" };
 
     await handleToolExecutionStart(
-      ctx as never,
-      {
-        type: "tool_execution_start",
+      ctx,
+      toolExecutionStartEvent({
         toolName: "exec",
         toolCallId,
         args: originalParams,
-      } as never,
+      }),
     );
     const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
     expect(result).toEqual(
@@ -156,14 +185,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
       }),
     );
     await handleToolExecutionEnd(
-      ctx as never,
-      {
-        type: "tool_execution_end",
+      ctx,
+      toolExecutionEndEvent({
         toolName: "exec",
         toolCallId,
         isError: true,
         result,
-      } as never,
+      }),
     );
 
     expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
@@ -208,13 +236,12 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
     };
 
     await handleToolExecutionStart(
-      ctx as never,
-      {
-        type: "tool_execution_start",
+      ctx,
+      toolExecutionStartEvent({
         toolName: "message",
         toolCallId,
         args: originalParams,
-      } as never,
+      }),
     );
     const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
     expect(result).toEqual(
@@ -226,14 +253,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
       }),
     );
     await handleToolExecutionEnd(
-      ctx as never,
-      {
-        type: "tool_execution_end",
+      ctx,
+      toolExecutionEndEvent({
         toolName: "message",
         toolCallId,
         isError: true,
         result,
-      } as never,
+      }),
     );
 
     expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -113,4 +113,77 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
       );
     });
   });
+
+  it("fails closed when before_tool_call blocks a Pi dynamic tool", async () => {
+    const hooks = installOpenClawOwnedToolHooks({ blockReason: "blocked by policy" });
+    const execute = vi.fn(async () => textToolResult("should not run"));
+    const tool = wrapToolWithBeforeToolCallHook(createContractTool("message", execute), {
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+      runId: "run-blocked",
+    });
+    const definition = toToolDefinitions([tool])[0];
+    if (!definition) {
+      throw new Error("missing Pi tool definition");
+    }
+    const ctx = createToolHandlerCtx();
+    ctx.params.runId = "run-blocked";
+    const toolCallId = "call-blocked";
+    const originalParams = {
+      action: "send",
+      text: "blocked",
+      provider: "telegram",
+      to: "chat-1",
+    };
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "message",
+        toolCallId,
+        args: originalParams,
+      } as never,
+    );
+    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          status: "error",
+          error: "blocked by policy",
+        }),
+      }),
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "message",
+        toolCallId,
+        isError: true,
+        result,
+      } as never,
+    );
+
+    expect(hooks.beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(hooks.afterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "message",
+          toolCallId,
+          params: originalParams,
+          error: "blocked by policy",
+        }),
+        expect.objectContaining({
+          agentId: "agent-1",
+          sessionId: "session-1",
+          sessionKey: "agent:agent-1:session-1",
+          runId: "run-blocked",
+          toolCallId,
+        }),
+      );
+    });
+  });
 });

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -1,15 +1,20 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   installOpenClawOwnedToolHooks,
   resetOpenClawOwnedToolHooks,
   textToolResult,
 } from "../../test/helpers/agents/openclaw-owned-tool-runtime-contract.js";
+import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
 } from "./pi-embedded-subscribe.handlers.tools.js";
-import type { ToolHandlerContext } from "./pi-embedded-subscribe.handlers.types.js";
+import type {
+  ToolCallSummary,
+  ToolHandlerContext,
+} from "./pi-embedded-subscribe.handlers.types.js";
 import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
 import { createBaseToolHandlerState } from "./pi-tool-handler-state.test-helpers.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
@@ -34,10 +39,12 @@ function createToolHandlerCtx(): ToolHandlerContext {
       agentId: "agent-1",
       sessionId: "session-1",
       sessionKey: "agent:agent-1:session-1",
-      session: { messages: [] },
     },
     state: {
       ...createBaseToolHandlerState(),
+      toolMetaById: new Map<string, ToolCallSummary>(),
+      pendingMessagingTargets: new Map<string, MessagingToolSend>(),
+      messagingToolSentTargets: [] as MessagingToolSend[],
       successfulCronAdds: 0,
     },
     log: { debug: vi.fn(), warn: vi.fn() },
@@ -78,6 +85,10 @@ function toolExecutionEndEvent(params: {
   } as ToolExecutionEndEvent;
 }
 
+function createToolExtensionContext(): ExtensionContext {
+  return {} as ExtensionContext;
+}
+
 describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
   afterEach(() => {
     resetOpenClawOwnedToolHooks();
@@ -110,7 +121,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
         args: originalParams,
       }),
     );
-    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    const result = await definition.execute(
+      toolCallId,
+      originalParams,
+      undefined,
+      undefined,
+      createToolExtensionContext(),
+    );
     await handleToolExecutionEnd(
       ctx,
       toolExecutionEndEvent({
@@ -175,7 +192,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
         args: originalParams,
       }),
     );
-    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    const result = await definition.execute(
+      toolCallId,
+      originalParams,
+      undefined,
+      undefined,
+      createToolExtensionContext(),
+    );
     expect(result).toEqual(
       expect.objectContaining({
         details: expect.objectContaining({
@@ -243,7 +266,13 @@ describe("OpenClaw-owned tool runtime contract — Pi adapter", () => {
         args: originalParams,
       }),
     );
-    const result = await definition.execute(toolCallId, originalParams, undefined, undefined, {});
+    const result = await definition.execute(
+      toolCallId,
+      originalParams,
+      undefined,
+      undefined,
+      createToolExtensionContext(),
+    );
     expect(result).toEqual(
       expect.objectContaining({
         details: expect.objectContaining({

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -1,0 +1,47 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../../src/plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../../src/plugins/hooks.test-helpers.js";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
+
+export function textToolResult(
+  text: string,
+  details: Record<string, unknown> = {},
+): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text }],
+    details,
+  };
+}
+
+export function installOpenClawOwnedToolHooks(params?: {
+  adjustedParams?: Record<string, unknown>;
+  blockReason?: string;
+}) {
+  const beforeToolCall = vi.fn(async () => {
+    if (params?.blockReason) {
+      return {
+        block: true,
+        blockReason: params.blockReason,
+      };
+    }
+    return params?.adjustedParams ? { params: params.adjustedParams } : {};
+  });
+  const afterToolCall = vi.fn(async () => {});
+  initializeGlobalHookRunner(
+    createMockPluginRegistry([
+      { hookName: "before_tool_call", handler: beforeToolCall },
+      { hookName: "after_tool_call", handler: afterToolCall },
+    ]),
+  );
+  return { beforeToolCall, afterToolCall };
+}
+
+export function resetOpenClawOwnedToolHooks(): void {
+  resetGlobalHookRunner();
+  setActivePluginRegistry(createEmptyPluginRegistry());
+}

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { vi } from "vitest";
+import { __testing as beforeToolCallTesting } from "../../../src/agents/pi-tools.before-tool-call.js";
 import type {
   CodexAppServerExtensionFactory,
   CodexAppServerToolResultEvent,
@@ -69,4 +70,5 @@ export function installCodexToolResultMiddleware(
 export function resetOpenClawOwnedToolHooks(): void {
   resetGlobalHookRunner();
   setActivePluginRegistry(createEmptyPluginRegistry());
+  beforeToolCallTesting.adjustedParamsByToolCallId.clear();
 }

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -1,5 +1,9 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { vi } from "vitest";
+import type {
+  CodexAppServerExtensionFactory,
+  CodexAppServerToolResultEvent,
+} from "../../../src/plugins/codex-app-server-extension-types.js";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -39,6 +43,27 @@ export function installOpenClawOwnedToolHooks(params?: {
     ]),
   );
   return { beforeToolCall, afterToolCall };
+}
+
+export function installCodexToolResultMiddleware(
+  handler: (event: CodexAppServerToolResultEvent) => AgentToolResult<unknown>,
+) {
+  const middleware = vi.fn(async (event: CodexAppServerToolResultEvent) => ({
+    result: handler(event),
+  }));
+  const registry = createEmptyPluginRegistry();
+  const factory: CodexAppServerExtensionFactory = async (codex) => {
+    codex.on("tool_result", middleware);
+  };
+  registry.codexAppServerExtensionFactories.push({
+    pluginId: "runtime-contract",
+    pluginName: "Runtime Contract",
+    rawFactory: factory,
+    factory,
+    source: "test",
+  });
+  setActivePluginRegistry(registry);
+  return { middleware };
 }
 
 export function resetOpenClawOwnedToolHooks(): void {

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -23,6 +23,19 @@ export function textToolResult(
   };
 }
 
+export function mediaToolResult(
+  text: string,
+  mediaUrl: string,
+  audioAsVoice = false,
+): AgentToolResult<unknown> {
+  return textToolResult(text, {
+    media: {
+      mediaUrl,
+      ...(audioAsVoice ? { audioAsVoice } : {}),
+    },
+  });
+}
+
 export function installOpenClawOwnedToolHooks(params?: {
   adjustedParams?: Record<string, unknown>;
   blockReason?: string;

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -46,6 +46,10 @@ export function installOpenClawOwnedToolHooks(params?: {
   return { beforeToolCall, afterToolCall };
 }
 
+/**
+ * Installs only the Codex app-server `tool_result` middleware fixture.
+ * Pair with `installOpenClawOwnedToolHooks()` when a test asserts before/after hook behavior.
+ */
 export function installCodexToolResultMiddleware(
   handler: (event: CodexAppServerToolResultEvent) => AgentToolResult<unknown>,
 ) {

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -11,7 +11,10 @@ import {
 } from "../../../src/plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../../src/plugins/hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "../../../src/plugins/registry-empty.js";
-import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../src/plugins/runtime.js";
 
 export function textToolResult(
   text: string,
@@ -86,6 +89,6 @@ export function installCodexToolResultMiddleware(
 
 export function resetOpenClawOwnedToolHooks(): void {
   resetGlobalHookRunner();
-  setActivePluginRegistry(createEmptyPluginRegistry());
+  resetPluginRuntimeStateForTest();
   beforeToolCallTesting.adjustedParamsByToolCallId.clear();
 }

--- a/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/test/helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -9,7 +9,7 @@ import {
   resetGlobalHookRunner,
 } from "../../../src/plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../../src/plugins/hooks.test-helpers.js";
-import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 
 export function textToolResult(


### PR DESCRIPTION
## Summary

This is the first deliberately test-only rung from RFC #71004. It adds a shared Pi/Codex runtime contract fixture for OpenClaw-owned dynamic tools and locks the invariant that both harness paths must preserve the same `before_tool_call`, tool execution, tool-result middleware, `after_tool_call`, error, block, and telemetry semantics.

No production runtime behavior changes in this PR.

```mermaid
flowchart TD
  ToolCatalog["OpenClaw tool catalog"] --> Contract["OpenClaw-owned tool contract"]
  Contract --> Before["before_tool_call may mutate or block"]
  Before --> Pi["Pi adapter"]
  Before --> Codex["Codex app-server adapter"]
  Pi --> Execute["tool.execute receives final merged params"]
  Codex --> Execute
  Execute --> Middleware["Codex tool_result middleware"]
  Middleware --> After["after_tool_call sees final params/result/error"]
  Execute --> Telemetry["messaging/media telemetry"]
```

## Why This Exists

#70965 showed the failure mode we want to prevent: Codex mode could accidentally bypass an OpenClaw-owned dynamic-tool hook contract because tool ownership was implicit. #70743 and #70772 showed the larger pattern: many GPT-5.4 Pi/Codex fixes are really runtime-contract problems, not isolated transport bugs.

This PR starts the safer path from #71004: capture parity as tests first, then refactor toward shared runtime contracts only after maintainers can see intended behavior in executable fixtures.

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/openclaw-owned-tool-runtime-contract.ts` | Shared fixture for installing OpenClaw-owned tool hooks and Codex result middleware in adapter tests. |
| `src/agents/openclaw-owned-tool-runtime-contract.test.ts` | Pi-side contract rows for mutation, blocking, errors, and messaging telemetry. |
| `extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts` | Codex app-server rows for wrapper ordering, middleware, no double wrapping, blocking, errors, and telemetry. |

## Contract Matrix

| Contract | Pi adapter | Codex app-server adapter |
| --- | --- | --- |
| `before_tool_call` runs for OpenClaw-owned dynamic tools | Yes | Yes |
| Partial hook param patches preserve original args and reach `tool.execute` | Yes | Yes |
| `after_tool_call` observes final merged params and successful result | Yes | Yes |
| Blocked tool fails closed and does not execute | Yes | Yes |
| Blocked/error tool reports through `after_tool_call` | Yes | Yes |
| Codex `tool_result` middleware runs before `after_tool_call` observes result | N/A | Yes |
| Already-wrapped tools are not double-wrapped | Existing Pi primitive | Yes |
| Successful messaging text/media/target telemetry is committed | Yes | Yes |
| Successful generated-media artifact telemetry is committed | Existing Pi media path | Yes |
| Messaging telemetry is not marked sent for blocked Codex message tool | N/A | Yes |

## How This Helps The RuntimePlan Work

This PR defines tool ownership before any shared `AgentRuntimePlan` exists. Later, the plan can produce the tool catalog/wrapping state once, and both Pi and Codex can consume it without reimplementing hook order or telemetry rules.

## Reviewer Notes

- This is intentionally one domain only: tools.
- It does not change runtime behavior or add hook surfaces.
- It should be reviewed as a contract baseline, not as a production bug fix.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts` — 4 tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts` — 7 tests
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/openclaw-owned-tool-runtime-contract.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/openclaw-owned-tool-runtime-contract.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts`

Refs #71004
