### PR TITLE
fix(matrix): pass loaded cfg to verify CLI subcommands (#70992) [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,6 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
-- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat: register chat.send runs in the chat run registry so lifecycle error events reach the client instead of being silently dropped, fixing stuck 'waiting' state and /abort reporting no active run. (#69747) Thanks @wangshu94.
 - Plugins/QQ Bot: enable the bundled qqbot plugin by default so its runtime dependency `@tencent-connect/qqbot-connector` is installed on first launch, unblocking the QR-code binding flow that dynamically imports the connector before any account is configured. (#71051) Thanks @cxyhhhhh.
 - Gateway/agent RPC: register active `agent` runs into the chat abort controller map so `chat.abort` and `sessions.abort` can interrupt them, matching `chat.send` behavior and unblocking external runtimes that drive the Gateway through the public `agent` RPC. Fixes #71128. (#71214) Thanks @bitloi.
+- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 
 ## 2026.4.23
 
@@ -155,7 +156,6 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
-- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Plugins/Google Chat: log webhook auth rejection reasons only after all candidates fail, and warn when add-on `appPrincipal` values do not match configuration. Fixes #71078. (#71145) Thanks @luyao618.
-- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 - Models/configure: preserve the existing default model when provider auth is re-run from configure while keeping explicit default-setting commands authoritative. Fixes #70696. (#70793) Thanks @Sathvik-1007.
 - Config/plugins: accept `plugins.entries.*.hooks.allowConversationAccess` in validation, generated schema metadata, and plugin policy inspection so trusted external plugins can enable conversation-access hooks such as `agent_end` without local schema patches. Fixes #71215. (#71221) Thanks @BillChirico.
 - Codex harness/models: keep legacy `codex/*` harness shorthand out of model picker and `/models` choice surfaces while migrating primary legacy refs to canonical `openai/*` plus explicit Codex harness config. (#71193) Thanks @vincentkoc.
@@ -156,6 +155,7 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
+- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Plugins/Google Chat: log webhook auth rejection reasons only after all candidates fail, and warn when add-on `appPrincipal` values do not match configuration. Fixes #71078. (#71145) Thanks @luyao618.
+- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
 - Models/configure: preserve the existing default model when provider auth is re-run from configure while keeping explicit default-setting commands authoritative. Fixes #70696. (#70793) Thanks @Sathvik-1007.
 - Config/plugins: accept `plugins.entries.*.hooks.allowConversationAccess` in validation, generated schema metadata, and plugin policy inspection so trusted external plugins can enable conversation-access hooks such as `agent_end` without local schema patches. Fixes #71215. (#71221) Thanks @BillChirico.
 - Codex harness/models: keep legacy `codex/*` harness shorthand out of model picker and `/models` choice surfaces while migrating primary legacy refs to canonical `openai/*` plus explicit Codex harness config. (#71193) Thanks @vincentkoc.
@@ -154,7 +155,11 @@ Docs: https://docs.openclaw.ai
 - Webhooks/security: re-resolve `SecretRef`-backed webhook route secrets on each request so `openclaw secrets reload` revokes the previous secret immediately instead of waiting for a gateway restart. (#70727) Thanks @drobison00.
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
+<<<<<<< HEAD
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
+=======
+- Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
+>>>>>>> a569d918cf (fix(matrix): document verify CLI config fix)
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,11 +155,8 @@ Docs: https://docs.openclaw.ai
 - Webhooks/security: re-resolve `SecretRef`-backed webhook route secrets on each request so `openclaw secrets reload` revokes the previous secret immediately instead of waiting for a gateway restart. (#70727) Thanks @drobison00.
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
-<<<<<<< HEAD
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
-=======
 - Matrix/CLI: pass resolved runtime config into verify commands, so `openclaw matrix verify status` and sibling verify subcommands no longer crash before acquiring the Matrix client. Fixes #70992. (#71102) Thanks @luyao618.
->>>>>>> a569d918cf (fix(matrix): document verify CLI config fix)
 
 ## 2026.4.22
 

--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -211,7 +211,9 @@ describe("matrix CLI verification commands", () => {
     });
     const program = buildProgram();
 
-    await program.parseAsync(["matrix", "verify", "bootstrap", "--json"], { from: "user" });
+    await program.parseAsync(["matrix", "verify", "bootstrap", "--json"], {
+      from: "user",
+    });
 
     expect(process.exitCode).toBe(1);
   });
@@ -265,6 +267,76 @@ describe("matrix CLI verification commands", () => {
     });
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it("passes loaded cfg to verify status action", async () => {
+    const fakeCfg = { channels: { matrix: {} } };
+    matrixRuntimeLoadConfigMock.mockReturnValue(fakeCfg);
+    mockMatrixVerificationStatus({ recoveryKeyCreatedAt: null });
+    const program = buildProgram();
+
+    await program.parseAsync(["matrix", "verify", "status"], { from: "user" });
+
+    expect(getMatrixVerificationStatusMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
+  });
+
+  it("passes loaded cfg to all verify subcommands", async () => {
+    const fakeCfg = { channels: { matrix: {} } };
+    matrixRuntimeLoadConfigMock.mockReturnValue(fakeCfg);
+
+    // verify bootstrap
+    const program1 = buildProgram();
+    await program1.parseAsync(["matrix", "verify", "bootstrap"], {
+      from: "user",
+    });
+    expect(bootstrapMatrixVerificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
+
+    // verify device
+    verifyMatrixRecoveryKeyMock.mockResolvedValue({ success: true });
+    const program2 = buildProgram();
+    await program2.parseAsync(["matrix", "verify", "device", "test-key"], {
+      from: "user",
+    });
+    expect(verifyMatrixRecoveryKeyMock).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
+
+    // verify backup status
+    getMatrixRoomKeyBackupStatusMock.mockResolvedValue({});
+    const program3 = buildProgram();
+    await program3.parseAsync(["matrix", "verify", "backup", "status"], {
+      from: "user",
+    });
+    expect(getMatrixRoomKeyBackupStatusMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
+
+    // verify backup reset
+    const program4 = buildProgram();
+    await program4.parseAsync(["matrix", "verify", "backup", "reset", "--yes"], { from: "user" });
+    expect(resetMatrixRoomKeyBackupMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
+
+    // verify backup restore
+    restoreMatrixRoomKeyBackupMock.mockResolvedValue({
+      success: true,
+      imported: 0,
+      total: 0,
+      backup: {},
+    });
+    const program5 = buildProgram();
+    await program5.parseAsync(["matrix", "verify", "backup", "restore"], {
+      from: "user",
+    });
+    expect(restoreMatrixRoomKeyBackupMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: fakeCfg }),
+    );
   });
 
   it("lists matrix devices", async () => {
@@ -332,7 +404,9 @@ describe("matrix CLI verification commands", () => {
       from: "user",
     });
 
-    expect(pruneMatrixStaleGatewayDevicesMock).toHaveBeenCalledWith({ accountId: "poe" });
+    expect(pruneMatrixStaleGatewayDevicesMock).toHaveBeenCalledWith({
+      accountId: "poe",
+    });
     expect(console.log).toHaveBeenCalledWith("Deleted stale OpenClaw devices: BritdXC6iL");
     expect(console.log).toHaveBeenCalledWith("Current device: A7hWrQ70ea");
     expect(console.log).toHaveBeenCalledWith("Remaining devices: 1");
@@ -452,7 +526,9 @@ describe("matrix CLI verification commands", () => {
       { from: "user" },
     );
 
-    expect(bootstrapMatrixVerificationMock).toHaveBeenCalledWith({ accountId: "ops" });
+    expect(bootstrapMatrixVerificationMock).toHaveBeenCalledWith({
+      accountId: "ops",
+    });
     expect(console.log).toHaveBeenCalledWith("Matrix verification bootstrap: complete");
     expect(console.log).toHaveBeenCalledWith(
       `Recovery key created at: ${formatExpectedLocalTimestamp("2026-03-09T06:00:00.000Z")}`,
@@ -705,7 +781,9 @@ describe("matrix CLI verification commands", () => {
     });
     const program = buildProgram();
 
-    await program.parseAsync(["matrix", "verify", "bootstrap", "--json"], { from: "user" });
+    await program.parseAsync(["matrix", "verify", "bootstrap", "--json"], {
+      from: "user",
+    });
 
     expect(process.exitCode).toBe(0);
   });
@@ -715,7 +793,9 @@ describe("matrix CLI verification commands", () => {
     mockMatrixVerificationStatus({ recoveryKeyCreatedAt: recoveryCreatedAt });
     const program = buildProgram();
 
-    await program.parseAsync(["matrix", "verify", "status", "--verbose"], { from: "user" });
+    await program.parseAsync(["matrix", "verify", "status", "--verbose"], {
+      from: "user",
+    });
 
     expect(console.log).toHaveBeenCalledWith(
       `Recovery key created at: ${formatExpectedLocalTimestamp(recoveryCreatedAt)}`,
@@ -920,7 +1000,9 @@ describe("matrix CLI verification commands", () => {
   it("requires --yes before resetting the Matrix room-key backup", async () => {
     const program = buildProgram();
 
-    await program.parseAsync(["matrix", "verify", "backup", "reset"], { from: "user" });
+    await program.parseAsync(["matrix", "verify", "backup", "reset"], {
+      from: "user",
+    });
 
     expect(process.exitCode).toBe(1);
     expect(resetMatrixRoomKeyBackupMock).not.toHaveBeenCalled();
@@ -936,7 +1018,10 @@ describe("matrix CLI verification commands", () => {
       from: "user",
     });
 
-    expect(resetMatrixRoomKeyBackupMock).toHaveBeenCalledWith({ accountId: "default" });
+    expect(resetMatrixRoomKeyBackupMock).toHaveBeenCalledWith({
+      accountId: "default",
+      cfg: {},
+    });
     expect(console.log).toHaveBeenCalledWith("Reset success: yes");
     expect(console.log).toHaveBeenCalledWith("Previous backup version: 1");
     expect(console.log).toHaveBeenCalledWith("Deleted backup version: 1");
@@ -981,6 +1066,7 @@ describe("matrix CLI verification commands", () => {
 
     expect(getMatrixVerificationStatusMock).toHaveBeenCalledWith({
       accountId: "assistant",
+      cfg: {},
       includeRecoveryKey: false,
     });
     expect(console.log).toHaveBeenCalledWith("Account: assistant");

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -96,6 +96,17 @@ function resolveMatrixCliAccountId(accountId?: string): string {
   return resolveMatrixAuthContext({ cfg, accountId }).accountId;
 }
 
+function resolveMatrixCliAccountContext(accountId?: string): {
+  accountId: string;
+  cfg: CoreConfig;
+} {
+  const cfg = getMatrixRuntime().config.loadConfig() as CoreConfig;
+  return {
+    accountId: resolveMatrixAuthContext({ cfg, accountId }).accountId,
+    cfg,
+  };
+}
+
 function formatMatrixCliCommand(command: string, accountId?: string): string {
   const normalizedAccountId = normalizeAccountId(accountId);
   const suffix = normalizedAccountId === "default" ? "" : ` --account ${normalizedAccountId}`;
@@ -925,13 +936,14 @@ export function registerMatrixCli(params: { program: Command }): void {
         includeRecoveryKey?: boolean;
         json?: boolean;
       }) => {
-        const accountId = resolveMatrixCliAccountId(options.account);
+        const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
         await runMatrixCliCommand({
           verbose: options.verbose === true,
           json: options.json === true,
           run: async () =>
             await getMatrixVerificationStatus({
               accountId,
+              cfg,
               includeRecoveryKey: options.includeRecoveryKey === true,
             }),
           onText: (status, verbose) => {
@@ -952,11 +964,11 @@ export function registerMatrixCli(params: { program: Command }): void {
     .option("--verbose", "Show detailed diagnostics")
     .option("--json", "Output as JSON")
     .action(async (options: { account?: string; verbose?: boolean; json?: boolean }) => {
-      const accountId = resolveMatrixCliAccountId(options.account);
+      const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
       await runMatrixCliCommand({
         verbose: options.verbose === true,
         json: options.json === true,
-        run: async () => await getMatrixRoomKeyBackupStatus({ accountId }),
+        run: async () => await getMatrixRoomKeyBackupStatus({ accountId, cfg }),
         onText: (status, verbose) => {
           printAccountLabel(accountId);
           printBackupSummary(status);
@@ -979,7 +991,7 @@ export function registerMatrixCli(params: { program: Command }): void {
     .option("--json", "Output as JSON")
     .action(
       async (options: { account?: string; yes?: boolean; verbose?: boolean; json?: boolean }) => {
-        const accountId = resolveMatrixCliAccountId(options.account);
+        const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
         await runMatrixCliCommand({
           verbose: options.verbose === true,
           json: options.json === true,
@@ -987,7 +999,7 @@ export function registerMatrixCli(params: { program: Command }): void {
             if (options.yes !== true) {
               throw new Error("Refusing to reset Matrix room-key backup without --yes");
             }
-            return await resetMatrixRoomKeyBackup({ accountId });
+            return await resetMatrixRoomKeyBackup({ accountId, cfg });
           },
           onText: (result, verbose) => {
             printAccountLabel(accountId);
@@ -1025,13 +1037,14 @@ export function registerMatrixCli(params: { program: Command }): void {
         verbose?: boolean;
         json?: boolean;
       }) => {
-        const accountId = resolveMatrixCliAccountId(options.account);
+        const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
         await runMatrixCliCommand({
           verbose: options.verbose === true,
           json: options.json === true,
           run: async () =>
             await restoreMatrixRoomKeyBackup({
               accountId,
+              cfg,
               recoveryKey: options.recoveryKey,
             }),
           onText: (result, verbose) => {
@@ -1074,13 +1087,14 @@ export function registerMatrixCli(params: { program: Command }): void {
         verbose?: boolean;
         json?: boolean;
       }) => {
-        const accountId = resolveMatrixCliAccountId(options.account);
+        const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
         await runMatrixCliCommand({
           verbose: options.verbose === true,
           json: options.json === true,
           run: async () =>
             await bootstrapMatrixVerification({
               accountId,
+              cfg,
               recoveryKey: options.recoveryKey,
               forceResetCrossSigning: options.forceResetCrossSigning === true,
             }),
@@ -1129,11 +1143,11 @@ export function registerMatrixCli(params: { program: Command }): void {
     .option("--json", "Output as JSON")
     .action(
       async (key: string, options: { account?: string; verbose?: boolean; json?: boolean }) => {
-        const accountId = resolveMatrixCliAccountId(options.account);
+        const { accountId, cfg } = resolveMatrixCliAccountContext(options.account);
         await runMatrixCliCommand({
           verbose: options.verbose === true,
           json: options.json === true,
-          run: async () => await verifyMatrixRecoveryKey(key, { accountId }),
+          run: async () => await verifyMatrixRecoveryKey(key, { accountId, cfg }),
           onText: (result, verbose) => {
             printAccountLabel(accountId);
             if (!result.success) {


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested locally (`pnpm test extensions/matrix` → 1147/1147 pass, including 2 new regression tests; `oxfmt --check` clean on changed files). Prompt summary available on request.

## Summary

- **Problem:** `openclaw matrix verify status` (and the other 5 `verify` subcommands) crashes with `Error: Matrix runtime client requires a resolved runtime config. Load and resolve config at the command or gateway boundary, then pass cfg through the runtime path.`
- **Why it matters:** All 6 Matrix `verify` CLI subcommands are broken and unusable for end users trying to inspect or repair their encrypted Matrix setup.
- **What changed:** Added a small `resolveMatrixCliAccountContext` helper that returns both `accountId` and the loaded `cfg`. The 6 `verify` subcommand action handlers now use it and forward `cfg` to their action functions.
- **What did NOT change (scope boundary):** `resolveMatrixCliAccountId` and its 4 non-verify call sites are intentionally untouched; behavior of unrelated CLI commands is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #70992
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `resolveMatrixCliAccountId` (in `extensions/matrix/src/cli.ts`) loaded the runtime config via `getMatrixRuntime().config.loadConfig()` to resolve the account ID, but then returned only the `accountId` and discarded the loaded `cfg`. Each `verify` subcommand handler called its action function (e.g. `getMatrixVerificationStatus`, `getMatrixRoomKeyBackupStatus`, …) with only `{ accountId }` and no `cfg`. Downstream, `resolveRuntimeMatrixClient` in `extensions/matrix/src/matrix/client-bootstrap.ts` requires `opts.cfg` and throws when it is undefined.
- **Missing detection / guardrail:** No unit test asserted that the CLI action handlers actually pass the resolved `cfg` to their action functions, so the contract drift between CLI and action layer was invisible.
- **Contributing context:** The `cfg` parameter appears to have been added to the action function signatures during a runtime refactor without updating the CLI call sites for the verify family.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/matrix/src/cli.test.ts`
- Scenario the test should lock in: each `verify` CLI subcommand passes the loaded `cfg` (not `undefined`) to its corresponding action function.
- Why this is the smallest reliable guardrail: the bug lives entirely at the CLI/action boundary; a unit-level mock assertion on the action call arguments is sufficient and does not require a real Matrix runtime client.
- Existing test that already covers this: N/A — this defect was previously uncovered.
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes

The following commands no longer crash with the runtime-config error and now run as documented:

- `openclaw matrix verify status`
- `openclaw matrix verify backup status`
- `openclaw matrix verify backup reset`
- `openclaw matrix verify backup restore`
- `openclaw matrix verify bootstrap`
- `openclaw matrix verify device <key>`

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No.**
- Secrets/tokens handling changed? **No** — `cfg` was already loaded by the same code path; it is now simply forwarded instead of discarded.
- New/changed network calls? **No.**
- Command/tool execution surface changed? **No** — same CLI surface, just no longer crashing.
- Data access scope changed? **No.**

## Compatibility / Migration

- Backward compatible? **Yes.**
- Config/env changes? **No.**
- Migration needed? **No.**

## Risks and Mitigations

Minimal risk. The new helper is additive; the original `resolveMatrixCliAccountId` is retained for the non-verify call sites that do not need `cfg`. All 1147 matrix-extension tests pass locally, including the 2 new regression tests in `cli.test.ts`.
