### PR TITLE
fix(cli): key gemini cli auth epoch on google account identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Auth/Claude CLI: sync refreshed Claude CLI OAuth credentials into the managed auth profile so long-running Claude CLI runs stop falling back to stale OpenClaw snapshots. (#70902) Thanks @starvex.
 - Sessions: make `sessions_spawn(mode="session")` errors name usable alternatives when the current channel cannot bind subagent threads. Fixes #67400. (#67790) Thanks @stainlu.
 - Agents/Claude CLI: pass the OpenClaw system prompt through Claude's prompt-file flag so Windows runs avoid argv length failures without changing system prompt semantics. Fixes #69158. (#69211) Thanks @skylee-01, @cassioanorte, @Syu0, and @Stache73.
+- Agents/CLI sessions: bind `google-gemini-cli` session auth-epoch to the Google account identity in `~/.gemini/oauth_creds.json`, so Gemini-backed agents resume their conversation after gateway restart instead of minting a fresh session, and stale bindings are invalidated when the authenticated Google account changes. Fixes #70973. (#71076) Thanks @openperf.
 
 ## 2026.4.25 (Unreleased)
 

--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -15,6 +15,7 @@ describe("resolveCliAuthEpoch", () => {
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => null,
       readCodexCliCredentialsCached: () => null,
+      readGeminiCliCredentialsCached: () => null,
       loadAuthProfileStoreForRuntime: () => ({
         version: 1,
         profiles: {},
@@ -74,6 +75,70 @@ describe("resolveCliAuthEpoch", () => {
     expect(second).not.toBe(first);
   });
 
+  it("keeps gemini cli oauth epochs stable through token rotation and flips on account change", async () => {
+    let access = "gemini-access-a";
+    let refresh = "gemini-refresh-a";
+    let expires = 1;
+    let accountId: string | undefined = "google-account-1";
+    let email: string | undefined = "user-a@example.com";
+    setCliAuthEpochTestDeps({
+      readGeminiCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "google-gemini-cli",
+        access,
+        refresh,
+        expires,
+        ...(accountId ? { accountId } : {}),
+        ...(email ? { email } : {}),
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+    access = "gemini-access-b";
+    refresh = "gemini-refresh-b";
+    expires = 2;
+    const second = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+
+    expect(first).toBeDefined();
+    // Access and refresh rotation must not shift the epoch while the lifted
+    // Google-account identity is stable.
+    expect(second).toBe(first);
+
+    email = "user-b@example.com";
+    const third = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+
+    expect(third).toBeDefined();
+    expect(third).not.toBe(second);
+
+    accountId = "google-account-2";
+    const fourth = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+
+    expect(fourth).toBeDefined();
+    expect(fourth).not.toBe(third);
+  });
+
+  it("falls back to the identity-less oauth epoch when gemini id_token is absent", async () => {
+    let refresh = "gemini-refresh-a";
+    setCliAuthEpochTestDeps({
+      readGeminiCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "google-gemini-cli",
+        access: "gemini-access",
+        refresh,
+        expires: 1,
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+    refresh = "gemini-refresh-b";
+    const second = await resolveCliAuthEpoch({ provider: "google-gemini-cli" });
+
+    expect(first).toBeDefined();
+    // Without lifted identity, the epoch is a provider-keyed constant that
+    // survives token rotation — same fallback as the Claude CLI OAuth branch.
+    expect(second).toBe(first);
+  });
+
   it("keeps oauth auth-profile epochs stable across token refreshes", async () => {
     let store: AuthProfileStore = {
       version: 1,
@@ -89,6 +154,7 @@ describe("resolveCliAuthEpoch", () => {
       },
     };
     setCliAuthEpochTestDeps({
+      readGeminiCliCredentialsCached: () => null,
       loadAuthProfileStoreForRuntime: () => store,
     });
 
@@ -133,6 +199,7 @@ describe("resolveCliAuthEpoch", () => {
       },
     };
     setCliAuthEpochTestDeps({
+      readGeminiCliCredentialsCached: () => null,
       loadAuthProfileStoreForRuntime: () => store,
     });
 

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -5,25 +5,29 @@ import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/ty
 import {
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
+  readGeminiCliCredentialsCached,
   type ClaudeCliCredential,
   type CodexCliCredential,
+  type GeminiCliCredential,
 } from "./cli-credentials.js";
 
 type CliAuthEpochDeps = {
   readClaudeCliCredentialsCached: typeof readClaudeCliCredentialsCached;
   readCodexCliCredentialsCached: typeof readCodexCliCredentialsCached;
+  readGeminiCliCredentialsCached: typeof readGeminiCliCredentialsCached;
   loadAuthProfileStoreForRuntime: typeof loadAuthProfileStoreForRuntime;
 };
 
 const defaultCliAuthEpochDeps: CliAuthEpochDeps = {
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
+  readGeminiCliCredentialsCached,
   loadAuthProfileStoreForRuntime,
 };
 
 const cliAuthEpochDeps: CliAuthEpochDeps = { ...defaultCliAuthEpochDeps };
 
-export const CLI_AUTH_EPOCH_VERSION = 3;
+export const CLI_AUTH_EPOCH_VERSION = 4;
 
 export function setCliAuthEpochTestDeps(overrides: Partial<CliAuthEpochDeps>): void {
   Object.assign(cliAuthEpochDeps, overrides);
@@ -72,6 +76,17 @@ function encodeCodexCredential(credential: CodexCliCredential): string {
   return encodeOAuthIdentity(credential);
 }
 
+function encodeGeminiCredential(credential: GeminiCliCredential): string {
+  // Delegate to the shared OAuth-identity encoder. The Gemini CLI reader
+  // lifts the Google-account identity (sub, email) off the openid id_token
+  // onto the credential, so the encoder fingerprints the user through stable,
+  // non-secret identity fields — matching the Claude/Codex OAuth contract.
+  // When the id_token is absent (older logins, scope omitted), the encoder
+  // falls back to a provider-keyed constant, the same identity-less behavior
+  // the Claude CLI OAuth branch tolerates.
+  return encodeOAuthIdentity(credential);
+}
+
 function encodeAuthProfileCredential(credential: AuthProfileCredential): string {
   switch (credential.type) {
     case "api_key":
@@ -113,6 +128,12 @@ function getLocalCliCredentialFingerprint(provider: string): string | undefined 
         ttlMs: 5000,
       });
       return credential ? hashCliAuthEpochPart(encodeCodexCredential(credential)) : undefined;
+    }
+    case "google-gemini-cli": {
+      const credential = cliAuthEpochDeps.readGeminiCliCredentialsCached({
+        ttlMs: 5000,
+      });
+      return credential ? hashCliAuthEpochPart(encodeGeminiCredential(credential)) : undefined;
     }
     default:
       return undefined;

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -12,6 +12,7 @@ let resetCliCredentialCachesForTest: typeof import("./cli-credentials.js").reset
 let writeClaudeCliKeychainCredentials: typeof import("./cli-credentials.js").writeClaudeCliKeychainCredentials;
 let writeClaudeCliCredentials: typeof import("./cli-credentials.js").writeClaudeCliCredentials;
 let readCodexCliCredentials: typeof import("./cli-credentials.js").readCodexCliCredentials;
+let readGeminiCliCredentialsCached: typeof import("./cli-credentials.js").readGeminiCliCredentialsCached;
 
 function mockExistingClaudeKeychainItem() {
   execFileSyncMock.mockImplementation((file: unknown, args: unknown) => {
@@ -74,6 +75,7 @@ describe("cli credentials", () => {
       writeClaudeCliKeychainCredentials,
       writeClaudeCliCredentials,
       readCodexCliCredentials,
+      readGeminiCliCredentialsCached,
     } = await import("./cli-credentials.js"));
   });
 
@@ -358,6 +360,71 @@ describe("cli credentials", () => {
         refresh: "fresh-refresh",
         expires: secondExpiry * 1000,
       });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("lifts Google account identity from the Gemini id_token", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gemini-"));
+    try {
+      const credPath = path.join(tempHome, ".gemini", "oauth_creds.json");
+      fs.mkdirSync(path.dirname(credPath), { recursive: true, mode: 0o700 });
+      const idTokenPayload = Buffer.from(
+        JSON.stringify({ sub: "google-account-42", email: "user@example.com" }),
+      ).toString("base64url");
+      const idToken = `header.${idTokenPayload}.signature`;
+      fs.writeFileSync(
+        credPath,
+        JSON.stringify({
+          access_token: "gemini-access",
+          refresh_token: "gemini-refresh",
+          id_token: idToken,
+          expiry_date: Date.parse("2026-04-25T12:00:00Z"),
+        }),
+        "utf8",
+      );
+
+      const creds = readGeminiCliCredentialsCached({ homeDir: tempHome, ttlMs: 0 });
+
+      expect(creds).toMatchObject({
+        type: "oauth",
+        provider: "google-gemini-cli",
+        access: "gemini-access",
+        refresh: "gemini-refresh",
+        accountId: "google-account-42",
+        email: "user@example.com",
+      });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("reads Gemini credentials without identity fields when id_token is absent", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gemini-noid-"));
+    try {
+      const credPath = path.join(tempHome, ".gemini", "oauth_creds.json");
+      fs.mkdirSync(path.dirname(credPath), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(
+        credPath,
+        JSON.stringify({
+          access_token: "gemini-access",
+          refresh_token: "gemini-refresh",
+          expiry_date: Date.parse("2026-04-25T12:00:00Z"),
+        }),
+        "utf8",
+      );
+
+      const creds = readGeminiCliCredentialsCached({ homeDir: tempHome, ttlMs: 0 });
+
+      expect(creds).toMatchObject({
+        type: "oauth",
+        provider: "google-gemini-cli",
+        access: "gemini-access",
+        refresh: "gemini-refresh",
+      });
+      expect(creds?.accountId).toBeUndefined();
+      expect(creds?.email).toBeUndefined();
     } finally {
       fs.rmSync(tempHome, { recursive: true, force: true });
     }

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -13,6 +13,7 @@ const log = createSubsystemLogger("agents/auth-profiles");
 const CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH = ".claude/.credentials.json";
 const CODEX_CLI_AUTH_FILENAME = "auth.json";
 const MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH = ".minimax/oauth_creds.json";
+const GEMINI_CLI_CREDENTIALS_RELATIVE_PATH = ".gemini/oauth_creds.json";
 
 const CLAUDE_CLI_KEYCHAIN_SERVICE = "Claude Code-credentials";
 const CLAUDE_CLI_KEYCHAIN_ACCOUNT = "Claude Code";
@@ -27,11 +28,13 @@ type CachedValue<T> = {
 let claudeCliCache: CachedValue<ClaudeCliCredential> | null = null;
 let codexCliCache: CachedValue<CodexCliCredential> | null = null;
 let minimaxCliCache: CachedValue<MiniMaxCliCredential> | null = null;
+let geminiCliCache: CachedValue<GeminiCliCredential> | null = null;
 
 export function resetCliCredentialCachesForTest(): void {
   claudeCliCache = null;
   codexCliCache = null;
   minimaxCliCache = null;
+  geminiCliCache = null;
 }
 
 export type ClaudeCliCredential =
@@ -65,6 +68,16 @@ export type MiniMaxCliCredential = {
   access: string;
   refresh: string;
   expires: number;
+};
+
+export type GeminiCliCredential = {
+  type: "oauth";
+  provider: "google-gemini-cli";
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  email?: string;
 };
 
 type ClaudeCliFileOptions = {
@@ -129,6 +142,11 @@ function resolveCodexHomePath(codexHome?: string) {
 function resolveMiniMaxCliCredentialsPath(homeDir?: string) {
   const baseDir = homeDir ?? resolveUserPath("~");
   return path.join(baseDir, MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH);
+}
+
+function resolveGeminiCliCredentialsPath(homeDir?: string) {
+  const baseDir = homeDir ?? resolveUserPath("~");
+  return path.join(baseDir, GEMINI_CLI_CREDENTIALS_RELATIVE_PATH);
 }
 
 function readFileMtimeMs(filePath: string): number | null {
@@ -208,6 +226,22 @@ function decodeJwtExpiryMs(token: string): number | null {
       : null;
   } catch {
     return null;
+  }
+}
+
+function decodeJwtIdentityClaims(token: string): { sub?: string; email?: string } {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return {};
+  }
+  try {
+    const payloadRaw = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payload = JSON.parse(payloadRaw) as { sub?: unknown; email?: unknown };
+    const sub = typeof payload.sub === "string" && payload.sub ? payload.sub : undefined;
+    const email = typeof payload.email === "string" && payload.email ? payload.email : undefined;
+    return { sub, email };
+  } catch {
+    return {};
   }
 }
 
@@ -326,6 +360,49 @@ function readPortalCliOauthCredentials<TProvider extends string>(
 function readMiniMaxCliCredentials(options?: { homeDir?: string }): MiniMaxCliCredential | null {
   const credPath = resolveMiniMaxCliCredentialsPath(options?.homeDir);
   return readPortalCliOauthCredentials(credPath, "minimax-portal");
+}
+
+function readGeminiCliCredentials(options?: { homeDir?: string }): GeminiCliCredential | null {
+  const credPath = resolveGeminiCliCredentialsPath(options?.homeDir);
+  const raw = loadJsonFile(credPath);
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const data = raw as Record<string, unknown>;
+  const accessToken = data.access_token;
+  const refreshToken = data.refresh_token;
+  const expiresAt = data.expiry_date;
+
+  if (typeof accessToken !== "string" || !accessToken) {
+    return null;
+  }
+  if (typeof refreshToken !== "string" || !refreshToken) {
+    return null;
+  }
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+    return null;
+  }
+
+  // Gemini CLI's login flow stores the openid id_token alongside the OAuth
+  // tokens. Decode it once here to lift the Google account identity (sub,
+  // email) onto the credential so the shared OAuth-identity encoder can key
+  // the auth epoch on stable, non-secret identity material — matching the
+  // Claude/Codex contract that #70132 codifies. Without this lift the encoder
+  // collapses to a provider-keyed constant and stale bindings can survive a
+  // re-login under a different Google account.
+  const idTokenRaw = data.id_token;
+  const identity =
+    typeof idTokenRaw === "string" && idTokenRaw ? decodeJwtIdentityClaims(idTokenRaw) : {};
+
+  return {
+    type: "oauth",
+    provider: "google-gemini-cli",
+    access: accessToken,
+    refresh: refreshToken,
+    expires: expiresAt,
+    ...(identity.email ? { email: identity.email } : {}),
+    ...(identity.sub ? { accountId: identity.sub } : {}),
+  };
 }
 
 function readClaudeCliKeychainCredentials(
@@ -605,6 +682,23 @@ export function readMiniMaxCliCredentialsCached(options?: {
     read: () => readMiniMaxCliCredentials({ homeDir: options?.homeDir }),
     setCache: (next) => {
       minimaxCliCache = next;
+    },
+    readSourceFingerprint: () => readFileMtimeMs(credPath),
+  });
+}
+
+export function readGeminiCliCredentialsCached(options?: {
+  ttlMs?: number;
+  homeDir?: string;
+}): GeminiCliCredential | null {
+  const credPath = resolveGeminiCliCredentialsPath(options?.homeDir);
+  return readCachedCliCredential({
+    ttlMs: options?.ttlMs ?? 0,
+    cache: geminiCliCache,
+    cacheKey: credPath,
+    read: () => readGeminiCliCredentials({ homeDir: options?.homeDir }),
+    setCache: (next) => {
+      geminiCliCache = next;
     },
     readSourceFingerprint: () => readFileMtimeMs(credPath),
   });

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -182,6 +182,33 @@ describe("cli-session helpers", () => {
     ).toEqual({ sessionId: "cli-session-1" });
   });
 
+  it("accepts v3 bindings without authEpoch as binding upgrades to v4", () => {
+    // Pre-v4 google-gemini-cli sessions persisted with authEpochVersion: 3
+    // and no authEpoch (the local credential fingerprint returned undefined
+    // before id_token identity lifting). The version-gate must skip the
+    // epoch comparison for these so the next request after upgrade reuses
+    // the stored session instead of forcing a one-time invalidation.
+    const binding = {
+      sessionId: "cli-session-1",
+      authProfileId: undefined,
+      // authEpoch deliberately absent
+      authEpochVersion: 3,
+      extraSystemPromptHash: "prompt-a",
+      mcpConfigHash: "mcp-a",
+    };
+
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        authProfileId: undefined,
+        authEpoch: "v4-identity-hash",
+        authEpochVersion: 4,
+        extraSystemPromptHash: "prompt-a",
+        mcpConfigHash: "mcp-a",
+      }),
+    ).toEqual({ sessionId: "cli-session-1" });
+  });
+
   it("does not treat model changes as a session mismatch", () => {
     const binding = {
       sessionId: "cli-session-1",


### PR DESCRIPTION
### Summary

- **Problem**: `getLocalCliCredentialFingerprint` in `src/agents/cli-auth-epoch.ts:114` dispatches on `provider` through a `switch` with explicit branches for `claude-cli` and `codex-cli`; `google-gemini-cli` falls through to the `default` branch and returns `undefined`. As a result, the `authEpoch` value stored alongside a `google-gemini-cli` CLI session binding never binds to the user's local Gemini OAuth state at `~/.gemini/oauth_creds.json`, and the auth-epoch contract that Claude CLI and Codex CLI rely on is unenforceable on Gemini sessions. Reported in #70973.
- **Root Cause**: The auth-epoch contract implemented by `encodeOAuthIdentity` keys the epoch on stable, non-secret OAuth identity fields (`clientId` / `email` / `enterpriseUrl` / `projectId` / `accountId`) so the stored binding survives access-token rotation and flips on re-authentication under a different account. Gemini CLI's `~/.gemini/oauth_creds.json` carries the OpenID `id_token` JWT alongside the OAuth tokens; its `sub` and `email` claims are the identity fields that line up with the `encodeOAuthIdentity` shape Claude and Codex already feed.
- **Fix**:
  1. In `src/agents/cli-credentials.ts`, decode the openid `id_token` once at credential-read time and lift `sub` → `accountId` and `email` → `email` onto `GeminiCliCredential`. The existing `readCachedCliCredential` helper continues to provide the 5000 ms TTL and `readFileMtimeMs`-based source-fingerprinting.
  2. In `src/agents/cli-auth-epoch.ts`, register `google-gemini-cli` in `getLocalCliCredentialFingerprint` and delegate `encodeGeminiCredential` to the shared `encodeOAuthIdentity`. With identity fields populated, the encoder produces an identity-keyed hash. When the `id_token` is absent (older logins, scope omitted), `encodeOAuthIdentity` collapses to a provider-keyed constant — the same identity-less fallback the Claude CLI OAuth branch produces, preserving backward compatibility for legacy login state.
  3. Bump `CLI_AUTH_EPOCH_VERSION` from `3` to `4` so existing `google-gemini-cli` bindings on disk (persisted with `authEpoch: undefined`, since the local fingerprint returned `undefined` before this change) hit the existing version-gate at `src/agents/cli-session.ts:152` and skip the epoch comparison on the first request after upgrade. Once the next turn writes a fresh binding under v4 with the identity-keyed hash, all subsequent comparisons run normally. This is the same migration mechanism the file's existing `"accepts older auth epoch versions for binding upgrades"` test already pins.
- **What changed**:
  - `src/agents/cli-credentials.ts`: add `GEMINI_CLI_CREDENTIALS_RELATIVE_PATH`, a `GeminiCliCredential` type with optional `accountId` / `email` identity fields, a `geminiCliCache` slot, a `resolveGeminiCliCredentialsPath` helper, and `readGeminiCliCredentials` / `readGeminiCliCredentialsCached` that read the OAuth file directly, decode the `id_token` JWT through a new private `decodeJwtIdentityClaims` helper (mirroring the existing `decodeJwtExpiryMs`), and lift `sub` / `email` onto the credential. Extend `resetCliCredentialCachesForTest` to clear the new cache.
  - `src/agents/cli-auth-epoch.ts`: import `readGeminiCliCredentialsCached` and `GeminiCliCredential`; register the reader on `CliAuthEpochDeps` and its defaults for test injection; add `encodeGeminiCredential` that delegates to the shared `encodeOAuthIdentity`; add the `case "google-gemini-cli"` branch mirroring the existing Codex and Claude branches; bump `CLI_AUTH_EPOCH_VERSION` from `3` to `4`.
  - `src/agents/cli-credentials.test.ts`: add two tests — `id_token` lift produces `accountId` / `email` on the credential, and credentials read without an `id_token` round-trip without identity fields (legacy fallback).
  - `src/agents/cli-auth-epoch.test.ts`: extend the existing "no local or auth-profile credentials" case to stub the new dep; assert that the Gemini local-credential epoch (a) stays stable across access/refresh rotation when identity is unchanged, (b) flips on `email` change, (c) flips on `accountId` change; add a separate test for the `id_token`-absent case asserting identity-less fallback stability.
  - `src/agents/cli-session.test.ts`: add `"accepts v3 bindings without authEpoch as binding upgrades to v4"` mirroring the existing `"accepts older auth epoch versions for binding upgrades"` case, pinning the version-gate behavior for the v3 → v4 migration.
- **What did NOT change (scope boundary)**:
  - `resolveCliAuthEpoch`'s public signature, the overall parts ordering, or the hash construction. Existing Claude / Codex callers compute bit-for-bit identical epochs.
  - `resolveCliSessionReuse` and the `cliSessionBindings` schema. No new fields, no migrations. Existing bindings on disk keep working through the file's existing `authEpochVersion` upgrade semantics.
  - The shared `encodeOAuthIdentity` helper and the Claude / Codex encoders — they keep returning the exact same strings for pre-existing inputs.
  - `readPortalCliOauthCredentials` and the MiniMax reader — untouched. Gemini gets a dedicated reader because, unlike MiniMax, it carries an `id_token`.
  - `extensions/google/` — no extension code changes. The new reader lives alongside the existing Claude and Codex readers to stay consistent with the current core pattern.
  - Warm-stdio / `claude-live-session.ts` — not applicable to the Gemini transport (`output: "json"`, `input: "arg"`).
  - No PII hashing — `sub` and `email` are non-secret OpenID claims, the same identity shape Claude / Codex already feed into `encodeOAuthIdentity`.

### Reproduction

1. Set up `google-gemini-cli` via Gemini CLI's own `gemini auth login` so `~/.gemini/oauth_creds.json` exists with real `access_token` / `refresh_token` / `expiry_date` / `id_token`.
2. Start OpenClaw with a `google-gemini-cli/*` default model and have a multi-turn conversation. A `cliSessionBindings["google-gemini-cli"]` entry is persisted with an identity-keyed `authEpoch`.
3. On subsequent turns (including across gateway restarts) the recomputed local `authEpoch` matches the stored one as long as the Gemini credential file still belongs to the same account, and the session is reused. When the user logs out and re-logs under a different Google account, `id_token.sub` changes, the epoch flips, `resolveCliSessionReuse` returns `{ invalidatedReason: "auth-epoch" }`, and OpenClaw mints a fresh binding — matching the behavior Claude and Codex already have.
4. **Migration of existing bindings**: a `google-gemini-cli` session persisted under a prior version stores `authEpochVersion: 3` with no `authEpoch` field. After upgrading to a build with this PR, the first request hits the version-gate (`3 !== 4`) and skips the epoch comparison, so the stored session is reused without churn. The turn then rewrites the binding under v4 with the identity-keyed hash, and all subsequent comparisons run normally.

### Risk / Mitigation

- **Risk**: Reading a new file from disk (`~/.gemini/oauth_creds.json`) on an auth-epoch hot path could regress startup / latency.
- **Mitigation**: The read goes through the existing `readCachedCliCredential` helper with a 5000 ms TTL and `readFileMtimeMs`-based source-fingerprinting, identical to the Codex reader. When the file is absent the read returns `null` in a single `stat` call. No new network I/O. The added `id_token` decoding is a single base64url + JSON parse on a value the file already contains, mirroring the existing `decodeJwtExpiryMs` pattern in the same file.
- **Risk**: A malformed or tampered `id_token` could cause the reader to throw on every auth-epoch computation.
- **Mitigation**: `decodeJwtIdentityClaims` wraps the parse in a try/catch and returns `{}` on any error — the credential round-trips without identity fields and the encoder falls back to the identity-less constant. The credential reader itself is unaffected by `id_token` malformation.
- **Risk**: Rotation of `id_token` payload contents (e.g., Google adding new claims) shifts the epoch.
- **Mitigation**: `decodeJwtIdentityClaims` only reads two specific string fields (`sub`, `email`); unknown additional claims are ignored. The encoder consumes only `accountId` / `email` from the lifted shape. Stable.
- **Risk**: A user with no `openid email` scope on their Gemini login (older flows) sees a constant epoch.
- **Mitigation**: Intentional and matches the Claude CLI OAuth branch's identity-less fallback exactly. The added "falls back to the identity-less oauth epoch when gemini id_token is absent" test pins this behavior.
- **Risk**: The version bump (`3` → `4`) is global; on the first request after upgrade, every CLI provider's existing bindings (Claude / Codex / Gemini) skip the auth-epoch check via the version-gate. A user who switched OAuth accounts in this exact deploy window could reuse a stale binding for one request before the new binding is written under v4.
- **Mitigation**: The encoders for Claude and Codex are unchanged in this PR, so the v3 stored hash and the v4 computed hash are bit-for-bit identical for steady-state users — the version-gate skip is a no-op for them in practice. The race window is bounded to a single request per binding because the next turn rewrites the binding at v4 with the current identity hash. The behavior is pinned by the new `"accepts v3 bindings without authEpoch as binding upgrades to v4"` test alongside the file's existing version-upgrade coverage.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents
- [x] CLI sessions
- [x] Provider: Google Gemini CLI
- [x] Tests

### Linked Issue/PR

Fixes #70973