### PR TITLE
fix(slack): resolve exec approval decisions from interactive buttons

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -799,6 +799,7 @@ async function handleSlackBlockAction(params: {
           params.ctx.runtime.log?.(
             `slack:interaction exec approval resolve failed id=${execApproval.approvalId}: ${String(resolveErr)}`,
           );
+          throw resolveErr;
         }
         try {
           await updateSlackInteractionMessage({

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -1,8 +1,13 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { enqueueSystemEvent, parseExecApprovalCommandText } from "openclaw/plugin-sdk/infra-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { dispatchSlackPluginInteractiveHandler } from "../../interactive-dispatch.js";
+import {
+  isSlackExecApprovalApprover,
+  isSlackExecApprovalAuthorizedSender,
+} from "../../exec-approvals.js";
 import {
   SLACK_REPLY_BUTTON_ACTION_ID,
   SLACK_REPLY_SELECT_ACTION_ID,
@@ -762,6 +767,56 @@ async function handleSlackBlockAction(params: {
       respond,
     });
     if (handledBindingApproval) {
+      return;
+    }
+    const execApproval = parseExecApprovalCommandText(pluginInteractionData);
+    if (execApproval) {
+      const isPluginApproval = execApproval.approvalId.startsWith("plugin:");
+      const pluginApprovalAuthorizedSender = isSlackExecApprovalApprover({
+        cfg: params.ctx.cfg,
+        accountId: params.ctx.accountId,
+        senderId: parsed.userId,
+      });
+      const execApprovalAuthorizedSender = isSlackExecApprovalAuthorizedSender({
+        cfg: params.ctx.cfg,
+        accountId: params.ctx.accountId,
+        senderId: parsed.userId,
+      });
+      const authorizedApprovalSender = isPluginApproval
+        ? pluginApprovalAuthorizedSender
+        : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
+      if (authorizedApprovalSender) {
+        try {
+          await resolveApprovalOverGateway({
+            cfg: params.ctx.cfg,
+            approvalId: execApproval.approvalId,
+            decision: execApproval.decision,
+            senderId: parsed.userId,
+            allowPluginFallback: pluginApprovalAuthorizedSender,
+            clientDisplayName: `Slack approval (${parsed.userId?.trim() || "unknown"})`,
+          });
+        } catch (resolveErr) {
+          params.ctx.runtime.log?.(
+            `slack:interaction exec approval resolve failed id=${execApproval.approvalId}: ${String(resolveErr)}`,
+          );
+        }
+        try {
+          await updateSlackInteractionMessage({
+            ctx: params.ctx,
+            channelId: parsed.channelId,
+            messageTs: parsed.messageTs,
+            text: parsed.typedBody.message?.text ?? "",
+            blocks: [],
+          });
+        } catch {
+          // Best-effort cleanup only.
+        }
+        return;
+      }
+      params.ctx.runtime.log?.(
+        `slack:interaction drop exec approval user=${parsed.userId} (not authorized)`,
+      );
+      await respondEphemeral(respond, "You are not authorized to approve this request.");
       return;
     }
   } else if (pluginInteractionData) {

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -13,8 +13,16 @@ const buildPluginBindingResolvedTextMock = vi.hoisted(() => vi.fn(() => "Binding
 
 let registerSlackInteractionEvents: typeof import("./interactions.js").registerSlackInteractionEvents;
 
-vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("openclaw/plugin-sdk/security-runtime", () => ({


### PR DESCRIPTION
## Summary

- **Problem:** Slack exec approval buttons (Allow Once / Always Allow / Deny) are received by the gateway but the approval decision is never forwarded to `exec.approval.resolve`. Commands time out after 30 minutes despite the user clicking the button.
- **Why it matters:** Exec approval via Slack is completely non-functional. Users must fall back to Control UI to approve commands.
- **What changed:** Added exec approval resolution logic to `handleSlackBlockAction` in the Slack plugin, mirroring the existing Telegram implementation. After `handleSlackPluginBindingApproval` returns false for a reply action, the code now parses the interaction data with `parseExecApprovalCommandText` and, if matched, calls `resolveApprovalOverGateway`.
- **What did NOT change (scope boundary):** No changes to the approval request delivery path, Control UI behavior, Telegram plugin, or gateway approval infrastructure.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71023
- Related #66916
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `handleSlackBlockAction()` in `interactions.block-actions.ts` does not check for exec approval command text after `handleSlackPluginBindingApproval()` returns false. The button value (`/approve <id> allow-once`) falls through to `enqueueSlackBlockActionEvent()` and is delivered to the agent as plain text instead of being resolved over the gateway.
- **Missing detection / guardrail:** No code path exists in the Slack plugin to parse exec approval commands from interactive button values and call `resolveApprovalOverGateway()`.
- **Contributing context:** The Telegram plugin has the correct implementation in `bot-handlers.runtime.ts` — it calls `parseExecApprovalCommandText()` on callback data and resolves via `resolveApprovalOverGateway()`. The Slack plugin was missing this equivalent code path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/events/interactions.block-actions.test.ts`
- Scenario the test should lock in: When a reply button interaction contains a valid exec approval command (`/approve <id> allow-once`), `resolveApprovalOverGateway` should be called with the correct approval ID and decision, and the event should not be enqueued as a system event.
- Why this is the smallest reliable guardrail: A seam test can mock `resolveApprovalOverGateway` and verify it is called with correct params without requiring a live Slack connection.
- Existing test that already covers this (if any): None — existing `block-actions` tests do not cover exec approval button interactions.
- If no new test is added, why not: The fix mirrors the established Telegram pattern; a follow-up test PR is recommended.

## User-visible / Behavior Changes

- Clicking exec approval buttons (Allow Once / Always Allow / Deny) in Slack now resolves the approval and executes the command, matching Control UI behavior.
- Previously, clicking these buttons had no effect and the approval timed out after 30 minutes.

## Diagram (if applicable)

```text
Before:
[Slack button click] -> handleSlackPluginBindingApproval (false)
                     -> enqueueSlackBlockActionEvent (plain text)
                     -> agent receives "/approve <id> allow-once" as text
                     -> incomplete turn / timeout

After:
[Slack button click] -> handleSlackPluginBindingApproval (false)
                     -> parseExecApprovalCommandText (match!)
                     -> resolveApprovalOverGateway
                     -> command executes
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — `resolveApprovalOverGateway` uses the existing gateway WebSocket client
- Command/tool execution surface changed? No — approval decisions were already reachable via Control UI; this enables the same path from Slack
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node 22.22.2
- Model/provider: ollama/qwen3.6:27b
- Integration/channel: Slack (Socket Mode)
- Relevant config (redacted):
  ```json
  {
    "channels": {
      "slack": {
        "enabled": true,
        "execApprovals": {
          "enabled": true,
          "approvers": ["U06TP4R5VRS"],
          "target": "both"
        }
      }
    },
    "tools": {
      "exec": {
        "security": "allowlist",
        "ask": "on-miss"
      }
    }
  }
  ```

### Steps

1. Send `@OpenClaw ping -c 4 localhost` in a Slack channel
2. Wait for exec approval buttons to appear
3. Click "Allow Once"

### Expected

- Command executes immediately after approval

### Actual

- Before fix: approval times out after 30 minutes, command never executes
- After fix: command executes immediately

## Evidence

- Gateway log before fix: `exec.approval.waitDecision 1799998ms` (30-minute timeout)
- Gateway log after fix: `slack: exec approval resolved: <id> -> allow-once` followed by command execution
- Control UI approval for the same request works correctly (confirming gateway infrastructure is functional)

## Human Verification (required)

- Verified scenarios: Slack DM and channel exec approval with Allow Once button — command executes after approval
- Edge cases checked: Unauthorized sender receives ephemeral "not authorized" message; plugin approval IDs (`plugin:*`) fall back correctly
- What you did **not** verify: Always Allow persistence across sessions; Deny button behavior (expected to work symmetrically)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `updateSlackInteractionMessage` may fail if the original message was deleted or the bot lacks permissions.
  - Mitigation: Wrapped in try/catch with best-effort semantics (same pattern used elsewhere in the Slack plugin).