### PR TITLE
[T0422-18] fix: allow CLI agents to trigger memoryFlush

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -169,30 +169,54 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
   });
 
-  it("skips memory flush for CLI providers", async () => {
+  it("allows memory flush for CLI providers", async () => {
+    const storePath = path.join(rootDir, "sessions-cli.json");
+    const sessionKey = "main";
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokens: 80_000,
       compactionCount: 1,
     };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (params: {
+        onAgentEvent?: (evt: { stream: string; data: { phase: string } }) => void;
+      }) => {
+        params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
+        return {
+          payloads: [],
+          meta: { agentMeta: { sessionId: "session-rotated" } },
+        };
+      },
+    );
 
     const entry = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { cliBackends: { "codex-cli": { command: "codex" } } } } },
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "codex-cli": { command: "codex" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      },
       followupRun: createTestFollowupRun({ provider: "codex-cli" }),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
       defaultModel: "codex-cli/gpt-5.5",
       agentCfgContextTokens: 100_000,
       resolvedVerboseLevel: "off",
       sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
+      sessionStore,
+      sessionKey,
+      storePath,
       isHeartbeat: false,
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
-    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(entry?.sessionId).toBe("session-rotated");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses runtime policy session key when checking memory-flush sandbox writability", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -377,8 +377,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
-  const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
-  if (params.isHeartbeat || isCli) {
+  if (params.isHeartbeat) {
     return entry ?? params.sessionEntry;
   }
 
@@ -431,7 +430,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
       `contextWindow=${contextWindowTokens} threshold=${threshold} ` +
-      `isHeartbeat=${params.isHeartbeat} isCli=${isCli} ` +
+      `isHeartbeat=${params.isHeartbeat} ` +
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"}`,
@@ -553,7 +552,7 @@ export async function runMemoryFlushIfNeeded(params: {
   })();
 
   const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
-  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
+  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat;
   let entry =
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
@@ -700,7 +699,6 @@ export async function runMemoryFlushIfNeeded(params: {
   const shouldFlushMemory =
     (memoryFlushWritable &&
       !params.isHeartbeat &&
-      !isCli &&
       shouldRunMemoryFlush({
         entry,
         tokenCount: tokenCountForFlush,


### PR DESCRIPTION
## Summary

- Remove `!isCli` / `|| isCli` gates from `runMemoryFlushIfNeeded` and `runPreflightCompactionIfNeeded` in `agent-runner-memory.ts`
- CLI-backend agents (e.g. `claude-cli`) can now trigger memory flush and preflight compaction, matching non-CLI provider behaviour
- Update test: "skips memory flush for CLI providers" → "allows memory flush for CLI providers"

## Context

During the Claude Code 4.15 migration (2026-04-22), we discovered that CLI agents never triggered `memoryFlush` because `isCliProvider()` short-circuited both compaction and flush paths. This was temporarily patched in dist files (`~/.openclaw/node_modules`), but those patches are lost on `npm install` / upgrade.

This PR upstreams those dist patches into the source. The slug generator fix (`resolveAgentEffectiveModelPrimary` for billing isolation) was already present in the source — only the `!isCli` gate removal was missing.

**Prior art:** `shared/reports/2026-04-22-claude-code-switch-retro.md` §3 坑 2 (L46-54) + §5.2.1 固化要求

## Changes

**`src/auto-reply/reply/agent-runner-memory.ts`** (4 hunks):
1. `runPreflightCompactionIfNeeded`: remove `isCli` variable and `|| isCli` early-return gate
2. Same function: remove `isCli` from debug log (variable no longer in scope)
3. `runMemoryFlushIfNeeded`: remove `&& !isCli` from `canAttemptFlush`
4. Same function: remove `!isCli &&` from `shouldFlushMemory`

**`src/auto-reply/reply/agent-runner-memory.test.ts`** (1 hunk):
- Replace "skips memory flush for CLI providers" with "allows memory flush for CLI providers" — test now verifies CLI providers **do** trigger flush and session rotation

## Test plan

- [x] `agent-runner-memory.test.ts` — 5/5 passing
- [ ] CI pipeline green
- [ ] Verify no other tests depend on CLI-provider flush skip behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)