### PR TITLE
[codex] Add DeepSeek V4 model names

### DIFF
--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -26,7 +26,7 @@ read_when:
     openclaw onboard --auth-choice deepseek-api-key
     ```
 
-    This will prompt for your API key and set `deepseek/deepseek-chat` as the default model.
+    This will prompt for your API key and set `deepseek/deepseek-v4-flash` as the default model.
 
   </Step>
   <Step title="Verify models are available">
@@ -60,13 +60,15 @@ is available to that process (for example, in `~/.openclaw/.env` or via
 
 ## Built-in catalog
 
-| Model ref                    | Name              | Input | Context | Max output | Notes                                             |
-| ---------------------------- | ----------------- | ----- | ------- | ---------- | ------------------------------------------------- |
-| `deepseek/deepseek-chat`     | DeepSeek Chat     | text  | 131,072 | 8,192      | Default model; DeepSeek V3.2 non-thinking surface |
-| `deepseek/deepseek-reasoner` | DeepSeek Reasoner | text  | 131,072 | 65,536     | Reasoning-enabled V3.2 surface                    |
+| Model ref                    | Name                       | Input | Context   | Max output | Notes                                                              |
+| ---------------------------- | -------------------------- | ----- | --------- | ---------- | ------------------------------------------------------------------ |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash          | text  | 1,000,000 | 384,000    | Default model; supports DeepSeek's non-thinking and thinking modes |
+| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro            | text  | 1,000,000 | 384,000    | Supports DeepSeek's non-thinking and thinking modes                |
+| `deepseek/deepseek-chat`     | DeepSeek Chat (legacy)     | text  | 1,000,000 | 384,000    | Compatibility alias for `deepseek-v4-flash` non-thinking mode      |
+| `deepseek/deepseek-reasoner` | DeepSeek Reasoner (legacy) | text  | 1,000,000 | 65,536     | Compatibility alias for `deepseek-v4-flash` thinking mode          |
 
 <Tip>
-Both bundled models currently advertise streaming usage compatibility in source.
+`deepseek-chat` and `deepseek-reasoner` are kept for compatibility and DeepSeek plans to deprecate both model names on 2026-07-24.
 </Tip>
 
 ## Config example
@@ -76,7 +78,7 @@ Both bundled models currently advertise streaming usage compatibility in source.
   env: { DEEPSEEK_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "deepseek/deepseek-chat" },
+      model: { primary: "deepseek/deepseek-v4-flash" },
     },
   },
 }

--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -1,10 +1,20 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import deepseekPlugin from "./index.js";
+import { DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
 
 describe("deepseek provider plugin", () => {
+  const deepSeekV4ThinkingProfile = {
+    levels: [
+      { id: "off", label: "off" },
+      { id: "low", label: "on" },
+    ],
+    defaultLevel: "off",
+  };
+
   it("registers DeepSeek with api-key auth wizard metadata", async () => {
     const provider = await registerSingleProviderPlugin(deepseekPlugin);
     const resolved = resolveProviderPluginChoice({
@@ -19,6 +29,7 @@ describe("deepseek provider plugin", () => {
     expect(resolved).not.toBeNull();
     expect(resolved?.provider.id).toBe("deepseek");
     expect(resolved?.method.id).toBe("api-key");
+    expect(DEEPSEEK_DEFAULT_MODEL_REF).toBe("deepseek/deepseek-v4-flash");
   });
 
   it("builds the static DeepSeek model catalog", async () => {
@@ -28,12 +39,117 @@ describe("deepseek provider plugin", () => {
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://api.deepseek.com");
     expect(catalogProvider.models?.map((model) => model.id)).toEqual([
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
       "deepseek-chat",
       "deepseek-reasoner",
     ]);
+    expect(catalogProvider.models?.find((model) => model.id === "deepseek-v4-flash")).toMatchObject(
+      {
+        name: "DeepSeek V4 Flash",
+        reasoning: true,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+        cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+        compat: {
+          supportsReasoningEffort: false,
+          supportsUsageInStreaming: true,
+          maxTokensField: "max_tokens",
+        },
+      },
+    );
     expect(
       catalogProvider.models?.find((model) => model.id === "deepseek-reasoner")?.reasoning,
     ).toBe(true);
+  });
+
+  it("advertises binary thinking controls for DeepSeek V4 models", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "deepseek", modelId: "deepseek-v4-flash" }),
+    ).toEqual(deepSeekV4ThinkingProfile);
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "deepseek", modelId: "deepseek-v4-pro" }),
+    ).toEqual(deepSeekV4ThinkingProfile);
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "deepseek", modelId: "deepseek-reasoner" }),
+    ).toEqual({
+      levels: [{ id: "low", label: "on" }],
+      defaultLevel: "low",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "deepseek", modelId: "deepseek-chat" }),
+    ).toEqual({
+      levels: [{ id: "off", label: "off" }],
+      defaultLevel: "off",
+    });
+  });
+
+  it("maps thinking controls to the DeepSeek thinking payload", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    let capturedPayload: Record<string, unknown> | undefined;
+    let payloadSeed: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload = { model: model.id, ...payloadSeed } as Record<string, unknown>;
+      payloadSeed = undefined;
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return {} as never;
+    };
+
+    const offStream = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      thinkingLevel: "off",
+    } as never);
+    await offStream?.(
+      { api: "openai-completions", id: "deepseek-v4-flash" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({ thinking: { type: "disabled" } });
+
+    payloadSeed = { tool_choice: "required" };
+    const onStream = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      thinkingLevel: "low",
+    } as never);
+    await onStream?.(
+      { api: "openai-completions", id: "deepseek-v4-flash" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "enabled" },
+      tool_choice: "required",
+    });
+
+    const reasonerStream = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      modelId: "deepseek-reasoner",
+      thinkingLevel: "off",
+      extraParams: { thinking: { type: "disabled" } },
+    } as never);
+    await reasonerStream?.(
+      { api: "openai-completions", id: "deepseek-reasoner" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({ thinking: { type: "enabled" } });
+
+    payloadSeed = { thinking: { type: "enabled" } };
+    const chatStream = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      modelId: "deepseek-chat",
+      thinkingLevel: "low",
+      extraParams: { thinking: { type: "enabled" } },
+    } as never);
+    await chatStream?.(
+      { api: "openai-completions", id: "deepseek-chat" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toEqual({ model: "deepseek-chat" });
   });
 
   it("publishes configured DeepSeek models through plugin-owned catalog augmentation", async () => {
@@ -47,11 +163,11 @@ describe("deepseek provider plugin", () => {
               deepseek: {
                 models: [
                   {
-                    id: "deepseek-chat",
-                    name: "DeepSeek Chat",
+                    id: "deepseek-v4-flash",
+                    name: "DeepSeek V4 Flash",
                     input: ["text"],
                     reasoning: false,
-                    contextWindow: 65536,
+                    contextWindow: 1_000_000,
                   },
                 ],
               },
@@ -62,11 +178,11 @@ describe("deepseek provider plugin", () => {
     ).toEqual([
       {
         provider: "deepseek",
-        id: "deepseek-chat",
-        name: "DeepSeek Chat",
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
         input: ["text"],
         reasoning: false,
-        contextWindow: 65536,
+        contextWindow: 1_000_000,
       },
     ]);
   });

--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -1,9 +1,15 @@
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { DEEPSEEK_THINKING_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
 import { applyDeepSeekConfig, DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildDeepSeekProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "deepseek";
+const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+function isDeepSeekV4ModelId(modelId: string | undefined): boolean {
+  return modelId ? DEEPSEEK_V4_MODEL_IDS.has(modelId.trim().toLowerCase()) : false;
+}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
@@ -42,5 +48,30 @@ export default defineSingleProviderPluginEntry({
       }),
     matchesContextOverflowError: ({ errorMessage }) =>
       /\bdeepseek\b.*(?:input.*too long|context.*exceed)/i.test(errorMessage),
+    ...DEEPSEEK_THINKING_STREAM_HOOKS,
+    resolveThinkingProfile: ({ modelId }) => {
+      if (modelId === "deepseek-reasoner") {
+        return {
+          levels: [{ id: "low", label: "on" }],
+          defaultLevel: "low",
+        };
+      }
+      if (modelId === "deepseek-chat") {
+        return {
+          levels: [{ id: "off", label: "off" }],
+          defaultLevel: "off",
+        };
+      }
+      if (isDeepSeekV4ModelId(modelId)) {
+        return {
+          levels: [
+            { id: "off", label: "off" },
+            { id: "low", label: "on" },
+          ],
+          defaultLevel: "off",
+        };
+      }
+      return undefined;
+    },
   },
 });

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -2,35 +2,72 @@ import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-s
 
 export const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
 
-// DeepSeek V3.2 API pricing (per 1M tokens)
+const DEEPSEEK_CONTEXT_WINDOW = 1_000_000;
+const DEEPSEEK_V4_MAX_TOKENS = 384_000;
+const DEEPSEEK_LEGACY_REASONER_MAX_TOKENS = 65_536;
+
+const DEEPSEEK_COMPAT = {
+  supportsUsageInStreaming: true,
+  supportsReasoningEffort: false,
+  maxTokensField: "max_tokens",
+} satisfies NonNullable<ModelDefinitionConfig["compat"]>;
+
+// DeepSeek V4 API pricing (per 1M tokens)
 // https://api-docs.deepseek.com/quick_start/pricing
-const DEEPSEEK_V3_2_COST = {
-  input: 0.28,
-  output: 0.42,
-  cacheRead: 0.028,
+const DEEPSEEK_V4_FLASH_COST = {
+  input: 1,
+  output: 2,
+  cacheRead: 0.2,
+  cacheWrite: 0,
+};
+
+const DEEPSEEK_V4_PRO_COST = {
+  input: 12,
+  output: 24,
+  cacheRead: 1,
   cacheWrite: 0,
 };
 
 export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = [
   {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+    maxTokens: DEEPSEEK_V4_MAX_TOKENS,
+    cost: DEEPSEEK_V4_FLASH_COST,
+    compat: DEEPSEEK_COMPAT,
+  },
+  {
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+    maxTokens: DEEPSEEK_V4_MAX_TOKENS,
+    cost: DEEPSEEK_V4_PRO_COST,
+    compat: DEEPSEEK_COMPAT,
+  },
+  {
     id: "deepseek-chat",
-    name: "DeepSeek Chat",
+    name: "DeepSeek Chat (legacy)",
     reasoning: false,
     input: ["text"],
-    contextWindow: 131072,
-    maxTokens: 8192,
-    cost: DEEPSEEK_V3_2_COST,
-    compat: { supportsUsageInStreaming: true },
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+    maxTokens: DEEPSEEK_V4_MAX_TOKENS,
+    cost: DEEPSEEK_V4_FLASH_COST,
+    compat: DEEPSEEK_COMPAT,
   },
   {
     id: "deepseek-reasoner",
-    name: "DeepSeek Reasoner",
+    name: "DeepSeek Reasoner (legacy)",
     reasoning: true,
     input: ["text"],
-    contextWindow: 131072,
-    maxTokens: 65536,
-    cost: DEEPSEEK_V3_2_COST,
-    compat: { supportsUsageInStreaming: true },
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+    maxTokens: DEEPSEEK_LEGACY_REASONER_MAX_TOKENS,
+    cost: DEEPSEEK_V4_FLASH_COST,
+    compat: DEEPSEEK_COMPAT,
   },
 ];
 

--- a/extensions/deepseek/onboard.ts
+++ b/extensions/deepseek/onboard.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/provider-onboard";
 import { buildDeepSeekModelDefinition, DEEPSEEK_BASE_URL, DEEPSEEK_MODEL_CATALOG } from "./api.js";
 
-export const DEEPSEEK_DEFAULT_MODEL_REF = "deepseek/deepseek-chat";
+export const DEEPSEEK_DEFAULT_MODEL_REF = "deepseek/deepseek-v4-flash";
 
 export function applyDeepSeekProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -10,6 +10,7 @@ import {
   composeProviderStreamWrappers,
   createMoonshotThinkingWrapper,
   createToolStreamWrapper,
+  DEEPSEEK_THINKING_STREAM_HOOKS,
   GOOGLE_THINKING_STREAM_HOOKS,
   KILOCODE_THINKING_STREAM_HOOKS,
   MINIMAX_FAST_MODE_STREAM_HOOKS,
@@ -215,6 +216,80 @@ describe("buildProviderStreamFamilyHooks", () => {
       thinking: { type: "disabled" },
     });
     expect((capturedPayload?.thinking as Record<string, unknown>) ?? {}).not.toHaveProperty("keep");
+
+    const deepseekHooks = DEEPSEEK_THINKING_STREAM_HOOKS;
+    const deepseekStream = requireStreamFn(
+      requireWrapStreamFn(deepseekHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "low",
+        modelId: "deepseek-v4-flash",
+      } as never),
+    );
+    payloadSeed = { tool_choice: "required" };
+    await deepseekStream(
+      { api: "openai-completions", id: "deepseek-v4-flash" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      tool_choice: "required",
+      thinking: { type: "enabled" },
+    });
+
+    const deepseekProStream = requireStreamFn(
+      requireWrapStreamFn(deepseekHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "low",
+        modelId: "deepseek-v4-pro",
+      } as never),
+    );
+    await deepseekProStream(
+      { api: "openai-completions", id: "deepseek-v4-pro" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      thinking: { type: "enabled" },
+    });
+
+    const deepseekReasonerStream = requireStreamFn(
+      requireWrapStreamFn(deepseekHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "off",
+        modelId: "deepseek-reasoner",
+        extraParams: { thinking: { type: "disabled" } },
+      } as never),
+    );
+    await deepseekReasonerStream(
+      { api: "openai-completions", id: "deepseek-reasoner" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      thinking: { type: "enabled" },
+    });
+
+    payloadSeed = { thinking: { type: "enabled" } };
+    const deepseekChatStream = requireStreamFn(
+      requireWrapStreamFn(deepseekHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "low",
+        modelId: "deepseek-chat",
+        extraParams: { thinking: { type: "enabled" } },
+      } as never),
+    );
+    await deepseekChatStream(
+      { api: "openai-completions", id: "deepseek-chat" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+    });
+    expect(capturedPayload).not.toHaveProperty("thinking");
 
     const openAiHooks = OPENAI_RESPONSES_STREAM_HOOKS;
     void requireStreamFn(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -28,6 +28,7 @@ import type { ProviderPlugin } from "../plugins/types.js";
 import type { ProviderWrapStreamFnContext } from "./plugin-entry.js";
 import {
   createMoonshotThinkingWrapper,
+  createPayloadPatchStreamWrapper,
   createToolStreamWrapper,
   resolveMoonshotThinkingType,
 } from "./provider-stream-shared.js";
@@ -49,7 +50,55 @@ export {
   streamWithPayloadPatch,
 } from "./provider-stream-shared.js";
 
+type DeepSeekThinkingType = "enabled" | "disabled";
+const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+function isDeepSeekV4ModelId(modelId: string | undefined): boolean {
+  return modelId ? DEEPSEEK_V4_MODEL_IDS.has(modelId.trim().toLowerCase()) : false;
+}
+
+function normalizeDeepSeekThinkingType(value: unknown): DeepSeekThinkingType | undefined {
+  if (typeof value === "boolean") {
+    return value ? "enabled" : "disabled";
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["enabled", "enable", "on", "true"].includes(normalized)) {
+      return "enabled";
+    }
+    if (["disabled", "disable", "off", "false"].includes(normalized)) {
+      return "disabled";
+    }
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return normalizeDeepSeekThinkingType((value as Record<string, unknown>).type);
+  }
+  return undefined;
+}
+
+function resolveDeepSeekThinkingType(params: {
+  configuredThinking: unknown;
+  modelId?: string;
+  thinkingLevel?: string;
+}): DeepSeekThinkingType | undefined {
+  if (params.modelId === "deepseek-reasoner") {
+    return "enabled";
+  }
+  if (!isDeepSeekV4ModelId(params.modelId)) {
+    return undefined;
+  }
+  const configured = normalizeDeepSeekThinkingType(params.configuredThinking);
+  if (configured) {
+    return configured;
+  }
+  if (!params.thinkingLevel) {
+    return undefined;
+  }
+  return params.thinkingLevel === "off" ? "disabled" : "enabled";
+}
+
 export type ProviderStreamFamily =
+  | "deepseek-thinking"
   | "google-thinking"
   | "kilocode-thinking"
   | "moonshot-thinking"
@@ -64,6 +113,25 @@ export function buildProviderStreamFamilyHooks(
   family: ProviderStreamFamily,
 ): ProviderStreamFamilyHooks {
   switch (family) {
+    case "deepseek-thinking":
+      return {
+        wrapStreamFn: (ctx: ProviderWrapStreamFnContext) =>
+          createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
+            const modelId = ctx.modelId ?? model.id;
+            if (modelId === "deepseek-chat") {
+              delete payload.thinking;
+              return;
+            }
+            const thinkingType = resolveDeepSeekThinkingType({
+              configuredThinking: ctx.extraParams?.thinking,
+              modelId,
+              thinkingLevel: ctx.thinkingLevel,
+            });
+            if (thinkingType) {
+              payload.thinking = { type: thinkingType };
+            }
+          }),
+      };
     case "google-thinking":
       return {
         wrapStreamFn: (ctx: ProviderWrapStreamFnContext) =>
@@ -148,6 +216,7 @@ export function buildProviderStreamFamilyHooks(
   throw new Error("Unsupported provider stream family");
 }
 
+export const DEEPSEEK_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("deepseek-thinking");
 export const GOOGLE_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("google-thinking");
 export const KILOCODE_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("kilocode-thinking");
 export const MOONSHOT_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("moonshot-thinking");


### PR DESCRIPTION
## Summary
- Add the official DeepSeek V4 API model names `deepseek-v4-flash` and `deepseek-v4-pro` to the bundled DeepSeek provider catalog and make `deepseek/deepseek-v4-flash` the onboarding default.
- Keep `deepseek-chat` and `deepseek-reasoner` as legacy compatibility aliases while aligning their thinking controls with DeepSeek's V4 modes.
- Add a DeepSeek-specific thinking payload wrapper that supports the official V4 model IDs, strips thinking payloads from `deepseek-chat`, preserves tool choice payloads, and avoids OpenAI `reasoning_effort`.

## Why
DeepSeek is deprecating `deepseek-chat` and `deepseek-reasoner` on 2026-07-24. This keeps existing configs working while exposing the current V4 model names requested in #71006.

## Validation
- `pnpm test:extension deepseek`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-sdk/provider-stream.test.ts`
- `pnpm test:extensions:package-boundary:compile`
- `node scripts/check-src-extension-import-boundary.mjs --json`
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json`
- `pnpm exec oxfmt --check extensions/deepseek/models.ts extensions/deepseek/index.ts extensions/deepseek/onboard.ts extensions/deepseek/index.test.ts docs/providers/deepseek.md src/plugin-sdk/provider-stream.ts src/plugin-sdk/provider-stream.test.ts`
- `git diff --check`
- `codex review -c model="gpt-5.4" --base origin/main`

## AI-Assisted Contribution Notes
- AI-assisted: yes, implemented with Codex.
- Testing level: targeted validation for the DeepSeek extension and shared provider-stream hook.
- Prompt/session context: requested DeepSeek V4 model-name support for #71006, then addressed bot and local Codex review feedback around DeepSeek thinking controls, legacy alias behavior, provider payload coupling, and avoiding unofficial model ID assumptions.
- Understanding: this changes the bundled DeepSeek model catalog/default/docs and adds a DeepSeek-specific thinking payload wrapper so the official V4 models use DeepSeek `thinking.type`, `deepseek-reasoner` stays thinking-on, and `deepseek-chat` stays non-thinking.
- Review follow-up: local Codex review reported no discrete regression in this patch, and addressed bot review conversations have been resolved.

Closes #71006
