### PR TITLE
perf(plugins): add O(1) fast-path for empty plugin loads

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3283,6 +3283,39 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(registry.plugins).toEqual([]);
   });
 
+  it("skips discovery and manifest registry loading entirely when onlyPluginIds is an explicit empty array", async () => {
+    useNoBundledPlugins();
+    const allowed = writePlugin({
+      id: "allowed-empty-scope",
+      filename: "allowed-empty-scope.cjs",
+      body: `module.exports = { id: "allowed-empty-scope", register() {} };`,
+    });
+
+    const discovery = await import("./discovery.js");
+    const manifestRegistry = await import("./manifest-registry.js");
+    const discoverySpy = vi.spyOn(discovery, "discoverOpenClawPlugins");
+    const manifestSpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistry");
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      config: {
+        plugins: {
+          load: { paths: [allowed.file] },
+          allow: ["allowed-empty-scope"],
+        },
+      },
+      onlyPluginIds: [],
+    });
+
+    expect(registry.plugins).toEqual([]);
+    expect(discoverySpy).not.toHaveBeenCalled();
+    expect(manifestSpy).not.toHaveBeenCalled();
+
+    discoverySpy.mockRestore();
+    manifestSpy.mockRestore();
+  });
+
   it("only publishes plugin commands to the global registry during activating loads", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -115,6 +115,7 @@ import {
   serializePluginIdScope,
 } from "./plugin-scope.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resolvePluginCacheInputs } from "./roots.js";
 import {
   getActivePluginRegistry,
@@ -2233,6 +2234,25 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const logger = options.logger ?? defaultLogger();
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
+
+  if (onlyPluginIdSet && onlyPluginIdSet.size === 0) {
+    const emptyRegistry = createEmptyPluginRegistry();
+    if (shouldActivate) {
+      clearAgentHarnesses();
+      clearPluginCommands();
+      clearPluginInteractiveHandlers();
+      clearDetachedTaskLifecycleRuntimeRegistration();
+      clearMemoryPluginState();
+      activatePluginRegistry(
+        emptyRegistry,
+        cacheKey,
+        runtimeSubagentMode,
+        options.workspaceDir,
+      );
+    }
+    return emptyRegistry;
+  }
+
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);


### PR DESCRIPTION
## Summary

- Problem: When `activation-planner` finds no matching plugins, `onlyPluginIds` is passed as an empty array `[]`. Previously, `loadOpenClawPlugins` would still perform expensive cache lookups, directory discovery (`discoverOpenClawPlugins`), and manifest parsing (`loadPluginManifestRegistry`) just to return an empty registry.
- Why it matters: This adds unnecessary CPU cycles and disk I/O for requests that are guaranteed to load zero plugins.
- What changed: Added an early fast-path exit that instantly returns an empty registry when `onlyPluginIdSet.size === 0`.
- What did NOT change: The `shouldActivate` state-clearance side-effects (`clearAgentHarnesses`, etc.) are properly mirrored to prevent ghost states from previously loaded plugins.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix (Performance optimization)
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65298
- Related #65120

## Root Cause (if applicable)
N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
 - [x] Unit test
 - [ ] Seam / integration test
 - [ ] End-to-end test
 - [ ] Existing coverage already sufficient

- Target test or file: `src/plugins/loader.test.ts`
- Scenario the test should lock in: Explicitly empty plugin loads (`onlyPluginIds: []`) should return an empty registry without invoking directory discovery or cache lookups.

## User-visible / Behavior Changes
None. This is a pure performance optimization for the plugin loader.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No

## Human Verification (required)

- Verified scenarios:
  - Fast-path correctly intercepts explicit empty array `[]` but allows `undefined` (full load) to pass through.
  - `shouldActivate` correctly clears global states (`clearAgentHarnesses`, etc.) to prevent ghost states.
  - Skips `discoverOpenClawPlugins` and `loadPluginManifestRegistry` entirely.

## AI assistance

- AI-assisted: yes