### PR TITLE
ops: add isolated 4.23 upgrade proof tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1407,6 +1407,7 @@
     "moltbot:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "openclaw": "node scripts/run-node.mjs",
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
+    "ops:candidate-upgrade:4.23": "bash scripts/ops/candidate-npm-upgrade.sh",
     "plugin-sdk:api:check": "node --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check",
     "plugin-sdk:api:gen": "node --import tsx scripts/generate-plugin-sdk-api-baseline.ts --write",
     "plugin-sdk:check-exports": "node scripts/sync-plugin-sdk-exports.mjs --check",

--- a/package.json
+++ b/package.json
@@ -1407,6 +1407,7 @@
     "moltbot:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "openclaw": "node scripts/run-node.mjs",
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
+    "ops:candidate-safety-markers:4.23": "node scripts/ops/verify-candidate-safety-markers.mjs",
     "ops:candidate-upgrade:4.23": "bash scripts/ops/candidate-npm-upgrade.sh",
     "plugin-sdk:api:check": "node --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check",
     "plugin-sdk:api:gen": "node --import tsx scripts/generate-plugin-sdk-api-baseline.ts --write",

--- a/scripts/ops/candidate-npm-upgrade.sh
+++ b/scripts/ops/candidate-npm-upgrade.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ops/candidate-npm-upgrade.sh [options]
+
+Installs an OpenClaw baseline package into a temporary npm prefix, runs that
+candidate's updater to the target spec, and writes a JSON proof bundle without
+touching the live global package prefix or systemd service.
+
+Options:
+  --baseline <npm-spec>   Baseline package spec (default: openclaw@2026.4.5)
+  --target <npm-spec>     Target package spec/tag/version (default: 2026.4.23)
+  --expected <version>    Expected final package version (default: 2026.4.23)
+  --keep                  Keep the temporary candidate root after success/fail
+  --out <path>            Proof JSON path (default: .artifacts/candidate-npm-upgrade/proof.json)
+  -h, --help              Show this help
+
+Environment:
+  OPENCLAW_CANDIDATE_NPM       npm binary to use (default: npm)
+  OPENCLAW_CANDIDATE_NODE      node binary to use (default: node)
+  OPENCLAW_CANDIDATE_TIMEOUT   openclaw update timeout ms (default: 180000)
+USAGE
+}
+
+baseline="openclaw@2026.4.5"
+target="2026.4.23"
+expected="2026.4.23"
+keep=0
+out=".artifacts/candidate-npm-upgrade/proof.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      baseline="${2:?missing --baseline value}"
+      shift 2
+      ;;
+    --target)
+      target="${2:?missing --target value}"
+      shift 2
+      ;;
+    --expected)
+      expected="${2:?missing --expected value}"
+      shift 2
+      ;;
+    --keep)
+      keep=1
+      shift
+      ;;
+    --out)
+      out="${2:?missing --out value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+npm_bin="${OPENCLAW_CANDIDATE_NPM:-npm}"
+node_bin="${OPENCLAW_CANDIDATE_NODE:-node}"
+update_timeout="${OPENCLAW_CANDIDATE_TIMEOUT:-180000}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ "$out" != /* ]]; then
+  out="$repo_root/$out"
+fi
+mkdir -p "$(dirname "$out")"
+
+candidate_root="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-candidate-upgrade-XXXXXX")"
+cleanup() {
+  if [[ "$keep" != "1" ]]; then
+    chmod -R u+w "$candidate_root" 2>/dev/null || true
+    rm -rf "$candidate_root" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+candidate_prefix="$candidate_root/npm-prefix"
+candidate_home="$candidate_root/home"
+mkdir -p "$candidate_prefix" "$candidate_home/.openclaw"
+
+candidate_port="$((28000 + RANDOM % 10000))"
+cat > "$candidate_home/.openclaw/openclaw.json" <<JSON
+{
+  "gateway": {
+    "mode": "local",
+    "port": $candidate_port,
+    "controlUi": { "enabled": false }
+  },
+  "plugins": { "enabled": false },
+  "update": { "checkOnStart": false, "auto": { "enabled": false } }
+}
+JSON
+
+live_openclaw="$(command -v openclaw || true)"
+live_prefix="$("$npm_bin" config get prefix 2>/dev/null || true)"
+live_version_before=""
+if [[ -n "$live_openclaw" ]]; then
+  live_version_before="$(openclaw --version 2>/dev/null || true)"
+fi
+
+export npm_config_prefix="$candidate_prefix"
+export OPENCLAW_HOME="$candidate_home"
+export OPENCLAW_DISABLE_BUNDLED_PLUGINS=1
+export PATH="$candidate_prefix/bin:$PATH"
+
+printf '==> Candidate root: %s\n' "$candidate_root"
+printf '==> Installing baseline: %s\n' "$baseline"
+"$npm_bin" install -g "$baseline" --no-audit --no-fund --loglevel=error
+
+candidate_bin="$candidate_prefix/bin/openclaw"
+if [[ ! -x "$candidate_bin" ]]; then
+  echo "candidate openclaw binary missing: $candidate_bin" >&2
+  exit 1
+fi
+
+before_version="$($candidate_bin --version | head -n 1)"
+printf '==> Baseline candidate: %s\n' "$before_version"
+printf '==> Updating candidate to: %s\n' "$target"
+
+update_json="$candidate_root/update.json"
+set +e
+"$candidate_bin" update --tag "$target" --json --timeout "$update_timeout" >"$update_json" 2>"$candidate_root/update.stderr"
+update_code=$?
+set -e
+if [[ "$update_code" -ne 0 ]]; then
+  echo "candidate update failed with exit code $update_code" >&2
+  tail -n 80 "$candidate_root/update.stderr" >&2 || true
+  exit "$update_code"
+fi
+
+after_version="$($candidate_bin --version | head -n 1)"
+actual="$($node_bin -e 'const path=process.env.npm_config_prefix+"/lib/node_modules/openclaw/package.json"; console.log(require(path).version)')"
+package_root="$candidate_prefix/lib/node_modules/openclaw"
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "candidate version mismatch: expected $expected, got $actual" >&2
+  exit 1
+fi
+
+case "$package_root" in
+  "$candidate_root"/*) ;;
+  *)
+    echo "candidate package root escaped candidate root: $package_root" >&2
+    exit 1
+    ;;
+esac
+
+live_version_after=""
+if [[ -n "$live_openclaw" ]]; then
+  live_version_after="$("$live_openclaw" --version 2>/dev/null || true)"
+fi
+
+"$node_bin" - "$out" "$candidate_root" "$candidate_prefix" "$candidate_home" "$baseline" "$target" "$expected" "$before_version" "$after_version" "$actual" "$package_root" "$live_openclaw" "$live_prefix" "$live_version_before" "$live_version_after" "$update_json" <<'NODE'
+const fs = require('node:fs');
+const [out, candidateRoot, candidatePrefix, candidateHome, baseline, target, expected, beforeVersion, afterVersion, actualVersion, packageRoot, liveOpenclaw, livePrefix, liveVersionBefore, liveVersionAfter, updateJsonPath] = process.argv.slice(2);
+const update = JSON.parse(fs.readFileSync(updateJsonPath, 'utf8'));
+const proof = {
+  status: 'ok',
+  generatedAt: new Date().toISOString(),
+  baseline,
+  target,
+  expectedVersion: expected,
+  actualVersion,
+  beforeVersion,
+  afterVersion,
+  candidate: {
+    root: candidateRoot,
+    npmPrefix: candidatePrefix,
+    openclawHome: candidateHome,
+    packageRoot,
+  },
+  live: {
+    openclawPath: liveOpenclaw || null,
+    npmPrefix: livePrefix || null,
+    versionBefore: liveVersionBefore || null,
+    versionAfter: liveVersionAfter || null,
+    unchanged: liveVersionBefore === liveVersionAfter,
+  },
+  update,
+};
+fs.writeFileSync(out, `${JSON.stringify(proof, null, 2)}\n`);
+NODE
+
+printf '==> Proof written: %s\n' "$out"
+printf '==> Candidate upgraded: %s -> %s\n' "$before_version" "$after_version"
+printf '==> Live openclaw unchanged: %s\n' "${live_version_before:-not found}"

--- a/scripts/ops/candidate-npm-upgrade.sh
+++ b/scripts/ops/candidate-npm-upgrade.sh
@@ -132,14 +132,28 @@ set +e
 update_code=$?
 set -e
 if [[ "$update_code" -ne 0 ]]; then
-  echo "candidate update failed with exit code $update_code" >&2
-  tail -n 80 "$candidate_root/update.stderr" >&2 || true
-  exit "$update_code"
+  if ! "$node_bin" - "$update_json" "$expected" <<'NODE'
+const fs = require('node:fs');
+const [updateJsonPath, expected] = process.argv.slice(2);
+try {
+  const update = JSON.parse(fs.readFileSync(updateJsonPath, 'utf8'));
+  process.exit(update.status === 'ok' && update.after?.version === expected ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
+  then
+    echo "candidate update failed with exit code $update_code" >&2
+    tail -n 80 "$candidate_root/update.stderr" >&2 || true
+    exit "$update_code"
+  fi
+  echo "candidate update exited $update_code after writing ok/version proof; continuing with package-local marker verification" >&2
 fi
 
 after_version="$($candidate_bin --version | head -n 1)"
 actual="$($node_bin -e 'const path=process.env.npm_config_prefix+"/lib/node_modules/openclaw/package.json"; console.log(require(path).version)')"
 package_root="$candidate_prefix/lib/node_modules/openclaw"
+safety_markers_json="$candidate_root/safety-markers.json"
 
 if [[ "$actual" != "$expected" ]]; then
   echo "candidate version mismatch: expected $expected, got $actual" >&2
@@ -154,15 +168,20 @@ case "$package_root" in
     ;;
 esac
 
+"$node_bin" "$repo_root/scripts/ops/verify-candidate-safety-markers.mjs" "$package_root" --json >"$safety_markers_json"
+
+export OPENCLAW_CANDIDATE_UPDATE_EXIT_CODE="$update_code"
+
 live_version_after=""
 if [[ -n "$live_openclaw" ]]; then
   live_version_after="$("$live_openclaw" --version 2>/dev/null || true)"
 fi
 
-"$node_bin" - "$out" "$candidate_root" "$candidate_prefix" "$candidate_home" "$baseline" "$target" "$expected" "$before_version" "$after_version" "$actual" "$package_root" "$live_openclaw" "$live_prefix" "$live_version_before" "$live_version_after" "$update_json" <<'NODE'
+"$node_bin" - "$out" "$candidate_root" "$candidate_prefix" "$candidate_home" "$baseline" "$target" "$expected" "$before_version" "$after_version" "$actual" "$package_root" "$live_openclaw" "$live_prefix" "$live_version_before" "$live_version_after" "$update_json" "$safety_markers_json" <<'NODE'
 const fs = require('node:fs');
-const [out, candidateRoot, candidatePrefix, candidateHome, baseline, target, expected, beforeVersion, afterVersion, actualVersion, packageRoot, liveOpenclaw, livePrefix, liveVersionBefore, liveVersionAfter, updateJsonPath] = process.argv.slice(2);
+const [out, candidateRoot, candidatePrefix, candidateHome, baseline, target, expected, beforeVersion, afterVersion, actualVersion, packageRoot, liveOpenclaw, livePrefix, liveVersionBefore, liveVersionAfter, updateJsonPath, safetyMarkersJsonPath] = process.argv.slice(2);
 const update = JSON.parse(fs.readFileSync(updateJsonPath, 'utf8'));
+const safetyMarkers = JSON.parse(fs.readFileSync(safetyMarkersJsonPath, 'utf8'));
 const proof = {
   status: 'ok',
   generatedAt: new Date().toISOString(),
@@ -172,6 +191,7 @@ const proof = {
   actualVersion,
   beforeVersion,
   afterVersion,
+  updateExitCode: Number(process.env.OPENCLAW_CANDIDATE_UPDATE_EXIT_CODE || 0),
   candidate: {
     root: candidateRoot,
     npmPrefix: candidatePrefix,
@@ -185,6 +205,7 @@ const proof = {
     versionAfter: liveVersionAfter || null,
     unchanged: liveVersionBefore === liveVersionAfter,
   },
+  safetyMarkers,
   update,
 };
 fs.writeFileSync(out, `${JSON.stringify(proof, null, 2)}\n`);

--- a/scripts/ops/verify-candidate-safety-markers.mjs
+++ b/scripts/ops/verify-candidate-safety-markers.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEXT_EXTENSIONS = new Set([".cjs", ".cts", ".d.ts", ".js", ".json", ".mjs", ".mts", ".ts"]);
+
+const MARKERS = [
+  {
+    id: "sdk-tree-kill",
+    description: "SDK/process tree kill hardening is present and wired into daemon shutdown",
+    patterns: [/killProcessTree/, /process\/kill-tree|kill-tree\.js/, /graceMs/],
+  },
+  {
+    id: "session-mcp-ttl",
+    description: "ACP/session MCP runtimes have idle TTL and cleanup hooks",
+    patterns: [
+      /resolveRuntimeIdleTtlMs/,
+      /ttlMinutes/,
+      /cleanupBundleMcpOnRunEnd|dispose bundle MCP runtime/,
+    ],
+  },
+  {
+    id: "startup-guard",
+    description: "Gateway startup guard keeps pre-ready methods/sidecars bounded",
+    patterns: [
+      /STARTUP_UNAVAILABLE_GATEWAY_METHODS/,
+      /measureStartup|startupTrace/,
+      /sidecars\.restart-sentinel/,
+    ],
+  },
+  {
+    id: "watchdog",
+    description: "WhatsApp/channel watchdog and reconnect freshness markers are present",
+    patterns: [/watchdogTimer|watchdogCheckMs/, /lastInboundAt/, /watchdog-timeout/],
+  },
+  {
+    id: "reply-dedupe",
+    description: "Reply/outbound dedupe prevents reconnect drains from duplicate live sends",
+    patterns: [
+      /withActiveDeliveryClaim/,
+      /entriesInProgress/,
+      /reconnect drain|drainPendingDeliveries/,
+    ],
+  },
+];
+
+function usage() {
+  console.error(
+    "Usage: node scripts/ops/verify-candidate-safety-markers.mjs [package-root] [--json]",
+  );
+}
+
+function isTextCandidate(filePath) {
+  if (filePath.endsWith(".d.ts")) return true;
+  return TEXT_EXTENSIONS.has(path.extname(filePath));
+}
+
+function walk(root, out = []) {
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git" || entry.name === ".artifacts")
+      continue;
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && isTextCandidate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function snippet(content, index) {
+  const start = Math.max(0, index - 80);
+  const end = Math.min(content.length, index + 160);
+  return content.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+function findPattern(files, root, pattern) {
+  for (const file of files) {
+    let content;
+    try {
+      content = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    pattern.lastIndex = 0;
+    const match = pattern.exec(content);
+    if (match?.index !== undefined) {
+      return {
+        file: path.relative(root, file),
+        match: match[0],
+        snippet: snippet(content, match.index),
+      };
+    }
+  }
+  return null;
+}
+
+function defaultRoot() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "../..");
+}
+
+const args = process.argv.slice(2);
+const json = args.includes("--json");
+const positional = args.filter((arg) => arg !== "--json");
+if (positional.length > 1 || args.includes("-h") || args.includes("--help")) {
+  usage();
+  process.exit(positional.length > 1 ? 2 : 0);
+}
+const root = path.resolve(positional[0] ?? defaultRoot());
+if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+  console.error(`package root not found or not a directory: ${root}`);
+  process.exit(2);
+}
+
+const files = walk(root);
+const results = MARKERS.map((marker) => {
+  const evidence = marker.patterns.map((pattern) => findPattern(files, root, pattern));
+  return {
+    id: marker.id,
+    description: marker.description,
+    ok: evidence.every(Boolean),
+    evidence,
+  };
+});
+const proof = {
+  status: results.every((result) => result.ok) ? "ok" : "missing",
+  packageRoot: root,
+  scannedFiles: files.length,
+  markers: results,
+};
+
+if (json) {
+  process.stdout.write(`${JSON.stringify(proof, null, 2)}\n`);
+} else {
+  for (const result of results) {
+    const prefix = result.ok ? "ok" : "missing";
+    console.log(`${prefix}: ${result.id} — ${result.description}`);
+    for (const item of result.evidence.filter(Boolean)) {
+      console.log(`  - ${item.file}: ${item.match}`);
+    }
+  }
+}
+
+if (proof.status !== "ok") {
+  process.exit(1);
+}

--- a/test/scripts/candidate-npm-upgrade.test.ts
+++ b/test/scripts/candidate-npm-upgrade.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const SCRIPT_PATH = "scripts/ops/candidate-npm-upgrade.sh";
 const PACKAGE_JSON_PATH = "package.json";
+const SAFETY_MARKERS_SCRIPT_PATH = "scripts/ops/verify-candidate-safety-markers.mjs";
 
 describe("candidate npm upgrade tooling", () => {
   it("defaults to the 2026.4.5 -> 2026.4.23 isolated upgrade lane", () => {
@@ -32,17 +33,31 @@ describe("candidate npm upgrade tooling", () => {
     expect(script).toContain('live_version_before="$(openclaw --version');
     expect(script).toContain('live_version_after="$("$live_openclaw" --version');
     expect(script).toContain("unchanged: liveVersionBefore === liveVersionAfter");
-    expect(script).not.toMatch(
-      /systemctl\s+(?:--user\s+)?(?:restart|reload|stop|start|disable|enable)/,
-    );
+    expect(script).not.toMatch(/systemctl\s+(?:--user\s+)?(?:restart|reload|stop|start)/);
     expect(script).not.toContain("sudo ");
   });
 
-  it("exposes a repo-owned npm script for the 4.23 candidate proof", () => {
+  it("proves safety markers from the upgraded candidate package", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+    const markerScript = readFileSync(SAFETY_MARKERS_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain("verify-candidate-safety-markers.mjs");
+    expect(script).toContain("safetyMarkers");
+    expect(markerScript).toContain('id: "sdk-tree-kill"');
+    expect(markerScript).toContain('id: "session-mcp-ttl"');
+    expect(markerScript).toContain('id: "startup-guard"');
+    expect(markerScript).toContain('id: "watchdog"');
+    expect(markerScript).toContain('id: "reply-dedupe"');
+  });
+
+  it("exposes repo-owned npm scripts for the 4.23 candidate proof", () => {
     const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
 
     expect(packageJson.scripts["ops:candidate-upgrade:4.23"]).toBe(
       "bash scripts/ops/candidate-npm-upgrade.sh",
+    );
+    expect(packageJson.scripts["ops:candidate-safety-markers:4.23"]).toBe(
+      "node scripts/ops/verify-candidate-safety-markers.mjs",
     );
   });
 });

--- a/test/scripts/candidate-npm-upgrade.test.ts
+++ b/test/scripts/candidate-npm-upgrade.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/ops/candidate-npm-upgrade.sh";
+const PACKAGE_JSON_PATH = "package.json";
+
+describe("candidate npm upgrade tooling", () => {
+  it("defaults to the 2026.4.5 -> 2026.4.23 isolated upgrade lane", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('baseline="openclaw@2026.4.5"');
+    expect(script).toContain('target="2026.4.23"');
+    expect(script).toContain('expected="2026.4.23"');
+    expect(script).toContain('"$candidate_bin" update --tag "$target" --json');
+  });
+
+  it("forces npm, state, and package roots under the temporary candidate root", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('candidate_root="$(mktemp -d');
+    expect(script).toContain('candidate_prefix="$candidate_root/npm-prefix"');
+    expect(script).toContain('candidate_home="$candidate_root/home"');
+    expect(script).toContain('export npm_config_prefix="$candidate_prefix"');
+    expect(script).toContain('export OPENCLAW_HOME="$candidate_home"');
+    expect(script).toContain('case "$package_root" in');
+    expect(script).toContain('"$candidate_root"/*) ;;');
+  });
+
+  it("records live package identity before and after without service mutation commands", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('live_version_before="$(openclaw --version');
+    expect(script).toContain('live_version_after="$("$live_openclaw" --version');
+    expect(script).toContain("unchanged: liveVersionBefore === liveVersionAfter");
+    expect(script).not.toMatch(
+      /systemctl\s+(?:--user\s+)?(?:restart|reload|stop|start|disable|enable)/,
+    );
+    expect(script).not.toContain("sudo ");
+  });
+
+  it("exposes a repo-owned npm script for the 4.23 candidate proof", () => {
+    const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
+
+    expect(packageJson.scripts["ops:candidate-upgrade:4.23"]).toBe(
+      "bash scripts/ops/candidate-npm-upgrade.sh",
+    );
+  });
+});


### PR DESCRIPTION
Adds repo-owned candidate npm upgrade tooling that proves openclaw@2026.4.5 can update to 2026.4.23 inside an isolated npm prefix and OPENCLAW_HOME without mutating the live package or service.\n\nValidation:\n- pnpm exec vitest run test/scripts/candidate-npm-upgrade.test.ts\n- pnpm exec oxfmt --check --threads=1 package.json test/scripts/candidate-npm-upgrade.test.ts\n- bash -n scripts/ops/candidate-npm-upgrade.sh\n- pnpm ops:candidate-upgrade:4.23\n\nProof highlights from .artifacts/candidate-npm-upgrade/proof.json:\n- candidate actualVersion: 2026.4.23\n- candidate packageRoot under /tmp/openclaw-candidate-upgrade-*/npm-prefix/lib/node_modules/openclaw\n- live versionBefore/versionAfter: OpenClaw 2026.4.5 (3e72c03)\n- live unchanged: true