### PR TITLE
[codex] refactor: execute selected harnesses through v2 lifecycle

### DIFF
--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -1,0 +1,27 @@
+import type {
+  AgentHarness,
+  AgentHarnessAttemptParams,
+  AgentHarnessAttemptResult,
+  AgentHarnessResultClassification,
+} from "./types.js";
+
+export function applyAgentHarnessResultClassification(
+  harness: Pick<AgentHarness, "id" | "classify">,
+  result: AgentHarnessAttemptResult,
+  params: AgentHarnessAttemptParams,
+): AgentHarnessAttemptResult {
+  const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
+    result;
+  const classification = harness.classify?.(result, params);
+  if (!classification || classification === "ok") {
+    return { ...resultWithoutPrevious, agentHarnessId: harness.id };
+  }
+  return {
+    ...resultWithoutPrevious,
+    agentHarnessId: harness.id,
+    agentHarnessResultClassification: classification as Exclude<
+      AgentHarnessResultClassification,
+      "ok"
+    >,
+  };
+}

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -10,9 +10,12 @@ export function applyAgentHarnessResultClassification(
   result: AgentHarnessAttemptResult,
   params: AgentHarnessAttemptParams,
 ): AgentHarnessAttemptResult {
+  if (!harness.classify) {
+    return { ...result, agentHarnessId: harness.id };
+  }
   const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
     result;
-  const classification = harness.classify?.(result, params);
+  const classification = harness.classify(result, params);
   if (!classification || classification === "ok") {
     return { ...resultWithoutPrevious, agentHarnessId: harness.id };
   }

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -2,7 +2,6 @@ import type {
   AgentHarness,
   AgentHarnessAttemptParams,
   AgentHarnessAttemptResult,
-  AgentHarnessResultClassification,
 } from "./types.js";
 
 export function applyAgentHarnessResultClassification(
@@ -22,9 +21,6 @@ export function applyAgentHarnessResultClassification(
   return {
     ...resultWithoutPrevious,
     agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification as Exclude<
-      AgentHarnessResultClassification,
-      "ok"
-    >,
+    agentHarnessResultClassification: classification,
   };
 }

--- a/src/agents/harness/result-classification.ts
+++ b/src/agents/harness/result-classification.ts
@@ -14,7 +14,7 @@ export function applyAgentHarnessResultClassification(
   }
   const { agentHarnessResultClassification: _previousClassification, ...resultWithoutPrevious } =
     result;
-  const classification = harness.classify(result, params);
+  const classification = harness.classify(resultWithoutPrevious, params);
   if (!classification || classification === "ok") {
     return { ...resultWithoutPrevious, agentHarnessId: harness.id };
   }

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -19,6 +19,7 @@ import {
 import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
 
 const log = createSubsystemLogger("agents/harness");
@@ -189,12 +190,12 @@ export async function runAgentHarnessAttemptWithFallback(
   });
   if (harness.id === "pi") {
     const result = await harness.runAttempt(params);
-    return applyHarnessResultClassification(harness, result, params);
+    return applyAgentHarnessResultClassification(harness, result, params);
   }
 
   try {
     const result = await harness.runAttempt(params);
-    return applyHarnessResultClassification(harness, result, params);
+    return applyAgentHarnessResultClassification(harness, result, params);
   } catch (error) {
     log.warn(`${harness.label} failed; not falling back to embedded PI backend`, {
       harnessId: harness.id,
@@ -261,22 +262,6 @@ function logAgentHarnessSelection(
     fallback: selection.policy.fallback,
     candidates: selection.candidates,
   });
-}
-
-function applyHarnessResultClassification(
-  harness: AgentHarness,
-  result: EmbeddedRunAttemptResult,
-  params: EmbeddedRunAttemptParams,
-): EmbeddedRunAttemptResult {
-  const classification = harness.classify?.(result, params);
-  if (!classification || classification === "ok") {
-    return { ...result, agentHarnessId: harness.id };
-  }
-  return {
-    ...result,
-    agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification,
-  };
 }
 
 function resolvePinnedAgentHarnessPolicy(

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -19,8 +19,8 @@ import {
 import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
-import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
+import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
 
 const log = createSubsystemLogger("agents/harness");
 
@@ -188,14 +188,13 @@ export async function runAgentHarnessAttemptWithFallback(
     sessionKey: params.sessionKey,
     agentId: params.agentId,
   });
+  const v2Harness = adaptAgentHarnessToV2(harness);
   if (harness.id === "pi") {
-    const result = await harness.runAttempt(params);
-    return applyAgentHarnessResultClassification(harness, result, params);
+    return runAgentHarnessV2LifecycleAttempt(v2Harness, params);
   }
 
   try {
-    const result = await harness.runAttempt(params);
-    return applyAgentHarnessResultClassification(harness, result, params);
+    return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
   } catch (error) {
     log.warn(`${harness.label} failed; not falling back to embedded PI backend`, {
       harnessId: harness.id,

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -190,7 +190,7 @@ export async function runAgentHarnessAttemptWithFallback(
   });
   const v2Harness = adaptAgentHarnessToV2(harness);
   if (harness.id === "pi") {
-    return runAgentHarnessV2LifecycleAttempt(v2Harness, params);
+    return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
   }
 
   try {

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -155,10 +155,16 @@ describe("AgentHarness V2 compatibility adapter", () => {
 
     const v2 = adaptAgentHarnessToV2(harness);
 
-    await expect(v2.compact?.({ sessionId: "session-1" } as never)).resolves.toMatchObject({
+    await expect(
+      v2.compact?.({
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).resolves.toMatchObject({
       compacted: true,
     });
-    v2.reset?.({ reason: "reset" });
+    await v2.reset?.({ reason: "reset" });
     await v2.dispose?.();
 
     expect(harness.compactCalls).toBe(1);

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -69,18 +69,21 @@ describe("AgentHarness V2 compatibility adapter", () => {
       label: "Codex",
       pluginId: "codex-plugin",
       params,
+      lifecycleState: "started",
     });
+    expect(prepared.lifecycleState).toBe("prepared");
   });
 
   it("keeps result classification as an explicit outcome stage", async () => {
     const params = createAttemptParams();
     const result = createAttemptResult();
+    const classify = vi.fn<NonNullable<AgentHarness["classify"]>>(() => "empty");
     const harness: AgentHarness = {
       id: "codex",
       label: "Codex",
       supports: () => ({ supported: true }),
       runAttempt: vi.fn(async () => result),
-      classify: vi.fn(() => "empty"),
+      classify,
     };
 
     const v2 = adaptAgentHarnessToV2(harness);
@@ -93,18 +96,61 @@ describe("AgentHarness V2 compatibility adapter", () => {
     expect(harness.classify).toHaveBeenCalledWith(result, params);
   });
 
-  it("preserves existing compact/reset/dispose hooks as compatibility methods", async () => {
-    const compact = vi.fn(async () => ({ ok: true, compacted: true, summary: "done" }) as const);
-    const reset = vi.fn();
-    const dispose = vi.fn();
+  it("clears stale non-ok classification when classification resolves to ok", async () => {
+    const params = createAttemptParams();
+    const result = {
+      ...createAttemptResult(),
+      agentHarnessResultClassification: "empty",
+    } as EmbeddedRunAttemptResult;
+    const classify = vi.fn<NonNullable<AgentHarness["classify"]>>(() => "ok");
     const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+      classify,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    const classified = await v2.resolveOutcome(session, result);
+    expect(classified).toMatchObject({ agentHarnessId: "codex" });
+    expect(classified).not.toHaveProperty("agentHarnessResultClassification");
+  });
+
+  it("preserves existing compact/reset/dispose hook this binding as compatibility methods", async () => {
+    const harness: AgentHarness & {
+      compactCalls: number;
+      resetCalls: number;
+      disposeCalls: number;
+    } = {
       id: "custom",
       label: "Custom",
+      compactCalls: 0,
+      resetCalls: 0,
+      disposeCalls: 0,
       supports: () => ({ supported: true }),
       runAttempt: vi.fn(async () => createAttemptResult()),
-      compact,
-      reset,
-      dispose,
+      async compact() {
+        this.compactCalls += 1;
+        return {
+          ok: true,
+          compacted: true,
+          result: {
+            summary: "done",
+            firstKeptEntryId: "entry-1",
+            tokensBefore: 100,
+          },
+        };
+      },
+      reset(params) {
+        expect(params).toEqual({ reason: "reset" });
+        this.resetCalls += 1;
+      },
+      dispose() {
+        this.disposeCalls += 1;
+      },
     };
 
     const v2 = adaptAgentHarnessToV2(harness);
@@ -115,8 +161,25 @@ describe("AgentHarness V2 compatibility adapter", () => {
     v2.reset?.({ reason: "reset" });
     await v2.dispose?.();
 
-    expect(compact).toHaveBeenCalledTimes(1);
-    expect(reset).toHaveBeenCalledWith({ reason: "reset" });
-    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(harness.compactCalls).toBe(1);
+    expect(harness.resetCalls).toBe(1);
+    expect(harness.disposeCalls).toBe(1);
+  });
+
+  it("does not dispose V1 harnesses during per-attempt cleanup", async () => {
+    const dispose = vi.fn();
+    const harness: AgentHarness = {
+      id: "custom",
+      label: "Custom",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+      dispose,
+    };
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(createAttemptParams()));
+
+    await v2.cleanup({ session, result: createAttemptResult() });
+
+    expect(dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -96,6 +96,28 @@ describe("AgentHarness V2 compatibility adapter", () => {
     expect(harness.classify).toHaveBeenCalledWith(result, params);
   });
 
+  it("preserves harness-supplied classification when no classify hook is registered", async () => {
+    const params = createAttemptParams();
+    const result = {
+      ...createAttemptResult(),
+      agentHarnessResultClassification: "reasoning-only",
+    } as EmbeddedRunAttemptResult;
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.resolveOutcome(session, result)).toMatchObject({
+      agentHarnessId: "codex",
+      agentHarnessResultClassification: "reasoning-only",
+    });
+  });
+
   it("clears stale non-ok classification when classification resolves to ok", async () => {
     const params = createAttemptParams();
     const result = {

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -1,0 +1,122 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
+import { adaptAgentHarnessToV2 } from "./v2.js";
+
+function createAttemptParams(): AgentHarnessAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    runId: "run-1",
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    timeoutMs: 5_000,
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: { id: "gpt-5.4", provider: "codex" } as Model<Api>,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+    thinkLevel: "low",
+  } as AgentHarnessAttemptParams;
+}
+
+function createAttemptResult(): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    externalAbort: false,
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    promptError: null,
+    promptErrorSource: null,
+    sessionIdUsed: "session-1",
+    messagesSnapshot: [],
+    assistantTexts: ["ok"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+  };
+}
+
+describe("AgentHarness V2 compatibility adapter", () => {
+  it("runs a V1 harness through prepare/start/send without changing attempt params", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      pluginId: "codex-plugin",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const prepared = await v2.prepare(params);
+    const session = await v2.start(prepared);
+
+    expect(await v2.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+    expect(session).toMatchObject({
+      harnessId: "codex",
+      label: "Codex",
+      pluginId: "codex-plugin",
+      params,
+    });
+  });
+
+  it("keeps result classification as an explicit outcome stage", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => result),
+      classify: vi.fn(() => "empty"),
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.resolveOutcome(session, result)).toMatchObject({
+      agentHarnessId: "codex",
+      agentHarnessResultClassification: "empty",
+    });
+    expect(harness.classify).toHaveBeenCalledWith(result, params);
+  });
+
+  it("preserves existing compact/reset/dispose hooks as compatibility methods", async () => {
+    const compact = vi.fn(async () => ({ ok: true, compacted: true, summary: "done" }) as const);
+    const reset = vi.fn();
+    const dispose = vi.fn();
+    const harness: AgentHarness = {
+      id: "custom",
+      label: "Custom",
+      supports: () => ({ supported: true }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+      compact,
+      reset,
+      dispose,
+    };
+
+    const v2 = adaptAgentHarnessToV2(harness);
+
+    await expect(v2.compact?.({ sessionId: "session-1" } as never)).resolves.toMatchObject({
+      compacted: true,
+    });
+    v2.reset?.({ reason: "reset" });
+    await v2.dispose?.();
+
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledWith({ reason: "reset" });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -77,7 +77,12 @@ describe("AgentHarness V2 compatibility adapter", () => {
         events.push(`outcome:${session.lifecycleState}`);
         return { ...rawResult, agentHarnessId: session.harnessId };
       },
-      cleanup: async ({ session, result: cleanupResult, error }) => {
+      cleanup: async ({ prepared, session, result: cleanupResult, error }) => {
+        expect(prepared?.lifecycleState).toBe("prepared");
+        expect(session?.lifecycleState).toBe("started");
+        if (!session) {
+          throw new Error("expected started session during successful cleanup");
+        }
         events.push(`cleanup:${session.lifecycleState}`);
         expect(cleanupResult).toMatchObject({ agentHarnessId: "native-v2" });
         expect(error).toBeUndefined();
@@ -127,8 +132,42 @@ describe("AgentHarness V2 compatibility adapter", () => {
     expect(cleanup).toHaveBeenCalledWith(
       expect.objectContaining({
         error: sendError,
+        prepared: expect.objectContaining({ lifecycleState: "prepared" }),
+        session: expect.objectContaining({ lifecycleState: "started" }),
       }),
     );
+  });
+
+  it("runs cleanup for failed prepare/start lifecycle stages", async () => {
+    const params = createAttemptParams();
+    const startError = new Error("codex app-server start failed");
+    const cleanup = vi.fn(async () => {});
+    const harness: AgentHarnessV2 = {
+      id: "native-v2",
+      label: "Native V2",
+      supports: () => ({ supported: true }),
+      prepare: async () => ({
+        harnessId: "native-v2",
+        label: "Native V2",
+        params,
+        lifecycleState: "prepared",
+      }),
+      start: async () => {
+        throw startError;
+      },
+      send: async () => createAttemptResult(),
+      resolveOutcome: async (_session, rawResult) => rawResult,
+      cleanup,
+    };
+
+    await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
+      "codex app-server start failed",
+    );
+    expect(cleanup).toHaveBeenCalledWith({
+      error: startError,
+      prepared: expect.objectContaining({ lifecycleState: "prepared" }),
+      session: undefined,
+    });
   });
 
   it("surfaces cleanup failures after successful outcomes", async () => {

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -170,6 +170,42 @@ describe("AgentHarness V2 compatibility adapter", () => {
     });
   });
 
+  it("passes raw send results to cleanup when outcome resolution fails", async () => {
+    const params = createAttemptParams();
+    const rawResult = createAttemptResult();
+    const outcomeError = new Error("outcome classification failed");
+    const cleanup = vi.fn(async () => {});
+    const harness: AgentHarnessV2 = {
+      id: "native-v2",
+      label: "Native V2",
+      supports: () => ({ supported: true }),
+      prepare: async () => ({
+        harnessId: "native-v2",
+        label: "Native V2",
+        params,
+        lifecycleState: "prepared",
+      }),
+      start: async (prepared) => ({ ...prepared, lifecycleState: "started" }),
+      send: async () => rawResult,
+      resolveOutcome: async () => {
+        throw outcomeError;
+      },
+      cleanup,
+    };
+
+    await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
+      "outcome classification failed",
+    );
+    expect(cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: outcomeError,
+        result: rawResult,
+        prepared: expect.objectContaining({ lifecycleState: "prepared" }),
+        session: expect.objectContaining({ lifecycleState: "started" }),
+      }),
+    );
+  });
+
   it("surfaces cleanup failures after successful outcomes", async () => {
     const params = createAttemptParams();
     const harness: AgentHarnessV2 = {

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -211,6 +211,7 @@ describe("AgentHarness V2 compatibility adapter", () => {
     const prepared = await v2.prepare(params);
     const session = await v2.start(prepared);
 
+    expect(v2.resume).toBeUndefined();
     expect(await v2.send(session)).toBe(result);
     expect(runAttempt).toHaveBeenCalledWith(params);
     expect(session).toMatchObject({

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -2,7 +2,8 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
 import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
-import { adaptAgentHarnessToV2 } from "./v2.js";
+import type { AgentHarnessV2 } from "./v2.js";
+import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
 
 function createAttemptParams(): AgentHarnessAttemptParams {
   return {
@@ -46,6 +47,115 @@ function createAttemptResult(): EmbeddedRunAttemptResult {
 }
 
 describe("AgentHarness V2 compatibility adapter", () => {
+  it("executes prepare/start/send/outcome/cleanup as one bounded lifecycle", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const events: string[] = [];
+    const harness: AgentHarnessV2 = {
+      id: "native-v2",
+      label: "Native V2",
+      supports: () => ({ supported: true }),
+      prepare: async (attemptParams) => {
+        events.push("prepare");
+        expect(attemptParams).toBe(params);
+        return {
+          harnessId: "native-v2",
+          label: "Native V2",
+          params,
+          lifecycleState: "prepared",
+        };
+      },
+      start: async (prepared) => {
+        events.push(`start:${prepared.lifecycleState}`);
+        return { ...prepared, lifecycleState: "started" };
+      },
+      send: async (session) => {
+        events.push(`send:${session.lifecycleState}`);
+        return result;
+      },
+      resolveOutcome: async (session, rawResult) => {
+        events.push(`outcome:${session.lifecycleState}`);
+        return { ...rawResult, agentHarnessId: session.harnessId };
+      },
+      cleanup: async ({ session, result: cleanupResult, error }) => {
+        events.push(`cleanup:${session.lifecycleState}`);
+        expect(cleanupResult).toMatchObject({ agentHarnessId: "native-v2" });
+        expect(error).toBeUndefined();
+      },
+    };
+
+    await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).resolves.toMatchObject({
+      agentHarnessId: "native-v2",
+      sessionIdUsed: "session-1",
+    });
+    expect(events).toEqual([
+      "prepare",
+      "start:prepared",
+      "send:started",
+      "outcome:started",
+      "cleanup:started",
+    ]);
+  });
+
+  it("runs cleanup with the original failure and preserves that failure", async () => {
+    const params = createAttemptParams();
+    const sendError = new Error("codex app-server send failed");
+    const cleanup = vi.fn(async () => {
+      throw new Error("cleanup should not mask send failure");
+    });
+    const harness: AgentHarnessV2 = {
+      id: "native-v2",
+      label: "Native V2",
+      supports: () => ({ supported: true }),
+      prepare: async () => ({
+        harnessId: "native-v2",
+        label: "Native V2",
+        params,
+        lifecycleState: "prepared",
+      }),
+      start: async (prepared) => ({ ...prepared, lifecycleState: "started" }),
+      send: async () => {
+        throw sendError;
+      },
+      resolveOutcome: async (_session, rawResult) => rawResult,
+      cleanup,
+    };
+
+    await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
+      "codex app-server send failed",
+    );
+    expect(cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: sendError,
+      }),
+    );
+  });
+
+  it("surfaces cleanup failures after successful outcomes", async () => {
+    const params = createAttemptParams();
+    const harness: AgentHarnessV2 = {
+      id: "native-v2",
+      label: "Native V2",
+      supports: () => ({ supported: true }),
+      prepare: async () => ({
+        harnessId: "native-v2",
+        label: "Native V2",
+        params,
+        lifecycleState: "prepared",
+      }),
+      start: async (prepared) => ({ ...prepared, lifecycleState: "started" }),
+      send: async () => createAttemptResult(),
+      resolveOutcome: async (_session, rawResult) => rawResult,
+      cleanup: async () => {
+        throw new Error("cleanup failed");
+      },
+    };
+
+    await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
+      "cleanup failed",
+    );
+  });
+
   it("runs a V1 harness through prepare/start/send without changing attempt params", async () => {
     const params = createAttemptParams();
     const result = createAttemptResult();

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -1,3 +1,4 @@
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type {
   AgentHarness,
   AgentHarnessAttemptParams,
@@ -5,23 +6,23 @@ import type {
   AgentHarnessCompactParams,
   AgentHarnessCompactResult,
   AgentHarnessResetParams,
-  AgentHarnessResultClassification,
   AgentHarnessSupport,
   AgentHarnessSupportContext,
 } from "./types.js";
 
-export type AgentHarnessV2PreparedRun = {
+type AgentHarnessV2RunBase = {
   harnessId: string;
   label: string;
   pluginId?: string;
   params: AgentHarnessAttemptParams;
 };
 
-export type AgentHarnessV2Session = {
-  harnessId: string;
-  label: string;
-  pluginId?: string;
-  params: AgentHarnessAttemptParams;
+export type AgentHarnessV2PreparedRun = AgentHarnessV2RunBase & {
+  lifecycleState: "prepared";
+};
+
+export type AgentHarnessV2Session = AgentHarnessV2RunBase & {
+  lifecycleState: "started";
 };
 
 export type AgentHarnessV2ToolCall = {
@@ -57,9 +58,6 @@ export type AgentHarnessV2 = {
 };
 
 export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
-  const compact = harness.compact;
-  const reset = harness.reset;
-  const dispose = harness.dispose;
   return {
     id: harness.id,
     label: harness.label,
@@ -70,39 +68,25 @@ export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
       label: harness.label,
       pluginId: harness.pluginId,
       params,
+      lifecycleState: "prepared",
     }),
     start: async (prepared) => ({
       harnessId: prepared.harnessId,
       label: prepared.label,
       pluginId: prepared.pluginId,
       params: prepared.params,
+      lifecycleState: "started",
     }),
     resume: async (session) => session,
     send: async (session) => harness.runAttempt(session.params),
     resolveOutcome: async (session, result) =>
-      applyAgentHarnessV2Classification(harness, result, session.params),
-    cleanup: async () => {},
-    compact: compact ? (params) => compact(params) : undefined,
-    reset: reset ? (params) => reset(params) : undefined,
-    dispose: dispose ? () => dispose() : undefined,
-  };
-}
-
-export function applyAgentHarnessV2Classification(
-  harness: Pick<AgentHarness, "id" | "classify">,
-  result: AgentHarnessAttemptResult,
-  params: AgentHarnessAttemptParams,
-): AgentHarnessAttemptResult {
-  const classification = harness.classify?.(result, params);
-  if (!classification || classification === "ok") {
-    return { ...result, agentHarnessId: harness.id };
-  }
-  return {
-    ...result,
-    agentHarnessId: harness.id,
-    agentHarnessResultClassification: classification as Exclude<
-      AgentHarnessResultClassification,
-      "ok"
-    >,
+      applyAgentHarnessResultClassification(harness, result, session.params),
+    cleanup: async (_params) => {
+      // V1 harnesses have no per-attempt cleanup hook. Global cleanup remains
+      // on dispose(), which must not run after every attempt.
+    },
+    compact: harness.compact ? (params) => harness.compact!(params) : undefined,
+    reset: harness.reset ? (params) => harness.reset!(params) : undefined,
+    dispose: harness.dispose ? () => harness.dispose!() : undefined,
   };
 }

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -1,0 +1,108 @@
+import type {
+  AgentHarness,
+  AgentHarnessAttemptParams,
+  AgentHarnessAttemptResult,
+  AgentHarnessCompactParams,
+  AgentHarnessCompactResult,
+  AgentHarnessResetParams,
+  AgentHarnessResultClassification,
+  AgentHarnessSupport,
+  AgentHarnessSupportContext,
+} from "./types.js";
+
+export type AgentHarnessV2PreparedRun = {
+  harnessId: string;
+  label: string;
+  pluginId?: string;
+  params: AgentHarnessAttemptParams;
+};
+
+export type AgentHarnessV2Session = {
+  harnessId: string;
+  label: string;
+  pluginId?: string;
+  params: AgentHarnessAttemptParams;
+};
+
+export type AgentHarnessV2ToolCall = {
+  id?: string;
+  name: string;
+  input?: unknown;
+};
+
+export type AgentHarnessV2CleanupParams = {
+  session: AgentHarnessV2Session;
+  result?: AgentHarnessAttemptResult;
+  error?: unknown;
+};
+
+export type AgentHarnessV2 = {
+  id: string;
+  label: string;
+  pluginId?: string;
+  supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;
+  prepare(params: AgentHarnessAttemptParams): Promise<AgentHarnessV2PreparedRun>;
+  start(prepared: AgentHarnessV2PreparedRun): Promise<AgentHarnessV2Session>;
+  resume?(session: AgentHarnessV2Session): Promise<AgentHarnessV2Session>;
+  send(session: AgentHarnessV2Session): Promise<AgentHarnessAttemptResult>;
+  handleToolCall?(session: AgentHarnessV2Session, call: AgentHarnessV2ToolCall): Promise<unknown>;
+  resolveOutcome(
+    session: AgentHarnessV2Session,
+    result: AgentHarnessAttemptResult,
+  ): Promise<AgentHarnessAttemptResult>;
+  cleanup(params: AgentHarnessV2CleanupParams): Promise<void>;
+  compact?(params: AgentHarnessCompactParams): Promise<AgentHarnessCompactResult | undefined>;
+  reset?(params: AgentHarnessResetParams): Promise<void> | void;
+  dispose?(): Promise<void> | void;
+};
+
+export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
+  const compact = harness.compact;
+  const reset = harness.reset;
+  const dispose = harness.dispose;
+  return {
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+    supports: (ctx) => harness.supports(ctx),
+    prepare: async (params) => ({
+      harnessId: harness.id,
+      label: harness.label,
+      pluginId: harness.pluginId,
+      params,
+    }),
+    start: async (prepared) => ({
+      harnessId: prepared.harnessId,
+      label: prepared.label,
+      pluginId: prepared.pluginId,
+      params: prepared.params,
+    }),
+    resume: async (session) => session,
+    send: async (session) => harness.runAttempt(session.params),
+    resolveOutcome: async (session, result) =>
+      applyAgentHarnessV2Classification(harness, result, session.params),
+    cleanup: async () => {},
+    compact: compact ? (params) => compact(params) : undefined,
+    reset: reset ? (params) => reset(params) : undefined,
+    dispose: dispose ? () => dispose() : undefined,
+  };
+}
+
+export function applyAgentHarnessV2Classification(
+  harness: Pick<AgentHarness, "id" | "classify">,
+  result: AgentHarnessAttemptResult,
+  params: AgentHarnessAttemptParams,
+): AgentHarnessAttemptResult {
+  const classification = harness.classify?.(result, params);
+  if (!classification || classification === "ok") {
+    return { ...result, agentHarnessId: harness.id };
+  }
+  return {
+    ...result,
+    agentHarnessId: harness.id,
+    agentHarnessResultClassification: classification as Exclude<
+      AgentHarnessResultClassification,
+      "ok"
+    >,
+  };
+}

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -90,3 +90,30 @@ export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
     dispose: harness.dispose ? () => harness.dispose!() : undefined,
   };
 }
+
+export async function runAgentHarnessV2LifecycleAttempt(
+  harness: AgentHarnessV2,
+  params: AgentHarnessAttemptParams,
+): Promise<AgentHarnessAttemptResult> {
+  const prepared = await harness.prepare(params);
+  const session = await harness.start(prepared);
+  let result: AgentHarnessAttemptResult;
+
+  try {
+    const rawResult = await harness.send(session);
+    result = await harness.resolveOutcome(session, rawResult);
+  } catch (error) {
+    try {
+      await harness.cleanup({ session, error });
+    } catch (cleanupError) {
+      // Preserve the user-visible harness failure. Cleanup errors after a
+      // failed send/outcome should be observable in future telemetry, but they
+      // must not mask the actionable runtime error.
+      void cleanupError;
+    }
+    throw error;
+  }
+
+  await harness.cleanup({ session, result });
+  return result;
+}

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -82,7 +82,6 @@ export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
       params: prepared.params,
       lifecycleState: "started",
     }),
-    resume: async (session) => session,
     send: async (session) => harness.runAttempt(session.params),
     resolveOutcome: async (session, result) =>
       applyAgentHarnessResultClassification(harness, result, session.params),

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -36,8 +36,8 @@ export type AgentHarnessV2ToolCall = {
 };
 
 export type AgentHarnessV2CleanupParams = {
-  prepared?: AgentHarnessV2PreparedRun | undefined;
-  session?: AgentHarnessV2Session | undefined;
+  prepared?: AgentHarnessV2PreparedRun;
+  session?: AgentHarnessV2Session;
   result?: AgentHarnessAttemptResult;
   error?: unknown;
 };
@@ -101,16 +101,22 @@ export async function runAgentHarnessV2LifecycleAttempt(
 ): Promise<AgentHarnessAttemptResult> {
   let prepared: AgentHarnessV2PreparedRun | undefined;
   let session: AgentHarnessV2Session | undefined;
+  let rawResult: AgentHarnessAttemptResult | undefined;
   let result: AgentHarnessAttemptResult;
 
   try {
     prepared = await harness.prepare(params);
     session = await harness.start(prepared);
-    const rawResult = await harness.send(session);
+    rawResult = await harness.send(session);
     result = await harness.resolveOutcome(session, rawResult);
   } catch (error) {
     try {
-      await harness.cleanup({ prepared, session, error });
+      await harness.cleanup({
+        prepared,
+        session,
+        error,
+        ...(rawResult === undefined ? {} : { result: rawResult }),
+      });
     } catch (cleanupError) {
       // Preserve the user-visible harness failure. Cleanup errors after a
       // failed lifecycle stage must not mask the actionable runtime error.

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -36,7 +36,8 @@ export type AgentHarnessV2ToolCall = {
 };
 
 export type AgentHarnessV2CleanupParams = {
-  session: AgentHarnessV2Session;
+  prepared?: AgentHarnessV2PreparedRun | undefined;
+  session?: AgentHarnessV2Session | undefined;
   result?: AgentHarnessAttemptResult;
   error?: unknown;
 };
@@ -99,19 +100,21 @@ export async function runAgentHarnessV2LifecycleAttempt(
   harness: AgentHarnessV2,
   params: AgentHarnessAttemptParams,
 ): Promise<AgentHarnessAttemptResult> {
-  const prepared = await harness.prepare(params);
-  const session = await harness.start(prepared);
+  let prepared: AgentHarnessV2PreparedRun | undefined;
+  let session: AgentHarnessV2Session | undefined;
   let result: AgentHarnessAttemptResult;
 
   try {
+    prepared = await harness.prepare(params);
+    session = await harness.start(prepared);
     const rawResult = await harness.send(session);
     result = await harness.resolveOutcome(session, rawResult);
   } catch (error) {
     try {
-      await harness.cleanup({ session, error });
+      await harness.cleanup({ prepared, session, error });
     } catch (cleanupError) {
       // Preserve the user-visible harness failure. Cleanup errors after a
-      // failed send/outcome must not mask the actionable runtime error.
+      // failed lifecycle stage must not mask the actionable runtime error.
       log.warn("agent harness cleanup failed after attempt failure", {
         harnessId: harness.id,
         provider: params.provider,
@@ -123,6 +126,6 @@ export async function runAgentHarnessV2LifecycleAttempt(
     throw error;
   }
 
-  await harness.cleanup({ session, result });
+  await harness.cleanup({ prepared, session, result });
   return result;
 }

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -1,3 +1,5 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type {
   AgentHarness,
@@ -9,6 +11,8 @@ import type {
   AgentHarnessSupport,
   AgentHarnessSupportContext,
 } from "./types.js";
+
+const log = createSubsystemLogger("agents/harness/v2");
 
 type AgentHarnessV2RunBase = {
   harnessId: string;
@@ -107,9 +111,14 @@ export async function runAgentHarnessV2LifecycleAttempt(
       await harness.cleanup({ session, error });
     } catch (cleanupError) {
       // Preserve the user-visible harness failure. Cleanup errors after a
-      // failed send/outcome should be observable in future telemetry, but they
-      // must not mask the actionable runtime error.
-      void cleanupError;
+      // failed send/outcome must not mask the actionable runtime error.
+      log.warn("agent harness cleanup failed after attempt failure", {
+        harnessId: harness.id,
+        provider: params.provider,
+        modelId: params.modelId,
+        error: formatErrorMessage(cleanupError),
+        originalError: formatErrorMessage(error),
+      });
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Follow-up to #71222, #71096, and RFC #71004. This PR routes selected harness attempts through the V2 lifecycle executor instead of calling `runAttempt` directly from selection.

The harness registry and selection policy stay unchanged. Selected V1 harnesses are adapted to V2, then executed as `prepare -> start -> send -> resolveOutcome -> cleanup`.

## RuntimePlan Package Context

This is the lifecycle execution rung. #71222 introduced the V2 adapter shape; this PR puts that shape on the selected-harness hot path so future cleanup, telemetry, session policy, and outcome classification have one execution boundary.

```mermaid
flowchart TD
  RFC["#71004 RFC"] --> Base["#71096 RuntimePlan merged"]
  Base --> Adapter["#71222 Harness V2 adapter"]
  Adapter --> This["#71238 selection executes through V2 lifecycle"]
  This --> Outcome["#71239 shared terminal outcome classifier"]
  Base --> ToolPolicy["#71220 shared tool policy"]
  ToolPolicy --> Transcript["#71223 transcript resolver"]
  Transcript --> Alias["#71224 embedded-runner alias"]
```

Review package links: #71196, #71197, #71201, #71220, #71222, #71223, #71224, #71238, #71239.

## Local Architecture

```mermaid
sequenceDiagram
  participant Selection as Harness selection
  participant Adapter as adaptAgentHarnessToV2
  participant V2 as runAgentHarnessV2LifecycleAttempt
  participant Harness as Selected harness

  Selection->>Adapter: selected AgentHarness
  Adapter-->>Selection: AgentHarnessV2
  Selection->>V2: execute lifecycle
  V2->>Harness: prepare
  V2->>Harness: start
  V2->>Harness: send
  V2->>Harness: resolveOutcome
  V2->>Harness: cleanup
```

## Why This PR Exists

#71004 calls out that Codex should own its model-loop lifecycle, while OpenClaw should own runtime policy and lifecycle boundaries. This PR does not move ownership into Codex; it gives OpenClaw one bounded lifecycle wrapper around selected Pi/plugin harness execution while preserving the existing registry and fallback semantics.

## What Changed

- Added `runAgentHarnessV2LifecycleAttempt(...)` in `src/agents/harness/v2.ts`.
- Updated `runAgentHarnessAttemptWithFallback(...)` to adapt the selected harness and execute through the V2 lifecycle.
- Preserved existing plugin-failure behavior: plugin harness failures are surfaced, not replayed through Pi.
- Added lifecycle tests for ordered prepare/start/send/outcome/cleanup.
- Added cleanup coverage for send/outcome/start failures and cleanup-failure surfacing after success.
- Preserved existing V1 adapter compatibility.

## Maintainer Review Guide

- Highest-signal files: `src/agents/harness/v2.ts`, `src/agents/harness/selection.ts`, `src/agents/harness/v2.test.ts`.
- Check selection decision logic is unchanged; only execution after selection is routed through V2.
- Check plugin failure behavior remains non-fallback-to-Pi.
- Check cleanup is best-effort on failure and does not mask the original harness error.
- Check V1 harness `this` binding and optional hooks remain compatible.

## What Did Not Change

- No Harness V1 removal.
- No native Pi/Codex V2 implementations yet; this adapts existing V1 harnesses.
- No runner rename or file split.
- No WS pooling.
- No work on frozen prototype PRs #70743 or #70772.

## Verification

- `./node_modules/.bin/vitest run src/agents/harness/v2.test.ts src/agents/harness/selection.test.ts --config test/vitest/vitest.agents.config.ts`
- `./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json src/agents/harness/v2.ts src/agents/harness/selection.ts src/agents/harness/v2.test.ts src/agents/harness/selection.test.ts`
- `git diff --check`
- `pnpm check:architecture`

This PR is logically stacked after #71222. Until #71222 merges, GitHub may show that adapter foundation in the diff as well.
