### PR TITLE
[codex] refactor: extract attempt transcript policy resolver

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
+import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
+
+describe("resolveAttemptTranscriptPolicy", () => {
+  it("uses RuntimePlan transcript policy when available", () => {
+    const plannedPolicy = {
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      preserveNativeAnthropicToolUseIds: false,
+      repairToolUseResultPairing: true,
+      preserveSignatures: true,
+      sanitizeThinkingSignatures: false,
+      dropThinkingBlocks: true,
+      applyGoogleTurnOrdering: false,
+      validateGeminiTurns: false,
+      validateAnthropicTurns: true,
+      allowSyntheticToolResults: true,
+    } as const;
+    const resolvePolicy = vi.fn(() => plannedPolicy);
+    const runtimePlan = {
+      transcript: {
+        resolvePolicy,
+      },
+    } as unknown as AgentRuntimePlan;
+    const runtimePlanModelContext = {
+      workspaceDir: "/tmp/openclaw-transcript-policy",
+      modelApi: "anthropic-messages",
+      model: { id: "claude-opus-4.6", provider: "anthropic" },
+    };
+
+    expect(
+      resolveAttemptTranscriptPolicy({
+        runtimePlan,
+        runtimePlanModelContext,
+        provider: "anthropic",
+        modelId: "claude-opus-4.6",
+      }),
+    ).toBe(plannedPolicy);
+    expect(resolvePolicy).toHaveBeenCalledWith(runtimePlanModelContext);
+  });
+
+  it("keeps the legacy provider transcript fallback when no RuntimePlan is available", () => {
+    const policy = resolveAttemptTranscriptPolicy({
+      runtimePlanModelContext: {
+        workspaceDir: "/tmp/openclaw-transcript-policy",
+        modelApi: "openai-responses",
+      },
+      provider: "",
+      modelId: "gpt-5.4",
+    });
+
+    expect(policy).toMatchObject({
+      sanitizeMode: "images-only",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      repairToolUseResultPairing: true,
+      allowSyntheticToolResults: false,
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 
@@ -27,7 +28,18 @@ describe("resolveAttemptTranscriptPolicy", () => {
     const runtimePlanModelContext = {
       workspaceDir: "/tmp/openclaw-transcript-policy",
       modelApi: "anthropic-messages",
-      model: { id: "claude-opus-4.6", provider: "anthropic" },
+      model: {
+        id: "claude-opus-4.6",
+        name: "Claude Opus 4.6",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8_192,
+      } satisfies ProviderRuntimeModel,
     };
 
     expect(

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 
+const resolveProviderRuntimePluginMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../plugins/provider-hook-runtime.js", () => ({
+  resolveProviderRuntimePlugin: resolveProviderRuntimePluginMock,
+}));
+
 describe("resolveAttemptTranscriptPolicy", () => {
+  beforeEach(() => {
+    resolveProviderRuntimePluginMock.mockReset();
+    resolveProviderRuntimePluginMock.mockReturnValue(undefined);
+  });
+
   it("uses RuntimePlan transcript policy when available", () => {
     const plannedPolicy = {
       sanitizeMode: "full",
@@ -54,6 +65,7 @@ describe("resolveAttemptTranscriptPolicy", () => {
   });
 
   it("keeps the legacy provider transcript fallback when no RuntimePlan is available", () => {
+    const env = { OPENCLAW_TEST_TRANSCRIPT_POLICY: "1" } as NodeJS.ProcessEnv;
     const policy = resolveAttemptTranscriptPolicy({
       runtimePlanModelContext: {
         workspaceDir: "/tmp/openclaw-transcript-policy",
@@ -61,6 +73,7 @@ describe("resolveAttemptTranscriptPolicy", () => {
       },
       provider: "custom-openai-compatible",
       modelId: "gpt-5.4",
+      env,
     });
 
     expect(policy).toMatchObject({
@@ -69,6 +82,12 @@ describe("resolveAttemptTranscriptPolicy", () => {
       toolCallIdMode: "strict",
       repairToolUseResultPairing: true,
       allowSyntheticToolResults: false,
+    });
+    expect(resolveProviderRuntimePluginMock).toHaveBeenCalledWith({
+      provider: "custom-openai-compatible",
+      config: undefined,
+      workspaceDir: "/tmp/openclaw-transcript-policy",
+      env,
     });
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -59,7 +59,7 @@ describe("resolveAttemptTranscriptPolicy", () => {
         workspaceDir: "/tmp/openclaw-transcript-policy",
         modelApi: "openai-responses",
       },
-      provider: "",
+      provider: "custom-openai-compatible",
       modelId: "gpt-5.4",
     });
 

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
@@ -1,0 +1,32 @@
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
+import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
+import { resolveTranscriptPolicy, type TranscriptPolicy } from "../../transcript-policy.js";
+
+export type AttemptRuntimeModelContext = {
+  workspaceDir?: string;
+  modelApi?: string;
+  model?: ProviderRuntimeModel;
+};
+
+export function resolveAttemptTranscriptPolicy(params: {
+  runtimePlan?: AgentRuntimePlan;
+  runtimePlanModelContext: AttemptRuntimeModelContext;
+  provider: string;
+  modelId: string;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): TranscriptPolicy {
+  return (
+    params.runtimePlan?.transcript.resolvePolicy(params.runtimePlanModelContext) ??
+    resolveTranscriptPolicy({
+      modelApi: params.runtimePlanModelContext.modelApi,
+      provider: params.provider,
+      modelId: params.modelId,
+      config: params.config,
+      workspaceDir: params.runtimePlanModelContext.workspaceDir,
+      env: params.env ?? process.env,
+      model: params.runtimePlanModelContext.model,
+    })
+  );
+}

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
@@ -1,13 +1,10 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { resolveTranscriptPolicy, type TranscriptPolicy } from "../../transcript-policy.js";
 
-export type AttemptRuntimeModelContext = {
-  workspaceDir?: string;
-  modelApi?: string;
-  model?: ProviderRuntimeModel;
-};
+export type AttemptRuntimeModelContext = NonNullable<
+  Parameters<AgentRuntimePlan["transcript"]["resolvePolicy"]>[0]
+>;
 
 export function resolveAttemptTranscriptPolicy(params: {
   runtimePlan?: AgentRuntimePlan;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -131,10 +131,7 @@ import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
-import {
-  resolveTranscriptPolicy,
-  shouldAllowProviderOwnedThinkingReplay,
-} from "../../transcript-policy.js";
+import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -272,6 +269,7 @@ import {
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.tool-call-normalization.js";
 import { buildEmbeddedAttemptToolRunContext } from "./attempt.tool-run-context.js";
+import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 import {
   resolveRunTimeoutDuringCompaction,
@@ -1059,17 +1057,14 @@ export async function runEmbeddedAttempt(
         .then(() => true)
         .catch(() => false);
 
-      const transcriptPolicy =
-        params.runtimePlan?.transcript.resolvePolicy(runtimePlanModelContext) ??
-        resolveTranscriptPolicy({
-          modelApi: params.model?.api,
-          provider: params.provider,
-          modelId: params.modelId,
-          config: params.config,
-          workspaceDir: effectiveWorkspace,
-          env: process.env,
-          model: params.model,
-        });
+      const transcriptPolicy = resolveAttemptTranscriptPolicy({
+        runtimePlan: params.runtimePlan,
+        runtimePlanModelContext,
+        provider: params.provider,
+        modelId: params.modelId,
+        config: params.config,
+        env: process.env,
+      });
 
       await prewarmSessionFile(params.sessionFile);
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {


### PR DESCRIPTION
## Summary

Follow-up to #71096 and RFC #71004. This PR is the first small contract-domain extraction from the embedded runner monolith: transcript policy resolution moves behind a focused resolver with tests.

Runtime behavior is intended to be equivalent.

## RuntimePlan Package Context

This is the first "split by contract domain" rung. It deliberately extracts only transcript policy resolution, not the whole `attempt.ts` file, because the package is trying to avoid cosmetic mega-splits before behavior ownership is clear.

```mermaid
flowchart TD
  RFC["#71004 RFC"] --> Base["#71096 RuntimePlan merged"]
  Base --> ToolPolicy["#71220 shared tool policy helper"]
  ToolPolicy --> This["#71223 transcript policy resolver"]
  This --> Alias["#71224 embedded-runner alias barrel"]
  ToolPolicy --> Harness["#71222/#71238 Harness V2 lifecycle"]
  Harness --> Outcome["#71239 shared terminal outcome classifier"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Local Architecture

```mermaid
flowchart TD
  Attempt["run/attempt.ts"] --> Resolver["resolveAttemptTranscriptPolicy"]
  Resolver --> Plan["RuntimePlan transcript policy"]
  Resolver --> Legacy["legacy resolveTranscriptPolicy fallback"]
  Plan --> Policy["effective transcript repair policy"]
  Legacy --> Policy
```

## Why This PR Exists

`attempt.ts` is too large to safely split mechanically while policy is still scattered. This PR extracts one contract-owned decision point and proves the RuntimePlan-first/legacy-fallback behavior in isolation. That gives maintainers a small, reviewable example of the intended runner split style.

## What Changed

- Added `run/attempt.transcript-policy.ts`.
- Moved the RuntimePlan-first transcript policy fallback out of `run/attempt.ts`.
- Added tests proving RuntimePlan policy wins when available.
- Added tests proving legacy transport/provider fallback remains when no RuntimePlan exists.

## Maintainer Review Guide

- Highest-signal files: `src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`.
- Check this is a narrow extraction, not a semantic rewrite.
- Check the fallback still uses the same provider/model context when no RuntimePlan is present.
- Check tests cover both RuntimePlan-present and RuntimePlan-absent paths.

## What Did Not Change

- No user-visible behavior change.
- No full runner split.
- No Pi/Codex rename.
- No Harness V2 migration.
- No WS pooling.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `./node_modules/.bin/vitest run src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts --config test/vitest/vitest.agents.config.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts`
- `git diff --check`
- `pnpm check:architecture`

Local broad `pnpm check:changed` has previously hit unrelated repository type/dependency drift; focused transcript-policy tests and architecture checks are the intended merge signal for this slice.
