### PR TITLE
feat(plugins): read setup provider env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/setup: honor explicit `setup.requiresRuntime: false` as a descriptor-only setup contract while keeping omitted values on the legacy setup-api fallback path. Thanks @vincentkoc.
 - Plugins/setup: report descriptor/runtime drift when setup-api registrations disagree with `setup.providers` or `setup.cliBackends`, without rejecting legacy setup plugins. Thanks @vincentkoc.
 - Plugin hooks: expose first-class run, message, sender, session, and trace correlation fields on message hook contexts and run lifecycle events. Thanks @vincentkoc.
-- Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups so descriptor-only setup providers can be detected before setup runtime loads. Thanks @vincentkoc.
+- Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups and warn non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata. Thanks @vincentkoc.
 - TUI/dependencies: remove direct `cli-highlight` usage from the OpenClaw TUI code-block renderer, keeping themed code coloring without the extra root dependency. Thanks @vincentkoc.
 - Diagnostics/OTEL: export run, model-call, and tool-execution diagnostic lifecycle events as OTEL spans without retaining live span state. Thanks @vincentkoc.
 - Providers/Anthropic Vertex: move the Vertex SDK runtime behind the bundled provider plugin so core no longer owns that provider-specific dependency. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/setup: honor explicit `setup.requiresRuntime: false` as a descriptor-only setup contract while keeping omitted values on the legacy setup-api fallback path. Thanks @vincentkoc.
 - Plugins/setup: report descriptor/runtime drift when setup-api registrations disagree with `setup.providers` or `setup.cliBackends`, without rejecting legacy setup plugins. Thanks @vincentkoc.
 - Plugin hooks: expose first-class run, message, sender, session, and trace correlation fields on message hook contexts and run lifecycle events. Thanks @vincentkoc.
+- Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups so descriptor-only setup providers can be detected before setup runtime loads. Thanks @vincentkoc.
 - TUI/dependencies: remove direct `cli-highlight` usage from the OpenClaw TUI code-block renderer, keeping themed code coloring without the extra root dependency. Thanks @vincentkoc.
 - Diagnostics/OTEL: export run, model-call, and tool-execution diagnostic lifecycle events as OTEL spans without retaining live span state. Thanks @vincentkoc.
 - Providers/Anthropic Vertex: move the Vertex SDK runtime behind the bundled provider plugin so core no longer owns that provider-specific dependency. Thanks @vincentkoc.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -167,7 +167,8 @@ conversation, and it runs after core approval handling finishes.
 Provider plugins have three layers:
 
 - **Manifest metadata** for cheap pre-runtime lookup: `providerAuthEnvVars`,
-  `providerAuthAliases`, `providerAuthChoices`, and `channelEnvVars`.
+  `setup.providers[].envVars`, `providerAuthAliases`, `providerAuthChoices`,
+  and `channelEnvVars`.
 - **Config-time hooks**: `catalog` (legacy `discovery`) plus
   `applyConfigDefaults`.
 - **Runtime hooks**: 40+ optional hooks covering auth, model resolution,

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -166,9 +166,9 @@ conversation, and it runs after core approval handling finishes.
 
 Provider plugins have three layers:
 
-- **Manifest metadata** for cheap pre-runtime lookup: `providerAuthEnvVars`,
-  `setup.providers[].envVars`, `providerAuthAliases`, `providerAuthChoices`,
-  and `channelEnvVars`.
+- **Manifest metadata** for cheap pre-runtime lookup:
+  `setup.providers[].envVars`, deprecated compatibility `providerAuthEnvVars`,
+  `providerAuthAliases`, `providerAuthChoices`, and `channelEnvVars`.
 - **Config-time hooks**: `catalog` (legacy `discovery`) plus
   `applyConfigDefaults`.
 - **Runtime hooks**: 40+ optional hooks covering auth, model resolution,
@@ -179,13 +179,16 @@ OpenClaw still owns the generic agent loop, failover, transcript handling, and
 tool policy. These hooks are the extension surface for provider-specific
 behavior without needing a whole custom inference transport.
 
-Use manifest `providerAuthEnvVars` when the provider has env-based credentials
-that generic auth/status/model-picker paths should see without loading plugin
-runtime. Use manifest `providerAuthAliases` when one provider id should reuse
-another provider id's env vars, auth profiles, config-backed auth, and API-key
-onboarding choice. Use manifest `providerAuthChoices` when onboarding/auth-choice
-CLI surfaces should know the provider's choice id, group labels, and simple
-one-flag auth wiring without loading provider runtime. Keep provider runtime
+Use manifest `setup.providers[].envVars` when the provider has env-based
+credentials that generic auth/status/model-picker paths should see without
+loading plugin runtime. Deprecated `providerAuthEnvVars` is still read by the
+compatibility adapter during the deprecation window, and non-bundled plugins
+that use it receive a manifest diagnostic. Use manifest `providerAuthAliases`
+when one provider id should reuse another provider id's env vars, auth profiles,
+config-backed auth, and API-key onboarding choice. Use manifest
+`providerAuthChoices` when onboarding/auth-choice CLI surfaces should know the
+provider's choice id, group labels, and simple one-flag auth wiring without
+loading provider runtime. Keep provider runtime
 `envVars` for operator-facing hints such as onboarding labels or OAuth
 client-id/client-secret setup vars.
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -148,7 +148,7 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
 | `syntheticAuthRefs`                  | No       | `string[]`                       | Provider or CLI backend refs whose plugin-owned synthetic auth hook should be probed during cold model discovery before runtime loads.                                                                                            |
 | `nonSecretAuthMarkers`               | No       | `string[]`                       | Bundled-plugin-owned placeholder API key values that represent non-secret local, OAuth, or ambient credential state.                                                                                                              |
 | `commandAliases`                     | No       | `object[]`                       | Command names owned by this plugin that should produce plugin-aware config and CLI diagnostics before runtime loads.                                                                                                              |
-| `providerAuthEnvVars`                | No       | `Record<string, string[]>`       | Cheap provider-auth env metadata that OpenClaw can inspect without loading plugin code.                                                                                                                                           |
+| `providerAuthEnvVars`                | No       | `Record<string, string[]>`       | Deprecated compatibility env metadata for provider auth/status lookup. Prefer `setup.providers[].envVars` for new plugins; OpenClaw still reads this during the deprecation window.                                               |
 | `providerAuthAliases`                | No       | `Record<string, string>`         | Provider ids that should reuse another provider id for auth lookup, for example a coding provider that shares the base provider API key and auth profiles.                                                                        |
 | `channelEnvVars`                     | No       | `Record<string, string[]>`       | Cheap channel env metadata that OpenClaw can inspect without loading plugin code. Use this for env-driven channel setup or auth surfaces that generic startup/config helpers should see.                                          |
 | `providerAuthChoices`                | No       | `object[]`                       | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                                                                                                                     |
@@ -328,9 +328,10 @@ hooks, set `requiresRuntime: true` and keep `setup-api` in place as the
 fallback execution path.
 
 OpenClaw also includes `setup.providers[].envVars` in generic provider auth and
-env-var lookups. Use `providerAuthEnvVars` when you need the broader
-provider-auth metadata surface; use `setup.providers[].envVars` when the env
-vars belong specifically to the setup/onboarding descriptor.
+env-var lookups. `providerAuthEnvVars` remains supported through a compatibility
+adapter during the deprecation window, but non-bundled plugins that still use it
+receive a manifest diagnostic. New plugins should put setup/status env metadata
+on `setup.providers[].envVars`.
 
 Set `requiresRuntime: false` only when those descriptors are sufficient for the
 setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
@@ -730,7 +731,7 @@ See [Configuration reference](/gateway/configuration) for the full `plugins.*` s
 - `channels`, `providers`, `cliBackends`, and `skills` can all be omitted when a plugin does not need them.
 - `providerDiscoveryEntry` must stay lightweight and should not import broad runtime code; use it for static provider catalog metadata or narrow discovery descriptors, not request-time execution.
 - Exclusive plugin kinds are selected through `plugins.slots.*`: `kind: "memory"` via `plugins.slots.memory`, `kind: "context-engine"` via `plugins.slots.contextEngine` (default `legacy`).
-- Env-var metadata (`providerAuthEnvVars`, `channelEnvVars`) is declarative only. Status, audit, cron delivery validation, and other read-only surfaces still apply plugin trust and effective activation policy before treating an env var as configured.
+- Env-var metadata (`setup.providers[].envVars`, deprecated `providerAuthEnvVars`, and `channelEnvVars`) is declarative only. Status, audit, cron delivery validation, and other read-only surfaces still apply plugin trust and effective activation policy before treating an env var as configured.
 - For runtime wizard metadata that requires provider code, see [Provider runtime hooks](/plugins/architecture-internals#provider-runtime-hooks).
 - If your plugin depends on native modules, document the build steps and any package-manager allowlist requirements (for example, pnpm `allow-build-scripts` + `pnpm rebuild <package>`).
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -327,6 +327,11 @@ narrows the candidate plugin and setup still needs richer setup-time runtime
 hooks, set `requiresRuntime: true` and keep `setup-api` in place as the
 fallback execution path.
 
+OpenClaw also includes `setup.providers[].envVars` in generic provider auth and
+env-var lookups. Use `providerAuthEnvVars` when you need the broader
+provider-auth metadata surface; use `setup.providers[].envVars` when the env
+vars belong specifically to the setup/onboarding descriptor.
+
 Set `requiresRuntime: false` only when those descriptors are sufficient for the
 setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
 and will not execute `setup-api` for setup lookup. Omitted `requiresRuntime`

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -478,6 +478,38 @@ describe("loadPluginManifestRegistry", () => {
     ]);
   });
 
+  it("reports non-bundled providerAuthEnvVars as deprecated compat metadata", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "external-openai",
+      providers: ["openai"],
+      providerAuthEnvVars: {
+        openai: ["OPENAI_API_KEY"],
+      },
+      configSchema: { type: "object" },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "external-openai",
+      rootDir: dir,
+      origin: "global",
+    });
+
+    expect(registry.plugins[0]?.providerAuthEnvVars).toEqual({
+      openai: ["OPENAI_API_KEY"],
+    });
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        pluginId: "external-openai",
+        source: path.join(dir, "openclaw.plugin.json"),
+        message: expect.stringContaining(
+          "providerAuthEnvVars is deprecated compatibility metadata",
+        ),
+      }),
+    );
+  });
+
   it("falls back providerDiscoverySource from .ts to emitted .js files", () => {
     const dir = makeTempDir();
     writeManifest(dir, {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -450,6 +450,28 @@ function buildBundleRecord(params: {
   };
 }
 
+function pushProviderAuthEnvVarsCompatDiagnostic(params: {
+  record: PluginManifestRecord;
+  diagnostics: PluginDiagnostic[];
+}): void {
+  if (params.record.origin === "bundled" || !params.record.providerAuthEnvVars) {
+    return;
+  }
+  const providerIds = Object.entries(params.record.providerAuthEnvVars)
+    .filter(([providerId, envVars]) => providerId.trim() && envVars.length > 0)
+    .map(([providerId]) => providerId)
+    .toSorted((left, right) => left.localeCompare(right));
+  if (providerIds.length === 0) {
+    return;
+  }
+  params.diagnostics.push({
+    level: "warn",
+    pluginId: params.record.id,
+    source: params.record.manifestPath,
+    message: `providerAuthEnvVars is deprecated compatibility metadata for provider env-var lookup; mirror ${providerIds.join(", ")} env vars to setup.providers[].envVars before the deprecation window closes`,
+  });
+}
+
 function matchesInstalledPluginRecord(params: {
   pluginId: string;
   candidate: PluginCandidate;
@@ -642,6 +664,7 @@ export function loadPluginManifestRegistry(
         if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
           records[existing.recordIndex] = record;
           seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+          pushProviderAuthEnvVarsCompatDiagnostic({ record, diagnostics });
         }
         continue;
       }
@@ -664,6 +687,7 @@ export function loadPluginManifestRegistry(
       if (candidateWins) {
         records[existing.recordIndex] = record;
         seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+        pushProviderAuthEnvVarsCompatDiagnostic({ record, diagnostics });
       }
       diagnostics.push({
         level: "warn",
@@ -676,6 +700,7 @@ export function loadPluginManifestRegistry(
 
     seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     records.push(record);
+    pushProviderAuthEnvVarsCompatDiagnostic({ record, diagnostics });
   }
 
   const registry = { plugins: records, diagnostics };

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -194,7 +194,13 @@ export type PluginManifest = {
    * config diagnostics before runtime loads.
    */
   commandAliases?: PluginManifestCommandAlias[];
-  /** Cheap provider-auth env lookup without booting plugin runtime. */
+  /**
+   * Cheap provider-auth env lookup without booting plugin runtime.
+   *
+   * @deprecated Prefer setup.providers[].envVars for generic setup/status env
+   * metadata. This field remains supported through the provider env-var
+   * compatibility adapter during the deprecation window.
+   */
   providerAuthEnvVars?: Record<string, string[]>;
   /** Provider ids that should reuse another provider id for auth lookup. */
   providerAuthAliases?: Record<string, string>;

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -15,6 +15,12 @@ type MockManifestRegistry = {
     kind?: "memory" | "context-engine" | Array<"memory" | "context-engine">;
     providerAuthEnvVars?: Record<string, string[]>;
     providerAuthAliases?: Record<string, string>;
+    setup?: {
+      providers?: Array<{
+        id: string;
+        envVars?: string[];
+      }>;
+    };
   }>;
   diagnostics: unknown[];
 };
@@ -55,6 +61,55 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(getProviderEnvVars("fireworks-plan")).toEqual(["FIREWORKS_ALT_API_KEY"]);
     expect(listKnownProviderAuthEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
     expect(listKnownSecretEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
+  });
+
+  it("includes setup provider env vars without loading setup runtime", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "external-model-studio",
+          origin: "global",
+          setup: {
+            providers: [
+              {
+                id: "model-studio",
+                envVars: ["MODEL_STUDIO_API_KEY", "MODEL_STUDIO_API_KEY"],
+              },
+            ],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(getProviderEnvVars("model-studio")).toEqual(["MODEL_STUDIO_API_KEY"]);
+    expect(listKnownProviderAuthEnvVarNames()).toContain("MODEL_STUDIO_API_KEY");
+    expect(listKnownSecretEnvVarNames()).toContain("MODEL_STUDIO_API_KEY");
+  });
+
+  it("appends setup provider env vars after explicit provider auth env vars", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "external-fireworks",
+          origin: "global",
+          providerAuthEnvVars: {
+            fireworks: ["FIREWORKS_API_KEY"],
+          },
+          setup: {
+            providers: [
+              {
+                id: "fireworks",
+                envVars: ["FIREWORKS_SETUP_KEY", "FIREWORKS_API_KEY"],
+              },
+            ],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(getProviderEnvVars("fireworks")).toEqual(["FIREWORKS_API_KEY", "FIREWORKS_SETUP_KEY"]);
   });
 
   it("keeps lazy manifest-backed exports cold until accessed and resolves them once", async () => {
@@ -111,6 +166,14 @@ describe("provider env vars dynamic manifest metadata", () => {
           providerAuthEnvVars: {
             whisperx: ["AWS_SECRET_ACCESS_KEY"],
           },
+          setup: {
+            providers: [
+              {
+                id: "workspace-setup",
+                envVars: ["WORKSPACE_SETUP_SECRET"],
+              },
+            ],
+          },
         },
       ],
       diagnostics: [],
@@ -125,11 +188,23 @@ describe("provider env vars dynamic manifest metadata", () => {
       }),
     ).toEqual([]);
     expect(
+      mod.getProviderEnvVars("workspace-setup", {
+        config: { plugins: {} },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual([]);
+    expect(
       mod.listKnownProviderAuthEnvVarNames({
         config: { plugins: {} },
         includeUntrustedWorkspacePlugins: false,
       }),
     ).not.toContain("AWS_SECRET_ACCESS_KEY");
+    expect(
+      mod.listKnownProviderAuthEnvVarNames({
+        config: { plugins: {} },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).not.toContain("WORKSPACE_SETUP_SECRET");
   });
 
   it("keeps explicitly trusted workspace plugin env vars when requested", async () => {

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -86,13 +86,15 @@ function resolveManifestProviderAuthEnvVarCandidates(
     if (!shouldUsePluginProviderEnvVars(plugin, params)) {
       continue;
     }
-    if (!plugin.providerAuthEnvVars) {
-      continue;
+    if (plugin.providerAuthEnvVars) {
+      for (const [providerId, keys] of Object.entries(plugin.providerAuthEnvVars).toSorted(
+        ([left], [right]) => left.localeCompare(right),
+      )) {
+        appendUniqueEnvVarCandidates(candidates, providerId, keys);
+      }
     }
-    for (const [providerId, keys] of Object.entries(plugin.providerAuthEnvVars).toSorted(
-      ([left], [right]) => left.localeCompare(right),
-    )) {
-      appendUniqueEnvVarCandidates(candidates, providerId, keys);
+    for (const provider of plugin.setup?.providers ?? []) {
+      appendUniqueEnvVarCandidates(candidates, provider.id, provider.envVars ?? []);
     }
   }
   const aliases = resolveProviderAuthAliasMap(params);


### PR DESCRIPTION
## Summary

- Problem: descriptor-only setup providers can declare env vars in `setup.providers[].envVars`, but generic provider auth/env lookup only read the legacy `providerAuthEnvVars` surface.
- Why it matters: phase 2 needs simple setup/status discovery to work from manifest descriptors before setup-api/runtime loads, while external plugins keep working through compat.
- What changed: provider env-var lookup now includes `setup.providers[].envVars`, preserves existing `providerAuthEnvVars` priority, applies the existing workspace trust filter, and emits a manifest warning for non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata.
- What did NOT change (scope boundary): no setup runtime enforcement, no breaking contract changes, and `providerAuthEnvVars` remains supported during the deprecation window.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: setup descriptor env vars were documented as setup/status metadata, but the shared provider env-var resolver did not consume them, and legacy `providerAuthEnvVars` had no deprecation diagnostic.
- Contributing context (if known): plugin architecture phase 2 is moving simple setup discovery toward manifest descriptors while preserving setup-api and legacy manifest compatibility.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/secrets/provider-env-vars.dynamic.test.ts`, `src/plugins/manifest-registry.test.ts`
- Scenario the test should lock in: setup provider env vars are included, deduped after explicit legacy provider auth env vars, filtered for untrusted workspace plugins, and non-bundled `providerAuthEnvVars` usage emits a deprecation diagnostic.
- Why this is the smallest reliable guardrail: provider env-var resolver owns auth/status env-var discovery; manifest registry owns compatibility diagnostics.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Provider auth/status env-var lookups can now detect env vars declared on `setup.providers[].envVars` before setup runtime loads. Non-bundled plugins using deprecated `providerAuthEnvVars` now get a warning, but still work.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin setup descriptors, provider env-var lookup
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/secrets/provider-env-vars.dynamic.test.ts src/plugins/manifest-registry.test.ts`.
2. Run `pnpm check:changed`.

### Expected

- Focused provider env-var and manifest registry tests pass.
- Changed gate passes for core, core tests, and docs lanes.

### Actual

- Focused tests passed: 44 tests.
- `pnpm check:changed` passed: secrets 48 files / 307 tests, plugins 102 files / 1195 tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: descriptor env vars are included, duplicate env vars are deduped, legacy `providerAuthEnvVars` remains first, untrusted workspace setup env vars are filtered, non-bundled legacy field usage warns.
- Edge cases checked: later-installed/global plugins, workspace trust gate, lazy manifest-backed exports, manifest diagnostics.
- What you did **not** verify: full production build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

`providerAuthEnvVars` remains supported through the compatibility adapter during the deprecation window. New and updated plugins should move provider setup/status env metadata to `setup.providers[].envVars`.

## Risks and Mitigations

- Risk: third-party workspace plugins could add env-var names to generic secret lookup.
  - Mitigation: this uses the existing workspace plugin trust filter used by `providerAuthEnvVars`.
- Risk: deprecation diagnostics could be noisy for existing external plugins.
  - Mitigation: the warning is non-fatal, only emitted for non-bundled manifests, and the compatibility field continues to work.
