### PR TITLE
fix(qqbot): require auth for bot-clear-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- QQBot/security: require framework auth for `/bot-clear-storage` so unauthorized QQ senders cannot trigger on-host file deletion through the unauthenticated pre-dispatch slash-command path, following the same gating as `/bot-approve` and `/bot-logs`.
 - Plugins/onboarding: record local plugin install source metadata without duplicating raw absolute local paths in persisted `plugins.installs`, while preserving linked load-path cleanup. (#70970) Thanks @vincentkoc.
 - Browser/tool: tell agents not to pass per-call `timeoutMs` on existing-session type, evaluate, and other Chrome MCP actions that reject timeout overrides.
 - Codex/GPT-5.4: harden fallback, auth-profile, tool-schema, and replay edge cases across native and embedded runtime paths. (#70743) Thanks @100yenadmin.

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -5,4 +5,8 @@ describe("QQBot framework slash commands", () => {
   it("routes bot-approve through the auth-gated framework registry", () => {
     expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-approve");
   });
+
+  it("routes bot-clear-storage through the auth-gated framework registry", () => {
+    expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-clear-storage");
+  });
 });

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
@@ -609,6 +609,7 @@ const CLEAR_STORAGE_MAX_DISPLAY = 10;
 registerCommand({
   name: "bot-clear-storage",
   description: "清理通过 QQBot 对话产生的下载文件，释放主机磁盘空间",
+  requireAuth: true,
   usage: [
     `/bot-clear-storage`,
     ``,


### PR DESCRIPTION
## Summary

- `/bot-clear-storage` was registered without `requireAuth: true`, which routed it through QQBot's **pre-dispatch** slash-command path rather than the auth-gated framework registry.
- Any QQ user who can DM the bot could send `/bot-clear-storage --force` and trigger `fs.unlinkSync` against every file under `~/.openclaw/media/qqbot/downloads/<appId>/` on the operator's host.
- The `c2c` guard (line ~625) restricts the command to private chat, but private chat is not an auth boundary.

Same class as #70706 (`/bot-approve`) which was merged yesterday; same one-line gating. `/bot-logs` already carries `requireAuth: true`, so logs are gated but on-disk deletion was not.

## Changes

- Add `requireAuth: true` to the `bot-clear-storage` registration in `extensions/qqbot/src/engine/commands/slash-commands-impl.ts`.
- Extend `slash-commands-impl.test.ts` to assert `bot-clear-storage` resolves through `getFrameworkCommands()`, mirroring the existing `bot-approve` coverage.
- `CHANGELOG.md` entry under Unreleased/Fixes.

## Test plan

- [x] `pnpm test extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts` — both framework-gating assertions pass
- [x] `pnpm test extensions/qqbot` — 200/200 passing
- [x] `pnpm check:changed` — typecheck, lint, conflict markers, import cycles all green