### PR TITLE
fix(status): clarify Runtime field as sandbox to disambiguate from Runner

### DIFF
--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage } from "./status-message.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -8,5 +9,25 @@ describe("formatFastModeLabel", () => {
 
   it("hides fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBeNull();
+  });
+});
+
+describe("buildStatusMessage", () => {
+  it("labels Runtime as the sandbox runtime", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-6",
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      activeModelAuth: "api-key",
+      now: 0,
+    });
+
+    expect(text).toContain("Runtime (sandbox):");
+    expect(text).not.toContain("Runtime: ");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -743,7 +743,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     model: activeModel,
   });
   const optionParts = [
-    `Runtime: ${runtime.label}`,
+    `Runtime (sandbox): ${runtime.label}`,
     `Runner: ${runnerLabel}`,
     `Think: ${thinkLevel}`,
     formatFastModeLabel(fastMode),


### PR DESCRIPTION
## Summary

One-line label tweak in `/status` output: `Runtime:` → `Runtime (sandbox):` so the field is self-documenting.

```diff
-  \`Runtime: \${runtime.label}\`,
+  \`Runtime (sandbox): \${runtime.label}\`,
```

Non-breaking: single string literal change in `src/status/status-message.ts:746`. JSON surface untouched.

## Why

2026.4.23 added the `Runner:` field to `/status` to report embedded Pi / CLI-backed / ACP harness backends (#70595). The existing `Runtime:` field describes **sandbox mode** (`direct` / `docker/all` / `docker/per-sender` / `unknown`), but side-by-side with `Runner:` the `Runtime:` label reads like "runtime engine":

```
⚙️ Runtime: direct · Runner: pi (embedded) · Think: medium · Text: low · elevated:full
```

Users (and at least one of me) first read `Runtime: direct` as "the runtime engine is direct" rather than "sandbox mode is off (no docker isolation)". The `(sandbox)` qualifier disambiguates without renaming the field (which would break any downstream text parsers).

## Test plan

- [x] `pnpm test:fast -- src/status/status-message.test.ts` → 1 file, 3 tests pass, including a new regression test that asserts:
  - Output contains `"Runtime (sandbox):"`
  - Output does not contain the bare `"Runtime: "` prefix (regressions-proofs the old label)
- [x] `OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:test` passes
- [x] No JSON schema changes (confirmed by grep — `status-json*.ts` untouched)
- [x] No other references to the old `"Runtime: "` string in src/

## Not in scope

- JSON surface rename — deliberately left unchanged; that would need its own deprecation path and is a separate decision
- `Runner:` wording — that one is clear as-is
- `Sandbox:` rename — considered but rejected as breaking for any scripts / tooling that parse `/status` text output

🤖 Generated with [Claude Code](https://claude.com/claude-code)