### PR TITLE
fix(matrix): repair trust CI followups

### DIFF
--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -911,6 +911,7 @@ describe("matrix CLI verification commands", () => {
 
     expect(pruneMatrixStaleGatewayDevicesMock).toHaveBeenCalledWith({
       accountId: "poe",
+      cfg: {},
     });
     expect(console.log).toHaveBeenCalledWith("Deleted stale OpenClaw devices: BritdXC6iL");
     expect(console.log).toHaveBeenCalledWith("Current device: A7hWrQ70ea");

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { createMatrixQaClient } from "../../substrate/client.js";
 import {
   createMatrixQaE2eeScenarioClient,
@@ -391,7 +391,9 @@ async function createMatrixQaCliSelfVerificationRuntime(params: {
   userId: string;
 }) {
   const outputDir = requireMatrixQaE2eeOutputDir(params.context);
-  const rootDir = await mkdtemp(path.join(tmpdir(), "openclaw-matrix-cli-qa-"));
+  const rootDir = await mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-matrix-cli-qa-"),
+  );
   const artifactDir = path.join(
     outputDir,
     "cli-self-verification",


### PR DESCRIPTION
Fixes the CI regressions introduced by 72731a37d255a2feffe1df3af9b838e39f8e1955.

Changes:
- update the Matrix CLI prune-stale test to expect the cfg passed by the command path
- create Matrix QA CLI temp roots under the OpenClaw preferred temp directory instead of host tmpdir()

Validation:
- pnpm run lint:tmp:no-random-messaging
- pnpm test extensions/matrix/src/cli.test.ts
- pnpm check:changed
- OPENCLAW_EXTENSION_BATCH_PARALLEL=2 pnpm test:extensions:batch -- "amazon-bedrock,bonjour,browser,cloudflare-ai-gateway,diagnostics-otel,fal,fireworks,line,llm-task,matrix,memory-core,memory-wiki,minimax,mistral,nextcloud-talk,video-generation-core,web-readability"