### PR TITLE
fix(telegram): honor outbound reaction directives

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -39,6 +39,7 @@ import {
   sendTelegramText,
   sendTelegramWithThreadFallback,
 } from "./delivery.send.js";
+import { reactMessageTelegram } from "../send.js";
 import { resolveTelegramReplyId, type TelegramThreadSpec } from "./helpers.js";
 import {
   markReplyApplied,
@@ -60,7 +61,41 @@ type DeliveryProgress = ReplyThreadDeliveryProgress & {
 type TelegramReplyChannelData = {
   buttons?: TelegramInlineButtons;
   pin?: boolean;
+  reaction?: string | { emoji?: string };
 };
+
+function resolveTelegramReactionEmoji(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value) && typeof value.emoji === "string") {
+    const trimmed = value.emoji.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
+async function maybeSendTelegramReaction(params: {
+  chatId: string;
+  replyToId?: number;
+  telegramData?: TelegramReplyChannelData;
+  cfg: Parameters<typeof reactMessageTelegram>[3]["cfg"];
+  accountId?: string;
+  gatewayClientScopes?: readonly string[];
+}) {
+  const reactionEmoji = resolveTelegramReactionEmoji(params.telegramData?.reaction);
+  if (!reactionEmoji || params.replyToId == null) {
+    return false;
+  }
+  await reactMessageTelegram(params.chatId, params.replyToId, reactionEmoji, {
+    cfg: params.cfg,
+    accountId: params.accountId,
+    gatewayClientScopes: params.gatewayClientScopes,
+    verbose: false,
+  }).catch(() => {});
+  return true;
+}
 
 type ChunkTextFn = (markdown: string) => ReturnType<typeof markdownToTelegramChunks>;
 
@@ -666,13 +701,17 @@ export async function deliverReplies(params: {
         ? [reply.mediaUrl]
         : [];
     const hasMedia = mediaList.length > 0;
+    const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
+    const hasReaction = Boolean(resolveTelegramReactionEmoji(telegramData?.reaction));
     if (!reply?.text && !hasMedia) {
       if (reply?.audioAsVoice) {
         logVerbose("telegram reply has audioAsVoice without media/text; skipping");
         continue;
       }
-      params.runtime.error?.(danger("reply missing text/media"));
-      continue;
+      if (!hasReaction) {
+        params.runtime.error?.(danger("reply missing text/media"));
+        continue;
+      }
     }
 
     const rawContent = reply.text || "";
@@ -709,10 +748,20 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
-      const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
       let firstDeliveredMessageId: number | undefined;
-      if (mediaList.length === 0) {
+      const reactionSent = await maybeSendTelegramReaction({
+        chatId: params.chatId,
+        replyToId,
+        telegramData,
+        cfg: params.cfg,
+        accountId: params.accountId,
+        gatewayClientScopes: params.gatewayClientScopes,
+      });
+      if (reactionSent) {
+        progress.hasDelivered = true;
+      }
+      if (mediaList.length === 0 && reply.text) {
         firstDeliveredMessageId = await deliverTextReply({
           bot: params.bot,
           chatId: params.chatId,
@@ -728,7 +777,7 @@ export async function deliverReplies(params: {
           replyToMode: params.replyToMode,
           progress,
         });
-      } else {
+      } else if (mediaList.length > 0) {
         firstDeliveredMessageId = await deliverMediaReply({
           reply,
           mediaList,

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -2,17 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
 const pinMessageTelegramMock = vi.fn();
+const reactMessageTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   pinMessageTelegram: (...args: unknown[]) => pinMessageTelegramMock(...args),
+  reactMessageTelegram: (...args: unknown[]) => reactMessageTelegramMock(...args),
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
 }));
 
-import { telegramOutbound } from "./outbound-adapter.js";
+import { sendTelegramPayloadMessages, telegramOutbound } from "./outbound-adapter.js";
 
 describe("telegramOutbound", () => {
   beforeEach(() => {
     pinMessageTelegramMock.mockReset();
+    reactMessageTelegramMock.mockReset();
     sendMessageTelegramMock.mockReset();
   });
 
@@ -117,5 +120,45 @@ describe("telegramOutbound", () => {
         verbose: false,
       }),
     );
+  });
+});
+
+describe("sendTelegramPayloadMessages", () => {
+  beforeEach(() => {
+    reactMessageTelegramMock.mockReset();
+    sendMessageTelegramMock.mockReset();
+  });
+
+  it("sends telegram reactions from channelData before returning reaction-only payloads", async () => {
+    reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+
+    const result = await sendTelegramPayloadMessages({
+      send: sendMessageTelegramMock,
+      react: reactMessageTelegramMock,
+      to: "telegram:8504602495",
+      payload: {
+        text: "",
+        channelData: {
+          telegram: {
+            reaction: "🔥",
+          },
+        },
+      },
+      baseOpts: {
+        cfg: {} as never,
+        verbose: false,
+        textMode: "html",
+        replyToMessageId: 3026,
+      },
+    });
+
+    expect(reactMessageTelegramMock).toHaveBeenCalledWith("telegram:8504602495", 3026, "🔥", {
+      cfg: {},
+      accountId: undefined,
+      gatewayClientScopes: undefined,
+      verbose: false,
+    });
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ messageId: "3026", chatId: "telegram:8504602495" });
   });
 });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -22,7 +22,7 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks } from "./format.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
-import { pinMessageTelegram } from "./send.js";
+import { pinMessageTelegram, reactMessageTelegram } from "./send.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 
@@ -45,6 +45,7 @@ async function resolveTelegramSendContext(params: {
   gatewayClientScopes?: readonly string[];
 }): Promise<{
   send: TelegramSendFn;
+  react: typeof reactMessageTelegram;
   baseOpts: {
     cfg: NonNullable<TelegramSendOpts>["cfg"];
     verbose: false;
@@ -60,6 +61,7 @@ async function resolveTelegramSendContext(params: {
     (await loadTelegramSendModule()).sendMessageTelegram;
   return {
     send,
+    react: reactMessageTelegram,
     baseOpts: {
       verbose: false,
       textMode: "html",
@@ -72,17 +74,31 @@ async function resolveTelegramSendContext(params: {
   };
 }
 
+function resolveTelegramReactionEmoji(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value) && typeof value.emoji === "string") {
+    const trimmed = value.emoji.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
 export async function sendTelegramPayloadMessages(params: {
   send: TelegramSendFn;
+  react?: typeof reactMessageTelegram;
   to: string;
   payload: ReplyPayload;
   baseOpts: Omit<NonNullable<TelegramSendOpts>, "buttons" | "mediaUrl" | "quoteText">;
 }): Promise<Awaited<ReturnType<TelegramSendFn>>> {
   const telegramData = params.payload.channelData?.telegram as
-    | { buttons?: TelegramInlineButtons; quoteText?: string }
+    | { buttons?: TelegramInlineButtons; quoteText?: string; reaction?: string | { emoji?: string } }
     | undefined;
   const quoteText =
     typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
+  const reactionEmoji = resolveTelegramReactionEmoji(telegramData?.reaction);
   const text =
     resolveInteractiveTextFallback({
       text: params.payload.text,
@@ -97,6 +113,23 @@ export async function sendTelegramPayloadMessages(params: {
     ...params.baseOpts,
     quoteText,
   };
+
+  if (reactionEmoji && params.react && payloadOpts.replyToMessageId != null) {
+    await params.react(params.to, payloadOpts.replyToMessageId, reactionEmoji, {
+      cfg: payloadOpts.cfg,
+      accountId: payloadOpts.accountId,
+      gatewayClientScopes: payloadOpts.gatewayClientScopes,
+      verbose: payloadOpts.verbose,
+    }).catch(() => {});
+  }
+
+  if (!text && mediaUrls.length === 0) {
+    return {
+      messageId:
+        payloadOpts.replyToMessageId != null ? String(payloadOpts.replyToMessageId) : "reaction-only",
+      chatId: params.to,
+    };
+  }
 
   // Telegram allows reply_markup on media; attach buttons only to the first send.
   return await sendPayloadMediaSequenceOrFallback({
@@ -217,7 +250,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     forceDocument,
     gatewayClientScopes,
   }) => {
-    const { send, baseOpts } = await resolveTelegramSendContext({
+    const { send, react, baseOpts } = await resolveTelegramSendContext({
       cfg,
       deps,
       accountId,
@@ -227,6 +260,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     });
     const result = await sendTelegramPayloadMessages({
       send,
+      react,
       to,
       payload,
       baseOpts: {

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -9,9 +9,13 @@ export type ReplyDirectiveParseResult = {
   replyToId?: string;
   replyToCurrent?: boolean;
   replyToTag: boolean;
+  reactionEmoji?: string;
+  reactionTag: boolean;
   audioAsVoice?: boolean;
   isSilent: boolean;
 };
+
+const REACTION_TAG_RE = /\[\[\s*react(?:_to_current)?\s*:\s*([^\]\n]+?)\s*\]\]/gi;
 
 export function parseReplyDirectives(
   raw: string,
@@ -19,6 +23,17 @@ export function parseReplyDirectives(
 ): ReplyDirectiveParseResult {
   const split = splitMediaFromOutput(raw);
   let text = split.text ?? "";
+  let reactionEmoji: string | undefined;
+  let reactionTag = false;
+
+  text = text.replace(REACTION_TAG_RE, (_match, emojiRaw: string | undefined) => {
+    reactionTag = true;
+    const trimmed = emojiRaw?.trim();
+    if (trimmed) {
+      reactionEmoji = trimmed;
+    }
+    return " ";
+  });
 
   const replyParsed = parseInlineDirectives(text, {
     currentMessageId: options.currentMessageId,
@@ -43,6 +58,8 @@ export function parseReplyDirectives(
     replyToId: replyParsed.replyToId,
     replyToCurrent: replyParsed.replyToCurrent || undefined,
     replyToTag: replyParsed.hasReplyTag,
+    reactionEmoji,
+    reactionTag,
     audioAsVoice: split.audioAsVoice,
     isSilent,
   };

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -53,6 +53,31 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it("normalizes telegram reaction directives into channel data", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: "[[react_to_current:🔥]]",
+        },
+      ]),
+    ).toEqual([
+      {
+        text: "",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: undefined,
+        replyToTag: false,
+        audioAsVoice: false,
+        channelData: {
+          telegram: {
+            reaction: "🔥",
+          },
+        },
+      },
+    ]);
+  });
+
   it("drops silent payloads without media and suppresses reasoning payloads", () => {
     expect(
       normalizeReplyPayloadsForDelivery([

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -119,6 +119,27 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeTelegramReactionChannelData(
+  channelData: Record<string, unknown> | undefined,
+  reactionEmoji: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!reactionEmoji) {
+    return channelData;
+  }
+  const telegram = isRecord(channelData?.telegram) ? channelData.telegram : {};
+  return {
+    ...(channelData ?? {}),
+    telegram: {
+      ...telegram,
+      reaction: reactionEmoji,
+    },
+  };
+}
+
 type PreparedOutboundPayloadPlanEntry = {
   payload: ReplyPayload;
   hasPresentation: boolean;
@@ -160,6 +181,7 @@ function createOutboundPayloadPlanEntry(
     replyToTag: payload.replyToTag || parsed.replyToTag,
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
+    channelData: mergeTelegramReactionChannelData(payload.channelData, parsed.reactionEmoji),
   };
   if (!isRenderablePayload(normalizedPayload) && !isSilent) {
     return null;


### PR DESCRIPTION
## Summary
- parse `[[react:...]]` / `[[react_to_current:...]]` during reply normalization
- carry Telegram reactions through `channelData.telegram.reaction`
- allow reaction-only Telegram replies instead of dropping them as `reply missing text/media`
- execute Telegram reactions in the outbound adapter before optional text/media sends
- add normalization + adapter test coverage

Closes #71140.

## What changed
### Shared outbound normalization
- `src/auto-reply/reply/reply-directives.ts`
- `src/infra/outbound/payloads.ts`
- `src/infra/outbound/payloads.test.ts`

Adds reaction directive parsing and preserves the normalized reaction intent as structured Telegram channel data.

### Telegram delivery / adapter
- `extensions/telegram/src/bot/delivery.replies.ts`
- `extensions/telegram/src/outbound-adapter.ts`
- `extensions/telegram/src/outbound-adapter.test.ts`

Allows reaction-only replies, resolves the reaction target from the reply target, and sends native Telegram reactions before optional message/media delivery.

## Validation
### Confirmed in a live installed build before source-porting
- reaction directives now apply native Telegram reactions instead of leaking raw control text
- GIF/media delivery works in the live Telegram lane
- full assistant-lane test succeeded in a real Telegram chat

### In this source clone
- patch ported and committed cleanly
- targeted repo test run is currently blocked by missing local dependency install in this clone (`Cannot find package 'tslog'` when running `node scripts/test-projects.mjs ...`)

I’m happy to tighten/adjust tests if there’s a preferred Telegram coverage lane for this area.
