### PR TITLE
fix(extensions/lmstudio): guard normalizeConfig by provider id

### DIFF
--- a/extensions/lmstudio/index.test.ts
+++ b/extensions/lmstudio/index.test.ts
@@ -48,6 +48,25 @@ describe("lmstudio plugin", () => {
     });
   });
 
+  // Regression: the core normalizeProviderConfigWithPlugin fallback iterates
+  // every active plugin when the matched plugin did not supply a normalizeConfig
+  // result, so this hook MUST be a no-op for foreign provider ids or it corrupts
+  // their baseUrl (e.g. doubled /v1 segments at request time).
+  it("leaves foreign providers untouched (does not append /v1 for non-lmstudio ids)", () => {
+    const provider = registerProvider();
+
+    for (const foreignId of ["custom-provider-a", "custom-provider-b", "custom-anthropic-proxy"]) {
+      const config = createRemoteProviderConfig({
+        baseUrl: "https://custom-proxy.example",
+      });
+      const result = provider?.normalizeConfig?.({
+        provider: foreignId,
+        providerConfig: config,
+      });
+      expect(result, `normalizeConfig must be a no-op for provider=${foreignId}`).toBeUndefined();
+    }
+  });
+
   it("synthesizes placeholder auth for configured lmstudio models without API key auth", () => {
     const provider = registerProvider();
 

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -101,7 +101,12 @@ export default definePluginEntry({
       shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) =>
         resolvedApiKey?.trim() === LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER ||
         resolvedApiKey?.trim() === CUSTOM_LOCAL_AUTH_MARKER,
-      normalizeConfig: ({ providerConfig }) => normalizeLmstudioProviderConfig(providerConfig),
+      // Gate by provider id: the core fallback in normalizeProviderConfigWithPlugin
+      // iterates every active plugin when the matched plugin did not return a change,
+      // so without this guard lmstudio's "always append /v1" normalizer would mutate
+      // foreign providers' baseUrl and produce a doubled /v1/v1 request path at runtime.
+      normalizeConfig: ({ provider, providerConfig }) =>
+        provider === PROVIDER_ID ? normalizeLmstudioProviderConfig(providerConfig) : undefined,
       prepareDynamicModel: async (ctx) => {
         const providerSetup = await loadProviderSetup();
         cachedDynamicModels.set(


### PR DESCRIPTION
## Summary

- **Problem:** The `lmstudio` bundled plugin's `normalizeConfig` hook unconditionally appended `/v1` to any `baseUrl` it was handed, including for providers it does not own.
- **Why it matters:** Any OpenClaw setup with a foreign Anthropic-compatible provider (custom proxy, self-hosted gateway, `anthropic-messages`-class route that is not LM Studio) had its generated `models.json` `baseUrl` silently mutated. The anthropic-messages transport then doubled the suffix into `/v1/v1/messages` at request time, producing a connection error on every call.
- **What changed:** Gate the `normalizeConfig` hook by provider id so it is a no-op when invoked for a foreign provider. Matches the pattern already used by `anthropic` / `google` / `qwen` / `arcee` / `openrouter` hooks.
- **What did NOT change:** LM Studio behavior for its own provider id is unchanged (the existing `lmstudio` canonicalization test continues to pass). No plugin SDK / contract / gateway protocol changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

No prior issue filed — discovered during live deployment against a LiteLLM-fronted Anthropic-compatible provider. Happy to open a tracking issue if the maintainers prefer that workflow.

## Root Cause

- **Root cause:** `normalizeProviderConfigWithPlugin` in `src/plugins/provider-runtime.ts:427-435` iterates every active plugin when the matched plugin did not return a normalizeConfig change. Every other bundled plugin self-filters by provider id or baseUrl shape before mutating; `extensions/lmstudio/index.ts` did not, so the hook ran (and appended `/v1`) for any provider OpenClaw resolved a different matched plugin for.
- **Missing detection / guardrail:** No existing regression asserted that a bundled `normalizeConfig` hook must be a no-op for foreign provider ids. The per-plugin unit tests assert behavior for the owning id only.
- **Contributing context (if known):** Invoked in practice whenever a user configures a non-LM-Studio provider whose `baseUrl` does not already end in `/v1`. The corrupted value was then persisted into `models.json` by the providers normalizer pass, so the defect survived restarts.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/lmstudio/index.test.ts` — new `it("leaves foreign providers untouched…")` case.
- **Scenario the test should lock in:** Calling `normalizeConfig` with `provider !== "lmstudio"` (and a non-`/v1` `baseUrl`) must return `undefined`. Exercised with three representative foreign ids.
- **Why this is the smallest reliable guardrail:** The bug lives entirely inside the plugin's exported `normalizeConfig` callback. A unit test against that callback catches the regression without instantiating the runtime fallback path.
- **Existing test that already covers this (if any):** None. The existing lmstudio canonicalization test only covers the owning id.
- **If no new test is added, why not:** N/A — one added.

## User-visible / Behavior Changes

Foreign provider `baseUrl` values will no longer be mutated by the LM Studio plugin at config-normalization time. Users who happen to have a `baseUrl` that did not end in `/v1` and were silently relying on the plugin appending one will need to write `/v1` explicitly in their config — but because the mutation was immediately broken by the anthropic-messages transport's own `/v1` prepend, no working setup depends on the old behavior in practice.

## Diagram

N/A — single boolean guard on a callback entrypoint.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (the fix prevents an incorrect network URL from being constructed; it does not add calls).
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux 6.6 (WSL2 distro)
- Runtime/container: Node 22, pnpm 10.33, bundled runtime
- Model/provider: Any Anthropic-compatible custom provider whose `baseUrl` does not already end in `/v1`
- Integration/channel (if any): N/A
- Relevant config (redacted): `openclaw.json § models.providers.<custom>` with `baseUrl: "https://<custom-proxy>"` and `apiStyle: "anthropic-messages"`.

### Steps

1. Configure a foreign Anthropic-compatible provider with `baseUrl: "https://<custom-proxy>"` (no trailing `/v1`).
2. Let OpenClaw regenerate `models.json`.
3. Send any request against that provider.

### Expected

- `models.json` `baseUrl` is preserved verbatim; request goes to `https://<custom-proxy>/v1/messages`.

### Actual (before fix)

- `models.json` `baseUrl` rewritten to `https://<custom-proxy>/v1`; request goes to `https://<custom-proxy>/v1/v1/messages`; server returns a connection/404 error.

### Actual (after fix)

- `models.json` `baseUrl` preserved; request goes to the correct single-`/v1` path.

## Evidence

- [x] Failing test/log before + passing after

New targeted test fails against `main` without the patch and passes with it:

```
$ pnpm test extensions/lmstudio/index.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Full lmstudio extension lane on the patched branch:

```
$ pnpm test:extension lmstudio
 Test Files  6 passed (6)
      Tests  68 passed (68)
```

## Human Verification

- **Verified scenarios:**
  - `pnpm test extensions/lmstudio/index.test.ts` — the new regression case asserts `undefined` for three foreign provider ids; existing lmstudio canonicalization test (`/api/v1/ → /v1`) still passes.
  - `pnpm test:extension lmstudio` — full lmstudio extension test lane (6 files, 68 tests) green.
  - `pnpm lint:extensions` — clean.
  - `pnpm format:check extensions/lmstudio/` — clean.
  - `pnpm tsgo:prod` — core + extensions prod typecheck clean.
  - End-to-end sanity against a real foreign Anthropic-compatible provider (custom proxy): before the patch, requests failed with `/v1/v1/messages` at the network layer; after the patch, requests succeed.
- **Edge cases checked:** `baseUrl` values that already end in `/v1` (lmstudio owner path — unchanged); foreign provider with trailing slash; plugin invoked against its own id (canonicalization still runs).
- **What I did not verify:** Did not run the full `pnpm test` / `pnpm check` sweep; relied on the smart lanes above. Also did not run `codex review --base origin/main` (no Codex access on this machine).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** (see *User-visible / Behavior Changes* above for the only edge where a user might need to explicitly write `/v1` — none of those setups actually worked before).
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** A user who was implicitly relying on `lmstudio` appending `/v1` to a foreign provider's `baseUrl` would need to write `/v1` themselves.
  - **Mitigation:** That code path produced a doubled `/v1/v1/messages` at request time, so it did not actually work in practice. No real deployment is expected to regress.

---

### AI-assisted PR disclosure

- This PR was prepared with Claude (Anthropic) assistance:
  - AI-assisted: **Yes**.
  - Degree of testing: **Lightly tested** — targeted unit test added and the full lmstudio extension lane (6 files, 68 tests), `lint:extensions`, `format:check`, and `tsgo:prod` were green locally. Full `pnpm test` / `pnpm check` sweep was not run on this branch.
  - Author understands the fix and verified the targeted lane manually. Bot review conversations will be addressed as part of the PR lifecycle.
