### PR TITLE
fix(gateway): fall back to lastCallUsage on /v1/chat/completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 - Discord/gateway: prevent startup from getting stuck at `awaiting gateway readiness` when Carbon gateway registration races with a lifecycle reconnect. Fixes #52372. (#68159) Thanks @IVY-AI-gif.
 - Plugins/cache: restore plugin command and interactive handler registries on loader cache hits, so cached external plugins keep slash commands and callback handlers available after reloads. Fixes #71100. Thanks @BomBastikDE.
+- Gateway/OpenAI-compatible: report non-zero token usage for `/v1/chat/completions` when the agent run has only last-call usage metadata available. Fixes #71118. (#71242) Thanks @RenzoMXD.
 - Plugin SDK/tool-result transforms: restrict harness tool-result middleware to bundled plugins, fail closed on middleware errors, validate rewritten result shapes, preserve Pi per-call ids, and keep Codex media trust checks anchored to raw tool provenance. Thanks @vincentkoc.
 - Gateway/MCP loopback: apply owner-only tool policy and run before-tool-call hooks on `127.0.0.1/mcp` `tools/list` and `tools/call`, so non-owner bearer callers can no longer see or invoke owner-only tools such as `cron`, `gateway`, and `nodes`, matching the existing HTTP `/tools/invoke` and embedded-agent paths. (#71159) Thanks @mmaps.
 - Codex harness/security: wait for final app-server approval decisions and sanitize approval preview text, so native Codex permission prompts cannot be resolved by an early placeholder decision or render unsafe terminal/control content. (#70751, #70569) Thanks @Lucenx9.

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ImageContent } from "../agents/command/types.js";
-import { normalizeUsage, toOpenAiChatCompletionsUsage } from "../agents/usage.js";
+import {
+  hasNonzeroUsage,
+  normalizeUsage,
+  toOpenAiChatCompletionsUsage,
+  type NormalizedUsage,
+} from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
@@ -369,6 +374,7 @@ async function resolveImagesForRequest(
 export const __testOnlyOpenAiHttp = {
   resolveImagesForRequest,
   resolveOpenAiChatCompletionsLimits,
+  resolveChatCompletionUsage,
 };
 
 function buildAgentPrompt(
@@ -466,16 +472,26 @@ type AgentUsageMeta = {
   total?: number;
 };
 
-function resolveRawAgentUsage(result: unknown): AgentUsageMeta | undefined {
-  return (
+function resolveAgentRunUsage(result: unknown): NormalizedUsage | undefined {
+  const agentMeta = (
     result as {
       meta?: {
         agentMeta?: {
           usage?: AgentUsageMeta;
+          lastCallUsage?: AgentUsageMeta;
         };
       };
     } | null
-  )?.meta?.agentMeta?.usage;
+  )?.meta?.agentMeta;
+  const primary = normalizeUsage(agentMeta?.usage);
+  if (hasNonzeroUsage(primary)) {
+    return primary;
+  }
+  const fallback = normalizeUsage(agentMeta?.lastCallUsage);
+  if (hasNonzeroUsage(fallback)) {
+    return fallback;
+  }
+  return primary ?? fallback;
 }
 
 function resolveChatCompletionUsage(result: unknown): {
@@ -483,7 +499,7 @@ function resolveChatCompletionUsage(result: unknown): {
   completion_tokens: number;
   total_tokens: number;
 } {
-  return toOpenAiChatCompletionsUsage(normalizeUsage(resolveRawAgentUsage(result)));
+  return toOpenAiChatCompletionsUsage(resolveAgentRunUsage(result));
 }
 
 function resolveIncludeUsageForStreaming(payload: OpenAiChatCompletionRequest): boolean {

--- a/src/gateway/openai-http.usage.test.ts
+++ b/src/gateway/openai-http.usage.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { __testOnlyOpenAiHttp } from "./openai-http.js";
+
+const { resolveChatCompletionUsage } = __testOnlyOpenAiHttp;
+
+describe("resolveChatCompletionUsage", () => {
+  it("maps agentMeta.usage to OpenAI prompt/completion/total fields", () => {
+    const result = {
+      meta: {
+        agentMeta: {
+          usage: { input: 120, output: 42, cacheRead: 10, total: 172 },
+        },
+      },
+    };
+
+    expect(resolveChatCompletionUsage(result)).toEqual({
+      prompt_tokens: 130,
+      completion_tokens: 42,
+      total_tokens: 172,
+    });
+  });
+
+  it("falls back to agentMeta.lastCallUsage when agentMeta.usage is missing", () => {
+    const result = {
+      meta: {
+        agentMeta: {
+          lastCallUsage: { input: 80, output: 20, total: 100 },
+        },
+      },
+    };
+
+    expect(resolveChatCompletionUsage(result)).toEqual({
+      prompt_tokens: 80,
+      completion_tokens: 20,
+      total_tokens: 100,
+    });
+  });
+
+  it("falls back to agentMeta.lastCallUsage when agentMeta.usage is all zero", () => {
+    const result = {
+      meta: {
+        agentMeta: {
+          usage: { input: 0, output: 0, total: 0 },
+          lastCallUsage: { input: 55, output: 7, total: 62 },
+        },
+      },
+    };
+
+    expect(resolveChatCompletionUsage(result)).toEqual({
+      prompt_tokens: 55,
+      completion_tokens: 7,
+      total_tokens: 62,
+    });
+  });
+
+  it("returns zeros when both agentMeta.usage and lastCallUsage are absent", () => {
+    const result = { meta: { agentMeta: {} } };
+
+    expect(resolveChatCompletionUsage(result)).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+
+  it("returns zeros when the result has no meta at all", () => {
+    expect(resolveChatCompletionUsage({})).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+    expect(resolveChatCompletionUsage(null)).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `/v1/chat/completions` returns `usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }` even when the upstream provider reported real counts (reproduced by #71118 on Gemini and Anthropic direct providers).
- **Why it matters:** OpenAI-compatible clients depend on `usage` for cost accounting, context budgeting, and UI display. Zeros silently break those integrations.
- **What changed:** `resolveChatCompletionUsage` in `src/gateway/openai-http.ts` now falls back to `agentMeta.lastCallUsage` when `agentMeta.usage` is missing or all-zero. `lastCallUsage` is the same source the `llm_output` plugin hook already receives.
- **What did NOT change (scope boundary):** No changes to runner internals (`src/agents/pi-embedded-runner/**`), plugin SDK, provider plugins, auth, or any wire protocol. Fix stays at the HTTP seam.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71118
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `resolveChatCompletionUsage` reads only `result.meta.agentMeta.usage`. That field is populated from the embedded runner's `usageAccumulator` (`toNormalizedUsage(usageAccumulator)` in `pi-embedded-runner/run.ts:1740`). On provider streaming paths where the accumulator is not fed, the field is `undefined` → `normalizeUsage(undefined)` → `undefined` → `toOpenAiChatCompletionsUsage(undefined)` → `{ 0, 0, 0 }`.
- **Missing detection / guardrail:** No unit test exercised the "accumulator empty but last-call usage present" shape before this PR.
- **Contributing context:** `EmbeddedPiAgentMeta.lastCallUsage` is populated via `normalizeUsage(lastAssistant.usage) ?? toLastCallUsage(accumulator)` — the same source the `llm_output` hook reads, so the data was always in-process; we just weren't consuming it at the HTTP seam.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/gateway/openai-http.usage.test.ts` (new).
- **Scenario the test should lock in:** HTTP response `usage` carries non-zero tokens when `agentMeta.usage` is missing but `agentMeta.lastCallUsage` is populated; still returns zeros when both are absent.
- **Why this is the smallest reliable guardrail:** `resolveChatCompletionUsage` is a pure function over a result shape. A unit test is deterministic, ~10 ms per case, and covers every branch of the fallback precedence. No gateway bootstrap needed.
- **Existing test that already covers this:** None.
- **If no new test is added, why not:** N/A — 5 new cases added.

## User-visible / Behavior Changes

`/v1/chat/completions` response `usage` now returns real `prompt_tokens` / `completion_tokens` / `total_tokens` on provider paths that previously reported zeros. No config change required. No flag. No contract change on the wire.

## Diagram

```text
Before:
agent run → agentMeta.usage = undefined        → usage: {0, 0, 0}  (wrong)
                            ↓ (never read)
             agentMeta.lastCallUsage = { input:80, output:20 }

After:
agent run → agentMeta.usage = undefined
                            ↓ (fallback)
             agentMeta.lastCallUsage = { input:80, output:20 }  → usage: {80, 20, 100}
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** — same data (token counts) already surfaced to the `llm_output` plugin hook.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04, kernel 6.8.0-110)
- Runtime: Node 25.9.0, pnpm 10.33.0
- Model/provider: unit tests use a synthetic `RunResult` shape; the #71118 report names Gemini and Anthropic direct providers on OpenClaw 2026.4.2 (macOS 14 arm64).
- Integration/channel: OpenAI-compatible HTTP (`/v1/chat/completions`).
- Relevant config: `gateway.http.endpoints.chatCompletions.enabled = true`.

### Steps

1. `pnpm test src/gateway/openai-http.usage.test.ts` on `main` — the `"falls back to agentMeta.lastCallUsage when agentMeta.usage is missing"` and `"... is all zero"` cases fail with `{0, 0, 0}`.
2. Apply the patch.
3. Re-run — 5/5 pass.

### Expected

`usage.prompt_tokens` and `usage.completion_tokens` reflect `lastCallUsage` when the accumulator is empty.

### Actual (before fix)

`usage.prompt_tokens = 0`, `usage.completion_tokens = 0`.

## Evidence

- [x] Failing test/log before + passing after (unit tests in `openai-http.usage.test.ts`)
- [x] Trace/log snippets (covered by tests — deterministic shape, no log capture needed)
- [ ] Screenshot/recording (N/A — JSON response field)
- [ ] Perf numbers (N/A)

## Human Verification

- **Verified scenarios:**
  - `agentMeta.usage` populated → pass-through unchanged.
  - `agentMeta.usage` missing, `lastCallUsage` populated → fallback used.
  - `agentMeta.usage` all-zero, `lastCallUsage` populated → fallback used.
  - Both absent → `{0, 0, 0}` preserved.
  - `null` / `{}` result → `{0, 0, 0}` preserved.
- **Edge cases checked:** zero-valued totals in `lastCallUsage` (fallback still picks a field with tokens via `hasNonzeroUsage`); `null` result; missing `meta`.
- **What I did not verify:** live end-to-end HTTP smoke on a Gemini/Anthropic direct provider (no key available on this box). Attempted Ollama smoke on CPU — same timeout occurred on unmodified `main` due to provider-harness latency (~5 min for a 2-token reply), unrelated to this fix. The deterministic unit tests reproduce the exact bug shape from the issue report.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** `lastCallUsage` carries only the last provider call's tokens, so a multi-call tool-loop run that also has an empty accumulator would under-report the aggregate.
  - **Mitigation:** The `agentMeta.usage` primary is used whenever it carries real data — the fallback only engages when the primary is missing or all-zero, at which point `lastCallUsage` is strictly more accurate than `{0, 0, 0}`. This is a Pareto improvement over current behavior, not a regression for any case.

---
