### PR TITLE
[codex] Add auth profile runtime contracts

### DIFF
--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -163,8 +163,8 @@ describe("Auth profile runtime contract - Codex app-server adapter", () => {
       authProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
       dynamicToolsFingerprint: "[]",
     });
+    // authProfileId is intentionally omitted to exercise the resume-bound profile path.
     const params = createParams(sessionFile, tmpDir);
-    delete params.authProfileId;
 
     const run = runCodexAppServerAttempt(params);
     await vi.waitFor(

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  abortAgentHarnessRun,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AUTH_PROFILE_RUNTIME_CONTRACT } from "../../../../test/helpers/agents/auth-profile-runtime-contract.js";
+import { runCodexAppServerAttempt, __testing } from "./run-attempt.js";
+import { writeCodexAppServerBinding } from "./session-binding.js";
+import { createCodexTestModel } from "./test-support.js";
+
+function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
+  return {
+    prompt: AUTH_PROFILE_RUNTIME_CONTRACT.workspacePrompt,
+    sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
+    sessionKey: AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
+    sessionFile,
+    workspaceDir,
+    runId: AUTH_PROFILE_RUNTIME_CONTRACT.runId,
+    provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider,
+    modelId: "gpt-5.4-codex",
+    model: createCodexTestModel(AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider),
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+  } as EmbeddedRunAttemptParams;
+}
+
+function threadStartResult(threadId = "thread-auth-contract") {
+  return {
+    thread: {
+      id: threadId,
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: "",
+      cliVersion: "0.118.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: "",
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+function turnStartResult(turnId = "turn-auth-contract") {
+  return {
+    turn: {
+      id: turnId,
+      status: "inProgress",
+      items: [],
+      error: null,
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    },
+  };
+}
+
+function createCodexAuthProfileHarness(params: { startMethod: "thread/start" | "thread/resume" }) {
+  const seenAuthProfileIds: Array<string | undefined> = [];
+  const requests: Array<{ method: string; params: unknown }> = [];
+  let notify: (notification: unknown) => Promise<void> = async () => undefined;
+  __testing.setCodexAppServerClientFactoryForTests(async (_startOptions, authProfileId) => {
+    seenAuthProfileIds.push(authProfileId);
+    return {
+      request: vi.fn(async (method: string, requestParams?: unknown) => {
+        requests.push({ method, params: requestParams });
+        if (method === params.startMethod) {
+          return threadStartResult();
+        }
+        if (method === "turn/start") {
+          return turnStartResult();
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: (handler: (notification: unknown) => Promise<void>) => {
+        notify = handler;
+        return () => undefined;
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+  });
+  return {
+    seenAuthProfileIds,
+    async waitForMethod(method: string) {
+      await vi.waitFor(() => expect(requests.some((entry) => entry.method === method)).toBe(true), {
+        interval: 1,
+      });
+    },
+    async completeTurn() {
+      await notify({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-auth-contract",
+          turnId: "turn-auth-contract",
+          turn: { id: "turn-auth-contract", status: "completed" },
+        },
+      });
+    },
+  };
+}
+
+describe("Auth profile runtime contract - Codex app-server adapter", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-auth-contract-"));
+  });
+
+  afterEach(async () => {
+    abortAgentHarnessRun(AUTH_PROFILE_RUNTIME_CONTRACT.sessionId);
+    __testing.resetCodexAppServerClientFactoryForTests();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("passes the exact OpenAI Codex auth profile into app-server startup", async () => {
+    const harness = createCodexAuthProfileHarness({ startMethod: "thread/start" });
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const params = createParams(sessionFile, tmpDir);
+    params.authProfileId = AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(
+      () =>
+        expect(harness.seenAuthProfileIds).toEqual([
+          AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+        ]),
+      { interval: 1 },
+    );
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+  });
+
+  it("reuses a bound OpenAI Codex auth profile when resume params omit authProfileId", async () => {
+    const harness = createCodexAuthProfileHarness({ startMethod: "thread/resume" });
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-auth-contract",
+      cwd: tmpDir,
+      authProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+      dynamicToolsFingerprint: "[]",
+    });
+    const params = createParams(sessionFile, tmpDir);
+    delete params.authProfileId;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(
+      () =>
+        expect(harness.seenAuthProfileIds).toEqual([
+          AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+        ]),
+      { interval: 1 },
+    );
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+  });
+});

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -8,7 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AUTH_PROFILE_RUNTIME_CONTRACT } from "../../../../test/helpers/agents/auth-profile-runtime-contract.js";
 import { runCodexAppServerAttempt, __testing } from "./run-attempt.js";
-import { writeCodexAppServerBinding } from "./session-binding.js";
+import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
 import { createCodexTestModel } from "./test-support.js";
 
 function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
@@ -177,5 +177,34 @@ describe("Auth profile runtime contract - Codex app-server adapter", () => {
     await harness.waitForMethod("turn/start");
     await harness.completeTurn();
     await run;
+  });
+
+  it("prefers an explicit runtime auth profile over a stale persisted binding", async () => {
+    const harness = createCodexAuthProfileHarness({ startMethod: "thread/resume" });
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-auth-contract",
+      cwd: tmpDir,
+      authProfileId: "openai-codex:stale",
+      dynamicToolsFingerprint: "[]",
+    });
+    const params = createParams(sessionFile, tmpDir);
+    params.authProfileId = AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(
+      () =>
+        expect(harness.seenAuthProfileIds).toEqual([
+          AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+        ]),
+      { interval: 1 },
+    );
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      authProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
   });
 });

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -175,6 +175,10 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
   it.each([
     [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider],
     [
+      AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+    ],
+    [
       AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
       AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
     ],
@@ -208,6 +212,38 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     );
   });
 
+  it("forwards an OpenAI Codex auth profile when the auth provider is the legacy codex-cli alias", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      expectedForwardedAuthProfile({
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+      }),
+    );
+  });
+
+  it("does not leak an OpenAI API-key auth profile into the Codex CLI alias", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBeUndefined();
+  });
+
   it("does not leak an OpenAI Codex auth profile into an unrelated CLI provider", async () => {
     await runAuthContractAttempt({
       tmpDir,
@@ -233,6 +269,25 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
       AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    );
+  });
+
+  it("accepts the legacy codex-cli auth-provider alias on the embedded OpenAI Codex path", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      expectedForwardedAuthProfile({
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+      }),
     );
   });
 
@@ -263,4 +318,10 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBeUndefined();
   });
+
+  it.todo("preserves OpenAI Codex auth profiles through the real codex/* harness startup path");
+
+  it.todo(
+    "validates openai/* forced through the Codex harness can use OpenAI Codex OAuth profiles",
+  );
 });

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -218,13 +218,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
-      expectedForwardedAuthProfile({
-        provider: AUTH_PROFILE_RUNTIME_CONTRACT.claudeCliProvider,
-        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
-        sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
-      }),
-    );
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBeUndefined();
   });
 
   it("forwards an OpenAI Codex auth profile through the embedded Pi path", async () => {

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AUTH_PROFILE_RUNTIME_CONTRACT,
+  expectedForwardedAuthProfile,
+} from "../../test/helpers/agents/auth-profile-runtime-contract.js";
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runAgentAttempt } from "./command/attempt-execution.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded.js";
+
+const runCliAgentMock = vi.hoisted(() => vi.fn());
+const runEmbeddedPiAgentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./cli-runner.js", () => ({
+  runCliAgent: runCliAgentMock,
+}));
+
+vi.mock("./model-selection.js", () => ({
+  isCliProvider: (provider: string) => {
+    const normalized = provider.trim().toLowerCase();
+    return (
+      normalized === AUTH_PROFILE_RUNTIME_CONTRACT.claudeCliProvider ||
+      normalized === AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider
+    );
+  },
+  normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
+}));
+
+vi.mock("./provider-auth-aliases.js", async () => {
+  const contract = await import("../../test/helpers/agents/auth-profile-runtime-contract.js");
+  return {
+    resolveProviderAuthAliasMap: () => ({
+      [contract.AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider]:
+        contract.AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+    }),
+    resolveProviderIdForAuth: contract.resolveContractAuthProvider,
+  };
+});
+
+vi.mock("./pi-embedded.js", () => ({
+  runEmbeddedPiAgent: runEmbeddedPiAgentMock,
+}));
+
+function makeCliResult(text: string): EmbeddedPiRunResult {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 5,
+      finalAssistantVisibleText: text,
+      agentMeta: {
+        sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        model: "gpt-5.4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      executionTrace: {
+        winnerProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        winnerModel: "gpt-5.4",
+        fallbackUsed: false,
+        runner: "cli",
+      },
+    },
+  };
+}
+
+async function runCliAuthContractAttempt(params: {
+  tmpDir: string;
+  storePath: string;
+  providerOverride: string;
+  authProfileProvider: string;
+  authProfileOverride: string;
+}) {
+  const sessionEntry: SessionEntry = {
+    sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
+    updatedAt: Date.now(),
+    authProfileOverride: params.authProfileOverride,
+    authProfileOverrideSource: "user",
+  };
+  const sessionStore: Record<string, SessionEntry> = {
+    [AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey]: sessionEntry,
+  };
+  await fs.writeFile(params.storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+  await runAgentAttempt({
+    providerOverride: params.providerOverride,
+    modelOverride: "gpt-5.4",
+    cfg: {} as OpenClawConfig,
+    sessionEntry,
+    sessionId: sessionEntry.sessionId,
+    sessionKey: AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
+    sessionAgentId: "main",
+    sessionFile: path.join(params.tmpDir, "session.jsonl"),
+    workspaceDir: params.tmpDir,
+    body: AUTH_PROFILE_RUNTIME_CONTRACT.workspacePrompt,
+    isFallbackRetry: false,
+    resolvedThinkLevel: "medium",
+    timeoutMs: 1_000,
+    runId: AUTH_PROFILE_RUNTIME_CONTRACT.runId,
+    opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+    runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+    spawnedBy: undefined,
+    messageChannel: undefined,
+    skillsSnapshot: undefined,
+    resolvedVerboseLevel: undefined,
+    agentDir: params.tmpDir,
+    onAgentEvent: vi.fn(),
+    authProfileProvider: params.authProfileProvider,
+    sessionStore,
+    storePath: params.storePath,
+    sessionHasHistory: false,
+  });
+}
+
+describe("Auth profile runtime contract - Pi and CLI adapter", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-contract-"));
+    storePath = path.join(tmpDir, "sessions.json");
+    runCliAgentMock.mockReset();
+    runEmbeddedPiAgentMock.mockReset();
+    runCliAgentMock.mockResolvedValue(makeCliResult("ok"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("forwards an OpenAI Codex auth profile when the selected provider is codex-cli", async () => {
+    await runCliAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      expectedForwardedAuthProfile({
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+      }),
+    );
+  });
+
+  it("does not leak an OpenAI Codex auth profile into an unrelated CLI provider", async () => {
+    await runCliAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.claudeCliProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      expectedForwardedAuthProfile({
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.claudeCliProvider,
+        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+      }),
+    );
+  });
+});

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -4,16 +4,18 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AUTH_PROFILE_RUNTIME_CONTRACT,
+  createAuthAliasManifestRegistry,
   expectedForwardedAuthProfile,
 } from "../../test/helpers/agents/auth-profile-runtime-contract.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runAgentAttempt } from "./command/attempt-execution.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 const loadPluginManifestRegistry = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn<() => PluginManifestRegistry>(() => ({
     plugins: [],
     diagnostics: [],
   })),
@@ -104,26 +106,6 @@ function makeEmbeddedResult(text: string): EmbeddedPiRunResult {
   };
 }
 
-function createAuthAliasManifestRegistry() {
-  return {
-    plugins: [
-      {
-        id: "openai",
-        origin: "bundled",
-        providerAuthChoices: [
-          {
-            provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
-            method: "oauth",
-            choiceId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
-            deprecatedChoiceIds: [AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider],
-          },
-        ],
-      },
-    ],
-    diagnostics: [],
-  };
-}
-
 async function runAuthContractAttempt(params: {
   tmpDir: string;
   storePath: string;
@@ -190,7 +172,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("resolves codex-cli through the real provider auth alias registry", () => {
+  it("resolves codex-cli through the provider auth alias resolver using a mocked manifest", () => {
     expect(resolveProviderIdForAuth(AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider)).toBe(
       AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
     );

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -10,9 +10,24 @@ import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runAgentAttempt } from "./command/attempt-execution.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
+const loadPluginManifestRegistry = vi.hoisted(() =>
+  vi.fn(() => ({
+    plugins: [],
+    diagnostics: [],
+  })),
+);
 const runCliAgentMock = vi.hoisted(() => vi.fn());
 const runEmbeddedPiAgentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/manifest-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/manifest-registry.js")>();
+  return {
+    ...actual,
+    loadPluginManifestRegistry,
+  };
+});
 
 vi.mock("./cli-runner.js", () => ({
   runCliAgent: runCliAgentMock,
@@ -28,17 +43,6 @@ vi.mock("./model-selection.js", () => ({
   },
   normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
 }));
-
-vi.mock("./provider-auth-aliases.js", async () => {
-  const contract = await import("../../test/helpers/agents/auth-profile-runtime-contract.js");
-  return {
-    resolveProviderAuthAliasMap: () => ({
-      [contract.AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider]:
-        contract.AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
-    }),
-    resolveProviderIdForAuth: contract.resolveContractAuthProvider,
-  };
-});
 
 vi.mock("./pi-embedded.js", () => ({
   runEmbeddedPiAgent: runEmbeddedPiAgentMock,
@@ -72,7 +76,55 @@ function makeCliResult(text: string): EmbeddedPiRunResult {
   };
 }
 
-async function runCliAuthContractAttempt(params: {
+function makeEmbeddedResult(text: string): EmbeddedPiRunResult {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 5,
+      finalAssistantVisibleText: text,
+      agentMeta: {
+        sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
+        provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        model: "gpt-5.4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      executionTrace: {
+        winnerProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        winnerModel: "gpt-5.4",
+        fallbackUsed: false,
+        runner: "embedded",
+      },
+    },
+  };
+}
+
+function createAuthAliasManifestRegistry() {
+  return {
+    plugins: [
+      {
+        id: "openai",
+        origin: "bundled",
+        providerAuthChoices: [
+          {
+            provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+            method: "oauth",
+            choiceId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+            deprecatedChoiceIds: [AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider],
+          },
+        ],
+      },
+    ],
+    diagnostics: [],
+  };
+}
+
+async function runAuthContractAttempt(params: {
   tmpDir: string;
   storePath: string;
   providerOverride: string;
@@ -127,17 +179,25 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-contract-"));
     storePath = path.join(tmpDir, "sessions.json");
+    loadPluginManifestRegistry.mockReset().mockReturnValue(createAuthAliasManifestRegistry());
     runCliAgentMock.mockReset();
     runEmbeddedPiAgentMock.mockReset();
     runCliAgentMock.mockResolvedValue(makeCliResult("ok"));
+    runEmbeddedPiAgentMock.mockResolvedValue(makeEmbeddedResult("ok"));
   });
 
   afterEach(async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it("resolves codex-cli through the real provider auth alias registry", () => {
+    expect(resolveProviderIdForAuth(AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider)).toBe(
+      AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+    );
+  });
+
   it("forwards an OpenAI Codex auth profile when the selected provider is codex-cli", async () => {
-    await runCliAuthContractAttempt({
+    await runAuthContractAttempt({
       tmpDir,
       storePath,
       providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
@@ -156,7 +216,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
   });
 
   it("does not leak an OpenAI Codex auth profile into an unrelated CLI provider", async () => {
-    await runCliAuthContractAttempt({
+    await runAuthContractAttempt({
       tmpDir,
       storePath,
       providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.claudeCliProvider,
@@ -172,5 +232,33 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
         sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
       }),
     );
+  });
+
+  it("forwards an OpenAI Codex auth profile through the embedded Pi path", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    );
+  });
+
+  it("does not leak an OpenAI Codex auth profile into an unrelated embedded provider", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: "openai",
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBeUndefined();
   });
 });

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -172,11 +172,22 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("resolves codex-cli through the provider auth alias resolver using a mocked manifest", () => {
-    expect(resolveProviderIdForAuth(AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider)).toBe(
+  it.each([
+    [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider],
+    [
+      AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
       AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
-    );
-  });
+    ],
+    [
+      AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider,
+      AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider,
+    ],
+  ] as const)(
+    "resolves %s through the provider auth alias resolver using a mocked manifest",
+    (provider, expectedAuthProvider) => {
+      expect(resolveProviderIdForAuth(provider)).toBe(expectedAuthProvider);
+    },
+  );
 
   it("forwards an OpenAI Codex auth profile when the selected provider is codex-cli", async () => {
     await runAuthContractAttempt({
@@ -231,11 +242,26 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     );
   });
 
+  it("forwards an OpenAI auth profile through the embedded OpenAI path", async () => {
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe(
+      AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+    );
+  });
+
   it("does not leak an OpenAI Codex auth profile into an unrelated embedded provider", async () => {
     await runAuthContractAttempt({
       tmpDir,
       storePath,
-      providerOverride: "openai",
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
       authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
       authProfileOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
     });

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -9,13 +9,15 @@ import {
 } from "../../test/helpers/agents/auth-profile-runtime-contract.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type * as ManifestRegistryModule from "../plugins/manifest-registry.js";
 import { runAgentAttempt } from "./command/attempt-execution.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
+type LoadPluginManifestRegistry = typeof ManifestRegistryModule.loadPluginManifestRegistry;
+
 const loadPluginManifestRegistry = vi.hoisted(() =>
-  vi.fn<() => PluginManifestRegistry>(() => ({
+  vi.fn<LoadPluginManifestRegistry>(() => ({
     plugins: [],
     diagnostics: [],
   })),
@@ -113,6 +115,7 @@ async function runAuthContractAttempt(params: {
   authProfileProvider: string;
   authProfileOverride: string;
 }) {
+  const cfg = {} as OpenClawConfig;
   const sessionEntry: SessionEntry = {
     sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
     updatedAt: Date.now(),
@@ -127,7 +130,7 @@ async function runAuthContractAttempt(params: {
   await runAgentAttempt({
     providerOverride: params.providerOverride,
     modelOverride: "gpt-5.4",
-    cfg: {} as OpenClawConfig,
+    cfg,
     sessionEntry,
     sessionId: sessionEntry.sessionId,
     sessionKey: AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
@@ -152,6 +155,13 @@ async function runAuthContractAttempt(params: {
     storePath: params.storePath,
     sessionHasHistory: false,
   });
+
+  return {
+    aliasLookupParams: {
+      config: cfg,
+      workspaceDir: params.tmpDir,
+    },
+  };
 }
 
 describe("Auth profile runtime contract - Pi and CLI adapter", () => {
@@ -189,12 +199,17 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
   ] as const)(
     "resolves %s through the provider auth alias resolver using a mocked manifest",
     (provider, expectedAuthProvider) => {
-      expect(resolveProviderIdForAuth(provider)).toBe(expectedAuthProvider);
+      expect(
+        resolveProviderIdForAuth(provider, {
+          config: {} as OpenClawConfig,
+          workspaceDir: tmpDir,
+        }),
+      ).toBe(expectedAuthProvider);
     },
   );
 
   it("forwards an OpenAI Codex auth profile when the selected provider is codex-cli", async () => {
-    await runAuthContractAttempt({
+    const { aliasLookupParams } = await runAuthContractAttempt({
       tmpDir,
       storePath,
       providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
@@ -207,13 +222,14 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
       expectedForwardedAuthProfile({
         provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
         authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        aliasLookupParams,
         sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
       }),
     );
   });
 
   it("forwards an OpenAI Codex auth profile when the auth provider is the legacy codex-cli alias", async () => {
-    await runAuthContractAttempt({
+    const { aliasLookupParams } = await runAuthContractAttempt({
       tmpDir,
       storePath,
       providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
@@ -226,6 +242,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
       expectedForwardedAuthProfile({
         provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
         authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        aliasLookupParams,
         sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
       }),
     );
@@ -273,7 +290,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
   });
 
   it("accepts the legacy codex-cli auth-provider alias on the embedded OpenAI Codex path", async () => {
-    await runAuthContractAttempt({
+    const { aliasLookupParams } = await runAuthContractAttempt({
       tmpDir,
       storePath,
       providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
@@ -286,6 +303,7 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
       expectedForwardedAuthProfile({
         provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
         authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider,
+        aliasLookupParams,
         sessionAuthProfileId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
       }),
     );

--- a/test/helpers/agents/auth-profile-runtime-contract.ts
+++ b/test/helpers/agents/auth-profile-runtime-contract.ts
@@ -1,0 +1,30 @@
+export const AUTH_PROFILE_RUNTIME_CONTRACT = {
+  sessionId: "session-auth-contract",
+  sessionKey: "agent:main:auth-contract",
+  runId: "run-auth-contract",
+  workspacePrompt: "continue with the bound Codex profile",
+  openAiCodexProvider: "openai-codex",
+  codexCliProvider: "codex-cli",
+  codexHarnessProvider: "codex",
+  claudeCliProvider: "claude-cli",
+  openAiCodexProfileId: "openai-codex:work",
+  anthropicProfileId: "anthropic:work",
+} as const;
+
+export function resolveContractAuthProvider(provider: string): string {
+  const normalized = provider.trim().toLowerCase();
+  return normalized === AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider
+    ? AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider
+    : normalized;
+}
+
+export function expectedForwardedAuthProfile(params: {
+  provider: string;
+  authProfileProvider: string;
+  sessionAuthProfileId: string | undefined;
+}): string | undefined {
+  return resolveContractAuthProvider(params.provider) ===
+    resolveContractAuthProvider(params.authProfileProvider)
+    ? params.sessionAuthProfileId
+    : undefined;
+}

--- a/test/helpers/agents/auth-profile-runtime-contract.ts
+++ b/test/helpers/agents/auth-profile-runtime-contract.ts
@@ -1,3 +1,6 @@
+import { resolveProviderIdForAuth } from "../../../src/agents/provider-auth-aliases.js";
+import type { PluginManifestRegistry } from "../../../src/plugins/manifest-registry.js";
+
 export const AUTH_PROFILE_RUNTIME_CONTRACT = {
   sessionId: "session-auth-contract",
   sessionKey: "agent:main:auth-contract",
@@ -11,11 +14,32 @@ export const AUTH_PROFILE_RUNTIME_CONTRACT = {
   anthropicProfileId: "anthropic:work",
 } as const;
 
-export function resolveContractAuthProvider(provider: string): string {
-  const normalized = provider.trim().toLowerCase();
-  return normalized === AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider
-    ? AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider
-    : normalized;
+export function createAuthAliasManifestRegistry(): PluginManifestRegistry {
+  return {
+    plugins: [
+      {
+        id: "openai",
+        origin: "bundled",
+        channels: [],
+        providers: [],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        rootDir: "/tmp/openclaw-auth-contract-plugin",
+        source: "test",
+        manifestPath: "/tmp/openclaw-auth-contract-plugin/plugin.json",
+        providerAuthChoices: [
+          {
+            provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+            method: "oauth",
+            choiceId: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+            deprecatedChoiceIds: [AUTH_PROFILE_RUNTIME_CONTRACT.codexCliProvider],
+          },
+        ],
+      },
+    ],
+    diagnostics: [],
+  };
 }
 
 export function expectedForwardedAuthProfile(params: {
@@ -23,8 +47,8 @@ export function expectedForwardedAuthProfile(params: {
   authProfileProvider: string;
   sessionAuthProfileId: string | undefined;
 }): string | undefined {
-  return resolveContractAuthProvider(params.provider) ===
-    resolveContractAuthProvider(params.authProfileProvider)
+  return resolveProviderIdForAuth(params.provider) ===
+    resolveProviderIdForAuth(params.authProfileProvider)
     ? params.sessionAuthProfileId
     : undefined;
 }

--- a/test/helpers/agents/auth-profile-runtime-contract.ts
+++ b/test/helpers/agents/auth-profile-runtime-contract.ts
@@ -6,10 +6,12 @@ export const AUTH_PROFILE_RUNTIME_CONTRACT = {
   sessionKey: "agent:main:auth-contract",
   runId: "run-auth-contract",
   workspacePrompt: "continue with the bound Codex profile",
+  openAiProvider: "openai",
   openAiCodexProvider: "openai-codex",
   codexCliProvider: "codex-cli",
   codexHarnessProvider: "codex",
   claudeCliProvider: "claude-cli",
+  openAiProfileId: "openai:work",
   openAiCodexProfileId: "openai-codex:work",
   anthropicProfileId: "anthropic:work",
 } as const;

--- a/test/helpers/agents/auth-profile-runtime-contract.ts
+++ b/test/helpers/agents/auth-profile-runtime-contract.ts
@@ -1,4 +1,7 @@
-import { resolveProviderIdForAuth } from "../../../src/agents/provider-auth-aliases.js";
+import {
+  resolveProviderIdForAuth,
+  type ProviderAuthAliasLookupParams,
+} from "../../../src/agents/provider-auth-aliases.js";
 import type { PluginManifestRegistry } from "../../../src/plugins/manifest-registry.js";
 
 export const AUTH_PROFILE_RUNTIME_CONTRACT = {
@@ -47,10 +50,11 @@ export function createAuthAliasManifestRegistry(): PluginManifestRegistry {
 export function expectedForwardedAuthProfile(params: {
   provider: string;
   authProfileProvider: string;
+  aliasLookupParams: ProviderAuthAliasLookupParams;
   sessionAuthProfileId: string | undefined;
 }): string | undefined {
-  return resolveProviderIdForAuth(params.provider) ===
-    resolveProviderIdForAuth(params.authProfileProvider)
+  return resolveProviderIdForAuth(params.provider, params.aliasLookupParams) ===
+    resolveProviderIdForAuth(params.authProfileProvider, params.aliasLookupParams)
     ? params.sessionAuthProfileId
     : undefined;
 }


### PR DESCRIPTION
## Summary

Adds the auth/profile contract rung from RFC #71004. This is test-only: it locks current auth/profile forwarding invariants across the Pi/CLI command path and the Codex app-server adapter before later PRs move auth policy into `AgentRuntimePlan`.

No production auth behavior changes in this PR.

```mermaid
flowchart TD
  Manifest["Provider auth alias manifest"] --> Resolver["resolveProviderIdForAuth"]
  Session["Session auth profile override"] --> AuthContract["Auth/profile runtime contract"]
  Resolver --> AuthContract
  AuthContract --> PiCli["Pi / CLI command adapter"]
  AuthContract --> Codex["Codex app-server adapter"]
  PiCli --> Forward["Forward matching profile"]
  PiCli --> NoLeak["No unrelated-provider leakage"]
  Codex --> Startup["Pass exact profile to startup"]
  Codex --> Resume["Reuse or override persisted binding"]
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/auth-profile-runtime-contract.ts` | Shared constants and real alias-resolver expectation helper. |
| `src/agents/auth-profile-runtime-contract.test.ts` | Pi/CLI command-path forwarding and no-leak matrix. |
| `extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts` | Codex app-server startup/resume binding behavior. |

## Contract Matrix

| Path | Covered behavior |
| --- | --- |
| Auth alias resolver | `openai`, `openai-codex`, `codex-cli`, and `codex` resolve through real `resolveProviderIdForAuth` using mocked plugin-manifest metadata. |
| Pi / CLI command adapter | `codex-cli` forwards existing `openai-codex:*` profiles through canonical and legacy auth-provider aliases. |
| Pi / CLI command adapter | `codex-cli/*` does not inherit a direct `openai:*` API-key profile. |
| Pi / CLI command adapter | Unrelated CLI providers do not inherit OpenAI-Codex profiles. |
| Embedded Pi adapter | `openai-codex/*` forwards matching `openai-codex:*` profiles through canonical and legacy aliases. |
| Embedded Pi adapter | `openai/*` forwards matching `openai:*` profiles and does not inherit `openai-codex:*` profiles. |
| Codex app-server adapter | Runtime `authProfileId` reaches app-server startup unchanged. |
| Codex app-server adapter | Persisted app-server binding is reused on resume when params omit `authProfileId`. |
| Codex app-server adapter | Explicit runtime profile overrides stale persisted binding and rewrites the binding. |

## Known Red Rows

These are explicit TODOs because proving them end-to-end requires the shared runtime-plan/harness-adapter phase or a targeted production fix, not more fixture-only assertions.

| Future row | Why not green here |
| --- | --- |
| Preserve OpenAI-Codex profiles through the real `codex/*` harness startup path. | Requires full embedded runner + harness selection + auth bootstrap path. |
| Validate `openai/*` forced through the Codex harness can use OpenAI-Codex OAuth profiles. | Crosses model selection, forced harness policy, and auth-provider validation. |

## How This Helps The RuntimePlan Work

The shared plan should resolve auth provider identity once and hand both adapters a stable auth profile decision. These tests define the expected behavior before that policy moves.

## Reviewer Notes

- Test-only, no production auth code changes.
- App-server tests prove exact startup/resume behavior, while TODOs honestly mark the deeper harness-path coverage still needed.
- This captures the audit’s Bug 8 class without trying to fix runtime behavior in Phase 1.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/auth-profile-runtime-contract.test.ts` — 12 passed, 2 todo
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts` — 3 passed
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/auth-profile-runtime-contract.ts src/agents/auth-profile-runtime-contract.test.ts extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/auth-profile-runtime-contract.ts src/agents/auth-profile-runtime-contract.test.ts extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts`

Refs #71004
Follows #71009
