### PR TITLE
fix(diagnostics-otel): add content capture, GenAI conventions, and logger jiti isolation

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -106,6 +106,28 @@ function formatError(err: unknown): string {
   }
 }
 
+const TRUNCATION_MARKER = "…[truncated]";
+const TRUNCATION_MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER, "utf8");
+
+/** Truncate a string to at most `maxBytes` UTF-8 bytes (including the marker), avoiding mid-codepoint cuts. */
+function truncateToBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= maxBytes) {
+    return text;
+  }
+  // Reserve space for the marker so the total stays within maxBytes.
+  const cutoff = Math.max(0, maxBytes - TRUNCATION_MARKER_BYTES);
+  // Decode back to avoid splitting a multi-byte character.
+  return (
+    buf
+      .subarray(0, cutoff)
+      .toString("utf8")
+      .replace(/\uFFFD$/, "") + TRUNCATION_MARKER
+  );
+}
+
+const MAX_CONTENT_ATTR_BYTES = 32 * 1024; // 32 KB per content attribute
+
 function redactOtelAttributes(attributes: Record<string, string | number | boolean>) {
   const redactedAttributes: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(attributes)) {
@@ -742,7 +764,56 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.tokens.cache_read": usage.cacheRead ?? 0,
           "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
           "openclaw.tokens.total": usage.total ?? 0,
+          // OpenTelemetry GenAI semantic conventions (primary)
+          "gen_ai.request.model": evt.model ?? "unknown",
+          "gen_ai.system": evt.provider ?? "unknown",
+          // Current GenAI registry attributes (gen_ai.system is deprecated)
+          "gen_ai.provider.name": evt.provider ?? "unknown",
+          "gen_ai.operation.name": "chat",
+          // Only emit GenAI split token counts when the components are actually
+          // known. Total-only payloads (e.g. CLI runner) would otherwise report
+          // misleading zeros that skew dashboards.
+          ...(usage.promptTokens != null ||
+          usage.input != null ||
+          usage.cacheRead != null ||
+          usage.cacheWrite != null
+            ? {
+                "gen_ai.usage.input_tokens":
+                  usage.promptTokens ??
+                  (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0),
+              }
+            : {}),
+          ...(usage.output != null ? { "gen_ai.usage.output_tokens": usage.output } : {}),
         };
+        if (evt.sessionKey) {
+          spanAttrs["langfuse.session.id"] = evt.sessionKey;
+        }
+        if (evt.costUsd) {
+          spanAttrs["gen_ai.usage.cost"] = evt.costUsd;
+        }
+        // Content capture: standard gen_ai.* attrs (primary), Langfuse compat (secondary).
+        // All content is redacted then truncated to MAX_CONTENT_ATTR_BYTES before export
+        // to avoid silent drops or rejections by OTEL backends with attribute size limits.
+        // Guard on captureContent policy here as a defense-in-depth check — the event
+        // emitter in agent-runner.ts gates content at the source, but the diagnostic
+        // event bus is shared across all plugin listeners, so we also enforce the
+        // opt-in at the exporter to prevent accidental content export.
+        if (contentCapturePolicy.inputMessages && evt.inputText) {
+          const redactedInput = truncateToBytes(
+            redactSensitiveText(evt.inputText),
+            MAX_CONTENT_ATTR_BYTES,
+          );
+          spanAttrs["gen_ai.prompt"] = redactedInput;
+          spanAttrs["langfuse.observation.input"] = redactedInput;
+        }
+        if (contentCapturePolicy.outputMessages && evt.outputText) {
+          const redactedOutput = truncateToBytes(
+            redactSensitiveText(evt.outputText),
+            MAX_CONTENT_ATTR_BYTES,
+          );
+          spanAttrs["gen_ai.completion"] = redactedOutput;
+          spanAttrs["langfuse.observation.output"] = redactedOutput;
+        }
 
         const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
         span.end();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1393,6 +1393,85 @@ export async function runReplyAgent(params: {
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
+    // Emit model.usage before the replyPayloads early return so streamed runs
+    // (where buildReplyPayloads suppresses the final array) still get usage events.
+    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
+      const input = usage.input;
+      const output = usage.output;
+      const cacheRead = usage.cacheRead;
+      const cacheWrite = usage.cacheWrite;
+      // Only synthesize promptTokens when at least one component is known.
+      const hasSplitComponents = input != null || cacheRead != null || cacheWrite != null;
+      const promptTokens = hasSplitComponents
+        ? (input ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0)
+        : undefined;
+      const totalTokens = usage.total ?? (promptTokens ?? 0) + (output ?? 0);
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      const usageEvent: Parameters<typeof emitDiagnosticEvent>[0] & { type: "model.usage" } = {
+        type: "model.usage",
+        ...(runResult.diagnosticTrace
+          ? { trace: freezeDiagnosticTraceContext(runResult.diagnosticTrace) }
+          : {}),
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        channel: replyToChannel,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens,
+          total: totalTokens,
+        },
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+        context: {
+          limit: contextTokensUsed,
+          used: totalTokens,
+        },
+        costUsd,
+        durationMs: Date.now() - runStartedAt,
+      };
+      // Include model-originated content when explicitly opted in via captureContent config.
+      // Prefer replyPayloads (sanitized by buildReplyPayloads: control tokens,
+      // heartbeat markers, messaging-tool duplicates, and reply directives are
+      // stripped). Fall back to payloadArray (raw, pre-sanitization) when
+      // replyPayloads is empty — this happens for streamed runs (block pipeline
+      // already delivered text) and messaging-tool-suppressed replies (text was
+      // sent via the tool path, not the final reply). The fallback captures
+      // model-originated content for observability even when the reply layer
+      // suppresses final delivery.
+      // Excludes isError and isReasoning payloads in both paths.
+      // Note: followupRun.prompt is the queue body, which may diverge from the
+      // effective prompt the model actually sees (attempt.ts adds bootstrap
+      // warnings, hook context, thread-history notes, etc.). Capturing the true
+      // effectivePrompt requires instrumentation at the model call boundary
+      // (attempt.ts), which is not yet implemented.
+      const cc = cfg.diagnostics?.otel?.captureContent;
+      if (cc === true || (typeof cc === "object" && cc && "enabled" in cc && cc.enabled)) {
+        if (typeof followupRun.prompt === "string") {
+          usageEvent.inputText = followupRun.prompt;
+        }
+        const contentSource = replyPayloads.length > 0 ? replyPayloads : payloadArray;
+        const outputTexts = contentSource
+          .filter(
+            (p): p is typeof p & { text: string } =>
+              typeof p.text === "string" && !p.isError && p.isReasoning !== true,
+          )
+          .map((p) => p.text);
+        if (outputTexts.length > 0) {
+          usageEvent.outputText = outputTexts.join("\n");
+        }
+      }
+      emitDiagnosticEvent(usageEvent);
+    }
+
     if (replyPayloads.length === 0) {
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
@@ -1419,47 +1498,6 @@ export async function runReplyAgent(params: {
         : replyPayloads;
 
     await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
-
-    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
-      const input = usage.input ?? 0;
-      const output = usage.output ?? 0;
-      const cacheRead = usage.cacheRead ?? 0;
-      const cacheWrite = usage.cacheWrite ?? 0;
-      const promptTokens = input + cacheRead + cacheWrite;
-      const totalTokens = usage.total ?? promptTokens + output;
-      const costConfig = resolveModelCostConfig({
-        provider: providerUsed,
-        model: modelUsed,
-        config: cfg,
-      });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      emitDiagnosticEvent({
-        type: "model.usage",
-        ...(runResult.diagnosticTrace
-          ? { trace: freezeDiagnosticTraceContext(runResult.diagnosticTrace) }
-          : {}),
-        sessionKey,
-        sessionId: followupRun.run.sessionId,
-        channel: replyToChannel,
-        provider: providerUsed,
-        model: modelUsed,
-        usage: {
-          input,
-          output,
-          cacheRead,
-          cacheWrite,
-          promptTokens,
-          total: totalTokens,
-        },
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-        context: {
-          limit: contextTokensUsed,
-          used: totalTokens,
-        },
-        costUsd,
-        durationMs: Date.now() - runStartedAt,
-      });
-    }
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -37,6 +37,10 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   };
   costUsd?: number;
   durationMs?: number;
+  /** User-facing input text. Only populated when diagnostics.otel.captureContent is enabled. */
+  inputText?: string;
+  /** User-facing output text. Only populated when diagnostics.otel.captureContent is enabled. */
+  outputText?: string;
 };
 
 export type DiagnosticWebhookReceivedEvent = DiagnosticBaseEvent & {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -71,7 +71,34 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+// Log transports must survive dual module loading (host ESM bundle + jiti plugin instance).
+// Use a globalThis-based singleton so plugins loaded via jiti register in the same Set
+// that the gateway's logger reads. Mirrors the pattern in diagnostic-events.ts.
+type LogTransportGlobalState = {
+  transports: Set<LogTransport>;
+  activeLogger: unknown; // TsLogger<LogObj> — stored as unknown to avoid type import in global
+  // Registry of all loggers built across module instances (gateway + jiti plugins).
+  // registerLogTransport() iterates this to late-attach transports to every logger,
+  // not just activeLogger. Entries are long-lived (one per module instance).
+  allLoggers: Set<unknown>;
+};
+
+function getLogTransportGlobalState(): LogTransportGlobalState {
+  const g = globalThis as typeof globalThis & {
+    __openclawLogTransportState?: LogTransportGlobalState;
+  };
+  if (!g.__openclawLogTransportState) {
+    g.__openclawLogTransportState = {
+      transports: new Set<LogTransport>(),
+      activeLogger: null,
+      allLoggers: new Set(),
+    };
+  }
+  return g.__openclawLogTransportState;
+}
+
+// Keep a module-level alias for hot-path reads (avoids repeated globalThis lookup).
+const externalTransports = getLogTransportGlobalState().transports;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -86,6 +113,29 @@ const MAX_DIAGNOSTIC_LOG_NAME_CHARS = 120;
 const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
+
+// Publish the active logger to globalThis so plugins loaded via jiti can find it
+// when calling registerLogTransport after the logger is already built.
+// Only overwrite if the current module instance owns the active logger (i.e. it was
+// our previous cachedLogger) or no logger has been published yet. This prevents
+// plugin loggers loaded via jiti from overwriting the gateway's primary logger,
+// which would cause registerLogTransport to attach to the wrong logger instance.
+function publishActiveLogger(logger: TsLogger<LogObj>): void {
+  const globalState = getLogTransportGlobalState();
+  // Remove the previous logger from this module instance (if rebuilding) to avoid stale refs.
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
+  globalState.allLoggers.add(logger);
+  if (!globalState.activeLogger || globalState.activeLogger === loggingState.cachedLogger) {
+    globalState.activeLogger = logger;
+  }
+}
+
+function shouldSkipLoadConfigFallback(argv: string[] = process.argv): boolean {
+  const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
+  return primary === "config" && secondary === "validate";
+}
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
   logger.attachTransport((logObj: LogObj) => {
@@ -428,6 +478,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     for (const transport of externalTransports) {
       attachExternalTransport(logger, transport);
     }
+    publishActiveLogger(logger);
     return logger;
   }
 
@@ -473,6 +524,8 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   for (const transport of externalTransports) {
     attachExternalTransport(logger, transport);
   }
+
+  publishActiveLogger(logger);
 
   return logger;
 }
@@ -566,27 +619,40 @@ export function getResolvedLoggerSettings(): LoggerResolvedSettings {
 
 // Test helpers
 export function setLoggerOverride(settings: LoggerSettings | null) {
+  const globalState = getLogTransportGlobalState();
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
   loggingState.overrideSettings = settings;
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
+  globalState.activeLogger = null;
 }
 
 export function resetLogger() {
+  const globalState = getLogTransportGlobalState();
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
+  globalState.activeLogger = null;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {
-  externalTransports.add(transport);
-  const logger = loggingState.cachedLogger as TsLogger<LogObj> | null;
-  if (logger) {
-    attachExternalTransport(logger, transport);
+  const globalState = getLogTransportGlobalState();
+  globalState.transports.add(transport);
+  // Late-attach to every logger built across all module instances (gateway + jiti plugins).
+  // This ensures channel-plugin loggers created before diagnostics-otel starts also get
+  // the OTLP transport, not just the gateway's activeLogger.
+  for (const logger of globalState.allLoggers) {
+    attachExternalTransport(logger as TsLogger<LogObj>, transport);
   }
   return () => {
-    externalTransports.delete(transport);
+    globalState.transports.delete(transport);
   };
 }
 


### PR DESCRIPTION
## Summary

Builds on #71250 (which moved OTEL log export to diagnostic events and added the `captureContent` config surface) to complete content capture, GenAI semantic conventions, and logger module isolation. Supersedes #50567.

**4 files changed, 220 insertions, 41 deletions.**

### Logger globalThis transport registry (`src/logging/logger.ts`)

`registerLogTransport` operates on a module-scoped `externalTransports` Set that is isolated from the daemon's copy when a plugin loads via jiti. This PR moves the transport registry to a `globalThis.__openclawLogTransportState` singleton (mirrors `diagnostic-events.ts`), adds `publishActiveLogger()` with ownership checks to prevent jiti plugin loggers from hijacking the gateway logger, and tracks all loggers in `allLoggers` so `registerLogTransport()` late-attaches to every logger across module instances.

### Content capture exporter (`extensions/diagnostics-otel/src/service.ts`)

Reads `inputText`/`outputText` from diagnostic events (wired in #71250), redacts via `redactSensitiveText`, truncates to 32 KB via `truncateToBytes`, and emits as:
- `gen_ai.prompt` / `gen_ai.completion` (GenAI semantic conventions)
- `langfuse.observation.input` / `langfuse.observation.output` (Langfuse compat)

Defense-in-depth: gated by `contentCapturePolicy.inputMessages`/`outputMessages` at the exporter in addition to the emission-side gate in agent-runner.

### GenAI semantic conventions (`extensions/diagnostics-otel/src/service.ts`)

Adds `gen_ai.provider.name`, `gen_ai.operation.name`, `langfuse.session.id`, `gen_ai.usage.cost`, and smart `gen_ai.usage.input_tokens` synthesis that skips misleading zeros for total-only providers.

### Content population in agent-runner (`src/auto-reply/reply/agent-runner.ts`)

Populates `inputText`/`outputText` on `model.usage` diagnostic events when `captureContent` is enabled. Prefers sanitized `replyPayloads` with fallback to raw `payloadArray` for streamed runs. Excludes `isError` and `isReasoning` payloads. Moves usage emission above the `replyPayloads.length === 0` early return so streamed runs still get usage events.

### Diagnostic event type (`src/infra/diagnostic-events.ts`)

Adds `inputText` and `outputText` optional fields to `DiagnosticUsageEvent`.

## Related

- Builds on #71250 (log diagnostic events + `captureContent` config)
- Supersedes #50567
- Related to #39156

## Verification

- `pnpm test src/logging/logger.test.ts extensions/diagnostics-otel/src/service.test.ts`
- `pnpm check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)