### PR TITLE
fix: tweak group silent caution prompt

### DIFF
--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -92,7 +92,8 @@ describe("group runtime loading", () => {
       silentReplyPolicy: "allow",
     });
     expect(allowed).toContain('reply with exactly "NO_REPLY"');
-    expect(allowed).toContain("Otherwise stay silent.");
+    expect(allowed).toContain('your final answer must still be exactly "NO_REPLY"');
+    expect(allowed).toContain("Never say that you are staying quiet");
 
     const disallowed = groups.buildGroupIntro({
       cfg: {} as OpenClawConfig,
@@ -104,7 +105,7 @@ describe("group runtime loading", () => {
     });
     expect(disallowed).toContain("Activation: always-on");
     expect(disallowed).not.toContain("NO_REPLY");
-    expect(disallowed).not.toContain("Otherwise stay silent.");
+    expect(disallowed).not.toContain("Never say that you are staying quiet");
 
     const rewritten = groups.buildGroupIntro({
       cfg: {} as OpenClawConfig,
@@ -116,7 +117,7 @@ describe("group runtime loading", () => {
     });
     expect(rewritten).toContain('reply with exactly "NO_REPLY"');
     expect(rewritten).toContain("short fallback reply");
-    expect(rewritten).not.toContain("Otherwise stay silent.");
+    expect(rewritten).not.toContain("Be extremely selective");
   });
 
   it("loads the group runtime only when requireMention resolution needs it", async () => {

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -94,6 +94,10 @@ describe("group runtime loading", () => {
     expect(allowed).toContain('reply with exactly "NO_REPLY"');
     expect(allowed).toContain('your final answer must still be exactly "NO_REPLY"');
     expect(allowed).toContain("Never say that you are staying quiet");
+    expect(allowed).toContain(
+      "Be extremely selective: reply only when directly addressed or clearly helpful.",
+    );
+    expect(allowed).not.toContain("Otherwise stay silent.");
 
     const disallowed = groups.buildGroupIntro({
       cfg: {} as OpenClawConfig,

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -281,7 +281,7 @@ export function buildGroupIntro(params: {
       : undefined;
   const cautionLine =
     activation === "always" && params.silentReplyPolicy === "allow"
-      ? "Be extremely selective: reply only when directly addressed or clearly helpful. Otherwise stay silent."
+      ? `Be extremely selective: reply only when directly addressed or clearly helpful. If no response is needed, your final answer must still be exactly "${params.silentToken}". Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply.`
       : undefined;
   const lurkLine =
     "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.";

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -281,7 +281,7 @@ export function buildGroupIntro(params: {
       : undefined;
   const cautionLine =
     activation === "always" && params.silentReplyPolicy === "allow"
-      ? `Be extremely selective: reply only when directly addressed or clearly helpful. If no response is needed, your final answer must still be exactly "${params.silentToken}". Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply.`
+      ? "Be extremely selective: reply only when directly addressed or clearly helpful."
       : undefined;
   const lurkLine =
     "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.";


### PR DESCRIPTION
## Summary
- replace the always-on group allow-policy caution line's vague "Otherwise stay silent" wording with explicit NO_REPLY final-answer guidance
- keep the stricter wording scoped to always-on groups where silent replies are allowed
- leave direct-chat and rewrite behavior unchanged

## Validation
- pnpm exec oxfmt --check src/auto-reply/reply/groups.ts src/auto-reply/reply/groups.test.ts
- pnpm exec vitest run src/auto-reply/reply/groups.test.ts --reporter verbose