### PR TITLE
fix(webchat): hide legacy runtime prompt transcript leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google Meet: make meeting creation join by default, with an explicit URL-only opt-out, so agents that create a Meet also enter it. Thanks @steipete.
 - Telegram/polling: persist accepted update offsets before long-running handlers complete so poller restarts do not replay already-ingested updates, while keeping same-process retries for handler failures. Thanks @steipete.
 - Telegram/config: include generated Telegram channel config schema metadata in packaged plugin manifests so forum-topic/group config is accepted before runtime loads. Thanks @steipete.
+- WebChat/sessions: hide legacy runtime-only prompts that were already persisted as transcript text, including memory flush, async approval, session startup, quoted internal context, and background-task status wrappers. Thanks @91wan.
 - Browser/tool: keep explicit AI snapshots from inheriting the efficient role-snapshot default and preserve numeric Playwright AI refs, so `--format ai` remains a real AI snapshot path. Fixes #62550. Thanks @ly85206559.
 - Gateway/config: keep in-process config patch reload comparisons on the resolved source snapshot when `${VAR}` env refs are restored on disk, avoiding false full gateway restarts for unchanged gateway/plugin secrets. Fixes #71208. Thanks @robbiethompson18.
 - Slack/messages: serialize write-client requests and whole outbound sends per target so rapid multi-message Slack replies preserve send order. Fixes #69101. (#69105) Thanks @nightq and @ztexydt-cqh.

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,4 +1,7 @@
-import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  stripInternalRuntimeContext,
+} from "../agents/internal-runtime-context.js";
 import {
   extractInboundSenderLabel,
   stripInboundMetadata,
@@ -7,6 +10,87 @@ import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 export { stripEnvelope };
+
+const LEGACY_BACKGROUND_TASK_STATUS_RE =
+  /^System:\s*\[[^\]]+\]\s*Background task (?:blocked|cancelled|done|failed|lost|started|timed out|update):[^\n]*(?:\r?\n)+/i;
+
+function unwrapLegacyRuntimeQuoteEnvelope(text: string): string {
+  const trimmed = text.trim();
+  const quotePairs: Array<[string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (!trimmed.startsWith(open)) {
+      continue;
+    }
+    const inner = trimmed.endsWith(close) ? trimmed.slice(1, -1) : trimmed.slice(1);
+    if (looksLikeLegacyRuntimeText(inner)) {
+      return inner;
+    }
+  }
+  return text;
+}
+
+function looksLikeLegacyRuntimeText(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith(INTERNAL_RUNTIME_CONTEXT_BEGIN) ||
+    trimmed.startsWith("Pre-compaction memory flush.") ||
+    trimmed.startsWith("An async command the user already approved has completed.") ||
+    trimmed.startsWith("An async command did not run.") ||
+    trimmed.startsWith("A new session was started via /new or /reset.") ||
+    /^System:\s*\[[^\]]+\]\s*Background task\b/i.test(trimmed)
+  );
+}
+
+function stripLegacyInternalOnlyPrompt(text: string): string {
+  const trimmed = text.trim();
+  if (
+    trimmed.startsWith("Pre-compaction memory flush.") &&
+    trimmed.includes("Store durable memories") &&
+    trimmed.includes("NO_REPLY")
+  ) {
+    return "";
+  }
+  if (
+    (trimmed.startsWith("An async command the user already approved has completed.") ||
+      trimmed.startsWith("An async command did not run.")) &&
+    trimmed.includes("Exact completion details:")
+  ) {
+    return "";
+  }
+  if (
+    trimmed.startsWith("A new session was started via /new or /reset.") &&
+    trimmed.includes("Session Startup sequence") &&
+    trimmed.includes("Current time:")
+  ) {
+    return "";
+  }
+  return text;
+}
+
+function stripLegacyBackgroundTaskStatusPrefix(text: string): string {
+  const unwrapped = unwrapLegacyRuntimeQuoteEnvelope(text);
+  if (!/^System:\s*\[[^\]]+\]\s*Background task\b/i.test(unwrapped.trimStart())) {
+    return text;
+  }
+  return unwrapped.trimStart().replace(LEGACY_BACKGROUND_TASK_STATUS_RE, "");
+}
+
+function stripVisibleTranscriptText(text: string, stripUserEnvelope: boolean): string {
+  const backgroundStripped = stripLegacyBackgroundTaskStatusPrefix(text);
+  const quoteUnwrapped = unwrapLegacyRuntimeQuoteEnvelope(backgroundStripped);
+  const runtimeStripped = stripInternalRuntimeContext(quoteUnwrapped);
+  const internalPromptStripped = stripLegacyInternalOnlyPrompt(runtimeStripped);
+  const inboundStripped = stripInboundMetadata(internalPromptStripped);
+  const stripped = stripUserEnvelope
+    ? stripMessageIdHints(stripEnvelope(inboundStripped))
+    : inboundStripped;
+  return stripLegacyInternalOnlyPrompt(stripped);
+}
 
 function extractMessageSenderLabel(entry: Record<string, unknown>): string | null {
   if (typeof entry.senderLabel === "string" && entry.senderLabel.trim()) {
@@ -41,28 +125,36 @@ function stripEnvelopeFromContentWithRole(
   stripUserEnvelope: boolean,
 ): { content: unknown[]; changed: boolean } {
   let changed = false;
-  const next = content.map((item) => {
+  const next: unknown[] = [];
+  for (const item of content) {
     if (!item || typeof item !== "object") {
-      return item;
+      next.push(item);
+      continue;
     }
     const entry = item as Record<string, unknown>;
     if (entry.type !== "text" || typeof entry.text !== "string") {
-      return item;
+      next.push(item);
+      continue;
     }
-    const runtimeStripped = stripInternalRuntimeContext(entry.text);
-    const inboundStripped = stripInboundMetadata(runtimeStripped);
-    const stripped = stripUserEnvelope
-      ? stripMessageIdHints(stripEnvelope(inboundStripped))
-      : inboundStripped;
+    const stripped = stripVisibleTranscriptText(entry.text, stripUserEnvelope);
+    if (!stripped.trim()) {
+      if (stripped !== entry.text) {
+        changed = true;
+        continue;
+      }
+      next.push(item);
+      continue;
+    }
     if (stripped === entry.text) {
-      return item;
+      next.push(item);
+      continue;
     }
     changed = true;
-    return {
+    next.push({
       ...entry,
       text: stripped,
-    };
-  });
+    });
+  }
   return { content: next, changed };
 }
 
@@ -83,11 +175,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   }
 
   if (typeof entry.content === "string") {
-    const runtimeStripped = stripInternalRuntimeContext(entry.content);
-    const inboundStripped = stripInboundMetadata(runtimeStripped);
-    const stripped = stripUserEnvelope
-      ? stripMessageIdHints(stripEnvelope(inboundStripped))
-      : inboundStripped;
+    const stripped = stripVisibleTranscriptText(entry.content, stripUserEnvelope);
     if (stripped !== entry.content) {
       next.content = stripped;
       changed = true;
@@ -99,11 +187,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const runtimeStripped = stripInternalRuntimeContext(entry.text);
-    const inboundStripped = stripInboundMetadata(runtimeStripped);
-    const stripped = stripUserEnvelope
-      ? stripMessageIdHints(stripEnvelope(inboundStripped))
-      : inboundStripped;
+    const stripped = stripVisibleTranscriptText(entry.text, stripUserEnvelope);
     if (stripped !== entry.text) {
       next.text = stripped;
       changed = true;

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -2,6 +2,33 @@ import { describe, expect, test, vi } from "vitest";
 import { buildSessionHistorySnapshot, SessionHistorySseState } from "./session-history-state.js";
 import * as sessionUtils from "./session-utils.js";
 
+function historyText(rawMessages: unknown[]): string[] {
+  return buildSessionHistorySnapshot({ rawMessages }).history.messages.map((message) => {
+    const content = message.content;
+    if (typeof content === "string") {
+      return content;
+    }
+    if (!Array.isArray(content)) {
+      return "";
+    }
+    return content
+      .map((block) =>
+        block && typeof block === "object" && typeof (block as { text?: unknown }).text === "string"
+          ? (block as { text: string }).text
+          : "",
+      )
+      .join("\n");
+  });
+}
+
+function userTextMessage(text: string): Record<string, unknown> {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    __openclaw: { seq: 1 },
+  };
+}
+
 describe("SessionHistorySseState", () => {
   test("uses the initial raw snapshot for both first history and seq seeding", () => {
     const readSpy = vi.spyOn(sessionUtils, "readSessionMessages").mockReturnValue([
@@ -106,5 +133,73 @@ describe("SessionHistorySseState", () => {
         }
       ).content?.[0]?.text,
     ).toBe("visible ask");
+  });
+
+  test.each([
+    [
+      "pre-compaction memory flush prompt",
+      [
+        "Pre-compaction memory flush. Store durable memories only in memory/2026-04-24.md (create memory/ if needed).",
+        "Treat workspace bootstrap/reference files such as MEMORY.md, DREAMS.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.",
+        "If memory/2026-04-24.md already exists, APPEND new content only and do not overwrite existing entries.",
+        "Do NOT create timestamped variant files (e.g., 2026-04-24-HHMM.md); always use the canonical 2026-04-24.md filename.",
+        "If nothing to store, reply with NO_REPLY.",
+        "Current time: Friday, April 24th, 2026 - 9:21 PM (Asia/Shanghai) / 2026-04-24 13:21 UTC",
+      ].join("\n"),
+    ],
+    [
+      "async command completion prompt",
+      [
+        "An async command the user already approved has completed.",
+        "Do not run the command again.",
+        "If the task requires more steps, continue from this result before replying to the user.",
+        "Only ask the user for help if you are actually blocked.",
+        "",
+        "Exact completion details:",
+        "Exec finished (gateway id=2b941bb5-df92-4543-832e-a0c8c61c7200, session=amber-cloud, code 0)",
+        "approval_smoke_ok",
+        "",
+        "Continue the task if needed, then reply to the user in a helpful way.",
+        "If it succeeded, share the relevant output.",
+        "If it failed, explain what went wrong.",
+      ].join("\n"),
+    ],
+    [
+      "session startup prompt",
+      [
+        "A new session was started via /new or /reset.",
+        "Execute your Session Startup sequence now - read the required files before responding to the user.",
+        "Current time: Friday, April 24th, 2026 - 11:31 PM (Asia/Shanghai) / 2026-04-24 15:31 UTC",
+      ].join(" "),
+    ],
+    [
+      "quoted internal runtime context",
+      [
+        "“<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "OpenClaw runtime context (internal):",
+        "This context is runtime-generated, not user-authored. Keep internal details private.",
+        "",
+        "[Internal task completion event]",
+        "source: subagent",
+        "status: completed successfully",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>”",
+      ].join("\n"),
+    ],
+  ])("drops legacy internal-only %s history messages", (_name, text) => {
+    expect(historyText([userTextMessage(text)])).toEqual([]);
+  });
+
+  test("keeps the real user body after a quoted background-task status prefix", () => {
+    expect(
+      historyText([
+        userTextMessage(
+          [
+            '"System: [2026-04-24 23:36:38 GMT+8] Background task done: ACP background task (run bb424a68).',
+            "",
+            '[Fri 2026-04-24 23:38 GMT+8] 升级前 5 分钟 checklist"',
+          ].join("\n"),
+        ),
+      ]),
+    ).toEqual(["升级前 5 分钟 checklist"]);
   });
 });

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -43,8 +43,45 @@ function resolveCursorSeq(cursor: string | undefined): number | undefined {
 function toSessionHistoryMessages(messages: unknown[]): SessionHistoryMessage[] {
   return messages.filter(
     (message): message is SessionHistoryMessage =>
-      Boolean(message) && typeof message === "object" && !Array.isArray(message),
+      Boolean(message) &&
+      typeof message === "object" &&
+      !Array.isArray(message) &&
+      !isEmptyVisibleSessionHistoryMessage(message),
   );
+}
+
+function isVisibleTranscriptRole(role: string): boolean {
+  return role === "user" || role === "assistant" || role === "system" || role === "unknown";
+}
+
+function isEmptyVisibleSessionHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (!isVisibleTranscriptRole(role)) {
+    return false;
+  }
+  if (typeof entry.content === "string") {
+    return !entry.content.trim();
+  }
+  if (typeof entry.text === "string") {
+    return !entry.text.trim();
+  }
+  if (!Array.isArray(entry.content)) {
+    return false;
+  }
+  if (entry.content.length === 0) {
+    return true;
+  }
+  return entry.content.every((item) => {
+    if (!item || typeof item !== "object") {
+      return false;
+    }
+    const block = item as Record<string, unknown>;
+    return block.type === "text" && typeof block.text === "string" && !block.text.trim();
+  });
 }
 
 function buildPaginatedSessionHistory(params: {


### PR DESCRIPTION
## Summary
- extend Gateway history display projection to hide legacy runtime-only prompt text that was already persisted as transcript content
- cover pre-compaction memory flush, async approval completion, session startup, quote-wrapped internal context, and background-task status wrappers
- keep mixed background-task status plus real user text visible as the user body

## Context
Follow-up to #71229. That PR fixed the root write path by separating model-facing prompt text from transcript-facing user turns. This keeps the legacy history projection compatible with already-written transcript rows that contain those runtime prompts as ordinary text.

Supersedes the remaining legacy-history gap from #71101.

## Validation
- RED first: `OPENCLAW_LOCAL_CHECK=0 OPENCLAW_VITEST_FS_MODULE_CACHE=0 pnpm test src/gateway/session-history-state.test.ts` failed on the pasted legacy samples before the fix
- `OPENCLAW_LOCAL_CHECK=0 OPENCLAW_VITEST_FS_MODULE_CACHE=0 pnpm test src/gateway/session-history-state.test.ts src/gateway/chat-sanitize.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- direct smoke: legacy internal-only samples project to `[]`; mixed background-task sample projects to `升级前 5 分钟 checklist`
- `OPENCLAW_LOCAL_CHECK=0 OPENCLAW_VITEST_FS_MODULE_CACHE=0 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`
