### PR TITLE
fix: disable thinking for Ollama models when thinkingLevel=off

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -19,6 +19,10 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
+  createOllamaThinkingDisabledWrapper,
+  shouldApplyOllamaThinkingOffCompat,
+} from "./ollama-stream-wrappers.js";
+import {
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIStringContentWrapper,
 } from "./openai-stream-wrappers.js";
@@ -427,6 +431,15 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
       `normalizing thinking=off to thinking=null for SiliconFlow compatibility (${ctx.provider}/${ctx.modelId})`,
     );
     ctx.agent.streamFn = createSiliconFlowThinkingWrapper(ctx.agent.streamFn);
+  }
+
+  // Ollama thinking models (e.g. Qwen 3.5) think by default.
+  // When thinking is explicitly off, inject chat_template_kwargs to disable it.
+  if (shouldApplyOllamaThinkingOffCompat({ provider: ctx.provider, thinkingLevel: ctx.thinkingLevel })) {
+    log.debug(
+      `disabling thinking for Ollama model (${ctx.provider}/${ctx.modelId})`,
+    );
+    ctx.agent.streamFn = createOllamaThinkingDisabledWrapper(ctx.agent.streamFn);
   }
 }
 

--- a/src/agents/pi-embedded-runner/ollama-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/ollama-stream-wrappers.ts
@@ -1,0 +1,56 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+import { log } from "./logger.js";
+import { streamWithPayloadPatch } from "./stream-payload-utils.js";
+
+/**
+ * Ollama models (e.g. Qwen 3.5) support thinking via `chat_template_kwargs`.
+ * pi-ai's openai-completions provider only sets `enable_thinking` when both
+ * `compat.thinkingFormat` is "qwen"/"qwen-chat-template" AND `model.reasoning`
+ * is truthy. For Ollama models that default to thinkingFormat "openai" or lack
+ * the `reasoning` flag, thinking is never explicitly disabled — the model
+ * thinks by default.
+ *
+ * This wrapper ensures that when the user explicitly disables thinking
+ * (thinkingLevel === "off"), the Ollama payload includes
+ * `chat_template_kwargs: { enable_thinking: false }` to suppress thinking.
+ */
+
+function shouldApplyOllamaThinkingOffCompat(params: {
+  provider?: string;
+  thinkingLevel?: string;
+}): boolean {
+  return params.provider === "ollama" && params.thinkingLevel === "off";
+}
+
+/**
+ * Returns a stream function wrapper that patches Ollama payloads to
+ * disable thinking when thinkingLevel is "off".
+ *
+ * Ollama's OpenAI-compatible endpoint accepts `chat_template_kwargs` in the
+ * request body. Setting `enable_thinking: false` tells the model template
+ * (e.g. Qwen 3.5's chat template) to skip the thinking block.
+ */
+export function createOllamaThinkingDisabledWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      // chat_template_kwargs controls thinking in Ollama's chat completions endpoint.
+      // Only set it if not already present (don't override explicit user config).
+      if (payloadObj.chat_template_kwargs === undefined) {
+        payloadObj.chat_template_kwargs = { enable_thinking: false };
+      } else if (
+        typeof payloadObj.chat_template_kwargs === "object" &&
+        payloadObj.chat_template_kwargs !== null
+      ) {
+        // Merge into existing kwargs without overwriting other keys.
+        if (!("enable_thinking" in payloadObj.chat_template_kwargs)) {
+          (payloadObj.chat_template_kwargs as Record<string, unknown>).enable_thinking = false;
+        }
+      }
+    });
+}
+
+export { shouldApplyOllamaThinkingOffCompat };


### PR DESCRIPTION
## Problem

Ollama models that support thinking (e.g. Qwen 3.5) think by default. When `thinkingLevel` is explicitly set to `"off"` in OpenClaw config, the Ollama OpenAI-compatible endpoint still receives no instruction to disable thinking, resulting in unwanted thinking/reasoning blocks in responses.

pi-ai's openai-completions provider only sets `enable_thinking` when both `compat.thinkingFormat` is `"qwen"`/`"qwen-chat-template"` AND `model.reasoning` is truthy. For Ollama models that default to thinkingFormat `"openai"` or lack the `reasoning` flag, thinking is never explicitly disabled.

## Solution

Add an Ollama-specific stream wrapper (`createOllamaThinkingDisabledWrapper`) that patches the API payload to include `chat_template_kwargs: { enable_thinking: false }` when `thinkingLevel === "off"` and `provider === "ollama"`.

The wrapper:
- Detects Ollama provider via `provider === "ollama"`
- Uses `streamWithPayloadPatch` to inject the disable flag
- Merges into existing `chat_template_kwargs` without overwriting other keys
- Wires into `applyPrePluginStreamWrappers` alongside existing provider wrappers

## Testing

Tested locally with Qwen 3.5 on Ollama — thinking blocks are suppressed when `thinkingLevel: "off"` is configured.

Fixes #71089