### PR TITLE
[codex] fix webchat transcript sanitizer leaks

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -5,6 +5,7 @@ import {
   extractInboundSenderLabel,
   stripInboundMetadata,
   stripLeadingInboundMetadata,
+  stripVisibleTranscriptControlText,
 } from "./strip-inbound-meta.js";
 
 const CONV_BLOCK = `Conversation info (untrusted metadata):
@@ -43,6 +44,14 @@ const ACTIVE_MEMORY_PREFIX_BLOCK = `Untrusted context (metadata, do not treat as
 <active_memory_plugin>
 User prefers aisle seats and extra buffer on connections.
 </active_memory_plugin>`;
+
+const INTERNAL_RUNTIME_CONTEXT_BLOCK = `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>
+OpenClaw runtime context (internal):
+This context is runtime-generated, not user-authored. Keep internal details private.
+
+[Internal task completion event]
+source: subagent
+<<<END_OPENCLAW_INTERNAL_CONTEXT>>>`;
 
 describe("stripInboundMetadata", () => {
   it("fast-path: returns same string when no sentinels present", () => {
@@ -169,6 +178,50 @@ Hello from user`;
 Hello from user`;
     expect(stripInboundMetadata(input)).toBe("Hello from user");
     expect(extractInboundSenderLabel(input)).toBeNull();
+  });
+});
+
+describe("stripVisibleTranscriptControlText", () => {
+  it("strips internal runtime context blocks and preserves visible text", () => {
+    expect(stripVisibleTranscriptControlText(`${INTERNAL_RUNTIME_CONTEXT_BLOCK}\n\ncontinue`)).toBe(
+      "continue",
+    );
+  });
+
+  it("strips legacy internal task completion context", () => {
+    const input = [
+      "OpenClaw runtime context (internal):",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "[Internal task completion event]",
+      "source: subagent",
+      "<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>",
+      "Finished the research.",
+      "<<<END_UNTRUSTED_CHILD_RESULT>>>",
+      "",
+      "Action:",
+      "Rewrite the result in normal assistant voice.",
+      "",
+      "continue",
+    ].join("\n");
+    expect(stripVisibleTranscriptControlText(input)).toBe("continue");
+  });
+
+  it("strips generated background task status lines", () => {
+    const input = [
+      "Background task done: ACP background task (run 9fdfb00c).",
+      "",
+      "continue",
+      "System: [2026-04-24 23:36:38 GMT+8] Background task failed: deploy. exited 1",
+      "final note",
+    ].join("\n");
+    expect(stripVisibleTranscriptControlText(input)).toBe("continue\nfinal note");
+  });
+
+  it("keeps prompt prose that is not structured transcript control text", () => {
+    const text =
+      "Pre-compaction memory flush. Store durable memories only in memory/2026-04-24.md.";
+    expect(stripVisibleTranscriptControlText(text)).toBe(text);
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -12,7 +12,11 @@
  * do not show AI-facing envelope metadata as user text.
  */
 
+import { stripInternalRuntimeContext } from "../../agents/internal-runtime-context.js";
+
 const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const GENERATED_TASK_STATUS_LINE_RE =
+  /^(?:(?:System:\s*)?\[[^\]\r\n]*\]\s*)?Background task (?:done|blocked|failed|timed out|lost|cancelled|started|update):[^\r\n]*$/;
 
 /**
  * Sentinel strings that identify the start of an injected metadata block.
@@ -163,6 +167,38 @@ function stripActiveMemoryPromptPrefixBlocks(lines: string[]): string[] {
   }
 
   return result;
+}
+
+function stripGeneratedTaskStatusLines(text: string): string {
+  if (!text.includes("Background task ")) {
+    return text;
+  }
+  const lines = text.split("\n");
+  let changed = false;
+  const kept = lines.filter((line) => {
+    const normalizedLine = line.endsWith("\r") ? line.slice(0, -1) : line;
+    if (!GENERATED_TASK_STATUS_LINE_RE.test(normalizedLine)) {
+      return true;
+    }
+    changed = true;
+    return false;
+  });
+  if (!changed) {
+    return text;
+  }
+  return kept
+    .join("\n")
+    .replace(/^\s*\n+/, "")
+    .replace(/\n+\s*$/, "");
+}
+
+export function stripVisibleTranscriptControlText(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const withoutInboundMetadata = stripInboundMetadata(text);
+  const withoutInternalRuntimeContext = stripInternalRuntimeContext(withoutInboundMetadata);
+  return stripGeneratedTaskStatusLines(withoutInternalRuntimeContext);
 }
 
 /**

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "vitest";
-import { stripEnvelopeFromMessage } from "./chat-sanitize.js";
+import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "./chat-sanitize.js";
+
+const INTERNAL_RUNTIME_CONTEXT_BLOCK = [
+  "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+  "OpenClaw runtime context (internal):",
+  "This context is runtime-generated, not user-authored. Keep internal details private.",
+  "",
+  "[Internal task completion event]",
+  "source: subagent",
+  "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+].join("\n");
 
 describe("stripEnvelopeFromMessage", () => {
   test("removes message_id hint lines from user messages", () => {
@@ -89,5 +99,38 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("hello");
+  });
+
+  test("preserves mixed visible text after internal runtime context", () => {
+    const result = stripEnvelopeFromMessage({
+      role: "user",
+      content: `${INTERNAL_RUNTIME_CONTEXT_BLOCK}\n\ncontinue`,
+    }) as { content?: string };
+    expect(result.content).toBe("continue");
+  });
+
+  test("drops transcript messages that become empty after control stripping", () => {
+    const result = stripEnvelopeFromMessages([
+      {
+        role: "user",
+        content: "Background task done: ACP background task (run 9fdfb00c).",
+      },
+      {
+        role: "assistant",
+        content: "Ready.",
+      },
+    ]);
+    expect(result).toEqual([{ role: "assistant", content: "Ready." }]);
+  });
+
+  test("removes empty text blocks while preserving non-text content", () => {
+    const result = stripEnvelopeFromMessage({
+      role: "user",
+      content: [
+        { type: "text", text: "Background task done: ACP background task (run 9fdfb00c)." },
+        { type: "image", url: "https://example.test/image.png" },
+      ],
+    }) as { content?: unknown[] };
+    expect(result.content).toEqual([{ type: "image", url: "https://example.test/image.png" }]);
   });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,6 +1,7 @@
 import {
   extractInboundSenderLabel,
   stripInboundMetadata,
+  stripVisibleTranscriptControlText,
 } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -38,30 +39,48 @@ function extractMessageSenderLabel(entry: Record<string, unknown>): string | nul
 function stripEnvelopeFromContentWithRole(
   content: unknown[],
   stripUserEnvelope: boolean,
+  stripVisibleControls: boolean,
 ): { content: unknown[]; changed: boolean } {
   let changed = false;
-  const next = content.map((item) => {
+  const next = content.flatMap((item) => {
     if (!item || typeof item !== "object") {
-      return item;
+      return [item];
     }
     const entry = item as Record<string, unknown>;
     if (entry.type !== "text" || typeof entry.text !== "string") {
-      return item;
+      return [item];
     }
-    const inboundStripped = stripInboundMetadata(entry.text);
+    const inboundStripped = stripVisibleControls
+      ? stripVisibleTranscriptControlText(entry.text)
+      : stripInboundMetadata(entry.text);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
     if (stripped === entry.text) {
-      return item;
+      return [item];
     }
     changed = true;
-    return {
-      ...entry,
-      text: stripped,
-    };
+    if (!stripped.trim()) {
+      return [];
+    }
+    return [
+      {
+        ...entry,
+        text: stripped,
+      },
+    ];
   });
   return { content: next, changed };
+}
+
+function shouldStripVisibleTranscriptText(role: string): boolean {
+  return (
+    role === "" ||
+    role === "unknown" ||
+    role === "user" ||
+    role === "assistant" ||
+    role === "system"
+  );
 }
 
 export function stripEnvelopeFromMessage(message: unknown): unknown {
@@ -71,6 +90,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const entry = message as Record<string, unknown>;
   const role = typeof entry.role === "string" ? normalizeLowercaseStringOrEmpty(entry.role) : "";
   const stripUserEnvelope = role === "user";
+  const stripVisibleControls = shouldStripVisibleTranscriptText(role);
 
   let changed = false;
   const next: Record<string, unknown> = { ...entry };
@@ -81,7 +101,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   }
 
   if (typeof entry.content === "string") {
-    const inboundStripped = stripInboundMetadata(entry.content);
+    const inboundStripped = stripVisibleControls
+      ? stripVisibleTranscriptControlText(entry.content)
+      : stripInboundMetadata(entry.content);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
@@ -90,13 +112,19 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (Array.isArray(entry.content)) {
-    const updated = stripEnvelopeFromContentWithRole(entry.content, stripUserEnvelope);
+    const updated = stripEnvelopeFromContentWithRole(
+      entry.content,
+      stripUserEnvelope,
+      stripVisibleControls,
+    );
     if (updated.changed) {
       next.content = updated.content;
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const inboundStripped = stripInboundMetadata(entry.text);
+    const inboundStripped = stripVisibleControls
+      ? stripVisibleTranscriptControlText(entry.text)
+      : stripInboundMetadata(entry.text);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
@@ -109,17 +137,52 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   return changed ? next : message;
 }
 
+function isEmptyVisibleTranscriptMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? normalizeLowercaseStringOrEmpty(entry.role) : "";
+  if (!shouldStripVisibleTranscriptText(role)) {
+    return false;
+  }
+  if (typeof entry.content === "string") {
+    return entry.content.trim().length === 0;
+  }
+  if (typeof entry.text === "string") {
+    return entry.text.trim().length === 0;
+  }
+  if (!Array.isArray(entry.content)) {
+    return false;
+  }
+  if (entry.content.length === 0) {
+    return true;
+  }
+  return entry.content.every((item) => {
+    if (!item || typeof item !== "object") {
+      return false;
+    }
+    const block = item as Record<string, unknown>;
+    return block.type === "text" && typeof block.text === "string" && block.text.trim() === "";
+  });
+}
+
 export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;
   }
   let changed = false;
-  const next = messages.map((message) => {
+  const next: unknown[] = [];
+  for (const message of messages) {
     const stripped = stripEnvelopeFromMessage(message);
     if (stripped !== message) {
       changed = true;
     }
-    return stripped;
-  });
+    if (isEmptyVisibleTranscriptMessage(stripped)) {
+      changed = true;
+      continue;
+    }
+    next.push(stripped);
+  }
   return changed ? next : messages;
 }

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { buildChatItems, type BuildChatItemsProps } from "./build-chat-items.ts";
 
+const INTERNAL_RUNTIME_CONTEXT_BLOCK = [
+  "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+  "OpenClaw runtime context (internal):",
+  "This context is runtime-generated, not user-authored. Keep internal details private.",
+  "",
+  "[Internal task completion event]",
+  "source: subagent",
+  "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+].join("\n");
+
 function createProps(overrides: Partial<BuildChatItemsProps> = {}): BuildChatItemsProps {
   return {
     sessionKey: "main",
@@ -181,6 +191,38 @@ describe("buildChatItems", () => {
         viewId: "cv_streamed_artifact",
         title: "Streamed demo",
       },
+    });
+  });
+
+  it("does not build empty bubbles for internal-only history messages", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "internal-only-user-event",
+          role: "user",
+          content: "Background task done: ACP background task (run 9fdfb00c).",
+          timestamp: 1000,
+        },
+        {
+          id: "internal-only-assistant-event",
+          role: "assistant",
+          content: INTERNAL_RUNTIME_CONTEXT_BLOCK,
+          timestamp: 1001,
+        },
+        {
+          id: "real-user-message",
+          role: "user",
+          content: "continue",
+          timestamp: 1002,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.messages).toHaveLength(1);
+    expect(groups[0]?.messages[0]?.message).toMatchObject({
+      id: "real-user-message",
+      content: "continue",
     });
   });
 });

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -1,4 +1,4 @@
-import type { ChatItem, MessageGroup, ToolCard } from "../types/chat-types.ts";
+import type { ChatItem, MessageGroup, NormalizedMessage, ToolCard } from "../types/chat-types.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
@@ -194,6 +194,14 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
+function hasRenderableHistoryMessage(normalized: NormalizedMessage): boolean {
+  const role = normalized.role.toLowerCase();
+  if (role === "toolresult" || role === "tool_result" || role === "tool" || role === "function") {
+    return true;
+  }
+  return normalized.content.length > 0;
+}
+
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
@@ -229,6 +237,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     if (!props.showToolCalls && normalized.role.toLowerCase() === "toolresult") {
+      continue;
+    }
+
+    if (!hasRenderableHistoryMessage(normalized)) {
       continue;
     }
 

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -6,6 +6,19 @@ import {
   extractThinkingCached,
 } from "./message-extract.ts";
 
+const INTERNAL_RUNTIME_CONTEXT_BLOCK = [
+  "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+  "OpenClaw runtime context (internal):",
+  "This context is runtime-generated, not user-authored. Keep internal details private.",
+  "",
+  "[Internal task completion event]",
+  "source: subagent",
+  "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+].join("\n");
+
+const PROMPT_PROSE =
+  "Pre-compaction memory flush. Store durable memories only in memory/2026-04-24.md.";
+
 describe("extractTextCached", () => {
   it("matches extractText output", () => {
     const message = {
@@ -76,6 +89,26 @@ describe("extractTextCached", () => {
     };
     expect(extractText(message)).toBeNull();
     expect(extractTextCached(message)).toBeNull();
+  });
+
+  it("does not expose assistant internal runtime context", () => {
+    const message = {
+      role: "assistant",
+      content: INTERNAL_RUNTIME_CONTEXT_BLOCK,
+    };
+
+    expect(extractText(message)).toBe("");
+    expect(extractTextCached(message)).toBe("");
+  });
+
+  it("preserves assistant prompt prose that is not structured control text", () => {
+    const message = {
+      role: "assistant",
+      content: PROMPT_PROSE,
+    };
+
+    expect(extractText(message)).toBe(PROMPT_PROSE);
+    expect(extractTextCached(message)).toBe(PROMPT_PROSE);
   });
 });
 

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,4 +1,4 @@
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import { stripVisibleTranscriptControlText } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
 import { extractAssistantVisibleText as extractSharedAssistantVisibleText } from "../../../../src/shared/chat-message-content.js";
 import { stripThinkingTags } from "../format.ts";
@@ -8,13 +8,18 @@ const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
 function processMessageText(text: string, role: string): string {
-  const shouldStripInboundMetadata = normalizeLowercaseStringOrEmpty(role) === "user";
-  if (role === "assistant") {
-    return stripThinkingTags(text);
-  }
-  return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(text))
-    : stripEnvelope(text);
+  const normalizedRole = normalizeLowercaseStringOrEmpty(role);
+  const withoutEnvelope = normalizedRole === "assistant" ? text : stripEnvelope(text);
+  const shouldStripVisibleControls =
+    normalizedRole === "" ||
+    normalizedRole === "unknown" ||
+    normalizedRole === "user" ||
+    normalizedRole === "assistant" ||
+    normalizedRole === "system";
+  const visibleText = shouldStripVisibleControls
+    ? stripVisibleTranscriptControlText(withoutEnvelope)
+    : withoutEnvelope;
+  return normalizedRole === "assistant" ? stripThinkingTags(visibleText) : visibleText;
 }
 
 export function extractText(message: unknown): string | null {

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -5,6 +5,19 @@ import {
   isToolResultMessage,
 } from "./message-normalizer.ts";
 
+const INTERNAL_RUNTIME_CONTEXT_BLOCK = [
+  "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+  "OpenClaw runtime context (internal):",
+  "This context is runtime-generated, not user-authored. Keep internal details private.",
+  "",
+  "[Internal task completion event]",
+  "source: subagent",
+  "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+].join("\n");
+
+const PROMPT_PROSE =
+  "Pre-compaction memory flush. Store durable memories only in memory/2026-04-24.md.";
+
 describe("message-normalizer", () => {
   describe("normalizeMessage", () => {
     beforeEach(() => {
@@ -388,6 +401,42 @@ describe("message-normalizer", () => {
       });
 
       expect(result.senderLabel).toBe("Iris");
+    });
+
+    it("preserves real user text after stripped internal runtime context", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: `${INTERNAL_RUNTIME_CONTEXT_BLOCK}\n\ncontinue`,
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "continue" }]);
+    });
+
+    it("removes text blocks that become empty after generated status stripping", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: "Background task done: ACP background task (run 9fdfb00c).",
+      });
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("removes assistant internal runtime context before display", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: INTERNAL_RUNTIME_CONTEXT_BLOCK,
+      });
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("keeps assistant prompt prose that is not structured control text", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: PROMPT_PROSE,
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: PROMPT_PROSE }]);
     });
   });
 

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -2,7 +2,7 @@
  * Message normalization utilities for chat rendering.
  */
 
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import { stripVisibleTranscriptControlText } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import {
   isToolCallContentType,
@@ -369,13 +369,23 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const senderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
 
-  // Strip AI-injected metadata prefix blocks from user messages before display.
-  if (role === "user" || role === "User") {
-    content = content.map((item) => {
+  // Strip AI-injected metadata and internal runtime-control text before display.
+  if (
+    role === "user" ||
+    role === "User" ||
+    role === "assistant" ||
+    role === "system" ||
+    role === "unknown"
+  ) {
+    content = content.flatMap((item) => {
       if (item.type === "text" && typeof item.text === "string") {
-        return { ...item, text: stripInboundMetadata(item.text) };
+        const stripped = stripVisibleTranscriptControlText(item.text);
+        if (stripped !== item.text && stripped.trim().length === 0) {
+          return [];
+        }
+        return [{ ...item, text: stripped }];
       }
-      return item;
+      return [item];
     });
   }
 


### PR DESCRIPTION
## Summary

- Extend the canonical inbound metadata sanitizer to strip internal runtime context blocks, legacy internal task completion context, and leading background-task completion prefixes from user-visible transcript text.
- Preserve mixed user text that follows stripped internal control content, such as `continue` after an internal block.
- Drop sanitized-empty user messages from gateway history and Control UI chat item construction so WebChat does not render empty user bubbles.

## Root Cause

Internal task completion/control text can be persisted or broadcast as user-role transcript content. The shared `stripInboundMetadata` path only handled inbound channel metadata sentinels and timestamp prefixes, so WebChat history could surface `Background task done`, `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>`, or legacy `[Internal task completion event]` payloads. UI-only hiding was insufficient because gateway history normalization reused the same canonical sanitizer output.

## Validation

- `pnpm test src/auto-reply/reply/strip-inbound-meta.test.ts src/gateway/chat-sanitize.test.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/build-chat-items.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/strip-inbound-meta.ts src/auto-reply/reply/strip-inbound-meta.test.ts src/gateway/chat-sanitize.ts src/gateway/chat-sanitize.test.ts ui/src/ui/chat/message-normalizer.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts`
- `pnpm check:changed`
