### PR TITLE
fix: back off between plugin runtime deps install retries

### DIFF
--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -1063,6 +1063,17 @@ function installPluginRuntimeDepsWithRetries(params) {
       if (attempt === attempts) {
         break;
       }
+      // Back off before retrying. Plugin staging failures are often transient
+      // filesystem races — for example npm's internal rmdir hitting ENOTEMPTY
+      // on a shared transitive dep (bare-os/prebuilds) while a concurrent
+      // install pass has the directory momentarily non-empty. Without a delay
+      // the immediate retry tends to hit the same state and fails again,
+      // exhausting all attempts on what is really a recoverable race.
+      const delayIndex = Math.min(attempt - 1, TEMP_REMOVE_RETRY_DELAYS_MS.length - 1);
+      const delay = TEMP_REMOVE_RETRY_DELAYS_MS[delayIndex];
+      if (delay !== undefined && delay > 0) {
+        sleepSync(delay);
+      }
     }
   }
   throw lastError;


### PR DESCRIPTION
## Summary

`installPluginRuntimeDepsWithRetries` retries the per-plugin staging up to 3 times, but with **no delay between attempts**. When the failure is a transient filesystem race — for example npm's internal `rmdir` hitting `ENOTEMPTY` on a shared transitive dep like `bare-os/prebuilds` while a concurrent install pass has the directory momentarily non-empty — the immediate retry hits the same state and fails again, exhausting all 3 attempts on what is really a recoverable race.

This PR reuses the existing `TEMP_REMOVE_RETRY_DELAYS_MS = [10, 25, 50]` backoff ladder already declared at the top of the module (used by `removeStaleRuntimeDepsTempDirs`), sleeping the corresponding delay after each failed attempt before retrying.

## Why this approach

- **Tiny surface area**: 11 lines, one function, no new imports.
- **Uses existing constants**: `TEMP_REMOVE_RETRY_DELAYS_MS` and `sleepSync` are already defined and battle-tested in the filesystem-level retry path above.
- **Preserves failure semantics**: if all 3 attempts still fail, `lastError` is thrown identically to before. Consumers see no behaviour change when the issue is genuinely permanent.
- **No concurrency changes**: doesn't touch the actual install logic, the npm invocation, or parallelism. Just gives the filesystem a beat to settle.
- **Windows-safe**: the Windows-specific fix in `v2026.4.23` release notes addressed the aliasing path; this complements it by hardening the retry loop for any transient rmdir/rename contention that slips through on any OS.

## Repro

Reported as [#71244](https://github.com/openclaw/openclaw/issues/71244):

1. Linux host running gateway + node services on `v2026.4.22` with the full plugin set (`acpx`, `browser`, `discord`, …).
2. Upgrade the package to `v2026.4.23`.
3. Restart services — gateway does its first bundled runtime deps staging for the new version dir.
4. `acpx` install fails with:

   ```
   npm error code ENOTEMPTY
   npm error syscall rmdir
   npm error path ~/.openclaw/plugin-runtime-deps/openclaw-2026.4.23-<hash>/node_modules/bare-os/prebuilds
   npm error ENOTEMPTY: directory not empty
   ```

5. Re-staging after `rm -rf ~/.openclaw/plugin-runtime-deps/openclaw-2026.4.23-*` + restart succeeds — which matches the "it's transient, a retry would fix it" hypothesis.

## Test plan

- [x] Patch applied and module re-exports unchanged.
- [ ] Maintainer-run: existing test suite for `stage-bundled-plugin-runtime-deps.mjs` passes unchanged (no test changes needed — the only behaviour observable to consumers is total latency under failure, not correctness).
- [ ] Optional: add a unit test that asserts `installPluginRuntimeDepsWithRetries` calls `sleepSync` between failed attempts with the declared backoff values. Happy to add on request.

## Alternatives considered

- **Serialize plugin staging** — would also remove the race but changes concurrency semantics globally and slows first-boot latency.
- **Detect specific npm stderr codes and only retry on `ENOTEMPTY|EBUSY|EPERM`** — more precise but adds stderr parsing surface; current `attempts = 3` already retries unconditionally, so backing off before each retry is a strict improvement without narrowing the retry scope.
- **Per-plugin isolated `node_modules`** — the "correct" refactor long-term but out of scope for a hotfix; this PR unblocks users on the current architecture.

Fixes #71244.