### PR TITLE
[codex] Add prompt overlay runtime contracts

### DIFF
--- a/extensions/codex/prompt-overlay-runtime-contract.test.ts
+++ b/extensions/codex/prompt-overlay-runtime-contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_CONTRACT_PROVIDER_ID,
+  GPT5_CONTRACT_MODEL_ID,
+  NON_GPT5_CONTRACT_MODEL_ID,
+  openAiPluginPersonalityConfig,
+  sharedGpt5PersonalityConfig,
+} from "../../test/helpers/agents/prompt-overlay-runtime-contract.js";
+import { buildCodexProvider } from "./provider.js";
+
+describe("Codex prompt overlay runtime contract", () => {
+  it("adds the shared GPT-5 behavior contract to Codex GPT-5 provider runs", () => {
+    const provider = buildCodexProvider();
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: CODEX_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+    } as never);
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides?.interaction_style).toContain(
+      "This is a live chat, not a memo.",
+    );
+  });
+
+  it("respects shared GPT-5 prompt overlay config for Codex runs", () => {
+    const provider = buildCodexProvider();
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: CODEX_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+      config: sharedGpt5PersonalityConfig("off"),
+    } as never);
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides).toEqual({});
+  });
+
+  it("keeps OpenAI plugin personality fallback available to Codex GPT-5 provider runs", () => {
+    const provider = buildCodexProvider();
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: CODEX_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+      config: openAiPluginPersonalityConfig("off"),
+    } as never);
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides).toEqual({});
+  });
+
+  it("does not add the shared GPT-5 overlay to non-GPT-5 Codex provider runs", () => {
+    const provider = buildCodexProvider();
+
+    expect(
+      provider.resolveSystemPromptContribution?.({
+        provider: CODEX_CONTRACT_PROVIDER_ID,
+        modelId: NON_GPT5_CONTRACT_MODEL_ID,
+      } as never),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/codex/prompt-overlay-runtime-contract.test.ts
+++ b/extensions/codex/prompt-overlay-runtime-contract.test.ts
@@ -3,7 +3,6 @@ import {
   CODEX_CONTRACT_PROVIDER_ID,
   GPT5_CONTRACT_MODEL_ID,
   NON_GPT5_CONTRACT_MODEL_ID,
-  openAiPluginPersonalityConfig,
   sharedGpt5PersonalityConfig,
 } from "../../test/helpers/agents/prompt-overlay-runtime-contract.js";
 import { buildCodexProvider } from "./provider.js";
@@ -28,18 +27,6 @@ describe("Codex prompt overlay runtime contract", () => {
       provider: CODEX_CONTRACT_PROVIDER_ID,
       modelId: GPT5_CONTRACT_MODEL_ID,
       config: sharedGpt5PersonalityConfig("off"),
-    } as never);
-
-    expect(contribution?.stablePrefix).toContain("<persona_latch>");
-    expect(contribution?.sectionOverrides).toEqual({});
-  });
-
-  it("keeps OpenAI plugin personality fallback available to Codex GPT-5 provider runs", () => {
-    const provider = buildCodexProvider();
-    const contribution = provider.resolveSystemPromptContribution?.({
-      provider: CODEX_CONTRACT_PROVIDER_ID,
-      modelId: GPT5_CONTRACT_MODEL_ID,
-      config: openAiPluginPersonalityConfig("off"),
     } as never);
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");

--- a/extensions/codex/prompt-overlay-runtime-contract.test.ts
+++ b/extensions/codex/prompt-overlay-runtime-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  CODEX_CONTRACT_PROVIDER_ID,
+  codexPromptOverlayContext,
   GPT5_CONTRACT_MODEL_ID,
   NON_GPT5_CONTRACT_MODEL_ID,
   sharedGpt5PersonalityConfig,
@@ -10,10 +10,9 @@ import { buildCodexProvider } from "./provider.js";
 describe("Codex prompt overlay runtime contract", () => {
   it("adds the shared GPT-5 behavior contract to Codex GPT-5 provider runs", () => {
     const provider = buildCodexProvider();
-    const contribution = provider.resolveSystemPromptContribution?.({
-      provider: CODEX_CONTRACT_PROVIDER_ID,
-      modelId: GPT5_CONTRACT_MODEL_ID,
-    } as never);
+    const contribution = provider.resolveSystemPromptContribution?.(
+      codexPromptOverlayContext({ modelId: GPT5_CONTRACT_MODEL_ID }),
+    );
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
     expect(contribution?.sectionOverrides?.interaction_style).toContain(
@@ -23,11 +22,12 @@ describe("Codex prompt overlay runtime contract", () => {
 
   it("respects shared GPT-5 prompt overlay config for Codex runs", () => {
     const provider = buildCodexProvider();
-    const contribution = provider.resolveSystemPromptContribution?.({
-      provider: CODEX_CONTRACT_PROVIDER_ID,
-      modelId: GPT5_CONTRACT_MODEL_ID,
-      config: sharedGpt5PersonalityConfig("off"),
-    } as never);
+    const contribution = provider.resolveSystemPromptContribution?.(
+      codexPromptOverlayContext({
+        modelId: GPT5_CONTRACT_MODEL_ID,
+        config: sharedGpt5PersonalityConfig("off"),
+      }),
+    );
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
     expect(contribution?.sectionOverrides).toEqual({});
@@ -37,10 +37,9 @@ describe("Codex prompt overlay runtime contract", () => {
     const provider = buildCodexProvider();
 
     expect(
-      provider.resolveSystemPromptContribution?.({
-        provider: CODEX_CONTRACT_PROVIDER_ID,
-        modelId: NON_GPT5_CONTRACT_MODEL_ID,
-      } as never),
+      provider.resolveSystemPromptContribution?.(
+        codexPromptOverlayContext({ modelId: NON_GPT5_CONTRACT_MODEL_ID }),
+      ),
     ).toBeUndefined();
   });
 });

--- a/src/agents/prompt-overlay-runtime-contract.test.ts
+++ b/src/agents/prompt-overlay-runtime-contract.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GPT5_CONTRACT_MODEL_ID,
+  GPT5_PREFIXED_CONTRACT_MODEL_ID,
+  NON_GPT5_CONTRACT_MODEL_ID,
+  NON_OPENAI_CONTRACT_PROVIDER_ID,
+  OPENAI_CODEX_CONTRACT_PROVIDER_ID,
+  OPENAI_CONTRACT_PROVIDER_ID,
+  openAiPluginPersonalityConfig,
+  sharedGpt5PersonalityConfig,
+} from "../../test/helpers/agents/prompt-overlay-runtime-contract.js";
+import { resolveGpt5SystemPromptContribution } from "./gpt5-prompt-overlay.js";
+
+describe("GPT-5 prompt overlay runtime contract", () => {
+  const resolveContribution = vi.fn(resolveGpt5SystemPromptContribution);
+
+  it("adds the behavior contract and friendly style to OpenAI-family GPT-5 models by default", () => {
+    const contribution = resolveContribution({
+      providerId: OPENAI_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+    });
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides?.interaction_style).toContain(
+      "This is a live chat, not a memo.",
+    );
+  });
+
+  it("lets the shared GPT-5 overlay config disable friendly style without removing the behavior contract", () => {
+    const contribution = resolveContribution({
+      providerId: NON_OPENAI_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_PREFIXED_CONTRACT_MODEL_ID,
+      config: sharedGpt5PersonalityConfig("off"),
+    });
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides).toEqual({});
+  });
+
+  it("scopes OpenAI plugin personality fallback to OpenAI-family GPT-5 providers", () => {
+    const openAiContribution = resolveContribution({
+      providerId: OPENAI_CODEX_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+      config: openAiPluginPersonalityConfig("off"),
+    });
+    const nonOpenAiContribution = resolveContribution({
+      providerId: NON_OPENAI_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_PREFIXED_CONTRACT_MODEL_ID,
+      config: openAiPluginPersonalityConfig("off"),
+    });
+
+    expect(openAiContribution?.stablePrefix).toContain("<persona_latch>");
+    expect(openAiContribution?.sectionOverrides).toEqual({});
+    expect(nonOpenAiContribution?.stablePrefix).toContain("<persona_latch>");
+    expect(nonOpenAiContribution?.sectionOverrides?.interaction_style).toContain(
+      "This is a live chat, not a memo.",
+    );
+  });
+
+  it("does not apply GPT-5 overlays to non-GPT-5 models", () => {
+    expect(
+      resolveContribution({
+        providerId: OPENAI_CONTRACT_PROVIDER_ID,
+        modelId: NON_GPT5_CONTRACT_MODEL_ID,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/prompt-overlay-runtime-contract.test.ts
+++ b/src/agents/prompt-overlay-runtime-contract.test.ts
@@ -4,6 +4,7 @@ import {
   GPT5_PREFIXED_CONTRACT_MODEL_ID,
   NON_GPT5_CONTRACT_MODEL_ID,
   NON_OPENAI_CONTRACT_PROVIDER_ID,
+  CODEX_CONTRACT_PROVIDER_ID,
   OPENAI_CODEX_CONTRACT_PROVIDER_ID,
   OPENAI_CONTRACT_PROVIDER_ID,
   openAiPluginPersonalityConfig,
@@ -55,6 +56,17 @@ describe("GPT-5 prompt overlay runtime contract", () => {
     expect(nonOpenAiContribution?.sectionOverrides?.interaction_style).toContain(
       "This is a live chat, not a memo.",
     );
+  });
+
+  it("keeps Codex virtual providers in the OpenAI-family personality fallback scope", () => {
+    const contribution = resolveContribution({
+      providerId: CODEX_CONTRACT_PROVIDER_ID,
+      modelId: GPT5_CONTRACT_MODEL_ID,
+      config: openAiPluginPersonalityConfig("off"),
+    });
+
+    expect(contribution?.stablePrefix).toContain("<persona_latch>");
+    expect(contribution?.sectionOverrides).toEqual({});
   });
 
   it("does not apply GPT-5 overlays to non-GPT-5 models", () => {

--- a/src/agents/prompt-overlay-runtime-contract.test.ts
+++ b/src/agents/prompt-overlay-runtime-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   GPT5_CONTRACT_MODEL_ID,
   GPT5_PREFIXED_CONTRACT_MODEL_ID,
@@ -13,10 +13,8 @@ import {
 import { resolveGpt5SystemPromptContribution } from "./gpt5-prompt-overlay.js";
 
 describe("GPT-5 prompt overlay runtime contract", () => {
-  const resolveContribution = vi.fn(resolveGpt5SystemPromptContribution);
-
   it("adds the behavior contract and friendly style to OpenAI-family GPT-5 models by default", () => {
-    const contribution = resolveContribution({
+    const contribution = resolveGpt5SystemPromptContribution({
       providerId: OPENAI_CONTRACT_PROVIDER_ID,
       modelId: GPT5_CONTRACT_MODEL_ID,
     });
@@ -28,7 +26,7 @@ describe("GPT-5 prompt overlay runtime contract", () => {
   });
 
   it("lets the shared GPT-5 overlay config disable friendly style without removing the behavior contract", () => {
-    const contribution = resolveContribution({
+    const contribution = resolveGpt5SystemPromptContribution({
       providerId: NON_OPENAI_CONTRACT_PROVIDER_ID,
       modelId: GPT5_PREFIXED_CONTRACT_MODEL_ID,
       config: sharedGpt5PersonalityConfig("off"),
@@ -39,12 +37,12 @@ describe("GPT-5 prompt overlay runtime contract", () => {
   });
 
   it("scopes OpenAI plugin personality fallback to OpenAI-family GPT-5 providers", () => {
-    const openAiContribution = resolveContribution({
+    const openAiContribution = resolveGpt5SystemPromptContribution({
       providerId: OPENAI_CODEX_CONTRACT_PROVIDER_ID,
       modelId: GPT5_CONTRACT_MODEL_ID,
       config: openAiPluginPersonalityConfig("off"),
     });
-    const nonOpenAiContribution = resolveContribution({
+    const nonOpenAiContribution = resolveGpt5SystemPromptContribution({
       providerId: NON_OPENAI_CONTRACT_PROVIDER_ID,
       modelId: GPT5_PREFIXED_CONTRACT_MODEL_ID,
       config: openAiPluginPersonalityConfig("off"),
@@ -59,7 +57,7 @@ describe("GPT-5 prompt overlay runtime contract", () => {
   });
 
   it("keeps Codex virtual providers in the OpenAI-family personality fallback scope", () => {
-    const contribution = resolveContribution({
+    const contribution = resolveGpt5SystemPromptContribution({
       providerId: CODEX_CONTRACT_PROVIDER_ID,
       modelId: GPT5_CONTRACT_MODEL_ID,
       config: openAiPluginPersonalityConfig("off"),
@@ -71,7 +69,7 @@ describe("GPT-5 prompt overlay runtime contract", () => {
 
   it("does not apply GPT-5 overlays to non-GPT-5 models", () => {
     expect(
-      resolveContribution({
+      resolveGpt5SystemPromptContribution({
         providerId: OPENAI_CONTRACT_PROVIDER_ID,
         modelId: NON_GPT5_CONTRACT_MODEL_ID,
       }),

--- a/test/helpers/agents/prompt-overlay-runtime-contract.ts
+++ b/test/helpers/agents/prompt-overlay-runtime-contract.ts
@@ -1,0 +1,33 @@
+import type { OpenClawConfig } from "../../../src/config/types.openclaw.js";
+
+export const GPT5_CONTRACT_MODEL_ID = "gpt-5.4";
+export const GPT5_PREFIXED_CONTRACT_MODEL_ID = "openai/gpt-5.4";
+export const NON_GPT5_CONTRACT_MODEL_ID = "gpt-4.1";
+export const OPENAI_CONTRACT_PROVIDER_ID = "openai";
+export const OPENAI_CODEX_CONTRACT_PROVIDER_ID = "openai-codex";
+export const CODEX_CONTRACT_PROVIDER_ID = "codex";
+export const NON_OPENAI_CONTRACT_PROVIDER_ID = "openrouter";
+
+export function openAiPluginPersonalityConfig(personality: "friendly" | "off"): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        openai: {
+          config: { personality },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+export function sharedGpt5PersonalityConfig(personality: "friendly" | "off"): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        promptOverlays: {
+          gpt5: { personality },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}

--- a/test/helpers/agents/prompt-overlay-runtime-contract.ts
+++ b/test/helpers/agents/prompt-overlay-runtime-contract.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../../src/config/types.openclaw.js";
+import type { ProviderSystemPromptContributionContext } from "../../../src/plugins/types.js";
 
 export const GPT5_CONTRACT_MODEL_ID = "gpt-5.4";
 export const GPT5_PREFIXED_CONTRACT_MODEL_ID = "openai/gpt-5.4";
@@ -17,7 +18,7 @@ export function openAiPluginPersonalityConfig(personality: "friendly" | "off"): 
         },
       },
     },
-  } as OpenClawConfig;
+  } satisfies OpenClawConfig;
 }
 
 export function sharedGpt5PersonalityConfig(personality: "friendly" | "off"): OpenClawConfig {
@@ -29,5 +30,19 @@ export function sharedGpt5PersonalityConfig(personality: "friendly" | "off"): Op
         },
       },
     },
-  } as OpenClawConfig;
+  } satisfies OpenClawConfig;
+}
+
+export function codexPromptOverlayContext(params?: {
+  modelId?: string;
+  config?: OpenClawConfig;
+}): ProviderSystemPromptContributionContext {
+  return {
+    provider: CODEX_CONTRACT_PROVIDER_ID,
+    modelId: params?.modelId ?? GPT5_CONTRACT_MODEL_ID,
+    promptMode: "full",
+    agentDir: "/tmp/openclaw-codex-prompt-contract-agent",
+    workspaceDir: "/tmp/openclaw-codex-prompt-contract-workspace",
+    ...(params?.config ? { config: params.config } : {}),
+  };
 }


### PR DESCRIPTION
## Summary

Adds the prompt-overlay contract rung from RFC #71004. This is test-only: no production prompt, provider runtime, Pi runner, or Codex app-server behavior changes.

```mermaid
flowchart TD
  ModelRef["Resolved provider/model"] --> OverlayContract["OpenClaw GPT-5 prompt overlay contract"]
  OverlayContract --> SharedConfig["agents.defaults.promptOverlays.gpt5"]
  OverlayContract --> OpenAIPlugin["OpenAI-family plugin personality fallback"]
  OverlayContract --> CoreResolver["Core GPT-5 overlay resolver"]
  OverlayContract --> CodexProvider["Codex provider contribution surface"]
  CoreResolver --> PromptBundle["Behavior contract + optional interaction style"]
  CodexProvider --> PromptBundle
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/prompt-overlay-runtime-contract.ts` | Shared config/model fixtures for GPT-5 overlay decisions. |
| `src/agents/prompt-overlay-runtime-contract.test.ts` | Core resolver provider-scope rows. |
| `extensions/codex/prompt-overlay-runtime-contract.test.ts` | Codex provider contribution surface rows. |

## Contract Matrix

| Surface | Contract rows |
| --- | --- |
| Core GPT-5 overlay resolver | OpenAI-family GPT-5 models get the behavior contract and friendly interaction style by default. |
| Core GPT-5 overlay resolver | Shared `agents.defaults.promptOverlays.gpt5.personality = off` disables friendly style but preserves behavior contract. |
| Core GPT-5 overlay resolver | `plugins.entries.openai.config.personality` fallback affects OpenAI-family GPT-5 providers but does not leak to non-OpenAI GPT-5 providers. |
| Core GPT-5 overlay resolver | Codex virtual providers are explicitly in the OpenAI-family personality fallback scope. |
| Core GPT-5 overlay resolver | Non-GPT-5 models do not receive GPT-5 overlays. |
| Codex provider contribution surface | Codex GPT-5 provider runs consume the shared GPT-5 behavior contract. |
| Codex provider contribution surface | Codex respects shared GPT-5 overlay config. |
| Codex provider contribution surface | Non-GPT-5 Codex provider runs do not receive GPT-5 overlays. |

## How This Helps The RuntimePlan Work

Prompt overlays are OpenClaw-owned policy. The plan should compute overlay chains once and hand them to whichever adapter runs the model. These tests prevent OpenAI plugin personality fallback from leaking into unrelated providers while keeping Codex/OpenAI-family behavior aligned.

## Reviewer Notes

- Test-only; no prompt text changes.
- Exercises the shared resolver and Codex provider contribution surface, not full Pi prompt-bundle assembly.
- Captures the audit’s Bug 7 provider-scope class.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/prompt-overlay-runtime-contract.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/prompt-overlay-runtime-contract.test.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/prompt-overlay-runtime-contract.ts src/agents/prompt-overlay-runtime-contract.test.ts extensions/codex/prompt-overlay-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/prompt-overlay-runtime-contract.ts src/agents/prompt-overlay-runtime-contract.test.ts extensions/codex/prompt-overlay-runtime-contract.test.ts`

Refs #71004
Follows #71009, #71029, #71038, #71039, #71042
