### PR TITLE
fix: replay DeepSeek reasoning_content on tool-turn history

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1954,6 +1954,91 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("replays reasoning_content on DeepSeek-compatible tool turns even for configured V4 models", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        api: "openai-completions",
+        provider: "deepseek",
+        baseUrl: "https://api.deepseek.com",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "deepseek",
+            model: "deepseek-v4-flash",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need to inspect a file before answering.",
+                thinkingSignature: "reasoning_content",
+              },
+              {
+                type: "toolCall",
+                id: "call_deepseek_1",
+                name: "read",
+                arguments: { path: "/tmp/repro.txt" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_deepseek_1",
+            toolName: "read",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+        tools: [
+          {
+            name: "read",
+            description: "Read one file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as {
+      messages?: Array<{
+        role?: string;
+        content?: unknown;
+        reasoning_content?: unknown;
+        tool_calls?: Array<{ function?: { arguments?: unknown } }>;
+      }>;
+    };
+
+    const assistant = params.messages?.find((message) => message.role === "assistant");
+    expect(assistant).toMatchObject({
+      content: null,
+      reasoning_content: "Need to inspect a file before answering.",
+    });
+    expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
+  });
+
   it("uses Mistral compat defaults for direct Mistral completions providers", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2120,6 +2120,100 @@ describe("openai transport stream", () => {
     expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
   });
 
+  it("maps replay-signature reasoning blocks into reasoning_content for DeepSeek tool-call history", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        api: "openai-completions",
+        provider: "deepseek",
+        baseUrl: "https://api.deepseek.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "deepseek",
+            model: "deepseek-v4-pro",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need to inspect the file first.",
+                thinkingSignature: JSON.stringify({
+                  id: "rs_live",
+                  type: "reasoning",
+                  encrypted_content: "opaque",
+                }),
+              },
+              {
+                type: "toolCall",
+                id: "call_replay_1",
+                name: "read",
+                arguments: { path: "/tmp/repro.txt" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_replay_1",
+            toolName: "read",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+        tools: [
+          {
+            name: "read",
+            description: "Read one file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as {
+      messages?: Array<
+        Record<string, unknown> & {
+          role?: string;
+          content?: unknown;
+          reasoning_content?: unknown;
+          tool_calls?: Array<{ function?: { arguments?: unknown } }>;
+        }
+      >;
+    };
+
+    const assistant = params.messages?.find((message) => message.role === "assistant");
+    expect(assistant).toMatchObject({
+      content: null,
+      reasoning_content: "Need to inspect the file first.",
+    });
+    expect(assistant).not.toHaveProperty(
+      '{"id":"rs_live","type":"reasoning","encrypted_content":"opaque"}',
+    );
+    expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
+  });
+
   it("uses Mistral compat defaults for direct Mistral completions providers", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2214,6 +2214,98 @@ describe("openai transport stream", () => {
     expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
   });
 
+  it.each([
+    ["reasoning", "Need to inspect the file first."],
+    ["reasoning_text", "Need to inspect the file first."],
+  ] as const)(
+    "maps %s into reasoning_content for DeepSeek tool-call replay",
+    (reasoningField, reasoningValue) => {
+      const params = buildOpenAICompletionsParams(
+        {
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+          api: "openai-completions",
+          provider: "deepseek",
+          baseUrl: "https://api.deepseek.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } as never,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: "openai-completions",
+              provider: "openrouter",
+              model: "openrouter/deepseek/deepseek-r1",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                {
+                  type: "thinking",
+                  thinking: reasoningValue,
+                  thinkingSignature: reasoningField,
+                },
+                {
+                  type: "toolCall",
+                  id: "call_reasoning_alias_1",
+                  name: "read",
+                  arguments: { path: "/tmp/repro.txt" },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_reasoning_alias_1",
+              toolName: "read",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+              timestamp: 2,
+            },
+          ],
+          tools: [
+            {
+              name: "read",
+              description: "Read one file",
+              parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+                required: ["path"],
+              },
+            },
+          ],
+        } as never,
+        undefined,
+      ) as {
+        messages?: Array<
+          Record<string, unknown> & {
+            role?: string;
+            content?: unknown;
+            reasoning?: unknown;
+            reasoning_text?: unknown;
+            reasoning_content?: unknown;
+            tool_calls?: Array<{ function?: { arguments?: unknown } }>;
+          }
+        >;
+      };
+
+      const assistant = params.messages?.find((message) => message.role === "assistant");
+      expect(assistant?.reasoning_content).toBe(reasoningValue);
+      expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
+    },
+  );
+
   it("uses Mistral compat defaults for direct Mistral completions providers", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2039,6 +2039,87 @@ describe("openai transport stream", () => {
     expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
   });
 
+  it("copies assistant content into reasoning_content for DeepSeek tool-call replay when older turns lack explicit replay fields", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        api: "openai-completions",
+        provider: "deepseek",
+        baseUrl: "https://api.deepseek.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "openai",
+            model: "gpt-5.4",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              { type: "text", text: "I should read the file first." },
+              {
+                type: "toolCall",
+                id: "call_foreign_1",
+                name: "read",
+                arguments: { path: "/tmp/repro.txt" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_foreign_1",
+            toolName: "read",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+        tools: [
+          {
+            name: "read",
+            description: "Read one file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as {
+      messages?: Array<{
+        role?: string;
+        content?: unknown;
+        reasoning_content?: unknown;
+        tool_calls?: Array<{ function?: { arguments?: unknown } }>;
+      }>;
+    };
+
+    const assistant = params.messages?.find((message) => message.role === "assistant");
+    expect(assistant).toMatchObject({
+      content: "I should read the file first.",
+      reasoning_content: "I should read the file first.",
+    });
+    expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"path":"/tmp/repro.txt"}');
+  });
+
   it("uses Mistral compat defaults for direct Mistral completions providers", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1702,6 +1702,48 @@ function injectToolCallThoughtSignatures(
   }
 }
 
+function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenAIModeModel): void {
+  const { capabilities } = detectOpenAICompletionsCompat(model);
+  const endpointClass = capabilities.endpointClass;
+  const isDefaultRoute = endpointClass === "default";
+  const isDeepSeekLike =
+    endpointClass === "deepseek-native" || (isDefaultRoute && model.provider === "deepseek");
+  if (!isDeepSeekLike) {
+    return;
+  }
+  for (const message of outgoingMessages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as {
+      role?: unknown;
+      content?: unknown;
+      tool_calls?: unknown;
+      reasoning_content?: unknown;
+      reasoning?: unknown;
+      reasoning_text?: unknown;
+    };
+    if (
+      record.role !== "assistant" ||
+      !Array.isArray(record.tool_calls) ||
+      record.tool_calls.length === 0
+    ) {
+      continue;
+    }
+    if (
+      typeof record.reasoning_content === "string" ||
+      typeof record.reasoning === "string" ||
+      typeof record.reasoning_text === "string"
+    ) {
+      continue;
+    }
+    if (typeof record.content !== "string" || record.content.trim().length === 0) {
+      continue;
+    }
+    record.reasoning_content = record.content;
+  }
+}
+
 export function buildOpenAICompletionsParams(
   model: OpenAIModeModel,
   context: Context,
@@ -1716,6 +1758,7 @@ export function buildOpenAICompletionsParams(
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
+  injectDeepSeekReasoningReplay(messages as unknown[], model);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: compat.requiresStringContent

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1725,16 +1725,23 @@ function extractReplayReasoningContent(record: Record<string, unknown>): {
   keysToDelete: string[];
 } {
   const keysToDelete: string[] = [];
+  let firstNonEmptyContent: string | undefined;
   for (const [key, value] of Object.entries(record)) {
     if (!parseReplayReasoningSignatureKey(key)) {
       continue;
     }
     keysToDelete.push(key);
-    if (typeof value === "string" && value.trim().length > 0) {
-      return { content: value, keysToDelete };
+    if (
+      firstNonEmptyContent === undefined &&
+      typeof value === "string" &&
+      value.trim().length > 0
+    ) {
+      firstNonEmptyContent = value;
     }
   }
-  return { keysToDelete };
+  return firstNonEmptyContent !== undefined
+    ? { content: firstNonEmptyContent, keysToDelete }
+    : { keysToDelete };
 }
 
 function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenAIModeModel): void {
@@ -1791,6 +1798,12 @@ function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenA
     }
     if (typeof record.content === "string" && record.content.trim().length > 0) {
       record.reasoning_content = record.content;
+      continue;
+    }
+    // P1 fix: unconditional empty-string fallback ensures reasoning_content is never undefined
+    // for DeepSeek tool-call history (verified safe against live API → 200 OK)
+    if (record.reasoning_content === undefined) {
+      record.reasoning_content = "";
     }
   }
 }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1765,23 +1765,32 @@ function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenA
     ) {
       continue;
     }
-    if (
-      typeof record.reasoning_content === "string" ||
-      typeof record.reasoning === "string" ||
-      typeof record.reasoning_text === "string"
-    ) {
-      continue;
-    }
     const extracted = extractReplayReasoningContent(record);
     for (const key of extracted.keysToDelete) {
       delete record[key];
     }
-    if (typeof record.content === "string" && record.content.trim().length > 0) {
-      record.reasoning_content = record.content;
+    if (
+      typeof record.reasoning_content === "string" &&
+      record.reasoning_content.trim().length > 0
+    ) {
+      continue;
+    }
+    const explicitReasoning =
+      typeof record.reasoning === "string" && record.reasoning.trim().length > 0
+        ? record.reasoning
+        : typeof record.reasoning_text === "string" && record.reasoning_text.trim().length > 0
+          ? record.reasoning_text
+          : undefined;
+    if (typeof explicitReasoning === "string" && explicitReasoning.trim().length > 0) {
+      record.reasoning_content = explicitReasoning;
       continue;
     }
     if (typeof extracted.content === "string" && extracted.content.trim().length > 0) {
       record.reasoning_content = extracted.content;
+      continue;
+    }
+    if (typeof record.content === "string" && record.content.trim().length > 0) {
+      record.reasoning_content = record.content;
     }
   }
 }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1702,6 +1702,41 @@ function injectToolCallThoughtSignatures(
   }
 }
 
+function parseReplayReasoningSignatureKey(key: string): boolean {
+  const trimmed = key.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { id?: unknown; type?: unknown };
+    return (
+      typeof parsed.id === "string" &&
+      parsed.id.startsWith("rs_") &&
+      typeof parsed.type === "string" &&
+      (parsed.type === "reasoning" || parsed.type.startsWith("reasoning."))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function extractReplayReasoningContent(record: Record<string, unknown>): {
+  content?: string;
+  keysToDelete: string[];
+} {
+  const keysToDelete: string[] = [];
+  for (const [key, value] of Object.entries(record)) {
+    if (!parseReplayReasoningSignatureKey(key)) {
+      continue;
+    }
+    keysToDelete.push(key);
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { content: value, keysToDelete };
+    }
+  }
+  return { keysToDelete };
+}
+
 function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenAIModeModel): void {
   const { capabilities } = detectOpenAICompletionsCompat(model);
   const endpointClass = capabilities.endpointClass;
@@ -1715,7 +1750,7 @@ function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenA
     if (!message || typeof message !== "object") {
       continue;
     }
-    const record = message as {
+    const record = message as Record<string, unknown> & {
       role?: unknown;
       content?: unknown;
       tool_calls?: unknown;
@@ -1737,10 +1772,17 @@ function injectDeepSeekReasoningReplay(outgoingMessages: unknown[], model: OpenA
     ) {
       continue;
     }
-    if (typeof record.content !== "string" || record.content.trim().length === 0) {
+    const extracted = extractReplayReasoningContent(record);
+    for (const key of extracted.keysToDelete) {
+      delete record[key];
+    }
+    if (typeof record.content === "string" && record.content.trim().length > 0) {
+      record.reasoning_content = record.content;
       continue;
     }
-    record.reasoning_content = record.content;
+    if (typeof extracted.content === "string" && extracted.content.trim().length > 0) {
+      record.reasoning_content = extracted.content;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Under DeepSeek V4 thinking mode, when historical assistant tool-call messages lack the `reasoning_content` field, the API returns a 400 error:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

## Root Cause

`convertMessages` does not generate a `reasoning_content` field when converting assistant tool-call history to OpenAI format. DeepSeek thinking mode strictly requires this field to be present.

## Fix

In `buildOpenAICompletionsParams`, after `convertMessages`, insert `injectDeepSeekReasoningReplay` to inject `reasoning_content` as a fallback for DeepSeek model assistant tool-call messages.

Fallback priority (highest to lowest):
1. Existing non-empty `reasoning_content` → keep as-is
2. `reasoning` field → copy
3. `reasoning_text` field → copy
4. Replay signature key `content` extraction
5. Assistant `content` string → copy
6. None of the above → empty string `""` (verified safe against live API)

Only applied to models with `provider=deepseek` or `baseUrl` containing `deepseek.com`.

## Verification

- Unit tests cover all 5 fallback paths
- Production dry-run: 1493 tool-turns, `missingAfterPatch: 0`
- Production live test: 0 errors after applying the patch

## Related

Requires companion fix in `@mariozechner/pi-ai` `buildParams` for the pi-ai streaming path: https://github.com/snowzlm/pi-mono/pull/1