### PR TITLE
[codex] test: assert runtime plan reaches harness attempts

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentInternalEvent } from "../internal-events.js";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
@@ -8,6 +9,7 @@ import {
 } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildAgentRuntimePlan,
   mockedBuildEmbeddedRunPayloads,
   mockedCoerceToFailoverError,
   mockedCompactDirect,
@@ -26,8 +28,55 @@ import {
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+const internalEvents: AgentInternalEvent[] = [];
+const forwardingCase = {
+  runId: "forward-attempt-params",
+  params: {
+    toolsAllow: ["exec", "read"],
+    bootstrapContextMode: "lightweight",
+    bootstrapContextRunKind: "cron",
+    disableMessageTool: true,
+    forceMessageTool: true,
+    requireExplicitMessageTarget: true,
+    internalEvents,
+  },
+  expected: {
+    toolsAllow: ["exec", "read"],
+    bootstrapContextMode: "lightweight",
+    bootstrapContextRunKind: "cron",
+    disableMessageTool: true,
+    forceMessageTool: true,
+    requireExplicitMessageTarget: true,
+    internalEvents,
+  },
+} satisfies {
+  runId: string;
+  params: Partial<RunEmbeddedPiAgentParams>;
+  expected: Record<string, unknown>;
+};
+
+function makeForwardedRuntimePlan(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    resolvedRef: {
+      provider: "anthropic",
+      modelId: "test-model",
+      harnessId: "pi",
+    },
+    tools: {
+      normalize: vi.fn(),
+      logDiagnostics: vi.fn(),
+    },
+    transport: {
+      resolveExtraParams: vi.fn(),
+    },
+    ...overrides,
+  };
+}
 
 describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
   beforeAll(async () => {
@@ -83,9 +132,50 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
   });
 
+  it("forwards optional attempt params and the runtime plan into one attempt call", async () => {
+    const runtimePlan = makeForwardedRuntimePlan();
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      ...forwardingCase.params,
+      runId: forwardingCase.runId,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...forwardingCase.expected,
+        runtimePlan: expect.objectContaining({
+          resolvedRef: expect.objectContaining({
+            provider: "anthropic",
+            modelId: "test-model",
+          }),
+          tools: expect.objectContaining({
+            normalize: expect.any(Function),
+          }),
+          transport: expect.objectContaining({
+            resolveExtraParams: expect.any(Function),
+          }),
+        }),
+      }),
+    );
+  });
+
   it("forwards explicit OpenAI Codex auth profiles to codex plugin harnesses", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const pluginRunAttempt = vi.fn(async () => makeAttemptResult({ assistantTexts: ["ok"] }));
+    const runtimePlan = makeForwardedRuntimePlan({
+      resolvedRef: {
+        provider: "codex",
+        modelId: "gpt-5.4",
+        harnessId: "codex",
+      },
+      auth: {
+        harnessAuthProvider: "openai-codex",
+        forwardedAuthProfileId: "openai-codex:work",
+      },
+    });
     clearAgentHarnesses();
     registerAgentHarness({
       id: "codex",
@@ -94,6 +184,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
       runAttempt: pluginRunAttempt,
     });
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
     mockedGetApiKeyForModel.mockRejectedValueOnce(new Error("generic auth should be skipped"));
 
     try {
@@ -122,6 +213,17 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         provider: "codex",
         authProfileId: "openai-codex:work",
         authProfileIdSource: "user",
+        runtimePlan: expect.objectContaining({
+          resolvedRef: expect.objectContaining({
+            provider: "codex",
+            modelId: "gpt-5.4",
+            harnessId: "codex",
+          }),
+          auth: expect.objectContaining({
+            harnessAuthProvider: "openai-codex",
+            forwardedAuthProfileId: "openai-codex:work",
+          }),
+        }),
       }),
     );
   });
@@ -129,6 +231,18 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
   it("forwards OpenAI Codex auth profiles when openai/* is forced through codex", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const pluginRunAttempt = vi.fn(async () => makeAttemptResult({ assistantTexts: ["ok"] }));
+    const runtimePlan = makeForwardedRuntimePlan({
+      resolvedRef: {
+        provider: "openai",
+        modelId: "gpt-5.4",
+        harnessId: "codex",
+      },
+      auth: {
+        providerForAuth: "openai",
+        harnessAuthProvider: "openai-codex",
+        forwardedAuthProfileId: "openai-codex:work",
+      },
+    });
     clearAgentHarnesses();
     registerAgentHarness({
       id: "codex",
@@ -136,6 +250,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       supports: () => ({ supported: false }),
       runAttempt: pluginRunAttempt,
     });
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
     mockedGetApiKeyForModel.mockRejectedValueOnce(new Error("generic auth should be skipped"));
 
     try {
@@ -164,6 +279,18 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         provider: "openai",
         authProfileId: "openai-codex:work",
         authProfileIdSource: "user",
+        runtimePlan: expect.objectContaining({
+          resolvedRef: expect.objectContaining({
+            provider: "openai",
+            modelId: "gpt-5.4",
+            harnessId: "codex",
+          }),
+          auth: expect.objectContaining({
+            providerForAuth: "openai",
+            harnessAuthProvider: "openai-codex",
+            forwardedAuthProfileId: "openai-codex:work",
+          }),
+        }),
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -32,36 +32,36 @@ import {
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
-const internalEvents: AgentInternalEvent[] = [];
 type RuntimePlanOverrides = Partial<Omit<AgentRuntimePlan, "auth" | "resolvedRef">> & {
   auth?: Partial<AgentRuntimePlan["auth"]>;
   resolvedRef?: Partial<AgentRuntimePlan["resolvedRef"]>;
 };
-const forwardingCase = {
-  runId: "forward-attempt-params",
-  params: {
-    toolsAllow: ["exec", "read"],
-    bootstrapContextMode: "lightweight",
-    bootstrapContextRunKind: "cron",
-    disableMessageTool: true,
-    forceMessageTool: true,
-    requireExplicitMessageTarget: true,
-    internalEvents,
-  },
-  expected: {
-    toolsAllow: ["exec", "read"],
-    bootstrapContextMode: "lightweight",
-    bootstrapContextRunKind: "cron",
-    disableMessageTool: true,
-    forceMessageTool: true,
-    requireExplicitMessageTarget: true,
-    internalEvents,
-  },
-} satisfies {
-  runId: string;
-  params: Partial<RunEmbeddedPiAgentParams>;
-  expected: Record<string, unknown>;
-};
+function makeForwardingCase(internalEvents: AgentInternalEvent[]) {
+  return {
+    runId: "forward-attempt-params",
+    params: {
+      toolsAllow: ["exec", "read"],
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
+      disableMessageTool: true,
+      forceMessageTool: true,
+      requireExplicitMessageTarget: true,
+      internalEvents,
+    },
+    expected: {
+      toolsAllow: ["exec", "read"],
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
+      disableMessageTool: true,
+      forceMessageTool: true,
+      requireExplicitMessageTarget: true,
+    },
+  } satisfies {
+    runId: string;
+    params: Partial<RunEmbeddedPiAgentParams>;
+    expected: Record<string, unknown>;
+  };
+}
 
 function makeForwardedRuntimePlan(overrides: RuntimePlanOverrides = {}): AgentRuntimePlan {
   const transcriptPolicy = {
@@ -189,6 +189,8 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
   });
 
   it("forwards optional attempt params and the runtime plan into one attempt call", async () => {
+    const internalEvents: AgentInternalEvent[] = [];
+    const forwardingCase = makeForwardingCase(internalEvents);
     const runtimePlan = makeForwardedRuntimePlan();
     mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
@@ -199,6 +201,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       runId: forwardingCase.runId,
     });
 
+    expect(mockedBuildAgentRuntimePlan).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -217,6 +220,9 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
+    const attemptParams = mockedRunEmbeddedAttempt.mock.calls[0]?.[0];
+    expect(attemptParams?.runtimePlan).toBe(runtimePlan);
+    expect(attemptParams?.internalEvents).toBe(internalEvents);
   });
 
   it("forwards explicit OpenAI Codex auth profiles to codex plugin harnesses", async () => {
@@ -265,6 +271,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(mockedBuildAgentRuntimePlan).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -284,6 +291,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
+    expect(pluginRunAttempt.mock.calls[0]?.[0].runtimePlan).toBe(runtimePlan);
   });
 
   it("forwards OpenAI Codex auth profiles when openai/* is forced through codex", async () => {
@@ -332,6 +340,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(mockedBuildAgentRuntimePlan).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -352,6 +361,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
+    expect(pluginRunAttempt.mock.calls[0]?.[0].runtimePlan).toBe(runtimePlan);
   });
 
   it("blocks undersized models before dispatching a provider attempt", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -64,6 +64,19 @@ const forwardingCase = {
 };
 
 function makeForwardedRuntimePlan(overrides: RuntimePlanOverrides = {}): AgentRuntimePlan {
+  const transcriptPolicy = {
+    sanitizeMode: "full",
+    sanitizeToolCallIds: true,
+    preserveNativeAnthropicToolUseIds: false,
+    repairToolUseResultPairing: true,
+    preserveSignatures: false,
+    sanitizeThinkingSignatures: true,
+    dropThinkingBlocks: false,
+    applyGoogleTurnOrdering: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
+    allowSyntheticToolResults: false,
+  } satisfies AgentRuntimePlan["transcript"]["policy"];
   const basePlan: AgentRuntimePlan = {
     auth: {
       authProfileProviderForAuth: "anthropic",
@@ -87,31 +100,10 @@ function makeForwardedRuntimePlan(overrides: RuntimePlanOverrides = {}): AgentRu
       resolveSystemPromptContribution: vi.fn(),
     },
     transcript: {
-      policy: {
-        sanitizeMode: "full",
-        sanitizeToolCallIds: true,
-        preserveNativeAnthropicToolUseIds: false,
-        repairToolUseResultPairing: true,
-        preserveSignatures: false,
-        sanitizeThinkingSignatures: true,
-        dropThinkingBlocks: false,
-        applyGoogleTurnOrdering: false,
-        validateGeminiTurns: false,
-        validateAnthropicTurns: false,
-        allowSyntheticToolResults: false,
-      },
-      resolvePolicy: vi.fn((params) => ({
+      policy: transcriptPolicy,
+      resolvePolicy: vi.fn((params): AgentRuntimePlan["transcript"]["policy"] => ({
+        ...transcriptPolicy,
         sanitizeMode: params?.modelApi === "anthropic-messages" ? "full" : "images-only",
-        sanitizeToolCallIds: true,
-        preserveNativeAnthropicToolUseIds: false,
-        repairToolUseResultPairing: true,
-        preserveSignatures: false,
-        sanitizeThinkingSignatures: true,
-        dropThinkingBlocks: false,
-        applyGoogleTurnOrdering: false,
-        validateGeminiTurns: false,
-        validateAnthropicTurns: false,
-        allowSyntheticToolResults: false,
       })),
     },
     transport: {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentHarness } from "../harness/types.js";
 import type { AgentInternalEvent } from "../internal-events.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import {
@@ -30,6 +31,7 @@ import {
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
+import type { EmbeddedRunAttemptParams } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 type RuntimePlanOverrides = Partial<Omit<AgentRuntimePlan, "auth" | "resolvedRef">> & {
@@ -220,14 +222,18 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
-    const attemptParams = mockedRunEmbeddedAttempt.mock.calls[0]?.[0];
+    const attemptParams = mockedRunEmbeddedAttempt.mock.calls[0]?.[0] as
+      | EmbeddedRunAttemptParams
+      | undefined;
     expect(attemptParams?.runtimePlan).toBe(runtimePlan);
     expect(attemptParams?.internalEvents).toBe(internalEvents);
   });
 
   it("forwards explicit OpenAI Codex auth profiles to codex plugin harnesses", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
-    const pluginRunAttempt = vi.fn(async () => makeAttemptResult({ assistantTexts: ["ok"] }));
+    const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
+      makeAttemptResult({ assistantTexts: ["ok"] }),
+    );
     const runtimePlan = makeForwardedRuntimePlan({
       resolvedRef: {
         provider: "codex",
@@ -291,12 +297,15 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
-    expect(pluginRunAttempt.mock.calls[0]?.[0].runtimePlan).toBe(runtimePlan);
+    const harnessParams = pluginRunAttempt.mock.calls[0]?.[0];
+    expect(harnessParams?.runtimePlan).toBe(runtimePlan);
   });
 
   it("forwards OpenAI Codex auth profiles when openai/* is forced through codex", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
-    const pluginRunAttempt = vi.fn(async () => makeAttemptResult({ assistantTexts: ["ok"] }));
+    const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
+      makeAttemptResult({ assistantTexts: ["ok"] }),
+    );
     const runtimePlan = makeForwardedRuntimePlan({
       resolvedRef: {
         provider: "openai",
@@ -361,7 +370,8 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
-    expect(pluginRunAttempt.mock.calls[0]?.[0].runtimePlan).toBe(runtimePlan);
+    const harnessParams = pluginRunAttempt.mock.calls[0]?.[0];
+    expect(harnessParams?.runtimePlan).toBe(runtimePlan);
   });
 
   it("blocks undersized models before dispatching a provider attempt", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentInternalEvent } from "../internal-events.js";
+import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
@@ -32,6 +33,10 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 const internalEvents: AgentInternalEvent[] = [];
+type RuntimePlanOverrides = Partial<Omit<AgentRuntimePlan, "auth" | "resolvedRef">> & {
+  auth?: Partial<AgentRuntimePlan["auth"]>;
+  resolvedRef?: Partial<AgentRuntimePlan["resolvedRef"]>;
+};
 const forwardingCase = {
   runId: "forward-attempt-params",
   params: {
@@ -58,23 +63,82 @@ const forwardingCase = {
   expected: Record<string, unknown>;
 };
 
-function makeForwardedRuntimePlan(
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
-  return {
+function makeForwardedRuntimePlan(overrides: RuntimePlanOverrides = {}): AgentRuntimePlan {
+  const basePlan: AgentRuntimePlan = {
+    auth: {
+      authProfileProviderForAuth: "anthropic",
+      providerForAuth: "anthropic",
+    },
+    delivery: {
+      isSilentPayload: vi.fn(() => false),
+      resolveFollowupRoute: vi.fn(),
+    },
+    observability: {
+      provider: "anthropic",
+      resolvedRef: "anthropic/test-model",
+      modelId: "test-model",
+    },
+    outcome: {
+      classifyRunResult: vi.fn(() => undefined),
+    },
+    prompt: {
+      provider: "anthropic",
+      modelId: "test-model",
+      resolveSystemPromptContribution: vi.fn(),
+    },
+    transcript: {
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: true,
+        dropThinkingBlocks: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: false,
+        allowSyntheticToolResults: false,
+      },
+      resolvePolicy: vi.fn((params) => ({
+        sanitizeMode: params?.modelApi === "anthropic-messages" ? "full" : "images-only",
+        sanitizeToolCallIds: true,
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: true,
+        dropThinkingBlocks: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: false,
+        allowSyntheticToolResults: false,
+      })),
+    },
+    transport: {
+      extraParams: {},
+      resolveExtraParams: vi.fn(() => ({})),
+    },
     resolvedRef: {
       provider: "anthropic",
       modelId: "test-model",
       harnessId: "pi",
     },
     tools: {
-      normalize: vi.fn(),
+      normalize: vi.fn((tools) => tools),
       logDiagnostics: vi.fn(),
     },
-    transport: {
-      resolveExtraParams: vi.fn(),
-    },
+  };
+  return {
+    ...basePlan,
     ...overrides,
+    auth: {
+      ...basePlan.auth,
+      ...overrides.auth,
+    },
+    resolvedRef: {
+      ...basePlan.resolvedRef,
+      ...overrides.resolvedRef,
+    },
   };
 }
 
@@ -143,6 +207,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       runId: forwardingCase.runId,
     });
 
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
         ...forwardingCase.expected,
@@ -208,6 +273,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "codex",
@@ -274,6 +340,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",


### PR DESCRIPTION
## Summary

Follow-up to #71096 and RFC #71004. This PR proves the prepared `AgentRuntimePlan` reaches the hot runner-to-harness seam for both the built-in Pi attempt and plugin harness attempts.

No production runtime behavior changes.

## RuntimePlan Package Context

This is the adoption-seam proof in the RuntimePlan package. Before later PRs delete duplicated policy assembly, this PR makes the forwarding contract executable.

```mermaid
flowchart TD
  RFC["#71004 RFC"] --> Base["#71096 RuntimePlan merged"]
  Base --> Contracts["#71196 leaf-safe contracts"]
  Contracts --> This["#71197 plan reaches harness attempts"]
  This --> Observability["#71201 observability coverage"]
  This --> Dedupe["#71220 shared policy helpers"]
  Dedupe --> Harness["#71222/#71238 Harness V2 lifecycle"]
  Dedupe --> Split["#71223 transcript resolver split"]
  Split --> Alias["#71224 embedded-runner alias"]
  Harness --> Outcome["#71239 shared outcome classifier"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Why This PR Exists

The next RuntimePlan cleanup PRs are only safe if the prepared plan is already present where Pi and Codex execution cross the harness boundary. Without this proof, removing legacy fallbacks would be another "looks right locally, regresses another path" change.

## Local Architecture

```mermaid
sequenceDiagram
  participant Runner as runEmbeddedPiAgent
  participant Plan as buildAgentRuntimePlan
  participant Pi as Built-in Pi attempt
  participant Plugin as Plugin harness attempt

  Runner->>Plan: build prepared OpenClaw policy
  Plan-->>Runner: AgentRuntimePlan
  Runner->>Pi: attempt params include runtimePlan
  Runner->>Plugin: harness params include runtimePlan
```

## What Changed

- Extended the forwarding test to assert built-in Pi attempts receive a complete `AgentRuntimePlan` shape.
- Extended plugin-harness forwarding tests to assert the same plan reaches Codex/plugin harness attempts.
- Locked Codex auth forwarding through the RuntimePlan for both direct `codex/*` and forced `openai/*` through Codex harness cases.

## Maintainer Review Guide

- Highest-signal file: `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`.
- Check that assertions validate plan identity and shape, not just a loose object fragment.
- Check call-count assertions preserve the "one attempt" forwarding contract.
- This is test-only and intentionally does not remove legacy fallback paths yet.

## What Did Not Change

- No production behavior change.
- No deletion of direct domain builders.
- No Harness V2 migration.
- No runner split or rename.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `./node_modules/.bin/vitest run src/agents/pi-embedded-runner/run.overflow-compaction.test.ts --config test/vitest/vitest.agents.config.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
- `git diff --check`

Local broad `pnpm check:changed` has previously hit unrelated repository type/dependency drift; this PR is test-only and the focused forwarding suite is the merge signal.
