### PR TITLE
fix: forward params.think to Ollama provider

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -118,6 +118,7 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: "none" | "short" | "long";
   cachedContent?: string;
   openaiWsWarmup?: boolean;
+  think?: boolean;
 };
 export type SupportedTransport = Exclude<CacheRetentionStreamOptions["transport"], undefined>;
 
@@ -314,6 +315,9 @@ function createStreamFnWithExtraParams(
         : undefined;
   if (typeof cachedContent === "string" && cachedContent.trim()) {
     streamParams.cachedContent = cachedContent.trim();
+  }
+  if (typeof extraParams.think === "boolean") {
+    streamParams.think = extraParams.think;
   }
   const initialCacheRetention = resolveCacheRetention(
     extraParams,


### PR DESCRIPTION
## Summary

`params.think` from model config was silently dropped in `createStreamFnWithExtraParams()` because it was not in the stream params whitelist. This prevented disabling thinking on Ollama thinking models (e.g. Qwen 3.5) for heartbeat and other lightweight tasks.

## Changes

- Added `think?: boolean` to `CacheRetentionStreamOptions` type
- Added `think` boolean check in `createStreamFnWithExtraParams()` whitelist

The boolean flows through stream options to the Ollama provider, which sends it as `options.think` in the API payload.

## Testing

- Verified the parameter is now included in the stream params when `extraParams.think` is set
- Type checking passes (boolean-only guard)

Closes #71089