### PR TITLE
[codex] Add schema normalization runtime contracts

### DIFF
--- a/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPermissiveTool } from "../../../../test/helpers/agents/schema-normalization-runtime-contract.js";
+import { createCodexTestModel } from "./test-support.js";
+import { startOrResumeThread } from "./thread-lifecycle.js";
+
+let tempDir: string;
+
+function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    sessionFile,
+    workspaceDir,
+    runId: "run-1",
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+  } as EmbeddedRunAttemptParams;
+}
+
+function createAppServerOptions(): Parameters<typeof startOrResumeThread>[0]["appServer"] {
+  return {
+    start: {
+      transport: "stdio",
+      command: "codex",
+      args: ["app-server"],
+      headers: {},
+    },
+    requestTimeoutMs: 60_000,
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: "workspace-write",
+  };
+}
+
+function threadStartResult(threadId = "thread-1") {
+  return {
+    thread: {
+      id: threadId,
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: tempDir,
+      cliVersion: "0.118.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: tempDir,
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+describe("Codex app-server schema normalization runtime contract", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-schema-contract-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("passes executable dynamic tool schemas through thread start unchanged", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const permissiveTool = createPermissiveTool("message");
+    const dynamicTool = {
+      name: permissiveTool.name,
+      description: permissiveTool.description,
+      inputSchema: permissiveTool.parameters,
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [dynamicTool],
+      appServer: createAppServerOptions(),
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "thread/start",
+      expect.objectContaining({
+        dynamicTools: [dynamicTool],
+      }),
+    );
+  });
+
+  it("treats dynamic tool schema changes as thread-fingerprint changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const appServer = createAppServerOptions();
+    let nextThreadId = 1;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult(`thread-${nextThreadId++}`);
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [
+        {
+          name: "message",
+          description: "Permissive test tool",
+          inputSchema: { type: "object" },
+        },
+      ],
+      appServer,
+    });
+    const permissiveTool = createPermissiveTool("message");
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [
+        {
+          name: permissiveTool.name,
+          description: permissiveTool.description,
+          inputSchema: permissiveTool.parameters,
+        },
+      ],
+      appServer,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/start"]);
+  });
+});

--- a/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createPermissiveTool } from "../../../../test/helpers/agents/schema-normalization-runtime-contract.js";
+import {
+  createParameterFreeTool,
+  createPermissiveTool,
+  normalizedParameterFreeSchema,
+} from "../../../../test/helpers/agents/schema-normalization-runtime-contract.js";
 import { createCodexTestModel } from "./test-support.js";
 import { startOrResumeThread } from "./thread-lifecycle.js";
 
@@ -77,7 +81,7 @@ function threadStartResult(threadId = "thread-1") {
   };
 }
 
-describe("Codex app-server schema normalization runtime contract", () => {
+describe("Codex app-server dynamic tool schema boundary contract", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-schema-contract-"));
   });
@@ -87,14 +91,14 @@ describe("Codex app-server schema normalization runtime contract", () => {
     vi.restoreAllMocks();
   });
 
-  it("passes executable dynamic tool schemas through thread start unchanged", async () => {
+  it("passes prepared executable dynamic tool schemas through thread start unchanged", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
-    const permissiveTool = createPermissiveTool("message");
+    const parameterFreeTool = createParameterFreeTool("message");
     const dynamicTool = {
-      name: permissiveTool.name,
-      description: permissiveTool.description,
-      inputSchema: permissiveTool.parameters,
+      name: parameterFreeTool.name,
+      description: parameterFreeTool.description,
+      inputSchema: normalizedParameterFreeSchema(),
     };
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createNativeOpenAIResponsesModel,
+  createParameterFreeTool,
+  createPermissiveTool,
+  createStrictCompatibleTool,
+  normalizedParameterFreeSchema,
+} from "../../test/helpers/agents/schema-normalization-runtime-contract.js";
+import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
+import { convertTools as convertWebSocketTools } from "./openai-ws-message-conversion.js";
+
+describe("OpenAI transport schema normalization runtime contract", () => {
+  const buildResponsesParams = vi.fn(buildOpenAIResponsesParams);
+  const convertWsTools = vi.fn(convertWebSocketTools);
+
+  it("keeps HTTP Responses and WebSocket strict decisions aligned for the same tool set", () => {
+    const tools = [createStrictCompatibleTool(), createPermissiveTool()] as never;
+    const httpParams = buildResponsesParams(
+      createNativeOpenAIResponsesModel() as never,
+      { systemPrompt: "system", messages: [], tools } as never,
+      undefined,
+    ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
+    const wsTools = convertWsTools(tools, { strict: true });
+
+    expect(httpParams.tools?.map((tool) => tool.strict)).toEqual([false, false]);
+    expect(wsTools.map((tool) => tool.strict)).toEqual([false, false]);
+  });
+
+  it("normalizes parameter-free tool schemas consistently for HTTP Responses and WebSocket", () => {
+    const tools = [createParameterFreeTool()] as never;
+    const httpParams = buildResponsesParams(
+      createNativeOpenAIResponsesModel() as never,
+      { systemPrompt: "system", messages: [], tools } as never,
+      undefined,
+    ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
+    const wsTools = convertWsTools(tools, { strict: true });
+
+    expect(httpParams.tools?.[0]?.strict).toBe(wsTools[0]?.strict);
+    expect(httpParams.tools?.[0]?.parameters).toMatchObject({
+      type: normalizedParameterFreeSchema().type,
+      properties: normalizedParameterFreeSchema().properties,
+    });
+    expect(wsTools[0]?.parameters).toMatchObject({
+      type: normalizedParameterFreeSchema().type,
+      properties: normalizedParameterFreeSchema().properties,
+    });
+  });
+});

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -6,6 +6,7 @@ import {
   createStrictCompatibleTool,
   normalizedParameterFreeSchema,
 } from "../../test/helpers/agents/schema-normalization-runtime-contract.js";
+import { buildProviderToolCompatFamilyHooks } from "../plugin-sdk/provider-tools.js";
 import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 import { convertTools as convertWebSocketTools } from "./openai-ws-message-conversion.js";
 
@@ -47,4 +48,28 @@ describe("OpenAI transport schema normalization runtime contract", () => {
   it.todo(
     "normalizes parameter-free tool schemas to the same strict-compatible object shape for HTTP Responses and WebSocket",
   );
+
+  it("keeps provider-prepared parameter-free schemas strict-compatible across HTTP Responses and WebSocket", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("openai");
+    const tools = hooks.normalizeToolSchemas({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      tools: [createParameterFreeTool()] as never,
+    }) as never;
+    const httpParams = buildOpenAIResponsesParams(
+      createNativeOpenAIResponsesModel() as never,
+      { systemPrompt: "system", messages: [], tools } as never,
+      undefined,
+    ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
+    const wsTools = convertWebSocketTools(tools, { strict: true });
+    const normalizedSchema = normalizedParameterFreeSchema();
+
+    expect(httpParams.tools?.[0]?.strict).toBe(true);
+    expect(wsTools[0]?.strict).toBe(true);
+    expect(httpParams.tools?.[0]?.parameters).toEqual(normalizedSchema);
+    expect(wsTools[0]?.parameters).toEqual(normalizedSchema);
+  });
+
+  it.todo("passes prepared executable schemas through compaction-triggered Responses requests");
 });

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -103,7 +103,7 @@ describe("OpenAI transport schema normalization runtime contract", () => {
       responsesServerCompaction: true,
     });
 
-    streamFn(model, { systemPrompt: "system", messages: [], tools } as never, {});
+    void streamFn(model, { systemPrompt: "system", messages: [], tools } as never, {});
 
     expect(payload?.context_management).toEqual([
       {

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   createNativeOpenAIResponsesModel,
   createParameterFreeTool,
@@ -10,17 +10,14 @@ import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 import { convertTools as convertWebSocketTools } from "./openai-ws-message-conversion.js";
 
 describe("OpenAI transport schema normalization runtime contract", () => {
-  const buildResponsesParams = vi.fn(buildOpenAIResponsesParams);
-  const convertWsTools = vi.fn(convertWebSocketTools);
-
   it("keeps HTTP Responses and WebSocket strict decisions aligned for the same tool set", () => {
     const tools = [createStrictCompatibleTool(), createPermissiveTool()] as never;
-    const httpParams = buildResponsesParams(
+    const httpParams = buildOpenAIResponsesParams(
       createNativeOpenAIResponsesModel() as never,
       { systemPrompt: "system", messages: [], tools } as never,
       undefined,
     ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
-    const wsTools = convertWsTools(tools, { strict: true });
+    const wsTools = convertWebSocketTools(tools, { strict: true });
 
     expect(httpParams.tools?.map((tool) => tool.strict)).toEqual([false, false]);
     expect(wsTools.map((tool) => tool.strict)).toEqual([false, false]);
@@ -28,12 +25,12 @@ describe("OpenAI transport schema normalization runtime contract", () => {
 
   it("documents the current HTTP/WS parameter-free schema normalization gap", () => {
     const tools = [createParameterFreeTool()] as never;
-    const httpParams = buildResponsesParams(
+    const httpParams = buildOpenAIResponsesParams(
       createNativeOpenAIResponsesModel() as never,
       { systemPrompt: "system", messages: [], tools } as never,
       undefined,
     ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
-    const wsTools = convertWsTools(tools, { strict: true });
+    const wsTools = convertWebSocketTools(tools, { strict: true });
     const normalizedSchema = normalizedParameterFreeSchema();
 
     expect(httpParams.tools?.[0]?.strict).toBe(wsTools[0]?.strict);

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -1,3 +1,4 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   createNativeOpenAIResponsesModel,
@@ -9,6 +10,7 @@ import {
 import { buildProviderToolCompatFamilyHooks } from "../plugin-sdk/provider-tools.js";
 import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 import { convertTools as convertWebSocketTools } from "./openai-ws-message-conversion.js";
+import { createOpenAIResponsesContextManagementWrapper } from "./pi-embedded-runner/openai-stream-wrappers.js";
 
 describe("OpenAI transport schema normalization runtime contract", () => {
   it("keeps HTTP Responses and WebSocket strict decisions aligned for the same tool set", () => {
@@ -71,5 +73,44 @@ describe("OpenAI transport schema normalization runtime contract", () => {
     expect(wsTools[0]?.parameters).toEqual(normalizedSchema);
   });
 
-  it.todo("passes prepared executable schemas through compaction-triggered Responses requests");
+  it("passes prepared executable schemas through compaction-triggered Responses requests", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("openai");
+    const tools = hooks.normalizeToolSchemas({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      tools: [createParameterFreeTool()] as never,
+    }) as never;
+    const model = createNativeOpenAIResponsesModel() as never;
+    let payload:
+      | { context_management?: unknown; tools?: Array<{ parameters?: unknown }> }
+      | undefined;
+    const baseStreamFn: StreamFn = (modelArg, contextArg, optionsArg) => {
+      payload = buildOpenAIResponsesParams(
+        modelArg,
+        {
+          ...(contextArg as unknown as Record<string, unknown>),
+          systemPrompt: "system",
+          messages: [],
+          tools,
+        } as never,
+        optionsArg as never,
+      ) as typeof payload;
+      optionsArg?.onPayload?.(payload, modelArg);
+      return {} as ReturnType<StreamFn>;
+    };
+    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, {
+      responsesServerCompaction: true,
+    });
+
+    streamFn(model, { systemPrompt: "system", messages: [], tools } as never, {});
+
+    expect(payload?.context_management).toEqual([
+      {
+        type: "compaction",
+        compact_threshold: 140_000,
+      },
+    ]);
+    expect(payload?.tools?.[0]?.parameters).toEqual(normalizedParameterFreeSchema());
+  });
 });

--- a/src/agents/schema-normalization-runtime-contract.test.ts
+++ b/src/agents/schema-normalization-runtime-contract.test.ts
@@ -26,7 +26,7 @@ describe("OpenAI transport schema normalization runtime contract", () => {
     expect(wsTools.map((tool) => tool.strict)).toEqual([false, false]);
   });
 
-  it("normalizes parameter-free tool schemas consistently for HTTP Responses and WebSocket", () => {
+  it("documents the current HTTP/WS parameter-free schema normalization gap", () => {
     const tools = [createParameterFreeTool()] as never;
     const httpParams = buildResponsesParams(
       createNativeOpenAIResponsesModel() as never,
@@ -34,15 +34,20 @@ describe("OpenAI transport schema normalization runtime contract", () => {
       undefined,
     ) as { tools?: Array<{ strict?: boolean; parameters?: unknown }> };
     const wsTools = convertWsTools(tools, { strict: true });
+    const normalizedSchema = normalizedParameterFreeSchema();
 
     expect(httpParams.tools?.[0]?.strict).toBe(wsTools[0]?.strict);
-    expect(httpParams.tools?.[0]?.parameters).toMatchObject({
-      type: normalizedParameterFreeSchema().type,
-      properties: normalizedParameterFreeSchema().properties,
+    expect(httpParams.tools?.[0]?.parameters).toEqual({
+      type: normalizedSchema.type,
+      properties: normalizedSchema.properties,
     });
-    expect(wsTools[0]?.parameters).toMatchObject({
-      type: normalizedParameterFreeSchema().type,
-      properties: normalizedParameterFreeSchema().properties,
+    expect(wsTools[0]?.parameters).toEqual({
+      type: normalizedSchema.type,
+      properties: normalizedSchema.properties,
     });
   });
+
+  it.todo(
+    "normalizes parameter-free tool schemas to the same strict-compatible object shape for HTTP Responses and WebSocket",
+  );
 });

--- a/src/plugin-sdk/schema-normalization-runtime-contract.test.ts
+++ b/src/plugin-sdk/schema-normalization-runtime-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   createNativeOpenAICodexResponsesModel,
   createNativeOpenAIResponsesModel,
@@ -11,11 +11,9 @@ import { buildProviderToolCompatFamilyHooks } from "./provider-tools.js";
 
 describe("OpenAI-family schema normalization runtime contract", () => {
   const hooks = buildProviderToolCompatFamilyHooks("openai");
-  const normalizeToolSchemas = vi.fn(hooks.normalizeToolSchemas);
-  const inspectToolSchemas = vi.fn(hooks.inspectToolSchemas);
 
   it("normalizes parameter-free schemas for native OpenAI Responses tools", () => {
-    const normalized = normalizeToolSchemas({
+    const normalized = hooks.normalizeToolSchemas({
       provider: "openai",
       modelId: "gpt-5.4",
       modelApi: "openai-responses",
@@ -27,7 +25,7 @@ describe("OpenAI-family schema normalization runtime contract", () => {
   });
 
   it("normalizes parameter-free schemas for native OpenAI Codex Responses tools", () => {
-    const normalized = normalizeToolSchemas({
+    const normalized = hooks.normalizeToolSchemas({
       provider: "openai-codex",
       modelId: "gpt-5.4",
       modelApi: "openai-codex-responses",
@@ -40,7 +38,7 @@ describe("OpenAI-family schema normalization runtime contract", () => {
 
   it("does not apply native strict normalization to proxy-like OpenAI routes", () => {
     const tools = [createParameterFreeTool()] as never;
-    const normalized = normalizeToolSchemas({
+    const normalized = hooks.normalizeToolSchemas({
       provider: "openai",
       modelId: "custom-gpt",
       modelApi: "openai-responses",
@@ -53,7 +51,7 @@ describe("OpenAI-family schema normalization runtime contract", () => {
 
   it("keeps permissive schemas observable for transport strict:false downgrade", () => {
     const tool = createPermissiveTool();
-    const normalized = normalizeToolSchemas({
+    const normalized = hooks.normalizeToolSchemas({
       provider: "openai-codex",
       modelId: "gpt-5.4",
       modelApi: "openai-codex-responses",
@@ -63,7 +61,7 @@ describe("OpenAI-family schema normalization runtime contract", () => {
 
     expect(normalized[0]?.parameters).toEqual(tool.parameters);
     expect(
-      inspectToolSchemas({
+      hooks.inspectToolSchemas({
         provider: "openai-codex",
         modelId: "gpt-5.4",
         modelApi: "openai-codex-responses",

--- a/src/plugin-sdk/schema-normalization-runtime-contract.test.ts
+++ b/src/plugin-sdk/schema-normalization-runtime-contract.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createNativeOpenAICodexResponsesModel,
+  createNativeOpenAIResponsesModel,
+  createParameterFreeTool,
+  createPermissiveTool,
+  createProxyOpenAIResponsesModel,
+  normalizedParameterFreeSchema,
+} from "../../test/helpers/agents/schema-normalization-runtime-contract.js";
+import { buildProviderToolCompatFamilyHooks } from "./provider-tools.js";
+
+describe("OpenAI-family schema normalization runtime contract", () => {
+  const hooks = buildProviderToolCompatFamilyHooks("openai");
+  const normalizeToolSchemas = vi.fn(hooks.normalizeToolSchemas);
+  const inspectToolSchemas = vi.fn(hooks.inspectToolSchemas);
+
+  it("normalizes parameter-free schemas for native OpenAI Responses tools", () => {
+    const normalized = normalizeToolSchemas({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      model: createNativeOpenAIResponsesModel() as never,
+      tools: [createParameterFreeTool()] as never,
+    });
+
+    expect(normalized[0]?.parameters).toEqual(normalizedParameterFreeSchema());
+  });
+
+  it("normalizes parameter-free schemas for native OpenAI Codex Responses tools", () => {
+    const normalized = normalizeToolSchemas({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-codex-responses",
+      model: createNativeOpenAICodexResponsesModel() as never,
+      tools: [createParameterFreeTool()] as never,
+    });
+
+    expect(normalized[0]?.parameters).toEqual(normalizedParameterFreeSchema());
+  });
+
+  it("does not apply native strict normalization to proxy-like OpenAI routes", () => {
+    const tools = [createParameterFreeTool()] as never;
+    const normalized = normalizeToolSchemas({
+      provider: "openai",
+      modelId: "custom-gpt",
+      modelApi: "openai-responses",
+      model: createProxyOpenAIResponsesModel() as never,
+      tools,
+    });
+
+    expect(normalized).toBe(tools);
+  });
+
+  it("keeps permissive schemas observable for transport strict:false downgrade", () => {
+    const tool = createPermissiveTool();
+    const normalized = normalizeToolSchemas({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-codex-responses",
+      model: createNativeOpenAICodexResponsesModel() as never,
+      tools: [tool] as never,
+    });
+
+    expect(normalized[0]?.parameters).toEqual(tool.parameters);
+    expect(
+      inspectToolSchemas({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        modelApi: "openai-codex-responses",
+        model: createNativeOpenAICodexResponsesModel() as never,
+        tools: [tool] as never,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/test/helpers/agents/schema-normalization-runtime-contract.ts
+++ b/test/helpers/agents/schema-normalization-runtime-contract.ts
@@ -1,0 +1,92 @@
+export function createParameterFreeTool(name = "ping") {
+  return {
+    name,
+    description: "Parameter-free test tool",
+    parameters: {},
+  };
+}
+
+export function createStrictCompatibleTool(name = "lookup") {
+  return {
+    name,
+    description: "Strict-compatible test tool",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+      },
+      required: ["path"],
+      additionalProperties: false,
+    },
+  };
+}
+
+export function createPermissiveTool(name = "schedule") {
+  return {
+    name,
+    description: "Permissive test tool",
+    parameters: {
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        cron: { type: "string" },
+      },
+      required: ["action"],
+      additionalProperties: true,
+    },
+  };
+}
+
+export function createNativeOpenAIResponsesModel() {
+  return {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+export function createNativeOpenAICodexResponsesModel() {
+  return {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+export function createProxyOpenAIResponsesModel() {
+  return {
+    id: "custom-gpt",
+    name: "Custom GPT",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://proxy.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+export function normalizedParameterFreeSchema() {
+  return {
+    type: "object",
+    properties: {},
+    required: [],
+    additionalProperties: false,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the schema-normalization contract rung from RFC #71004. This is test-only: no production schema normalization, OpenAI transport, Pi runner, or Codex app-server behavior changes.

```mermaid
flowchart TD
  ToolCatalog["OpenClaw tool catalog"] --> ProviderCompat["Provider schema compatibility hooks"]
  ProviderCompat --> OpenAIResponses["OpenAI HTTP Responses"]
  ProviderCompat --> OpenAIWS["OpenAI WebSocket"]
  ProviderCompat --> ResponsesCompaction["Responses compaction wrapper"]
  ProviderCompat --> CodexDynamicTools["Codex app-server dynamic-tool boundary"]
  OpenAIResponses --> ExecutableSchemas["Executable tool schemas"]
  OpenAIWS --> ExecutableSchemas
  ResponsesCompaction --> ExecutableSchemas
  CodexDynamicTools --> ExecutableSchemas
  ExecutableSchemas --> Todo["TODO: full raw parameter-free strict parity"]
```

## Files Changed And Why

| File | Purpose |
| --- | --- |
| `test/helpers/agents/schema-normalization-runtime-contract.ts` | Shared schema/model fixtures. |
| `src/plugin-sdk/schema-normalization-runtime-contract.test.ts` | Provider compatibility hook rows. |
| `src/agents/schema-normalization-runtime-contract.test.ts` | HTTP Responses, WS, and compaction transport rows. |
| `extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts` | Codex dynamic-tool boundary rows. |

## Contract Matrix

| Surface | Contract rows |
| --- | --- |
| Provider compatibility hooks | Native OpenAI Responses parameter-free schemas normalize to strict-compatible object schemas. |
| Provider compatibility hooks | Native OpenAI Codex Responses parameter-free schemas normalize through the same OpenAI-family helper. |
| Provider compatibility hooks | Proxy-like OpenAI routes are not tightened as native OpenAI routes. |
| Provider compatibility hooks | Permissive schemas remain observable for transport-level `strict:false` downgrade. |
| HTTP/WS transports | HTTP Responses and WebSocket choose matching strict flags for the same mixed strict/permissive tool set. |
| HTTP/WS transports | Provider-prepared parameter-free schemas stay strict-compatible across HTTP Responses and WebSocket. |
| Responses compaction | Provider-prepared executable schemas survive context-management compaction injection unchanged. |
| HTTP/WS transports | Raw parameter-free transport schemas remain executable object shells. Full raw-schema strict-compatible parity is marked `todo`. |
| Codex app-server boundary | Prepared executable dynamic tool schemas are passed through thread start unchanged. Codex does not own schema normalization in this phase. |
| Codex app-server boundary | Dynamic tool schema changes invalidate the thread fingerprint. |

## Known Red Row

| Future row | Why not green here |
| --- | --- |
| Raw parameter-free HTTP/WS schemas normalize to the same strict-compatible object shape before transport. | Requires moving schema normalization to the shared runtime-plan/tool-catalog boundary. |

## How This Helps The RuntimePlan Work

Tool schema normalization is OpenClaw-owned policy. The runtime plan should normalize executable schemas once before Pi or Codex transports see them. These tests prevent HTTP Responses, WS, compaction, and Codex dynamic-tool boundaries from drifting during that migration.

## Reviewer Notes

- Test-only; no new schema normalizer API.
- Does not claim Codex app-server performs schema normalization.
- Captures the audit’s Bug 6 class and the compaction preservation path.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-sdk/schema-normalization-runtime-contract.test.ts` — 4 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/schema-normalization-runtime-contract.test.ts` — 4 passed, 1 todo
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json test/helpers/agents/schema-normalization-runtime-contract.ts src/plugin-sdk/schema-normalization-runtime-contract.test.ts src/agents/schema-normalization-runtime-contract.test.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts`
- `git diff --check -- test/helpers/agents/schema-normalization-runtime-contract.ts src/plugin-sdk/schema-normalization-runtime-contract.test.ts src/agents/schema-normalization-runtime-contract.test.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts`

Refs #71004
Follows #71009, #71029, #71038, #71039, #71042, #71044
