### PR TITLE
fix(qqbot): enable qqbot plugin by default so runtime deps install be…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Webhooks/security: re-resolve `SecretRef`-backed webhook route secrets on each request so `openclaw secrets reload` revokes the previous secret immediately instead of waiting for a gateway restart. (#70727) Thanks @drobison00.
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
+- Plugins/QQ Bot: enable the bundled qqbot plugin by default so its runtime dependency `@tencent-connect/qqbot-connector` is installed on first launch, unblocking the QR-code binding flow that dynamically imports the connector before any account is configured. (#71051) Thanks @cxyhhhhh.
 
 ## 2026.4.22
 

--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "channelEnvVars": {
     "qqbot": ["QQBOT_APP_ID", "QQBOT_CLIENT_SECRET"]
   },
+  "enabledByDefault": true,
   "skills": ["./skills"],
   "configSchema": {
     "type": "object",


### PR DESCRIPTION
## Summary

- **Problem**: The qqbot plugin manifest was missing `enabledByDefault: true`. Without it, `ensureBundledPluginRuntimeDeps` treats qqbot as bundled-but-disabled-by-default (`isBundledPluginConfiguredForRuntimeDeps` returns `false` when no qqbot channel/account is configured yet), so `@tencent-connect/qqbot-connector` is never installed into `dist/extensions/qqbot/node_modules` on first launch.
- **Why it matters**: This creates a chicken-and-egg failure for the QR-code binding flow. `finalize.ts` dynamically imports `@tencent-connect/qqbot-connector` to run `qrConnect()`, but the package isn't present yet because no account is configured — and binding is exactly the step that configures the first account. Users hit: `ERR_MODULE_NOT_FOUND: Cannot find package '@tencent-connect/qqbot-connector'`.
- **What changed**: Added `"enabledByDefault": true` to `extensions/qqbot/openclaw.plugin.json`, making the host install qqbot's runtime deps eagerly on first launch.
- **What did NOT change (scope boundary)**: No code logic changes. The existing runtime-deps install pipeline handles everything once the gate is opened. This mirrors the pattern already used by 59 other bundled plugins (mistral / groq / deepgram / amazon-bedrock-mantle, etc.) whose providers must be available before any channel config exists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<!-- fill in the matching beta-blocker issue number -->
- Related #<!-- fill in related issue/PR number -->
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: `extensions/qqbot/openclaw.plugin.json` was missing the `enabledByDefault: true` field. `isBundledPluginConfiguredForRuntimeDeps` returns `false` when no qqbot channel/account is configured, causing `ensureBundledPluginRuntimeDeps` to skip installing qqbot's runtime dependencies entirely.
- **Missing detection / guardrail**: No validation or warning for the case where a plugin declares `channelEnvVars` but does not set `enabledByDefault`.
- **Contributing context (if known)**: The qqbot plugin was added later as a channel plugin and did not follow the convention established by other bundled plugins.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `src/plugins/bundled-runtime-deps.test.ts`
- **Scenario the test should lock in**: When a bundled plugin declares `channelEnvVars` and requires runtime dependencies, `ensureBundledPluginRuntimeDeps` should install its dependencies even if no account is configured, as long as `enabledByDefault: true` is set.
- **Why this is the smallest reliable guardrail**: This function is the sole entry point for runtime dependency installation; testing its response to `enabledByDefault` directly covers this scenario.
- **If no new test is added, why not**: This change only modifies a JSON manifest with no logic changes. The existing `bundled-runtime-deps.test.ts` already covers `enabledByDefault` behavior.

## User-visible / Behavior Changes

- On first launch, qqbot's runtime dependency (`@tencent-connect/qqbot-connector`) is now automatically installed. Users no longer need a pre-existing account configuration to use the QR-code binding flow.
- Previously, selecting "QR-code binding" on first launch resulted in `ERR_MODULE_NOT_FOUND`. It now works as expected.

## Diagram (if applicable)

```text
Before:
[first launch] -> ensureBundledPluginRuntimeDeps
               -> qqbot has no enabledByDefault
               -> isBundledPluginConfiguredForRuntimeDeps = false
               -> skip installing @tencent-connect/qqbot-connector
               -> [user selects QR bind] -> import qqbot-connector -> ERR_MODULE_NOT_FOUND ❌

After:
[first launch] -> ensureBundledPluginRuntimeDeps
               -> qqbot enabledByDefault: true
               -> isBundledPluginConfiguredForRuntimeDeps = true
               -> install @tencent-connect/qqbot-connector ✓
               -> [user selects QR bind] -> import qqbot-connector -> qrConnect() succeeds ✅
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: QQ Bot (qqbot)
- Relevant config: Fresh install, no pre-existing qqbot account configuration

### Steps

1. Fresh install of openclaw with no pre-configured qqbot account.
2. Run `openclaw channels add` and select QQ Bot.
3. Select "扫码绑定（推荐）" (QR-code binding).

### Expected

- The QR-code binding flow starts normally and displays a QR code for the user to scan.

### Actual (before fix)

- Error: `QQ Bot 绑定失败: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@tencent-connect/qqbot-connector' imported from .../dist/extensions/qqbot/channel-*.js`

## Evidence

- [x] Trace/log snippets

Before fix:
```
QQ Bot 绑定失败: Error [ERR_MODULE_NOT_FOUND]: Cannot find package
'@tencent-connect/qqbot-connector' imported from
.../dist/extensions/qqbot/channel-*.js
```

After fix: `@tencent-connect/qqbot-connector` is pre-installed on first launch; QR-code binding flow proceeds normally.

## Human Verification (required)

- **Verified scenarios**: Fresh environment first launch followed by QR-code binding flow; confirmed `@tencent-connect/qqbot-connector` is pre-installed.
- **Edge cases checked**: Upgrade scenario with existing account configuration is unaffected (`enabledByDefault` only influences the initial install gate).
- **What you did NOT verify**: Cross-platform (Windows/Linux) installation behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk**: `enabledByDefault: true` causes qqbot's runtime dependencies to be installed on first launch for all users, even those who do not intend to use QQ Bot.
  - **Mitigation**: This is consistent with the behavior of 59 other bundled plugins (anthropic, google, microsoft, etc.). Runtime dependency installation is lightweight and only triggers on first launch or when dependencies are missing, with negligible impact on startup performance.
