### PR TITLE
fix(stability): preserve error message, stack, and cause in bundle writer (#71071)

### DIFF
--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -88,7 +88,12 @@ describe("diagnostic stability bundles", () => {
       reason: "json_body_limit",
     });
 
-    const error = Object.assign(new Error("contains secret message"), { code: "ERR_TEST" });
+    const error = Object.assign(
+      new Error(
+        "startup failed for alice@example.com token=eyJhbGciOiJIUzI1NiJ9.payloadsecret.signaturesecret",
+      ),
+      { code: "ERR_TEST" },
+    );
     const result = writeDiagnosticStabilityBundleSync({
       reason: "gateway.restart_startup_failed",
       error,
@@ -116,6 +121,14 @@ describe("diagnostic stability bundles", () => {
         count: 2,
       },
     });
+    // Safe parts of the error message are preserved so startup failures are
+    // actually diagnosable (#71071).
+    expect(bundle.error?.message).toContain("startup failed");
+    expect(typeof bundle.error?.stack).toBe("string");
+    expect(bundle.error?.stack).toContain("Error");
+    // Sensitive fragments are redacted by redactTextForSupport.
+    expect(bundle.error?.message).not.toContain("alice@example.com");
+    expect(bundle.error?.message).not.toContain("eyJhbGciOiJIUzI1NiJ9");
     expect(bundle.snapshot.events[0]).toMatchObject({
       type: "webhook.error",
       channel: "telegram",
@@ -124,8 +137,86 @@ describe("diagnostic stability bundles", () => {
     expect(bundle.snapshot.events[0]).not.toHaveProperty("error");
     expect(raw).not.toContain("chat-secret");
     expect(raw).not.toContain("message body");
-    expect(raw).not.toContain("contains secret message");
+    expect(raw).not.toContain("alice@example.com");
+    expect(raw).not.toContain("eyJhbGciOiJIUzI1NiJ9");
     expect(raw).not.toContain(os.hostname());
+  });
+
+  it("preserves error message, stack, and nested cause for startup failures", () => {
+    // Regression test for #71071: stability bundles must retain the actionable
+    // error metadata that engineers need to diagnose gateway startup failures.
+    const inner = new Error("root cause: hooks.allowedSessionKeyPrefixes is required");
+    const outer = Object.assign(new Error("gateway startup failed: config validation"), {
+      code: "ERR_CONFIG_PARSE",
+      cause: inner,
+    });
+
+    const result = writeDiagnosticStabilityBundleForFailureSync("gateway.startup_failed", outer, {
+      stateDir: tempDir,
+      now: new Date("2026-04-22T12:00:00.000Z"),
+    });
+
+    if (result.status !== "written") {
+      throw new Error(`expected written bundle, got ${result.status}`);
+    }
+    const bundle = readBundle(result.path);
+    expect(bundle.error?.name).toBe("Error");
+    expect(bundle.error?.code).toBe("ERR_CONFIG_PARSE");
+    expect(bundle.error?.message).toContain("gateway startup failed");
+    expect(bundle.error?.message).toContain("config validation");
+    expect(bundle.error?.stack).toContain("Error");
+    expect(bundle.error?.cause?.message).toContain("hooks.allowedSessionKeyPrefixes is required");
+    expect(bundle.error?.cause?.stack).toContain("Error");
+  });
+
+  it("truncates and redacts oversized error messages and stacks", () => {
+    const longSecret = "a".repeat(4096);
+    const error = Object.assign(new Error(`huge blob ${longSecret}`), {
+      code: "ERR_BIG",
+    });
+    // Synthesize an equally oversized stack with a redactable token.
+    error.stack = `Error: huge blob\n  at token=eyJhbGciOiJIUzI1NiJ9.payloadsecret.signaturesecret\n${"x".repeat(8192)}`;
+
+    const result = writeDiagnosticStabilityBundleForFailureSync("gateway.startup_failed", error, {
+      stateDir: tempDir,
+      now: new Date("2026-04-22T12:00:00.000Z"),
+    });
+    if (result.status !== "written") {
+      throw new Error(`expected written bundle, got ${result.status}`);
+    }
+    const bundle = readBundle(result.path);
+    // Message and stack must be bounded to keep bundles small.
+    expect(bundle.error?.message?.length).toBeLessThanOrEqual(1024 + 32);
+    expect(bundle.error?.stack?.length).toBeLessThanOrEqual(4096 + 32);
+    expect(bundle.error?.message?.endsWith("...<truncated>")).toBe(true);
+    expect(bundle.error?.stack?.endsWith("...<truncated>")).toBe(true);
+    // JWT in the stack trace must not leak.
+    expect(bundle.error?.stack).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+  });
+
+  it("limits error cause chains to avoid runaway recursion", () => {
+    // Build a chain deeper than the permitted recursion limit.
+    const depth5 = new Error("depth 5");
+    const depth4 = Object.assign(new Error("depth 4"), { cause: depth5 });
+    const depth3 = Object.assign(new Error("depth 3"), { cause: depth4 });
+    const depth2 = Object.assign(new Error("depth 2"), { cause: depth3 });
+    const depth1 = Object.assign(new Error("depth 1"), { cause: depth2 });
+    const depth0 = Object.assign(new Error("depth 0"), { cause: depth1 });
+
+    const result = writeDiagnosticStabilityBundleForFailureSync("gateway.startup_failed", depth0, {
+      stateDir: tempDir,
+      now: new Date("2026-04-22T12:00:00.000Z"),
+    });
+    if (result.status !== "written") {
+      throw new Error(`expected written bundle, got ${result.status}`);
+    }
+    const bundle = readBundle(result.path);
+    // We keep the top-level error plus up to MAX_ERROR_CAUSE_DEPTH (3) nested causes.
+    expect(bundle.error?.message).toContain("depth 0");
+    expect(bundle.error?.cause?.message).toContain("depth 1");
+    expect(bundle.error?.cause?.cause?.message).toContain("depth 2");
+    expect(bundle.error?.cause?.cause?.cause?.message).toContain("depth 3");
+    expect(bundle.error?.cause?.cause?.cause?.cause).toBeUndefined();
   });
 
   it("skips empty recorder snapshots by default", () => {
@@ -139,9 +230,18 @@ describe("diagnostic stability bundles", () => {
   });
 
   it("writes failure bundles even when the recorder snapshot is empty", () => {
+    // The error.message is now preserved (sanitized) so engineers can diagnose
+    // startup failures straight from the stability bundle (#71071). Use a
+    // payload containing a token to ensure sensitive content is still redacted.
+    const error = Object.assign(
+      new Error(
+        "raw startup config payload token=eyJhbGciOiJIUzI1NiJ9.payloadsecret.signaturesecret",
+      ),
+      { code: "ERR_CONFIG_PARSE" },
+    );
     const result = writeDiagnosticStabilityBundleForFailureSync(
       "gateway.restart_startup_failed",
-      Object.assign(new Error("raw startup config payload"), { code: "ERR_CONFIG_PARSE" }),
+      error,
       {
         stateDir: tempDir,
         now: new Date("2026-04-22T12:00:00.000Z"),
@@ -164,7 +264,10 @@ describe("diagnostic stability bundles", () => {
         events: [],
       },
     });
-    expect(raw).not.toContain("raw startup config payload");
+    expect(bundle.error?.message).toContain("raw startup config payload");
+    expect(bundle.error?.stack).toContain("Error");
+    // JWT-like tokens are redacted before being written to disk.
+    expect(raw).not.toContain("eyJhbGciOiJIUzI1NiJ9");
   });
 
   it("registers a fatal hook only while installed", () => {

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -8,6 +8,7 @@ import {
   MAX_DIAGNOSTIC_STABILITY_LIMIT,
   type DiagnosticStabilitySnapshot,
 } from "./diagnostic-stability.js";
+import { redactTextForSupport } from "./diagnostic-support-redaction.js";
 
 export const DIAGNOSTIC_STABILITY_BUNDLE_VERSION = 1;
 export const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_LIMIT = MAX_DIAGNOSTIC_STABILITY_LIMIT;
@@ -18,6 +19,18 @@ const SAFE_REASON_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
 const BUNDLE_PREFIX = "openclaw-stability-";
 const BUNDLE_SUFFIX = ".json";
 const REDACTED_HOSTNAME = "<redacted-hostname>";
+const MAX_ERROR_MESSAGE_LENGTH = 1024;
+const MAX_ERROR_STACK_LENGTH = 4096;
+const MAX_ERROR_CAUSE_DEPTH = 3;
+const ERROR_TRUNCATION_SUFFIX = "...<truncated>";
+
+export type DiagnosticStabilityBundleError = {
+  name?: string;
+  code?: string;
+  message?: string;
+  stack?: string;
+  cause?: DiagnosticStabilityBundleError;
+};
 
 export type DiagnosticStabilityBundle = {
   version: typeof DIAGNOSTIC_STABILITY_BUNDLE_VERSION;
@@ -33,10 +46,7 @@ export type DiagnosticStabilityBundle = {
   host: {
     hostname: string;
   };
-  error?: {
-    name?: string;
-    code?: string;
-  };
+  error?: DiagnosticStabilityBundleError;
   snapshot: DiagnosticStabilitySnapshot;
 };
 
@@ -113,7 +123,80 @@ function readErrorName(error: unknown): string | undefined {
   return typeof name === "string" && SAFE_REASON_CODE.test(name) ? name : undefined;
 }
 
-function readSafeErrorMetadata(error: unknown): DiagnosticStabilityBundle["error"] | undefined {
+function redactAndTruncate(value: string, maxLength: number): string {
+  const redacted = redactTextForSupport(value);
+  if (redacted.length <= maxLength) {
+    return redacted;
+  }
+  return `${redacted.slice(0, maxLength)}${ERROR_TRUNCATION_SUFFIX}`;
+}
+
+function readErrorMessage(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("message" in error)) {
+    return undefined;
+  }
+  const message = (error as { message?: unknown }).message;
+  if (typeof message !== "string" || message.length === 0) {
+    return undefined;
+  }
+  return redactAndTruncate(message, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+function readErrorStack(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("stack" in error)) {
+    return undefined;
+  }
+  const stack = (error as { stack?: unknown }).stack;
+  if (typeof stack !== "string" || stack.length === 0) {
+    return undefined;
+  }
+  return redactAndTruncate(stack, MAX_ERROR_STACK_LENGTH);
+}
+
+function readErrorCause(error: unknown, depth: number): DiagnosticStabilityBundleError | undefined {
+  if (depth >= MAX_ERROR_CAUSE_DEPTH) {
+    return undefined;
+  }
+  if (!error || typeof error !== "object" || !("cause" in error)) {
+    return undefined;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause === undefined || cause === null) {
+    return undefined;
+  }
+  return readSafeErrorMetadataAtDepth(cause, depth + 1);
+}
+
+function readSafeErrorMetadataAtDepth(
+  error: unknown,
+  depth: number,
+): DiagnosticStabilityBundleError | undefined {
+  const name = readErrorName(error);
+  const code = readErrorCode(error);
+  const message = readErrorMessage(error);
+  const stack = readErrorStack(error);
+  const cause = readErrorCause(error, depth);
+  if (!name && !code && !message && !stack && !cause) {
+    return undefined;
+  }
+  return {
+    ...(name ? { name } : {}),
+    ...(code ? { code } : {}),
+    ...(message ? { message } : {}),
+    ...(stack ? { stack } : {}),
+    ...(cause ? { cause } : {}),
+  };
+}
+
+function readSafeErrorMetadata(error: unknown): DiagnosticStabilityBundleError | undefined {
+  return readSafeErrorMetadataAtDepth(error, 0);
+}
+
+// Parser path: imported bundles may be adversarial, so we only keep the
+// name/code fields that are already constrained by SAFE_REASON_CODE. This
+// deliberately drops any message/stack/cause from disk-sourced bundles to
+// avoid re-emitting untrusted free-form text during sanitized reads.
+function readImportedSafeErrorMetadata(error: unknown): DiagnosticStabilityBundleError | undefined {
   const name = readErrorName(error);
   const code = readErrorCode(error);
   if (!name && !code) {
@@ -454,7 +537,8 @@ function parseDiagnosticStabilityBundle(value: unknown): DiagnosticStabilityBund
   }
   const processInfo = readObject(bundle.process, "process");
   readObject(bundle.host, "host");
-  const error = bundle.error === undefined ? undefined : readSafeErrorMetadata(bundle.error);
+  const error =
+    bundle.error === undefined ? undefined : readImportedSafeErrorMetadata(bundle.error);
   return {
     version: DIAGNOSTIC_STABILITY_BUNDLE_VERSION,
     generatedAt: readTimestampString(bundle.generatedAt, "generatedAt"),


### PR DESCRIPTION
## Summary

Fixes #71071 — the stability bundle writer dropped the error `message`, `stack`, and `cause`, writing only `{"error":{"name":"Error"}}` when the gateway failed to start. That made the bundle (the file we point operators at) effectively empty, and forced cross-referencing the main log to find the real cause.

## Root cause

`readSafeErrorMetadata` in `src/logging/diagnostic-stability-bundle.ts` only returned `{ name, code }`. `JSON.stringify(error)` on a native `Error` also serializes to `{}` because `message`/`stack` aren't enumerable, so there was no fallback. The omission looked intentional (secret-hygiene), which is why simply dumping the error wasn't the right fix.

## Fix

Extend `readSafeErrorMetadata` (writer path only) to capture:

- `message` — passed through `redactTextForSupport` and bounded to **1 KB**
- `stack` — redacted and bounded to **4 KB**
- `cause` — recursively captured up to **MAX_ERROR_CAUSE_DEPTH = 3**

`redactTextForSupport` already strips JWTs, basic-auth, cookies, URL credentials, emails, matrix IDs, long decimal IDs, etc., so sensitive fragments don't leak into bundles on disk. A `...<truncated>` suffix flags bounded strings.

The parser path (`readImportedSafeErrorMetadata`) deliberately still drops `message`/`stack`/`cause` from bundles read back from disk. Imported bundles may be adversarial, and only the `SAFE_REASON_CODE`-constrained `name`/`code` fields can be trusted without re-sanitizing free-form text. Writer ↔ reader asymmetry is intentional and documented in-line.

## Tests

All in `src/logging/diagnostic-stability-bundle.test.ts`:

- **existing** `writes a payload-free bundle with safe failure metadata` — extended to assert that safe message fragments survive while JWTs/emails are redacted
- **existing** `writes failure bundles even when the recorder snapshot is empty` — same: message now preserved, JWT still redacted
- **new** `preserves error message, stack, and nested cause for startup failures` — direct regression test for #71071 (`cause` chain)
- **new** `truncates and redacts oversized error messages and stacks` — verifies 1 KB / 4 KB bounds + JWT scrubbing in stack lines
- **new** `limits error cause chains to avoid runaway recursion` — verifies the depth-3 cap on nested causes

```
✓ src/logging/diagnostic-stability-bundle.test.ts  (13 tests)
✓ src/logging/diagnostic-support-export.test.ts   (9 tests)
✓ src/cli/gateway-cli/run.option-collisions.test.ts (16 tests)
✓ src/gateway/gateway-stability.test.ts            (3 tests)
✓ src/logging/diagnostic.test.ts                   (11 tests)
✓ src/logging/diagnostic-stability.test.ts         (7 tests)
```

Typecheck: `pnpm tsgo:core` and `pnpm tsgo:test:src` both clean.

## Scope notes

The issue report also mentions `events: []` / `count: 0` in the sample bundle. That's orthogonal — those events are empty because the failure happens before the diagnostic recorder sees anything, not because of a writer bug — so it's out of scope here.

## Not addressed

- Events array at startup (as above)
- Backfilling `message`/`stack` into the reader. Only the writer preserves them on purpose (controlled input); the reader stays conservative.

Fixes #71071

🩹 Small fix, big leverage — stability bundles are now actually readable when a gateway refuses to boot.
