### PR TITLE
fix(telegram): prevent replay on poll stall + sendMessage retry

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -31,7 +31,9 @@ import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
   buildTelegramUpdateKey,
   createTelegramUpdateDedupe,
+  createTelegramUpdateIdDedupe,
   resolveTelegramUpdateId,
+  telegramUpdateIdDedupeKey,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import { resolveDefaultAgentId } from "./bot.agent.runtime.js";
@@ -279,49 +281,32 @@ export function createTelegramBotCore(
   });
 
   const recentUpdates = createTelegramUpdateDedupe();
+  const recentUpdateIds = createTelegramUpdateIdDedupe();
+  const inFlightUpdateIds = new Set<number>();
   const pendingUpdateKeys = new Set<string>();
   const activeHandledUpdateKeys = new Map<string, boolean>();
   const initialUpdateId =
     typeof opts.updateOffset?.lastUpdateId === "number" ? opts.updateOffset.lastUpdateId : null;
 
-  // Track update_ids that have entered the middleware pipeline but have not completed yet.
-  // This includes updates that are "queued" behind sequentialize(...) for a chat/topic key.
-  // We only persist a watermark that is strictly less than the smallest pending update_id,
-  // so we never write an offset that would skip an update still waiting to run.
-  const pendingUpdateIds = new Set<number>();
-  const failedUpdateIds = new Set<number>();
-  let highestCompletedUpdateId: number | null = initialUpdateId;
+  // Persisted watermark tracks the highest update_id we have *accepted into*
+  // the in-process delivery pipeline (not the highest whose turn has
+  // completed). Advancing on ingest prevents Telegram from replaying the same
+  // update after the poller transport is force-restarted mid-turn, which
+  // would otherwise land a duplicate cold turn on top of the in-progress one
+  // (see openclaw/openclaw#70954-adjacent incident, 2026-04-24 gateway.err.log).
+  // The update_id LRU (recentUpdateIds) and pendingUpdateKeys are the
+  // in-memory second line of defense when offset persistence has not yet
+  // landed on disk.
+  let highestAcceptedUpdateId: number | null = initialUpdateId;
   let highestPersistedUpdateId: number | null = initialUpdateId;
-  const maybePersistSafeWatermark = () => {
+  const maybePersistAcceptedWatermark = () => {
     if (typeof opts.updateOffset?.onUpdateId !== "function") {
       return;
     }
-    if (highestCompletedUpdateId === null) {
+    if (highestAcceptedUpdateId === null) {
       return;
     }
-    let safe = highestCompletedUpdateId;
-    if (pendingUpdateIds.size > 0) {
-      let minPending: number | null = null;
-      for (const id of pendingUpdateIds) {
-        if (minPending === null || id < minPending) {
-          minPending = id;
-        }
-      }
-      if (minPending !== null) {
-        safe = Math.min(safe, minPending - 1);
-      }
-    }
-    if (failedUpdateIds.size > 0) {
-      let minFailed: number | null = null;
-      for (const id of failedUpdateIds) {
-        if (minFailed === null || id < minFailed) {
-          minFailed = id;
-        }
-      }
-      if (minFailed !== null) {
-        safe = Math.min(safe, minFailed - 1);
-      }
-    }
+    const safe = highestAcceptedUpdateId;
     if (highestPersistedUpdateId !== null && safe <= highestPersistedUpdateId) {
       return;
     }
@@ -341,8 +326,12 @@ export function createTelegramBotCore(
 
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
-    const skipCutoff = highestPersistedUpdateId ?? initialUpdateId;
-    if (typeof updateId === "number" && skipCutoff !== null && updateId <= skipCutoff) {
+    // Use the startup watermark, not the moving in-process watermark. Since
+    // ingest now advances highestPersistedUpdateId to the current update's id,
+    // comparing against it here would have handlers skip the very update they
+    // are processing. initialUpdateId still filters any Telegram-side replay
+    // of an update that finished before this process started.
+    if (typeof updateId === "number" && initialUpdateId !== null && updateId <= initialUpdateId) {
       return true;
     }
     const key = buildTelegramUpdateKey(ctx);
@@ -368,22 +357,34 @@ export function createTelegramBotCore(
   bot.use(async (ctx, next) => {
     const updateId = resolveTelegramUpdateId(ctx);
     const updateKey = buildTelegramUpdateKey(ctx);
-    let completed = false;
-    if (typeof updateId === "number") {
-      failedUpdateIds.delete(updateId);
-      pendingUpdateIds.add(updateId);
+    const updateIdKey =
+      typeof updateId === "number" ? telegramUpdateIdDedupeKey(updateId) : undefined;
+    // Second line of defense: skip any update whose update_id is already
+    // in-flight in this process or was recently handled. Runs before the
+    // broader updateKey dedupe so replays after a forced poll restart are
+    // rejected even if the offset write has not yet persisted.
+    if (typeof updateId === "number" && updateIdKey) {
+      if (inFlightUpdateIds.has(updateId) || recentUpdateIds.peek(updateIdKey)) {
+        logSkippedUpdate(updateIdKey);
+        return;
+      }
     }
     if (updateKey) {
       if (pendingUpdateKeys.has(updateKey) || recentUpdates.peek(updateKey)) {
         logSkippedUpdate(updateKey);
-        if (typeof updateId === "number") {
-          pendingUpdateIds.delete(updateId);
-        }
         return;
       }
       pendingUpdateKeys.add(updateKey);
       activeHandledUpdateKeys.set(updateKey, false);
     }
+    if (typeof updateId === "number" && updateIdKey) {
+      inFlightUpdateIds.add(updateId);
+      if (highestAcceptedUpdateId === null || updateId > highestAcceptedUpdateId) {
+        highestAcceptedUpdateId = updateId;
+      }
+      maybePersistAcceptedWatermark();
+    }
+    let completed = false;
     try {
       await next();
       completed = true;
@@ -395,15 +396,10 @@ export function createTelegramBotCore(
         }
         pendingUpdateKeys.delete(updateKey);
       }
-      if (typeof updateId === "number") {
-        pendingUpdateIds.delete(updateId);
+      if (typeof updateId === "number" && updateIdKey) {
+        inFlightUpdateIds.delete(updateId);
         if (completed) {
-          if (highestCompletedUpdateId === null || updateId > highestCompletedUpdateId) {
-            highestCompletedUpdateId = updateId;
-          }
-          maybePersistSafeWatermark();
-        } else {
-          failedUpdateIds.add(updateId);
+          recentUpdateIds.check(updateIdKey);
         }
       }
     }

--- a/extensions/telegram/src/bot-updates.test.ts
+++ b/extensions/telegram/src/bot-updates.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramUpdateIdDedupe, telegramUpdateIdDedupeKey } from "./bot-updates.js";
+
+describe("createTelegramUpdateIdDedupe", () => {
+  it("marks update_ids as seen only after the first check", () => {
+    const cache = createTelegramUpdateIdDedupe();
+    const key = telegramUpdateIdDedupeKey(42);
+    expect(cache.peek(key)).toBe(false);
+    expect(cache.check(key)).toBe(false);
+    expect(cache.peek(key)).toBe(true);
+    expect(cache.check(key)).toBe(true);
+  });
+
+  it("expires entries after the 5-minute TTL", () => {
+    const cache = createTelegramUpdateIdDedupe();
+    const key = telegramUpdateIdDedupeKey(7);
+    const base = 1_000_000_000;
+    expect(cache.check(key, base)).toBe(false);
+    expect(cache.peek(key, base + 60_000)).toBe(true);
+    // Just before 5 minutes → still cached.
+    expect(cache.peek(key, base + 5 * 60_000 - 1)).toBe(true);
+    // At 5 minutes the entry has aged out.
+    expect(cache.peek(key, base + 5 * 60_000)).toBe(false);
+    // check() after expiry treats the update_id as unseen again.
+    expect(cache.check(key, base + 5 * 60_000 + 1)).toBe(false);
+  });
+
+  it("evicts the oldest entry once the 512-entry cap is exceeded", () => {
+    const cache = createTelegramUpdateIdDedupe();
+    const now = 1_000_000_000;
+    for (let i = 0; i < 512; i += 1) {
+      cache.check(telegramUpdateIdDedupeKey(i), now + i);
+    }
+    expect(cache.size()).toBe(512);
+    // Inserting one more evicts the least-recently-used entry (id=0).
+    cache.check(telegramUpdateIdDedupeKey(9999), now + 1_000);
+    expect(cache.size()).toBe(512);
+    expect(cache.peek(telegramUpdateIdDedupeKey(0), now + 1_000)).toBe(false);
+    expect(cache.peek(telegramUpdateIdDedupeKey(511), now + 1_000)).toBe(true);
+    expect(cache.peek(telegramUpdateIdDedupeKey(9999), now + 1_000)).toBe(true);
+  });
+
+  it("refreshes recency on peek-free check and evicts the true LRU entry", () => {
+    const cache = createTelegramUpdateIdDedupe();
+    const now = 1_000_000_000;
+    for (let i = 0; i < 512; i += 1) {
+      cache.check(telegramUpdateIdDedupeKey(i), now + i);
+    }
+    // Touch id=0 so id=1 becomes the least-recently-used entry.
+    cache.check(telegramUpdateIdDedupeKey(0), now + 10_000);
+    cache.check(telegramUpdateIdDedupeKey(9999), now + 20_000);
+    expect(cache.peek(telegramUpdateIdDedupeKey(0), now + 20_000)).toBe(true);
+    expect(cache.peek(telegramUpdateIdDedupeKey(1), now + 20_000)).toBe(false);
+  });
+
+  it("keys are namespaced so they cannot collide with other dedupe keys", () => {
+    expect(telegramUpdateIdDedupeKey(1)).toBe("update_id:1");
+    const cache = createTelegramUpdateIdDedupe();
+    cache.check("update:1");
+    expect(cache.peek(telegramUpdateIdDedupeKey(1))).toBe(false);
+  });
+
+  it("peek is non-mutating — does not extend TTL or touch recency", () => {
+    const cache = createTelegramUpdateIdDedupe();
+    const key = telegramUpdateIdDedupeKey(1);
+    const base = 1_000_000_000;
+    cache.check(key, base);
+    const peekSpy = vi.fn(() => cache.peek(key, base + 60_000));
+    peekSpy();
+    peekSpy();
+    // Entry still expires 5 minutes after the original check, not after peeks.
+    expect(cache.peek(key, base + 5 * 60_000)).toBe(false);
+  });
+});

--- a/extensions/telegram/src/bot-updates.ts
+++ b/extensions/telegram/src/bot-updates.ts
@@ -5,6 +5,8 @@ import type { TelegramContext } from "./bot/types.js";
 const MEDIA_GROUP_TIMEOUT_MS = 500;
 const RECENT_TELEGRAM_UPDATE_TTL_MS = 5 * 60_000;
 const RECENT_TELEGRAM_UPDATE_MAX = 2000;
+const RECENT_TELEGRAM_UPDATE_ID_TTL_MS = 5 * 60_000;
+const RECENT_TELEGRAM_UPDATE_ID_MAX = 512;
 
 export type MediaGroupEntry = {
   messages: Array<{
@@ -63,5 +65,16 @@ export const createTelegramUpdateDedupe = () =>
     ttlMs: RECENT_TELEGRAM_UPDATE_TTL_MS,
     maxSize: RECENT_TELEGRAM_UPDATE_MAX,
   });
+
+// Second-line defense keyed strictly on Telegram update.update_id. Backstops the
+// broader dedupe when the transport is force-restarted mid-turn and Telegram
+// replays updates whose offset write has not yet landed on disk.
+export const createTelegramUpdateIdDedupe = () =>
+  createDedupeCache({
+    ttlMs: RECENT_TELEGRAM_UPDATE_ID_TTL_MS,
+    maxSize: RECENT_TELEGRAM_UPDATE_ID_MAX,
+  });
+
+export const telegramUpdateIdDedupeKey = (updateId: number) => `update_id:${updateId}`;
 
 export { MEDIA_GROUP_TIMEOUT_MS };

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1091,7 +1091,7 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
-  it("does not persist update offset past pending updates", async () => {
+  it("persists update offset at ingest so forced poll restarts do not replay in-flight turns", async () => {
     // For this test we need sequentialize(...) to behave like a normal middleware and call next().
     sequentializeSpy.mockImplementationOnce(
       () => async (_ctx: unknown, next: () => Promise<void>) => {
@@ -1146,26 +1146,26 @@ describe("createTelegramBot", () => {
       releaseUpdate101 = resolve;
     });
 
-    // Start processing update 101 but keep it pending (simulates an update queued behind sequentialize()).
+    // Start processing update 101 but keep its turn in-flight (simulates the poll-stall
+    // scenario: the transport may be force-restarted before the turn resolves).
     const p101 = runMiddlewareChain({ update: { update_id: 101 } }, async () => update101Gate);
-    // Let update 101 enter the chain and mark itself pending before 102 completes.
+    // Let update 101 enter the middleware pipeline before the second update is dispatched.
     await Promise.resolve();
+    await flushTelegramTestMicrotasks();
 
-    // Complete update 102 while 101 is still pending. The persisted watermark must not jump to 102.
+    // Update 101's watermark persists on ingest even though its turn has not completed,
+    // so a transport restart re-polling at offset=102 will not replay it.
+    expect(onUpdateId).toHaveBeenCalledWith(101);
+
     await runMiddlewareChain({ update: { update_id: 102 } }, async () => {});
-
-    const persistedValues = onUpdateId.mock.calls.map((call) => Number(call[0]));
-    const maxPersisted = persistedValues.length > 0 ? Math.max(...persistedValues) : -Infinity;
-    expect(maxPersisted).toBeLessThan(101);
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).toHaveBeenCalledWith(102);
 
     releaseUpdate101?.();
     await p101;
-
-    // Once the pending update finishes, the watermark can safely catch up.
-    const persistedAfterDrain = onUpdateId.mock.calls.map((call) => Number(call[0]));
-    const maxPersistedAfterDrain =
-      persistedAfterDrain.length > 0 ? Math.max(...persistedAfterDrain) : -Infinity;
-    expect(maxPersistedAfterDrain).toBe(102);
+    // Draining the in-flight turn does not regress the persisted watermark.
+    const persistedValues = onUpdateId.mock.calls.map((call) => Number(call[0]));
+    expect(Math.max(...persistedValues)).toBe(102);
   });
   it("logs and swallows update watermark persistence failures", async () => {
     sequentializeSpy.mockImplementationOnce(
@@ -1237,7 +1237,7 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("does not persist failed updates into the watermark", async () => {
+  it("persists the offset at ingest even when the turn fails, then dedupes the replay", async () => {
     sequentializeSpy.mockImplementationOnce(
       () => async (_ctx: unknown, next: () => Promise<void>) => {
         await next();
@@ -1283,21 +1283,18 @@ describe("createTelegramBot", () => {
       await dispatch(0);
     };
 
+    // A failing turn must still advance the persisted offset — we accepted
+    // responsibility for the update when it entered the pipeline, so on restart
+    // Telegram must not replay it even though the handler ultimately threw.
     await expect(
       runMiddlewareChain({ update: { update_id: 201 } }, async () => {
         throw new Error("middleware boom");
       }),
     ).rejects.toThrow("middleware boom");
+    await flushTelegramTestMicrotasks();
+    expect(onUpdateId).toHaveBeenCalledWith(201);
 
     await runMiddlewareChain({ update: { update_id: 202 } }, async () => {});
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onUpdateId).not.toHaveBeenCalled();
-    expect(onUpdateId).not.toHaveBeenCalledWith(201);
-    expect(onUpdateId).not.toHaveBeenCalledWith(202);
-
-    await runMiddlewareChain({ update: { update_id: 201 } }, async () => {});
-
     await flushTelegramTestMicrotasks();
     expect(onUpdateId).toHaveBeenCalledWith(202);
   });

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -171,6 +171,45 @@ export function isSafeToRetrySendError(err: unknown): boolean {
   return false;
 }
 
+const SEND_MESSAGE_RETRY_CODES = new Set(["ECONNRESET", "ETIMEDOUT"]);
+// Matches the bare grammY "Network request for 'sendMessage' failed!" surface
+// that fires when a send is interrupted before a response. Deliberately does
+// NOT match the "failed after N attempts" envelope, which means grammY's own
+// retry loop already exhausted attempts — another retry on top compounds the
+// duplicate-delivery risk.
+const SEND_MESSAGE_RETRY_MESSAGE_RE =
+  /network request(?:\s+for\s+['"][^'"]+['"])?\s+failed(?!\s+after\b)/i;
+
+/**
+ * Retry predicate for the sendMessage wrapper. Matches the specific transient
+ * network failures observed in production (ECONNRESET, ETIMEDOUT, and the
+ * grammY "Network request for '<method>' failed" message) and explicitly
+ * rejects any Telegram 4xx (400/403/429). Broader than `isSafeToRetrySendError`
+ * — it tolerates a small risk of duplicate delivery when the network error
+ * fires after Telegram has already accepted the request, in exchange for
+ * retrying through the common transient failures that currently drop user
+ * replies entirely.
+ */
+export function isRetryableSendMessageError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  if (isTelegramClientRejection(err)) {
+    return false;
+  }
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code && SEND_MESSAGE_RETRY_CODES.has(code)) {
+      return true;
+    }
+    const message = formatErrorMessage(candidate);
+    if (message && SEND_MESSAGE_RETRY_MESSAGE_RE.test(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean): boolean {
   for (const candidate of collectTelegramErrorCandidates(err)) {
     if (!candidate || typeof candidate !== "object" || !("error_code" in candidate)) {

--- a/extensions/telegram/src/send-message-retry.test.ts
+++ b/extensions/telegram/src/send-message-retry.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { isRetryableSendMessageError } from "./network-errors.js";
+import { SEND_MESSAGE_RETRY_BACKOFF_MS, withSendMessageRetry } from "./send-message-retry.js";
+
+const withCode = (message: string, code: string) => Object.assign(new Error(message), { code });
+
+const telegramError = (errorCode: number, description: string) =>
+  Object.assign(new Error(`${errorCode}: ${description}`), {
+    error_code: errorCode,
+    description,
+  });
+
+describe("isRetryableSendMessageError", () => {
+  it("matches ECONNRESET and ETIMEDOUT", () => {
+    expect(isRetryableSendMessageError(withCode("connection reset", "ECONNRESET"))).toBe(true);
+    expect(isRetryableSendMessageError(withCode("request timed out", "ETIMEDOUT"))).toBe(true);
+  });
+
+  it("matches the grammY 'Network request for <method> failed' message", () => {
+    expect(
+      isRetryableSendMessageError(new Error("Network request for 'sendMessage' failed!")),
+    ).toBe(true);
+  });
+
+  it("does not match the 'failed after N attempts' envelope (grammY already retried)", () => {
+    expect(
+      isRetryableSendMessageError(
+        new Error("Network request for 'sendMessage' failed after 1 attempts."),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([400, 403, 429])("rejects Telegram %s client rejections", (code) => {
+    expect(isRetryableSendMessageError(telegramError(code, "not retryable"))).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isRetryableSendMessageError(new Error("some application bug"))).toBe(false);
+    expect(isRetryableSendMessageError(null)).toBe(false);
+  });
+});
+
+describe("withSendMessageRetry", () => {
+  const expectedBackoffs = SEND_MESSAGE_RETRY_BACKOFF_MS;
+
+  const setup = () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const random = vi.fn(() => 0.5); // Zero-jitter midpoint for deterministic assertions.
+    const log = vi.fn((_message: string) => {});
+    return { sleep, random, log };
+  };
+
+  it("returns the first-attempt result without sleeping", async () => {
+    const { sleep, random } = setup();
+    const fn = vi.fn(async () => "ok");
+    const result = await withSendMessageRetry(fn, { sleep, random });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries transient errors using the 500 → 2000 → 8000ms backoff schedule", async () => {
+    const { sleep, random, log } = setup();
+    const transient = withCode("ECONNRESET", "ECONNRESET");
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValueOnce("ok");
+
+    const result = await withSendMessageRetry(fn, { sleep, random, log });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3);
+    // random()==0.5 → symmetric jitter term is zero, so the delays equal the base backoffs.
+    expect(sleep.mock.calls.map((call) => call[0])).toEqual([...expectedBackoffs]);
+    expect(log).toHaveBeenCalledTimes(3);
+  });
+
+  it("applies ±25% jitter around each base backoff", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const log = vi.fn((_message: string) => {});
+    // Alternating extremes: fully negative jitter, then fully positive jitter, then midpoint.
+    const random = vi.fn().mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValueOnce(0.5);
+    const transient = withCode("ECONNRESET", "ECONNRESET");
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValueOnce("ok");
+    await withSendMessageRetry(fn, { sleep, random, log });
+    const delays = sleep.mock.calls.map((call) => call[0]);
+    const [first = 0, second = 0, third = 0] = delays;
+    expect(first).toBe(Math.round(expectedBackoffs[0] * 0.75));
+    expect(second).toBe(Math.round(expectedBackoffs[1] * 1.25));
+    expect(third).toBe(expectedBackoffs[2]);
+    const observed = [first, second, third];
+    expectedBackoffs.forEach((base, i) => {
+      const delay = observed[i] ?? 0;
+      expect(delay).toBeGreaterThanOrEqual(Math.round(base * 0.75));
+      expect(delay).toBeLessThanOrEqual(Math.round(base * 1.25));
+    });
+  });
+
+  it("does not retry permanent Telegram client rejections", async () => {
+    const { sleep, random } = setup();
+    const permanent = telegramError(400, "Bad Request: chat not found");
+    const fn = vi.fn(async () => {
+      throw permanent;
+    });
+    await expect(withSendMessageRetry(fn, { sleep, random })).rejects.toBe(permanent);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("gives up after the attempt limit and surfaces the last error", async () => {
+    const { sleep, random } = setup();
+    const transient = withCode("ECONNRESET", "ECONNRESET");
+    const fn = vi.fn(async () => {
+      throw transient;
+    });
+    await expect(withSendMessageRetry(fn, { sleep, random })).rejects.toBe(transient);
+    expect(fn).toHaveBeenCalledTimes(expectedBackoffs.length + 1);
+    expect(sleep).toHaveBeenCalledTimes(expectedBackoffs.length);
+  });
+
+  it("honors an injected retry predicate", async () => {
+    const { sleep, random } = setup();
+    const err = new Error("custom");
+    const isRetryable = vi.fn(() => false);
+    const fn = vi.fn(async () => {
+      throw err;
+    });
+    await expect(withSendMessageRetry(fn, { sleep, random, isRetryable })).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(isRetryable).toHaveBeenCalledWith(err);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/send-message-retry.ts
+++ b/extensions/telegram/src/send-message-retry.ts
@@ -1,0 +1,70 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isRetryableSendMessageError } from "./network-errors.js";
+
+const SEND_MESSAGE_BACKOFF_MS: readonly [number, number, number] = [500, 2000, 8000];
+const SEND_MESSAGE_JITTER = 0.25;
+
+export type SendMessageRetryLogger = (message: string) => void;
+
+export type SendMessageRetryOptions = {
+  /** Injected for deterministic tests. Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected for deterministic tests. Defaults to Math.random. */
+  random?: () => number;
+  /** Injected for deterministic tests. Defaults to the shared retry predicate. */
+  isRetryable?: (err: unknown) => boolean;
+  /** Optional diagnostic-level logger. */
+  log?: SendMessageRetryLogger;
+  /** Label used in retry log lines. Defaults to "sendMessage". */
+  label?: string;
+};
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+
+const applyJitter = (baseMs: number, random: () => number) => {
+  const delta = baseMs * SEND_MESSAGE_JITTER * (random() * 2 - 1);
+  return Math.max(0, Math.round(baseMs + delta));
+};
+
+/**
+ * Wrap a Telegram sendMessage call with a bounded retry on transient network
+ * errors. Up to three retries with 500ms → 2s → 8s backoff (±25% jitter).
+ * Only retries errors that match `isRetryableSendMessageError` — permanent
+ * 4xx rejections (400/403/429) short-circuit immediately.
+ */
+export async function withSendMessageRetry<T>(
+  fn: () => Promise<T>,
+  options: SendMessageRetryOptions = {},
+): Promise<T> {
+  const sleep = options.sleep ?? defaultSleep;
+  const random = options.random ?? Math.random;
+  const isRetryable = options.isRetryable ?? isRetryableSendMessageError;
+  const label = options.label ?? "sendMessage";
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= SEND_MESSAGE_BACKOFF_MS.length; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt === SEND_MESSAGE_BACKOFF_MS.length || !isRetryable(err)) {
+        throw err;
+      }
+      const baseMs = SEND_MESSAGE_BACKOFF_MS[attempt] ?? 0;
+      const delayMs = applyJitter(baseMs, random);
+      options.log?.(
+        `telegram ${label} retry ${attempt + 1}/${SEND_MESSAGE_BACKOFF_MS.length} in ${delayMs}ms: ${formatErrorMessage(err)}`,
+      );
+      await sleep(delayMs);
+    }
+  }
+  // Unreachable: the loop either returns a value or throws. Narrow for the type
+  // checker and preserve the latest error context if reached.
+  throw lastError;
+}
+
+export const SEND_MESSAGE_RETRY_BACKOFF_MS: readonly [number, number, number] =
+  SEND_MESSAGE_BACKOFF_MS;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -24,6 +24,7 @@ import {
 } from "./network-errors.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 import { makeProxyFetch } from "./proxy.js";
+import { withSendMessageRetry } from "./send-message-retry.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -690,12 +691,17 @@ export async function sendMessageTelegram(
           ...(opts.silent === true ? { disable_notification: true } : {}),
         };
         const hasPlainParams = Object.keys(plainParams).length > 0;
+        const retryLog = opts.verbose ? (message: string) => logVerbose(message) : undefined;
         const requestPlain = (retryLabel: string) =>
           requestWithChatNotFound(
             () =>
-              hasPlainParams
-                ? api.sendMessage(chatId, chunk.plainText, plainParams)
-                : api.sendMessage(chatId, chunk.plainText),
+              withSendMessageRetry(
+                () =>
+                  hasPlainParams
+                    ? api.sendMessage(chatId, chunk.plainText, plainParams)
+                    : api.sendMessage(chatId, chunk.plainText),
+                { label: retryLabel, ...(retryLog ? { log: retryLog } : {}) },
+              ),
             retryLabel,
           );
         if (!chunk.htmlText) {
@@ -711,7 +717,11 @@ export async function sendMessageTelegram(
           verbose: opts.verbose,
           requestHtml: (retryLabel) =>
             requestWithChatNotFound(
-              () => api.sendMessage(chatId, htmlText, htmlParams),
+              () =>
+                withSendMessageRetry(() => api.sendMessage(chatId, htmlText, htmlParams), {
+                  label: retryLabel,
+                  ...(retryLog ? { log: retryLog } : {}),
+                }),
               retryLabel,
             ),
           requestPlain,


### PR DESCRIPTION
## Summary

Three surgical reliability fixes on the Telegram extension, all driven by the 2026-04-24 gateway.err.log incident:

- **Fix 1 — advance `getUpdates` offset on ingest.** `bot-core.ts` now persists the update watermark the moment an update enters the middleware pipeline, rather than after the turn completes. When the poller transport is force-restarted mid-turn, the fresh runner resumes at the already-advanced offset and Telegram no longer replays the in-flight update onto a cold agent instance.
- **Fix 2 — second-line LRU dedupe on `update.update_id`.** New 512-entry, 5-min TTL LRU plus an in-flight `Set<number>` in `bot-core.ts` reject replays during the narrow window between ingest and the async offset disk write landing. Marked on completion so a handler failure can still be retried.
- **Fix 3 — bounded retry on outbound `sendMessage`.** New `withSendMessageRetry` helper wraps the `api.sendMessage` calls inside `sendMessageTelegram`: up to three retries with 500ms → 2s → 8s backoff and ±25% jitter. Retries only on ECONNRESET, ETIMEDOUT, and the bare grammY \"Network request for '<method>' failed!\" surface; 400/403/429 short-circuit, and the \"failed after N attempts\" envelope is excluded (grammY has already retried — compounding would magnify the duplicate risk).

## Evidence (from ~/.openclaw/logs/gateway.err.log, 2026-04-24)

\`\`\`
11:57:25 EDT  [telegram] Polling stall detected (no completed getUpdates for 97.56s); forcing restart
11:57:40      [telegram] Polling runner stop timed out after 15s; forcing restart cycle
12:36:39/40   [telegram] sendMessage failed: Network request for 'sendMessage' failed!  (twice, no retry)
\`\`\`

Symptom: forced transport restart while a turn was running caused Telegram to re-deliver the same update to a fresh agent, producing a duplicate \"sorry I got stuck\" reply colliding with the in-progress turn. Fix 1 + 2 close the replay window; Fix 3 restores delivery for the subsequent send failures.

## Files touched

- \`extensions/telegram/src/bot-core.ts\` — offset-on-ingest, in-flight + LRU dedupe.
- \`extensions/telegram/src/bot-updates.ts\` — new \`createTelegramUpdateIdDedupe\` factory and key helper.
- \`extensions/telegram/src/network-errors.ts\` — new \`isRetryableSendMessageError\` predicate.
- \`extensions/telegram/src/send.ts\` — \`withSendMessageRetry\` wiring around plain + HTML chunk sends.
- \`extensions/telegram/src/send-message-retry.ts\` (new) — retry wrapper.
- \`extensions/telegram/src/bot-updates.test.ts\` (new) — LRU eviction/TTL coverage.
- \`extensions/telegram/src/send-message-retry.test.ts\` (new) — retry wrapper coverage.
- \`extensions/telegram/src/bot.create-telegram-bot.test.ts\` — two existing \"pending watermark\" / \"failed-update watermark\" tests rewritten to reflect the new ingest-time semantics.

## Test plan

- [x] \`pnpm test extensions/telegram\` → **1408 tests, all passing.**
- [x] \`pnpm check:changed\` → extension typecheck + extension-test typecheck + extension lint + runtime import cycles + changed tests (**1405 tests passing**).
- [x] New unit tests:
  - Dedupe cache: first-seen vs seen; 5-min TTL expiry; 512-entry eviction; LRU recency refresh; key namespacing; peek is non-mutating.
  - Retry wrapper: success path with no sleep; 500→2000→8000 schedule; ±25% jitter bounds; permanent 4xx short-circuit; exhaustion; injected predicate.
  - Retry predicate: ECONNRESET/ETIMEDOUT match, \"failed!\" matches, \"failed after N attempts\" does NOT match, 400/403/429 rejected.
- [ ] Watching production gateway.err.log to confirm the 'Polling stall detected ... forcing restart' replays stop producing duplicate replies once shipped.
- [ ] Watching production gateway.err.log to confirm transient sendMessage failures now retry instead of dropping user replies.

## Risk

- **Behavior change for failed turns:** offset now advances even if the handler throws. Previously a thrown handler blocked the watermark, Telegram could replay, and the retry would execute the handler again. New behavior prefers occasional message-loss over duplicate-delivery, which matches the user-visible symptom the fix is targeting. Two existing tests (\`does not persist update offset past pending updates\`, \`does not persist failed updates into the watermark\`) were rewritten to document the new semantic; the 11 \"retries X callback after a bubbled failure\" tests still pass because the LRU only marks on completion, leaving failed updates eligible for retry.
- **Duplicate-delivery risk on send retry:** ECONNRESET/ETIMEDOUT can fire after Telegram accepted the message, so a retry may double-post. Bounded to 3 retries, excludes the \"failed after N attempts\" envelope where grammY has already retried, and only fires on the specific transient surfaces logged in production.

Please review — **do NOT merge.**