### PR TITLE
feat(plugins): warn on ignored setup runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Plugin hooks: expose first-class run, message, sender, session, and trace correlation fields on message hook contexts and run lifecycle events. Thanks @vincentkoc.
 - Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups and warn non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata. Thanks @vincentkoc.
 - Plugins/setup: surface manifest provider auth choices directly in provider setup flow before falling back to setup runtime or install-catalog choices. Thanks @vincentkoc.
+- Plugins/setup: warn when descriptor-only setup plugins still ship ignored setup runtime entries, keeping `setup.requiresRuntime: false` semantics explicit without breaking existing metadata. Thanks @vincentkoc.
 - TUI/dependencies: remove direct `cli-highlight` usage from the OpenClaw TUI code-block renderer, keeping themed code coloring without the extra root dependency. Thanks @vincentkoc.
 - Diagnostics/OTEL: export run, model-call, and tool-execution diagnostic lifecycle events as OTEL spans without retaining live span state. Thanks @vincentkoc.
 - Providers/Anthropic Vertex: move the Vertex SDK runtime behind the bundled provider plugin so core no longer owns that provider-specific dependency. Thanks @vincentkoc.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -337,9 +337,11 @@ on `setup.providers[].envVars`.
 
 Set `requiresRuntime: false` only when those descriptors are sufficient for the
 setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
-and will not execute `setup-api` for setup lookup. Omitted `requiresRuntime`
-keeps legacy fallback behavior so existing plugins that added descriptors
-without the flag do not break.
+and will not execute `setup-api` or `openclaw.setupEntry` for setup lookup. If
+a descriptor-only plugin still ships one of those setup runtime entries,
+OpenClaw reports an additive diagnostic and continues ignoring it. Omitted
+`requiresRuntime` keeps legacy fallback behavior so existing plugins that added
+descriptors without the flag do not break.
 
 Because setup lookup can execute plugin-owned `setup-api` code, normalized
 `setup.providers[].id` and `setup.cliBackends[]` values must stay unique across

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -388,6 +388,37 @@ describe("setup-registry getJiti", () => {
     expect(mocks.createJiti).not.toHaveBeenCalled();
   });
 
+  it("does not report descriptor-only diagnostics for bundled setup-api fallback paths", () => {
+    const parentDir = makeTempDir();
+    const pluginRoot = path.join(parentDir, "openai");
+    fs.mkdirSync(pluginRoot);
+    expect(fs.existsSync(path.join(process.cwd(), "extensions", "openai", "setup-api.ts"))).toBe(
+      true,
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-openai",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "workspace-openai" }],
+            requiresRuntime: false,
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(resolvePluginSetupRegistry({ env: {} })).toEqual({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    });
+    expect(mocks.createJiti).not.toHaveBeenCalled();
+  });
+
   it("reports setup descriptor drift without rejecting runtime registrations", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -378,7 +378,12 @@ describe("setup-registry getJiti", () => {
       cliBackends: [],
       configMigrations: [],
       autoEnableProbes: [],
-      diagnostics: [],
+      diagnostics: [
+        expect.objectContaining({
+          pluginId: "openai",
+          code: "setup-descriptor-runtime-disabled",
+        }),
+      ],
     });
     expect(mocks.createJiti).not.toHaveBeenCalled();
   });

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -47,6 +47,7 @@ type SetupAutoEnableProbeEntry = {
 };
 
 export type PluginSetupRegistryDiagnosticCode =
+  | "setup-descriptor-runtime-disabled"
   | "setup-descriptor-provider-missing-runtime"
   | "setup-descriptor-provider-runtime-undeclared"
   | "setup-descriptor-cli-backend-missing-runtime"
@@ -283,6 +284,10 @@ function resolveRegister(mod: OpenClawPluginModule): {
   return {};
 }
 
+function resolveSetupRuntimeSource(record: PluginManifestRecord): string | null {
+  return record.setupSource ?? resolveSetupApiPath(record.rootDir);
+}
+
 function resolveSetupRegistration(record: PluginManifestRecord): {
   setupSource: string;
   register: (api: ReturnType<typeof buildPluginApi>) => void | Promise<void>;
@@ -290,7 +295,7 @@ function resolveSetupRegistration(record: PluginManifestRecord): {
   if (record.setup?.requiresRuntime === false) {
     return null;
   }
-  const setupSource = record.setupSource ?? resolveSetupApiPath(record.rootDir);
+  const setupSource = resolveSetupRuntimeSource(record);
   if (!setupSource) {
     return null;
   }
@@ -399,6 +404,24 @@ function mapNormalizedIds(ids: readonly string[]): Map<string, string> {
   return mapped;
 }
 
+function pushDescriptorRuntimeDisabledDiagnostic(params: {
+  record: PluginManifestRecord;
+  diagnostics: PluginSetupRegistryDiagnostic[];
+}): void {
+  if (params.record.setup?.requiresRuntime !== false) {
+    return;
+  }
+  if (!resolveSetupRuntimeSource(params.record)) {
+    return;
+  }
+  params.diagnostics.push({
+    pluginId: params.record.id,
+    code: "setup-descriptor-runtime-disabled",
+    message:
+      "setup.requiresRuntime is false, so OpenClaw ignored the plugin setup runtime entry. Remove setup-api/openclaw.setupEntry or set requiresRuntime true if setup lookup still needs plugin code.",
+  });
+}
+
 function pushSetupDescriptorDriftDiagnostics(params: {
   record: PluginManifestRecord;
   providers: readonly ProviderPlugin[];
@@ -502,6 +525,13 @@ export function resolvePluginSetupRegistry(params?: {
 
   for (const record of manifestRegistry.plugins) {
     if (selectedPluginIds && !selectedPluginIds.has(record.id)) {
+      continue;
+    }
+    if (record.setup?.requiresRuntime === false) {
+      pushDescriptorRuntimeDisabledDiagnostic({
+        record,
+        diagnostics,
+      });
       continue;
     }
     const setupRegistration = resolveSetupRegistration(record);

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -291,7 +291,7 @@ function resolveRegister(mod: OpenClawPluginModule): {
   return {};
 }
 
-function resolveSetupRuntimeSource(record: PluginManifestRecord): string | null {
+function resolveLoadableSetupRuntimeSource(record: PluginManifestRecord): string | null {
   return record.setupSource ?? resolveSetupApiPath(record.rootDir);
 }
 
@@ -311,7 +311,7 @@ function resolveSetupRegistration(record: PluginManifestRecord): {
   if (record.setup?.requiresRuntime === false) {
     return null;
   }
-  const setupSource = resolveSetupRuntimeSource(record);
+  const setupSource = resolveLoadableSetupRuntimeSource(record);
   if (!setupSource) {
     return null;
   }

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -190,7 +190,10 @@ function buildSetupCliBackendCacheKey(params: {
   });
 }
 
-function resolveSetupApiPath(rootDir: string): string | null {
+function resolveSetupApiPath(
+  rootDir: string,
+  options?: { includeBundledSourceFallback?: boolean },
+): string | null {
   const orderedExtensions = RUNNING_FROM_BUILT_ARTIFACT
     ? SETUP_API_EXTENSIONS
     : ([...SETUP_API_EXTENSIONS.slice(3), ...SETUP_API_EXTENSIONS.slice(0, 3)] as const);
@@ -208,6 +211,10 @@ function resolveSetupApiPath(rootDir: string): string | null {
   const direct = findSetupApi(rootDir);
   if (direct) {
     return direct;
+  }
+
+  if (options?.includeBundledSourceFallback === false) {
+    return null;
   }
 
   const bundledExtensionDir = path.basename(rootDir);
@@ -286,6 +293,15 @@ function resolveRegister(mod: OpenClawPluginModule): {
 
 function resolveSetupRuntimeSource(record: PluginManifestRecord): string | null {
   return record.setupSource ?? resolveSetupApiPath(record.rootDir);
+}
+
+function resolveDeclaredSetupRuntimeSource(record: PluginManifestRecord): string | null {
+  return (
+    record.setupSource ??
+    resolveSetupApiPath(record.rootDir, {
+      includeBundledSourceFallback: false,
+    })
+  );
 }
 
 function resolveSetupRegistration(record: PluginManifestRecord): {
@@ -408,10 +424,7 @@ function pushDescriptorRuntimeDisabledDiagnostic(params: {
   record: PluginManifestRecord;
   diagnostics: PluginSetupRegistryDiagnostic[];
 }): void {
-  if (params.record.setup?.requiresRuntime !== false) {
-    return;
-  }
-  if (!resolveSetupRuntimeSource(params.record)) {
+  if (!resolveDeclaredSetupRuntimeSource(params.record)) {
     return;
   }
   params.diagnostics.push({


### PR DESCRIPTION
## Summary

- Problem: `setup.requiresRuntime: false` already prevents setup runtime loading, but a plugin can still accidentally ship `setup-api` or `openclaw.setupEntry` and get no signal that it is ignored.
- Why it matters: descriptor-only setup should be an explicit contract, not a silent footgun during the migration away from setup runtime paths.
- What changed: add an additive setup registry diagnostic when descriptor-only setup metadata still has an ignored setup runtime entry, plus docs, changelog, and coverage.
- What did NOT change (scope boundary): legacy plugins without `requiresRuntime: false` still use the setup-api fallback path.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #71240
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Plugin authors now get an additive setup diagnostic when `setup.requiresRuntime: false` ignores a setup runtime entry.

## Diagram (if applicable)

```text
Before:
manifest requiresRuntime=false + setup-api -> setup-api ignored silently

After:
manifest requiresRuntime=false + setup-api -> setup-api ignored + diagnostic emitted
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): plugins setup registry
- Relevant config (redacted): N/A

### Steps

1. Define a plugin manifest with `setup.requiresRuntime: false`.
2. Add a setup runtime entry via `setup-api` or `openclaw.setupEntry`.
3. Resolve the setup registry.

### Expected

- Setup runtime remains ignored.
- Registry includes a diagnostic explaining the ignored runtime entry.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/plugins/setup-registry.test.ts`; `pnpm check:changed`; `pnpm build`
- Edge cases checked: descriptor-only setup still does not load `setup-api`; legacy omitted `requiresRuntime` behavior remains unchanged by existing setup registry coverage.
- What you did **not** verify: external third-party plugin package manually.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: diagnostic noise for intentionally descriptor-only plugins that forgot to remove old setup entrypoints.
  - Mitigation: diagnostic is additive and behavior remains unchanged; docs explain either remove the runtime entry or set `requiresRuntime: true`.
