### PR TITLE
feat(plugins): derive setup auth choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/setup: report descriptor/runtime drift when setup-api registrations disagree with `setup.providers` or `setup.cliBackends`, without rejecting legacy setup plugins. Thanks @vincentkoc.
 - Plugin hooks: expose first-class run, message, sender, session, and trace correlation fields on message hook contexts and run lifecycle events. Thanks @vincentkoc.
 - Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups and warn non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata. Thanks @vincentkoc.
+- Plugins/setup: derive generic provider setup choices from descriptor-safe `setup.providers[].authMethods` before falling back to setup runtime. Thanks @vincentkoc.
 - Plugins/setup: surface manifest provider auth choices directly in provider setup flow before falling back to setup runtime or install-catalog choices. Thanks @vincentkoc.
 - Plugins/setup: warn when descriptor-only setup plugins still ship ignored setup runtime entries, keeping `setup.requiresRuntime: false` semantics explicit without breaking existing metadata. Thanks @vincentkoc.
 - Plugins/channels: use manifest `channelConfigs` for read-only external channel discovery when no setup entry is available or setup descriptors declare runtime unnecessary. Thanks @vincentkoc.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -335,6 +335,11 @@ adapter during the deprecation window, but non-bundled plugins that still use it
 receive a manifest diagnostic. New plugins should put setup/status env metadata
 on `setup.providers[].envVars`.
 
+OpenClaw can also derive simple setup choices from `setup.providers[].authMethods`
+when no setup entry is available, or when `setup.requiresRuntime: false`
+declares setup runtime unnecessary. Explicit `providerAuthChoices` entries stay
+preferred for custom labels, CLI flags, onboarding scope, and assistant metadata.
+
 Set `requiresRuntime: false` only when those descriptors are sufficient for the
 setup surface. OpenClaw treats explicit `false` as a descriptor-only contract
 and will not execute `setup-api` or `openclaw.setupEntry` for setup lookup. If

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -5,10 +5,10 @@
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",
   "dependencies": {
-    "@clack/prompts": "^1.2.0",
-    "@mariozechner/pi-ai": "0.70.2"
+    "@clack/prompts": "^1.2.0"
   },
   "devDependencies": {
+    "@mariozechner/pi-ai": "0.70.2",
     "@openclaw/plugin-sdk": "workspace:*"
   },
   "openclaw": {

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -265,6 +265,9 @@ vi.mock("@slack/bolt", () => {
     command() {
       /* no-op */
     }
+    use() {
+      /* no-op */
+    }
     start = vi.fn().mockResolvedValue(undefined);
     stop = vi.fn().mockResolvedValue(undefined);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,10 +588,10 @@ importers:
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.2.0
+    devDependencies:
       '@mariozechner/pi-ai':
         specifier: 0.70.2
         version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-    devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk

--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -230,6 +230,138 @@ describe("provider auth choice manifest helpers", () => {
     ]);
   });
 
+  it("derives generic auth choices from descriptor-safe setup provider auth methods", () => {
+    setManifestPlugins([
+      {
+        id: "demo-provider",
+        name: "Demo Provider",
+        origin: "global",
+        setup: {
+          providers: [
+            {
+              id: "demo-provider",
+              authMethods: ["api-key", "oauth"],
+            },
+          ],
+          requiresRuntime: false,
+        },
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([
+      {
+        pluginId: "demo-provider",
+        providerId: "demo-provider",
+        methodId: "api-key",
+        choiceId: "demo-provider-api-key",
+        choiceLabel: "Demo Provider API key",
+        groupId: "demo-provider",
+        groupLabel: "Demo Provider",
+      },
+      {
+        pluginId: "demo-provider",
+        providerId: "demo-provider",
+        methodId: "oauth",
+        choiceId: "demo-provider-oauth",
+        choiceLabel: "Demo Provider OAuth",
+        groupId: "demo-provider",
+        groupLabel: "Demo Provider",
+      },
+    ]);
+  });
+
+  it("uses setup provider auth methods when no setup entry exists", () => {
+    setManifestPlugins([
+      {
+        id: "no-runtime-provider",
+        origin: "global",
+        setup: {
+          providers: [
+            {
+              id: "no-runtime-provider",
+              authMethods: ["api-key"],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoice("no-runtime-provider-api-key")).toEqual({
+      pluginId: "no-runtime-provider",
+      providerId: "no-runtime-provider",
+      methodId: "api-key",
+      choiceId: "no-runtime-provider-api-key",
+      choiceLabel: "No Runtime Provider API key",
+      groupId: "no-runtime-provider",
+      groupLabel: "No Runtime Provider",
+    });
+  });
+
+  it("keeps setup-entry providers on explicit manifest or runtime auth choices", () => {
+    setManifestPlugins([
+      {
+        id: "runtime-provider",
+        origin: "global",
+        setupSource: "/plugins/runtime-provider/setup-entry.cjs",
+        setup: {
+          providers: [
+            {
+              id: "runtime-provider",
+              authMethods: ["api-key"],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([]);
+  });
+
+  it("does not duplicate explicit provider auth choices with setup auth methods", () => {
+    setManifestPlugins([
+      {
+        id: "explicit-provider",
+        origin: "global",
+        providerAuthChoices: [
+          {
+            provider: "explicit-provider",
+            method: "api-key",
+            choiceId: "explicit-api-key",
+            choiceLabel: "Explicit API key",
+          },
+        ],
+        setup: {
+          providers: [
+            {
+              id: "explicit-provider",
+              authMethods: ["api-key", "oauth"],
+            },
+          ],
+          requiresRuntime: false,
+        },
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([
+      {
+        pluginId: "explicit-provider",
+        providerId: "explicit-provider",
+        methodId: "api-key",
+        choiceId: "explicit-api-key",
+        choiceLabel: "Explicit API key",
+      },
+      {
+        pluginId: "explicit-provider",
+        providerId: "explicit-provider",
+        methodId: "oauth",
+        choiceId: "explicit-provider-oauth",
+        choiceLabel: "Explicit Provider OAuth",
+        groupId: "explicit-provider",
+        groupLabel: "Explicit Provider",
+      },
+    ]);
+  });
+
   it("prefers bundled auth-choice handlers when choice IDs collide across origins", () => {
     setManifestPlugins([
       {

--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -270,6 +270,45 @@ describe("provider auth choice manifest helpers", () => {
     ]);
   });
 
+  it("sanitizes setup provider auth descriptors before deriving prompt labels", () => {
+    setManifestPlugins([
+      {
+        id: "evil-provider",
+        origin: "workspace",
+        setup: {
+          providers: [
+            {
+              id: "evil\u001b[31m-provider",
+              authMethods: ["jwt\u001b[2K", "oidc"],
+            },
+          ],
+          requiresRuntime: false,
+        },
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([
+      {
+        pluginId: "evil-provider",
+        providerId: "evil-provider",
+        methodId: "jwt",
+        choiceId: "evil-provider-jwt",
+        choiceLabel: "Evil Provider JWT",
+        groupId: "evil-provider",
+        groupLabel: "Evil Provider",
+      },
+      {
+        pluginId: "evil-provider",
+        providerId: "evil-provider",
+        methodId: "oidc",
+        choiceId: "evil-provider-oidc",
+        choiceLabel: "Evil Provider OIDC",
+        groupId: "evil-provider",
+        groupLabel: "Evil Provider",
+      },
+    ]);
+  });
+
   it("uses setup provider auth methods when no setup entry exists", () => {
     setManifestPlugins([
       {

--- a/src/plugins/provider-auth-choices.ts
+++ b/src/plugins/provider-auth-choices.ts
@@ -1,5 +1,6 @@
 import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -53,6 +54,15 @@ const PROVIDER_AUTH_CHOICE_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number
   global: 2,
   workspace: 3,
 };
+const DESCRIPTOR_LABEL_ACRONYMS: ReadonlyMap<string, string> = new Map([
+  ["api", "API"],
+  ["jwt", "JWT"],
+  ["oauth", "OAuth"],
+  ["oidc", "OIDC"],
+  ["pkce", "PKCE"],
+  ["saml", "SAML"],
+  ["sso", "SSO"],
+] as const);
 
 function resolveProviderAuthChoiceOriginPriority(origin: PluginOrigin | undefined): number {
   if (!origin) {
@@ -92,20 +102,23 @@ function toProviderAuthChoiceCandidate(params: {
 }
 
 function formatDescriptorLabel(value: string): string {
-  return value
+  return sanitizeForLog(value)
+    .trim()
     .split(/[-_\s]+/gu)
     .filter(Boolean)
     .map((part) => {
       const lower = part.toLowerCase();
-      if (lower === "api") {
-        return "API";
-      }
-      if (lower === "oauth") {
-        return "OAuth";
+      const acronym = DESCRIPTOR_LABEL_ACRONYMS.get(lower);
+      if (acronym) {
+        return acronym;
       }
       return `${lower.slice(0, 1).toUpperCase()}${lower.slice(1)}`;
     })
     .join(" ");
+}
+
+function normalizeManifestAuthDescriptorId(value: string): string {
+  return sanitizeForLog(value).trim();
 }
 
 function toSetupProviderAuthChoiceCandidate(params: {
@@ -137,12 +150,12 @@ function listSetupProviderAuthChoiceCandidates(plugin: PluginManifestRecord) {
     (plugin.providerAuthChoices ?? []).map((choice) => `${choice.provider}::${choice.method}`),
   );
   return (plugin.setup?.providers ?? []).flatMap((provider) => {
-    const providerId = provider.id.trim();
+    const providerId = normalizeManifestAuthDescriptorId(provider.id);
     if (!providerId) {
       return [];
     }
     return (provider.authMethods ?? [])
-      .map((methodId) => methodId.trim())
+      .map(normalizeManifestAuthDescriptorId)
       .filter(Boolean)
       .filter((methodId) => !explicitProviderMethods.has(`${providerId}::${methodId}`))
       .map((methodId) =>

--- a/src/plugins/provider-auth-choices.ts
+++ b/src/plugins/provider-auth-choices.ts
@@ -91,6 +91,70 @@ function toProviderAuthChoiceCandidate(params: {
   };
 }
 
+function formatDescriptorLabel(value: string): string {
+  return value
+    .split(/[-_\s]+/gu)
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (lower === "api") {
+        return "API";
+      }
+      if (lower === "oauth") {
+        return "OAuth";
+      }
+      return `${lower.slice(0, 1).toUpperCase()}${lower.slice(1)}`;
+    })
+    .join(" ");
+}
+
+function toSetupProviderAuthChoiceCandidate(params: {
+  plugin: PluginManifestRecord;
+  providerId: string;
+  methodId: string;
+}): ProviderAuthChoiceCandidate {
+  const providerLabel = formatDescriptorLabel(params.providerId);
+  const methodLabel = formatDescriptorLabel(params.methodId);
+  const choiceLabel =
+    params.methodId === "api-key" ? `${providerLabel} API key` : `${providerLabel} ${methodLabel}`;
+  return {
+    pluginId: params.plugin.id,
+    origin: params.plugin.origin,
+    providerId: params.providerId,
+    methodId: params.methodId,
+    choiceId: `${params.providerId}-${params.methodId}`,
+    choiceLabel,
+    groupId: params.providerId,
+    groupLabel: providerLabel,
+  };
+}
+
+function listSetupProviderAuthChoiceCandidates(plugin: PluginManifestRecord) {
+  if (plugin.setup?.requiresRuntime !== false && plugin.setupSource) {
+    return [];
+  }
+  const explicitProviderMethods = new Set(
+    (plugin.providerAuthChoices ?? []).map((choice) => `${choice.provider}::${choice.method}`),
+  );
+  return (plugin.setup?.providers ?? []).flatMap((provider) => {
+    const providerId = provider.id.trim();
+    if (!providerId) {
+      return [];
+    }
+    return (provider.authMethods ?? [])
+      .map((methodId) => methodId.trim())
+      .filter(Boolean)
+      .filter((methodId) => !explicitProviderMethods.has(`${providerId}::${methodId}`))
+      .map((methodId) =>
+        toSetupProviderAuthChoiceCandidate({
+          plugin,
+          providerId,
+          methodId,
+        }),
+      );
+  });
+}
+
 function stripChoiceOrigin(choice: ProviderAuthChoiceCandidate): ProviderAuthChoiceMetadata {
   const { origin: _origin, ...metadata } = choice;
   return metadata;
@@ -121,13 +185,18 @@ function resolveManifestProviderAuthChoiceCandidates(params?: {
     ) {
       return [];
     }
-    return (plugin.providerAuthChoices ?? []).map((choice) =>
-      toProviderAuthChoiceCandidate({
-        pluginId: plugin.id,
-        origin: plugin.origin,
-        choice,
-      }),
-    );
+    const choices: ProviderAuthChoiceCandidate[] = [];
+    for (const choice of plugin.providerAuthChoices ?? []) {
+      choices.push(
+        toProviderAuthChoiceCandidate({
+          pluginId: plugin.id,
+          origin: plugin.origin,
+          choice,
+        }),
+      );
+    }
+    choices.push(...listSetupProviderAuthChoiceCandidates(plugin));
+    return choices;
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: `setup.providers[].authMethods` was documented setup metadata, but simple provider setup discovery still needed explicit `providerAuthChoices` or setup runtime choices.
- Why it matters: descriptor-only provider plugins should expose basic setup choices without loading setup-entry code.
- What changed: derive generic manifest provider auth choices from `setup.providers[].authMethods` when no setup entry exists, or when `setup.requiresRuntime: false` declares setup runtime unnecessary.
- What did NOT change (scope boundary): explicit `providerAuthChoices` still win for custom labels, CLI flags, onboarding scope, and assistant metadata; setup-entry plugins without `requiresRuntime: false` still fall back to runtime choices.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #71275
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Descriptor-safe provider plugins can appear in setup from `setup.providers[].authMethods` without setup runtime loading.

## Diagram (if applicable)

```text
Before:
setup.providers[].authMethods -> metadata only -> runtime/providerAuthChoices needed

After:
setup.providers[].authMethods + no setup entry/requiresRuntime=false -> generic setup choice
explicit providerAuthChoices -> preferred metadata
legacy setup entry -> runtime fallback
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: provider setup descriptors
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Declare `setup.providers[].authMethods` in a provider plugin manifest.
2. Omit setup-entry, or set `setup.requiresRuntime: false`.
3. Resolve manifest provider auth/setup choices.

### Expected

- Generic provider setup choices are available from manifest metadata.
- Explicit `providerAuthChoices` are not duplicated.
- Plugins with setup-entry and omitted `requiresRuntime` still rely on runtime/explicit choices.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/plugins/provider-auth-choices.test.ts src/flows/provider-flow.test.ts`; `pnpm check:changed`; `pnpm build`
- Edge cases checked: descriptor-only setup, no setup-entry setup, setup-entry fallback, explicit choice dedupe.
- What you did **not** verify: external third-party provider package manually.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: generic labels may be less polished than plugin-authored choices.
  - Mitigation: explicit `providerAuthChoices` remain preferred and are still the documented path for rich metadata and CLI wiring.
