### PR TITLE
fix: apply toolsAllow filter to bundled MCP/LSP tools

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -736,7 +736,10 @@ export async function runEmbeddedAttempt(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
-    const effectiveTools = [...tools, ...filteredBundledTools];
+    const effectiveTools = [
+      ...tools,
+      ...applyEmbeddedAttemptToolsAllow(filteredBundledTools, params.toolsAllow),
+    ];
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,


### PR DESCRIPTION
## Summary

Fixes #70939

Scheduled cron `agentTurn` runs pass `toolsAllow` to restrict tool access, but the allowlist was only applied to the base tool registry. Bundled MCP/LSP tools were materialized later and appended to the effective tool list without reapplying `toolsAllow`.

## Impact

An exec-only cron could compile with `exec + 45 Atlassian MCP tools`, wasting **~370k input tokens/day** across allowlisted cron jobs.

## Fix

Wrap `filteredBundledTools` with `applyEmbeddedAttemptToolsAllow()` before merging into `effectiveTools` in `attempt.ts:739`, so bundled MCP/LSP tools are also subject to the `toolsAllow` policy.

## Change

```diff
- const effectiveTools = [...tools, ...filteredBundledTools];
+ const effectiveTools = [
+   ...tools,
+   ...applyEmbeddedAttemptToolsAllow(filteredBundledTools, params.toolsAllow),
+ ];
```