### PR TITLE
fix(kimi): prevent infinite tool call loop

### DIFF
--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -178,9 +178,16 @@ function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
   }
 
   (message as { content: unknown[] }).content = nextContent;
-  const typedMessage = message as { stopReason?: unknown };
-  if (typedMessage.stopReason === "stop") {
-    typedMessage.stopReason = "toolUse";
+  const typedMessage = message as { stopReason?: unknown; role?: unknown };
+  // Only rewrite stopReason to toolUse if the message actually contains tool calls
+  // AND the message is from the assistant (not a tool result or other message type)
+  if (typedMessage.stopReason === "stop" && typedMessage.role === "assistant") {
+    const hasToolCalls = nextContent.some(
+      (block) => block && typeof block === "object" && (block as { type?: unknown }).type === "toolCall",
+    );
+    if (hasToolCalls) {
+      typedMessage.stopReason = "toolUse";
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes infinite tool call loop when using Kimi Code model.

### Problem

The `rewriteKimiTaggedToolCallsInMessage` function unconditionally rewrites `stopReason` from `"stop"` to `"toolUse"` for ALL messages. This causes the model to enter an infinite loop after receiving tool results, because the final answer (which should have `stopReason="stop"`) gets rewritten to `"toolUse"`, triggering another round of tool execution.

### Root Cause

```typescript
// Before (buggy):
if (typedMessage.stopReason === "stop") {
    typedMessage.stopReason = "toolUse";
}
```

This logic incorrectly applies to:
- ✅ Assistant generating tool calls (correct to rewrite)
- ❌ Assistant generating final answer after tool results (should NOT rewrite)

### Solution

Only rewrite `stopReason` when the message actually contains tool calls:

```typescript
// After (fixed):
if (typedMessage.stopReason === "stop" && typedMessage.role === "assistant") {
    const hasToolCalls = nextContent.some(block => block && block.type === "toolCall");
    if (hasToolCalls) {
        typedMessage.stopReason = "toolUse";
    }
}
```

### Changes

- Modified `rewriteKimiTaggedToolCallsInMessage` in `extensions/kimi-coding/stream.ts`
- Added check for `role === "assistant"` 
- Added check for actual tool call presence in content

### Testing

1. Start conversation with Kimi Code model
2. Send request requiring tool calls (e.g., "Check configuration")
3. Verify agent calls tools then generates final answer
4. Verify no infinite repetition

Before fix: 50+ repeated tool calls
After fix: 1-3 tool calls then final answer ✅

### Related

Fixes #71273

---

**Checklist:**
- [x] Bug fix (non-breaking change)
- [x] Tested locally
- [x] No breaking changes
