### PR TITLE
fix(slack): resolve exec approval button clicks via gateway instead of system events

### DIFF
--- a/extensions/slack/src/exec-approval-resolver.test.ts
+++ b/extensions/slack/src/exec-approval-resolver.test.ts
@@ -1,0 +1,109 @@
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/infra-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const approvalGatewayRuntimeHoisted = vi.hoisted(() => ({
+  resolveApprovalOverGatewaySpy: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: (...args: unknown[]) =>
+    approvalGatewayRuntimeHoisted.resolveApprovalOverGatewaySpy(...args),
+}));
+
+describe("resolveSlackExecApproval", () => {
+  async function invokeResolver(params: {
+    approvalId: string;
+    decision: ExecApprovalReplyDecision;
+    senderId: string;
+    allowPluginFallback?: boolean;
+  }) {
+    const { resolveSlackExecApproval } = await import("./exec-approval-resolver.js");
+
+    await resolveSlackExecApproval({
+      cfg: {} as never,
+      gatewayUrl: undefined,
+      ...params,
+    });
+  }
+
+  function expectApprovalGatewayCall(params: {
+    approvalId: string;
+    decision: ExecApprovalReplyDecision;
+    senderId: string;
+    allowPluginFallback?: boolean;
+  }) {
+    expect(approvalGatewayRuntimeHoisted.resolveApprovalOverGatewaySpy).toHaveBeenCalledWith({
+      cfg: {} as never,
+      approvalId: params.approvalId,
+      decision: params.decision,
+      senderId: params.senderId,
+      gatewayUrl: undefined,
+      allowPluginFallback: params.allowPluginFallback,
+      clientDisplayName: `Slack approval (${params.senderId})`,
+    });
+  }
+
+  beforeEach(() => {
+    approvalGatewayRuntimeHoisted.resolveApprovalOverGatewaySpy
+      .mockReset()
+      .mockResolvedValue(undefined);
+  });
+
+  it("routes exec approval through resolveApprovalOverGateway", async () => {
+    await invokeResolver({
+      approvalId: "abc123",
+      decision: "allow-once",
+      senderId: "U42",
+    });
+
+    expectApprovalGatewayCall({
+      approvalId: "abc123",
+      decision: "allow-once",
+      senderId: "U42",
+    });
+  });
+
+  it("routes plugin approval ids with plugin prefix", async () => {
+    await invokeResolver({
+      approvalId: "plugin:xyz789",
+      decision: "deny",
+      senderId: "U99",
+    });
+
+    expectApprovalGatewayCall({
+      approvalId: "plugin:xyz789",
+      decision: "deny",
+      senderId: "U99",
+    });
+  });
+
+  it("passes allowPluginFallback through", async () => {
+    await invokeResolver({
+      approvalId: "legacy-plugin-456",
+      decision: "allow-always",
+      senderId: "U7",
+      allowPluginFallback: true,
+    });
+
+    expectApprovalGatewayCall({
+      approvalId: "legacy-plugin-456",
+      decision: "allow-always",
+      senderId: "U7",
+      allowPluginFallback: true,
+    });
+  });
+
+  it("uses Slack-specific client display name", async () => {
+    await invokeResolver({
+      approvalId: "test-123",
+      decision: "allow-once",
+      senderId: "U55",
+    });
+
+    expect(approvalGatewayRuntimeHoisted.resolveApprovalOverGatewaySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientDisplayName: "Slack approval (U55)",
+      }),
+    );
+  });
+});

--- a/extensions/slack/src/exec-approval-resolver.ts
+++ b/extensions/slack/src/exec-approval-resolver.ts
@@ -1,0 +1,26 @@
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/infra-runtime";
+
+export type ResolveSlackExecApprovalParams = {
+  cfg: OpenClawConfig;
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+  senderId?: string | null;
+  allowPluginFallback?: boolean;
+  gatewayUrl?: string;
+};
+
+export async function resolveSlackExecApproval(
+  params: ResolveSlackExecApprovalParams,
+): Promise<void> {
+  await resolveApprovalOverGateway({
+    cfg: params.cfg,
+    approvalId: params.approvalId,
+    decision: params.decision,
+    senderId: params.senderId,
+    gatewayUrl: params.gatewayUrl,
+    allowPluginFallback: params.allowPluginFallback,
+    clientDisplayName: `Slack approval (${params.senderId?.trim() || "unknown"})`,
+  });
+}

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -1,8 +1,13 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+import { enqueueSystemEvent, parseExecApprovalCommandText } from "openclaw/plugin-sdk/infra-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { SLACK_REPLY_BUTTON_ACTION_ID, SLACK_REPLY_SELECT_ACTION_ID } from "../../blocks-render.js";
+import { resolveSlackExecApproval } from "../../exec-approval-resolver.js";
+import {
+  isSlackExecApprovalApprover,
+  isSlackExecApprovalAuthorizedSender,
+} from "../../exec-approvals.js";
 import { dispatchSlackPluginInteractiveHandler } from "../../interactive-dispatch.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -757,6 +762,55 @@ async function handleSlackBlockAction(params: {
       respond,
     });
     if (handledBindingApproval) {
+      return;
+    }
+    // Check if this is an exec approval button click (e.g. "/approve <id> allow-once").
+    // Without this, exec approval decisions from Slack buttons are delivered as plain
+    // system events instead of being resolved over the gateway, causing a 30-minute
+    // timeout (the same pattern Telegram handles in its callback handler).
+    const approvalCommand = parseExecApprovalCommandText(pluginInteractionData);
+    if (approvalCommand) {
+      const isPluginApproval = approvalCommand.approvalId.startsWith("plugin:");
+      const pluginApprovalAuthorizedSender = isSlackExecApprovalApprover({
+        cfg: params.ctx.cfg,
+        accountId: params.ctx.accountId,
+        senderId: parsed.userId,
+      });
+      const execApprovalAuthorizedSender = isSlackExecApprovalAuthorizedSender({
+        cfg: params.ctx.cfg,
+        accountId: params.ctx.accountId,
+        senderId: parsed.userId,
+      });
+      const authorizedApprovalSender = isPluginApproval
+        ? pluginApprovalAuthorizedSender
+        : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
+      if (authorizedApprovalSender) {
+        try {
+          await resolveSlackExecApproval({
+            cfg: params.ctx.cfg,
+            approvalId: approvalCommand.approvalId,
+            decision: approvalCommand.decision,
+            senderId: parsed.userId,
+            allowPluginFallback: pluginApprovalAuthorizedSender,
+          });
+        } catch (resolveErr) {
+          params.ctx.runtime.log?.(
+            `slack: failed to resolve exec approval ${approvalCommand.approvalId}: ${String(resolveErr)}`,
+          );
+        }
+        // Update the message to remove approval buttons (already handled by
+        // updateSlackLegacyBlockAction below via the normal flow, but we
+        // return early to avoid also enqueueing a system event).
+        await updateSlackLegacyBlockAction({
+          ctx: params.ctx,
+          parsed,
+          respond,
+        });
+        return;
+      }
+      params.ctx.runtime.log?.(
+        `slack: blocked exec approval from ${parsed.userId} (not authorized)`,
+      );
       return;
     }
   } else if (pluginInteractionData) {


### PR DESCRIPTION
## Summary

When a user clicks an exec approval button (**Allow Once** / **Allow Always** / **Deny**) in Slack, the approval decision is enqueued as a plain system event via `enqueueSlackBlockActionEvent()` instead of being resolved over the gateway WebSocket via `exec.approval.resolve`. This causes the approval to never reach the waiting agent, resulting in a 30-minute timeout.

Fixes #71023

## Root Cause

`handleSlackBlockAction()` in `interactions.block-actions.ts` checks for plugin binding approvals via `handleSlackPluginBindingApproval()`, which correctly returns `false` for exec approvals (they aren't plugin bindings). The function then falls through to `enqueueSlackBlockActionEvent()`, which delivers the approval decision as a plain system event — the gateway never sees it.

The Telegram extension handles this correctly: after the plugin binding check, it calls `parseExecApprovalCommandText()` on the callback data and routes matches through `resolveApprovalOverGateway()`.

## Fix

**New file:** `extensions/slack/src/exec-approval-resolver.ts`
- Mirrors Telegram's `exec-approval-resolver.ts` — calls `resolveApprovalOverGateway()` with Slack-specific context

**Modified:** `extensions/slack/src/monitor/events/interactions.block-actions.ts`
- After the plugin binding check and before `enqueueSlackBlockActionEvent()`, parses the button value with `parseExecApprovalCommandText()`
- If it's an exec approval, verifies sender authorization via existing `isSlackExecApprovalApprover()` / `isSlackExecApprovalAuthorizedSender()`
- Calls `resolveSlackExecApproval()` to resolve via gateway WebSocket
- Clears approval buttons from the Slack message after resolution
- Blocks unauthorized senders with a verbose log entry and early return

**New test:** `extensions/slack/src/exec-approval-resolver.test.ts`
- Verifies the resolver correctly forwards to `resolveApprovalOverGateway()` with proper params
- Tests plugin prefix routing, `allowPluginFallback` passthrough, and Slack-specific display name

## Flow (before → after)

**Before:**
1. User clicks "Allow Once" → Slack fires block action
2. `handleSlackPluginBindingApproval()` → `false` (not a binding)
3. Falls to `enqueueSlackBlockActionEvent()` → plain system event
4. Agent never receives approval → **30 min timeout**

**After:**
1. User clicks "Allow Once" → Slack fires block action
2. `handleSlackPluginBindingApproval()` → `false` (not a binding)
3. `parseExecApprovalCommandText(pluginInteractionData)` → matches approval command
4. Authorization check → `resolveSlackExecApproval()` → **resolved via gateway WebSocket** ✅
5. Approval buttons cleared from message