### PR TITLE
feat(tools): support optional environment proxy for web_fetch

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -116,6 +116,10 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   return true;
 }
 
+function resolveFetchUseEnvProxy(fetch?: WebFetchConfig): boolean {
+  return fetch?.useEnvProxy === true;
+}
+
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
   const raw =
     fetch && "maxCharsCap" in fetch && typeof fetch.maxCharsCap === "number"
@@ -272,6 +276,7 @@ type WebFetchRuntimeParams = {
   userAgent: string;
   readabilityEnabled: boolean;
   config?: OpenClawConfig;
+  useEnvProxy: boolean;
   ssrfPolicy?: {
     allowRfc2544BenchmarkRange?: boolean;
   };
@@ -417,6 +422,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      useEnvProxy: params.useEnvProxy,
       lookupFn: params.lookupFn,
       policy: allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange } : undefined,
       init: {
@@ -605,6 +611,8 @@ export function createWebFetchTool(options?: {
     return null;
   }
   const readabilityEnabled = resolveFetchReadabilityEnabled(fetch);
+  const useEnvProxy = resolveFetchUseEnvProxy(fetch);
+
   const userAgent =
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
@@ -652,6 +660,7 @@ export function createWebFetchTool(options?: {
         readabilityEnabled,
         config: options?.config,
         ssrfPolicy: fetch?.ssrfPolicy,
+        useEnvProxy,
         lookupFn: options?.lookupFn,
         resolveProviderFallback,
       });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -395,7 +395,7 @@ async function maybeFetchProviderWebFetchPayload(
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
   const allowRfc2544BenchmarkRange = params.ssrfPolicy?.allowRfc2544BenchmarkRange === true;
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${allowRfc2544BenchmarkRange ? ":allow-rfc2544" : ""}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}:${params.useEnvProxy ? "env-proxy" : "no-env-proxy"}${allowRfc2544BenchmarkRange ? ":allow-rfc2544" : ""}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {

--- a/src/agents/tools/web-guarded-fetch.test.ts
+++ b/src/agents/tools/web-guarded-fetch.test.ts
@@ -21,6 +21,10 @@ vi.mock("../../infra/net/fetch-guard.js", () => {
   };
 });
 
+vi.mock("../../infra/net/proxy-env.js", () => ({
+  shouldUseTrustedEnvProxyForUrl: vi.fn(() => true),
+}));
+
 describe("web-guarded-fetch", () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -5,6 +5,7 @@ import {
   withStrictGuardedFetchMode,
   withTrustedEnvProxyGuardedFetchMode,
 } from "../../infra/net/fetch-guard.js";
+import { shouldUseTrustedEnvProxyForUrl } from "../../infra/net/proxy-env.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
@@ -34,6 +35,16 @@ function resolveTimeoutMs(params: {
   return undefined;
 }
 
+function shouldUseTrustedEnvProxy(params: {
+  url: string;
+  useEnvProxy?: boolean;
+}): boolean {
+  if (params.useEnvProxy !== true) {
+    return false;
+  }
+  return shouldUseTrustedEnvProxyForUrl(params.url);
+}
+
 export async function fetchWithWebToolsNetworkGuard(
   params: WebToolGuardedFetchOptions,
 ): Promise<GuardedFetchResult> {
@@ -42,8 +53,12 @@ export async function fetchWithWebToolsNetworkGuard(
     ...rest,
     timeoutMs: resolveTimeoutMs({ timeoutMs: rest.timeoutMs, timeoutSeconds }),
   };
+  const useTrustedEnvProxy = shouldUseTrustedEnvProxy({
+    url: rest.url,
+    useEnvProxy,
+  });
   return fetchWithSsrFGuard(
-    useEnvProxy
+    useTrustedEnvProxy
       ? withTrustedEnvProxyGuardedFetchMode(resolved)
       : withStrictGuardedFetchMode(resolved),
   );

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -276,6 +276,31 @@ describe("web_fetch extraction fallbacks", () => {
     expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
   });
 
+  it("uses EnvHttpProxyAgent when web_fetch.useEnvProxy is enabled", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: makeFetchHeaders({ "content-type": "text/plain" }),
+        text: async () => "proxy body",
+        url: resolveRequestUrl(input),
+      } as Response),
+    );
+    const tool = createFetchTool({
+      useEnvProxy: true,
+      firecrawl: { enabled: false },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/proxy-env" });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(requestInit?.dispatcher).toBeDefined();
+    expect(requestInit?.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.
   // The sanitization of these fields is verified by external-content.test.ts tests.
 

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -119,6 +119,17 @@ function withoutAmbientFirecrawlEnv() {
   vi.stubEnv("FIRECRAWL_API_KEY", "");
 }
 
+function clearProxyEnv() {
+  vi.stubEnv("HTTP_PROXY", "");
+  vi.stubEnv("HTTPS_PROXY", "");
+  vi.stubEnv("ALL_PROXY", "");
+  vi.stubEnv("http_proxy", "");
+  vi.stubEnv("https_proxy", "");
+  vi.stubEnv("all_proxy", "");
+  vi.stubEnv("NO_PROXY", "");
+  vi.stubEnv("no_proxy", "");
+}
+
 async function executeFetch(
   tool: ReturnType<typeof createFetchTool>,
   params: { url: string; extractMode?: "text" | "markdown" },
@@ -299,6 +310,60 @@ describe("web_fetch extraction fallbacks", () => {
       | undefined;
     expect(requestInit?.dispatcher).toBeDefined();
     expect(requestInit?.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("keeps strict mode when only ALL_PROXY is configured", async () => {
+    clearProxyEnv();
+    vi.stubEnv("ALL_PROXY", "http://127.0.0.1:7890");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: makeFetchHeaders({ "content-type": "text/plain" }),
+        text: async () => "proxy body",
+        url: resolveRequestUrl(input),
+      } as Response),
+    );
+    const tool = createFetchTool({
+      useEnvProxy: true,
+      firecrawl: { enabled: false },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/all-proxy-only" });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(requestInit?.dispatcher).toBeDefined();
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("keeps strict mode when NO_PROXY bypasses the target host", async () => {
+    clearProxyEnv();
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "example.com");
+    vi.stubEnv("no_proxy", "example.com");
+    const mockFetch = installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: makeFetchHeaders({ "content-type": "text/plain" }),
+        text: async () => "proxy body",
+        url: resolveRequestUrl(input),
+      } as Response),
+    );
+    const tool = createFetchTool({
+      useEnvProxy: true,
+      firecrawl: { enabled: false },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/no-proxy-match" });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(requestInit?.dispatcher).toBeDefined();
+    expect(requestInit?.dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
   });
 
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -8244,6 +8244,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
                   },
+                  useEnvProxy: {
+                    type: "boolean",
+                    title: "Web Fetch Use Environment Proxy",
+                    description:
+                      "Use HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment settings for web_fetch requests (default: false).",
+                  },
                   ssrfPolicy: {
                     type: "object",
                     properties: {
@@ -24994,6 +25000,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "tools.web.fetch.readability": {
       label: "Web Fetch Readability Extraction",
       help: "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+      tags: ["tools"],
+    },
+    "tools.web.fetch.useEnvProxy": {
+      label: "Web Fetch Use Environment Proxy",
+      help: "Use HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment settings for web_fetch requests (default: false).",
       tags: ["tools"],
     },
     "tools.web.fetch.ssrfPolicy": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -808,6 +808,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+  "tools.web.fetch.useEnvProxy":
+    "Use HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment settings for web_fetch requests (default: false).",
   "tools.web.fetch.ssrfPolicy":
     "Scoped SSRF policy overrides for web_fetch. Keep this narrow and opt in only for known local-network proxy environments.",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -290,6 +290,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
   "tools.web.fetch.readability": "Web Fetch Readability Extraction",
+  "tools.web.fetch.useEnvProxy": "Web Fetch Use Environment Proxy",
   "tools.web.fetch.ssrfPolicy": "Web Fetch SSRF Policy",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
     "Web Fetch Allow RFC 2544 Benchmark Range",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -563,6 +563,8 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** Use HTTP(S) proxy settings from environment variables (default: false). */
+      useEnvProxy?: boolean;
       /** SSRF policy configuration for web_fetch. */
       ssrfPolicy?: {
         /** Allow RFC 2544 benchmark range IPs (198.18.0.0/15) for fake-IP proxy compatibility (e.g., Clash TUN mode, Surge). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -349,6 +349,7 @@ export const ToolsWebFetchSchema = z
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
     readability: z.boolean().optional(),
+    useEnvProxy: z.boolean().optional(),
     ssrfPolicy: z
       .object({
         allowRfc2544BenchmarkRange: z.boolean().optional(),

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -3,8 +3,10 @@ import {
   hasEnvHttpProxyConfigured,
   hasProxyEnvConfigured,
   matchesNoProxy,
+  resolveHttpProtocolFromUrl,
   resolveEnvHttpProxyUrl,
   shouldUseEnvHttpProxyForUrl,
+  shouldUseTrustedEnvProxyForUrl,
 } from "./proxy-env.js";
 
 describe("hasProxyEnvConfigured", () => {
@@ -284,5 +286,39 @@ describe("shouldUseEnvHttpProxyForUrl", () => {
     },
   ])("$name", ({ url, env, expected }) => {
     expect(shouldUseEnvHttpProxyForUrl(url, env)).toBe(expected);
+  });
+});
+
+describe("resolveHttpProtocolFromUrl", () => {
+  it.each([
+    { url: "http://example.com", expected: "http" },
+    { url: "https://example.com", expected: "https" },
+    { url: "ftp://example.com/file", expected: undefined },
+    { url: "not-a-url", expected: undefined },
+  ])("resolves $url", ({ url, expected }) => {
+    expect(resolveHttpProtocolFromUrl(url)).toBe(expected);
+  });
+});
+
+describe("shouldUseTrustedEnvProxyForUrl", () => {
+  it.each([
+    {
+      name: "matches shouldUseEnvHttpProxyForUrl for proxy-eligible targets",
+      url: "https://api.example.com/v1",
+      env: { HTTPS_PROXY: "http://proxy.test:8080" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "matches shouldUseEnvHttpProxyForUrl for NO_PROXY exclusions",
+      url: "https://internal.corp.example/v1",
+      env: {
+        HTTPS_PROXY: "http://proxy.test:8080",
+        NO_PROXY: "corp.example",
+      } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+  ])("$name", ({ url, env, expected }) => {
+    expect(shouldUseTrustedEnvProxyForUrl(url, env)).toBe(expected);
+    expect(shouldUseTrustedEnvProxyForUrl(url, env)).toBe(shouldUseEnvHttpProxyForUrl(url, env));
   });
 });

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -54,24 +54,29 @@ export function hasEnvHttpProxyConfigured(
   return resolveEnvHttpProxyUrl(protocol, env) !== undefined;
 }
 
+export function resolveHttpProtocolFromUrl(url: string): "http" | "https" | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:") {
+      return "http";
+    }
+    if (parsed.protocol === "https:") {
+      return "https";
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function shouldUseEnvHttpProxyForUrl(
   targetUrl: string,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  let protocol: "http" | "https";
-  try {
-    const parsed = new URL(targetUrl);
-    if (parsed.protocol === "http:") {
-      protocol = "http";
-    } else if (parsed.protocol === "https:") {
-      protocol = "https";
-    } else {
-      return false;
-    }
-  } catch {
+  const protocol = resolveHttpProtocolFromUrl(targetUrl);
+  if (!protocol) {
     return false;
   }
-
   return hasEnvHttpProxyConfigured(protocol, env) && !matchesNoProxy(targetUrl, env);
 }
 
@@ -177,4 +182,17 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
   }
 
   return false;
+}
+
+/**
+ * Returns true when a target URL can safely use trusted env-proxy mode:
+ * - target URL is HTTP(S)
+ * - protocol-specific HTTP(S) proxy env is configured
+ * - target URL is NOT bypassed by NO_PROXY
+ */
+export function shouldUseTrustedEnvProxyForUrl(
+  targetUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return shouldUseEnvHttpProxyForUrl(targetUrl, env);
 }

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -257,7 +257,6 @@ function shouldAutoUpgradeToTrustedEnvProxy(params: {
   if (params.dispatcherPolicy) {
     return false;
   }
-
   return shouldUseEnvHttpProxyForUrl(params.url);
 }
 


### PR DESCRIPTION
# feat(tools): support optional environment proxy for web_fetch

## Summary

This PR adds an explicit `tools.web.fetch.useEnvProxy` config flag so `web_fetch` can optionally honor environment proxy settings.
 also gating so enabling this flag does not bypass pinned-DNS SSRF checks in `ALL_PROXY`-only or `NO_PROXY`-bypass paths.

## What Changed

- Added `useEnvProxy?: boolean` to `tools.web.fetch` config types and runtime schema.
- Wired `useEnvProxy` through `createWebFetchTool` into guarded fetch execution.
- Added strict gating for trusted env-proxy mode:
  - only when protocol-specific `HTTP_PROXY` / `HTTPS_PROXY` is configured;
  - never when target matches `NO_PROXY`;
  - never based on `ALL_PROXY` alone.
- Extracted shared helper logic in `src/infra/net/proxy-env.ts` so `web_fetch` and media-understanding use consistent gating behavior.
- Added/updated regression tests for `ALL_PROXY` and `NO_PROXY` cases.

## Why

Some corporate/intranet environments require egress through environment-configured proxies.
The flag enables this behavior explicitly, while the gating fix preserves SSRF safety guarantees when env proxy bypass rules apply.

## Validation

- `pnpm test src/infra/net/proxy-env.test.ts src/agents/tools/web-tools.fetch.test.ts src/media-understanding/shared.test.ts`

## Related Issue

Closes #71053

## AI-assisted

- [x] AI-assisted and manually reviewed.
