### PR TITLE
[codex] refactor: add embedded runner directory barrel

### DIFF
--- a/src/agents/embedded-runner/index.ts
+++ b/src/agents/embedded-runner/index.ts
@@ -1,0 +1,17 @@
+export {
+  abortEmbeddedAgentRun,
+  compactEmbeddedAgentSession,
+  isEmbeddedAgentRunActive,
+  isEmbeddedAgentRunStreaming,
+  queueEmbeddedAgentMessage,
+  resolveActiveEmbeddedAgentRunSessionId,
+  resolveEmbeddedSessionLane,
+  runEmbeddedAgent,
+  waitForEmbeddedAgentRunEnd,
+} from "../embedded-runner.js";
+export type {
+  EmbeddedAgentCompactResult,
+  EmbeddedAgentMeta,
+  EmbeddedAgentRunMeta,
+  EmbeddedAgentRunResult,
+} from "../embedded-runner.js";

--- a/src/agents/embedded-runner/index.ts
+++ b/src/agents/embedded-runner/index.ts
@@ -1,17 +1,1 @@
-export {
-  abortEmbeddedAgentRun,
-  compactEmbeddedAgentSession,
-  isEmbeddedAgentRunActive,
-  isEmbeddedAgentRunStreaming,
-  queueEmbeddedAgentMessage,
-  resolveActiveEmbeddedAgentRunSessionId,
-  resolveEmbeddedSessionLane,
-  runEmbeddedAgent,
-  waitForEmbeddedAgentRunEnd,
-} from "../embedded-runner.js";
-export type {
-  EmbeddedAgentCompactResult,
-  EmbeddedAgentMeta,
-  EmbeddedAgentRunMeta,
-  EmbeddedAgentRunResult,
-} from "../embedded-runner.js";
+export * from "../embedded-runner.js";


### PR DESCRIPTION
## Summary

Follow-up to #71096 and RFC #71004. This PR adds the canonical `src/agents/embedded-runner/` directory barrel without moving implementation files or breaking existing Pi-prefixed imports.

No runtime behavior changes.

## RuntimePlan Package Context

This is the naming/observability cleanup rung, intentionally kept as an alias-only step. It gives maintainers and future PRs a neutral import target while preserving old Pi names until the runner split is stable.

```mermaid
flowchart TD
  RFC["#71004 RFC"] --> Base["#71096 RuntimePlan merged"]
  Base --> Transcript["#71223 transcript resolver split"]
  Transcript --> This["#71224 embedded-runner directory alias"]
  Base --> Harness["#71222/#71238 Harness V2 lifecycle"]
  Harness --> Outcome["#71239 shared terminal outcome classifier"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Local Architecture

```mermaid
flowchart LR
  New["src/agents/embedded-runner/index.ts"] --> Neutral["src/agents/embedded-runner.ts"]
  Neutral --> Existing["existing embedded-agent exports"]
  Old["pi-embedded-runner compatibility paths"] --> Existing
```

## Why This PR Exists

The runtime now dispatches both Pi and Codex-backed harness paths, so the old Pi-only package name is misleading. A pure alias step lets future code use the neutral path without a risky file move or import migration in the same PR.

## What Changed

- Added `src/agents/embedded-runner/index.ts`.
- The new directory barrel re-exports the existing neutral embedded-agent API from `src/agents/embedded-runner.ts`.
- Existing `pi-embedded-runner` and `pi-embedded` compatibility paths remain unchanged.

## Maintainer Review Guide

- Highest-signal file: `src/agents/embedded-runner/index.ts`.
- Check that this is a pure barrel/alias change.
- Check no implementation files moved and no compatibility imports were removed.
- This PR is deliberately small because the risky rename/split work is deferred.

## What Did Not Change

- No implementation file moves.
- No import migration.
- No deletion or deprecation enforcement.
- No runtime behavior changes.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `node --import tsx -e "import('./src/agents/embedded-runner/index.ts').then((module) => { if (typeof module.runEmbeddedAgent !== 'function') throw new Error('missing runEmbeddedAgent'); console.log('ok'); })"`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/embedded-runner/index.ts`
- `git diff --check`
- `pnpm check:architecture`

Local broad `pnpm check:changed` has previously hit unrelated repository type/dependency drift; direct import smoke, lint, diff-check, and architecture checks are the intended merge signal for this alias-only slice.
