### PR TITLE
feat(diagnostics): emit tool execution events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Diagnostics/OTEL: attach diagnostic trace context to exported OTEL logs so log records can correlate with future spans without adding retained process state. Thanks @vincentkoc.
 - Diagnostics/OTEL: pass immutable per-run diagnostic trace context through agent and tool hook contexts, and parent exported diagnostic spans from validated context without retaining global trace state. Thanks @vincentkoc.
 - Diagnostics/OTEL: make exporter startup restart-safe so config reloads do not retain stale SDKs, log transports, or diagnostic event listeners. Thanks @vincentkoc.
+- Diagnostics: emit structured tool execution diagnostic events with trace context, timing, and redacted error metadata. Thanks @vincentkoc.
 - Control UI/chat: add a Steer action on queued messages so a browser follow-up can be injected into the active run without retyping it.
 - Control UI/Talk: add browser WebRTC realtime voice sessions backed by OpenAI Realtime, with Gateway-minted ephemeral client secrets and `openclaw_agent_consult` handoff to the full OpenClaw agent.
 - Agents/tools: add optional per-call `timeoutMs` support for image, video, music, and TTS generation tools so agents can extend provider request timeouts only when a specific generation needs it.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c0f788d1895ced2ffdad9f82e6afc592171e6651c61c0fc5083f0040437cda6d  plugin-sdk-api-baseline.json
-70e320157331080b98f9c2acae58e89ad1dc70b48adad265225a7eb76b6ac29f  plugin-sdk-api-baseline.jsonl
+c57d43f93ec2930b099dd5c5777f201f1bdd1ab432eeb4049b6e62ff23fe8112  plugin-sdk-api-baseline.json
+ece1ea689914c4070b587551e86c6bed6598feba90457ab489222e168b2d9298  plugin-sdk-api-baseline.jsonl

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -812,6 +812,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordHeartbeat(evt);
               return;
             case "tool.loop":
+            case "tool.execution.started":
+            case "tool.execution.completed":
+            case "tool.execution.error":
             case "diagnostic.memory.sample":
             case "diagnostic.memory.pressure":
             case "payload.large":

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -388,8 +388,6 @@ describe("before_tool_call loop detection behavior", () => {
         toolCallId: "tool-call-1",
         paramsSummary: {
           kind: "object",
-          keys: ["command", "token"],
-          keyCount: 2,
         },
         trace,
       });
@@ -431,6 +429,32 @@ describe("before_tool_call loop detection behavior", () => {
         errorCategory: "Error",
       });
       expect(JSON.stringify(emitted[1])).not.toContain("sk-1234567890abcdef1234567890abcdef");
+    });
+  });
+
+  it("summarizes hostile object params without enumerating keys", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "bash", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+    const params = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("should not enumerate params");
+        },
+      },
+    );
+
+    await withToolExecutionEvents(async (emitted) => {
+      await tool.execute("tool-call-proxy", params, undefined, undefined);
+
+      expect(emitted[0]).toMatchObject({
+        type: "tool.execution.started",
+        paramsSummary: { kind: "object" },
+      });
     });
   });
 });

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
   type DiagnosticToolLoopEvent,
 } from "../infra/diagnostic-events.js";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
@@ -75,6 +76,22 @@ describe("before_tool_call loop detection behavior", () => {
     const emitted: DiagnosticToolLoopEvent[] = [];
     const stop = onDiagnosticEvent((evt) => {
       if (evt.type === "tool.loop" && filter(evt)) {
+        emitted.push(evt);
+      }
+    });
+    try {
+      await run(emitted);
+    } finally {
+      stop();
+    }
+  }
+
+  async function withToolExecutionEvents(
+    run: (emitted: DiagnosticEventPayload[]) => Promise<void>,
+  ) {
+    const emitted: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type.startsWith("tool.execution.")) {
         emitted.push(evt);
       }
     });
@@ -329,6 +346,91 @@ describe("before_tool_call loop detection behavior", () => {
         detector: "known_poll_no_progress",
         toolName: "process",
       });
+    });
+  });
+
+  it("emits diagnostic tool execution events without parameter values", async () => {
+    const trace = {
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+      traceFlags: "01",
+    };
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "bash", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      runId: "run-1",
+      trace,
+      loopDetection: { enabled: false },
+    });
+
+    await withToolExecutionEvents(async (emitted) => {
+      await tool.execute(
+        "tool-call-1",
+        { command: "pwd", token: "sk-1234567890abcdef1234567890abcdef" },
+        undefined,
+        undefined,
+      );
+
+      expect(emitted.map((evt) => evt.type)).toEqual([
+        "tool.execution.started",
+        "tool.execution.completed",
+      ]);
+      expect(emitted[0]).toMatchObject({
+        type: "tool.execution.started",
+        runId: "run-1",
+        sessionKey: "session-key",
+        sessionId: "session-id",
+        toolName: "exec",
+        toolCallId: "tool-call-1",
+        paramsSummary: {
+          kind: "object",
+          keys: ["command", "token"],
+          keyCount: 2,
+        },
+        trace,
+      });
+      expect(emitted[0]?.trace).not.toBe(trace);
+      expect(Object.isFrozen(emitted[0]?.trace)).toBe(true);
+      expect(emitted[1]).toMatchObject({
+        type: "tool.execution.completed",
+        durationMs: expect.any(Number),
+      });
+      expect(JSON.stringify(emitted)).not.toContain("sk-1234567890abcdef1234567890abcdef");
+      expect(JSON.stringify(emitted)).not.toContain("pwd");
+    });
+  });
+
+  it("emits diagnostic tool execution error events with redacted errors", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValue(new Error("failed with key sk-1234567890abcdef1234567890abcdef"));
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    await withToolExecutionEvents(async (emitted) => {
+      await expect(
+        tool.execute("tool-call-error", { path: "/tmp/file" }, undefined, undefined),
+      ).rejects.toThrow("failed with key");
+
+      expect(emitted.map((evt) => evt.type)).toEqual([
+        "tool.execution.started",
+        "tool.execution.error",
+      ]);
+      expect(emitted[1]).toMatchObject({
+        type: "tool.execution.error",
+        toolName: "read",
+        toolCallId: "tool-call-error",
+        durationMs: expect.any(Number),
+        errorCategory: "Error",
+      });
+      expect(JSON.stringify(emitted[1])).not.toContain("sk-1234567890abcdef1234567890abcdef");
     });
   });
 });

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,9 +1,15 @@
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import {
+  emitDiagnosticEvent,
+  type DiagnosticToolParamsSummary,
+} from "../infra/diagnostic-events.js";
+import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { copyPluginToolMeta } from "../plugins/tools.js";
@@ -79,6 +85,39 @@ function unwrapErrorCause(err: unknown): unknown {
     return err.cause;
   }
   return err;
+}
+
+function summarizeToolParams(params: unknown): DiagnosticToolParamsSummary {
+  if (params === null) {
+    return { kind: "null" };
+  }
+  if (params === undefined) {
+    return { kind: "undefined" };
+  }
+  if (Array.isArray(params)) {
+    return { kind: "array", length: params.length };
+  }
+  if (typeof params === "object") {
+    const keys = Object.keys(params).toSorted();
+    return { kind: "object", keys, keyCount: keys.length };
+  }
+  if (typeof params === "string") {
+    return { kind: "string", length: params.length };
+  }
+  if (typeof params === "number") {
+    return { kind: "number" };
+  }
+  if (typeof params === "boolean") {
+    return { kind: "boolean" };
+  }
+  return { kind: "other" };
+}
+
+function errorCategory(err: unknown): string {
+  if (err instanceof Error && err.name.trim()) {
+    return err.name;
+  }
+  return typeof err;
 }
 
 function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: number): boolean {
@@ -415,8 +454,27 @@ export function wrapToolWithBeforeToolCallHook(
         }
       }
       const normalizedToolName = normalizeToolName(toolName || "tool");
+      const startedAt = Date.now();
+      const eventBase = {
+        ...(ctx?.runId && { runId: ctx.runId }),
+        ...(ctx?.sessionKey && { sessionKey: ctx.sessionKey }),
+        ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
+        ...(ctx?.trace && { trace: freezeDiagnosticTraceContext(ctx.trace) }),
+        toolName: normalizedToolName,
+        ...(toolCallId && { toolCallId }),
+        paramsSummary: summarizeToolParams(outcome.params),
+      };
+      emitDiagnosticEvent({
+        type: "tool.execution.started",
+        ...eventBase,
+      });
       try {
         const result = await execute(toolCallId, outcome.params, signal, onUpdate);
+        emitDiagnosticEvent({
+          type: "tool.execution.completed",
+          ...eventBase,
+          durationMs: Date.now() - startedAt,
+        });
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
@@ -426,6 +484,14 @@ export function wrapToolWithBeforeToolCallHook(
         });
         return result;
       } catch (err) {
+        const cause = unwrapErrorCause(err);
+        emitDiagnosticEvent({
+          type: "tool.execution.error",
+          ...eventBase,
+          durationMs: Date.now() - startedAt,
+          errorCategory: errorCategory(cause),
+          error: redactSensitiveText(formatErrorMessage(cause)),
+        });
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -7,9 +7,7 @@ import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
-import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { copyPluginToolMeta } from "../plugins/tools.js";
@@ -98,8 +96,7 @@ function summarizeToolParams(params: unknown): DiagnosticToolParamsSummary {
     return { kind: "array", length: params.length };
   }
   if (typeof params === "object") {
-    const keys = Object.keys(params).toSorted();
-    return { kind: "object", keys, keyCount: keys.length };
+    return { kind: "object" };
   }
   if (typeof params === "string") {
     return { kind: "string", length: params.length };
@@ -118,6 +115,25 @@ function errorCategory(err: unknown): string {
     return err.name;
   }
   return typeof err;
+}
+
+function diagnosticErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as { code?: unknown; status?: unknown; statusCode?: unknown };
+  const code = candidate.code ?? candidate.status ?? candidate.statusCode;
+  if (typeof code === "number" && Number.isFinite(code)) {
+    return String(code);
+  }
+  if (typeof code !== "string") {
+    return undefined;
+  }
+  const trimmed = code.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.slice(0, 64);
 }
 
 function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: number): boolean {
@@ -454,7 +470,6 @@ export function wrapToolWithBeforeToolCallHook(
         }
       }
       const normalizedToolName = normalizeToolName(toolName || "tool");
-      const startedAt = Date.now();
       const eventBase = {
         ...(ctx?.runId && { runId: ctx.runId }),
         ...(ctx?.sessionKey && { sessionKey: ctx.sessionKey }),
@@ -468,6 +483,7 @@ export function wrapToolWithBeforeToolCallHook(
         type: "tool.execution.started",
         ...eventBase,
       });
+      const startedAt = Date.now();
       try {
         const result = await execute(toolCallId, outcome.params, signal, onUpdate);
         emitDiagnosticEvent({
@@ -485,12 +501,13 @@ export function wrapToolWithBeforeToolCallHook(
         return result;
       } catch (err) {
         const cause = unwrapErrorCause(err);
+        const errorCode = diagnosticErrorCode(cause);
         emitDiagnosticEvent({
           type: "tool.execution.error",
           ...eventBase,
           durationMs: Date.now() - startedAt,
           errorCategory: errorCategory(cause),
-          error: redactSensitiveText(formatErrorMessage(cause)),
+          ...(errorCode ? { errorCode } : {}),
         });
         await recordLoopOutcome({
           ctx,

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -155,7 +155,7 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
 };
 
 export type DiagnosticToolParamsSummary =
-  | { kind: "object"; keys: string[]; keyCount: number }
+  | { kind: "object" }
   | { kind: "array"; length: number }
   | { kind: "string"; length: number }
   | { kind: "number" | "boolean" | "null" | "undefined" | "other" };
@@ -182,7 +182,7 @@ export type DiagnosticToolExecutionErrorEvent = DiagnosticToolExecutionBaseEvent
   type: "tool.execution.error";
   durationMs: number;
   errorCategory: string;
-  error?: string;
+  errorCode?: string;
 };
 
 export type DiagnosticMemoryUsage = {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -154,6 +154,37 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticToolParamsSummary =
+  | { kind: "object"; keys: string[]; keyCount: number }
+  | { kind: "array"; length: number }
+  | { kind: "string"; length: number }
+  | { kind: "number" | "boolean" | "null" | "undefined" | "other" };
+
+type DiagnosticToolExecutionBaseEvent = DiagnosticBaseEvent & {
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  toolName: string;
+  toolCallId?: string;
+  paramsSummary?: DiagnosticToolParamsSummary;
+};
+
+export type DiagnosticToolExecutionStartedEvent = DiagnosticToolExecutionBaseEvent & {
+  type: "tool.execution.started";
+};
+
+export type DiagnosticToolExecutionCompletedEvent = DiagnosticToolExecutionBaseEvent & {
+  type: "tool.execution.completed";
+  durationMs: number;
+};
+
+export type DiagnosticToolExecutionErrorEvent = DiagnosticToolExecutionBaseEvent & {
+  type: "tool.execution.error";
+  durationMs: number;
+  errorCategory: string;
+  error?: string;
+};
+
 export type DiagnosticMemoryUsage = {
   rssBytes: number;
   heapTotalBytes: number;
@@ -204,6 +235,9 @@ export type DiagnosticEventPayload =
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
   | DiagnosticToolLoopEvent
+  | DiagnosticToolExecutionStartedEvent
+  | DiagnosticToolExecutionCompletedEvent
+  | DiagnosticToolExecutionErrorEvent
   | DiagnosticMemorySampleEvent
   | DiagnosticMemoryPressureEvent
   | DiagnosticPayloadLargeEvent;

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -235,6 +235,18 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.count = event.count;
       record.pairedToolName = event.pairedToolName;
       break;
+    case "tool.execution.started":
+      record.toolName = event.toolName;
+      break;
+    case "tool.execution.completed":
+      record.toolName = event.toolName;
+      record.durationMs = event.durationMs;
+      break;
+    case "tool.execution.error":
+      record.toolName = event.toolName;
+      record.durationMs = event.durationMs;
+      record.reason = event.errorCategory;
+      break;
     case "diagnostic.memory.sample":
       record.memory = copyMemory(event.memory);
       break;


### PR DESCRIPTION
## Summary

- Problem: diagnostics had trace context and aggregate model usage, but no structured source events for individual tool executions.
- Why it matters: OTEL tool spans need a stable, redacted event contract before exporter enrichment can be added safely.
- What changed: added `tool.execution.started`, `tool.execution.completed`, and `tool.execution.error` diagnostic events from the existing wrapped tool execution seam.
- What did NOT change (scope boundary): no OTEL tool spans yet, no model-call hooks/events, and no tool parameter values or result bodies are captured.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/70980
- Related https://github.com/openclaw/openclaw/pull/70995
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools.before-tool-call.e2e.test.ts`, `src/infra/diagnostic-events.test.ts`, `extensions/diagnostics-otel/src/service.test.ts`
- Scenario the test should lock in: wrapped tool calls emit started/completed events, failures emit started/error events, trace context is copied/frozen, parameter summaries omit values, and errors are redacted.
- Why this is the smallest reliable guardrail: the existing before-tool-call wrapper is the single seam for wrapped Pi tool execution.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Diagnostics subscribers can now observe structured tool execution lifecycle events. No user-facing UI/default behavior changes.

## Diagram (if applicable)

```text
Before:
tool wrapper -> tool.execute() -> loop diagnostics only

After:
tool wrapper -> tool.execution.started -> tool.execute() -> completed/error
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): diagnostics/tool execution
- Relevant config (redacted): diagnostics default-enabled test state

### Steps

1. Wrap a tool with `wrapToolWithBeforeToolCallHook`.
2. Execute it successfully.
3. Execute another wrapped tool that throws.
4. Observe emitted diagnostic events.

### Expected

- Successful execution emits `tool.execution.started` then `tool.execution.completed`.
- Failed execution emits `tool.execution.started` then `tool.execution.error`.
- Events include run/session/tool identity and trace context when present.
- Events include parameter shape only, not parameter values.
- Error messages are redacted.

### Actual

- Covered by passing tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/pi-tools.before-tool-call.e2e.test.ts`
  - `pnpm test src/infra/diagnostic-events.test.ts`
  - `pnpm test extensions/diagnostics-otel/src/service.test.ts`
  - `pnpm plugin-sdk:api:gen && pnpm plugin-sdk:api:check`
  - `pnpm format:check -- src/infra/diagnostic-events.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.before-tool-call.e2e.test.ts extensions/diagnostics-otel/src/service.ts CHANGELOG.md docs/.generated/plugin-sdk-api-baseline.sha256`
  - `pnpm exec oxlint --tsconfig tsconfig.oxlint.json src/infra/diagnostic-events.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.before-tool-call.e2e.test.ts extensions/diagnostics-otel/src/service.ts`
- Edge cases checked: success, thrown error, trace copy/freeze, parameter summary without values, diagnostics-otel explicit ignore until exporter enrichment.
- What you did **not** verify: full `pnpm check:changed`; local core typecheck is blocked by unrelated OpenAI compat type errors in `src/agents/openai-transport-stream.ts` / model compat fields.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: diagnostic events could leak tool inputs.
  - Mitigation: events emit only parameter kind/key names/counts/string lengths, never parameter values or result bodies.
- Risk: diagnostics-otel could start treating these as spans before the exporter contract is reviewed.
  - Mitigation: diagnostics-otel explicitly ignores the new event types in this PR.
