### PR TITLE
[codex] refactor: keep runtime plan type contracts leaf-safe

### DIFF
--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -1,7 +1,11 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { TSchema } from "typebox";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   resolveProviderFollowupFallbackRoute,
   resolveProviderSystemPromptContribution,
@@ -33,6 +37,7 @@ function hasMedia(payload: { mediaUrl?: string; mediaUrls?: string[] }): boolean
 export function buildAgentRuntimeDeliveryPlan(
   params: BuildAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
+  const config = params.config as OpenClawConfig | undefined;
   return {
     isSilentPayload(payload): boolean {
       return isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN) && !hasMedia(payload);
@@ -40,15 +45,15 @@ export function buildAgentRuntimeDeliveryPlan(
     resolveFollowupRoute(routeParams) {
       return resolveProviderFollowupFallbackRoute({
         provider: params.provider,
-        config: params.config,
+        config,
         workspaceDir: params.workspaceDir,
         context: {
-          config: params.config,
+          config,
           agentDir: params.agentDir,
           workspaceDir: params.workspaceDir,
           provider: params.provider,
           modelId: params.modelId,
-          payload: routeParams.payload,
+          payload: routeParams.payload as ReplyPayload,
           originatingChannel: routeParams.originatingChannel,
           originatingTo: routeParams.originatingTo,
           originRoutable: routeParams.originRoutable,
@@ -66,13 +71,15 @@ export function buildAgentRuntimeOutcomePlan(): AgentRuntimeOutcomePlan {
 }
 
 export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
+  const config = params.config as OpenClawConfig | undefined;
+  const model = params.model as ProviderRuntimeModel | undefined;
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
   const transport = params.resolvedTransport;
   const auth = buildAgentRuntimeAuthPlan({
     provider: params.provider,
     authProfileProvider: params.authProfileProvider,
     sessionAuthProfileId: params.sessionAuthProfileId,
-    config: params.config,
+    config,
     workspaceDir: params.workspaceDir,
     harnessId: params.harnessId,
     harnessRuntime: params.harnessRuntime,
@@ -87,12 +94,12 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
   };
   const toolContext = {
     provider: params.provider,
-    config: params.config,
+    config,
     workspaceDir: params.workspaceDir,
     env: process.env,
     modelId: params.modelId,
     modelApi,
-    model: params.model,
+    model,
   };
   const resolveToolContext = (overrides?: {
     workspaceDir?: string;
@@ -102,7 +109,9 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
     ...toolContext,
     ...(overrides?.workspaceDir !== undefined ? { workspaceDir: overrides.workspaceDir } : {}),
     ...(overrides?.modelApi !== undefined ? { modelApi: overrides.modelApi } : {}),
-    ...(overrides?.model !== undefined ? { model: overrides.model } : {}),
+    ...(overrides?.model !== undefined
+      ? { model: overrides.model as ProviderRuntimeModel | undefined }
+      : {}),
   });
   const resolveTranscriptRuntimePolicy = (overrides?: {
     workspaceDir?: string;
@@ -112,25 +121,25 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
     resolveTranscriptPolicy({
       provider: params.provider,
       modelId: params.modelId,
-      config: params.config,
+      config,
       workspaceDir: overrides?.workspaceDir ?? params.workspaceDir,
       env: process.env,
       modelApi: overrides?.modelApi ?? modelApi,
-      model: overrides?.model ?? params.model,
+      model: (overrides?.model as ProviderRuntimeModel | undefined) ?? model,
     });
   const resolveTransportExtraParams = (
     overrides: Parameters<AgentRuntimePlan["transport"]["resolveExtraParams"]>[0] = {},
   ) =>
     resolvePreparedExtraParams({
-      cfg: params.config,
+      cfg: config,
       provider: params.provider,
       modelId: params.modelId,
       agentDir: params.agentDir,
       workspaceDir: overrides.workspaceDir ?? params.workspaceDir,
       extraParamsOverride: overrides.extraParamsOverride ?? params.extraParamsOverride,
-      thinkingLevel: overrides.thinkingLevel ?? params.thinkingLevel,
+      thinkingLevel: (overrides.thinkingLevel ?? params.thinkingLevel) as ThinkLevel | undefined,
       agentId: overrides.agentId ?? params.agentId,
-      model: overrides.model ?? params.model,
+      model: (overrides.model as ProviderRuntimeModel | undefined) ?? model,
       resolvedTransport: overrides.resolvedTransport ?? transport,
     });
 
@@ -143,9 +152,12 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
       resolveSystemPromptContribution(context) {
         return resolveProviderSystemPromptContribution({
           provider: params.provider,
-          config: params.config,
+          config,
           workspaceDir: context.workspaceDir ?? params.workspaceDir,
-          context,
+          context: {
+            ...context,
+            config: context.config as OpenClawConfig | undefined,
+          },
         });
       },
     },

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -34,10 +34,14 @@ function hasMedia(payload: { mediaUrl?: string; mediaUrls?: string[] }): boolean
   return resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
+function asOpenClawConfig(value: unknown): OpenClawConfig | undefined {
+  return value && typeof value === "object" ? (value as OpenClawConfig) : undefined;
+}
+
 export function buildAgentRuntimeDeliveryPlan(
   params: BuildAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
-  const config = params.config as OpenClawConfig | undefined;
+  const config = asOpenClawConfig(params.config);
   return {
     isSilentPayload(payload): boolean {
       return isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN) && !hasMedia(payload);
@@ -71,7 +75,7 @@ export function buildAgentRuntimeOutcomePlan(): AgentRuntimeOutcomePlan {
 }
 
 export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
-  const config = params.config as OpenClawConfig | undefined;
+  const config = asOpenClawConfig(params.config);
   const model = params.model as ProviderRuntimeModel | undefined;
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
   const transport = params.resolvedTransport;
@@ -156,7 +160,7 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
           workspaceDir: context.workspaceDir ?? params.workspaceDir,
           context: {
             ...context,
-            config: context.config as OpenClawConfig | undefined,
+            config: asOpenClawConfig(context.config),
           },
         });
       },

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -34,7 +34,9 @@ function hasMedia(payload: { mediaUrl?: string; mediaUrls?: string[] }): boolean
 }
 
 function asOpenClawConfig(value: unknown): OpenClawConfig | undefined {
-  return value && typeof value === "object" ? (value as OpenClawConfig) : undefined;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as OpenClawConfig)
+    : undefined;
 }
 
 export function buildAgentRuntimeDeliveryPlan(

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -25,22 +25,6 @@ import type {
   BuildAgentRuntimePlanParams,
 } from "./types.js";
 
-type BuildConcreteAgentRuntimeDeliveryPlanParams = Omit<
-  BuildAgentRuntimeDeliveryPlanParams,
-  "config"
-> & {
-  config?: OpenClawConfig;
-};
-
-type BuildConcreteAgentRuntimePlanParams = Omit<
-  BuildAgentRuntimePlanParams,
-  "config" | "model" | "thinkingLevel"
-> & {
-  config?: OpenClawConfig;
-  model?: ProviderRuntimeModel;
-  thinkingLevel?: ThinkLevel;
-};
-
 function formatResolvedRef(params: { provider: string; modelId: string }): string {
   return `${params.provider}/${params.modelId}`;
 }
@@ -55,10 +39,20 @@ function asOpenClawConfig(value: unknown): OpenClawConfig | undefined {
     : undefined;
 }
 
+function asProviderRuntimeModel(
+  value: BuildAgentRuntimePlanParams["model"],
+): ProviderRuntimeModel | undefined {
+  return value !== undefined ? (value as ProviderRuntimeModel) : undefined;
+}
+
+function asThinkLevel(value: BuildAgentRuntimePlanParams["thinkingLevel"]): ThinkLevel | undefined {
+  return value !== undefined ? (value as ThinkLevel) : undefined;
+}
+
 export function buildAgentRuntimeDeliveryPlan(
-  params: BuildConcreteAgentRuntimeDeliveryPlanParams,
+  params: BuildAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
-  const config = params.config;
+  const config = asOpenClawConfig(params.config);
   return {
     isSilentPayload(payload): boolean {
       return isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN) && !hasMedia(payload);
@@ -91,11 +85,9 @@ export function buildAgentRuntimeOutcomePlan(): AgentRuntimeOutcomePlan {
   };
 }
 
-export function buildAgentRuntimePlan(
-  params: BuildConcreteAgentRuntimePlanParams,
-): AgentRuntimePlan {
-  const config = params.config;
-  const model = params.model;
+export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
+  const config = asOpenClawConfig(params.config);
+  const model = asProviderRuntimeModel(params.model);
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
   const transport = params.resolvedTransport;
   const auth = buildAgentRuntimeAuthPlan({
@@ -132,9 +124,7 @@ export function buildAgentRuntimePlan(
     ...toolContext,
     ...(overrides?.workspaceDir !== undefined ? { workspaceDir: overrides.workspaceDir } : {}),
     ...(overrides?.modelApi !== undefined ? { modelApi: overrides.modelApi } : {}),
-    ...(overrides?.model !== undefined
-      ? { model: overrides.model as ProviderRuntimeModel | undefined }
-      : {}),
+    ...(overrides?.model !== undefined ? { model: asProviderRuntimeModel(overrides.model) } : {}),
   });
   const resolveTranscriptRuntimePolicy = (overrides?: {
     workspaceDir?: string;
@@ -148,7 +138,7 @@ export function buildAgentRuntimePlan(
       workspaceDir: overrides?.workspaceDir ?? params.workspaceDir,
       env: process.env,
       modelApi: overrides?.modelApi ?? modelApi,
-      model: (overrides?.model as ProviderRuntimeModel | undefined) ?? model,
+      model: asProviderRuntimeModel(overrides?.model) ?? model,
     });
   const resolveTransportExtraParams = (
     overrides: Parameters<AgentRuntimePlan["transport"]["resolveExtraParams"]>[0] = {},
@@ -160,9 +150,9 @@ export function buildAgentRuntimePlan(
       agentDir: params.agentDir,
       workspaceDir: overrides.workspaceDir ?? params.workspaceDir,
       extraParamsOverride: overrides.extraParamsOverride ?? params.extraParamsOverride,
-      thinkingLevel: (overrides.thinkingLevel ?? params.thinkingLevel) as ThinkLevel | undefined,
+      thinkingLevel: asThinkLevel(overrides.thinkingLevel ?? params.thinkingLevel),
       agentId: overrides.agentId ?? params.agentId,
-      model: (overrides.model as ProviderRuntimeModel | undefined) ?? model,
+      model: asProviderRuntimeModel(overrides.model) ?? model,
       resolvedTransport: overrides.resolvedTransport ?? transport,
     });
 

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -25,6 +25,22 @@ import type {
   BuildAgentRuntimePlanParams,
 } from "./types.js";
 
+type BuildConcreteAgentRuntimeDeliveryPlanParams = Omit<
+  BuildAgentRuntimeDeliveryPlanParams,
+  "config"
+> & {
+  config?: OpenClawConfig;
+};
+
+type BuildConcreteAgentRuntimePlanParams = Omit<
+  BuildAgentRuntimePlanParams,
+  "config" | "model" | "thinkingLevel"
+> & {
+  config?: OpenClawConfig;
+  model?: ProviderRuntimeModel;
+  thinkingLevel?: ThinkLevel;
+};
+
 function formatResolvedRef(params: { provider: string; modelId: string }): string {
   return `${params.provider}/${params.modelId}`;
 }
@@ -40,9 +56,9 @@ function asOpenClawConfig(value: unknown): OpenClawConfig | undefined {
 }
 
 export function buildAgentRuntimeDeliveryPlan(
-  params: BuildAgentRuntimeDeliveryPlanParams,
+  params: BuildConcreteAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
-  const config = asOpenClawConfig(params.config);
+  const config = params.config;
   return {
     isSilentPayload(payload): boolean {
       return isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN) && !hasMedia(payload);
@@ -75,9 +91,11 @@ export function buildAgentRuntimeOutcomePlan(): AgentRuntimeOutcomePlan {
   };
 }
 
-export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
-  const config = asOpenClawConfig(params.config);
-  const model = params.model as ProviderRuntimeModel | undefined;
+export function buildAgentRuntimePlan(
+  params: BuildConcreteAgentRuntimePlanParams,
+): AgentRuntimePlan {
+  const config = params.config;
+  const model = params.model;
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
   const transport = params.resolvedTransport;
   const auth = buildAgentRuntimeAuthPlan({

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -3,7 +3,6 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import type { TSchema } from "typebox";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
-import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
@@ -57,7 +56,7 @@ export function buildAgentRuntimeDeliveryPlan(
           workspaceDir: params.workspaceDir,
           provider: params.provider,
           modelId: params.modelId,
-          payload: routeParams.payload as ReplyPayload,
+          payload: routeParams.payload,
           originatingChannel: routeParams.originatingChannel,
           originatingTo: routeParams.originatingTo,
           originRoutable: routeParams.originRoutable,

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { FailoverReason } from "../pi-embedded-helpers/types.js";
+import type {
+  AgentRuntimeFailoverReason,
+  AgentRuntimeReplyPayload,
+  AgentRuntimeThinkLevel,
+} from "./types.js";
+
+describe("AgentRuntimePlan structural type compatibility", () => {
+  it("keeps copied scalar unions aligned with their source contracts", () => {
+    expectTypeOf<AgentRuntimeThinkLevel>().toEqualTypeOf<ThinkLevel>();
+    expectTypeOf<AgentRuntimeFailoverReason>().toEqualTypeOf<FailoverReason>();
+  });
+
+  it("keeps runtime reply payloads assignable to the real reply payload shape", () => {
+    expectTypeOf<AgentRuntimeReplyPayload>().toMatchTypeOf<ReplyPayload>();
+  });
+});

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -14,7 +14,7 @@ describe("AgentRuntimePlan structural type compatibility", () => {
     expectTypeOf<AgentRuntimeFailoverReason>().toEqualTypeOf<FailoverReason>();
   });
 
-  it("keeps runtime reply payloads assignable to the real reply payload shape", () => {
-    expectTypeOf<AgentRuntimeReplyPayload>().toMatchTypeOf<ReplyPayload>();
+  it("keeps real reply payloads assignable to the runtime leaf payload shape", () => {
+    expectTypeOf<ReplyPayload>().toMatchTypeOf<AgentRuntimeReplyPayload>();
   });
 });

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -3,11 +3,14 @@ import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { FailoverReason } from "../pi-embedded-helpers/types.js";
 import type { PromptMode } from "../system-prompt.types.js";
+import type { buildAgentRuntimeDeliveryPlan, buildAgentRuntimePlan } from "./build.js";
 import type {
   AgentRuntimeFailoverReason,
   AgentRuntimePromptMode,
   AgentRuntimeReplyPayload,
   AgentRuntimeThinkLevel,
+  BuildAgentRuntimeDeliveryPlanParams,
+  BuildAgentRuntimePlanParams,
 } from "./types.js";
 
 type Equal<X, Y> = [X] extends [Y] ? ([Y] extends [X] ? true : false) : false;
@@ -27,5 +30,14 @@ describe("AgentRuntimePlan structural type compatibility", () => {
     >;
     expectTypeOf<ReplyPayload>().toMatchTypeOf<AgentRuntimeReplyPayload>();
     expectTypeOf<AgentRuntimeReplyPayload>().toMatchTypeOf<ReplyPayload>();
+  });
+
+  it("keeps builder call signatures aligned with exported structural params", () => {
+    expectTypeOf<
+      Parameters<typeof buildAgentRuntimeDeliveryPlan>[0]
+    >().toEqualTypeOf<BuildAgentRuntimeDeliveryPlanParams>();
+    expectTypeOf<
+      Parameters<typeof buildAgentRuntimePlan>[0]
+    >().toEqualTypeOf<BuildAgentRuntimePlanParams>();
   });
 });

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -2,8 +2,10 @@ import { describe, expectTypeOf, it } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { FailoverReason } from "../pi-embedded-helpers/types.js";
+import type { PromptMode } from "../system-prompt.types.js";
 import type {
   AgentRuntimeFailoverReason,
+  AgentRuntimePromptMode,
   AgentRuntimeReplyPayload,
   AgentRuntimeThinkLevel,
 } from "./types.js";
@@ -12,6 +14,7 @@ describe("AgentRuntimePlan structural type compatibility", () => {
   it("keeps copied scalar unions aligned with their source contracts", () => {
     expectTypeOf<AgentRuntimeThinkLevel>().toEqualTypeOf<ThinkLevel>();
     expectTypeOf<AgentRuntimeFailoverReason>().toEqualTypeOf<FailoverReason>();
+    expectTypeOf<AgentRuntimePromptMode>().toEqualTypeOf<PromptMode>();
   });
 
   it("keeps real reply payloads assignable to the runtime leaf payload shape", () => {

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -17,7 +17,8 @@ describe("AgentRuntimePlan structural type compatibility", () => {
     expectTypeOf<AgentRuntimePromptMode>().toEqualTypeOf<PromptMode>();
   });
 
-  it("keeps real reply payloads assignable to the runtime leaf payload shape", () => {
+  it("keeps reply payload shapes structurally compatible with the runtime leaf payload shape", () => {
     expectTypeOf<ReplyPayload>().toMatchTypeOf<AgentRuntimeReplyPayload>();
+    expectTypeOf<AgentRuntimeReplyPayload>().toMatchTypeOf<ReplyPayload>();
   });
 });

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -10,6 +10,15 @@ import type {
   AgentRuntimeThinkLevel,
 } from "./types.js";
 
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
+      ? true
+      : false
+    : false;
+
+type Assert<T extends true> = T;
+
 describe("AgentRuntimePlan structural type compatibility", () => {
   it("keeps copied scalar unions aligned with their source contracts", () => {
     expectTypeOf<AgentRuntimeThinkLevel>().toEqualTypeOf<ThinkLevel>();
@@ -18,6 +27,9 @@ describe("AgentRuntimePlan structural type compatibility", () => {
   });
 
   it("keeps reply payload shapes structurally compatible with the runtime leaf payload shape", () => {
+    type _ReplyPayloadKeysStayInSync = Assert<
+      Equal<keyof ReplyPayload, keyof AgentRuntimeReplyPayload>
+    >;
     expectTypeOf<ReplyPayload>().toMatchTypeOf<AgentRuntimeReplyPayload>();
     expectTypeOf<AgentRuntimeReplyPayload>().toMatchTypeOf<ReplyPayload>();
   });

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -10,12 +10,7 @@ import type {
   AgentRuntimeThinkLevel,
 } from "./types.js";
 
-type Equal<X, Y> =
-  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
-    ? (<T>() => T extends Y ? 1 : 2) extends <T>() => T extends X ? 1 : 2
-      ? true
-      : false
-    : false;
+type Equal<X, Y> = [X] extends [Y] ? ([Y] extends [X] ? true : false) : false;
 
 type Assert<T extends true> = T;
 

--- a/src/agents/runtime-plan/types.test.ts
+++ b/src/agents/runtime-plan/types.test.ts
@@ -8,11 +8,11 @@ describe("AgentRuntimePlan leaf contracts", () => {
   it("keeps runtime plan type contracts independent from concrete runtime policy modules", async () => {
     const source = await fs.readFile(TYPES_PATH, "utf8");
 
-    expect(source).not.toMatch(/from "\.\.\/\.\.\/auto-reply\//);
-    expect(source).not.toMatch(/from "\.\.\/\.\.\/config\//);
-    expect(source).not.toMatch(/from "\.\.\/\.\.\/plugins\//);
-    expect(source).not.toMatch(/from "\.\.\/pi-embedded-/);
-    expect(source).not.toMatch(/from "\.\.\/transcript-policy/);
-    expect(source).not.toMatch(/from "\.\.\/system-prompt/);
+    expect(source).not.toMatch(/from\s+["'][^"']*auto-reply(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'][^"']*config(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'][^"']*plugins(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'][^"']*pi-embedded-/);
+    expect(source).not.toMatch(/from\s+["'][^"']*transcript-policy(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'][^"']*system-prompt(?:\/|\.js|["'])/);
   });
 });

--- a/src/agents/runtime-plan/types.test.ts
+++ b/src/agents/runtime-plan/types.test.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const TYPES_PATH = fileURLToPath(new URL("./types.ts", import.meta.url));
+
+describe("AgentRuntimePlan leaf contracts", () => {
+  it("keeps runtime plan type contracts independent from concrete runtime policy modules", async () => {
+    const source = await fs.readFile(TYPES_PATH, "utf8");
+
+    expect(source).not.toMatch(/from "\.\.\/\.\.\/auto-reply\//);
+    expect(source).not.toMatch(/from "\.\.\/\.\.\/config\//);
+    expect(source).not.toMatch(/from "\.\.\/\.\.\/plugins\//);
+    expect(source).not.toMatch(/from "\.\.\/pi-embedded-/);
+    expect(source).not.toMatch(/from "\.\.\/transcript-policy/);
+    expect(source).not.toMatch(/from "\.\.\/system-prompt/);
+  });
+});

--- a/src/agents/runtime-plan/types.test.ts
+++ b/src/agents/runtime-plan/types.test.ts
@@ -4,15 +4,34 @@ import { describe, expect, it } from "vitest";
 
 const TYPES_PATH = fileURLToPath(new URL("./types.ts", import.meta.url));
 
+const concreteRuntimePolicyImportPatterns = [
+  /from\s+["'][^"']*auto-reply(?:\/|\.js|["'])/,
+  /from\s+["'](?:[^"']*\/)?config(?:\/|\.js|["'])/,
+  /from\s+["'](?:[^"']*\/)?plugins(?:\/|\.js|["'])/,
+  /from\s+["'][^"']*pi-embedded-/,
+  /from\s+["'][^"']*transcript-policy(?:\.[^/"']+)?(?:\/|\.js|["'])/,
+  /from\s+["'][^"']*system-prompt(?:\.[^/"']+)?(?:\/|\.js|["'])/,
+];
+
 describe("AgentRuntimePlan leaf contracts", () => {
   it("keeps runtime plan type contracts independent from concrete runtime policy modules", async () => {
     const source = await fs.readFile(TYPES_PATH, "utf8");
 
-    expect(source).not.toMatch(/from\s+["'][^"']*auto-reply(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'](?:[^"']*\/)?config(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'](?:[^"']*\/)?plugins(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'][^"']*pi-embedded-/);
-    expect(source).not.toMatch(/from\s+["'][^"']*transcript-policy(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'][^"']*system-prompt(?:\/|\.js|["'])/);
+    for (const pattern of concreteRuntimePolicyImportPatterns) {
+      expect(source).not.toMatch(pattern);
+    }
+  });
+
+  it("guards against policy type imports re-entering the leaf contract", () => {
+    const forbiddenImports = [
+      'import type { PromptContribution } from "../system-prompt.types.js";',
+      'import type { TranscriptPolicy } from "../transcript-policy.types.js";',
+    ];
+
+    for (const importStatement of forbiddenImports) {
+      expect(
+        concreteRuntimePolicyImportPatterns.some((pattern) => pattern.test(importStatement)),
+      ).toBe(true);
+    }
   });
 });

--- a/src/agents/runtime-plan/types.test.ts
+++ b/src/agents/runtime-plan/types.test.ts
@@ -9,8 +9,8 @@ describe("AgentRuntimePlan leaf contracts", () => {
     const source = await fs.readFile(TYPES_PATH, "utf8");
 
     expect(source).not.toMatch(/from\s+["'][^"']*auto-reply(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'][^"']*config(?:\/|\.js|["'])/);
-    expect(source).not.toMatch(/from\s+["'][^"']*plugins(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'](?:[^"']*\/)?config(?:\/|\.js|["'])/);
+    expect(source).not.toMatch(/from\s+["'](?:[^"']*\/)?plugins(?:\/|\.js|["'])/);
     expect(source).not.toMatch(/from\s+["'][^"']*pi-embedded-/);
     expect(source).not.toMatch(/from\s+["'][^"']*transcript-policy(?:\/|\.js|["'])/);
     expect(source).not.toMatch(/from\s+["'][^"']*system-prompt(?:\/|\.js|["'])/);

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -53,7 +53,20 @@ export type AgentRuntimeReplyPayload = {
   text?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
-  [key: string]: unknown;
+  presentation?: unknown;
+  delivery?: unknown;
+  interactive?: unknown;
+  btw?: {
+    question: string;
+  };
+  replyToId?: string;
+  replyToTag?: boolean;
+  replyToCurrent?: boolean;
+  audioAsVoice?: boolean;
+  isError?: boolean;
+  isReasoning?: boolean;
+  isCompactionNotice?: boolean;
+  channelData?: Record<string, unknown>;
 };
 
 export type AgentRuntimeSystemPromptSectionId =

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -1,13 +1,60 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { TSchema } from "typebox";
-import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import type { ReplyPayload } from "../../auto-reply/types.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
-import type { FailoverReason } from "../pi-embedded-helpers/types.js";
-import type { PromptMode } from "../system-prompt.types.js";
 
 export type AgentRuntimeTransport = "sse" | "websocket" | "auto";
+
+export type AgentRuntimeThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "adaptive"
+  | "max";
+
+export type AgentRuntimePromptMode = "full" | "minimal" | "none";
+
+export type AgentRuntimeFailoverReason =
+  | "auth"
+  | "auth_permanent"
+  | "format"
+  | "rate_limit"
+  | "overloaded"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "session_expired"
+  | "unknown";
+
+export type AgentRuntimeConfig = unknown;
+
+export type AgentRuntimeModel = {
+  id?: string;
+  name?: string;
+  api?: string;
+  provider?: string;
+  baseUrl?: string;
+  reasoning?: boolean;
+  input?: string[];
+  cost?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow?: number;
+  maxTokens?: number;
+  contextTokens?: number;
+  compat?: unknown;
+};
+
+export type AgentRuntimeReplyPayload = {
+  text?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  [key: string]: unknown;
+};
 
 export type AgentRuntimeSystemPromptSectionId =
   | "interaction_style"
@@ -21,12 +68,12 @@ export type AgentRuntimeSystemPromptContribution = {
 };
 
 export type AgentRuntimeSystemPromptContributionContext = {
-  config?: OpenClawConfig;
+  config?: AgentRuntimeConfig;
   agentDir?: string;
   workspaceDir?: string;
   provider: string;
   modelId: string;
-  promptMode: PromptMode;
+  promptMode: AgentRuntimePromptMode;
   runtimeChannel?: string;
   runtimeCapabilities?: string[];
   agentId?: string;
@@ -61,7 +108,7 @@ export type AgentRuntimeTranscriptPolicy = {
 export type AgentRuntimeOutcomeClassification =
   | {
       message: string;
-      reason?: FailoverReason;
+      reason?: AgentRuntimeFailoverReason;
       status?: number;
       code?: string;
       rawError?: string;
@@ -109,7 +156,7 @@ export type AgentRuntimeToolPlan = {
     params?: {
       workspaceDir?: string;
       modelApi?: string;
-      model?: ProviderRuntimeModel;
+      model?: AgentRuntimeModel;
     },
   ): AgentTool<TSchemaType, TResult>[];
   logDiagnostics(
@@ -117,15 +164,17 @@ export type AgentRuntimeToolPlan = {
     params?: {
       workspaceDir?: string;
       modelApi?: string;
-      model?: ProviderRuntimeModel;
+      model?: AgentRuntimeModel;
     },
   ): void;
 };
 
 export type AgentRuntimeDeliveryPlan = {
-  isSilentPayload(payload: Pick<ReplyPayload, "text" | "mediaUrl" | "mediaUrls">): boolean;
+  isSilentPayload(
+    payload: Pick<AgentRuntimeReplyPayload, "text" | "mediaUrl" | "mediaUrls">,
+  ): boolean;
   resolveFollowupRoute(params: {
-    payload: ReplyPayload;
+    payload: AgentRuntimeReplyPayload;
     originatingChannel?: string;
     originatingTo?: string;
     originRoutable: boolean;
@@ -141,10 +190,10 @@ export type AgentRuntimeTransportPlan = {
   extraParams: Record<string, unknown>;
   resolveExtraParams(params?: {
     extraParamsOverride?: Record<string, unknown>;
-    thinkingLevel?: ThinkLevel;
+    thinkingLevel?: AgentRuntimeThinkLevel;
     agentId?: string;
     workspaceDir?: string;
-    model?: ProviderRuntimeModel;
+    model?: AgentRuntimeModel;
     resolvedTransport?: AgentRuntimeTransport;
   }): Record<string, unknown>;
 };
@@ -159,7 +208,7 @@ export type AgentRuntimePlan = {
     resolvePolicy(params?: {
       workspaceDir?: string;
       modelApi?: string;
-      model?: ProviderRuntimeModel;
+      model?: AgentRuntimeModel;
     }): AgentRuntimeTranscriptPolicy;
   };
   delivery: AgentRuntimeDeliveryPlan;
@@ -177,7 +226,7 @@ export type AgentRuntimePlan = {
 };
 
 export type BuildAgentRuntimeDeliveryPlanParams = {
-  config?: OpenClawConfig;
+  config?: AgentRuntimeConfig;
   workspaceDir?: string;
   agentDir?: string;
   provider: string;
@@ -185,12 +234,12 @@ export type BuildAgentRuntimeDeliveryPlanParams = {
 };
 
 export type BuildAgentRuntimePlanParams = {
-  config?: OpenClawConfig;
+  config?: AgentRuntimeConfig;
   workspaceDir?: string;
   agentDir?: string;
   provider: string;
   modelId: string;
-  model?: ProviderRuntimeModel;
+  model?: AgentRuntimeModel;
   modelApi?: string | null;
   harnessId?: string;
   harnessRuntime?: string;
@@ -198,7 +247,7 @@ export type BuildAgentRuntimePlanParams = {
   authProfileProvider?: string;
   sessionAuthProfileId?: string;
   agentId?: string;
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: AgentRuntimeThinkLevel;
   extraParamsOverride?: Record<string, unknown>;
   resolvedTransport?: AgentRuntimeTransport;
 };

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -49,13 +49,93 @@ export type AgentRuntimeModel = {
   compat?: unknown;
 };
 
+export type AgentRuntimeInteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
+
+export type AgentRuntimeInteractiveReplyButton = {
+  label: string;
+  value?: string;
+  url?: string;
+  style?: AgentRuntimeInteractiveButtonStyle;
+};
+
+export type AgentRuntimeInteractiveReplyOption = {
+  label: string;
+  value: string;
+};
+
+export type AgentRuntimeInteractiveReplyBlock =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "buttons";
+      buttons: AgentRuntimeInteractiveReplyButton[];
+    }
+  | {
+      type: "select";
+      placeholder?: string;
+      options: AgentRuntimeInteractiveReplyOption[];
+    };
+
+export type AgentRuntimeInteractiveReply = {
+  blocks: AgentRuntimeInteractiveReplyBlock[];
+};
+
+export type AgentRuntimeMessagePresentationTone =
+  | "info"
+  | "success"
+  | "warning"
+  | "danger"
+  | "neutral";
+
+export type AgentRuntimeMessagePresentationBlock =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "context";
+      text: string;
+    }
+  | {
+      type: "divider";
+    }
+  | {
+      type: "buttons";
+      buttons: AgentRuntimeInteractiveReplyButton[];
+    }
+  | {
+      type: "select";
+      placeholder?: string;
+      options: AgentRuntimeInteractiveReplyOption[];
+    };
+
+export type AgentRuntimeMessagePresentation = {
+  title?: string;
+  tone?: AgentRuntimeMessagePresentationTone;
+  blocks: AgentRuntimeMessagePresentationBlock[];
+};
+
+export type AgentRuntimeReplyPayloadDeliveryPin = {
+  enabled: boolean;
+  notify?: boolean;
+  required?: boolean;
+};
+
+export type AgentRuntimeReplyPayloadDelivery = {
+  pin?: boolean | AgentRuntimeReplyPayloadDeliveryPin;
+};
+
 export type AgentRuntimeReplyPayload = {
   text?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
-  presentation?: unknown;
-  delivery?: unknown;
-  interactive?: unknown;
+  trustedLocalMedia?: boolean;
+  sensitiveMedia?: boolean;
+  presentation?: AgentRuntimeMessagePresentation;
+  delivery?: AgentRuntimeReplyPayloadDelivery;
+  interactive?: AgentRuntimeInteractiveReply;
   btw?: {
     question: string;
   };


### PR DESCRIPTION
## Summary

Follow-up to the merged RuntimePlan implementation (#71096) and the umbrella RFC (#71004). This PR keeps `src/agents/runtime-plan/types.ts` as a leaf structural contract layer instead of allowing it to import concrete OpenClaw runtime policy modules.

No runtime behavior changes.

## RuntimePlan Package Context

This PR is part of the post-#71096 RuntimePlan hardening package. The package goal is to make OpenClaw-owned policy explicit and shared before larger runner splits or naming cleanup happen.

```mermaid
flowchart TD
  RFC["#71004 RFC: contract-first Pi/Codex runtime"] --> Base["#71096 merged RuntimePlan implementation"]
  Base --> P71196["#71196 leaf-safe RuntimePlan contracts"]
  P71196 --> P71197["#71197 RuntimePlan reaches harness attempts"]
  P71197 --> P71201["#71201 RuntimePlan observability coverage"]
  P71201 --> P71220["#71220 shared tool policy helper"]
  P71220 --> P71222["#71222 additive Harness V2 adapter"]
  P71222 --> P71238["#71238 selection executes via V2 lifecycle"]
  P71220 --> P71223["#71223 transcript policy resolver split"]
  P71223 --> P71224["#71224 embedded-runner alias barrel"]
  P71238 --> P71239["#71239 shared terminal outcome classifier"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Why This PR Exists

`AgentRuntimePlan` is supposed to sit below both Pi and Codex. The builder can wire concrete policy to existing OpenClaw helpers, but the type contract itself should not depend upward on auto-reply, config, plugin runtime model, Pi fallback helper, transcript policy, or prompt-mode implementation modules.

If those imports creep back into `types.ts`, the contract layer stops being a stable seam and future refactors can recreate the coupling that #71004/#71096 are trying to remove.

## Local Architecture

```mermaid
flowchart LR
  Types["runtime-plan/types.ts\nleaf structural contracts"]
  Build["runtime-plan/build.ts\nconcrete wiring adapter"]
  Pi["Pi embedded runner"]
  Codex["Codex app-server adapter"]
  Concrete["Existing concrete OpenClaw policy modules"]

  Types --> Build
  Build --> Pi
  Build --> Codex
  Build --> Concrete
  Concrete -. forbidden import .-> Types
```

## What Changed

- Replaced concrete internal imports in `runtime-plan/types.ts` with local structural RuntimePlan contract types.
- Kept concrete casts and wiring in `runtime-plan/build.ts`, where adapter policy belongs.
- Added topology guard coverage proving `runtime-plan/types.ts` does not import concrete runtime policy modules.
- Added compatibility tests so copied scalar/structural contracts drift loudly instead of silently.

## Maintainer Review Guide

- Highest-signal file: `src/agents/runtime-plan/types.ts`.
- Check that `types.ts` stays structural and leaf-safe; concrete helper imports should remain in `build.ts`.
- Check the topology guard is broad enough to catch both barrel and file imports.
- This PR intentionally accepts structural copies with compatibility tests instead of importing the upstream source unions.

## What Did Not Change

- No runtime behavior change.
- No Pi/Codex harness execution change.
- No Harness V2 migration.
- No runner split or rename.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `./node_modules/.bin/vitest run src/agents/runtime-plan/types.test.ts --config test/vitest/vitest.agents.config.ts`
- `./node_modules/.bin/vitest run src/agents/runtime-plan/build.test.ts --config test/vitest/vitest.unit-fast.config.ts`
- `./node_modules/.bin/vitest run src/agents/runtime-plan/types.compat.test.ts src/agents/runtime-plan/build.test.ts --config test/vitest/vitest.unit-fast.config.ts`
- `pnpm check:architecture`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/runtime-plan/types.ts src/agents/runtime-plan/build.ts src/agents/runtime-plan/types.test.ts src/agents/runtime-plan/types.compat.test.ts src/agents/runtime-plan/build.test.ts`
- `git diff --check`

Local broad `pnpm check:changed` has previously hit unrelated repository type/dependency drift; this PR's targeted topology, unit, lint, and architecture checks are the intended merge signal.
