### PR TITLE
perf(plugins): use native require for compiled JS before jiti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/CLI: prefer native require for compiled bundled plugin JavaScript before jiti so read-only config, status, device, and node commands avoid unnecessary transform overhead on slow hosts. Fixes #62842. Thanks @Effet.
 - Plugins/compat: add missing dated compatibility records for legacy extension-api, memory registration, provider hook/type aliases, runtime aliases, channel SDK helpers, and approval/test utility shims. Thanks @vincentkoc.
 - Plugins/CLI: make plugin install and uninstall config writes conflict-aware, clear stale denylist entries on explicit reinstall/removal, and delete managed plugin files only after config/index commit succeeds. Thanks @codex.
 - Plugins: fail `plugins update` when tracked plugin or hook updates error, keep bundled runtime-dependency repair behind restrictive allowlists, and reject package installs with unloadable extension entries. Thanks @codex.

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -972,6 +972,14 @@ describe("bundled channel entry shape guards", () => {
     vi.doMock("../../plugins/channel-catalog-registry.js", () => ({
       listChannelCatalogEntries: () => [],
     }));
+    // jiti-loader-cache prefers native require() for compiled .js before
+    // falling back to jiti. This test drives plugin loading via the jiti
+    // mock — disable the native-require fast path so the mocked jiti loader
+    // is exercised instead of loading the on-disk fixture directly.
+    vi.doMock("../../plugins/native-module-require.js", () => ({
+      isJavaScriptModulePath: () => false,
+      tryNativeRequireJavaScriptModule: () => ({ ok: false }),
+    }));
 
     let reentered = false;
     vi.doMock("jiti", () => ({

--- a/src/plugins/jiti-loader-cache.test.ts
+++ b/src/plugins/jiti-loader-cache.test.ts
@@ -202,4 +202,60 @@ describe("getCachedPluginJitiLoader", () => {
     expect(firstAlias?.beta).toBe("/repo/alpha/sub");
     expect((firstAlias as Record<symbol, unknown>)[marker]).toBe(true);
   });
+
+  it("serves compiled .js targets from native require without invoking the jiti loader", async () => {
+    const jitiLoader = vi.fn();
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({ createJiti }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: (p: string) =>
+        p.endsWith(".js") || p.endsWith(".mjs") || p.endsWith(".cjs"),
+      tryNativeRequireJavaScriptModule: (target: string) => ({
+        ok: true,
+        moduleExport: { loadedFrom: target },
+      }),
+    }));
+    const { getCachedPluginJitiLoader } = await importFreshModule<
+      typeof import("./jiti-loader-cache.js")
+    >(import.meta.url, "./jiti-loader-cache.js?scope=native-require-fastpath");
+
+    const cache = new Map();
+    const loader = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/demo/api.js",
+      importerUrl: "file:///repo/src/plugins/public-surface-loader.ts",
+      jitiFilename: "file:///repo/src/plugins/public-surface-loader.ts",
+    });
+
+    const result = loader("/repo/dist/extensions/demo/api.js") as { loadedFrom: string };
+    expect(result.loadedFrom).toBe("/repo/dist/extensions/demo/api.js");
+    // jiti is created eagerly, but its loader must NOT be invoked for .js
+    // targets that `tryNativeRequireJavaScriptModule` resolves.
+    expect(jitiLoader).not.toHaveBeenCalled();
+  });
+
+  it("falls back to jiti when the native-require helper declines", async () => {
+    const jitiLoader = vi.fn(() => ({ fromJiti: true }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({ createJiti }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: () => true,
+      tryNativeRequireJavaScriptModule: () => ({ ok: false }),
+    }));
+    const { getCachedPluginJitiLoader } = await importFreshModule<
+      typeof import("./jiti-loader-cache.js")
+    >(import.meta.url, "./jiti-loader-cache.js?scope=native-require-fallback");
+
+    const cache = new Map();
+    const loader = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/demo/api.js",
+      importerUrl: "file:///repo/src/plugins/public-surface-loader.ts",
+      jitiFilename: "file:///repo/src/plugins/public-surface-loader.ts",
+    });
+
+    const result = loader("/repo/dist/extensions/demo/api.js") as { fromJiti: boolean };
+    expect(result.fromJiti).toBe(true);
+    expect(jitiLoader).toHaveBeenCalledWith("/repo/dist/extensions/demo/api.js");
+  });
 });

--- a/src/plugins/jiti-loader-cache.test.ts
+++ b/src/plugins/jiti-loader-cache.test.ts
@@ -258,4 +258,64 @@ describe("getCachedPluginJitiLoader", () => {
     expect(result.fromJiti).toBe(true);
     expect(jitiLoader).toHaveBeenCalledWith("/repo/dist/extensions/demo/api.js");
   });
+
+  it("skips the native-require fast path when tryNative is explicitly false", async () => {
+    const jitiLoader = vi.fn(() => ({ fromJiti: true }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({ createJiti }));
+    const nativeStub = vi.fn(() => ({ ok: true, moduleExport: { fromNative: true } }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: () => true,
+      tryNativeRequireJavaScriptModule: nativeStub,
+    }));
+    const { getCachedPluginJitiLoader } = await importFreshModule<
+      typeof import("./jiti-loader-cache.js")
+    >(import.meta.url, "./jiti-loader-cache.js?scope=native-require-opt-out");
+
+    const cache = new Map();
+    const loader = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/demo/api.js",
+      importerUrl: "file:///repo/src/plugins/bundled-capability-runtime.ts",
+      jitiFilename: "file:///repo/src/plugins/bundled-capability-runtime.ts",
+      aliasMap: { "openclaw/plugin-sdk": "/repo/shim.js" },
+      tryNative: false,
+    });
+
+    const result = loader("/repo/dist/extensions/demo/api.js") as { fromJiti: boolean };
+    expect(result.fromJiti).toBe(true);
+    // With tryNative: false the wrapper must route every target through jiti
+    // so its alias rewrites still apply; native require must not be consulted.
+    expect(nativeStub).not.toHaveBeenCalled();
+    expect(jitiLoader).toHaveBeenCalledWith("/repo/dist/extensions/demo/api.js");
+  });
+
+  it("forwards extra loader arguments through to the jiti fallback", async () => {
+    const jitiLoader = vi.fn(() => ({ fromJiti: true }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({ createJiti }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: () => true,
+      tryNativeRequireJavaScriptModule: () => ({ ok: false }),
+    }));
+    const { getCachedPluginJitiLoader } = await importFreshModule<
+      typeof import("./jiti-loader-cache.js")
+    >(import.meta.url, "./jiti-loader-cache.js?scope=native-require-rest-args");
+
+    const cache = new Map();
+    const loader = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/demo/api.js",
+      importerUrl: "file:///repo/src/plugins/public-surface-loader.ts",
+      jitiFilename: "file:///repo/src/plugins/public-surface-loader.ts",
+    });
+
+    const loose = loader as unknown as (t: string, ...a: unknown[]) => unknown;
+    loose("/repo/dist/extensions/demo/api.js", { hint: "x" }, 42);
+    expect(jitiLoader).toHaveBeenCalledWith(
+      "/repo/dist/extensions/demo/api.js",
+      { hint: "x" },
+      42,
+    );
+  });
 });

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -1,4 +1,5 @@
 import { createJiti } from "jiti";
+import { tryNativeRequireJavaScriptModule } from "./native-module-require.js";
 import {
   buildPluginLoaderJitiOptions,
   createPluginLoaderJitiCacheKey,
@@ -74,10 +75,24 @@ export function getCachedPluginJitiLoader(params: {
   if (cached) {
     return cached;
   }
-  const loader = (params.createLoader ?? createJiti)(jitiFilename, {
+  const jitiLoader = (params.createLoader ?? createJiti)(jitiFilename, {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });
+  // The returned loader prefers native require() for already-compiled JS
+  // artifacts (the bundled plugin public surfaces shipped in dist/) because
+  // jiti's transform pipeline provides no value for output that is already
+  // plain JS and adds several seconds of per-load overhead on slower hosts.
+  // Jiti stays on the hot path for TS / TSX and for the small set of
+  // require(esm)/async-module fallbacks `tryNativeRequireJavaScriptModule`
+  // declines to handle.
+  const loader = ((target: string) => {
+    const native = tryNativeRequireJavaScriptModule(target);
+    if (native.ok) {
+      return native.moduleExport;
+    }
+    return jitiLoader(target);
+  }) as PluginJitiLoader;
   params.cache.set(scopedCacheKey, loader);
   return loader;
 }

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -79,19 +79,27 @@ export function getCachedPluginJitiLoader(params: {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });
-  // The returned loader prefers native require() for already-compiled JS
-  // artifacts (the bundled plugin public surfaces shipped in dist/) because
-  // jiti's transform pipeline provides no value for output that is already
-  // plain JS and adds several seconds of per-load overhead on slower hosts.
-  // Jiti stays on the hot path for TS / TSX and for the small set of
-  // require(esm)/async-module fallbacks `tryNativeRequireJavaScriptModule`
-  // declines to handle.
-  const loader = ((target: string) => {
+  // When the caller has explicitly opted out of native loading (for example
+  // `bundled-capability-runtime` in Vitest+dist mode, which depends on
+  // jiti's alias rewriting to surface a narrow SDK slice), route every
+  // target through jiti so those alias rewrites still apply.
+  if (!tryNative) {
+    params.cache.set(scopedCacheKey, jitiLoader);
+    return jitiLoader;
+  }
+  // Otherwise prefer native require() for already-compiled JS artifacts
+  // (the bundled plugin public surfaces shipped in dist/). jiti's transform
+  // pipeline provides no value for output that is already plain JS and adds
+  // several seconds of per-load overhead on slower hosts. jiti still runs
+  // for TS / TSX sources and for the small set of require(esm) /
+  // async-module fallbacks `tryNativeRequireJavaScriptModule` declines to
+  // handle.
+  const loader = ((target: string, ...rest: unknown[]) => {
     const native = tryNativeRequireJavaScriptModule(target);
     if (native.ok) {
       return native.moduleExport;
     }
-    return jitiLoader(target);
+    return (jitiLoader as (t: string, ...a: unknown[]) => unknown)(target, ...rest);
   }) as PluginJitiLoader;
   params.cache.set(scopedCacheKey, loader);
   return loader;

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -8,6 +8,15 @@ import {
   resetRegistryJitiMocks,
 } from "./test-helpers/registry-jiti-mocks.js";
 
+// jiti-loader-cache prefers native require() for compiled .js before falling
+// back to jiti. These tests scripts plugin-loading behaviour through the
+// jiti mock — disable the native-require fast path so the mocked jiti loader
+// stays authoritative for the test fixture files on disk.
+vi.mock("./native-module-require.js", () => ({
+  isJavaScriptModulePath: (_modulePath: string) => false,
+  tryNativeRequireJavaScriptModule: (_modulePath: string) => ({ ok: false }),
+}));
+
 const tempDirs: string[] = [];
 const mocks = getRegistryJitiMocks();
 


### PR DESCRIPTION
## Summary

Adds a native-require fast path in `getCachedPluginJitiLoader` so the loader tries `tryNativeRequireJavaScriptModule` before falling back to jiti for compiled `.js` targets. jiti stays on the hot path for TS sources and the recoverable-error fallbacks it already handles.

## Motivation

Reproducible on a modest NAS running `openclaw` installed from npm (Node 22.22, ZFS-backed container, `telegram` + `discord` configured). CPU profiling of a clean `openclaw config get gateway.mode`:

```
openclaw-deps/jiti        18 811 ms   78.4%   ← dominant
openclaw-dist              1 008 ms    4.2%
openclaw-deps/ajv            976 ms    4.1%
openclaw-deps/zod            873 ms    3.6%
(idle)                       865 ms    3.6%
openclaw-deps/json5          424 ms    1.8%
... everything else       < 200 ms    <1%
ext/telegram                  24 ms    0.1%
ext/discord                    1 ms   <0.1%
```

The big-ticket loads are bundled doctor contracts and channel plugin APIs — shipped as already-compiled `.js` in `dist/extensions/*/`. jiti's transform pipeline provides no value for them but still pays the per-instance setup cost.

Native `await import()` / `require()` of the same artifacts:

| artifact | jiti | native |
| --- | --- | --- |
| `telegram/contract-api.js` | 7 600–10 000 ms | 2 020 ms |
| `telegram/channel-plugin-api.js` | 11 000–16 000 ms | 2 583 ms |
| `discord/doctor-contract-api.js` | 460–900 ms | 63 ms |
| `whatsapp/doctor-contract-api.js` | — | 2 ms |

Similar tooling already exists in `tryNativeRequireJavaScriptModule` (used inside `doctor-contract-registry` and via the Windows-gated path in `channel-entry-contract`); this centralises it behind the shared `getCachedPluginJitiLoader` so every caller benefits.

## Change

```ts
const loader = ((target: string) => {
  const native = tryNativeRequireJavaScriptModule(target);
  if (native.ok) {
    return native.moduleExport;
  }
  return jitiLoader(target);
}) as PluginJitiLoader;
```

Jiti is still created eagerly (preserves existing assertions about when `createJiti` is invoked) and used for:
- TS / TSX / MTS / CTS sources (`isJavaScriptModulePath` returns false)
- Windows, unless the helper is called with `allowWindows: true`
- Anything the helper declines for other reasons

## Benchmark

Same NAS, same config, same artifacts:

| command | before | after |
| --- | ---: | ---: |
| `config get gateway.mode` | 24 s | **6 s** |
| `status` | 45 s | **18 s** |
| `devices list` | 55 s | **26 s** |
| `nodes status` | 55 s | **26 s** |

Post-patch profiling confirms jiti drops out of the top buckets entirely. The remaining `status`/`devices`/`nodes` time is dominated by config schema validation and eager provider-plugin module eval — unrelated to this change and tracked separately.

## Tests

- `src/plugins/jiti-loader-cache.test.ts` — added regression coverage for the fast path (returns the native module, skips jiti) and the fallback (native declines → jiti serves)
- `src/plugins/setup-registry.test.ts`, `src/channels/plugins/bundled.shape-guard.test.ts` — preserve existing jiti-driven fixtures by mocking the native-require helper so the scripted plugin mocks still resolve

`pnpm test:plugins` → 1185 passed; `pnpm test:runtime-config` → 998 passed on this branch.

Relates to openclaw#62842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)