### PR TITLE
[codex] Add outcome fallback runtime contracts

### DIFF
--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
+import { afterEach, describe, expect, it } from "vitest";
+import { OUTCOME_FALLBACK_RUNTIME_CONTRACT } from "../../../../test/helpers/agents/outcome-fallback-runtime-contract.js";
+import {
+  CodexAppServerEventProjector,
+  type CodexAppServerToolTelemetry,
+} from "./event-projector.js";
+import { createCodexTestModel } from "./test-support.js";
+
+const THREAD_ID = "thread-outcome-contract";
+const TURN_ID = "turn-outcome-contract";
+const tempDirs = new Set<string>();
+
+type ProjectorNotification = Parameters<CodexAppServerEventProjector["handleNotification"]>[0];
+
+async function createParams(): Promise<EmbeddedRunAttemptParams> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-outcome-contract-"));
+  tempDirs.add(tempDir);
+  const sessionFile = path.join(tempDir, "session.jsonl");
+  SessionManager.open(sessionFile);
+  return {
+    prompt: OUTCOME_FALLBACK_RUNTIME_CONTRACT.prompt,
+    sessionId: OUTCOME_FALLBACK_RUNTIME_CONTRACT.sessionId,
+    sessionKey: OUTCOME_FALLBACK_RUNTIME_CONTRACT.sessionKey,
+    sessionFile,
+    workspaceDir: tempDir,
+    runId: OUTCOME_FALLBACK_RUNTIME_CONTRACT.runId,
+    provider: "codex",
+    modelId: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+  } as EmbeddedRunAttemptParams;
+}
+
+async function createProjector(): Promise<CodexAppServerEventProjector> {
+  return new CodexAppServerEventProjector(await createParams(), THREAD_ID, TURN_ID);
+}
+
+function buildToolTelemetry(
+  overrides: Partial<CodexAppServerToolTelemetry> = {},
+): CodexAppServerToolTelemetry {
+  return {
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    toolMediaUrls: [],
+    toolAudioAsVoice: false,
+    ...overrides,
+  };
+}
+
+function forCurrentTurn(
+  method: ProjectorNotification["method"],
+  params: Record<string, unknown>,
+): ProjectorNotification {
+  return {
+    method,
+    params: { threadId: THREAD_ID, turnId: TURN_ID, ...params },
+  } as ProjectorNotification;
+}
+
+afterEach(async () => {
+  for (const tempDir of tempDirs) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
+  it("preserves an empty terminal turn for OpenClaw-owned fallback classification", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: { id: TURN_ID, status: "completed", items: [] },
+      }),
+    );
+
+    const result = projector.buildResult(buildToolTelemetry());
+
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+    expect(result.promptError).toBeNull();
+  });
+
+  it("preserves exact NO_REPLY as assistant text instead of classifying in the adapter", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("item/agentMessage/delta", {
+        itemId: "msg-1",
+        delta: "NO_REPLY",
+      }),
+    );
+
+    const result = projector.buildResult(buildToolTelemetry());
+
+    expect(result.assistantTexts).toEqual(["NO_REPLY"]);
+    expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "NO_REPLY" }]);
+    expect(result.promptError).toBeNull();
+  });
+
+  it("preserves tool side-effect telemetry so fallback can stay disabled", async () => {
+    const projector = await createProjector();
+
+    const result = projector.buildResult(
+      buildToolTelemetry({
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["sent out of band"],
+      }),
+    );
+
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["sent out of band"]);
+  });
+});

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -112,6 +112,88 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
     expect(result.promptError).toBeNull();
   });
 
+  it("preserves reasoning-only terminal turns for OpenClaw-owned fallback classification", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("item/reasoning/textDelta", {
+        itemId: "reasoning-1",
+        delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText,
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [{ type: "reasoning", id: "reasoning-1" }],
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildToolTelemetry());
+
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+    expect(result.promptError).toBeNull();
+    expect(result.messagesSnapshot).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: `Codex reasoning:\n${OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText}`,
+            },
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("preserves planning-only terminal turns for OpenClaw-owned fallback classification", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("item/plan/delta", {
+        itemId: "plan-1",
+        delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText,
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [
+            {
+              type: "plan",
+              id: "plan-1",
+              text: OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildToolTelemetry());
+
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+    expect(result.promptError).toBeNull();
+    expect(result.messagesSnapshot).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: `Codex plan:\n${OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText}`,
+            },
+          ],
+        }),
+      ]),
+    );
+  });
+
   it("preserves tool side-effect telemetry so fallback can stay disabled", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -95,6 +95,15 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
         delta: "NO_REPLY",
       }),
     );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-1", text: "NO_REPLY" }],
+        },
+      }),
+    );
 
     const result = projector.buildResult(buildToolTelemetry());
 

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import { afterEach, describe, expect, it } from "vitest";
-import { OUTCOME_FALLBACK_RUNTIME_CONTRACT } from "../../../../test/helpers/agents/outcome-fallback-runtime-contract.js";
+import { classifyEmbeddedPiRunResultForModelFallback } from "../../../../src/agents/pi-embedded-runner/result-fallback-classifier.js";
+import {
+  createContractRunResult,
+  OUTCOME_FALLBACK_RUNTIME_CONTRACT,
+} from "../../../../test/helpers/agents/outcome-fallback-runtime-contract.js";
 import {
   CodexAppServerEventProjector,
   type CodexAppServerToolTelemetry,
@@ -16,6 +20,8 @@ const TURN_ID = "turn-outcome-contract";
 const tempDirs = new Set<string>();
 
 type ProjectorNotification = Parameters<CodexAppServerEventProjector["handleNotification"]>[0];
+type ProjectedAttemptResult = ReturnType<CodexAppServerEventProjector["buildResult"]>;
+type TerminalClassification = "empty" | "reasoning-only" | "planning-only";
 
 async function createParams(): Promise<EmbeddedRunAttemptParams> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-outcome-contract-"));
@@ -62,6 +68,27 @@ function forCurrentTurn(
     method,
     params: { threadId: THREAD_ID, turnId: TURN_ID, ...params },
   } as ProjectorNotification;
+}
+
+function classifyProjectedAttemptResult(
+  result: ProjectedAttemptResult,
+  classification?: TerminalClassification,
+) {
+  const finalAssistantText = result.assistantTexts.join("\n\n").trim();
+  return classifyEmbeddedPiRunResultForModelFallback({
+    provider: "codex",
+    model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+    result: createContractRunResult({
+      ...result,
+      meta: {
+        durationMs: 1,
+        aborted: result.aborted,
+        agentHarnessResultClassification: classification,
+        finalAssistantRawText: finalAssistantText || undefined,
+        finalAssistantVisibleText: finalAssistantText || undefined,
+      },
+    }),
+  });
 }
 
 afterEach(async () => {
@@ -207,5 +234,121 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
     expect(result.assistantTexts).toEqual([]);
     expect(result.didSendViaMessagingTool).toBe(true);
     expect(result.messagingToolSentTexts).toEqual(["sent out of band"]);
+  });
+
+  it.each([
+    {
+      name: "empty",
+      classification: "empty",
+      expectedCode: "empty_result",
+      build: async () => {
+        const projector = await createProjector();
+        await projector.handleNotification(
+          forCurrentTurn("turn/completed", {
+            turn: { id: TURN_ID, status: "completed", items: [] },
+          }),
+        );
+        return projector.buildResult(buildToolTelemetry());
+      },
+    },
+    {
+      name: "reasoning-only",
+      classification: "reasoning-only",
+      expectedCode: "reasoning_only_result",
+      build: async () => {
+        const projector = await createProjector();
+        await projector.handleNotification(
+          forCurrentTurn("item/reasoning/textDelta", {
+            itemId: "reasoning-1",
+            delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText,
+          }),
+        );
+        await projector.handleNotification(
+          forCurrentTurn("turn/completed", {
+            turn: {
+              id: TURN_ID,
+              status: "completed",
+              items: [{ type: "reasoning", id: "reasoning-1" }],
+            },
+          }),
+        );
+        return projector.buildResult(buildToolTelemetry());
+      },
+    },
+    {
+      name: "planning-only",
+      classification: "planning-only",
+      expectedCode: "planning_only_result",
+      build: async () => {
+        const projector = await createProjector();
+        await projector.handleNotification(
+          forCurrentTurn("item/plan/delta", {
+            itemId: "plan-1",
+            delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText,
+          }),
+        );
+        await projector.handleNotification(
+          forCurrentTurn("turn/completed", {
+            turn: {
+              id: TURN_ID,
+              status: "completed",
+              items: [
+                {
+                  type: "plan",
+                  id: "plan-1",
+                  text: OUTCOME_FALLBACK_RUNTIME_CONTRACT.planningOnlyText,
+                },
+              ],
+            },
+          }),
+        );
+        return projector.buildResult(buildToolTelemetry());
+      },
+    },
+  ] as const)(
+    "keeps $name terminal turns fallback-ready once a harness classification exists",
+    async ({ build, classification, expectedCode }) => {
+      const result = await build();
+
+      expect(classifyProjectedAttemptResult(result, classification)).toMatchObject({
+        reason: "format",
+        code: expectedCode,
+      });
+    },
+  );
+
+  it("keeps exact NO_REPLY classified as an intentional silent terminal reply", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("item/agentMessage/delta", {
+        itemId: "msg-1",
+        delta: "NO_REPLY",
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-1", text: "NO_REPLY" }],
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildToolTelemetry());
+
+    expect(classifyProjectedAttemptResult(result)).toBeNull();
+  });
+
+  it("keeps tool side effects classified as non-fallback terminal outcomes", async () => {
+    const projector = await createProjector();
+    const result = projector.buildResult(
+      buildToolTelemetry({
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["sent out of band"],
+      }),
+    );
+
+    expect(classifyProjectedAttemptResult(result, "empty")).toBeNull();
   });
 });

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -38,45 +38,52 @@ describe("Outcome/fallback runtime contract - Pi fallback classifier", () => {
     },
   );
 
-  it("advances to the configured fallback after a classified GPT-5 terminal result", async () => {
-    const primary = createContractRunResult({
-      meta: {
-        durationMs: 1,
-        agentHarnessResultClassification: "empty",
-      },
-    });
-    const fallback = createContractRunResult({
-      payloads: [{ text: "fallback ok" }],
-      meta: { durationMs: 1, finalAssistantVisibleText: "fallback ok" },
-    });
-    const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
+  it.each([
+    ["empty", "empty_result"],
+    ["reasoning-only", "reasoning_only_result"],
+    ["planning-only", "planning_only_result"],
+  ] as const)(
+    "advances to the configured fallback after a classified GPT-5 %s terminal result",
+    async (classification, code) => {
+      const primary = createContractRunResult({
+        meta: {
+          durationMs: 1,
+          agentHarnessResultClassification: classification,
+        },
+      });
+      const fallback = createContractRunResult({
+        payloads: [{ text: "fallback ok" }],
+        meta: { durationMs: 1, finalAssistantVisibleText: "fallback ok" },
+      });
+      const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
 
-    const result = await runWithModelFallback({
-      cfg: createContractFallbackConfig() as unknown as OpenClawConfig,
-      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
-      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
-      run,
-      classifyResult: ({ provider, model, result }) =>
-        classifyEmbeddedPiRunResultForModelFallback({
-          provider,
-          model,
-          result,
-        }),
-    });
+      const result = await runWithModelFallback({
+        cfg: createContractFallbackConfig() as unknown as OpenClawConfig,
+        provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+        model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        run,
+        classifyResult: ({ provider, model, result }) =>
+          classifyEmbeddedPiRunResultForModelFallback({
+            provider,
+            model,
+            result,
+          }),
+      });
 
-    expect(result.result).toBe(fallback);
-    expect(run).toHaveBeenCalledTimes(2);
-    expect(run.mock.calls[1]).toEqual([
-      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
-      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
-    ]);
-    expect(result.attempts[0]).toMatchObject({
-      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
-      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
-      reason: "format",
-      code: "empty_result",
-    });
-  });
+      expect(result.result).toBe(fallback);
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[1]).toEqual([
+        OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+        OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+      ]);
+      expect(result.attempts[0]).toMatchObject({
+        provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+        model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        reason: "format",
+        code,
+      });
+    },
+  );
 
   it.each([
     {

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -48,7 +48,7 @@ describe("Outcome/fallback runtime contract - Pi fallback classifier", () => {
     const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
 
     const result = await runWithModelFallback({
-      cfg: createContractFallbackConfig() as OpenClawConfig,
+      cfg: createContractFallbackConfig() as unknown as OpenClawConfig,
       provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
       model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
       run,
@@ -74,31 +74,103 @@ describe("Outcome/fallback runtime contract - Pi fallback classifier", () => {
     });
   });
 
-  it("does not fallback for intentional silence, visible replies, aborts, or tool side effects", () => {
-    const cases = [
-      createContractRunResult({
+  it.each([
+    {
+      name: "intentional NO_REPLY",
+      result: createContractRunResult({
         meta: { durationMs: 1, finalAssistantRawText: "NO_REPLY" },
       }),
-      createContractRunResult({
+    },
+    {
+      name: "visible reply",
+      result: createContractRunResult({
         payloads: [{ text: "visible answer" }],
         meta: { durationMs: 1 },
       }),
-      createContractRunResult({
+    },
+    {
+      name: "abort",
+      result: createContractRunResult({
         meta: { durationMs: 1, aborted: true, agentHarnessResultClassification: "empty" },
       }),
-      createContractRunResult({
+    },
+    {
+      name: "tool summary side effect",
+      result: createContractRunResult({
         meta: { durationMs: 1, toolSummary: { calls: 1, tools: ["message"] } },
       }),
-    ];
+    },
+    {
+      name: "messaging text side effect",
+      result: createContractRunResult({
+        messagingToolSentTexts: ["sent out of band"],
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+    },
+    {
+      name: "messaging media side effect",
+      result: createContractRunResult({
+        messagingToolSentMediaUrls: ["https://example.test/image.png"],
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+    },
+    {
+      name: "messaging target side effect",
+      result: createContractRunResult({
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel-1" }],
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+    },
+    {
+      name: "cron side effect",
+      result: createContractRunResult({
+        successfulCronAdds: 1,
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+    },
+    {
+      name: "direct block reply",
+      result: createContractRunResult({
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+      hasDirectlySentBlockReply: true,
+    },
+    {
+      name: "block reply pipeline output",
+      result: createContractRunResult({
+        meta: { durationMs: 1, agentHarnessResultClassification: "empty" },
+      }),
+      hasBlockReplyPipelineOutput: true,
+    },
+  ])("does not fallback for $name", async (contractCase) => {
+    expect(
+      classifyEmbeddedPiRunResultForModelFallback({
+        provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+        model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        result: contractCase.result,
+        hasDirectlySentBlockReply: contractCase.hasDirectlySentBlockReply,
+        hasBlockReplyPipelineOutput: contractCase.hasBlockReplyPipelineOutput,
+      }),
+    ).toBeNull();
 
-    for (const result of cases) {
-      expect(
+    const run = vi.fn().mockResolvedValue(contractCase.result);
+    const result = await runWithModelFallback({
+      cfg: createContractFallbackConfig() as unknown as OpenClawConfig,
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      run,
+      classifyResult: ({ provider, model, result }) =>
         classifyEmbeddedPiRunResultForModelFallback({
-          provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
-          model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+          provider,
+          model,
           result,
+          hasDirectlySentBlockReply: contractCase.hasDirectlySentBlockReply,
+          hasBlockReplyPipelineOutput: contractCase.hasBlockReplyPipelineOutput,
         }),
-      ).toBeNull();
-    }
+    });
+
+    expect(result.result).toBe(contractCase.result);
+    expect(result.attempts).toEqual([]);
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -8,6 +8,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import { classifyEmbeddedPiRunResultForModelFallback } from "./pi-embedded-runner/result-fallback-classifier.js";
 
+vi.mock("./auth-profiles/source-check.js", () => ({
+  hasAnyAuthProfileStoreSource: () => false,
+}));
+
 describe("Outcome/fallback runtime contract - Pi fallback classifier", () => {
   it.each([
     ["empty", "empty_result"],

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createContractFallbackConfig,
+  createContractRunResult,
+  OUTCOME_FALLBACK_RUNTIME_CONTRACT,
+} from "../../test/helpers/agents/outcome-fallback-runtime-contract.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runWithModelFallback } from "./model-fallback.js";
+import { classifyEmbeddedPiRunResultForModelFallback } from "./pi-embedded-runner/result-fallback-classifier.js";
+
+describe("Outcome/fallback runtime contract - Pi fallback classifier", () => {
+  it.each([
+    ["empty", "empty_result"],
+    ["reasoning-only", "reasoning_only_result"],
+    ["planning-only", "planning_only_result"],
+  ] as const)(
+    "maps harness classification %s to a format fallback code",
+    (classification, code) => {
+      expect(
+        classifyEmbeddedPiRunResultForModelFallback({
+          provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+          model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+          result: createContractRunResult({
+            meta: {
+              durationMs: 1,
+              agentHarnessResultClassification: classification,
+            },
+          }),
+        }),
+      ).toMatchObject({
+        reason: "format",
+        code,
+      });
+    },
+  );
+
+  it("advances to the configured fallback after a classified GPT-5 terminal result", async () => {
+    const primary = createContractRunResult({
+      meta: {
+        durationMs: 1,
+        agentHarnessResultClassification: "empty",
+      },
+    });
+    const fallback = createContractRunResult({
+      payloads: [{ text: "fallback ok" }],
+      meta: { durationMs: 1, finalAssistantVisibleText: "fallback ok" },
+    });
+    const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
+
+    const result = await runWithModelFallback({
+      cfg: createContractFallbackConfig() as OpenClawConfig,
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      run,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedPiRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+    });
+
+    expect(result.result).toBe(fallback);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]).toEqual([
+      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+    ]);
+    expect(result.attempts[0]).toMatchObject({
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      reason: "format",
+      code: "empty_result",
+    });
+  });
+
+  it("does not fallback for intentional silence, visible replies, aborts, or tool side effects", () => {
+    const cases = [
+      createContractRunResult({
+        meta: { durationMs: 1, finalAssistantRawText: "NO_REPLY" },
+      }),
+      createContractRunResult({
+        payloads: [{ text: "visible answer" }],
+        meta: { durationMs: 1 },
+      }),
+      createContractRunResult({
+        meta: { durationMs: 1, aborted: true, agentHarnessResultClassification: "empty" },
+      }),
+      createContractRunResult({
+        meta: { durationMs: 1, toolSummary: { calls: 1, tools: ["message"] } },
+      }),
+    ];
+
+    for (const result of cases) {
+      expect(
+        classifyEmbeddedPiRunResultForModelFallback({
+          provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+          model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+          result,
+        }),
+      ).toBeNull();
+    }
+  });
+});

--- a/test/helpers/agents/outcome-fallback-runtime-contract.ts
+++ b/test/helpers/agents/outcome-fallback-runtime-contract.ts
@@ -1,0 +1,45 @@
+import type { EmbeddedPiRunResult } from "../../../src/agents/pi-embedded-runner/types.js";
+
+export const OUTCOME_FALLBACK_RUNTIME_CONTRACT = {
+  primaryProvider: "openai-codex",
+  primaryModel: "gpt-5.4",
+  fallbackProvider: "anthropic",
+  fallbackModel: "claude-haiku-3-5",
+  sessionId: "session-outcome-contract",
+  sessionKey: "agent:main:outcome-contract",
+  runId: "run-outcome-contract",
+  prompt: "finish the contract turn",
+} as const;
+
+export function createContractRunResult(
+  overrides: Partial<EmbeddedPiRunResult> = {},
+): EmbeddedPiRunResult {
+  return {
+    payloads: [],
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    successfulCronAdds: 0,
+    meta: {
+      durationMs: 1,
+      ...overrides.meta,
+    },
+    ...overrides,
+  };
+}
+
+export function createContractFallbackConfig() {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: `${OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider}/${OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel}`,
+          fallbacks: [
+            `${OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider}/${OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel}`,
+          ],
+        },
+      },
+    },
+  } as const;
+}

--- a/test/helpers/agents/outcome-fallback-runtime-contract.ts
+++ b/test/helpers/agents/outcome-fallback-runtime-contract.ts
@@ -9,6 +9,8 @@ export const OUTCOME_FALLBACK_RUNTIME_CONTRACT = {
   sessionKey: "agent:main:outcome-contract",
   runId: "run-outcome-contract",
   prompt: "finish the contract turn",
+  reasoningOnlyText: "I need to reason about this before answering.",
+  planningOnlyText: "Inspect state, then decide the next step.",
 } as const;
 
 export function createContractRunResult(

--- a/test/helpers/agents/outcome-fallback-runtime-contract.ts
+++ b/test/helpers/agents/outcome-fallback-runtime-contract.ts
@@ -14,6 +14,7 @@ export const OUTCOME_FALLBACK_RUNTIME_CONTRACT = {
 export function createContractRunResult(
   overrides: Partial<EmbeddedPiRunResult> = {},
 ): EmbeddedPiRunResult {
+  const { meta, ...rest } = overrides;
   return {
     payloads: [],
     didSendViaMessagingTool: false,
@@ -21,11 +22,11 @@ export function createContractRunResult(
     messagingToolSentMediaUrls: [],
     messagingToolSentTargets: [],
     successfulCronAdds: 0,
+    ...rest,
     meta: {
       durationMs: 1,
-      ...overrides.meta,
+      ...meta,
     },
-    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the outcome/fallback contract rung from RFC #71004. This is test-only: it locks how GPT-5 terminal outcomes are classified for fallback and how the Codex app-server adapter preserves terminal state for OpenClaw-owned classification.

No production runtime behavior changes in this PR.

```mermaid
flowchart TD
  Attempt["Agent attempt result"] --> Classifier["OpenClaw outcome classifier"]
  Classifier --> Fallback["Model fallback chain"]
  Codex["Codex app-server projector"] --> Attempt
  Pi["Pi run result"] --> Attempt
  Classifier --> Silent["Intentional NO_REPLY stays terminal"]
  Classifier --> Effects["Tool/block side effects stay terminal"]
  Classifier --> Classified["empty / reasoning-only / planning-only advance fallback"]
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/outcome-fallback-runtime-contract.ts` | Shared GPT-5 outcome/fallback fixture data. |
| `src/agents/outcome-fallback-runtime-contract.test.ts` | Shared/Pi classifier and model-fallback advancement rows. |
| `extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts` | Codex projector terminal-state preservation and fallback-readiness rows. |

## Contract Matrix

| Path | Covered behavior |
| --- | --- |
| Pi / shared fallback | Harness-owned `empty`, `reasoning-only`, and `planning-only` classifications map to `format` fallback codes. |
| Pi / shared fallback | Classified GPT-5 terminal results advance to the configured fallback model. |
| Pi / shared fallback | Intentional `NO_REPLY`, visible replies, aborts, block replies, and tool side effects do not trigger fallback. |
| Codex app-server adapter | Empty terminal turns remain empty results for OpenClaw-owned fallback classification. |
| Codex app-server adapter | Reasoning-only terminal turns preserve reasoning mirror text without visible assistant output. |
| Codex app-server adapter | Planning-only terminal turns preserve plan mirror text without visible assistant output. |
| Codex app-server adapter | Codex-projected empty/reasoning/planning terminal results are fallback-ready once a harness classification exists. |
| Codex app-server adapter | Exact `NO_REPLY` remains an intentional silent terminal reply. |
| Codex app-server adapter | Tool side-effect telemetry keeps fallback disabled. |

## Important Boundary

This PR does **not** claim the current Codex harness already supplies `classify()`. It proves:

- The shared OpenClaw fallback classifier advances correctly when an attempt result has a harness-owned terminal classification.
- The Codex app-server projector preserves enough terminal state for that classification seam to be wired in the runtime-plan/harness-adapter phase.

## How This Helps The RuntimePlan Work

The plan should own outcome classification and fallback semantics once. These tests prevent the GPT-5.4 stall class from reappearing when Pi/Codex behavior is migrated into that shared policy.

## Reviewer Notes

- Test-only, no Codex harness `classify()` implementation in this PR.
- The synthetic Codex fallback-readiness rows are deliberately framed as readiness, not current harness behavior.
- This captures the audit’s Bug 1 class plus `NO_REPLY`/side-effect non-fallback behavior.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/outcome-fallback-runtime-contract.test.ts` — 16 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts` — 10 passed
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/outcome-fallback-runtime-contract.ts src/agents/outcome-fallback-runtime-contract.test.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/outcome-fallback-runtime-contract.ts src/agents/outcome-fallback-runtime-contract.test.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts`

Refs #71004
Follows #71009
Follows #71029
