### PR TITLE
fix(cron): mirror active-jobs mark/clear on startup catchup and manual run

### DIFF
--- a/src/cron/active-jobs-symmetry.test.ts
+++ b/src/cron/active-jobs-symmetry.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
+import { CronService } from "./service.js";
+import {
+  createDeferred,
+  setupCronServiceSuite,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-active-jobs-symmetry-",
+  baseTimeIso: "2025-12-13T17:00:00.000Z",
+});
+
+type IsolatedRunResult = Awaited<
+  ReturnType<NonNullable<ConstructorParameters<typeof CronService>[0]["runIsolatedAgentJob"]>>
+>;
+
+describe("cron activeJobIds — mark/clear symmetry across execution paths", () => {
+  beforeEach(() => {
+    resetCronActiveJobsForTests();
+  });
+
+  it("startup catchup marks the job active during execution and clears it on completion (#68157)", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2025-12-13T17:00:00.000Z");
+    const overdueAt = now - 60_000;
+
+    const jobs: CronJob[] = [
+      {
+        id: "catchup-isolated",
+        name: "catchup isolated",
+        enabled: true,
+        createdAtMs: overdueAt - 3_600_000,
+        updatedAtMs: overdueAt,
+        schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hi" },
+        delivery: { mode: "none" },
+        state: {
+          nextRunAtMs: overdueAt,
+        },
+      },
+    ];
+
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs });
+
+    const entered = createDeferred<void>();
+    const release = createDeferred<IsolatedRunResult>();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => {
+        entered.resolve();
+        return await release.promise;
+      },
+    });
+
+    try {
+      const startPromise = cron.start();
+
+      await entered.promise;
+
+      expect(isCronJobActive("catchup-isolated")).toBe(true);
+
+      release.resolve({ status: "ok", summary: "ok" });
+      await startPromise;
+
+      expect(isCronJobActive("catchup-isolated")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("manual run marks the job active during execution and clears it even when the inner throws (#68157)", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2025-12-13T17:00:00.000Z");
+    const futureNext = now + 3_600_000;
+
+    const jobs: CronJob[] = [
+      {
+        id: "manual-isolated",
+        name: "manual isolated",
+        enabled: true,
+        createdAtMs: now - 3_600_000,
+        updatedAtMs: now,
+        schedule: { kind: "cron", expr: "0 18 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hi" },
+        delivery: { mode: "none" },
+        state: {
+          nextRunAtMs: futureNext,
+        },
+      },
+    ];
+
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs });
+
+    const entered = createDeferred<void>();
+    const release = createDeferred<IsolatedRunResult>();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => {
+        entered.resolve();
+        return await release.promise;
+      },
+    });
+
+    try {
+      await cron.start();
+
+      const runPromise = cron.run("manual-isolated", "force");
+      await entered.promise;
+
+      expect(isCronJobActive("manual-isolated")).toBe(true);
+
+      release.reject(new Error("synthetic inner failure"));
+      await runPromise;
+
+      expect(isCronJobActive("manual-isolated")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -6,6 +6,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { createCronExecutionId } from "../run-id.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
@@ -643,6 +644,7 @@ async function prepareManualRun(
       job,
       startedAt: preflight.now,
     });
+    markCronJobActive(job.id);
     const executionJob = structuredClone(job);
     return {
       ok: true,
@@ -665,88 +667,92 @@ async function finishPreparedManualRun(
   const jobId = prepared.jobId;
   const taskRunId = prepared.taskRunId;
 
-  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
   try {
-    coreResult = await executeJobCoreWithTimeout(state, executionJob);
-  } catch (err) {
-    coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
-  }
-  const endedAt = state.deps.nowMs();
-  tryFinishManualTaskRun(state, {
-    taskRunId,
-    coreResult,
-    endedAt,
-  });
-
-  await locked(state, async () => {
-    await ensureLoaded(state, { skipRecompute: true });
-    const job = state.store?.jobs.find((entry) => entry.id === jobId);
-    if (!job) {
-      return;
+    let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
+    try {
+      coreResult = await executeJobCoreWithTimeout(state, executionJob);
+    } catch (err) {
+      coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }
+    const endedAt = state.deps.nowMs();
+    tryFinishManualTaskRun(state, {
+      taskRunId,
+      coreResult,
+      endedAt,
+    });
 
-    const shouldDelete = applyJobResult(
-      state,
-      job,
-      {
+    await locked(state, async () => {
+      await ensureLoaded(state, { skipRecompute: true });
+      const job = state.store?.jobs.find((entry) => entry.id === jobId);
+      if (!job) {
+        return;
+      }
+
+      const shouldDelete = applyJobResult(
+        state,
+        job,
+        {
+          status: coreResult.status,
+          error: coreResult.error,
+          delivered: coreResult.delivered,
+          startedAt,
+          endedAt,
+        },
+        { preserveSchedule: mode === "force" },
+      );
+
+      emit(state, {
+        jobId: job.id,
+        action: "finished",
         status: coreResult.status,
         error: coreResult.error,
+        summary: coreResult.summary,
         delivered: coreResult.delivered,
-        startedAt,
-        endedAt,
-      },
-      { preserveSchedule: mode === "force" },
-    );
+        deliveryStatus: job.state.lastDeliveryStatus,
+        deliveryError: job.state.lastDeliveryError,
+        delivery: coreResult.delivery,
+        sessionId: coreResult.sessionId,
+        sessionKey: coreResult.sessionKey,
+        runAtMs: startedAt,
+        durationMs: job.state.lastDurationMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+        model: coreResult.model,
+        provider: coreResult.provider,
+        usage: coreResult.usage,
+      });
 
-    emit(state, {
-      jobId: job.id,
-      action: "finished",
-      status: coreResult.status,
-      error: coreResult.error,
-      summary: coreResult.summary,
-      delivered: coreResult.delivered,
-      deliveryStatus: job.state.lastDeliveryStatus,
-      deliveryError: job.state.lastDeliveryError,
-      delivery: coreResult.delivery,
-      sessionId: coreResult.sessionId,
-      sessionKey: coreResult.sessionKey,
-      runAtMs: startedAt,
-      durationMs: job.state.lastDurationMs,
-      nextRunAtMs: job.state.nextRunAtMs,
-      model: coreResult.model,
-      provider: coreResult.provider,
-      usage: coreResult.usage,
+      if (shouldDelete && state.store) {
+        state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
+        emit(state, { jobId: job.id, action: "removed" });
+      }
+
+      // Manual runs should not advance other due jobs without executing them.
+      // Use maintenance-only recompute to repair missing values while
+      // preserving existing past-due nextRunAtMs entries for future timer ticks.
+      const postRunSnapshot = shouldDelete
+        ? null
+        : {
+            enabled: job.enabled,
+            updatedAtMs: job.updatedAtMs,
+            state: structuredClone(job.state),
+          };
+      const postRunRemoved = shouldDelete;
+      // Isolated Telegram send can persist target writeback directly to disk.
+      // Reload before final persist so manual `cron run` keeps those changes.
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      mergeManualRunSnapshotAfterReload({
+        state,
+        jobId,
+        snapshot: postRunSnapshot,
+        removed: postRunRemoved,
+      });
+      recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+      await persist(state);
+      armTimer(state);
     });
-
-    if (shouldDelete && state.store) {
-      state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
-      emit(state, { jobId: job.id, action: "removed" });
-    }
-
-    // Manual runs should not advance other due jobs without executing them.
-    // Use maintenance-only recompute to repair missing values while
-    // preserving existing past-due nextRunAtMs entries for future timer ticks.
-    const postRunSnapshot = shouldDelete
-      ? null
-      : {
-          enabled: job.enabled,
-          updatedAtMs: job.updatedAtMs,
-          state: structuredClone(job.state),
-        };
-    const postRunRemoved = shouldDelete;
-    // Isolated Telegram send can persist target writeback directly to disk.
-    // Reload before final persist so manual `cron run` keeps those changes.
-    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-    mergeManualRunSnapshotAfterReload({
-      state,
-      jobId,
-      snapshot: postRunSnapshot,
-      removed: postRunRemoved,
-    });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
-    await persist(state);
-    armTimer(state);
-  });
+  } finally {
+    clearCronJobActive(jobId);
+  }
 }
 
 export async function run(state: CronServiceState, id: string, mode?: "due" | "force") {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1051,6 +1051,7 @@ async function runStartupCatchupCandidate(
     startedAt,
   });
   emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
+  markCronJobActive(candidate.job.id);
   try {
     const result = await executeJobCoreWithTimeout(state, candidate.job);
     return {
@@ -1077,6 +1078,8 @@ async function runStartupCatchupCandidate(
       startedAt,
       endedAt: state.deps.nowMs(),
     };
+  } finally {
+    clearCronJobActive(candidate.job.id);
   }
 }
 


### PR DESCRIPTION
## Summary

- Problem: Upstream #60310 (7d1575b5df) wired `activeJobIds` mark/clear only into `runDueJob` and `executeJob`, leaving `runStartupCatchupCandidate` and `prepareManualRun`/`finishPreparedManualRun` uninstrumented. `task-registry.maintenance.ts:124-128`'s cron branch depends solely on `isCronJobActive`, so runs on those two paths are misclassified as `lost` after `TASK_RECONCILE_GRACE_MS` (5 min) while the cron service is still executing them.
- Why it matters: `DEFAULT_JOB_TIMEOUT_MS` is 10 min and cron isolated `agentTurn` emits no `recordTaskRunProgressByRunId` calls, so `lastEventAt` is pinned to `startedAt` and the 5-min grace is routinely exceeded. Affects startup catch-up on every gateway restart with missed jobs (up to `DEFAULT_MAX_MISSED_JOBS_PER_RESTART=5` per restart) and every `openclaw cron run <id>` / agent tool / UI manual run.
- What changed: Mirror the existing mark/clear pattern on the two missing paths inside `try/finally`. ~13 production lines + 1 import; 1 new test file with 2 regression tests.
- What did NOT change (scope boundary): `runDueJob` and `executeJob` paths are untouched; the `runningAtMs` persistence mechanism is not modified; cron does not register `tryRecoverTaskBeforeMarkLost` (deferred to a possible follow-up).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related #68157 — partially addresses the task-registry misclassification aspect described there; the `runningAtMs` persistence aspect is a separate state machine and is not touched by this PR.
- Related #68191 — independent broader proposal by @hclsys on the same general area.
- Related #69313 — introduced the `tryRecoverTaskBeforeMarkLost` hook infrastructure; this PR is complementary. See **Risks and Mitigations** below.
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Partial application of the #60310 (7d1575b5df) contract. The commit added `activeJobIds` + `markCronJobActive`/`clearCronJobActive` and taught `task-registry.maintenance.hasBackingSession` to depend solely on `isCronJobActive` for `runtime='cron'` (`task-registry.maintenance.ts:124-128`), but wired the mark/clear pair into only 2 of the 4 cron execution paths.
- Missing detection / guardrail: No test asserts the `activeJobIds` invariant at the cron layer across all execution paths. The existing `task-registry.maintenance.issue-60299.test.ts` stubs `isCronJobActive=true` directly on the consuming side, so a producing-side gap never surfaces there.
- Contributing context: isolated `agentTurn` has no `recordTaskRunProgressByRunId` emission, so `lastEventAt` never advances past `startedAt` — the 5-min grace compares against a frozen reference and expires deterministically while the underlying LLM round-trip is still running.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cron/active-jobs-symmetry.test.ts` (new).
- Scenario the test should lock in:
  1. Startup catch-up marks the cron job active during `runStartupCatchupCandidate` and clears it afterwards.
  2. Manual run marks during `prepareManualRun` and clears in `finishPreparedManualRun`'s `finally`, including when the inner execution throws.
- Why this is the smallest reliable guardrail: It drives the real `CronService.start()` / `cron.run()` entry points and uses the real `activeJobIds` singleton (via `resetCronActiveJobsForTests`). The only mock is `runIsolatedAgentJob`, which is a legitimate constructor-level dep and is replaced by a deferred promise so the test can observe the mid-flight invariant. No `isCronJobActive` stubbing, so the test cannot pass on a phantom branch.
- Existing test that already covers this: None — `task-registry.maintenance.issue-60299.test.ts:151-165` covers the consuming side (`isCronJobActive=true` => reconcile skipped) but never exercises the producing side across all four cron paths, which is where the partial-merge gap lives.

## User-visible / Behavior Changes

None. Internal contract completion only. Existing callers, return shapes, and events are unchanged; the only observable difference is that `isCronJobActive(jobId)` now returns `true` during `runStartupCatchupCandidate` and manual-run execution (matching the behaviour that already exists for `runDueJob` / `executeJob`).

## Diagram (if applicable)

\`\`\`text
Before (runStartupCatchupCandidate / manual run paths):
  ops.start  (or cron.run)
    -> runStartupCatchupCandidate  (or prepareManualRun+finishPreparedManualRun)
       -> executeJobCoreWithTimeout  [... running, 6-10 min ...]
       (activeJobIds never touched)
    -> task-registry maintenance tick (every ~60s)
       -> hasBackingSession(task) -> isCronJobActive(jobId) == false
       -> lastEventAt === startedAt; grace expires at 5 min
       -> markTaskLost   // mid-execution, misclassified

After:
  ops.start  (or cron.run)
    -> runStartupCatchupCandidate  (or prepareManualRun+finishPreparedManualRun)
       markCronJobActive(jobId)
       try { executeJobCoreWithTimeout } finally { clearCronJobActive(jobId) }
    -> task-registry maintenance tick
       -> hasBackingSession(task) -> isCronJobActive(jobId) == true
       -> reconcile skipped while the run is live
\`\`\`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.4 (darwin 25.4.0)
- Runtime/container: local `pnpm` workspace on `upstream/main` at `b7fba2100f`
- Model/provider: N/A (unit-level regression)
- Integration/channel (if any): N/A
- Relevant config (redacted): default cron config

### Steps

1. Check out `upstream/main` and copy `src/cron/active-jobs-symmetry.test.ts` from this PR only.
2. Run \`pnpm exec vitest run --config test/vitest/vitest.cron.config.ts src/cron/active-jobs-symmetry.test.ts\` — both tests fail at the \`expect(isCronJobActive(...)).toBe(true)\` assertions (startup catch-up and manual run).
3. Apply the production changes in this PR and rerun — both tests pass.
4. Also run \`pnpm exec vitest run src/tasks/task-registry.maintenance.issue-60299.test.ts\` — 5/5 green, no regression.

### Expected

- Pre-fix: `active-jobs-symmetry.test.ts` 2/2 fail.
- Post-fix: `active-jobs-symmetry.test.ts` 2/2 green; `task-registry.maintenance.issue-60299.test.ts` 5/5 green; full cron vitest scope (79 files / 665 tests) green.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after

Pre-fix run on `upstream/main` plus the new test file alone:

\`\`\`
FAIL  |cron| src/cron/active-jobs-symmetry.test.ts > ... > startup catchup marks the job active during execution and clears it on completion
AssertionError: expected false to be true
  ❯ src/cron/active-jobs-symmetry.test.ts
  ❯ expect(isCronJobActive("catchup-isolated")).toBe(true);

FAIL  |cron| src/cron/active-jobs-symmetry.test.ts > ... > manual run marks the job active during execution and clears it even when the inner throws
AssertionError: expected false to be true

Test Files  1 failed (1)
     Tests  2 failed (2)
\`\`\`

Post-fix:

\`\`\`
Test Files  1 passed (1)
     Tests  2 passed (2)
\`\`\`

Cron suite (post-fix):

\`\`\`
Test Files  79 passed (79)
     Tests  665 passed (665)
\`\`\`

## Human Verification (required)

- Verified scenarios: pre-fix `active-jobs-symmetry.test.ts` failing on the two asserts; post-fix the same file green; post-fix `task-registry.maintenance.issue-60299.test.ts` green (5/5); post-fix full cron vitest scope green (79 files / 665 tests); `pnpm tsgo:all` green; `pnpm check` exit 0; `pnpm build` exit 0.
- Edge cases checked: mark-after-early-return — `prepareManualRun` returns `ran:false` for every preflight bail-out (`invalid-spec`, `already-running`, `not-due`) before reaching `markCronJobActive`, so `finishPreparedManualRun` is only called when the mark was set; the outer `try/finally` guarantees the clear even when `tryFinishManualTaskRun` or the `locked` block throws. Thrown-inner path — `executeJobCoreWithTimeout` failures are already captured into `{ status: "error" }` inside the inner `try`; the second regression test directly exercises the thrown-inner path with a rejecting deferred promise.
- What you did **not** verify: end-to-end behaviour against a live task-registry sweeper in a running gateway (the test asserts the cron-layer invariant directly; the consuming side is already covered by `task-registry.maintenance.issue-60299.test.ts`). Also did not run the scenario against a real long-running production LLM `agentTurn` (no live model invocation).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A future fifth cron execution path could be added without mark/clear, recreating the same partial-merge gap.
  - Mitigation: `active-jobs-symmetry.test.ts` now asserts the invariant across the startup-catch-up and manual-run paths. A refactor that drops mark/clear from `runDueJob` or `executeJob`, or adds a new execution path without mark/clear, would need an explicit decision about whether to extend the symmetry test, making the contract visible.
- Risk: Architecture redirection. PR #69313 introduced the `tryRecoverTaskBeforeMarkLost` hook infrastructure and maintainers may prefer that direction over direct injection.
  - Mitigation: Registering the hook alone would not close this gap — the recover callback would still need an alive-signal source, which is exactly what `activeJobIds` provides. This PR completes the existing `activeJobIds` contract; registering the hook for cross-runtime parity is a natural follow-up if that is the preferred long-term direction.

[AI-assisted]