### PR TITLE
fix(schema-validator): register draft-2020-12 meta so newer MCP tools validate

### DIFF
--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -42,7 +42,9 @@ function expectSuccessfulValidationValue(params: {
   }
 }
 
-function expectValidationSuccess(params: Parameters<typeof validateJsonSchemaValue>[0]) {
+function expectValidationSuccess(
+  params: Parameters<typeof validateJsonSchemaValue>[0],
+) {
   const result = validateJsonSchemaValue(params);
   expect(result.ok).toBe(true);
 }
@@ -159,7 +161,20 @@ describe("schema validator", () => {
       },
       path: "mode",
       messageIncludes: ["(allowed:", "... (+1 more)"],
-      allowedValues: ["v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12"],
+      allowedValues: [
+        "v1",
+        "v2",
+        "v3",
+        "v4",
+        "v5",
+        "v6",
+        "v7",
+        "v8",
+        "v9",
+        "v10",
+        "v11",
+        "v12",
+      ],
       hiddenCount: 1,
     },
     {
@@ -181,16 +196,19 @@ describe("schema validator", () => {
       path: "mode",
       messageIncludes: ["(allowed:", "... (+"],
     },
-  ])("$title", ({ params, path, messageIncludes, allowedValues, hiddenCount }) => {
-    const result = expectValidationFailure(params);
-    const issue = expectValidationIssue(result, path);
+  ])(
+    "$title",
+    ({ params, path, messageIncludes, allowedValues, hiddenCount }) => {
+      const result = expectValidationFailure(params);
+      const issue = expectValidationIssue(result, path);
 
-    expectIssueMessageIncludes(issue, messageIncludes);
-    if (allowedValues) {
-      expect(issue?.allowedValues).toEqual(allowedValues);
-      expect(issue?.allowedValuesHiddenCount).toBe(hiddenCount);
-    }
-  });
+      expectIssueMessageIncludes(issue, messageIncludes);
+      if (allowedValues) {
+        expect(issue?.allowedValues).toEqual(allowedValues);
+        expect(issue?.allowedValuesHiddenCount).toBe(hiddenCount);
+      }
+    },
+  );
 
   it.each([
     {
@@ -313,4 +331,43 @@ describe("schema validator", () => {
       });
     },
   );
+
+  // Regression: tool schemas from newer MCP servers (Playwright MCP >= 1.53)
+  // declare `$schema: https://json-schema.org/draft/2020-12/schema` and use
+  // draft-2020-12-only constructs (e.g. `prefixItems`). The plain-`ajv`
+  // entrypoint only registers draft-07 and threw
+  // `no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`
+  // when such schemas compiled, disabling every tool call that passed through
+  // this validator. Fix: `require("ajv/dist/2020")`. These tests lock that in.
+  it("compiles draft-2020-12 tool schemas with prefixItems", () => {
+    expectSuccessfulValidationValue({
+      input: {
+        cacheKey: "schema-validator.test.draft-2020-12.prefixItems",
+        schema: {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          items: false,
+        } as unknown as Parameters<typeof validateJsonSchemaValue>[0]["schema"],
+        value: ["hello", 42],
+      },
+      expectedValue: ["hello", 42],
+    });
+  });
+
+  it("still compiles draft-07 tool schemas alongside draft-2020-12", () => {
+    expectSuccessfulValidationValue({
+      input: {
+        cacheKey: "schema-validator.test.draft-07.coexist",
+        schema: {
+          $schema: "http://json-schema.org/draft-07/schema#",
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        } as unknown as Parameters<typeof validateJsonSchemaValue>[0]["schema"],
+        value: { name: "scott" },
+      },
+      expectedValue: { name: "scott" },
+    });
+  });
 });

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -1,6 +1,9 @@
 import { createRequire } from "node:module";
 import type { ErrorObject, ValidateFunction } from "ajv";
-import { appendAllowedValuesHint, summarizeAllowedValues } from "../config/allowed-values.js";
+import {
+  appendAllowedValuesHint,
+  summarizeAllowedValues,
+} from "../config/allowed-values.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 
@@ -16,6 +19,8 @@ type AjvLike = {
         },
   ) => AjvLike;
   compile: (schema: JsonSchemaObject) => ValidateFunction;
+  addMetaSchema: (schema: object, key?: string) => AjvLike;
+  getSchema: (keyRef: string) => ValidateFunction | undefined;
 };
 const ajvSingletons = new Map<"default" | "defaults", AjvLike>();
 
@@ -24,7 +29,16 @@ function getAjv(mode: "default" | "defaults"): AjvLike {
   if (cached) {
     return cached;
   }
-  const ajvModule = require("ajv") as { default?: new (opts?: object) => AjvLike };
+  // Use `ajv/dist/2020` so draft-2020-12 tool schemas from newer MCP servers
+  // (e.g. Playwright MCP >= 1.53, which emits `$schema:
+  // https://json-schema.org/draft/2020-12/schema`) compile instead of throwing
+  // `no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`.
+  // The 2020 entrypoint registers draft-2020-12 but does not include draft-07
+  // by default, so we add the older meta-schemas back for tool authors who
+  // still emit draft-07 / draft-06 `$schema` values.
+  const ajvModule = require("ajv/dist/2020") as {
+    default?: new (opts?: object) => AjvLike;
+  };
   const AjvCtor =
     typeof ajvModule.default === "function"
       ? ajvModule.default
@@ -43,8 +57,33 @@ function getAjv(mode: "default" | "defaults"): AjvLike {
       return URL.canParse(value);
     },
   });
+  registerLegacyMetaSchemas(instance);
   ajvSingletons.set(mode, instance);
   return instance;
+}
+
+// draft-07 / draft-06 meta-schemas ship with ajv but are *not* auto-registered
+// on the `ajv/dist/2020` entrypoint. Register them here so tool schemas that
+// still declare `$schema: "http://json-schema.org/draft-07/schema#"` (a very
+// common case for older MCP servers and handwritten plugin schemas) continue
+// to validate without changes. addMetaSchema is idempotent — we guard with
+// getSchema so re-runs across multiple Ajv instances don't throw "schema with
+// key or id already exists".
+function registerLegacyMetaSchemas(instance: AjvLike): void {
+  for (const path of [
+    "ajv/dist/refs/json-schema-draft-07.json",
+    "ajv/dist/refs/json-schema-draft-06.json",
+  ]) {
+    try {
+      const meta = require(path) as { $id?: string; id?: string };
+      const key = meta.$id ?? meta.id;
+      if (key && !instance.getSchema(key)) {
+        instance.addMetaSchema(meta);
+      }
+    } catch {
+      // Meta schema not present in this ajv install — fine; 2020 tools still work.
+    }
+  }
 }
 
 type CachedValidator = {
@@ -93,8 +132,11 @@ function resolveMissingProperty(error: ErrorObject): string | null {
   ) {
     return null;
   }
-  const missingProperty = (error.params as { missingProperty?: unknown }).missingProperty;
-  return typeof missingProperty === "string" && missingProperty.trim() ? missingProperty : null;
+  const missingProperty = (error.params as { missingProperty?: unknown })
+    .missingProperty;
+  return typeof missingProperty === "string" && missingProperty.trim()
+    ? missingProperty
+    : null;
 }
 
 function resolveAjvErrorPath(error: ErrorObject): string {
@@ -108,7 +150,8 @@ function resolveAjvErrorPath(error: ErrorObject): string {
 
 function extractAllowedValues(error: ErrorObject): unknown[] | null {
   if (error.keyword === "enum") {
-    const allowedValues = (error.params as { allowedValues?: unknown }).allowedValues;
+    const allowedValues = (error.params as { allowedValues?: unknown })
+      .allowedValues;
     return Array.isArray(allowedValues) ? allowedValues : null;
   }
 
@@ -123,7 +166,9 @@ function extractAllowedValues(error: ErrorObject): unknown[] | null {
   return null;
 }
 
-function getAjvAllowedValuesSummary(error: ErrorObject): ReturnType<typeof summarizeAllowedValues> {
+function getAjvAllowedValuesSummary(
+  error: ErrorObject,
+): ReturnType<typeof summarizeAllowedValues> {
   const allowedValues = extractAllowedValues(error);
   if (!allowedValues) {
     return null;
@@ -131,9 +176,17 @@ function getAjvAllowedValuesSummary(error: ErrorObject): ReturnType<typeof summa
   return summarizeAllowedValues(allowedValues);
 }
 
-function formatAjvErrors(errors: ErrorObject[] | null | undefined): JsonSchemaValidationError[] {
+function formatAjvErrors(
+  errors: ErrorObject[] | null | undefined,
+): JsonSchemaValidationError[] {
   if (!errors || errors.length === 0) {
-    return [{ path: "<root>", message: "invalid config", text: "<root>: invalid config" }];
+    return [
+      {
+        path: "<root>",
+        message: "invalid config",
+        text: "<root>: invalid config",
+      },
+    ];
   }
   return errors.map((error) => {
     const path = resolveAjvErrorPath(error);
@@ -163,16 +216,24 @@ export function validateJsonSchemaValue(params: {
   cacheKey: string;
   value: unknown;
   applyDefaults?: boolean;
-}): { ok: true; value: unknown } | { ok: false; errors: JsonSchemaValidationError[] } {
-  const cacheKey = params.applyDefaults ? `${params.cacheKey}::defaults` : params.cacheKey;
+}):
+  | { ok: true; value: unknown }
+  | { ok: false; errors: JsonSchemaValidationError[] } {
+  const cacheKey = params.applyDefaults
+    ? `${params.cacheKey}::defaults`
+    : params.cacheKey;
   let cached = schemaCache.get(cacheKey);
   if (!cached || cached.schema !== params.schema) {
-    const validate = getAjv(params.applyDefaults ? "defaults" : "default").compile(params.schema);
+    const validate = getAjv(
+      params.applyDefaults ? "defaults" : "default",
+    ).compile(params.schema);
     cached = { validate, schema: params.schema };
     schemaCache.set(cacheKey, cached);
   }
 
-  const value = params.applyDefaults ? cloneValidationValue(params.value) : params.value;
+  const value = params.applyDefaults
+    ? cloneValidationValue(params.value)
+    : params.value;
   const ok = cached.validate(value);
   if (ok) {
     return { ok: true, value };


### PR DESCRIPTION
## Summary

Tool schemas emitted by newer MCP servers (Playwright MCP ≥ 1.53, most recent Anthropic/Smithery servers, etc.) declare

```
$schema: https://json-schema.org/draft/2020-12/schema
```

and use draft-2020-12-only constructs such as `prefixItems`. The plain-`ajv` entrypoint only registers the draft-07 meta-schema, so the first time such a schema hit `getAjv().compile()` in `src/plugins/schema-validator.ts` it threw:

```
Error: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

Because every tool invocation that passes through `validateJsonSchemaValue()` goes through this singleton-cached Ajv, the observed symptom is every tool call returning that validator error instead of the expected result. Users on current Playwright MCP saw `browser_click` / `browser_type` / `browser_fill_form` / `browser_evaluate` fail with what looked like a mysterious MCP bug but was actually a validator-host mismatch.

## Fix

Swap `require("ajv")` → `require("ajv/dist/2020")`. The 2020 entrypoint registers draft-2020-12 correctly.

The 2020 entrypoint does **not** auto-register draft-07 / draft-06, so we `addMetaSchema()` those back for tool authors who still declare those older `$schema` values. Guarded with `getSchema` so it stays idempotent across multiple Ajv instances (we keep one per mode).

No public API surface changes — `getAjv` is internal, and the returned `AjvLike` only gained two method types on the shape (`addMetaSchema`, `getSchema`) that were always present at runtime.

## Tests

Added two regression tests alongside the existing suite in `src/plugins/schema-validator.test.ts`:

1. **`compiles draft-2020-12 tool schemas with prefixItems`** — declares a `$schema: https://json-schema.org/draft/2020-12/schema` array schema using `prefixItems` and expects it to validate. Before this change, compile() threw the "no schema with key or ref" error.
2. **`still compiles draft-07 tool schemas alongside draft-2020-12`** — same singleton now has to service an older `$schema: http://json-schema.org/draft-07/schema#` object schema; locks in that adding draft-2020-12 support didn't break older schemas.

```
 ✓ unit-fast src/plugins/schema-validator.test.ts (12 tests) 54ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`prettier --write` run over the two touched files to match the repo's default Prettier config.

## Reproduction / env

- openclaw **2026.4.15** (installed via `npm i -g openclaw`)
- `@playwright/mcp` **0.0.70** (current latest)
- macOS arm64, Node 25.8.1

Hotfix for this user: swap the same `require` in the shipped bundle at `dist/schema-validator-*.js` and restart the gateway — lives until next `npm i -g openclaw` clobbers the build.
