### PR TITLE
feat: add FuturMix provider plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -387,3 +387,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/fal/**"
+"extensions: futurmix":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/futurmix/**"

--- a/docs/providers/futurmix.md
+++ b/docs/providers/futurmix.md
@@ -1,0 +1,109 @@
+---
+summary: "FuturMix setup (auth + model selection)"
+title: "FuturMix"
+read_when:
+  - You want to use FuturMix with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+[FuturMix](https://futurmix.ai) is a unified AI gateway providing
+OpenAI-compatible access to 22+ models from OpenAI, Anthropic, and Google
+through a single API endpoint and key.
+
+| Property | Value                      |
+| -------- | -------------------------- |
+| Provider | `futurmix`                 |
+| Auth     | `FUTURMIX_API_KEY`         |
+| API      | OpenAI-compatible          |
+| Base URL | `https://futurmix.ai/v1`   |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an API key at
+    [futurmix.ai](https://futurmix.ai).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice futurmix-api-key
+    ```
+  </Step>
+  <Step title="Set a default model">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "futurmix/claude-sonnet-4-6" },
+        },
+      },
+    }
+    ```
+  </Step>
+</Steps>
+
+### Non-interactive example
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice futurmix-api-key \
+  --futurmix-api-key "$FUTURMIX_API_KEY"
+```
+
+<Note>
+The onboarding preset sets `futurmix/claude-sonnet-4-6` as the default
+model.
+</Note>
+
+## Built-in catalog
+
+OpenClaw ships this bundled FuturMix catalog:
+
+| Model ref                                   | Name                | Input       | Context   | Notes                      |
+| ------------------------------------------- | ------------------- | ----------- | --------- | -------------------------- |
+| `futurmix/claude-opus-4-7`                  | Claude Opus 4-7     | text, image | 200,000   | Default model; reasoning   |
+| `futurmix/claude-opus-4-6`                  | Claude Opus 4-6     | text, image | 200,000   | Reasoning enabled          |
+| `futurmix/claude-sonnet-4-6`                | Claude Sonnet 4-6   | text, image | 200,000   | Fast, capable              |
+| `futurmix/claude-sonnet-4-5-20250929`       | Claude Sonnet 4.5   | text, image | 200,000   | Balanced performance       |
+| `futurmix/claude-haiku-4-5-20251001`        | Claude Haiku 4.5    | text, image | 200,000   | Lightweight, fast          |
+| `futurmix/gemini-2.5-pro`                   | Gemini 2.5 Pro      | text, image | 1,048,576 | 1M context                 |
+| `futurmix/gemini-2.5-flash`                 | Gemini 2.5 Flash    | text, image | 1,048,576 | Fast, 1M context           |
+| `futurmix/gpt-5.4`                          | GPT-5.4             | text, image | 128,000   | Latest OpenAI              |
+| `futurmix/gpt-5.4-mini`                     | GPT-5.4 Mini        | text, image | 128,000   | Compact, efficient         |
+
+<AccordionGroup>
+  <Accordion title="Environment note">
+    If the Gateway runs as a daemon (launchd/systemd), make sure
+    `FUTURMIX_API_KEY` is available to that process (for example, in
+    `~/.openclaw/.env` or via `env.shellEnv`).
+
+    <Warning>
+    Keys set only in your interactive shell are not visible to daemon-managed
+    gateway processes. Use `~/.openclaw/.env` or `env.shellEnv` config for
+    persistent availability.
+    </Warning>
+
+  </Accordion>
+
+  <Accordion title="Troubleshooting">
+    - Verify your key works: `openclaw models list --provider futurmix`
+    - If models are not appearing, confirm the API key is set in the correct
+      environment for your Gateway process.
+    - Model refs use the form `futurmix/<model-id>`.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Provider rules, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config schema including provider settings.
+  </Card>
+  <Card title="FuturMix" href="https://futurmix.ai" icon="arrow-up-right-from-square">
+    FuturMix dashboard, API docs, and pricing.
+  </Card>
+</CardGroup>

--- a/extensions/futurmix/index.ts
+++ b/extensions/futurmix/index.ts
@@ -1,0 +1,34 @@
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applyFuturMixConfig, FUTURMIX_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildFuturMixProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "futurmix";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "FuturMix Provider",
+  description: "FuturMix AI gateway provider plugin",
+  provider: {
+    label: "FuturMix",
+    docsPath: "/providers/futurmix",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "FuturMix API key",
+        hint: "API key",
+        optionKey: "futurmixApiKey",
+        flagName: "--futurmix-api-key",
+        envVar: "FUTURMIX_API_KEY",
+        promptMessage: "Enter FuturMix API key",
+        defaultModel: FUTURMIX_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyFuturMixConfig(cfg),
+        wizard: {
+          groupLabel: "FuturMix",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildFuturMixProvider,
+    },
+  },
+});

--- a/extensions/futurmix/models.ts
+++ b/extensions/futurmix/models.ts
@@ -11,10 +11,10 @@ export const FUTURMIX_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 200000,
     maxTokens: 32000,
     cost: {
-      input: 15.0,
-      output: 75.0,
-      cacheRead: 1.5,
-      cacheWrite: 18.75,
+      input: 5.0,
+      output: 25.0,
+      cacheRead: 0.5,
+      cacheWrite: 6.25,
     },
   },
   {
@@ -25,10 +25,10 @@ export const FUTURMIX_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 200000,
     maxTokens: 32000,
     cost: {
-      input: 15.0,
-      output: 75.0,
-      cacheRead: 1.5,
-      cacheWrite: 18.75,
+      input: 5.0,
+      output: 25.0,
+      cacheRead: 0.5,
+      cacheWrite: 6.25,
     },
   },
   {

--- a/extensions/futurmix/models.ts
+++ b/extensions/futurmix/models.ts
@@ -1,0 +1,147 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const FUTURMIX_BASE_URL = "https://futurmix.ai/v1";
+
+export const FUTURMIX_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4-7",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32000,
+    cost: {
+      input: 15.0,
+      output: 75.0,
+      cacheRead: 1.5,
+      cacheWrite: 18.75,
+    },
+  },
+  {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4-6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32000,
+    cost: {
+      input: 15.0,
+      output: 75.0,
+      cacheRead: 1.5,
+      cacheWrite: 18.75,
+    },
+  },
+  {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4-6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 64000,
+    cost: {
+      input: 3.0,
+      output: 15.0,
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-sonnet-4-5-20250929",
+    name: "Claude Sonnet 4.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 64000,
+    cost: {
+      input: 3.0,
+      output: 15.0,
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    },
+  },
+  {
+    id: "claude-haiku-4-5-20251001",
+    name: "Claude Haiku 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 8192,
+    cost: {
+      input: 1.0,
+      output: 5.0,
+      cacheRead: 0.08,
+      cacheWrite: 1.25,
+    },
+  },
+  {
+    id: "gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: {
+      input: 1.25,
+      output: 10.0,
+      cacheRead: 0.31,
+      cacheWrite: 1.25,
+    },
+  },
+  {
+    id: "gemini-2.5-flash",
+    name: "Gemini 2.5 Flash",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: {
+      input: 0.15,
+      output: 0.60,
+      cacheRead: 0.0375,
+      cacheWrite: 0.15,
+    },
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: {
+      input: 2.50,
+      output: 10.0,
+      cacheRead: 1.25,
+      cacheWrite: 2.50,
+    },
+  },
+  {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: {
+      input: 0.40,
+      output: 1.60,
+      cacheRead: 0.10,
+      cacheWrite: 0.40,
+    },
+  },
+];
+
+export function buildFuturMixModelDefinition(
+  model: (typeof FUTURMIX_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    id: model.id,
+    name: model.name,
+    api: "openai-completions",
+    reasoning: model.reasoning,
+    input: model.input,
+    cost: model.cost,
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+  };
+}

--- a/extensions/futurmix/onboard.ts
+++ b/extensions/futurmix/onboard.ts
@@ -1,0 +1,26 @@
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildFuturMixModelDefinition,
+  FUTURMIX_BASE_URL,
+  FUTURMIX_MODEL_CATALOG,
+} from "./models.js";
+
+export const FUTURMIX_DEFAULT_MODEL_REF = "futurmix/claude-sonnet-4-6";
+
+const futurmixPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: FUTURMIX_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "futurmix",
+    api: "openai-completions",
+    baseUrl: FUTURMIX_BASE_URL,
+    catalogModels: FUTURMIX_MODEL_CATALOG.map(buildFuturMixModelDefinition),
+    aliases: [{ modelRef: FUTURMIX_DEFAULT_MODEL_REF, alias: "FuturMix" }],
+  }),
+});
+
+export function applyFuturMixConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return futurmixPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/futurmix/openclaw.plugin.json
+++ b/extensions/futurmix/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "futurmix",
+  "enabledByDefault": true,
+  "providers": ["futurmix"],
+  "providerAuthEnvVars": {
+    "futurmix": ["FUTURMIX_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "futurmix",
+      "method": "api-key",
+      "choiceId": "futurmix-api-key",
+      "choiceLabel": "FuturMix API key",
+      "groupId": "futurmix",
+      "groupLabel": "FuturMix",
+      "groupHint": "API key",
+      "optionKey": "futurmixApiKey",
+      "cliFlag": "--futurmix-api-key",
+      "cliOption": "--futurmix-api-key <key>",
+      "cliDescription": "FuturMix API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/futurmix/package.json
+++ b/extensions/futurmix/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/futurmix-provider",
+  "version": "2026.4.24",
+  "private": true,
+  "description": "OpenClaw FuturMix provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/futurmix/provider-catalog.ts
+++ b/extensions/futurmix/provider-catalog.ts
@@ -1,0 +1,14 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildFuturMixModelDefinition,
+  FUTURMIX_BASE_URL,
+  FUTURMIX_MODEL_CATALOG,
+} from "./models.js";
+
+export function buildFuturMixProvider(): ModelProviderConfig {
+  return {
+    baseUrl: FUTURMIX_BASE_URL,
+    api: "openai-completions",
+    models: FUTURMIX_MODEL_CATALOG.map(buildFuturMixModelDefinition),
+  };
+}

--- a/extensions/futurmix/tsconfig.json
+++ b/extensions/futurmix/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Add FuturMix as a bundled provider plugin. FuturMix is an AI platform that provides access to multiple leading models .

## Changes

- Add `extensions/futurmix/` directory with 7 files:
 - `openclaw.plugin.json` — plugin manifest with API key auth
 - `package.json` — workspace package config
 - `tsconfig.json` — TypeScript configuration
 - `index.ts` — main entry using `defineSingleProviderPluginEntry`
 - `models.ts` — model catalog (Claude, Gemini, GPT families)
 - `provider-catalog.ts` — provider config builder
 - `onboard.ts` — onboarding/preset appliers

## Provider Details

- **Provider ID:** `futurmix`
- **
- **Auth:** `FUTURMIX_API_KEY` environment variable
- **API:** `openai-completions` (OpenAI-compatible)
- **Docs:** [futurmix.ai/models](https://futurmix.ai/models)

## Models Included

| Model | Reasoning | Input |
|-------|-----------|-------|
| Claude Opus 4-7 | Yes | text, image |
| Claude Opus 4-6 | Yes | text, image |
| Claude Sonnet 4-6 | Yes | text, image |
| Claude Sonnet 4.5 | Yes | text, image |
| Claude Haiku 4.5 | No | text, image |
| Gemini 2.5 Pro | Yes | text, image |
| Gemini 2.5 Flash | Yes | text, image |
| GPT-5.4 | No | text, image |
| GPT-5.4 Mini | No | text, image |

## Why

This adds another OpenAI-compatible provider option for users who want one platform layer instead of managing many direct providers. FuturMix supports both the OpenAI chat completions format and the Anthropic messages format natively.

## Pattern

Follows the same structure as the Together provider plugin (`extensions/together/`).