### PR TITLE
fix(cli-runner): append --verbose for Claude CLI stream-json live ses…

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -141,23 +141,31 @@ export function buildClaudeLiveArgs(params: {
   systemPrompt: string;
   useResume: boolean;
 }): string[] {
+  // Claude Code CLI >=2.1.114 rejects `--output-format=stream-json` without
+  // `--verbose` ("Error: When using --print, --output-format=stream-json
+  // requires --verbose"). Live sessions always use stream-json I/O, so inject
+  // `--verbose` once at the end; `appendArg` is idempotent so it is a no-op
+  // when callers already pass it through backend.args.
   return appendArg(
-    upsertArgValue(
+    appendArg(
       upsertArgValue(
-        params.useResume
-          ? stripLiveProcessArgs(params.args, params.backend)
-          : appendSystemPromptArg(
-              stripLiveProcessArgs(params.args, params.backend),
-              params.backend,
-              params.systemPrompt,
-            ),
-        "--input-format",
-        "stream-json",
+        upsertArgValue(
+          params.useResume
+            ? stripLiveProcessArgs(params.args, params.backend)
+            : appendSystemPromptArg(
+                stripLiveProcessArgs(params.args, params.backend),
+                params.backend,
+                params.systemPrompt,
+              ),
+          "--input-format",
+          "stream-json",
+        ),
+        "--permission-prompt-tool",
+        "stdio",
       ),
-      "--permission-prompt-tool",
-      "stdio",
+      "--replay-user-messages",
     ),
-    "--replay-user-messages",
+    "--verbose",
   );
 }
 


### PR DESCRIPTION
…sions

Claude Code CLI >=2.1.114 rejects --output-format=stream-json when --verbose is not present, erroring out with:

    Error: When using --print, --output-format=stream-json requires --verbose

buildClaudeLiveArgs() already forces --input-format=stream-json and expects the backend to set --output-format=stream-json via backend.args. Without --verbose the CLI exits before OpenClaw can read any stream frame, which surfaces as FailoverError (reason=unknown) on the very first turn.

Add --verbose once at the end of the argv chain. appendArg() is idempotent, so backends that already pass --verbose through backend.args are unaffected.

Repro: any Slack/message inbound on a gateway running claude-code 2.1.114+ triggers an immediate "Something went wrong" reply with the following in journalctl:

    [agent/cli-backend] claude live session turn failed: ...
        durationMs=12 error=FailoverError
    [model-fallback/decision] ... reason=unknown ...

After the patch the first turn succeeds and subsequent replies stream normally.

## Summary

…sions

Claude Code CLI >=2.1.114 rejects --output-format=stream-json when --verbose is not present, erroring out with:

    Error: When using --print, --output-format=stream-json requires --verbose

buildClaudeLiveArgs() already forces --input-format=stream-json and expects the backend to set --output-format=stream-json via backend.args. Without --verbose the CLI exits before OpenClaw can read any stream frame, which surfaces as FailoverError (reason=unknown) on the very first turn.

Add --verbose once at the end of the argv chain. appendArg() is idempotent, so backends that already pass --verbose through backend.args are unaffected.

Repro: any Slack/message inbound on a gateway running claude-code 2.1.114+ triggers an immediate "Something went wrong" reply with the following in journalctl:

    [agent/cli-backend] claude live session turn failed: ...
        durationMs=12 error=FailoverError
    [model-fallback/decision] ... reason=unknown ...

After the patch the first turn succeeds and subsequent replies stream normally.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix

## Scope (select all touched areas)

- [ ] Gateway / orchestration

## Linked Issue/PR

- Closes #
- Related # (will file a separate issue for the warm-session-resume "No conversation found with session ID" regression I found in the same repro)
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

Root cause: claude-code CLI added a hard validation in 2.1.114 requiring --verbose whenever --output-format=stream-json is used with --print. OpenClaw's buildClaudeLiveArgs only injects --input-format, --permission-prompt-tool, --replay-user-messages; --verbose was assumed to come from backend.args, which is not the case for default backends.
Missing detection / guardrail: failTurn currently logs only error.name, so the real stderr ("requires --verbose") is dropped and the failover layer reports reason=unknown. I can send a small follow-up PR that surfaces error.message + tailed session.stderr in the warn log if that'd be welcome.
Contributing context: claude-code 2.1.114 appears to have changed this behaviour without a migration note visible to downstream integrators.

## Regression Test Plan (if applicable)
Coverage level that should have caught this:
 Unit test
Target test or file: src/agents/cli-runner.spawn.test.ts — existing buildClaudeLiveArgs(...) call site around line 1092
Scenario the test should lock in: result of buildClaudeLiveArgs must include "--verbose" (both useResume: true and useResume: false branches)
Why this is the smallest reliable guardrail: any future refactor of the argv builder is caught immediately at CI, without needing a live claude-code binary in the loop.
Existing test that already covers this: none — current assertions only check --resume/--session-id handling.
If no new test is added, why not: happy to add one in this PR if maintainers prefer.

## User-visible / Behavior Changes

None. End users only observe that previously-failing replies now succeed.

## Diagram (if applicable)

N/A (argv-level change, no new flow.)

## Security Impact (required)

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? Yes (minor) — claude-code is invoked with --verbose, which increases stdout chatter (structured stream-json frames only; no secrets). Already consumed by createCliJsonlStreamingParser.
Data access scope changed? No

## Repro + Verification

### Environment

OS: **WSL2 Ubuntu** 22.04 (kernel 6.6.87.2-microsoft-standard-WSL2)
Runtime: Node v22.22.2, pnpm 10.33.0
Model/provider: claude-cli/claude-opus-4-7 via @anthropic-ai/claude-code@2.1.114
Integration/channel: Slack socket mode
Relevant config: channels.slack.enabled=true, agents.defaults.model.primary=claude-cli/claude-opus-4-7

### Steps

1.npm i -g @anthropic-ai/claude-code@2.1.114
2.Start an OpenClaw gateway against main (pre-patch)
3. Send any message in a Slack channel where the bot is mentioned

### Expected

- Bot replies normally.

### Actual

-Slack shows "Something went wrong while processing your request.", journal shows claude live session turn failed: ... durationMs=12 error=FailoverError and [model-fallback/decision] ... reason=unknown. Running the same argv by hand reproduces Error: When using --print, --output-format=stream-json requires --verbose.

## Evidence

- [ ] Failing test/log before + passing after

Before:
[agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=635
[agent/cli-backend] claude live session start: activeSessions=1
[agent/cli-backend] claude live session turn failed: durationMs=12 error=FailoverError
[model-fallback/decision] decision=candidate_failed ... reason=unknown
Embedded agent failed before reply: Claude CLI failed.
After:
[agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=690
[agent/cli-backend] claude live session start: activeSessions=1
[agent/cli-backend] claude live session turn: durationMs=8003 rawLines=14
[slack] delivered reply to channel:C...


## Human Verification (required)

Verified scenarios:
Cold live-session turn against claude-opus-4-7 end-to-end (Slack mention → reply delivery)
appendArg idempotency: running with a backend that already passes --verbose in backend.args produces exactly one --verbose in final argv

Both useResume: true and useResume: 
false argv paths still produce the required flag

Edge cases checked:
backend.args containing --verbose already → no duplicate
useResume: true branch (strip path) → --verbose still present

What I did not verify:
Other providers (codex-cli, gemini-cli) — untouched by this patch
claude-code < 2.1.114 — --verbose has been a valid flag on older versions too, so no known regression
macOS/Windows-native builds — verified on Linux x64 only

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:--verbose enables richer diagnostic frames in stream-json (system init, tool_use metadata, etc.). The JSONL streaming parser (createCliJsonlStreamingParser) already tolerates unknown frame types, but the slightly larger frame volume could mildly affect per-turn rawLines counts. No test in the current suite asserts an exact frame count, so no regression expected.

  - Mitigation:appendArg is idempotent — backends that already pass --verbose via backend.args are unaffected (no duplicate flag)
Scoped to live-session path only (shouldUseClaudeLiveSession → claude-stdio + jsonl + stdin). Non-live CLI invocations and other providers are untouched
Validated locally against @anthropic-ai/claude-code@2.1.114: first turn went from durationMs=12 FailoverError reason=unknown → successful ~1.7s response with clean reply delivery through Slack