### PR TITLE
fix: reduce cron.list preview overhead

### DIFF
--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CronJob } from "./types.js";
+
+const resolveDeliveryTarget = vi.hoisted(() =>
+  vi.fn(async () => ({ ok: true as const, channel: "slack", to: "D0ACC24QT0U" })),
+);
+const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
+
+vi.mock("./isolated-agent/delivery-target.js", () => ({
+  resolveDeliveryTarget,
+}));
+
+vi.mock("../agents/agent-scope-config.js", () => ({
+  resolveDefaultAgentId,
+}));
+
+import { resolveCronDeliveryPreviews } from "./delivery-preview.js";
+
+function createJob(id: string, overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id,
+    name: id,
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "hello" },
+    delivery: { mode: "announce", channel: "slack", to: "D0ACC24QT0U" },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("resolveCronDeliveryPreviews", () => {
+  beforeEach(() => {
+    resolveDeliveryTarget.mockClear().mockResolvedValue({
+      ok: true,
+      channel: "slack",
+      to: "D0ACC24QT0U",
+    });
+    resolveDefaultAgentId.mockClear().mockReturnValue("main");
+  });
+
+  it("dedupes identical delivery target lookups within a page", async () => {
+    const previews = await resolveCronDeliveryPreviews({
+      cfg: {} as OpenClawConfig,
+      defaultAgentId: "main",
+      jobs: [createJob("job-1"), createJob("job-2")],
+    });
+
+    expect(resolveDeliveryTarget).toHaveBeenCalledTimes(1);
+    expect(previews["job-1"]).toEqual(previews["job-2"]);
+  });
+
+  it("reuses the cached preview on a subsequent call", async () => {
+    const firstJob = createJob("job-1", {
+      delivery: { mode: "announce", channel: "slack", to: "D0CACHE1" },
+    });
+    const secondJob = createJob("job-2", {
+      delivery: { mode: "announce", channel: "slack", to: "D0CACHE1" },
+    });
+
+    await resolveCronDeliveryPreviews({
+      cfg: {} as OpenClawConfig,
+      defaultAgentId: "main",
+      jobs: [firstJob],
+    });
+    await resolveCronDeliveryPreviews({
+      cfg: {} as OpenClawConfig,
+      defaultAgentId: "main",
+      jobs: [secondJob],
+    });
+
+    expect(resolveDeliveryTarget).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -83,23 +83,68 @@ export async function resolveCronDeliveryPreview(params: {
   };
 }
 
+const CRON_DELIVERY_PREVIEW_CACHE_TTL_MS = 60_000;
+const cronDeliveryPreviewCache = new Map<string, { value: CronDeliveryPreview; ts: number }>();
+
+function buildCronDeliveryPreviewCacheKey(params: {
+  cfg: OpenClawConfig;
+  defaultAgentId?: string;
+  job: CronJob;
+}): string {
+  const plan = resolveCronDeliveryPlan(params.job);
+  return JSON.stringify({
+    agentId:
+      params.job.agentId?.trim() ||
+      params.defaultAgentId ||
+      resolveDefaultAgentId(params.cfg) ||
+      "",
+    sessionKey: params.job.sessionKey ?? "",
+    channel: plan.channel ?? "last",
+    to: plan.to ?? "",
+    threadId: plan.threadId ?? "",
+    accountId: plan.accountId ?? "",
+    mode: plan.mode ?? "announce",
+    requested: plan.requested !== false,
+  });
+}
+
 export async function resolveCronDeliveryPreviews(params: {
   cfg: OpenClawConfig;
   defaultAgentId?: string;
   jobs: CronJob[];
 }): Promise<Record<string, CronDeliveryPreview>> {
+  const now = Date.now();
+  const pendingByKey = new Map<string, Promise<CronDeliveryPreview>>();
   const entries = await Promise.all(
-    params.jobs.map(
-      async (job) =>
-        [
-          job.id,
-          await resolveCronDeliveryPreview({
-            cfg: params.cfg,
-            defaultAgentId: params.defaultAgentId,
-            job,
-          }),
-        ] as const,
-    ),
+    params.jobs.map(async (job) => {
+      const cacheKey = buildCronDeliveryPreviewCacheKey({
+        cfg: params.cfg,
+        defaultAgentId: params.defaultAgentId,
+        job,
+      });
+      const cached = cronDeliveryPreviewCache.get(cacheKey);
+      if (cached && now - cached.ts <= CRON_DELIVERY_PREVIEW_CACHE_TTL_MS) {
+        return [job.id, cached.value] as const;
+      }
+      let pending = pendingByKey.get(cacheKey);
+      if (!pending) {
+        pending = resolveCronDeliveryPreview({
+          cfg: params.cfg,
+          defaultAgentId: params.defaultAgentId,
+          job,
+        }).then((value) => {
+          cronDeliveryPreviewCache.set(cacheKey, { value, ts: Date.now() });
+          return value;
+        });
+        pendingByKey.set(cacheKey, pending);
+      }
+      return [job.id, await pending] as const;
+    }),
   );
+  for (const [cacheKey, cached] of cronDeliveryPreviewCache) {
+    if (now - cached.ts > CRON_DELIVERY_PREVIEW_CACHE_TTL_MS) {
+      cronDeliveryPreviewCache.delete(cacheKey);
+    }
+  }
   return Object.fromEntries(entries);
 }

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -20,6 +20,24 @@ function createBaseJob(overrides?: Partial<CronJob>): CronJob {
 }
 
 describe("cron listPage sort guards", () => {
+  it("defaults to a 50-item page instead of returning the full registry", async () => {
+    const jobs = Array.from({ length: 75 }, (_, idx) =>
+      createBaseJob({
+        id: `job-${idx + 1}`,
+        name: `job ${idx + 1}`,
+        state: { nextRunAtMs: Date.parse("2026-02-27T15:30:00.000Z") + idx },
+      }),
+    );
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state);
+    expect(page.jobs).toHaveLength(50);
+    expect(page.limit).toBe(50);
+    expect(page.total).toBe(75);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextOffset).toBe(50);
+  });
+
   it("does not throw when sorting by name with malformed name fields", async () => {
     const jobs = [
       createBaseJob({ id: "job-a", name: undefined as unknown as string }),

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -231,7 +231,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const sorted = sortJobs(filtered, sortBy, sortDir);
     const total = sorted.length;
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
-    const defaultLimit = total === 0 ? 50 : total;
+    const defaultLimit = 50;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
     const jobs = sorted.slice(offset, offset + limit);
     const nextOffset = offset + jobs.length;

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -164,12 +164,15 @@ export const cronHandlers: GatewayRequestHandlers = {
       sortBy: p.sortBy,
       sortDir: p.sortDir,
     });
-    const deliveryPreviews = await resolveCronDeliveryPreviews({
-      cfg: loadConfig(),
-      defaultAgentId: context.cron.getDefaultAgentId(),
-      jobs: page.jobs,
-    });
-    respond(true, { ...page, deliveryPreviews }, undefined);
+    const deliveryPreviewsEnabled = process.env.OPENCLAW_CRON_LIST_DELIVERY_PREVIEWS === "1";
+    const deliveryPreviews = deliveryPreviewsEnabled
+      ? await resolveCronDeliveryPreviews({
+          cfg: loadConfig(),
+          defaultAgentId: context.cron.getDefaultAgentId(),
+          jobs: page.jobs,
+        })
+      : {};
+    respond(true, { ...page, deliveryPreviews, deliveryPreviewsEnabled }, undefined);
   },
   "cron.status": async ({ params, respond, context }) => {
     if (!validateCronStatusParams(params)) {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -3,6 +3,9 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../../cron/types.js";
 
 const loadConfig = vi.hoisted(() => vi.fn<() => OpenClawConfig>(() => ({}) as OpenClawConfig));
+const resolveCronDeliveryPreviews = vi.hoisted(() =>
+  vi.fn(async () => ({ "cron-1": { label: "preview", detail: "preview detail" } })),
+);
 
 vi.mock("../../config/config.js", async () => {
   const actual =
@@ -13,6 +16,10 @@ vi.mock("../../config/config.js", async () => {
   };
 });
 
+vi.mock("../../cron/delivery-preview.js", () => ({
+  resolveCronDeliveryPreviews,
+}));
+
 import { cronHandlers } from "./cron.js";
 
 function createCronContext(currentJob?: CronJob) {
@@ -20,6 +27,14 @@ function createCronContext(currentJob?: CronJob) {
     cron: {
       add: vi.fn(async () => ({ id: "cron-1" })),
       update: vi.fn(async () => ({ id: "cron-1" })),
+      listPage: vi.fn(async () => ({
+        jobs: [currentJob ?? createCronJob()],
+        total: 1,
+        offset: 0,
+        limit: 1,
+        hasMore: false,
+        nextOffset: null,
+      })),
       getDefaultAgentId: vi.fn(() => "main"),
       getJob: vi.fn(() => currentJob),
     },
@@ -57,6 +72,20 @@ async function invokeCronUpdate(params: Record<string, unknown>, currentJob: Cro
   return { context, respond };
 }
 
+async function invokeCronList(params: Record<string, unknown> = {}, currentJob?: CronJob) {
+  const context = createCronContext(currentJob);
+  const respond = vi.fn();
+  await cronHandlers["cron.list"]({
+    req: {} as never,
+    params: params as never,
+    respond: respond as never,
+    context: context as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return { context, respond };
+}
+
 function createCronJob(overrides: Partial<CronJob> = {}): CronJob {
   return {
     id: "cron-1",
@@ -77,6 +106,10 @@ function createCronJob(overrides: Partial<CronJob> = {}): CronJob {
 describe("cron method validation", () => {
   beforeEach(() => {
     loadConfig.mockReset().mockReturnValue({} as OpenClawConfig);
+    resolveCronDeliveryPreviews.mockClear().mockResolvedValue({
+      "cron-1": { label: "preview", detail: "preview detail" },
+    });
+    delete process.env.OPENCLAW_CRON_LIST_DELIVERY_PREVIEWS;
   });
 
   it("rejects ambiguous announce delivery on add when multiple channels are configured", async () => {
@@ -160,6 +193,41 @@ describe("cron method validation", () => {
       expect.objectContaining({
         message: expect.stringContaining("delivery.channel is required"),
       }),
+    );
+  });
+
+  it("returns cron.list without delivery previews by default", async () => {
+    const job = createCronJob();
+    const { respond } = await invokeCronList({ includeDisabled: true }, job);
+
+    expect(resolveCronDeliveryPreviews).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        jobs: [job],
+        deliveryPreviews: {},
+        deliveryPreviewsEnabled: false,
+      }),
+      undefined,
+    );
+  });
+
+  it("allows opt-in delivery previews for cron.list via env flag", async () => {
+    process.env.OPENCLAW_CRON_LIST_DELIVERY_PREVIEWS = "1";
+    const job = createCronJob();
+    const { respond } = await invokeCronList({ includeDisabled: true }, job);
+
+    expect(resolveCronDeliveryPreviews).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        jobs: [job],
+        deliveryPreviews: {
+          "cron-1": { label: "preview", detail: "preview detail" },
+        },
+        deliveryPreviewsEnabled: true,
+      }),
+      undefined,
     );
   });
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -418,7 +418,7 @@ export class OpenClawApp extends LitElement {
   @state() cronJobsTotal = 0;
   @state() cronJobsHasMore = false;
   @state() cronJobsNextOffset: number | null = null;
-  @state() cronJobsLimit = 50;
+  @state() cronJobsLimit = 25;
   @state() cronJobsQuery = "";
   @state() cronJobsEnabledFilter: import("./types.js").CronJobsEnabledFilter = "all";
   @state() cronJobsScheduleKindFilter: import("./controllers/cron.js").CronJobsScheduleKindFilter =

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -27,7 +27,7 @@ function createState(overrides: Partial<CronState> = {}): CronState {
     cronJobsTotal: 0,
     cronJobsHasMore: false,
     cronJobsNextOffset: null,
-    cronJobsLimit: 50,
+    cronJobsLimit: 25,
     cronJobsQuery: "",
     cronJobsEnabledFilter: "all",
     cronJobsScheduleKindFilter: "all",
@@ -1201,7 +1201,7 @@ describe("cron controller", () => {
     const request = vi.fn(async (method: string, payload?: unknown) => {
       if (method === "cron.list") {
         expect(payload).toMatchObject({
-          limit: 50,
+          limit: 25,
           offset: 0,
           query: "daily",
           enabled: "enabled",

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -621,6 +621,7 @@ export type CronJobsListResult = {
   offset?: number;
   nextOffset?: number | null;
   hasMore?: boolean;
+  deliveryPreviewsEnabled?: boolean;
 };
 
 export type CronRunsResult = {


### PR DESCRIPTION
## Summary
- keep `cron.list` delivery previews off by default and make them opt-in via `OPENCLAW_CRON_LIST_DELIVERY_PREVIEWS=1`
- add cache + dedupe for preview resolution when previews are enabled
- reduce default cron pagination work on both server and UI paths
- add targeted regression tests for preview gating, preview cache/dedupe, and default pagination

## Verification
- node scripts/test-projects.mjs src/gateway/server-methods/cron.validation.test.ts src/cron/service.list-page-sort-guards.test.ts
- node scripts/test-projects.mjs src/cron/delivery-preview.test.ts
- npx vitest run src/ui/controllers/cron.test.ts src/ui/views/cron.test.ts

## Notes
- a broader `pnpm test:ui -- ui/src/ui/controllers/cron.test.ts` run also surfaced unrelated existing style-path failures under `src/styles/*.test.ts`; those were not caused by this change.