### PR TITLE
fix(logging): keep log transport internals private

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -56,7 +56,7 @@ let mockedResolveAuthProfileOrder: ReturnType<
 >;
 let runWithModelFallback: ModelFallbackModule["runWithModelFallback"];
 let _probeThrottleInternals: ModelFallbackModule["_probeThrottleInternals"];
-let registerLogTransport: LoggerModule["registerLogTransport"];
+let registerLogTransportForTest: LoggerModule["__test__"]["registerLogTransportForTest"];
 let resetLogger: LoggerModule["resetLogger"];
 let setLoggerOverride: LoggerModule["setLoggerOverride"];
 
@@ -82,7 +82,7 @@ async function loadModelFallbackProbeModules() {
   mockedResolveAuthProfileOrder = vi.mocked(authProfilesOrderModule.resolveAuthProfileOrder);
   runWithModelFallback = modelFallbackModule.runWithModelFallback;
   _probeThrottleInternals = modelFallbackModule._probeThrottleInternals;
-  registerLogTransport = loggerModule.registerLogTransport;
+  registerLogTransportForTest = loggerModule.__test__.registerLogTransportForTest;
   resetLogger = loggerModule.resetLogger;
   setLoggerOverride = loggerModule.setLoggerOverride;
 }
@@ -282,7 +282,7 @@ describe("runWithModelFallback – probe logic", () => {
       consoleLevel: "silent",
       file: path.join(os.tmpdir(), `openclaw-model-fallback-probe-${Date.now()}.log`),
     });
-    unregisterLogTransport = registerLogTransport((record) => {
+    unregisterLogTransport = registerLogTransportForTest((record) => {
       records.push(record);
     });
 

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagnostic-log-capture.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
@@ -56,12 +57,11 @@ let mockedResolveAuthProfileOrder: ReturnType<
 >;
 let runWithModelFallback: ModelFallbackModule["runWithModelFallback"];
 let _probeThrottleInternals: ModelFallbackModule["_probeThrottleInternals"];
-let registerLogTransportForTest: LoggerModule["__test__"]["registerLogTransportForTest"];
 let resetLogger: LoggerModule["resetLogger"];
 let setLoggerOverride: LoggerModule["setLoggerOverride"];
 
 const makeCfg = makeModelFallbackCfg;
-let unregisterLogTransport: (() => void) | undefined;
+let cleanupLogCapture: (() => void) | undefined;
 
 async function loadModelFallbackProbeModules() {
   const authProfilesStoreModule = await import("./auth-profiles/store.js");
@@ -82,7 +82,6 @@ async function loadModelFallbackProbeModules() {
   mockedResolveAuthProfileOrder = vi.mocked(authProfilesOrderModule.resolveAuthProfileOrder);
   runWithModelFallback = modelFallbackModule.runWithModelFallback;
   _probeThrottleInternals = modelFallbackModule._probeThrottleInternals;
-  registerLogTransportForTest = loggerModule.__test__.registerLogTransportForTest;
   resetLogger = loggerModule.resetLogger;
   setLoggerOverride = loggerModule.setLoggerOverride;
 }
@@ -236,8 +235,8 @@ describe("runWithModelFallback – probe logic", () => {
 
   afterEach(() => {
     Date.now = realDateNow;
-    unregisterLogTransport?.();
-    unregisterLogTransport = undefined;
+    cleanupLogCapture?.();
+    cleanupLogCapture = undefined;
     setLoggerOverride(null);
     resetLogger();
     vi.restoreAllMocks();
@@ -275,15 +274,13 @@ describe("runWithModelFallback – probe logic", () => {
 
   it("logs primary metadata on probe success and failure fallback decisions", async () => {
     const cfg = makeCfg();
-    const records: Array<Record<string, unknown>> = [];
+    const logCapture = createDiagnosticLogRecordCapture();
+    cleanupLogCapture = logCapture.cleanup;
     mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 60 * 1000);
     setLoggerOverride({
       level: "trace",
       consoleLevel: "silent",
       file: path.join(os.tmpdir(), `openclaw-model-fallback-probe-${Date.now()}.log`),
-    });
-    unregisterLogTransport = registerLogTransportForTest((record) => {
-      records.push(record);
     });
 
     const run = vi.fn().mockResolvedValue("probed-ok");
@@ -311,6 +308,7 @@ describe("runWithModelFallback – probe logic", () => {
       .mockResolvedValueOnce("fallback-ok");
 
     const fallbackResult = await runPrimaryCandidate(fallbackCfg, fallbackRun);
+    await logCapture.flush();
 
     expect(fallbackResult.result).toBe("fallback-ok");
     expect(fallbackRun).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", {
@@ -318,14 +316,9 @@ describe("runWithModelFallback – probe logic", () => {
     });
     expect(fallbackRun).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5");
 
-    const decisionPayloads = records
-      .filter(
-        (record) =>
-          record["2"] === "model fallback decision" &&
-          record["1"] &&
-          typeof record["1"] === "object",
-      )
-      .map((record) => record["1"] as Record<string, unknown>);
+    const decisionPayloads = logCapture.records
+      .filter((record) => record.message === "model fallback decision")
+      .map((record) => record.attributes ?? {});
 
     expect(decisionPayloads).toEqual(
       expect.arrayContaining([

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1014,7 +1014,7 @@ describe("runWithModelFallback", () => {
       });
 
       expect(result.result).toBe("ok");
-      const warning = warnLogs.findText('Model "openai/gpt-6spoof" not found');
+      const warning = await warnLogs.findText('Model "openai/gpt-6spoof" not found');
       expect(warning).toContain('Model "openai/gpt-6spoof" not found');
       expect(warning).not.toContain("\u001B");
       expect(warning).not.toContain("\n");

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -966,7 +966,7 @@ describe("model-selection", () => {
       }
     });
 
-    it("sanitizes control characters in providerless-model warnings", () => {
+    it("sanitizes control characters in providerless-model warnings", async () => {
       const warnLogs = createWarnLogCapture("openclaw-model-selection-test");
       try {
         const cfg: Partial<OpenClawConfig> = {
@@ -987,7 +987,7 @@ describe("model-selection", () => {
           provider: "google",
           model: "\u001B[31mclaude-3-5-sonnet\nspoof",
         });
-        const warning = warnLogs.findText('Falling back to "google/claude-3-5-sonnet"');
+        const warning = await warnLogs.findText('Falling back to "google/claude-3-5-sonnet"');
         expect(warning).toContain('Falling back to "google/claude-3-5-sonnet"');
         expect(warning).not.toContain("\u001B");
         expect(warning).not.toContain("\n");

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -107,7 +107,7 @@ const installRunEmbeddedMocks = () => {
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
 let unregisterLogTransport: (() => void) | undefined;
-let registerLogTransportFn: typeof import("../logging/logger.js").registerLogTransport;
+let registerLogTransportForTestFn: typeof import("../logging/logger.js").__test__.registerLogTransportForTest;
 let resetLoggerFn: typeof import("../logging/logger.js").resetLogger;
 let setLoggerOverrideFn: typeof import("../logging/logger.js").setLoggerOverride;
 const originalFetch = globalThis.fetch;
@@ -117,7 +117,7 @@ beforeAll(async () => {
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
   ({
-    registerLogTransport: registerLogTransportFn,
+    __test__: { registerLogTransportForTest: registerLogTransportForTestFn },
     resetLogger: resetLoggerFn,
     setLoggerOverride: setLoggerOverrideFn,
   } = await import("../logging/logger.js"));
@@ -870,7 +870,7 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       consoleLevel: "silent",
       file: path.join(os.tmpdir(), `openclaw-auth-rotation-${Date.now()}.log`),
     });
-    unregisterLogTransport = registerLogTransportFn((record) => {
+    unregisterLogTransport = registerLogTransportForTestFn((record) => {
       records.push(record);
     });
 

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -5,7 +5,6 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
-import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagnostic-log-capture.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import { buildAttemptReplayMetadata } from "./pi-embedded-runner/run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
@@ -107,6 +106,7 @@ const installRunEmbeddedMocks = () => {
 };
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
+let createDiagnosticLogRecordCaptureFn: typeof import("../logging/test-helpers/diagnostic-log-capture.js").createDiagnosticLogRecordCapture;
 let cleanupLogCapture: (() => void) | undefined;
 let resetLoggerFn: typeof import("../logging/logger.js").resetLogger;
 let setLoggerOverrideFn: typeof import("../logging/logger.js").setLoggerOverride;
@@ -116,6 +116,8 @@ beforeAll(async () => {
   vi.resetModules();
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
+  ({ createDiagnosticLogRecordCapture: createDiagnosticLogRecordCaptureFn } =
+    await import("../logging/test-helpers/diagnostic-log-capture.js"));
   ({ resetLogger: resetLoggerFn, setLoggerOverride: setLoggerOverrideFn } =
     await import("../logging/logger.js"));
 });
@@ -861,7 +863,7 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
   });
 
   it("logs structured failover decision metadata for overloaded assistant rotation", async () => {
-    const logCapture = createDiagnosticLogRecordCapture();
+    const logCapture = createDiagnosticLogRecordCaptureFn();
     cleanupLogCapture = logCapture.cleanup;
     setLoggerOverrideFn({
       level: "trace",

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -5,6 +5,7 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
+import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagnostic-log-capture.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import { buildAttemptReplayMetadata } from "./pi-embedded-runner/run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
@@ -106,8 +107,7 @@ const installRunEmbeddedMocks = () => {
 };
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
-let unregisterLogTransport: (() => void) | undefined;
-let registerLogTransportForTestFn: typeof import("../logging/logger.js").__test__.registerLogTransportForTest;
+let cleanupLogCapture: (() => void) | undefined;
 let resetLoggerFn: typeof import("../logging/logger.js").resetLogger;
 let setLoggerOverrideFn: typeof import("../logging/logger.js").setLoggerOverride;
 const originalFetch = globalThis.fetch;
@@ -116,11 +116,8 @@ beforeAll(async () => {
   vi.resetModules();
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
-  ({
-    __test__: { registerLogTransportForTest: registerLogTransportForTestFn },
-    resetLogger: resetLoggerFn,
-    setLoggerOverride: setLoggerOverrideFn,
-  } = await import("../logging/logger.js"));
+  ({ resetLogger: resetLoggerFn, setLoggerOverride: setLoggerOverrideFn } =
+    await import("../logging/logger.js"));
 });
 
 async function runEmbeddedPiAgentInline(
@@ -152,8 +149,8 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  unregisterLogTransport?.();
-  unregisterLogTransport = undefined;
+  cleanupLogCapture?.();
+  cleanupLogCapture = undefined;
   setLoggerOverrideFn(null);
   resetLoggerFn();
 });
@@ -864,14 +861,12 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
   });
 
   it("logs structured failover decision metadata for overloaded assistant rotation", async () => {
-    const records: Array<Record<string, unknown>> = [];
+    const logCapture = createDiagnosticLogRecordCapture();
+    cleanupLogCapture = logCapture.cleanup;
     setLoggerOverrideFn({
       level: "trace",
       consoleLevel: "silent",
       file: path.join(os.tmpdir(), `openclaw-auth-rotation-${Date.now()}.log`),
-    });
-    unregisterLogTransport = registerLogTransportForTestFn((record) => {
-      records.push(record);
     });
 
     await runAutoPinnedRotationCase({
@@ -880,18 +875,17 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       sessionKey: "agent:test:overloaded-logging",
       runId: "run:overloaded-logging",
     });
+    await logCapture.flush();
 
-    const decisionRecord = records.find(
+    const decisionRecord = logCapture.records.find(
       (record) =>
-        record["2"] === "embedded run failover decision" &&
-        record["1"] &&
-        typeof record["1"] === "object" &&
-        (record["1"] as Record<string, unknown>).decision === "rotate_profile",
+        record.message === "embedded run failover decision" &&
+        record.attributes?.decision === "rotate_profile",
     );
 
     expect(decisionRecord).toBeDefined();
     const safeProfileId = redactIdentifier("openai:p1", { len: 12 });
-    expect((decisionRecord as Record<string, unknown>)["1"]).toMatchObject({
+    expect(decisionRecord?.attributes).toMatchObject({
       event: "embedded_run_failover_decision",
       runId: "run:overloaded-logging",
       decision: "rotate_profile",
@@ -903,16 +897,14 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       rawErrorPreview: expect.stringContaining('"request_id":"sha256:'),
     });
 
-    const stateRecord = records.find(
+    const stateRecord = logCapture.records.find(
       (record) =>
-        record["2"] === "auth profile failure state updated" &&
-        record["1"] &&
-        typeof record["1"] === "object" &&
-        (record["1"] as Record<string, unknown>).profileId === safeProfileId,
+        record.message === "auth profile failure state updated" &&
+        record.attributes?.profileId === safeProfileId,
     );
 
     expect(stateRecord).toBeDefined();
-    expect((stateRecord as Record<string, unknown>)["1"]).toMatchObject({
+    expect(stateRecord?.attributes).toMatchObject({
       event: "auth_profile_failure_state_updated",
       runId: "run:overloaded-logging",
       profileId: safeProfileId,

--- a/src/logging/logger-transport.test.ts
+++ b/src/logging/logger-transport.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { importFreshModule } from "../../test/helpers/import-fresh.js";
+import { createSuiteLogPathTracker } from "./log-test-helpers.js";
+
+type LoggerModule = typeof import("./logger.js");
+
+const logPathTracker = createSuiteLogPathTracker("openclaw-logger-transport-");
+const importedModules: LoggerModule[] = [];
+const unsubscribeCallbacks: Array<() => void> = [];
+
+async function importLoggerModule(scope: string): Promise<LoggerModule> {
+  const module = await importFreshModule<LoggerModule>(
+    import.meta.url,
+    `./logger.js?scope=${scope}`,
+  );
+  importedModules.push(module);
+  module.setLoggerOverride({
+    level: "info",
+    file: logPathTracker.nextPath(),
+  });
+  return module;
+}
+
+describe("logger transport registry", () => {
+  beforeAll(async () => {
+    await logPathTracker.setup();
+  });
+
+  afterEach(() => {
+    while (unsubscribeCallbacks.length > 0) {
+      unsubscribeCallbacks.pop()?.();
+    }
+    while (importedModules.length > 0) {
+      const module = importedModules.pop();
+      module?.resetLogger();
+      module?.setLoggerOverride(null);
+    }
+  });
+
+  afterAll(async () => {
+    await logPathTracker.cleanup();
+  });
+
+  it("shares late-registered transports across fresh logger module instances", async () => {
+    const gatewayLoggerModule = await importLoggerModule("gateway");
+    const pluginLoggerModule = await importLoggerModule("plugin");
+    const gatewayLogger = gatewayLoggerModule.getLogger();
+    const pluginLogger = pluginLoggerModule.getLogger();
+    const records: unknown[] = [];
+
+    unsubscribeCallbacks.push(
+      pluginLoggerModule.registerLogTransport((record) => {
+        records.push(record);
+      }),
+    );
+
+    gatewayLogger.info("gateway message");
+    pluginLogger.info("plugin message");
+
+    expect(records).toHaveLength(2);
+  });
+});

--- a/src/logging/logger-transport.test.ts
+++ b/src/logging/logger-transport.test.ts
@@ -49,7 +49,7 @@ describe("logger transport registry", () => {
     const records: unknown[] = [];
 
     unsubscribeCallbacks.push(
-      pluginLoggerModule.registerLogTransport((record) => {
+      pluginLoggerModule.__test__.registerLogTransportForTest((record) => {
         records.push(record);
       }),
     );
@@ -58,5 +58,13 @@ describe("logger transport registry", () => {
     pluginLogger.info("plugin message");
 
     expect(records).toHaveLength(2);
+  });
+
+  it("does not expose production log transport registration", async () => {
+    const loggerModule = await importLoggerModule("public-api");
+
+    expect(
+      (loggerModule as unknown as Record<string, unknown>).registerLogTransport,
+    ).toBeUndefined();
   });
 });

--- a/src/logging/logger-transport.test.ts
+++ b/src/logging/logger-transport.test.ts
@@ -6,7 +6,6 @@ type LoggerModule = typeof import("./logger.js");
 
 const logPathTracker = createSuiteLogPathTracker("openclaw-logger-transport-");
 const importedModules: LoggerModule[] = [];
-const unsubscribeCallbacks: Array<() => void> = [];
 
 async function importLoggerModule(scope: string): Promise<LoggerModule> {
   const module = await importFreshModule<LoggerModule>(
@@ -27,9 +26,6 @@ describe("logger transport registry", () => {
   });
 
   afterEach(() => {
-    while (unsubscribeCallbacks.length > 0) {
-      unsubscribeCallbacks.pop()?.();
-    }
     while (importedModules.length > 0) {
       const module = importedModules.pop();
       module?.resetLogger();
@@ -41,30 +37,24 @@ describe("logger transport registry", () => {
     await logPathTracker.cleanup();
   });
 
-  it("shares late-registered transports across fresh logger module instances", async () => {
-    const gatewayLoggerModule = await importLoggerModule("gateway");
-    const pluginLoggerModule = await importLoggerModule("plugin");
-    const gatewayLogger = gatewayLoggerModule.getLogger();
-    const pluginLogger = pluginLoggerModule.getLogger();
-    const records: unknown[] = [];
-
-    unsubscribeCallbacks.push(
-      pluginLoggerModule.__test__.registerLogTransportForTest((record) => {
-        records.push(record);
-      }),
-    );
-
-    gatewayLogger.info("gateway message");
-    pluginLogger.info("plugin message");
-
-    expect(records).toHaveLength(2);
-  });
-
-  it("does not expose production log transport registration", async () => {
+  it("does not expose production or test log transport registration", async () => {
     const loggerModule = await importLoggerModule("public-api");
 
     expect(
       (loggerModule as unknown as Record<string, unknown>).registerLogTransport,
+    ).toBeUndefined();
+    expect(
+      (loggerModule.__test__ as unknown as Record<string, unknown>).registerLogTransportForTest,
+    ).toBeUndefined();
+  });
+
+  it("does not publish mutable log transport state on a well-known global symbol", async () => {
+    await importLoggerModule("global-state");
+
+    expect(
+      (globalThis as typeof globalThis & Record<PropertyKey, unknown>)[
+        Symbol.for("openclaw.logging.transports")
+      ],
     ).toBeUndefined();
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -76,7 +76,9 @@ const LOG_TRANSPORT_STATE_KEY = Symbol.for("openclaw.logging.transports");
 
 type LogTransportGlobalState = {
   transports: Set<LogTransport>;
-  loggers: Set<TsLogger<LogObj>>;
+  loggerRefs: Set<WeakRef<TsLogger<LogObj>>>;
+  loggerRefByLogger: WeakMap<TsLogger<LogObj>, WeakRef<TsLogger<LogObj>>>;
+  finalizer: FinalizationRegistry<WeakRef<TsLogger<LogObj>>>;
   attachedTransports: WeakMap<TsLogger<LogObj>, Set<LogTransport>>;
 };
 
@@ -88,7 +90,11 @@ function getLogTransportGlobalState(): LogTransportGlobalState {
   }
   const created = resolveGlobalSingleton<LogTransportGlobalState>(LOG_TRANSPORT_STATE_KEY, () => ({
     transports: new Set<LogTransport>(),
-    loggers: new Set<TsLogger<LogObj>>(),
+    loggerRefs: new Set<WeakRef<TsLogger<LogObj>>>(),
+    loggerRefByLogger: new WeakMap<TsLogger<LogObj>, WeakRef<TsLogger<LogObj>>>(),
+    finalizer: new FinalizationRegistry<WeakRef<TsLogger<LogObj>>>((ref) => {
+      getLogTransportGlobalState().loggerRefs.delete(ref);
+    }),
     attachedTransports: new WeakMap<TsLogger<LogObj>, Set<LogTransport>>(),
   }));
   processStore[LOG_TRANSPORT_STATE_KEY] = created;
@@ -136,7 +142,13 @@ function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTranspo
 
 function registerLoggerForExternalTransports(logger: TsLogger<LogObj>): void {
   const state = getLogTransportGlobalState();
-  state.loggers.add(logger);
+  let ref = state.loggerRefByLogger.get(logger);
+  if (!ref) {
+    ref = new WeakRef(logger);
+    state.loggerRefByLogger.set(logger, ref);
+    state.loggerRefs.add(ref);
+    state.finalizer.register(logger, ref, ref);
+  }
   for (const transport of state.transports) {
     attachExternalTransport(logger, transport);
   }
@@ -146,7 +158,25 @@ function unregisterLoggerForExternalTransports(logger: TsLogger<LogObj> | null):
   if (!logger) {
     return;
   }
-  getLogTransportGlobalState().loggers.delete(logger);
+  const state = getLogTransportGlobalState();
+  const ref = state.loggerRefByLogger.get(logger);
+  if (!ref) {
+    return;
+  }
+  state.loggerRefs.delete(ref);
+  state.finalizer.unregister(ref);
+}
+
+function forEachRegisteredLogger(callback: (logger: TsLogger<LogObj>) => void): void {
+  const state = getLogTransportGlobalState();
+  for (const ref of state.loggerRefs) {
+    const logger = ref.deref();
+    if (!logger) {
+      state.loggerRefs.delete(ref);
+      continue;
+    }
+    callback(logger);
+  }
 }
 
 function clampDiagnosticLogText(value: string, maxChars: number): string {
@@ -627,12 +657,12 @@ export function resetLogger() {
   loggingState.overrideSettings = null;
 }
 
-export function registerLogTransport(transport: LogTransport): () => void {
+function registerLogTransport(transport: LogTransport): () => void {
   const state = getLogTransportGlobalState();
   state.transports.add(transport);
-  for (const logger of state.loggers) {
+  forEachRegisteredLogger((logger) => {
     attachExternalTransport(logger, transport);
-  }
+  });
   return () => {
     state.transports.delete(transport);
   };
@@ -640,6 +670,12 @@ export function registerLogTransport(transport: LogTransport): () => void {
 
 export const __test__ = {
   shouldSkipMutatingLoggingConfigRead,
+  registerLogTransportForTest(transport: LogTransport): () => void {
+    if (process.env.VITEST !== "true") {
+      throw new Error("registerLogTransportForTest is only available in tests");
+    }
+    return registerLogTransport(transport);
+  },
 };
 
 function formatLocalDate(date: Date): string {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -14,6 +14,7 @@ import {
   POSIX_OPENCLAW_TMP_DIR,
   resolvePreferredOpenClawTmpDir,
 } from "../infra/tmp-openclaw-dir.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
@@ -71,7 +72,30 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+const LOG_TRANSPORT_STATE_KEY = Symbol.for("openclaw.logging.transports");
+
+type LogTransportGlobalState = {
+  transports: Set<LogTransport>;
+  loggers: Set<TsLogger<LogObj>>;
+  attachedTransports: WeakMap<TsLogger<LogObj>, Set<LogTransport>>;
+};
+
+function getLogTransportGlobalState(): LogTransportGlobalState {
+  const processStore = process as NodeJS.Process & Record<PropertyKey, unknown>;
+  const existing = processStore[LOG_TRANSPORT_STATE_KEY];
+  if (existing) {
+    return existing as LogTransportGlobalState;
+  }
+  const created = resolveGlobalSingleton<LogTransportGlobalState>(LOG_TRANSPORT_STATE_KEY, () => ({
+    transports: new Set<LogTransport>(),
+    loggers: new Set<TsLogger<LogObj>>(),
+    attachedTransports: new WeakMap<TsLogger<LogObj>, Set<LogTransport>>(),
+  }));
+  processStore[LOG_TRANSPORT_STATE_KEY] = created;
+  return created;
+}
+
+const externalTransports = getLogTransportGlobalState().transports;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -88,6 +112,16 @@ const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
+  const state = getLogTransportGlobalState();
+  let attached = state.attachedTransports.get(logger);
+  if (!attached) {
+    attached = new Set<LogTransport>();
+    state.attachedTransports.set(logger, attached);
+  }
+  if (attached.has(transport)) {
+    return;
+  }
+  attached.add(transport);
   logger.attachTransport((logObj: LogObj) => {
     if (!externalTransports.has(transport)) {
       return;
@@ -98,6 +132,21 @@ function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTranspo
       // never block on logging failures
     }
   });
+}
+
+function registerLoggerForExternalTransports(logger: TsLogger<LogObj>): void {
+  const state = getLogTransportGlobalState();
+  state.loggers.add(logger);
+  for (const transport of state.transports) {
+    attachExternalTransport(logger, transport);
+  }
+}
+
+function unregisterLoggerForExternalTransports(logger: TsLogger<LogObj> | null): void {
+  if (!logger) {
+    return;
+  }
+  getLogTransportGlobalState().loggers.delete(logger);
 }
 
 function clampDiagnosticLogText(value: string, maxChars: number): string {
@@ -425,9 +474,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   // Silent logging does not write files; skip all filesystem setup in this path.
   if (settings.level === "silent") {
     attachDiagnosticEventTransport(logger);
-    for (const transport of externalTransports) {
-      attachExternalTransport(logger, transport);
-    }
+    registerLoggerForExternalTransports(logger);
     return logger;
   }
 
@@ -470,9 +517,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     }
   });
   attachDiagnosticEventTransport(logger);
-  for (const transport of externalTransports) {
-    attachExternalTransport(logger, transport);
-  }
+  registerLoggerForExternalTransports(logger);
 
   return logger;
 }
@@ -506,6 +551,7 @@ export function getLogger(): TsLogger<LogObj> {
   const cachedLogger = loggingState.cachedLogger as TsLogger<LogObj> | null;
   const cachedSettings = loggingState.cachedSettings as ResolvedSettings | null;
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
+    unregisterLoggerForExternalTransports(cachedLogger);
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
   }
@@ -566,6 +612,7 @@ export function getResolvedLoggerSettings(): LoggerResolvedSettings {
 
 // Test helpers
 export function setLoggerOverride(settings: LoggerSettings | null) {
+  unregisterLoggerForExternalTransports(loggingState.cachedLogger as TsLogger<LogObj> | null);
   loggingState.overrideSettings = settings;
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
@@ -573,6 +620,7 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
 }
 
 export function resetLogger() {
+  unregisterLoggerForExternalTransports(loggingState.cachedLogger as TsLogger<LogObj> | null);
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
@@ -580,13 +628,13 @@ export function resetLogger() {
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {
-  externalTransports.add(transport);
-  const logger = loggingState.cachedLogger as TsLogger<LogObj> | null;
-  if (logger) {
+  const state = getLogTransportGlobalState();
+  state.transports.add(transport);
+  for (const logger of state.loggers) {
     attachExternalTransport(logger, transport);
   }
   return () => {
-    externalTransports.delete(transport);
+    state.transports.delete(transport);
   };
 }
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -68,36 +68,7 @@ type ResolvedSettings = {
   maxFileBytes: number;
 };
 export type LoggerResolvedSettings = ResolvedSettings;
-export type LogTransportRecord = Record<string, unknown>;
-export type LogTransport = (logObj: LogTransportRecord) => void;
-
-const LOG_TRANSPORT_STATE_KEY = Symbol.for("openclaw.logging.transports");
-
-type LogTransportGlobalState = {
-  transports: Set<LogTransport>;
-  loggerRefs: Set<WeakRef<TsLogger<LogObj>>>;
-  loggerRefByLogger: WeakMap<TsLogger<LogObj>, WeakRef<TsLogger<LogObj>>>;
-  finalizer: FinalizationRegistry<WeakRef<TsLogger<LogObj>>>;
-  attachedTransports: WeakMap<TsLogger<LogObj>, Set<LogTransport>>;
-};
-
-function getLogTransportGlobalState(): LogTransportGlobalState {
-  const target = globalThis as typeof globalThis & {
-    [LOG_TRANSPORT_STATE_KEY]?: LogTransportGlobalState;
-  };
-  target[LOG_TRANSPORT_STATE_KEY] ??= {
-    transports: new Set<LogTransport>(),
-    loggerRefs: new Set<WeakRef<TsLogger<LogObj>>>(),
-    loggerRefByLogger: new WeakMap<TsLogger<LogObj>, WeakRef<TsLogger<LogObj>>>(),
-    finalizer: new FinalizationRegistry<WeakRef<TsLogger<LogObj>>>((ref) => {
-      getLogTransportGlobalState().loggerRefs.delete(ref);
-    }),
-    attachedTransports: new WeakMap<TsLogger<LogObj>, Set<LogTransport>>(),
-  };
-  return target[LOG_TRANSPORT_STATE_KEY];
-}
-
-const externalTransports = getLogTransportGlobalState().transports;
+type TsLogRecord = Record<string, unknown>;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -112,68 +83,6 @@ const MAX_DIAGNOSTIC_LOG_NAME_CHARS = 120;
 const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
-
-function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
-  const state = getLogTransportGlobalState();
-  let attached = state.attachedTransports.get(logger);
-  if (!attached) {
-    attached = new Set<LogTransport>();
-    state.attachedTransports.set(logger, attached);
-  }
-  if (attached.has(transport)) {
-    return;
-  }
-  attached.add(transport);
-  logger.attachTransport((logObj: LogObj) => {
-    if (!externalTransports.has(transport)) {
-      return;
-    }
-    try {
-      transport(logObj as LogTransportRecord);
-    } catch {
-      // never block on logging failures
-    }
-  });
-}
-
-function registerLoggerForExternalTransports(logger: TsLogger<LogObj>): void {
-  const state = getLogTransportGlobalState();
-  let ref = state.loggerRefByLogger.get(logger);
-  if (!ref) {
-    ref = new WeakRef(logger);
-    state.loggerRefByLogger.set(logger, ref);
-    state.loggerRefs.add(ref);
-    state.finalizer.register(logger, ref, ref);
-  }
-  for (const transport of state.transports) {
-    attachExternalTransport(logger, transport);
-  }
-}
-
-function unregisterLoggerForExternalTransports(logger: TsLogger<LogObj> | null): void {
-  if (!logger) {
-    return;
-  }
-  const state = getLogTransportGlobalState();
-  const ref = state.loggerRefByLogger.get(logger);
-  if (!ref) {
-    return;
-  }
-  state.loggerRefs.delete(ref);
-  state.finalizer.unregister(ref);
-}
-
-function forEachRegisteredLogger(callback: (logger: TsLogger<LogObj>) => void): void {
-  const state = getLogTransportGlobalState();
-  for (const ref of state.loggerRefs) {
-    const logger = ref.deref();
-    if (!logger) {
-      state.loggerRefs.delete(ref);
-      continue;
-    }
-    callback(logger);
-  }
-}
 
 function clampDiagnosticLogText(value: string, maxChars: number): string {
   return value.length > maxChars ? `${value.slice(0, maxChars)}...(truncated)` : value;
@@ -312,7 +221,7 @@ function findLogTraceContext(
   return undefined;
 }
 
-function buildDiagnosticLogRecord(logObj: LogTransportRecord) {
+function buildDiagnosticLogRecord(logObj: TsLogRecord) {
   const meta = logObj._meta as
     | {
         logLevelName?: string;
@@ -410,7 +319,7 @@ function buildDiagnosticLogRecord(logObj: LogTransportRecord) {
 function attachDiagnosticEventTransport(logger: TsLogger<LogObj>): void {
   logger.attachTransport((logObj: LogObj) => {
     try {
-      emitDiagnosticEvent(buildDiagnosticLogRecord(logObj as LogTransportRecord));
+      emitDiagnosticEvent(buildDiagnosticLogRecord(logObj as TsLogRecord));
     } catch {
       // never block on logging failures
     }
@@ -500,7 +409,6 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   // Silent logging does not write files; skip all filesystem setup in this path.
   if (settings.level === "silent") {
     attachDiagnosticEventTransport(logger);
-    registerLoggerForExternalTransports(logger);
     return logger;
   }
 
@@ -543,7 +451,6 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     }
   });
   attachDiagnosticEventTransport(logger);
-  registerLoggerForExternalTransports(logger);
 
   return logger;
 }
@@ -577,7 +484,6 @@ export function getLogger(): TsLogger<LogObj> {
   const cachedLogger = loggingState.cachedLogger as TsLogger<LogObj> | null;
   const cachedSettings = loggingState.cachedSettings as ResolvedSettings | null;
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
-    unregisterLoggerForExternalTransports(cachedLogger);
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
   }
@@ -638,7 +544,6 @@ export function getResolvedLoggerSettings(): LoggerResolvedSettings {
 
 // Test helpers
 export function setLoggerOverride(settings: LoggerSettings | null) {
-  unregisterLoggerForExternalTransports(loggingState.cachedLogger as TsLogger<LogObj> | null);
   loggingState.overrideSettings = settings;
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
@@ -646,32 +551,14 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
 }
 
 export function resetLogger() {
-  unregisterLoggerForExternalTransports(loggingState.cachedLogger as TsLogger<LogObj> | null);
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
 }
 
-function registerLogTransport(transport: LogTransport): () => void {
-  const state = getLogTransportGlobalState();
-  state.transports.add(transport);
-  forEachRegisteredLogger((logger) => {
-    attachExternalTransport(logger, transport);
-  });
-  return () => {
-    state.transports.delete(transport);
-  };
-}
-
 export const __test__ = {
   shouldSkipMutatingLoggingConfigRead,
-  registerLogTransportForTest(transport: LogTransport): () => void {
-    if (process.env.VITEST !== "true") {
-      throw new Error("registerLogTransportForTest is only available in tests");
-    }
-    return registerLogTransport(transport);
-  },
 };
 
 function formatLocalDate(date: Date): string {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -14,7 +14,6 @@ import {
   POSIX_OPENCLAW_TMP_DIR,
   resolvePreferredOpenClawTmpDir,
 } from "../infra/tmp-openclaw-dir.js";
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
@@ -83,12 +82,10 @@ type LogTransportGlobalState = {
 };
 
 function getLogTransportGlobalState(): LogTransportGlobalState {
-  const processStore = process as NodeJS.Process & Record<PropertyKey, unknown>;
-  const existing = processStore[LOG_TRANSPORT_STATE_KEY];
-  if (existing) {
-    return existing as LogTransportGlobalState;
-  }
-  const created = resolveGlobalSingleton<LogTransportGlobalState>(LOG_TRANSPORT_STATE_KEY, () => ({
+  const target = globalThis as typeof globalThis & {
+    [LOG_TRANSPORT_STATE_KEY]?: LogTransportGlobalState;
+  };
+  target[LOG_TRANSPORT_STATE_KEY] ??= {
     transports: new Set<LogTransport>(),
     loggerRefs: new Set<WeakRef<TsLogger<LogObj>>>(),
     loggerRefByLogger: new WeakMap<TsLogger<LogObj>, WeakRef<TsLogger<LogObj>>>(),
@@ -96,9 +93,8 @@ function getLogTransportGlobalState(): LogTransportGlobalState {
       getLogTransportGlobalState().loggerRefs.delete(ref);
     }),
     attachedTransports: new WeakMap<TsLogger<LogObj>, Set<LogTransport>>(),
-  }));
-  processStore[LOG_TRANSPORT_STATE_KEY] = created;
-  return created;
+  };
+  return target[LOG_TRANSPORT_STATE_KEY];
 }
 
 const externalTransports = getLogTransportGlobalState().transports;

--- a/src/logging/test-helpers/diagnostic-log-capture.ts
+++ b/src/logging/test-helpers/diagnostic-log-capture.ts
@@ -1,0 +1,25 @@
+import {
+  onInternalDiagnosticEvent,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+
+export type CapturedDiagnosticLogRecord = Extract<DiagnosticEventPayload, { type: "log.record" }>;
+
+export function flushDiagnosticLogRecords(): Promise<void> {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+export function createDiagnosticLogRecordCapture() {
+  const records: CapturedDiagnosticLogRecord[] = [];
+  const unsubscribe = onInternalDiagnosticEvent((event) => {
+    if (event.type === "log.record") {
+      records.push(event);
+    }
+  });
+
+  return {
+    records,
+    flush: flushDiagnosticLogRecords,
+    cleanup: unsubscribe,
+  };
+}

--- a/src/logging/test-helpers/warn-log-capture.ts
+++ b/src/logging/test-helpers/warn-log-capture.ts
@@ -1,26 +1,25 @@
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
-import { __test__, resetLogger, setLoggerOverride, type LogTransportRecord } from "../logger.js";
+import { resetLogger, setLoggerOverride } from "../logger.js";
+import { createDiagnosticLogRecordCapture } from "./diagnostic-log-capture.js";
 
 export function createWarnLogCapture(prefix: string) {
-  const records: LogTransportRecord[] = [];
+  const capture = createDiagnosticLogRecordCapture();
   setLoggerOverride({
     level: "warn",
     consoleLevel: "silent",
     file: path.join(resolvePreferredOpenClawTmpDir(), `${prefix}-${process.pid}-${Date.now()}.log`),
   });
-  const unregister = __test__.registerLogTransportForTest((record) => {
-    records.push(record);
-  });
   return {
-    findText(needle: string): string | undefined {
-      return records
-        .flatMap((record) => Object.values(record))
+    async findText(needle: string): Promise<string | undefined> {
+      await capture.flush();
+      return capture.records
+        .flatMap((record) => [record.message, ...Object.values(record.attributes ?? {})])
         .filter((value): value is string => typeof value === "string")
         .find((value) => value.includes(needle));
     },
     cleanup() {
-      unregister();
+      capture.cleanup();
       setLoggerOverride(null);
       resetLogger();
     },

--- a/src/logging/test-helpers/warn-log-capture.ts
+++ b/src/logging/test-helpers/warn-log-capture.ts
@@ -1,11 +1,6 @@
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
-import {
-  registerLogTransport,
-  resetLogger,
-  setLoggerOverride,
-  type LogTransportRecord,
-} from "../logger.js";
+import { __test__, resetLogger, setLoggerOverride, type LogTransportRecord } from "../logger.js";
 
 export function createWarnLogCapture(prefix: string) {
   const records: LogTransportRecord[] = [];
@@ -14,7 +9,7 @@ export function createWarnLogCapture(prefix: string) {
     consoleLevel: "silent",
     file: path.join(resolvePreferredOpenClawTmpDir(), `${prefix}-${process.pid}-${Date.now()}.log`),
   });
-  const unregister = registerLogTransport((record) => {
+  const unregister = __test__.registerLogTransportForTest((record) => {
     records.push(record);
   });
   return {

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -17,7 +17,6 @@ export {
   isValidDiagnosticTraceId,
   parseDiagnosticTraceparent,
 } from "../infra/diagnostic-trace-context.js";
-export { registerLogTransport } from "../logging/logger.js";
 export { redactSensitiveText } from "../logging/redact.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type {


### PR DESCRIPTION
## Summary
- keep log transport sharing internal/test-only; remove `registerLogTransport` from the diagnostics-otel plugin SDK surface
- make the global logger registry weak-reference backed so stale module-instance loggers are not strongly retained
- use a direct `globalThis[Symbol.for(...)]` singleton for mutable logger transport state, avoiding the process/global dual-store pattern
- keep regression coverage for trusted test transport sharing across fresh logger module instances and assert no production registration export exists

This salvages the useful logger-isolation part of #71313 without exposing a plugin-accessible global raw-log subscription API.

## Tests
- pnpm test src/logging/logger-transport.test.ts src/agents/model-fallback.probe.test.ts src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
- pnpm check:changed (all lanes passed until extension-misc no-output timeout; rerun below passed)
- pnpm test:extensions
- post-rebase: pnpm test src/logging/logger-transport.test.ts
