### PR TITLE
fix(plugins): honor descriptor-only setup flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Gradium: add a bundled text-to-speech provider with voice-note and telephony output support. (#64958) Thanks @LaurentMazare.
+- Plugins/setup: honor explicit `setup.requiresRuntime: false` as a descriptor-only setup contract while keeping omitted values on the legacy setup-api fallback path. Thanks @vincentkoc.
 - TUI/dependencies: remove direct `cli-highlight` usage from the OpenClaw TUI code-block renderer, keeping themed code coloring without the extra root dependency. Thanks @vincentkoc.
 - Diagnostics/OTEL: export run, model-call, and tool-execution diagnostic lifecycle events as OTEL spans without retaining live span state. Thanks @vincentkoc.
 - Plugins/activation: expose activation plan reasons and a richer plan API so callers can inspect why a plugin was selected while preserving existing id-list activation behavior. (#70943) Thanks @vincentkoc.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -71,10 +71,12 @@ or fallback behavior without changing runtime loading semantics.
 
 Setup discovery now prefers descriptor-owned ids such as `setup.providers` and
 `setup.cliBackends` to narrow candidate plugins before it falls back to
-`setup-api` for plugins that still need setup-time runtime hooks. If more than
-one discovered plugin claims the same normalized setup provider or CLI backend
-id, setup lookup refuses the ambiguous owner instead of relying on discovery
-order.
+`setup-api` for plugins that still need setup-time runtime hooks. Explicit
+`setup.requiresRuntime: false` is a descriptor-only cutoff; omitted
+`requiresRuntime` keeps the legacy setup-api fallback for compatibility. If more
+than one discovered plugin claims the same normalized setup provider or CLI
+backend id, setup lookup refuses the ambiguous owner instead of relying on
+discovery order.
 
 ### What the loader caches
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -327,6 +327,12 @@ narrows the candidate plugin and setup still needs richer setup-time runtime
 hooks, set `requiresRuntime: true` and keep `setup-api` in place as the
 fallback execution path.
 
+Set `requiresRuntime: false` only when those descriptors are sufficient for the
+setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
+and will not execute `setup-api` for setup lookup. Omitted `requiresRuntime`
+keeps legacy fallback behavior so existing plugins that added descriptors
+without the flag do not break.
+
 Because setup lookup can execute plugin-owned `setup-api` code, normalized
 `setup.providers[].id` and `setup.cliBackends[]` values must stay unique across
 discovered plugins. Ambiguous ownership fails closed instead of picking a

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -349,6 +349,39 @@ describe("setup-registry getJiti", () => {
     expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(path.join(pluginRoot, "setup-api.js"));
   });
 
+  it("treats explicit descriptor-only setup as a runtime cutoff", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(pluginRoot, "setup-api.js"),
+      "export default { register(api) { api.registerProvider({ id: 'openai', label: 'OpenAI', auth: [] }); api.registerCliBackend({ id: 'codex-cli', config: { command: 'codex' } }); } };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "openai" }],
+            cliBackends: ["codex-cli"],
+            requiresRuntime: false,
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(resolvePluginSetupProvider({ provider: "openai", env: {} })).toBeUndefined();
+    expect(resolvePluginSetupCliBackend({ backend: "codex-cli", env: {} })).toBeUndefined();
+    expect(resolvePluginSetupRegistry({ env: {} })).toEqual({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+    });
+    expect(mocks.createJiti).not.toHaveBeenCalled();
+  });
+
   it("does not load setup-api modules from the current working directory", () => {
     const pluginRoot = makeTempDir();
     const workspaceRoot = makeTempDir();

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -272,6 +272,9 @@ function resolveSetupRegistration(record: PluginManifestRecord): {
   setupSource: string;
   register: (api: ReturnType<typeof buildPluginApi>) => void | Promise<void>;
 } | null {
+  if (record.setup?.requiresRuntime === false) {
+    return null;
+  }
   const setupSource = record.setupSource ?? resolveSetupApiPath(record.rootDir);
   if (!setupSource) {
     return null;


### PR DESCRIPTION
## Summary

- Problem: `setup.requiresRuntime: false` was documented as descriptor-only, but setup lookup still executed `setup-api` when one existed.
- Why it matters: descriptor-first setup needs a real compat boundary so plugin authors can opt out of setup runtime execution intentionally.
- What changed: explicit `requiresRuntime: false` now cuts off setup-api loading; omitted values keep the legacy fallback path.
- What did NOT change (scope boundary): no bundled plugin descriptors or setup-api registrations were migrated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/70998
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: setup lookup only used descriptors to narrow candidate plugins, then always attempted setup runtime loading when a setup-api file existed.
- Missing detection / guardrail: no test asserted the explicit descriptor-only `requiresRuntime: false` contract.
- Contributing context: omitted `requiresRuntime` still needs legacy fallback behavior for existing plugins.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/setup-registry.test.ts`
- Scenario the test should lock in: explicit `setup.requiresRuntime: false` prevents provider/backend/registry setup-api loading.
- Why this is the smallest reliable guardrail: the setup registry owns descriptor narrowing and setup-api execution.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugin manifests that explicitly set `setup.requiresRuntime: false` are now treated as descriptor-only for setup lookup. Omitted values stay backward compatible.

## Diagram (if applicable)

```text
Before:
setup descriptor + setup-api + requiresRuntime false -> setup-api still loaded

After:
setup descriptor + setup-api + requiresRuntime false -> descriptor-only cutoff
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via repo pnpm toolchain
- Model/provider: N/A
- Integration/channel (if any): plugin setup registry
- Relevant config (redacted): N/A

### Steps

1. Create a manifest record with `setup.providers`, `setup.cliBackends`, `setup.requiresRuntime: false`, and a local `setup-api.js`.
2. Resolve setup provider/backend/registry entries.
3. Assert no setup-api runtime loader is invoked.

### Expected

- Explicit descriptor-only setup does not execute setup-api.

### Actual

- Before this patch, setup-api could still execute.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/plugins/setup-registry.test.ts`; `pnpm format:check CHANGELOG.md docs/plugins/manifest.md docs/plugins/architecture-internals.md src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`; `git diff --check HEAD~1..HEAD`
- Edge cases checked: provider lookup, CLI backend lookup, full setup registry resolution, legacy omitted `requiresRuntime` behavior remains covered by existing tests.
- What you did **not** verify: full `pnpm check:changed`; local run is blocked by unrelated core model-compat type errors on this machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a third-party plugin may have set `requiresRuntime: false` while still relying on setup-api side effects.
  - Mitigation: omitted values keep legacy fallback behavior; only explicit `false` opts into descriptor-only semantics.
