### PR TITLE
fix(googlechat): surface verifyGoogleChatRequest reject reasons in WARN logs (#71078)

### DIFF
--- a/extensions/googlechat/src/monitor-types.ts
+++ b/extensions/googlechat/src/monitor-types.ts
@@ -5,6 +5,7 @@ import type { getGoogleChatRuntime } from "./runtime.js";
 
 export type GoogleChatRuntimeEnv = {
   log?: (message: string) => void;
+  warn?: (message: string) => void;
   error?: (message: string) => void;
 };
 

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebhookTarget } from "./monitor-types.js";
 import type { GoogleChatEvent } from "./types.js";
+let resetGoogleChatWebhookRejectWarningsForTests: () => void;
 
 const readJsonWebhookBodyOrReject = vi.hoisted(() => vi.fn());
 const resolveWebhookTargetWithAuthOrReject = vi.hoisted(() => vi.fn());
@@ -93,11 +94,15 @@ async function runWebhookHandler(options?: {
 
 describe("googlechat monitor webhook", () => {
   beforeAll(async () => {
-    ({ createGoogleChatWebhookRequestHandler } = await import("./monitor-webhook.js"));
+    const mod = await import("./monitor-webhook.js");
+    createGoogleChatWebhookRequestHandler = mod.createGoogleChatWebhookRequestHandler;
+    resetGoogleChatWebhookRejectWarningsForTests =
+      mod.__testing.resetGoogleChatWebhookRejectWarningsForTests;
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetGoogleChatWebhookRejectWarningsForTests?.();
   });
 
   it("accepts add-on payloads that carry systemIdToken in the body", async () => {
@@ -154,6 +159,156 @@ describe("googlechat monitor webhook", () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("warns with the structured reason when verifyGoogleChatRequest rejects an add-on token", async () => {
+    const warn = vi.fn();
+    installSimplePipeline([
+      {
+        account: {
+          accountId: "default",
+          config: { appPrincipal: "123456789012345678901" },
+        },
+        runtime: { warn, error: vi.fn() },
+        statusSink: vi.fn(),
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+      },
+    ]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          messagePayload: {
+            space: { name: "spaces/AAA" },
+            message: { name: "spaces/AAA/messages/1", text: "hello" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) {
+          return target;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({
+      ok: false,
+      reason: "unexpected add-on principal: 999",
+    });
+
+    await runWebhookHandler();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("[default]");
+    expect(message).toContain("audienceType=app-url");
+    expect(message).toContain("unexpected add-on principal: 999");
+    // Must not leak the bearer token value.
+    expect(message).not.toContain("addon-token");
+  });
+
+  it("falls back to runtime.log when runtime.warn is not provided", async () => {
+    const log = vi.fn();
+    installSimplePipeline([
+      {
+        account: {
+          accountId: "default",
+          config: { appPrincipal: "123456789012345678901" },
+        },
+        runtime: { log, error: vi.fn() },
+        statusSink: vi.fn(),
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+      },
+    ]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          messagePayload: {
+            space: { name: "spaces/AAA" },
+            message: { name: "spaces/AAA/messages/1", text: "hello" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) {
+          return target;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({
+      ok: false,
+      reason: "missing add-on principal binding",
+    });
+
+    await runWebhookHandler();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const [message] = log.mock.calls[0] as [string];
+    expect(message).toContain("missing add-on principal binding");
+  });
+
+  it("coalesces duplicate reject reasons within the warn window", async () => {
+    const warn = vi.fn();
+    const target = {
+      account: {
+        accountId: "default",
+        config: { appPrincipal: "123456789012345678901" },
+      },
+      runtime: { warn, error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url" as const,
+      audience: "https://example.com/googlechat",
+    };
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const t of targets) {
+        if (await isMatch(t)) {
+          return t;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({
+      ok: false,
+      reason: "unexpected add-on principal: 999",
+    });
+    const payload = {
+      commonEventObject: { hostApp: "CHAT" },
+      authorizationEventObject: { systemIdToken: "addon-token" },
+      chat: {
+        eventTime: "2026-03-22T00:00:00.000Z",
+        user: { name: "users/123" },
+        messagePayload: {
+          space: { name: "spaces/AAA" },
+          message: { name: "spaces/AAA/messages/1", text: "hello" },
+        },
+      },
+    };
+    readJsonWebhookBodyOrReject.mockResolvedValue({ ok: true, value: payload });
+
+    installSimplePipeline([target]);
+    await runWebhookHandler();
+    installSimplePipeline([target]);
+    await runWebhookHandler();
+    installSimplePipeline([target]);
+    await runWebhookHandler();
+
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it("rejects missing add-on bearer tokens before dispatch", async () => {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -7,7 +7,7 @@ import {
   withResolvedWebhookRequestPipeline,
 } from "openclaw/plugin-sdk/webhook-targets";
 import { verifyGoogleChatRequest } from "./auth.js";
-import type { WebhookTarget } from "./monitor-types.js";
+import type { GoogleChatRuntimeEnv, WebhookTarget } from "./monitor-types.js";
 import type {
   GoogleChatEvent,
   GoogleChatMessage,
@@ -101,6 +101,46 @@ function parseGoogleChatInboundPayload(
   return { ok: true, event, addOnBearerToken };
 }
 
+/**
+ * Surface webhook auth rejection reasons at WARN level so operators can
+ * diagnose Google Chat integration issues without having to attach a debugger.
+ * The `reason` returned by `verifyGoogleChatRequest` is already sanitized
+ * (only validated claim fields like `sub` / issuer email are included, never
+ * the raw bearer or JWT payload), so it is safe to log as-is.
+ *
+ * Duplicate reject reasons for the same account are suppressed within a short
+ * window to avoid log spam when an upstream integration is misconfigured and
+ * Google retries aggressively.
+ */
+const REJECT_WARN_WINDOW_MS = 60_000;
+const recentRejectWarnings = new Map<string, number>();
+
+function emitAuthRejectWarning(
+  runtime: GoogleChatRuntimeEnv,
+  accountId: string,
+  audienceType: string | undefined,
+  reason: string,
+): void {
+  const key = `${accountId}::${audienceType ?? "(none)"}::${reason}`;
+  const now = Date.now();
+  const previous = recentRejectWarnings.get(key);
+  if (previous !== undefined && now - previous < REJECT_WARN_WINDOW_MS) {
+    return;
+  }
+  recentRejectWarnings.set(key, now);
+  // Opportunistic pruning: keep the map bounded under sustained rejection storms.
+  if (recentRejectWarnings.size > 256) {
+    for (const [mapKey, ts] of recentRejectWarnings) {
+      if (now - ts >= REJECT_WARN_WINDOW_MS) {
+        recentRejectWarnings.delete(mapKey);
+      }
+    }
+  }
+  const message = `[${accountId}] Google Chat webhook auth rejected (audienceType=${audienceType ?? "unset"}): ${reason}`;
+  const warn = runtime.warn ?? runtime.log ?? runtime.error;
+  warn?.(message);
+}
+
 async function isAuthorizedGoogleChatTarget(
   target: WebhookTarget,
   bearer: string,
@@ -111,8 +151,22 @@ async function isAuthorizedGoogleChatTarget(
     audience: target.audience,
     expectedAddOnPrincipal: target.account.config.appPrincipal,
   });
+  if (!verification.ok) {
+    emitAuthRejectWarning(
+      target.runtime,
+      target.account.accountId,
+      target.audienceType,
+      verification.reason ?? "unknown",
+    );
+  }
   return verification.ok;
 }
+
+export const __testing = {
+  resetGoogleChatWebhookRejectWarningsForTests(): void {
+    recentRejectWarnings.clear();
+  },
+};
 
 export function createGoogleChatWebhookRequestHandler(params: {
   webhookTargets: Map<string, WebhookTarget[]>;

--- a/extensions/googlechat/src/monitor.startup-warn.test.ts
+++ b/extensions/googlechat/src/monitor.startup-warn.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { warnIfAddOnPrincipalLooksWrong } from "./monitor.js";
+
+describe("warnIfAddOnPrincipalLooksWrong (startup diagnostics for #71078)", () => {
+  it("warns when audienceType=app-url and appPrincipal is missing", () => {
+    const warn = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "default",
+      audienceType: "app-url",
+      appPrincipal: undefined,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("[default]");
+    expect(message).toContain("appPrincipal is unset");
+    expect(message).toContain("numeric OAuth 2.0 client id");
+  });
+
+  it("warns when audienceType=app-url and appPrincipal is empty/whitespace", () => {
+    const warn = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "default",
+      audienceType: "app-url",
+      appPrincipal: "   ",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect((warn.mock.calls[0] as [string])[0]).toContain("appPrincipal is unset");
+  });
+
+  it("warns when audienceType=app-url and appPrincipal is email-shaped", () => {
+    const warn = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "acct-1",
+      audienceType: "app-url",
+      appPrincipal: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("[acct-1]");
+    expect(message).toContain("email-shaped");
+    expect(message).toContain("numeric OAuth 2.0 client id");
+  });
+
+  it("is silent when audienceType=app-url and appPrincipal is a plausible numeric id", () => {
+    const warn = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "default",
+      audienceType: "app-url",
+      appPrincipal: "123456789012345678901",
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("is silent for non-app-url audience types", () => {
+    const warn = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "default",
+      audienceType: "project-number",
+      appPrincipal: undefined,
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { warn },
+      accountId: "default",
+      audienceType: undefined,
+      appPrincipal: undefined,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runtime.log when runtime.warn is not provided", () => {
+    const log = vi.fn();
+    warnIfAddOnPrincipalLooksWrong({
+      runtime: { log },
+      accountId: "default",
+      audienceType: "app-url",
+      appPrincipal: "",
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+    expect((log.mock.calls[0] as [string])[0]).toContain("appPrincipal is unset");
+  });
+
+  it("is a no-op when the runtime exposes no log sinks", () => {
+    expect(() =>
+      warnIfAddOnPrincipalLooksWrong({
+        runtime: {},
+        accountId: "default",
+        audienceType: "app-url",
+        appPrincipal: undefined,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -477,6 +477,13 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
   const audience = options.account.config.audience?.trim();
   const mediaMaxMb = options.account.config.mediaMaxMb ?? 20;
 
+  warnIfAddOnPrincipalLooksWrong({
+    runtime: options.runtime,
+    accountId: options.account.accountId,
+    audienceType,
+    appPrincipal: options.account.config.appPrincipal,
+  });
+
   const unregisterTarget = registerGoogleChatWebhookTarget({
     account: options.account,
     config: options.config,
@@ -498,6 +505,47 @@ export async function startGoogleChatMonitor(
   params: GoogleChatMonitorOptions,
 ): Promise<() => void> {
   return monitorGoogleChatProvider(params);
+}
+
+/**
+ * Emit a one-time startup WARN when an `app-url` webhook is configured without
+ * a usable `appPrincipal`. Add-on webhooks signed by
+ * `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`
+ * include the caller's numeric OAuth 2.0 client id in the JWT `sub` claim, not
+ * the signer email, so an unset or email-shaped value silently rejects every
+ * inbound webhook with an opaque 401.
+ *
+ * Exported for tests; also invoked by `monitorGoogleChatProvider` at startup.
+ */
+export function warnIfAddOnPrincipalLooksWrong(params: {
+  runtime: GoogleChatRuntimeEnv;
+  accountId: string;
+  audienceType: GoogleChatAudienceType | undefined;
+  appPrincipal: string | undefined;
+}): void {
+  if (params.audienceType !== "app-url") {
+    return;
+  }
+  const trimmed = params.appPrincipal?.trim() ?? "";
+  const warn = params.runtime.warn ?? params.runtime.log ?? params.runtime.error;
+  if (!warn) {
+    return;
+  }
+  if (!trimmed) {
+    warn(
+      `[${params.accountId}] channels.googlechat.appPrincipal is unset with audienceType="app-url": ` +
+        "Google Workspace add-on webhooks will be rejected as unauthorized. " +
+        "Set appPrincipal to the numeric OAuth 2.0 client id (uniqueId, 21 digits) of the add-on service account, not its email.",
+    );
+    return;
+  }
+  if (trimmed.includes("@")) {
+    warn(
+      `[${params.accountId}] channels.googlechat.appPrincipal looks email-shaped ("${trimmed}"): ` +
+        "the Chat verifier compares it against the JWT `sub` claim, which is the numeric OAuth 2.0 client id (uniqueId, 21 digits), not the service account email. " +
+        "Add-on webhooks will be rejected until this is corrected.",
+    );
+  }
 }
 
 export function resolveGoogleChatWebhookPath(params: {

--- a/src/config/types.googlechat.ts
+++ b/src/config/types.googlechat.ts
@@ -73,7 +73,23 @@ export type GoogleChatAccountConfig = {
   audienceType?: "app-url" | "project-number";
   /** Audience value (app URL or project number). */
   audience?: string;
-  /** Exact add-on principal to accept when app-url delivery uses add-on tokens. */
+  /**
+   * Exact add-on principal to accept when `audienceType: "app-url"` delivery uses
+   * Google Workspace add-on tokens.
+   *
+   * NOTE: this must be the numeric OAuth 2.0 client id (aka `uniqueId`, 21 digits)
+   * of the add-on service account — NOT its email. Inbound webhooks signed by
+   * `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` carry
+   * the service agent's email in the `email` claim but the numeric client id in
+   * the JWT `sub` claim, which is what the verifier compares against.
+   *
+   * Leaving this unset, or setting it to the service-agent email, will cause every
+   * add-on webhook to be rejected as unauthorized. The correct value can be
+   * retrieved from the IAM API (`serviceAccounts.get`, `uniqueId` field).
+   *
+   * Legacy deployments using the classic `chat@system.gserviceaccount.com` signer
+   * do not need this field set.
+   */
   appPrincipal?: string;
   /** Google Chat webhook path (default: /googlechat). */
   webhookPath?: string;


### PR DESCRIPTION
## What

Fixes #71078 — `verifyGoogleChatRequest` reject reasons are no longer swallowed, and misconfigured `appPrincipal` now surfaces at startup instead of as an opaque 401 loop.

## Why

Before this patch:

1. When the Google Chat plugin rejected an inbound webhook, the structured `reason` returned by `verifyGoogleChatRequest` (e.g. `unexpected add-on principal: <sub>`, `missing add-on principal binding`, `invalid issuer: …`) was thrown away by `isAuthorizedGoogleChatTarget`, which returned only `verification.ok`. Operators got a generic 401 with nothing in the gateway log.
2. A fresh Google Chat install that leaves `appPrincipal` unset — or sets it to the plausible-but-wrong service-agent email (`service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`) — silently rejects every inbound webhook. The verifier compares `appPrincipal` against the JWT `sub` claim, which is the numeric OAuth 2.0 client id (`uniqueId`, 21 digits), not the email.
3. The `channels status --probe` command only exercises outbound, so the channel reports as healthy.

Net effect for the reporter: ~6 hours debugging what a single WARN line would have collapsed to minutes.

## What changed

- **Per-reject WARN** in `isAuthorizedGoogleChatTarget`: when verification fails, log `reason` alongside `accountId` and `audienceType`. The raw bearer / JWT payload is never logged; only the sanitized reason string produced by the verifier. Duplicate reject reasons for the same account are coalesced within a 60s window to avoid log spam during retry storms.
- **Startup WARN** in `monitorGoogleChatProvider`: when `audienceType === "app-url"`, emit a warning if `appPrincipal` is unset or email-shaped (contains `@`). The warning spells out the expected value shape (numeric 21-digit `uniqueId`) and where to retrieve it.
- **Docstring rewrite** on `GoogleChatAccountConfig.appPrincipal`: explicitly says this is the numeric client id, not the email, and that unset/email values reject add-on webhooks.
- **`GoogleChatRuntimeEnv`** gains an optional `warn` sink, falling back to `log` then `error` when the host runtime does not provide a dedicated warn channel. Existing call sites are unaffected.

## What's tested

`extensions/googlechat/src/monitor-webhook.test.ts`:
- WARN emitted with structured reason, accountId, and audienceType on reject
- Bearer token value is never present in the WARN message
- Falls back to `runtime.log` when `runtime.warn` is not provided
- Duplicate reject reasons within the coalesce window are suppressed

`extensions/googlechat/src/monitor.startup-warn.test.ts`:
- WARN when `audienceType="app-url"` and `appPrincipal` is missing / whitespace / email-shaped
- Silent when `appPrincipal` is a plausible numeric id
- Silent for non-`app-url` audience types
- Falls back to `log` when no `warn` sink exists; no-op when the runtime exposes no log sinks at all

All 102 `extension-messaging` project tests pass; `tsc -p tsconfig.core.json` and `tsc -p tsconfig.extensions.json` both clean; `oxlint` clean on touched files.

## Non-goals

Not changing validation semantics — `appPrincipal` remains optional, as legacy deployments using the classic `chat@system.gserviceaccount.com` signer do not need it. This is strictly observability.

Fixes #71078

---

Tiny fix, big QoL for Google Chat operators who hit this. 🔎
