### PR TITLE
fix(gateway): resume main-agent sessions orphaned by mid-loop restart

### DIFF
--- a/src/agents/main-session-orphan-recovery.test.ts
+++ b/src/agents/main-session-orphan-recovery.test.ts
@@ -230,7 +230,7 @@ describe("recoverOrphanedMainSessions", () => {
     expect(gateway.callGateway).not.toHaveBeenCalled();
   });
 
-  it("skips subagent entries (handled by subagent orphan recovery)", async () => {
+  it("skips subagent entries by spawnDepth (handled by subagent orphan recovery)", async () => {
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
       "agent:main:subagent:abc": {
         sessionId: "session-sub-1",
@@ -249,6 +249,67 @@ describe("recoverOrphanedMainSessions", () => {
 
     expect(result.recovered).toBe(0);
     expect(result.skipped).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("skips subagent entries by subagentRole when spawnDepth is unset", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:other:xyz": {
+        sessionId: "session-sub-2",
+        updatedAt: Date.now(),
+        status: "running",
+        subagentRole: "leaf",
+      } as sessions.SessionEntry,
+    });
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([
+      userText("leaf task"),
+      assistantText("running"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("skips cron runs (lifecycle owned by cron scheduler)", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:cron:daily:run:abc": {
+        sessionId: "session-cron-1",
+        updatedAt: Date.now(),
+        status: "running",
+      } as sessions.SessionEntry,
+    });
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([
+      userText("cron prompt"),
+      assistantText("running"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("skips ACP sessions (lifecycle owned by ACP control plane)", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:acp:some-acp-id": {
+        sessionId: "session-acp-1",
+        updatedAt: Date.now(),
+        status: "running",
+      } as sessions.SessionEntry,
+    });
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([
+      userText("acp request"),
+      assistantText("running"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
     expect(gateway.callGateway).not.toHaveBeenCalled();
   });
 

--- a/src/agents/main-session-orphan-recovery.test.ts
+++ b/src/agents/main-session-orphan-recovery.test.ts
@@ -25,9 +25,10 @@ vi.mock("../config/sessions.js", () => ({
       `/tmp/openclaw-test-state/agents/${opts?.agentId ?? "main"}/agent/sessions.json`,
   ),
   updateSessionStore: vi.fn(
-    async (_storePath: string, mutator: (store: Record<string, unknown>) => void) => {
+    (_storePath: string, mutator: (store: Record<string, unknown>) => void) => {
       // Invoke the mutator with an empty store so the code path stays exercised.
-      await mutator({});
+      mutator({});
+      return Promise.resolve();
     },
   ),
 }));
@@ -340,9 +341,7 @@ describe("recoverOrphanedMainSessions", () => {
         status: "running",
       } as sessions.SessionEntry,
     };
-    await (mutator as (s: Record<string, sessions.SessionEntry>) => Promise<void> | void)(
-      simulated,
-    );
+    (mutator as (s: Record<string, sessions.SessionEntry>) => void)(simulated);
     expect(simulated["agent:main:main"]?.status).toBe("failed");
     expect(simulated["agent:main:main"]?.abortedLastRun).toBe(true);
     expect(simulated["agent:main:main"]?.updatedAt).toBe(now);

--- a/src/agents/main-session-orphan-recovery.test.ts
+++ b/src/agents/main-session-orphan-recovery.test.ts
@@ -74,6 +74,16 @@ function compactionMarker(): TestMessage {
   };
 }
 
+/**
+ * The production `PROCESS_BOOT_MS` is frozen at module load, which for the
+ * test file is strictly before any test runs. Fixture sessions built with
+ * `updatedAt: Date.now()` are therefore always "after boot" by default and
+ * would be skipped by the boot-time gate. Tests that expect the scanner to
+ * act on a fixture pass `bootMs: TEST_BOOT_MS` (1 hour in the future) so the
+ * fixture's `updatedAt` looks strictly pre-boot.
+ */
+const TEST_BOOT_MS = Date.now() + 60 * 60 * 1000;
+
 function mockSingleRunningSession(
   entryOverrides: Partial<sessions.SessionEntry> = {},
   messages: unknown[] = [],
@@ -148,6 +158,19 @@ describe("isMainSessionResumable", () => {
       ]),
     ).toBe(true);
   });
+
+  it("returns false when the tail is a non-compaction system message", () => {
+    // A plain system message after the tool_result (not a compaction marker)
+    // is an unrecognised shape; we do not resume speculatively.
+    expect(
+      isMainSessionResumable([
+        userText("do the thing"),
+        assistantText("running tool..."),
+        toolResultTurn(),
+        { role: "system", content: [{ type: "text", text: "session reset hint" }] },
+      ]),
+    ).toBe(false);
+  });
 });
 
 describe("recoverOrphanedMainSessions", () => {
@@ -178,6 +201,7 @@ describe("recoverOrphanedMainSessions", () => {
 
     const result = await recoverOrphanedMainSessions({
       nowMs: Date.now(),
+      bootMs: TEST_BOOT_MS,
       resumedSessionKeys: new Set<string>(),
     });
 
@@ -206,7 +230,7 @@ describe("recoverOrphanedMainSessions", () => {
       assistantText("here is the answer"),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(result.skipped).toBe(1);
@@ -224,11 +248,33 @@ describe("recoverOrphanedMainSessions", () => {
       } as sessions.SessionEntry,
     });
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(result.skipped).toBe(0);
     expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions whose updatedAt is newer than bootMs (owned by current process)", async () => {
+    // Fixture is `updatedAt: now`; pass a bootMs strictly before `now` so the
+    // scanner treats the session as touched by the current process.
+    const now = Date.now();
+    mockSingleRunningSession({ updatedAt: now }, [
+      userText("fresh user message"),
+      assistantText("running tool"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({
+      nowMs: now + 100,
+      bootMs: now - 1000,
+    });
+
+    expect(result.recovered).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.expired).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(sessions.updateSessionStore).not.toHaveBeenCalled();
   });
 
   it("skips subagent entries by spawnDepth (handled by subagent orphan recovery)", async () => {
@@ -246,7 +292,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(result.skipped).toBe(0);
@@ -268,7 +314,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(gateway.callGateway).not.toHaveBeenCalled();
@@ -288,7 +334,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(gateway.callGateway).not.toHaveBeenCalled();
@@ -308,7 +354,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(gateway.callGateway).not.toHaveBeenCalled();
@@ -323,6 +369,7 @@ describe("recoverOrphanedMainSessions", () => {
 
     const result = await recoverOrphanedMainSessions({
       nowMs: now,
+      bootMs: TEST_BOOT_MS,
       staleMs: 60 * 60 * 1000,
     });
 
@@ -357,6 +404,7 @@ describe("recoverOrphanedMainSessions", () => {
 
     const result = await recoverOrphanedMainSessions({
       nowMs: now,
+      bootMs: TEST_BOOT_MS,
       staleMs: 60 * 60 * 1000,
     });
 
@@ -374,7 +422,7 @@ describe("recoverOrphanedMainSessions", () => {
     ]);
     vi.mocked(gateway.callGateway).mockRejectedValue(new Error("gateway unavailable"));
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(0);
     expect(result.failed).toBe(1);
@@ -389,7 +437,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     const call = getResumeCall();
     const message = (call.params as Record<string, unknown>).message as string;
@@ -407,10 +455,12 @@ describe("recoverOrphanedMainSessions", () => {
     const resumedSessionKeys = new Set<string>();
     const first = await recoverOrphanedMainSessions({
       nowMs: Date.now(),
+      bootMs: TEST_BOOT_MS,
       resumedSessionKeys,
     });
     const second = await recoverOrphanedMainSessions({
       nowMs: Date.now(),
+      bootMs: TEST_BOOT_MS,
       resumedSessionKeys,
     });
 
@@ -448,7 +498,7 @@ describe("recoverOrphanedMainSessions", () => {
       toolResultTurn(),
     ]);
 
-    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now(), bootMs: TEST_BOOT_MS });
 
     expect(result.recovered).toBe(2);
     expect(gateway.callGateway).toHaveBeenCalledTimes(2);

--- a/src/agents/main-session-orphan-recovery.test.ts
+++ b/src/agents/main-session-orphan-recovery.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as sessions from "../config/sessions.js";
+import * as gateway from "../gateway/call.js";
+import * as sessionUtils from "../gateway/session-utils.fs.js";
+import {
+  isMainSessionResumable,
+  recoverOrphanedMainSessions,
+} from "./main-session-orphan-recovery.js";
+import * as sessionDirs from "./session-dirs.js";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    session: { store: undefined },
+  })),
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: vi.fn(() => "/tmp/openclaw-test-state"),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  resolveStorePath: vi.fn(
+    (_store: unknown, opts?: { agentId?: string }) =>
+      `/tmp/openclaw-test-state/agents/${opts?.agentId ?? "main"}/agent/sessions.json`,
+  ),
+  updateSessionStore: vi.fn(
+    async (_storePath: string, mutator: (store: Record<string, unknown>) => void) => {
+      // Invoke the mutator with an empty store so the code path stays exercised.
+      await mutator({});
+    },
+  ),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => ({ runId: "test-main-run" })),
+}));
+
+vi.mock("../gateway/session-utils.fs.js", () => ({
+  readSessionMessages: vi.fn(() => []),
+}));
+
+vi.mock("./session-dirs.js", () => ({
+  resolveAgentSessionDirs: vi.fn(async () => ["/tmp/openclaw-test-state/agents/main/sessions"]),
+}));
+
+type TestMessage = {
+  role: string;
+  content: string | Array<{ type: string; text?: string; tool_use_id?: string }>;
+  __openclaw?: Record<string, unknown>;
+};
+
+function toolResultTurn(toolUseId = "toolu_1"): TestMessage {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: toolUseId }],
+  };
+}
+
+function userText(text: string): TestMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function assistantText(text: string): TestMessage {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function compactionMarker(): TestMessage {
+  return {
+    role: "system",
+    content: [{ type: "text", text: "Compaction" }],
+    __openclaw: { kind: "compaction" },
+  };
+}
+
+function mockSingleRunningSession(
+  entryOverrides: Partial<sessions.SessionEntry> = {},
+  messages: unknown[] = [],
+): void {
+  vi.mocked(sessions.loadSessionStore).mockReturnValue({
+    "agent:main:main": {
+      sessionId: "session-main-1",
+      updatedAt: Date.now(),
+      status: "running",
+      ...entryOverrides,
+    } as sessions.SessionEntry,
+  });
+  vi.mocked(sessionUtils.readSessionMessages).mockReturnValue(messages);
+}
+
+function getResumeCall() {
+  const call = vi.mocked(gateway.callGateway).mock.calls[0];
+  expect(call).toBeDefined();
+  return call[0];
+}
+
+describe("isMainSessionResumable", () => {
+  it("returns true when tool_result tail has no assistant follow-up", () => {
+    expect(
+      isMainSessionResumable([
+        userText("do the thing"),
+        assistantText("running tool..."),
+        toolResultTurn(),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true with batched parallel tool_results and no follow-up", () => {
+    expect(
+      isMainSessionResumable([
+        userText("search two things"),
+        assistantText("firing two searches"),
+        toolResultTurn("toolu_1"),
+        toolResultTurn("toolu_2"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when assistant message follows the tool_results", () => {
+    expect(
+      isMainSessionResumable([
+        userText("do the thing"),
+        assistantText("running tool..."),
+        toolResultTurn(),
+        assistantText("here is the answer"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false when transcript is empty", () => {
+    expect(isMainSessionResumable([])).toBe(false);
+  });
+
+  it("returns false when transcript ends in a plain user message", () => {
+    expect(isMainSessionResumable([assistantText("earlier answer"), userText("new request")])).toBe(
+      false,
+    );
+  });
+
+  it("ignores compaction markers when walking the tail", () => {
+    expect(
+      isMainSessionResumable([
+        userText("do the thing"),
+        assistantText("running tool..."),
+        toolResultTurn(),
+        compactionMarker(),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("recoverOrphanedMainSessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionDirs.resolveAgentSessionDirs).mockResolvedValue([
+      "/tmp/openclaw-test-state/agents/main/sessions",
+    ]);
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "test-main-run" });
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({});
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([]);
+    vi.mocked(sessions.resolveStorePath).mockImplementation(
+      (_store, opts?: { agentId?: string }) =>
+        `/tmp/openclaw-test-state/agents/${opts?.agentId ?? "main"}/agent/sessions.json`,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resumes a main session stuck on tool_result tail", async () => {
+    mockSingleRunningSession({}, [
+      userText("please search"),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({
+      nowMs: Date.now(),
+      resumedSessionKeys: new Set<string>(),
+    });
+
+    expect(result.recovered).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.expired).toBe(0);
+    expect(result.skipped).toBe(0);
+
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    const call = getResumeCall();
+    expect(call.method).toBe("agent");
+    const callParams = call.params as Record<string, unknown>;
+    expect(callParams.sessionKey).toBe("agent:main:main");
+    expect(callParams.lane).toBe("main");
+    expect(callParams.deliver).toBe(false);
+    expect(typeof callParams.idempotencyKey).toBe("string");
+    expect(callParams.message).toContain("gateway restart");
+    expect(callParams.message).toContain("please search");
+  });
+
+  it("skips sessions whose transcript already ends in an assistant message", async () => {
+    mockSingleRunningSession({}, [
+      userText("please search"),
+      assistantText("searching"),
+      toolResultTurn(),
+      assistantText("here is the answer"),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.expired).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(sessions.updateSessionStore).not.toHaveBeenCalled();
+  });
+
+  it("skips entries whose status is not 'running'", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:main": {
+        sessionId: "session-main-1",
+        updatedAt: Date.now(),
+        status: "done",
+      } as sessions.SessionEntry,
+    });
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("skips subagent entries (handled by subagent orphan recovery)", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:abc": {
+        sessionId: "session-sub-1",
+        updatedAt: Date.now(),
+        status: "running",
+        spawnDepth: 1,
+      } as sessions.SessionEntry,
+    });
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([
+      userText("sub task"),
+      assistantText("running"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("marks stale running sessions as failed when tail is not resumable", async () => {
+    const now = Date.now();
+    mockSingleRunningSession({ updatedAt: now - 2 * 60 * 60 * 1000 }, [
+      userText("hello"),
+      assistantText("hi"),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({
+      nowMs: now,
+      staleMs: 60 * 60 * 1000,
+    });
+
+    expect(result.expired).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(sessions.updateSessionStore).toHaveBeenCalledOnce();
+
+    const [storePath, mutator] = vi.mocked(sessions.updateSessionStore).mock.calls[0];
+    expect(storePath).toContain("/agents/main/agent/sessions.json");
+
+    const simulated: Record<string, sessions.SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "session-main-1",
+        updatedAt: now - 2 * 60 * 60 * 1000,
+        status: "running",
+      } as sessions.SessionEntry,
+    };
+    await (mutator as (s: Record<string, sessions.SessionEntry>) => Promise<void> | void)(
+      simulated,
+    );
+    expect(simulated["agent:main:main"]?.status).toBe("failed");
+    expect(simulated["agent:main:main"]?.abortedLastRun).toBe(true);
+    expect(simulated["agent:main:main"]?.updatedAt).toBe(now);
+  });
+
+  it("does not resurrect stale resumable sessions beyond the stale window", async () => {
+    const now = Date.now();
+    mockSingleRunningSession({ updatedAt: now - 2 * 60 * 60 * 1000 }, [
+      userText("long ago"),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({
+      nowMs: now,
+      staleMs: 60 * 60 * 1000,
+    });
+
+    expect(result.expired).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(sessions.updateSessionStore).toHaveBeenCalledOnce();
+  });
+
+  it("preserves running status when callGateway fails so next restart can retry", async () => {
+    mockSingleRunningSession({}, [
+      userText("please search"),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+    vi.mocked(gateway.callGateway).mockRejectedValue(new Error("gateway unavailable"));
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(sessions.updateSessionStore).not.toHaveBeenCalled();
+  });
+
+  it("truncates very long last human messages in the resume prompt", async () => {
+    const longText = "x".repeat(5000);
+    mockSingleRunningSession({}, [
+      userText(longText),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+
+    await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    const call = getResumeCall();
+    const message = (call.params as Record<string, unknown>).message as string;
+    expect(message.length).toBeLessThan(5000);
+    expect(message).toContain("...");
+  });
+
+  it("dedupes resumed sessions across retries via resumedSessionKeys", async () => {
+    mockSingleRunningSession({}, [
+      userText("please search"),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+
+    const resumedSessionKeys = new Set<string>();
+    const first = await recoverOrphanedMainSessions({
+      nowMs: Date.now(),
+      resumedSessionKeys,
+    });
+    const second = await recoverOrphanedMainSessions({
+      nowMs: Date.now(),
+      resumedSessionKeys,
+    });
+
+    expect(first.recovered).toBe(1);
+    expect(second.recovered).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+  });
+
+  it("scans every agent session directory and dedupes by store path", async () => {
+    vi.mocked(sessionDirs.resolveAgentSessionDirs).mockResolvedValue([
+      "/tmp/openclaw-test-state/agents/main/sessions",
+      "/tmp/openclaw-test-state/agents/ops/sessions",
+    ]);
+
+    const runningEntry = (sessionId: string): sessions.SessionEntry =>
+      ({
+        sessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      }) as sessions.SessionEntry;
+
+    vi.mocked(sessions.loadSessionStore).mockImplementation((storePath) => {
+      const store: Record<string, sessions.SessionEntry> = {};
+      if (storePath.includes("/agents/main/")) {
+        store["agent:main:main"] = runningEntry("session-main-1");
+      } else if (storePath.includes("/agents/ops/")) {
+        store["agent:ops:main"] = runningEntry("session-ops-1");
+      }
+      return store;
+    });
+    vi.mocked(sessionUtils.readSessionMessages).mockReturnValue([
+      userText("please search"),
+      assistantText("searching"),
+      toolResultTurn(),
+    ]);
+
+    const result = await recoverOrphanedMainSessions({ nowMs: Date.now() });
+
+    expect(result.recovered).toBe(2);
+    expect(gateway.callGateway).toHaveBeenCalledTimes(2);
+    const resumedKeys = vi
+      .mocked(gateway.callGateway)
+      .mock.calls.map((call) => (call[0].params as Record<string, unknown>).sessionKey);
+    expect(resumedKeys).toContain("agent:main:main");
+    expect(resumedKeys).toContain("agent:ops:main");
+  });
+});

--- a/src/agents/main-session-orphan-recovery.ts
+++ b/src/agents/main-session-orphan-recovery.ts
@@ -29,6 +29,7 @@ import { callGateway } from "../gateway/call.js";
 import { readSessionMessages } from "../gateway/session-utils.fs.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
+import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 
 const log = createSubsystemLogger("main-session-orphan-recovery");
@@ -56,11 +57,23 @@ export type MainSessionRecoveryResult = {
   expired: number;
 };
 
-function isSubagentSessionEntry(entry: SessionEntry, sessionKey: string): boolean {
+/**
+ * Exclude session keys that already have their own recovery (subagent) or
+ * lifecycle ownership (cron, ACP). Also treat any entry with a non-null
+ * `subagentRole` or positive `spawnDepth` as out-of-scope, so callers of
+ * `acp-spawn` / `subagent-spawn` whose key shape drifts from the canonical
+ * `:subagent:` format are still skipped.
+ */
+function shouldSkipForMainRecovery(entry: SessionEntry, sessionKey: string): boolean {
   if (typeof entry.spawnDepth === "number" && entry.spawnDepth > 0) {
     return true;
   }
-  return sessionKey.includes(":subagent:");
+  if (entry.subagentRole != null) {
+    return true;
+  }
+  return (
+    isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey) || isAcpSessionKey(sessionKey)
+  );
 }
 
 function getMessageRole(msg: unknown): string | undefined {
@@ -250,7 +263,7 @@ async function processAgentSessionStore(params: {
     if (!entry || entry.status !== "running") {
       continue;
     }
-    if (isSubagentSessionEntry(entry, sessionKey)) {
+    if (shouldSkipForMainRecovery(entry, sessionKey)) {
       continue;
     }
     if (resumedSessionKeys.has(sessionKey)) {

--- a/src/agents/main-session-orphan-recovery.ts
+++ b/src/agents/main-session-orphan-recovery.ts
@@ -58,6 +58,15 @@ export type MainSessionRecoveryResult = {
 };
 
 /**
+ * Captured once at module load so every scheduler invocation in this
+ * process shares the same "anything newer than this was touched by the
+ * current gateway" cutoff. Using module-load time (rather than Date.now()
+ * inside the scheduler) guarantees the cutoff is never after a session
+ * the current process has already written to.
+ */
+const PROCESS_BOOT_MS = Date.now();
+
+/**
  * Exclude session keys that already have their own recovery (subagent) or
  * lifecycle ownership (cron, ACP). Also treat any entry with a non-null
  * `subagentRole` or positive `spawnDepth` as out-of-scope, so callers of
@@ -139,10 +148,12 @@ function extractMessageText(msg: unknown): string | undefined {
 /**
  * A session is resumable when the newest meaningful turn is a tool_result
  * (with no trailing assistant message). Walking backwards past compaction
- * markers, the first turn we decide on is either:
+ * markers only, the first turn we decide on is either:
  *   - an assistant turn              → tool-use loop already completed
  *   - a tool_result carrier          → orphaned mid-loop, resume it
  *   - a plain user turn              → pending new request, not our bug shape
+ *   - any other role (system, tool
+ *     metadata, unknown)             → unrecognised tail, do not resume
  */
 export function isMainSessionResumable(messages: unknown[]): boolean {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -157,9 +168,7 @@ export function isMainSessionResumable(messages: unknown[]): boolean {
     if ((role === "user" || role === "tool") && hasToolResultContent(msg)) {
       return true;
     }
-    if (role === "user" || role === "tool") {
-      return false;
-    }
+    return false;
   }
   return false;
 }
@@ -246,10 +255,11 @@ async function processAgentSessionStore(params: {
   storePath: string;
   nowMs: number;
   staleMs: number;
+  bootMs: number;
   resumedSessionKeys: Set<string>;
   result: MainSessionRecoveryResult;
 }): Promise<void> {
-  const { storePath, nowMs, staleMs, resumedSessionKeys, result } = params;
+  const { storePath, nowMs, staleMs, bootMs, resumedSessionKeys, result } = params;
   let store: Record<string, SessionEntry>;
   try {
     store = loadSessionStore(storePath);
@@ -264,6 +274,13 @@ async function processAgentSessionStore(params: {
       continue;
     }
     if (shouldSkipForMainRecovery(entry, sessionKey)) {
+      continue;
+    }
+    // Gate on the boot timestamp: anything touched at/after this process
+    // started is a session the current gateway is actively driving (e.g. a
+    // user message that landed during the scheduler's 5 s bootstrap delay),
+    // not an orphan from a previous lifetime.
+    if (typeof entry.updatedAt === "number" && entry.updatedAt >= bootMs) {
       continue;
     }
     if (resumedSessionKeys.has(sessionKey)) {
@@ -315,6 +332,7 @@ export async function recoverOrphanedMainSessions(
     stateDir?: string;
     nowMs?: number;
     staleMs?: number;
+    bootMs?: number;
     resumedSessionKeys?: Set<string>;
   } = {},
 ): Promise<MainSessionRecoveryResult> {
@@ -327,6 +345,7 @@ export async function recoverOrphanedMainSessions(
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
   const nowMs = params.nowMs ?? Date.now();
   const staleMs = params.staleMs ?? SESSION_RUNNING_STALE_MS;
+  const bootMs = params.bootMs ?? PROCESS_BOOT_MS;
 
   try {
     const stateDir = params.stateDir ?? resolveStateDir(process.env);
@@ -346,6 +365,7 @@ export async function recoverOrphanedMainSessions(
         storePath,
         nowMs,
         staleMs,
+        bootMs,
         resumedSessionKeys,
         result,
       });
@@ -371,10 +391,12 @@ export function scheduleMainSessionOrphanRecovery(
     maxRetries?: number;
     staleMs?: number;
     stateDir?: string;
+    bootMs?: number;
   } = {},
 ): void {
   const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
   const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
+  const bootMs = params.bootMs ?? PROCESS_BOOT_MS;
   const resumedSessionKeys = new Set<string>();
 
   const attemptRecovery = (attempt: number, delay: number) => {
@@ -382,15 +404,23 @@ export function scheduleMainSessionOrphanRecovery(
       void recoverOrphanedMainSessions({
         stateDir: params.stateDir,
         staleMs: params.staleMs,
+        bootMs,
         resumedSessionKeys,
       })
         .then((result) => {
-          if (result.failed > 0 && attempt < maxRetries) {
+          if (result.failed === 0) {
+            return;
+          }
+          if (attempt < maxRetries) {
             const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
             log.info(
               `main-session orphan recovery had ${result.failed} failure(s); retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
             );
             attemptRecovery(attempt + 1, nextDelay);
+          } else {
+            log.warn(
+              `main-session orphan recovery gave up after ${maxRetries} retries; ${result.failed} session(s) remain status:"running"`,
+            );
           }
         })
         .catch((err) => {

--- a/src/agents/main-session-orphan-recovery.ts
+++ b/src/agents/main-session-orphan-recovery.ts
@@ -1,0 +1,400 @@
+/**
+ * Post-restart orphan recovery for main-agent sessions.
+ *
+ * When the gateway restarts mid tool-use loop, the session transcript
+ * ends in persisted tool_result entries with no trailing assistant
+ * message. The session-store entry stays `status: "running"`, which
+ * makes subsequent user messages see the "currently busy" guard and
+ * the session is effectively dead until manually reset.
+ *
+ * This module scans every main-agent session store at startup, resumes
+ * sessions whose transcript tail is a tool_result without a trailing
+ * assistant message, and marks stale "running" entries as failed so the
+ * busy guard clears.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/70555
+ */
+
+import crypto from "node:crypto";
+import path from "node:path";
+import { loadConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { callGateway } from "../gateway/call.js";
+import { readSessionMessages } from "../gateway/session-utils.fs.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { CommandLane } from "../process/lanes.js";
+import { resolveAgentSessionDirs } from "./session-dirs.js";
+
+const log = createSubsystemLogger("main-session-orphan-recovery");
+
+/** Delay before attempting recovery to let the gateway finish bootstrapping. */
+const DEFAULT_RECOVERY_DELAY_MS = 5_000;
+
+/**
+ * Maximum time a session can remain `status: "running"` without
+ * `updatedAt` progress before it is considered unrecoverable. Aligned
+ * with `2 * SESSION_LOCK_STALE_MS` so orphan recovery and lock cleanup
+ * agree on what "too stale to touch" means.
+ */
+const SESSION_RUNNING_STALE_MS = 60 * 60 * 1000;
+
+const MAX_RECOVERY_RETRIES = 3;
+const RETRY_BACKOFF_MULTIPLIER = 2;
+const MAX_LAST_HUMAN_MESSAGE_LEN = 2000;
+const GATEWAY_RESUME_TIMEOUT_MS = 10_000;
+
+export type MainSessionRecoveryResult = {
+  recovered: number;
+  failed: number;
+  skipped: number;
+  expired: number;
+};
+
+function isSubagentSessionEntry(entry: SessionEntry, sessionKey: string): boolean {
+  if (typeof entry.spawnDepth === "number" && entry.spawnDepth > 0) {
+    return true;
+  }
+  return sessionKey.includes(":subagent:");
+}
+
+function getMessageRole(msg: unknown): string | undefined {
+  if (!msg || typeof msg !== "object") {
+    return undefined;
+  }
+  const role = (msg as { role?: unknown }).role;
+  return typeof role === "string" ? role : undefined;
+}
+
+function isCompactionMarker(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") {
+    return false;
+  }
+  const meta = (msg as { __openclaw?: unknown }).__openclaw;
+  if (!meta || typeof meta !== "object") {
+    return false;
+  }
+  return (meta as { kind?: unknown }).kind === "compaction";
+}
+
+function hasToolResultContent(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") {
+    return false;
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(
+    (block: unknown) =>
+      typeof block === "object" &&
+      block !== null &&
+      (block as Record<string, unknown>).type === "tool_result",
+  );
+}
+
+function extractMessageText(msg: unknown): string | undefined {
+  if (!msg || typeof msg !== "object") {
+    return undefined;
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const text = content
+      .filter(
+        (c: unknown) =>
+          typeof c === "object" &&
+          c !== null &&
+          (c as Record<string, unknown>).type === "text" &&
+          typeof (c as Record<string, unknown>).text === "string",
+      )
+      .map((c: unknown) => (c as Record<string, string>).text)
+      .filter(Boolean)
+      .join("\n");
+    return text || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * A session is resumable when the newest meaningful turn is a tool_result
+ * (with no trailing assistant message). Walking backwards past compaction
+ * markers, the first turn we decide on is either:
+ *   - an assistant turn              → tool-use loop already completed
+ *   - a tool_result carrier          → orphaned mid-loop, resume it
+ *   - a plain user turn              → pending new request, not our bug shape
+ */
+export function isMainSessionResumable(messages: unknown[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i];
+    if (isCompactionMarker(msg)) {
+      continue;
+    }
+    const role = getMessageRole(msg);
+    if (role === "assistant") {
+      return false;
+    }
+    if ((role === "user" || role === "tool") && hasToolResultContent(msg)) {
+      return true;
+    }
+    if (role === "user" || role === "tool") {
+      return false;
+    }
+  }
+  return false;
+}
+
+function findLastHumanMessage(messages: unknown[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i];
+    if (isCompactionMarker(msg)) {
+      continue;
+    }
+    if (getMessageRole(msg) !== "user" || hasToolResultContent(msg)) {
+      continue;
+    }
+    const text = extractMessageText(msg);
+    if (text) {
+      return text.length > MAX_LAST_HUMAN_MESSAGE_LEN
+        ? `${text.slice(0, MAX_LAST_HUMAN_MESSAGE_LEN)}...`
+        : text;
+    }
+  }
+  return undefined;
+}
+
+function buildResumeMessage(lastHumanMessage?: string): string {
+  let message =
+    `[System] Your previous turn was interrupted by a gateway restart while ` +
+    `tool results were being persisted. Continue from where you left off.`;
+  if (lastHumanMessage) {
+    message += `\n\nThe last message from the user before the interruption was:\n\n${lastHumanMessage}`;
+  }
+  return message;
+}
+
+async function resumeOrphanedMainSession(params: {
+  sessionKey: string;
+  lastHumanMessage?: string;
+}): Promise<boolean> {
+  const resumeMessage = buildResumeMessage(params.lastHumanMessage);
+  try {
+    await callGateway({
+      method: "agent",
+      params: {
+        message: resumeMessage,
+        sessionKey: params.sessionKey,
+        idempotencyKey: crypto.randomUUID(),
+        deliver: false,
+        lane: CommandLane.Main,
+      },
+      timeoutMs: GATEWAY_RESUME_TIMEOUT_MS,
+    });
+    log.info(`resumed orphaned main session: ${params.sessionKey}`);
+    return true;
+  } catch (err) {
+    log.warn(`failed to resume orphaned main session ${params.sessionKey}: ${String(err)}`);
+    return false;
+  }
+}
+
+async function markSessionFailed(params: {
+  storePath: string;
+  sessionKey: string;
+  nowMs: number;
+}): Promise<void> {
+  try {
+    await updateSessionStore(params.storePath, (store) => {
+      const entry = store[params.sessionKey];
+      if (!entry || entry.status !== "running") {
+        return;
+      }
+      entry.status = "failed";
+      entry.abortedLastRun = true;
+      if (typeof entry.endedAt !== "number") {
+        entry.endedAt = params.nowMs;
+      }
+      entry.updatedAt = params.nowMs;
+      store[params.sessionKey] = entry;
+    });
+  } catch (err) {
+    log.warn(`failed to mark stale main session ${params.sessionKey} as failed: ${String(err)}`);
+  }
+}
+
+async function processAgentSessionStore(params: {
+  storePath: string;
+  nowMs: number;
+  staleMs: number;
+  resumedSessionKeys: Set<string>;
+  result: MainSessionRecoveryResult;
+}): Promise<void> {
+  const { storePath, nowMs, staleMs, resumedSessionKeys, result } = params;
+  let store: Record<string, SessionEntry>;
+  try {
+    store = loadSessionStore(storePath);
+  } catch (err) {
+    log.warn(`failed to load main-session store ${storePath}: ${String(err)}`);
+    return;
+  }
+
+  for (const sessionKey of Object.keys(store).toSorted()) {
+    const entry = store[sessionKey];
+    if (!entry || entry.status !== "running") {
+      continue;
+    }
+    if (isSubagentSessionEntry(entry, sessionKey)) {
+      continue;
+    }
+    if (resumedSessionKeys.has(sessionKey)) {
+      result.skipped++;
+      continue;
+    }
+
+    const ageMs = typeof entry.updatedAt === "number" ? nowMs - entry.updatedAt : Infinity;
+    const messages = readSessionMessages(entry.sessionId, storePath, entry.sessionFile);
+    const resumable = isMainSessionResumable(messages);
+
+    if (!resumable) {
+      if (ageMs > staleMs) {
+        await markSessionFailed({ storePath, sessionKey, nowMs });
+        result.expired++;
+      } else {
+        result.skipped++;
+      }
+      continue;
+    }
+
+    if (ageMs > staleMs) {
+      // Resumable shape but idle beyond the stale window: treat as
+      // unrecoverable so we do not resurrect abandoned sessions.
+      await markSessionFailed({ storePath, sessionKey, nowMs });
+      result.expired++;
+      continue;
+    }
+
+    log.info(`found orphaned main session: ${sessionKey}`);
+    const resumed = await resumeOrphanedMainSession({
+      sessionKey,
+      lastHumanMessage: findLastHumanMessage(messages),
+    });
+
+    if (resumed) {
+      resumedSessionKeys.add(sessionKey);
+      result.recovered++;
+    } else {
+      // Flag stays as status=running so the next restart can retry
+      // the resume without touching transcript state.
+      result.failed++;
+    }
+  }
+}
+
+export async function recoverOrphanedMainSessions(
+  params: {
+    stateDir?: string;
+    nowMs?: number;
+    staleMs?: number;
+    resumedSessionKeys?: Set<string>;
+  } = {},
+): Promise<MainSessionRecoveryResult> {
+  const result: MainSessionRecoveryResult = {
+    recovered: 0,
+    failed: 0,
+    skipped: 0,
+    expired: 0,
+  };
+  const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
+  const nowMs = params.nowMs ?? Date.now();
+  const staleMs = params.staleMs ?? SESSION_RUNNING_STALE_MS;
+
+  try {
+    const stateDir = params.stateDir ?? resolveStateDir(process.env);
+    const cfg = loadConfig();
+    const configuredStore = cfg.session?.store;
+    const sessionDirs = await resolveAgentSessionDirs(stateDir);
+    const seenStorePaths = new Set<string>();
+
+    for (const sessionsDir of sessionDirs) {
+      const agentId = path.basename(path.dirname(sessionsDir));
+      const storePath = resolveStorePath(configuredStore, { agentId });
+      if (seenStorePaths.has(storePath)) {
+        continue;
+      }
+      seenStorePaths.add(storePath);
+      await processAgentSessionStore({
+        storePath,
+        nowMs,
+        staleMs,
+        resumedSessionKeys,
+        result,
+      });
+    }
+  } catch (err) {
+    log.warn(`main-session orphan recovery scan failed: ${String(err)}`);
+    if (result.failed === 0) {
+      result.failed = 1;
+    }
+  }
+
+  if (result.recovered > 0 || result.failed > 0 || result.expired > 0) {
+    log.info(
+      `main-session orphan recovery complete: recovered=${result.recovered} failed=${result.failed} expired=${result.expired} skipped=${result.skipped}`,
+    );
+  }
+  return result;
+}
+
+export function scheduleMainSessionOrphanRecovery(
+  params: {
+    delayMs?: number;
+    maxRetries?: number;
+    staleMs?: number;
+    stateDir?: string;
+  } = {},
+): void {
+  const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
+  const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
+  const resumedSessionKeys = new Set<string>();
+
+  const attemptRecovery = (attempt: number, delay: number) => {
+    setTimeout(() => {
+      void recoverOrphanedMainSessions({
+        stateDir: params.stateDir,
+        staleMs: params.staleMs,
+        resumedSessionKeys,
+      })
+        .then((result) => {
+          if (result.failed > 0 && attempt < maxRetries) {
+            const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
+            log.info(
+              `main-session orphan recovery had ${result.failed} failure(s); retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
+            );
+            attemptRecovery(attempt + 1, nextDelay);
+          }
+        })
+        .catch((err) => {
+          if (attempt < maxRetries) {
+            const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
+            log.warn(
+              `scheduled main-session orphan recovery failed: ${String(err)}; retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
+            );
+            attemptRecovery(attempt + 1, nextDelay);
+          } else {
+            log.warn(
+              `scheduled main-session orphan recovery failed after ${maxRetries} retries: ${String(err)}`,
+            );
+          }
+        });
+    }, delay).unref?.();
+  };
+
+  attemptRecovery(0, initialDelay);
+}

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -354,6 +354,12 @@ export async function startGatewaySidecars(params: {
     scheduleSubagentOrphanRecovery();
   });
 
+  await measureStartup(params.startupTrace, "sidecars.main-session-recovery", async () => {
+    const { scheduleMainSessionOrphanRecovery } =
+      await import("../agents/main-session-orphan-recovery.js");
+    scheduleMainSessionOrphanRecovery();
+  });
+
   return { pluginServices };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** When the gateway restarts mid tool-use loop, the main session stays `status:"running"` with tool_results persisted but no follow-up assistant message. Every subsequent user message hits the "currently busy" guard and the session is effectively dead until manually reset (18+ hours in the reported case).
- **Why it matters:** Channel users (DingTalk, and any other channel that honors the busy guard) see `当前还在忙...` forever; production deployments depend on the gateway being restart-safe for any config change that triggers `deferGatewayRestartUntilIdle`, e.g. `plugins.entries.tavily.enabled`.
- **What changed:** New `src/agents/main-session-orphan-recovery.ts` scans every agent session store after post-attach, resumes transcripts that end in a `tool_result` without a trailing assistant message via the normal `agent` method, and flips stale `"running"` entries (idle > 60 min) to `"failed"` so the busy guard clears.
- **What did NOT change (scope boundary):** No change to the subagent orphan-recovery path, the lifecycle state machine, reload-handler deferral logic, lock-file format, channel plugins, session key normalization, or any config surface.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope 

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70555

## Root Cause

- **Root cause:** `startGatewaySidecars` already cleans stale `.jsonl.lock` files on startup (`src/gateway/server-startup-post-attach.ts:149-170`) but never inspects main-session-store entries. After a restart, sessions left with `status:"running"` and a `tool_result` tail have no recovery path — the model is never re-invoked, so the follow-up assistant turn is never produced, and the `"running"` status keeps the "currently busy" guard active indefinitely.
- **Missing detection / guardrail:** `deriveGatewaySessionLifecycleSnapshot` (`src/gateway/session-lifecycle-state.ts:92-130`) has no `"restart"` / `"resume"` phase, and nothing in the post-attach path scans for orphaned main-agent `"running"` entries. Subagent sessions already had an equivalent recovery via `scheduleSubagentOrphanRecovery` (`src/gateway/server-startup-post-attach.ts:352-354`); main sessions did not.
- **Contributing context:** `deferGatewayRestartUntilIdle` (`src/gateway/server-reload-handlers.ts:257-279`) correctly queues the restart, but its `maxWaitMs` (default 5 min, `src/gateway/restart.ts:21`) `onTimeout` branch fires `emitGatewayRestart()` even when in-flight operations have not completed. When the Tavily plugin toggle landed during a live `web_search` loop, that forced the orphaned-session state in the report.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/main-session-orphan-recovery.test.ts` (new, 19 cases).
- **Scenario the test should lock in:** a `status:"running"` session whose transcript tail is one or more `tool_result` content blocks with no trailing assistant message must trigger `callGateway({ method: "agent", params: { sessionKey, lane: "main", deliver: false, ... } })` to resume. Covered shapes include: single tool_result tail, batched parallel tool_results, transcripts with interleaved compaction markers, and multi-agent session dirs. Non-target shapes (assistant tail, empty transcript, plain-text user-tail pending request, subagent / cron / ACP entries) must be skipped.
- **Why this is the smallest reliable guardrail:** the bug's distinguishing shape is detectable from transcript structure alone (`isMainSessionResumable(messages)`); a pure unit test pins that contract. The scan + store update path is covered via module-level mocks on `loadSessionStore` / `updateSessionStore` / `callGateway`, exactly matching the style of `src/agents/subagent-orphan-recovery.test.ts`.
- **Existing test that already covers this:** None. `src/agents/subagent-orphan-recovery.test.ts` covers only the subagent-run-registry path, which has no equivalent signal for main sessions. `src/gateway/server-startup-session-migration.test.ts` only tests session key canonicalization.
- **If no new test is added:** N/A — a new test file is added.

## User-visible / Behavior Changes

When the gateway restarts while a main session is mid tool-use loop, users will now see one of two outcomes within ~5 seconds of the gateway coming back up:

1. The interrupted tool-use loop is resumed and completes (assistant follow-up is generated).
2. If the session is genuinely unrecoverable — transcript shape isn't a `tool_result` tail, or `updatedAt` is older than 60 minutes — the session is flipped to `status:"failed"`, which clears the "currently busy" guard so the next user message is accepted.

No change to normal-path behavior: the recovery only fires for entries matching the orphan signature. Subagent, cron, and ACP sessions are skipped (each has its own lifecycle owner).

> **Note on delivery:** the resume call uses `deliver: false` to match `src/agents/subagent-orphan-recovery.ts`. The resumed turn advances lifecycle state and clears the busy guard, but the completed assistant response may not be pushed into the original channel. The primary user-reported symptom (busy guard + can't send new messages) is fully fixed; if maintainers want the response delivered back to the user's channel in the same restart cycle, flipping to `deliver: true` is a one-line change and I'm happy to update.

## Diagram

```text
Before:
[gateway restart] -> [cleanStaleLockFiles removes .jsonl.lock]
                  -> [session-store entry status:"running" untouched]
                  -> [tool_result tail, no assistant follow-up]
                  -> [user message hits "busy" guard forever]

After:
[gateway restart] -> [cleanStaleLockFiles removes .jsonl.lock]
                  -> [scheduleMainSessionOrphanRecovery, 5s delay]
                  -> [scan every agent session store for status:"running"]
                        -> skip subagent / cron / ACP entries
                        -> if tool_result tail + fresh: callGateway("agent", resume message)
                        -> if > 60 min idle, or tail not resumable: status:"failed" (busy guard clears)
                        -> on callGateway failure: leave "running" so next restart retries
```

## Security Impact

- New permissions/capabilities? **No** — reuses the existing `callGateway` `agent` method and `updateSessionStore` APIs.
- Secrets/tokens handling changed? **No** — no PAT / credential / auth-profile paths touched.
- New/changed network calls? **No** — runs locally against session stores on disk.
- Command/tool execution surface changed? **No** — the resume message flows through the same `agent` method path that normal user turns use; no new method scope.
- Data access scope changed? **No** — reads / writes only `~/.openclaw/agents/<agent>/agent/sessions.json` entries that the gateway already owns. Subagent entries are explicitly skipped (they remain owned by `recoverOrphanedSubagentSessions`).

## Repro + Verification

### Environment

- OS: Linux / macOS (bug filed on macOS 25.3.0 arm64)
- Runtime/container: Node 22+ gateway
- Model/provider: provider-agnostic — reproduced on `bailian/qwen3.6-plus` via DashScope compatible-mode
- Integration/channel: DingTalk DM in the report; the fix is channel-agnostic
- Relevant config (redacted): any config patch that triggers `deferGatewayRestartUntilIdle` (e.g. `plugins.entries.<id>.enabled`)

### Steps

1. Start a main-agent tool-use loop (e.g. two parallel `web_search` calls).
2. While tool results are streaming back, patch `openclaw.json` to toggle a plugin gate so `deferGatewayRestartUntilIdle` queues a restart.
3. Let the defer window expire (or let in-flight operations drop to zero) so `emitGatewayRestart()` fires.
4. Gateway restarts; `cleanStaleLockFiles` removes the `.jsonl.lock` as `dead-pid`.
5. Send a new message from the user.

### Expected

Within ~5 seconds of the gateway coming back up, the session entry leaves `"running"` — either via a resumed assistant turn that drives the transcript to `done`, or (if the transcript is genuinely unrecoverable / too old) via `status:"failed"`. The user's next message is accepted instead of hitting the busy guard.

### Actual (before this PR)

Session remains `status:"running"` indefinitely; new user messages see the busy-queue reply and pile up until the session is manually reset.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Regression test:** `recoverOrphanedMainSessions > resumes a main session stuck on tool_result tail` in `src/agents/main-session-orphan-recovery.test.ts`. Builds the exact transcript shape from the report timeline and asserts `callGateway` is invoked with the correct `sessionKey`, `lane: "main"`, `deliver: false`, a `crypto.randomUUID()` idempotency key, and a resume message containing the last human turn.

**Adjacent regression guard:** `src/agents/subagent-orphan-recovery.test.ts` (14 cases) still passes — this module explicitly skips `spawnDepth > 0`, non-null `subagentRole`, and subagent / cron / ACP key shapes via the canonical `isSubagentSessionKey` / `isCronSessionKey` / `isAcpSessionKey` helpers in `src/routing/session-key.ts`, so the two recovery paths do not contend.

**Local validation:**

```
pnpm test src/agents/main-session-orphan-recovery.test.ts                            → 19/19 PASS
pnpm test src/agents/subagent-orphan-recovery.test.ts
           src/agents/main-session-orphan-recovery.test.ts
           src/gateway/session-lifecycle-state.test.ts
           src/gateway/server-startup-session-migration.test.ts
           src/gateway/server-startup-post-attach.test.ts                            → 39/39 PASS
pnpm tsgo:core                                                                       → PASS
pnpm tsgo:core:test                                                                  → PASS
pnpm lint  <changed files>                                                           → PASS
pnpm format:check <changed files>                                                    → PASS
```

## Human Verification

- **Verified scenarios:**
  - Transcript-shape detection: single `tool_result` tail, batched parallel tool_results (>= 2), trailing compaction marker, assistant-tail, plain-user-tail, empty transcript.
  - Scanner filter: `status:"running"` entries matched; `status:"done"` / `"failed"` ignored; subagent (spawnDepth + role + key), cron, and ACP entries skipped.
  - Mark-failed path: stale running session (updatedAt > `staleMs`) with non-resumable tail gets `status:"failed"`, `abortedLastRun:true`, `endedAt` set, `updatedAt` bumped; mutator is a no-op if another writer already flipped the status inside the lock.
  - Resume failure: `callGateway` rejection leaves `status:"running"` intact so the next restart retries; `updateSessionStore` is not called on the failure path.
  - Dedupe: passing a shared `resumedSessionKeys: Set<string>` across two `recoverOrphanedMainSessions` calls resumes exactly once.
  - Multi-agent scan: two session dirs produce two distinct store paths, both are scanned, and resumed session keys match expectations.
- **Edge cases checked:** long last-human-message (5000 chars) truncated at 2000 + ellipsis; store load failure per agent dir degrades to `warn + continue` instead of throwing up the scan; `.unref?.()` on the scheduler timer so it never holds the process alive in tests.
- **What I did not verify:**
  - Real end-to-end repro against a live DingTalk channel — I didn't have a running gateway + DingTalk account to drive. Fix was validated by unit-level simulation of the exact transcript shape from the issue report.
  - Whether `deliver: false` vs `deliver: true` is the right semantic for main sessions — see the note in **User-visible / Behavior Changes** above. Matched the existing subagent pattern; happy to flip if maintainers prefer.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive sidecar. Sessions that were persisted by older gateway versions without `status` set are skipped (the filter requires `status === "running"`).
- Config/env changes? **No** — no new keys, flags, or env vars.
- Migration needed? **No**.

## Risks and Mitigations

- **Risk:** My scanner doesn't consult live `.jsonl.lock` state, so in a theoretical multi-gateway deployment another live process could own a session my scanner tries to resume.
  - **Mitigation:** OpenClaw is single-gateway-per-host in practice. `cleanStaleLockFiles` runs before my scan so dead locks are already normalized. If multi-gateway contention ever becomes real, a lock-presence check in `shouldSkipForMainRecovery` is a narrow follow-up.
- **Risk:** The 5-second bootstrap delay means a user message that lands in the first 5 seconds after restart still sees `status:"running"` and gets queued behind the busy guard.
  - **Mitigation:** 5 seconds matches `subagent-orphan-recovery`'s established delay, which has been in production without complaint. The user's existing bug state persists for 18+ hours today; a 5-second window is a substantial improvement.
- **Risk:** `deliver: false` may leave the resumed assistant response not delivered to the original channel.
  - **Mitigation:** Primary user-visible symptom (stuck busy guard) is fully cleared regardless. Transcript remains recoverable via chat history / control UI. Flipping to `deliver: true` is a one-line follow-up if maintainers want fuller delivery.

