### PR TITLE
fix(line): require explicit wildcard for open DMs

### DIFF
--- a/extensions/line/src/config-schema.test.ts
+++ b/extensions/line/src/config-schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { LineConfigSchema } from "./config-schema.js";
+
+function expectValidLineConfig(config: unknown) {
+  const res = LineConfigSchema.safeParse(config);
+  expect(res.success).toBe(true);
+  if (!res.success) {
+    throw new Error("expected LINE config to be valid");
+  }
+  return res.data;
+}
+
+function expectInvalidLineConfig(config: unknown) {
+  const res = LineConfigSchema.safeParse(config);
+  expect(res.success).toBe(false);
+  if (res.success) {
+    throw new Error("expected LINE config to be invalid");
+  }
+  return res.error.issues;
+}
+
+describe("line config schema", () => {
+  it('rejects dmPolicy="open" without allowFrom "*"', () => {
+    const issues = expectInvalidLineConfig({
+      dmPolicy: "open",
+      allowFrom: ["U123"],
+    });
+
+    expect(issues[0]?.path.join(".")).toBe("allowFrom");
+  });
+
+  it('rejects dmPolicy="open" without allowFrom', () => {
+    const issues = expectInvalidLineConfig({
+      dmPolicy: "open",
+    });
+
+    expect(issues[0]?.path.join(".")).toBe("allowFrom");
+  });
+
+  it('accepts dmPolicy="open" with allowFrom "*"', () => {
+    const cfg = expectValidLineConfig({
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    });
+
+    expect(cfg.dmPolicy).toBe("open");
+  });
+
+  it('rejects account-level dmPolicy="open" without account allowFrom "*"', () => {
+    const issues = expectInvalidLineConfig({
+      accounts: {
+        work: {
+          dmPolicy: "open",
+          allowFrom: ["U123"],
+        },
+      },
+    });
+
+    expect(issues[0]?.path.join(".")).toBe("accounts.work.allowFrom");
+    expect(issues[0]?.message).toBe(
+      'LINE account dmPolicy="open" requires that account allowFrom to include "*"',
+    );
+  });
+
+  it('accepts account-level dmPolicy="open" with account allowFrom "*"', () => {
+    const cfg = expectValidLineConfig({
+      accounts: {
+        work: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    expect(cfg.accounts?.work?.dmPolicy).toBe("open");
+  });
+});

--- a/extensions/line/src/config-schema.ts
+++ b/extensions/line/src/config-schema.ts
@@ -1,4 +1,7 @@
-import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import {
+  buildChannelConfigSchema,
+  requireOpenAllowFrom,
+} from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "openclaw/plugin-sdk/zod";
 
 const DmPolicySchema = z.enum(["open", "allowlist", "pairing", "disabled"]);
@@ -13,7 +16,7 @@ const ThreadBindingsSchema = z
   })
   .strict();
 
-const LineCommonConfigSchema = z.object({
+const LineCommonConfigShape = {
   enabled: z.boolean().optional(),
   channelAccessToken: z.string().optional(),
   channelSecret: z.string().optional(),
@@ -28,7 +31,7 @@ const LineCommonConfigSchema = z.object({
   mediaMaxMb: z.number().optional(),
   webhookPath: z.string().optional(),
   threadBindings: ThreadBindingsSchema.optional(),
-});
+};
 
 const LineGroupConfigSchema = z
   .object({
@@ -40,15 +43,49 @@ const LineGroupConfigSchema = z
   })
   .strict();
 
-const LineAccountConfigSchema = LineCommonConfigSchema.extend({
-  groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
-}).strict();
+function requireLineOpenAllowFrom(
+  value: { dmPolicy?: string; allowFrom?: Array<string | number> },
+  ctx: z.RefinementCtx,
+  message: string,
+): void {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message,
+  });
+}
 
-export const LineConfigSchema = LineCommonConfigSchema.extend({
-  accounts: z.record(z.string(), LineAccountConfigSchema.optional()).optional(),
-  defaultAccount: z.string().optional(),
-  groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
-}).strict();
+const LineAccountConfigSchema = z
+  .object({
+    ...LineCommonConfigShape,
+    groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireLineOpenAllowFrom(
+      value,
+      ctx,
+      'LINE account dmPolicy="open" requires that account allowFrom to include "*"',
+    );
+  });
+
+export const LineConfigSchema = z
+  .object({
+    ...LineCommonConfigShape,
+    accounts: z.record(z.string(), LineAccountConfigSchema.optional()).optional(),
+    defaultAccount: z.string().optional(),
+    groups: z.record(z.string(), LineGroupConfigSchema.optional()).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireLineOpenAllowFrom(
+      value,
+      ctx,
+      'channels.line.dmPolicy="open" requires channels.line.allowFrom to include "*"',
+    );
+  });
 
 export const LineChannelConfigSchema = buildChannelConfigSchema(LineConfigSchema);
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: LINE accepted `dmPolicy: "open"` with missing or specific `allowFrom` entries, even though the runtime treats `open` as accepting all DM senders.
- Why it matters: An operator could read `allowFrom: ["U123"]` as a restriction while `dmPolicy: "open"` makes the channel broadly reachable.
- What changed: The LINE config schema now requires `allowFrom` to include `"*"` whenever top-level or account-level `dmPolicy` is `"open"`, matching the explicit-open pattern used by other channel schemas.
- What did NOT change (scope boundary): Runtime message handling and the setup wizard behavior are unchanged; configs that already use `allowFrom: ["*"]` continue to work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: LINE's schema did not reuse the shared `requireOpenAllowFrom` guard that makes broad-open channel configs explicit.
- Missing detection / guardrail: There was no LINE schema regression test covering `dmPolicy: "open"` without a wildcard allowlist.
- Contributing context (if known): The LINE setup wizard already writes `allowFrom: ["*"]` for open mode, so the validation gap was mostly visible in hand-written configs.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/line/src/config-schema.test.ts`
- Scenario the test should lock in: top-level and account-level `dmPolicy: "open"` are rejected unless the matching `allowFrom` contains `"*"`.
- Why this is the smallest reliable guardrail: The bug is in schema validation, so a focused schema test catches it without booting the LINE runtime.
- Existing test that already covers this (if any): None found for LINE open-DM wildcard validation.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

LINE configs that set `dmPolicy: "open"` must now explicitly include `allowFrom: ["*"]`. Existing explicit-open configs remain valid. Operators who intended a restricted allowlist should use `dmPolicy: "allowlist"` instead of `"open"`.

## Diagram (if applicable)

N/A

```text
Before:
LINE config dmPolicy=open + allowFrom=["U123"] -> schema accepts -> runtime accepts all DM senders

After:
LINE config dmPolicy=open + allowFrom=["U123"] -> schema rejects -> operator must choose explicit wildcard or allowlist mode
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): LINE
- Relevant config (redacted): `channels.line.dmPolicy="open"` with and without `channels.line.allowFrom=["*"]`

### Steps

1. Parse a LINE config with `dmPolicy: "open"` and `allowFrom: ["U123"]`.
2. Parse a LINE config with `dmPolicy: "open"` and `allowFrom: ["*"]`.
3. Parse an account-level LINE config with `accounts.work.dmPolicy: "open"` and `accounts.work.allowFrom: ["U123"]`.

### Expected

- Specific allowlists are rejected for open mode.
- Explicit wildcard open mode is accepted.
- Account-level open mode follows the same rule.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-level open without wildcard rejected, top-level open with wildcard accepted, account-level open without wildcard rejected.
- Edge cases checked: formatting, lint, and extension test typecheck for the touched files.
- What you did **not** verify: Live LINE webhook delivery; this PR only changes config schema validation.

Commands run:

```sh
corepack pnpm -s vitest extensions/line/src/config-schema.test.ts --run
corepack pnpm exec oxfmt --check --threads=1 extensions/line/src/config-schema.ts extensions/line/src/config-schema.test.ts
corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/line/src/config-schema.ts extensions/line/src/config-schema.test.ts
corepack pnpm -s tsgo:extensions:test
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) Yes
- If yes, exact upgrade steps: If a LINE config intentionally allows all DM senders, add `allowFrom: ["*"]`. If it intended to restrict senders, change `dmPolicy` to `"allowlist"` and keep the specific `allowFrom` entries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing hand-written LINE configs with `dmPolicy: "open"` and no wildcard will fail validation.
  - Mitigation: The failure points at `allowFrom`, and the migration is explicit: add `"*"` for open mode or switch to `allowlist` for restricted mode.
