### PR TITLE
[codex] Add transcript repair runtime contracts

### DIFF
--- a/extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantHistoryMessage,
+  currentPromptHistoryMessage,
+  mediaOnlyHistoryMessage,
+  structuredHistoryMessage,
+} from "../../../../test/helpers/agents/transcript-repair-runtime-contract.js";
+import { projectContextEngineAssemblyForCodex } from "./context-engine-projection.js";
+
+describe("Codex transcript projection runtime contract", () => {
+  it("drops only the duplicate trailing current prompt while preserving prior structured context", () => {
+    const prompt = "newest inbound message";
+
+    const result = projectContextEngineAssemblyForCodex({
+      prompt,
+      originalHistoryMessages: [structuredHistoryMessage()],
+      assembledMessages: [
+        structuredHistoryMessage(),
+        assistantHistoryMessage(),
+        currentPromptHistoryMessage(prompt),
+      ],
+    });
+
+    expect(result.promptText).toContain("Current user request:\nnewest inbound message");
+    expect(result.promptText).toContain("[user]\nolder structured context\n[image omitted]");
+    expect(result.promptText).toContain("[assistant]\nack");
+    expect(result.promptText).not.toContain("[user]\nnewest inbound message");
+  });
+
+  it("keeps media-only user history visible as omitted media instead of dropping the turn", () => {
+    const result = projectContextEngineAssemblyForCodex({
+      prompt: "newest inbound message",
+      originalHistoryMessages: [mediaOnlyHistoryMessage()],
+      assembledMessages: [
+        mediaOnlyHistoryMessage(),
+        currentPromptHistoryMessage("newest inbound message"),
+      ],
+    });
+
+    expect(result.promptText).toContain("[user]\n[image omitted]");
+    expect(result.promptText).not.toContain("data:image/png");
+    expect(result.promptText).not.toContain("bbbb");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts
+++ b/src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  inlineDataUriOrphanLeaf,
+  QUEUED_USER_MESSAGE_MARKER,
+  structuredOrphanLeaf,
+  textOrphanLeaf,
+} from "../../../../test/helpers/agents/transcript-repair-runtime-contract.js";
+import { mergeOrphanedTrailingUserPrompt } from "./attempt.prompt-helpers.js";
+import {
+  DEFAULT_MESSAGE_MERGE_STRATEGY_ID,
+  registerMessageMergeStrategyForTest,
+  resolveMessageMergeStrategy,
+} from "./message-merge-strategy.js";
+
+let restoreStrategy: (() => void) | undefined;
+
+afterEach(() => {
+  restoreStrategy?.();
+  restoreStrategy = undefined;
+});
+
+describe("Pi transcript repair runtime contract", () => {
+  it("merges text orphan leaves into the next prompt with the queued marker", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: textOrphanLeaf(),
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt: `${QUEUED_USER_MESSAGE_MARKER}\nolder active-turn message\n\nnewest inbound message`,
+    });
+  });
+
+  it("does not duplicate an orphan leaf that is already present in the next prompt", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "summary\nolder active-turn message\nnewest inbound message",
+      trigger: "user",
+      leafMessage: textOrphanLeaf(),
+    });
+
+    expect(result).toEqual({
+      merged: false,
+      removeLeaf: true,
+      prompt: "summary\nolder active-turn message\nnewest inbound message",
+    });
+  });
+
+  it("preserves structured text and media references before removing the leaf", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: structuredOrphanLeaf(),
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt:
+        `${QUEUED_USER_MESSAGE_MARKER}\n` +
+        "please inspect this\n" +
+        "[image_url] https://example.test/cat.png\n" +
+        "[input_audio] https://example.test/cat.wav\n\n" +
+        "newest inbound message",
+    });
+  });
+
+  it("summarizes inline data URI media instead of embedding payload bytes", () => {
+    const result = mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: inlineDataUriOrphanLeaf(),
+    });
+
+    expect(result.merged).toBe(true);
+    expect(result.removeLeaf).toBe(true);
+    expect(result.prompt).toContain("please inspect this inline image");
+    expect(result.prompt).toContain("[image_url] inline data URI (image/png, 4118 chars)");
+    expect(result.prompt).not.toContain("base64");
+    expect(result.prompt).not.toContain("aaaa");
+  });
+
+  it("exposes transcript repair through the active message merge strategy", () => {
+    const strategy = resolveMessageMergeStrategy();
+    const result = strategy.mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "manual",
+      leafMessage: textOrphanLeaf("queued via strategy"),
+    });
+
+    expect(strategy.id).toBe("orphan-trailing-user-prompt");
+    expect(result).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt: `${QUEUED_USER_MESSAGE_MARKER}\nqueued via strategy\n\nnewest inbound message`,
+    });
+  });
+
+  it("allows the active transcript repair strategy to be replaced for adapter contracts", () => {
+    const mergeOrphanedTrailingUserPrompt = vi.fn((params: { prompt: string }) => ({
+      prompt: `custom strategy: ${params.prompt}`,
+      merged: false,
+      removeLeaf: false,
+    }));
+
+    restoreStrategy = registerMessageMergeStrategyForTest({
+      id: DEFAULT_MESSAGE_MERGE_STRATEGY_ID,
+      mergeOrphanedTrailingUserPrompt,
+    });
+
+    const result = resolveMessageMergeStrategy().mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "manual",
+      leafMessage: textOrphanLeaf("queued via custom strategy"),
+    });
+
+    expect(mergeOrphanedTrailingUserPrompt).toHaveBeenCalledWith({
+      prompt: "newest inbound message",
+      trigger: "manual",
+      leafMessage: textOrphanLeaf("queued via custom strategy"),
+    });
+    expect(result).toEqual({
+      merged: false,
+      removeLeaf: false,
+      prompt: "custom strategy: newest inbound message",
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts
+++ b/src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts
@@ -78,7 +78,8 @@ describe("Pi transcript repair runtime contract", () => {
     expect(result.removeLeaf).toBe(true);
     expect(result.prompt).toContain("please inspect this inline image");
     expect(result.prompt).toContain("[image_url] inline data URI (image/png, 4118 chars)");
-    expect(result.prompt).not.toContain("base64");
+    expect(result.prompt).not.toContain("data:");
+    expect(result.prompt).not.toContain("data:image/png;base64,");
     expect(result.prompt).not.toContain("aaaa");
   });
 
@@ -99,7 +100,7 @@ describe("Pi transcript repair runtime contract", () => {
   });
 
   it("allows the active transcript repair strategy to be replaced for adapter contracts", () => {
-    const mergeOrphanedTrailingUserPrompt = vi.fn((params: { prompt: string }) => ({
+    const mergeOrphanedTrailingUserPromptSpy = vi.fn((params: { prompt: string }) => ({
       prompt: `custom strategy: ${params.prompt}`,
       merged: false,
       removeLeaf: false,
@@ -107,7 +108,7 @@ describe("Pi transcript repair runtime contract", () => {
 
     restoreStrategy = registerMessageMergeStrategyForTest({
       id: DEFAULT_MESSAGE_MERGE_STRATEGY_ID,
-      mergeOrphanedTrailingUserPrompt,
+      mergeOrphanedTrailingUserPrompt: mergeOrphanedTrailingUserPromptSpy,
     });
 
     const result = resolveMessageMergeStrategy().mergeOrphanedTrailingUserPrompt({
@@ -116,7 +117,7 @@ describe("Pi transcript repair runtime contract", () => {
       leafMessage: textOrphanLeaf("queued via custom strategy"),
     });
 
-    expect(mergeOrphanedTrailingUserPrompt).toHaveBeenCalledWith({
+    expect(mergeOrphanedTrailingUserPromptSpy).toHaveBeenCalledWith({
       prompt: "newest inbound message",
       trigger: "manual",
       leafMessage: textOrphanLeaf("queued via custom strategy"),

--- a/test/helpers/agents/transcript-repair-runtime-contract.ts
+++ b/test/helpers/agents/transcript-repair-runtime-contract.ts
@@ -29,7 +29,7 @@ export function inlineDataUriOrphanLeaf(): { content: unknown[] } {
 export function mediaOnlyHistoryMessage(): AgentMessage {
   return {
     role: "user",
-    content: [{ type: "image", url: `data:image/png;base64,${"b".repeat(2048)}` }],
+    content: [{ type: "image", data: "b".repeat(2048), mimeType: "image/png" }],
     timestamp: 1,
   } as AgentMessage;
 }
@@ -39,7 +39,7 @@ export function structuredHistoryMessage(): AgentMessage {
     role: "user",
     content: [
       { type: "text", text: "older structured context" },
-      { type: "image", url: "https://example.test/context.png" },
+      { type: "image", data: "c".repeat(64), mimeType: "image/png" },
     ],
     timestamp: 1,
   } as AgentMessage;

--- a/test/helpers/agents/transcript-repair-runtime-contract.ts
+++ b/test/helpers/agents/transcript-repair-runtime-contract.ts
@@ -1,0 +1,62 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export const QUEUED_USER_MESSAGE_MARKER =
+  "[Queued user message that arrived while the previous turn was still active]";
+
+export function textOrphanLeaf(text = "older active-turn message"): { content: string } {
+  return { content: text };
+}
+
+export function structuredOrphanLeaf(): { content: unknown[] } {
+  return {
+    content: [
+      { type: "text", text: "please inspect this" },
+      { type: "image_url", image_url: { url: "https://example.test/cat.png" } },
+      { type: "input_audio", audio_url: "https://example.test/cat.wav" },
+    ],
+  };
+}
+
+export function inlineDataUriOrphanLeaf(): { content: unknown[] } {
+  return {
+    content: [
+      { type: "text", text: "please inspect this inline image" },
+      { type: "image_url", image_url: { url: `data:image/png;base64,${"a".repeat(4096)}` } },
+    ],
+  };
+}
+
+export function mediaOnlyHistoryMessage(): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "image", url: `data:image/png;base64,${"b".repeat(2048)}` }],
+    timestamp: 1,
+  } as AgentMessage;
+}
+
+export function structuredHistoryMessage(): AgentMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: "older structured context" },
+      { type: "image", url: "https://example.test/context.png" },
+    ],
+    timestamp: 1,
+  } as AgentMessage;
+}
+
+export function currentPromptHistoryMessage(prompt: string): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: prompt }],
+    timestamp: 2,
+  } as AgentMessage;
+}
+
+export function assistantHistoryMessage(text = "ack"): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: 2,
+  } as AgentMessage;
+}


### PR DESCRIPTION
## Summary

Adds the transcript-repair contract rung from RFC #71004. This is test-only: it does not change Pi runtime behavior, Codex app-server behavior, or production transcript repair code.

```mermaid
flowchart TD
  UserTurn["Queued user turn"] --> TranscriptPolicy["OpenClaw transcript repair contract"]
  TranscriptPolicy --> PiMerge["Pi orphan user merge strategy"]
  TranscriptPolicy --> CodexProjection["Codex context projection"]
  PiMerge --> PreparedPrompt["Prepared prompt keeps older user content"]
  CodexProjection --> QuotedContext["Quoted context keeps prior structured/media turns"]
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/transcript-repair-runtime-contract.ts` | Shared text/structured/media/data-URI transcript fixtures. |
| `src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts` | Pi orphan repair and strategy-seam contract rows. |
| `extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts` | Codex projection rows for preserving prior structured/media context. |

## Contract Matrix

| Surface | Contract rows |
| --- | --- |
| Pi orphan repair | Text orphan leaf is merged with the queued-user marker. |
| Pi orphan repair | Already-present orphan text is not duplicated. |
| Pi orphan repair | Structured text + media references survive before leaf removal. |
| Pi orphan repair | Inline data URI media is summarized, not embedded into prompt bytes. |
| Pi strategy seam | Active message merge strategy is the single dispatch point and can be replaced for adapter tests. |
| Codex projection | Duplicate trailing current prompt is dropped, while prior structured context remains visible. |
| Codex projection | Media-only prior user history remains represented as omitted media, without data URI bytes. |

## Known Boundary

Codex coverage is projection-only in this phase. A shared Codex transcript repair strategy belongs in `AgentRuntimePlan` consumption, not in this test-only PR.

## How This Helps The RuntimePlan Work

Transcript repair is OpenClaw-owned policy. These fixtures make payload-shape behavior explicit before the plan centralizes text, structured content, media, and data URI handling.

## Reviewer Notes

- Test-only; no runner rename or transcript code refactor.
- Captures the audit’s Bug 3 class by making structured/media preservation executable.
- The Codex side proves current adapter projection behavior, not final shared repair ownership.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/transcript-repair-runtime-contract.ts src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/transcript-repair-runtime-contract.ts src/agents/pi-embedded-runner/run/transcript-repair-runtime-contract.test.ts extensions/codex/src/app-server/transcript-repair-runtime-contract.test.ts`

Refs #71004
Follows #71009, #71029, #71038, #71039
