### PR TITLE
[codex] feat: add agent harness v2 lifecycle adapter

### DIFF
--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -1,0 +1,27 @@
+import type {
+  AgentHarness,
+  AgentHarnessAttemptParams,
+  AgentHarnessAttemptResult,
+  AgentHarnessResultClassification,
+} from "./types.js";
+
+export function applyAgentHarnessResultClassification(
+  harness: Pick<AgentHarness, "id" | "classify">,
+  result: AgentHarnessAttemptResult,
+  params: AgentHarnessAttemptParams,
+): AgentHarnessAttemptResult {
+  const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
+    result;
+  const classification = harness.classify?.(result, params);
+  if (!classification || classification === "ok") {
+    return { ...resultWithoutPrevious, agentHarnessId: harness.id };
+  }
+  return {
+    ...resultWithoutPrevious,
+    agentHarnessId: harness.id,
+    agentHarnessResultClassification: classification as Exclude<
+      AgentHarnessResultClassification,
+      "ok"
+    >,
+  };
+}

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -10,9 +10,12 @@ export function applyAgentHarnessResultClassification(
   result: AgentHarnessAttemptResult,
   params: AgentHarnessAttemptParams,
 ): AgentHarnessAttemptResult {
+  if (!harness.classify) {
+    return { ...result, agentHarnessId: harness.id };
+  }
   const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
     result;
-  const classification = harness.classify?.(result, params);
+  const classification = harness.classify(result, params);
   if (!classification || classification === "ok") {
     return { ...resultWithoutPrevious, agentHarnessId: harness.id };
   }

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -2,7 +2,6 @@ import type {
   AgentHarness,
   AgentHarnessAttemptParams,
   AgentHarnessAttemptResult,
-  AgentHarnessResultClassification,
 } from "./types.js";
 
 export function applyAgentHarnessResultClassification(
@@ -22,9 +21,6 @@ export function applyAgentHarnessResultClassification(
   return {
     ...resultWithoutPrevious,
     agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification as Exclude<
-      AgentHarnessResultClassification,
-      "ok"
-    >,
+    agentHarnessResultClassification: classification,
   };
 }

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -14,7 +14,7 @@ export function applyAgentHarnessResultClassification(
   }
   const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
     result;
-  const classification = harness.classify(result, params);
+  const classification = harness.classify(resultWithoutPrevious, params);
   if (!classification || classification === "ok") {
     return { ...resultWithoutPrevious, agentHarnessId: harness.id };
   }

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -19,6 +19,7 @@ import {
 import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
 
 const log = createSubsystemLogger("agents/harness");
@@ -189,12 +190,12 @@ export async function runAgentHarnessAttemptWithFallback(
   });
   if (harness.id === "pi") {
     const result = await harness.runAttempt(params);
-    return applyHarnessResultClassification(harness, result, params);
+    return applyAgentHarnessResultClassification(harness, result, params);
   }
 
   try {
     const result = await harness.runAttempt(params);
-    return applyHarnessResultClassification(harness, result, params);
+    return applyAgentHarnessResultClassification(harness, result, params);
   } catch (error) {
     log.warn(`${harness.label} failed; not falling back to embedded PI backend`, {
       harnessId: harness.id,
@@ -261,22 +262,6 @@ function logAgentHarnessSelection(
     fallback: selection.policy.fallback,
     candidates: selection.candidates,
   });
-}
-
-function applyHarnessResultClassification(
-  harness: AgentHarness,
-  result: EmbeddedRunAttemptResult,
-  params: EmbeddedRunAttemptParams,
-): EmbeddedRunAttemptResult {
-  const classification = harness.classify?.(result, params);
-  if (!classification || classification === "ok") {
-    return { ...result, agentHarnessId: harness.id };
-  }
-  return {
-    ...result,
-    agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification,
-  };
 }
 
 function resolvePinnedAgentHarnessPolicy(

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -155,10 +155,16 @@ describe("AgentHarness V2 compatibility adapter", () => {
 
     const v2 = adaptAgentHarnessToV2(harness);
 
-    await expect(v2.compact?.({ sessionId: "session-1" } as never)).resolves.toMatchObject({
+    await expect(
+      v2.compact?.({
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).resolves.toMatchObject({
       compacted: true,
     });
-    v2.reset?.({ reason: "reset" });
+    await v2.reset?.({ reason: "reset" });
     await v2.dispose?.();
 
     expect(harness.compactCalls).toBe(1);

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -69,18 +69,21 @@ describe("AgentHarness V2 compatibility adapter", () => {
       label: "Codex",
       pluginId: "codex-plugin",
       params,
+      lifecycleState: "started",
     });
+    expect(prepared.lifecycleState).toBe("prepared");
   });
 
   it("keeps result classification as an explicit outcome stage", async () => {
     const params = createAttemptParams();
     const result = createAttemptResult();
+    const classify = vi.fn<NonNullable<AgentHarness["classify"]>>(() => "empty");
     const harness: AgentHarness = {
       id: "codex",
       label: "Codex",
       supports: () => ({ supported: true }),
       runAttempt: vi.fn(async () => result),
-      classify: vi.fn(() => "empty"),
+      classify,
     };
 
     const v2 = adaptAgentHarnessToV2(harness);
@@ -93,18 +96,61 @@ describe("AgentHarness V2 compatibility adapter", () => {
     expect(harness.classify).toHaveBeenCalledWith(result, params);
   });
 
-  it("preserves existing compact/reset/dispose hooks as compatibility methods", async () => {
-    const compact = vi.fn(async () => ({ ok: true, compacted: true, summary: "done" }) as const);
-    const reset = vi.fn();
-    const dispose = vi.fn();
+  it("clears stale non-ok classification when classification resolves to ok", async () => {
+    const params = createAttemptParams();
+    const result = {
+      ...createAttemptResult(),
+      agentHarnessResultClassification: "empty",
+    } as EmbeddedRunAttemptResult;
+    const classify = vi.fn<NonNullable<AgentHarness["classify"]>>(() => "ok");
     const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+      classify,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    const classified = await v2.resolveOutcome(session, result);
+    expect(classified).toMatchObject({ agentHarnessId: "codex" });
+    expect(classified).not.toHaveProperty("agentHarnessResultClassification");
+  });
+
+  it("preserves existing compact/reset/dispose hook this binding as compatibility methods", async () => {
+    const harness: AgentHarness & {
+      compactCalls: number;
+      resetCalls: number;
+      disposeCalls: number;
+    } = {
       id: "custom",
       label: "Custom",
+      compactCalls: 0,
+      resetCalls: 0,
+      disposeCalls: 0,
       supports: () => ({ supported: true }),
       runAttempt: vi.fn(async () => createAttemptResult()),
-      compact,
-      reset,
-      dispose,
+      async compact() {
+        this.compactCalls += 1;
+        return {
+          ok: true,
+          compacted: true,
+          result: {
+            summary: "done",
+            firstKeptEntryId: "entry-1",
+            tokensBefore: 100,
+          },
+        };
+      },
+      reset(params) {
+        expect(params).toEqual({ reason: "reset" });
+        this.resetCalls += 1;
+      },
+      dispose() {
+        this.disposeCalls += 1;
+      },
     };
 
     const v2 = adaptAgentHarnessToV2(harness);
@@ -115,8 +161,25 @@ describe("AgentHarness V2 compatibility adapter", () => {
     v2.reset?.({ reason: "reset" });
     await v2.dispose?.();
 
-    expect(compact).toHaveBeenCalledTimes(1);
-    expect(reset).toHaveBeenCalledWith({ reason: "reset" });
-    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(harness.compactCalls).toBe(1);
+    expect(harness.resetCalls).toBe(1);
+    expect(harness.disposeCalls).toBe(1);
+  });
+
+  it("does not dispose V1 harnesses during per-attempt cleanup", async () => {
+    const dispose = vi.fn();
+    const harness: AgentHarness = {
+      id: "custom",
+      label: "Custom",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+      dispose,
+    };
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(createAttemptParams()));
+
+    await v2.cleanup({ session, result: createAttemptResult() });
+
+    expect(dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -96,6 +96,28 @@ describe("AgentHarness V2 compatibility adapter", () => {
     expect(harness.classify).toHaveBeenCalledWith(result, params);
   });
 
+  it("preserves harness-supplied classification when no classify hook is registered", async () => {
+    const params = createAttemptParams();
+    const result = {
+      ...createAttemptResult(),
+      agentHarnessResultClassification: "reasoning-only",
+    } as EmbeddedRunAttemptResult;
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.resolveOutcome(session, result)).toMatchObject({
+      agentHarnessId: "codex",
+      agentHarnessResultClassification: "reasoning-only",
+    });
+  });
+
   it("clears stale non-ok classification when classification resolves to ok", async () => {
     const params = createAttemptParams();
     const result = {

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -1,0 +1,122 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
+import { adaptAgentHarnessToV2 } from "./v2.js";
+
+function createAttemptParams(): AgentHarnessAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    runId: "run-1",
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    timeoutMs: 5_000,
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: { id: "gpt-5.4", provider: "codex" } as Model<Api>,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+    thinkLevel: "low",
+  } as AgentHarnessAttemptParams;
+}
+
+function createAttemptResult(): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    externalAbort: false,
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    promptError: null,
+    promptErrorSource: null,
+    sessionIdUsed: "session-1",
+    messagesSnapshot: [],
+    assistantTexts: ["ok"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+  };
+}
+
+describe("AgentHarness V2 compatibility adapter", () => {
+  it("runs a V1 harness through prepare/start/send without changing attempt params", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      pluginId: "codex-plugin",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const prepared = await v2.prepare(params);
+    const session = await v2.start(prepared);
+
+    expect(await v2.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+    expect(session).toMatchObject({
+      harnessId: "codex",
+      label: "Codex",
+      pluginId: "codex-plugin",
+      params,
+    });
+  });
+
+  it("keeps result classification as an explicit outcome stage", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+      classify: vi.fn(() => "empty"),
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.resolveOutcome(session, result)).toMatchObject({
+      agentHarnessId: "codex",
+      agentHarnessResultClassification: "empty",
+    });
+    expect(harness.classify).toHaveBeenCalledWith(result, params);
+  });
+
+  it("preserves existing compact/reset/dispose hooks as compatibility methods", async () => {
+    const compact = vi.fn(async () => ({ ok: true, compacted: true, summary: "done" }) as const);
+    const reset = vi.fn();
+    const dispose = vi.fn();
+    const harness: AgentHarness = {
+      id: "custom",
+      label: "Custom",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+      compact,
+      reset,
+      dispose,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+
+    await expect(v2.compact?.({ sessionId: "session-1" } as never)).resolves.toMatchObject({
+      compacted: true,
+    });
+    v2.reset?.({ reason: "reset" });
+    await v2.dispose?.();
+
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledWith({ reason: "reset" });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -1,3 +1,4 @@
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type {
   AgentHarness,
   AgentHarnessAttemptParams,
@@ -5,23 +6,23 @@ import type {
   AgentHarnessCompactParams,
   AgentHarnessCompactResult,
   AgentHarnessResetParams,
-  AgentHarnessResultClassification,
   AgentHarnessSupport,
   AgentHarnessSupportContext,
 } from "./types.js";
 
-export type AgentHarnessV2PreparedRun = {
+type AgentHarnessV2RunBase = {
   harnessId: string;
   label: string;
   pluginId?: string;
   params: AgentHarnessAttemptParams;
 };
 
-export type AgentHarnessV2Session = {
-  harnessId: string;
-  label: string;
-  pluginId?: string;
-  params: AgentHarnessAttemptParams;
+export type AgentHarnessV2PreparedRun = AgentHarnessV2RunBase & {
+  lifecycleState: "prepared";
+};
+
+export type AgentHarnessV2Session = AgentHarnessV2RunBase & {
+  lifecycleState: "started";
 };
 
 export type AgentHarnessV2ToolCall = {
@@ -57,9 +58,6 @@ export type AgentHarnessV2 = {
 };
 
 export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
-  const compact = harness.compact;
-  const reset = harness.reset;
-  const dispose = harness.dispose;
   return {
     id: harness.id,
     label: harness.label,
@@ -70,39 +68,25 @@ export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
       label: harness.label,
       pluginId: harness.pluginId,
       params,
+      lifecycleState: "prepared",
     }),
     start: async (prepared) => ({
       harnessId: prepared.harnessId,
       label: prepared.label,
       pluginId: prepared.pluginId,
       params: prepared.params,
+      lifecycleState: "started",
     }),
     resume: async (session) => session,
     send: async (session) => harness.runAttempt(session.params),
     resolveOutcome: async (session, result) =>
-      applyAgentHarnessV2Classification(harness, result, session.params),
-    cleanup: async () => {},
-    compact: compact ? (params) => compact(params) : undefined,
-    reset: reset ? (params) => reset(params) : undefined,
-    dispose: dispose ? () => dispose() : undefined,
-  };
-}
-
-export function applyAgentHarnessV2Classification(
-  harness: Pick<AgentHarness, "id" | "classify">,
-  result: AgentHarnessAttemptResult,
-  params: AgentHarnessAttemptParams,
-): AgentHarnessAttemptResult {
-  const classification = harness.classify?.(result, params);
-  if (!classification || classification === "ok") {
-    return { ...result, agentHarnessId: harness.id };
-  }
-  return {
-    ...result,
-    agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification as Exclude<
-      AgentHarnessResultClassification,
-      "ok"
-    >,
+      applyAgentHarnessResultClassification(harness, result, session.params),
+    cleanup: async (_params) => {
+      // V1 harnesses have no per-attempt cleanup hook. Global cleanup remains
+      // on dispose(), which must not run after every attempt.
+    },
+    compact: harness.compact ? (params) => harness.compact!(params) : undefined,
+    reset: harness.reset ? (params) => harness.reset!(params) : undefined,
+    dispose: harness.dispose ? () => harness.dispose!() : undefined,
   };
 }

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -1,0 +1,108 @@
+import type {
+  AgentHarness,
+  AgentHarnessAttemptParams,
+  AgentHarnessAttemptResult,
+  AgentHarnessCompactParams,
+  AgentHarnessCompactResult,
+  AgentHarnessResetParams,
+  AgentHarnessResultClassification,
+  AgentHarnessSupport,
+  AgentHarnessSupportContext,
+} from "./types.js";
+
+export type AgentHarnessV2PreparedRun = {
+  harnessId: string;
+  label: string;
+  pluginId?: string;
+  params: AgentHarnessAttemptParams;
+};
+
+export type AgentHarnessV2Session = {
+  harnessId: string;
+  label: string;
+  pluginId?: string;
+  params: AgentHarnessAttemptParams;
+};
+
+export type AgentHarnessV2ToolCall = {
+  id?: string;
+  name: string;
+  input?: unknown;
+};
+
+export type AgentHarnessV2CleanupParams = {
+  session: AgentHarnessV2Session;
+  result?: AgentHarnessAttemptResult;
+  error?: unknown;
+};
+
+export type AgentHarnessV2 = {
+  id: string;
+  label: string;
+  pluginId?: string;
+  supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;
+  prepare(params: AgentHarnessAttemptParams): Promise<AgentHarnessV2PreparedRun>;
+  start(prepared: AgentHarnessV2PreparedRun): Promise<AgentHarnessV2Session>;
+  resume?(session: AgentHarnessV2Session): Promise<AgentHarnessV2Session>;
+  send(session: AgentHarnessV2Session): Promise<AgentHarnessAttemptResult>;
+  handleToolCall?(session: AgentHarnessV2Session, call: AgentHarnessV2ToolCall): Promise<unknown>;
+  resolveOutcome(
+    session: AgentHarnessV2Session,
+    result: AgentHarnessAttemptResult,
+  ): Promise<AgentHarnessAttemptResult>;
+  cleanup(params: AgentHarnessV2CleanupParams): Promise<void>;
+  compact?(params: AgentHarnessCompactParams): Promise<AgentHarnessCompactResult | undefined>;
+  reset?(params: AgentHarnessResetParams): Promise<void> | void;
+  dispose?(): Promise<void> | void;
+};
+
+export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
+  const compact = harness.compact;
+  const reset = harness.reset;
+  const dispose = harness.dispose;
+  return {
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+    supports: (ctx) => harness.supports(ctx),
+    prepare: async (params) => ({
+      harnessId: harness.id,
+      label: harness.label,
+      pluginId: harness.pluginId,
+      params,
+    }),
+    start: async (prepared) => ({
+      harnessId: prepared.harnessId,
+      label: prepared.label,
+      pluginId: prepared.pluginId,
+      params: prepared.params,
+    }),
+    resume: async (session) => session,
+    send: async (session) => harness.runAttempt(session.params),
+    resolveOutcome: async (session, result) =>
+      applyAgentHarnessV2Classification(harness, result, session.params),
+    cleanup: async () => {},
+    compact: compact ? (params) => compact(params) : undefined,
+    reset: reset ? (params) => reset(params) : undefined,
+    dispose: dispose ? () => dispose() : undefined,
+  };
+}
+
+export function applyAgentHarnessV2Classification(
+  harness: Pick<AgentHarness, "id" | "classify">,
+  result: AgentHarnessAttemptResult,
+  params: AgentHarnessAttemptParams,
+): AgentHarnessAttemptResult {
+  const classification = harness.classify?.(result, params);
+  if (!classification || classification === "ok") {
+    return { ...result, agentHarnessId: harness.id };
+  }
+  return {
+    ...result,
+    agentHarnessId: harness.id,
+    agentHarnessResultClassification: classification as Exclude<
+      AgentHarnessResultClassification,
+      "ok"
+    >,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #71096 and RFC #71004. This PR adds the first additive Harness V2 lifecycle contract without migrating selection/execution yet.

No behavior change for existing harnesses.

## RuntimePlan Package Context

This is the lifecycle foundation rung. RuntimePlan centralizes OpenClaw-owned policy; Harness V2 gives that policy a lifecycle-shaped execution boundary without redesigning the existing harness registry.

```mermaid
flowchart TD
  RFC["#71004 RFC"] --> Base["#71096 RuntimePlan merged"]
  Base --> Dedupe["#71220 shared policy helper"]
  Dedupe --> This["#71222 additive Harness V2 adapter"]
  This --> Execute["#71238 selected harnesses run through V2"]
  Execute --> Outcome["#71239 shared terminal outcome classifier"]
  Dedupe --> Transcript["#71223 transcript resolver split"]
  Transcript --> Alias["#71224 embedded-runner alias"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Local Architecture

```mermaid
flowchart LR
  V1["Current AgentHarness\nrunAttempt/compact/reset/dispose"] --> Adapter["adaptAgentHarnessToV2"]
  Adapter --> Prepare["prepare"]
  Prepare --> Start["start/resume"]
  Start --> Send["send"]
  Send --> Outcome["resolveOutcome"]
  Outcome --> Cleanup["cleanup"]
```

## Why This PR Exists

The existing harness SPI is intentionally small and should not be redesigned. The missing piece is an internal lifecycle boundary where OpenClaw can consistently attach RuntimePlan policy, telemetry, cleanup, and outcome classification. This PR adds that boundary additively and keeps V1 compatibility.

## What Changed

- Added `src/agents/harness/v2.ts` with an internal lifecycle-shaped harness interface.
- Added `adaptAgentHarnessToV2(...)` so existing V1 harnesses can run through the V2 shape.
- Kept result classification as an explicit `resolveOutcome(...)` stage.
- Preserved V1 `compact`, `reset`, and `dispose` compatibility methods.
- Added focused tests for lifecycle forwarding, classification, hook delegation, and stale-classification handling.

## Maintainer Review Guide

- Highest-signal files: `src/agents/harness/v2.ts`, `src/agents/harness/result-classification.ts`, `src/agents/harness/v2.test.ts`.
- Check this remains additive: no selection path should change in this PR.
- Check V1 adapter behavior remains compatible with existing harnesses.
- Check classification behavior preserves harness-supplied terminal classifications when no explicit classifier exists.

## What Did Not Change

- No runtime selection changes; that is #71238.
- No Pi/Codex migration to native V2 implementations.
- No runner split or rename.
- No new plugin hook surface.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `./node_modules/.bin/vitest run src/agents/harness/v2.test.ts --config test/vitest/vitest.agents.config.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/harness/v2.ts src/agents/harness/result-classification.ts src/agents/harness/v2.test.ts`
- `git diff --check`
- `pnpm check:architecture`

Local broad `pnpm check:changed` has previously hit unrelated repository type/dependency drift; focused Harness V2 tests and architecture checks are the intended merge signal for this slice.
