### PR TITLE
fix(plugins): hydrate bundled channel config metadata

### DIFF
--- a/src/config/doc-baseline.runtime.ts
+++ b/src/config/doc-baseline.runtime.ts
@@ -1,3 +1,4 @@
+import { collectBundledChannelConfigs as collectBundledChannelConfigsImpl } from "../plugins/bundled-channel-config-metadata.js";
 import { loadPluginManifestRegistry as loadPluginManifestRegistryImpl } from "../plugins/manifest-registry.js";
 import {
   collectChannelSchemaMetadata as collectChannelSchemaMetadataImpl,
@@ -6,6 +7,7 @@ import {
 import { buildConfigSchema as buildConfigSchemaImpl } from "./schema.js";
 
 export const loadPluginManifestRegistry = loadPluginManifestRegistryImpl;
+export const collectBundledChannelConfigs = collectBundledChannelConfigsImpl;
 export const collectChannelSchemaMetadata = collectChannelSchemaMetadataImpl;
 export const collectPluginSchemaMetadata = collectPluginSchemaMetadataImpl;
 export const buildConfigSchema = buildConfigSchemaImpl;

--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -368,6 +368,7 @@ async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> 
     cache: false,
     env,
     config: {},
+    bundledChannelConfigCollector: runtime.collectBundledChannelConfigs,
   });
   logConfigDocBaselineDebug(`loaded ${manifestRegistry.plugins.length} bundled plugin manifests`);
   const bundledRegistry = {

--- a/src/config/runtime-schema.ts
+++ b/src/config/runtime-schema.ts
@@ -1,4 +1,5 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { collectBundledChannelConfigs } from "../plugins/bundled-channel-config-metadata.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../plugins/plugin-registry.js";
 import {
   collectChannelSchemaMetadata,
@@ -16,6 +17,7 @@ function loadManifestRegistry(config: OpenClawConfig, env?: NodeJS.ProcessEnv) {
     env,
     workspaceDir,
     includeDisabled: true,
+    bundledChannelConfigCollector: collectBundledChannelConfigs,
   });
 }
 

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -5,6 +5,7 @@ import type { PluginCandidate } from "./discovery.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
+import type { BundledChannelConfigCollector } from "./manifest-registry.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
   getPackageManifestMetadata,
@@ -88,6 +89,7 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
   includeDisabled?: boolean;
+  bundledChannelConfigCollector?: BundledChannelConfigCollector;
 }): PluginManifestRegistry {
   if (params.pluginIds && params.pluginIds.length === 0) {
     return { plugins: [], diagnostics: [] };
@@ -111,5 +113,8 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
     candidates,
     diagnostics: [...diagnostics],
     installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(params.index),
+    ...(params.bundledChannelConfigCollector
+      ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }
+      : {}),
   });
 }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   clearPluginManifestRegistryCache,
@@ -628,6 +629,97 @@ describe("loadPluginManifestRegistry", () => {
         moonshot: "static",
       },
     });
+  });
+
+  it("hydrates bundled channel config metadata from plugin-local config surfaces", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "alpha",
+      channels: ["alpha"],
+      configSchema: { type: "object" },
+      channelConfigs: {
+        alpha: {
+          schema: {
+            type: "object",
+            properties: {
+              manifestOnly: { type: "boolean" },
+            },
+          },
+          uiHints: {
+            manifestOnly: { help: "manifest hint" },
+          },
+        },
+      },
+    });
+    writeTextFile(dir, "index.ts", "export {};\n");
+    writeTextFile(
+      dir,
+      "src/config-schema.js",
+      [
+        "export const AlphaChannelConfigSchema = {",
+        "  schema: {",
+        "    type: 'object',",
+        "    properties: {",
+        "      generatedOnly: { type: 'string' },",
+        "    },",
+        "    additionalProperties: false,",
+        "  },",
+        "  uiHints: {",
+        "    generatedOnly: { label: 'Generated only' },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "alpha",
+        rootDir: dir,
+        origin: "bundled",
+        packageDir: dir,
+        packageManifest: {
+          channel: {
+            id: "alpha",
+            label: "Alpha",
+            blurb: "Alpha channel",
+          },
+        },
+      }),
+    ]);
+
+    expect(registry.plugins[0]?.channelConfigs?.alpha).toEqual({
+      schema: {
+        type: "object",
+        properties: {
+          generatedOnly: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      label: "Alpha",
+      description: "Alpha channel",
+      uiHints: {
+        generatedOnly: { label: "Generated only" },
+        manifestOnly: { help: "manifest hint" },
+      },
+    });
+    expect(collectChannelSchemaMetadata(registry)).toEqual([
+      {
+        id: "alpha",
+        label: "Alpha",
+        description: "Alpha channel",
+        configSchema: {
+          type: "object",
+          properties: {
+            generatedOnly: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+        configUiHints: {
+          generatedOnly: { label: "Generated only" },
+          manifestOnly: { help: "manifest hint" },
+        },
+      },
+    ]);
   });
 
   it("reports non-bundled providerAuthEnvVars as deprecated compat metadata", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
+import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   clearPluginManifestRegistryCache,
@@ -671,21 +672,31 @@ describe("loadPluginManifestRegistry", () => {
       ].join("\n"),
     );
 
-    const registry = loadRegistry([
-      createPluginCandidate({
-        idHint: "alpha",
-        rootDir: dir,
-        origin: "bundled",
-        packageDir: dir,
-        packageManifest: {
-          channel: {
-            id: "alpha",
-            label: "Alpha",
-            blurb: "Alpha channel",
-          },
+    const candidate = createPluginCandidate({
+      idHint: "alpha",
+      rootDir: dir,
+      origin: "bundled",
+      packageDir: dir,
+      packageManifest: {
+        channel: {
+          id: "alpha",
+          label: "Alpha",
+          blurb: "Alpha channel",
         },
-      }),
-    ]);
+      },
+    });
+    expect(loadRegistry([candidate]).plugins[0]?.channelConfigs?.alpha?.schema).toEqual({
+      type: "object",
+      properties: {
+        manifestOnly: { type: "boolean" },
+      },
+    });
+
+    const registry = loadPluginManifestRegistry({
+      cache: false,
+      bundledChannelConfigCollector: collectBundledChannelConfigs,
+      candidates: [candidate],
+    });
 
     expect(registry.plugins[0]?.channelConfigs?.alpha).toEqual({
       schema: {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -9,7 +9,6 @@ import { sanitizeForLog } from "../terminal/ansi.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
-import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import {
   normalizePluginsConfigWithResolver,
   type NormalizedPluginsConfig,
@@ -159,6 +158,12 @@ export type PluginManifestRegistry = {
   diagnostics: PluginDiagnostic[];
 };
 
+export type BundledChannelConfigCollector = (params: {
+  pluginDir: string;
+  manifest: PluginManifest;
+  packageManifest?: OpenClawPackageManifest;
+}) => Record<string, PluginManifestChannelConfig> | undefined;
+
 const registryCache = pluginManifestRegistryCache as Map<
   string,
   { expiresAt: number; registry: PluginManifestRegistry }
@@ -294,10 +299,11 @@ function buildRecord(params: {
   manifestPath: string;
   schemaCacheKey?: string;
   configSchema?: Record<string, unknown>;
+  bundledChannelConfigCollector?: BundledChannelConfigCollector;
 }): PluginManifestRecord {
   const manifestChannelConfigs =
-    params.candidate.origin === "bundled"
-      ? collectBundledChannelConfigs({
+    params.candidate.origin === "bundled" && params.bundledChannelConfigCollector
+      ? params.bundledChannelConfigCollector({
           pluginDir: params.candidate.packageDir ?? params.candidate.rootDir,
           manifest: params.manifest,
           packageManifest: params.candidate.packageManifest,
@@ -551,6 +557,7 @@ export function loadPluginManifestRegistry(
     candidates?: PluginCandidate[];
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
+    bundledChannelConfigCollector?: BundledChannelConfigCollector;
   } = {},
 ): PluginManifestRegistry {
   const config = params.config ?? {};
@@ -558,7 +565,10 @@ export function loadPluginManifestRegistry(
   const env = params.env ?? process.env;
   const cacheKey = buildCacheKey({ workspaceDir: params.workspaceDir, plugins: normalized, env });
   const cacheEnabled =
-    params.cache !== false && !params.installRecords && shouldUseManifestCache(env);
+    params.cache !== false &&
+    !params.installRecords &&
+    !params.bundledChannelConfigCollector &&
+    shouldUseManifestCache(env);
   if (cacheEnabled) {
     const cached = registryCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
@@ -668,6 +678,9 @@ export function loadPluginManifestRegistry(
           manifestPath: manifestRes.manifestPath,
           schemaCacheKey,
           configSchema,
+          ...(params.bundledChannelConfigCollector
+            ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }
+            : {}),
         });
 
     const existing = seenIds.get(manifest.id);

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -9,6 +9,7 @@ import { sanitizeForLog } from "../terminal/ansi.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
+import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import {
   normalizePluginsConfigWithResolver,
   type NormalizedPluginsConfig,
@@ -294,8 +295,16 @@ function buildRecord(params: {
   schemaCacheKey?: string;
   configSchema?: Record<string, unknown>;
 }): PluginManifestRecord {
+  const manifestChannelConfigs =
+    params.candidate.origin === "bundled"
+      ? collectBundledChannelConfigs({
+          pluginDir: params.candidate.packageDir ?? params.candidate.rootDir,
+          manifest: params.manifest,
+          packageManifest: params.candidate.packageManifest,
+        })
+      : params.manifest.channelConfigs;
   const channelConfigs = mergePackageChannelMetaIntoChannelConfigs({
-    channelConfigs: params.manifest.channelConfigs,
+    channelConfigs: manifestChannelConfigs,
     packageChannel: params.candidate.packageManifest?.channel,
   });
   const packageChannelCommands = normalizePackageChannelCommands(

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -7,6 +7,7 @@ import {
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
 import type {
+  BundledChannelConfigCollector,
   PluginManifestContractListKey,
   PluginManifestRecord,
   PluginManifestRegistry,
@@ -25,6 +26,7 @@ export type PluginRegistryContributionOptions = LoadPluginRegistryParams & {
 export type LoadPluginRegistryManifestParams = LoadPluginRegistryParams & {
   includeDisabled?: boolean;
   pluginIds?: readonly string[];
+  bundledChannelConfigCollector?: BundledChannelConfigCollector;
 };
 
 export type PluginRegistryContributionKey =
@@ -201,6 +203,9 @@ export function loadPluginManifestRegistryForPluginRegistry(
     env: params.env,
     pluginIds: params.pluginIds,
     includeDisabled: params.includeDisabled,
+    ...(params.bundledChannelConfigCollector
+      ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }
+      : {}),
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: bundled channel schema metadata still depended on the central generated config artifact for schema/UI richness.
- Why it matters: plugin registry records should carry channel schema metadata directly when schema-building paths ask for it, so bundled plugins behave like external plugins at that seam.
- What changed: schema-building paths opt into hydrating bundled registry `channelConfigs` from plugin-local config surfaces before `collectChannelSchemaMetadata` consumes them.
- Scope boundary: no generated snapshot expansion, no config/env key changes, and ordinary manifest registry loads stay lightweight.

## Linked Issue/PR

- Related #71298

## Root Cause

The manifest registry loaded bundled plugin manifests but did not have a scoped way to synthesize bundled `channelConfigs` from plugin-local config surfaces, so dynamic channel metadata was incomplete unless another generated metadata path masked it.

## Regression Test Plan

- Added `src/plugins/manifest-registry.test.ts` coverage for a bundled plugin candidate with `channels[]`, package channel metadata, manifest UI hints, and plugin-local `src/config-schema.js`.
- The test asserts default registry loading keeps the cheap manifest metadata, while opt-in schema loading hydrates the registry record and `collectChannelSchemaMetadata(registry)` output.

## Verification

- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/plugins/manifest-registry.test.ts src/plugins/bundled-plugin-metadata.test.ts src/config/zod-schema.providers.lazy-runtime.test.ts`
- `pnpm build`
- `pnpm test:startup:memory` (`status --json`: 311.0 MB RSS, limit 400 MB)
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `git diff --check origin/main...HEAD`

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
