### PR TITLE
[codex] Add delivery NO_REPLY runtime contracts

### DIFF
--- a/extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
+import { afterEach, describe, expect, it } from "vitest";
+import { isSilentReplyPayloadText } from "../../../../src/auto-reply/tokens.js";
+import { DELIVERY_NO_REPLY_RUNTIME_CONTRACT } from "../../../../test/helpers/agents/delivery-no-reply-runtime-contract.js";
+import { CodexAppServerEventProjector } from "./event-projector.js";
+import { createCodexTestModel } from "./test-support.js";
+
+const THREAD_ID = "thread-delivery-contract";
+const TURN_ID = "turn-delivery-contract";
+const tempDirs = new Set<string>();
+
+type ProjectorNotification = Parameters<CodexAppServerEventProjector["handleNotification"]>[0];
+
+async function createParams(): Promise<EmbeddedRunAttemptParams> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-delivery-contract-"));
+  tempDirs.add(tempDir);
+  const sessionFile = path.join(tempDir, "session.jsonl");
+  SessionManager.open(sessionFile);
+  return {
+    prompt: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.prompt,
+    sessionId: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.sessionId,
+    sessionKey: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.sessionKey,
+    sessionFile,
+    workspaceDir: tempDir,
+    runId: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.runId,
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+  } as EmbeddedRunAttemptParams;
+}
+
+function forCurrentTurn(
+  method: ProjectorNotification["method"],
+  params: Record<string, unknown>,
+): ProjectorNotification {
+  return {
+    method,
+    params: { threadId: THREAD_ID, turnId: TURN_ID, ...params },
+  } as ProjectorNotification;
+}
+
+afterEach(async () => {
+  for (const tempDir of tempDirs) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("Delivery/NO_REPLY runtime contract - Codex app-server adapter", () => {
+  it.each([
+    DELIVERY_NO_REPLY_RUNTIME_CONTRACT.silentText,
+    `  ${DELIVERY_NO_REPLY_RUNTIME_CONTRACT.silentText}  `,
+    DELIVERY_NO_REPLY_RUNTIME_CONTRACT.jsonSilentText,
+  ])("preserves silent terminal text %s for shared delivery suppression", async (text) => {
+    const projector = new CodexAppServerEventProjector(await createParams(), THREAD_ID, TURN_ID);
+    await projector.handleNotification(
+      forCurrentTurn("item/agentMessage/delta", {
+        itemId: "msg-1",
+        delta: text,
+      }),
+    );
+
+    const result = projector.buildResult({
+      didSendViaMessagingTool: false,
+      messagingToolSentTexts: [],
+      messagingToolSentMediaUrls: [],
+      messagingToolSentTargets: [],
+      toolMediaUrls: [],
+      toolAudioAsVoice: false,
+    });
+
+    expect(result.assistantTexts).toEqual([text.trim()]);
+    expect(isSilentReplyPayloadText(result.assistantTexts[0])).toBe(true);
+  });
+});

--- a/extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts
@@ -28,7 +28,7 @@ async function createParams(): Promise<EmbeddedRunAttemptParams> {
     workspaceDir: tempDir,
     runId: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.runId,
     provider: "codex",
-    modelId: "gpt-5.4",
+    modelId: "gpt-5.4-codex",
     model: createCodexTestModel("codex"),
     thinkLevel: "medium",
   } as EmbeddedRunAttemptParams;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1438,6 +1438,11 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     expect(typing.markDispatchIdle).toHaveBeenCalled();
   });
 
+  // Phase 1 contract marker: Codex preserves JSON NO_REPLY envelopes, but
+  // follow-up delivery still only suppresses exact text tokens. Runtime-plan
+  // delivery migration should flip this into an executable green row.
+  it.todo("suppresses JSON NO_REPLY followups without origin or dispatcher delivery");
+
   it("keeps NO_REPLY followups with media deliverable", async () => {
     const { onBlockReply } = await runMessagingCase({
       agentResult: {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { DELIVERY_NO_REPLY_RUNTIME_CONTRACT } from "../../../test/helpers/agents/delivery-no-reply-runtime-contract.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
@@ -1408,6 +1409,77 @@ describe("createFollowupRunner messaging tool dedupe", () => {
 
     expect(routeReplyMock).not.toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses exact NO_REPLY followups without origin or dispatcher delivery", async () => {
+    const typing = createMockTypingController();
+    const onBlockReply = createAsyncReplySpy();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: `  ${DELIVERY_NO_REPLY_RUNTIME_CONTRACT.silentText}  ` }],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing,
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.originChannel,
+        originatingTo: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.originTo,
+      }),
+    );
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(typing.markRunComplete).toHaveBeenCalled();
+    expect(typing.markDispatchIdle).toHaveBeenCalled();
+  });
+
+  it("keeps NO_REPLY followups with media deliverable", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [
+          {
+            text: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.silentText,
+            mediaUrl: "file:///tmp/followup.png",
+          },
+        ],
+      },
+      queued: {
+        ...baseQueuedRun("webchat"),
+        originatingChannel: undefined,
+        originatingTo: undefined,
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.silentText,
+        mediaUrl: "file:///tmp/followup.png",
+      }),
+    );
+  });
+
+  it("falls back to dispatcher when successful output has no complete origin route", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [{ text: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.dispatcherText }] },
+      queued: {
+        ...baseQueuedRun("webchat"),
+        originatingChannel: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.originChannel,
+        originatingTo: undefined,
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: DELIVERY_NO_REPLY_RUNTIME_CONTRACT.dispatcherText }),
+    );
   });
 
   it("falls back to dispatcher when same-channel origin routing fails", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1069,7 +1069,7 @@ describe("createFollowupRunner bootstrap warning dedupe", () => {
   });
 });
 
-describe("createFollowupRunner messaging tool dedupe", () => {
+describe("createFollowupRunner messaging delivery and dedupe", () => {
   function createMessagingDedupeRunner(
     onBlockReply: (payload: unknown) => Promise<void>,
     overrides: Partial<{

--- a/test/helpers/agents/delivery-no-reply-runtime-contract.ts
+++ b/test/helpers/agents/delivery-no-reply-runtime-contract.ts
@@ -1,0 +1,12 @@
+export const DELIVERY_NO_REPLY_RUNTIME_CONTRACT = {
+  sessionId: "session-delivery-contract",
+  sessionKey: "agent:main:delivery-contract",
+  runId: "run-delivery-contract",
+  prompt: "deliver the follow-up contract turn",
+  originChannel: "discord",
+  originTo: "channel:C1",
+  dispatcherText: "visible dispatcher fallback",
+  visibleText: "visible follow-up",
+  silentText: "NO_REPLY",
+  jsonSilentText: '{"action":"NO_REPLY"}',
+} as const;


### PR DESCRIPTION
## Summary

Adds the delivery/NO_REPLY contract rung from RFC #71004. This is test-only: it locks currently-green follow-up delivery behavior for silent replies, dispatcher fallback, and Codex app-server preservation of silent terminal text. It also documents one known JSON-envelope delivery gap as a TODO for the later runtime-plan delivery migration.

No production delivery behavior changes in this PR.

```mermaid
flowchart TD
  Outcome["Agent payloads"] --> Delivery["OpenClaw delivery policy"]
  Delivery --> Silent["Exact/whitespace NO_REPLY suppresses visible delivery"]
  Delivery --> Media["NO_REPLY + media remains deliverable"]
  Delivery --> Dispatcher["Missing origin route falls back to dispatcher"]
  Delivery --> Todo["TODO: JSON NO_REPLY envelope suppression"]
  Codex["Codex app-server adapter"] --> Outcome
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/delivery-no-reply-runtime-contract.ts` | Shared NO_REPLY and delivery fixture data. |
| `src/auto-reply/reply/followup-runner.test.ts` | Follow-up runner delivery/suppression/fallback rows. |
| `extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts` | Codex terminal text preservation rows. |

## Contract Matrix

| Path | Covered behavior |
| --- | --- |
| Follow-up runner | Exact/whitespace `NO_REPLY` payloads do not route to origin or dispatcher and still clean up typing state. |
| Follow-up runner | `NO_REPLY` payloads with media remain deliverable instead of being suppressed as silent text. |
| Follow-up runner | Successful visible output with incomplete origin routing falls back to dispatcher. |
| Follow-up runner | Existing route-failure and provider-drop rows remain covered by the same focused shard. |
| Follow-up runner | JSON `NO_REPLY` envelope suppression is explicitly marked `todo`. |
| Codex app-server adapter | Exact, whitespace, and JSON `NO_REPLY` terminal text is preserved for shared delivery suppression instead of adapter-specific handling. |

## Known Red Row

| Future row | Why not green here |
| --- | --- |
| JSON/enveloped `NO_REPLY` suppression in follow-up delivery | Current production delivery suppresses exact text tokens only; behavior change belongs in `AgentRuntimePlan` delivery policy. |

## How This Helps The RuntimePlan Work

Delivery is OpenClaw-owned policy. Codex should preserve terminal content and side-channel state; the shared delivery layer should decide whether output is visible, silent, routed to origin, or routed to dispatcher.

## Reviewer Notes

- Test-only; no delivery code changes.
- The JSON `NO_REPLY` row is intentionally TODO, not forgotten.
- Captures the audit’s Bug 4 class without introducing more patch churn in follow-up routing.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/followup-runner.test.ts` — 28 passed, 1 todo
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/delivery-no-reply-runtime-contract.ts src/auto-reply/reply/followup-runner.test.ts extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/delivery-no-reply-runtime-contract.ts src/auto-reply/reply/followup-runner.test.ts extensions/codex/src/app-server/delivery-no-reply-runtime-contract.test.ts`

Refs #71004
Follows #71009
Follows #71029
Follows #71038
