### PR TITLE
fix(deps): keep plugin ownership records live

### DIFF
--- a/scripts/sbom-risk-report.mjs
+++ b/scripts/sbom-risk-report.mjs
@@ -184,13 +184,17 @@ export function collectSbomRiskReport(params = {}) {
       return left.importer.localeCompare(right.importer);
     });
 
-  const rootDependencyNames = new Set(rootDependencies.map((dependency) => dependency.name));
+  const workspaceDependencyNames = new Set(
+    Object.values(lockfile.importers ?? {}).flatMap((record) =>
+      normalizeDependencies(record).map((dependency) => dependency.name),
+    ),
+  );
   const ownershipGaps = rootDependencies
     .filter((dependency) => !ownershipFor(dependencyOwnership, dependency.name))
     .map((dependency) => dependency.name)
     .toSorted(compareStrings);
   const staleOwnershipRecords = Object.keys(dependencyOwnership.dependencies ?? {})
-    .filter((name) => !rootDependencyNames.has(name))
+    .filter((name) => !workspaceDependencyNames.has(name))
     .toSorted(compareStrings);
   const ownershipWarnings = rootDependencyRows
     .filter(

--- a/test/scripts/sbom-risk-report.test.ts
+++ b/test/scripts/sbom-risk-report.test.ts
@@ -118,4 +118,62 @@ snapshots:
       "root dependency 'missing-owner' is missing from scripts/lib/dependency-ownership.json",
     ]);
   });
+
+  it("does not mark plugin importer dependencies as stale ownership records", () => {
+    const repoRoot = makeTempRepo();
+    writeRepoFile(
+      repoRoot,
+      "package.json",
+      JSON.stringify({
+        dependencies: {
+          "core-lib": "1.0.0",
+        },
+      }),
+    );
+    writeRepoFile(
+      repoRoot,
+      "pnpm-lock.yaml",
+      `
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      core-lib:
+        specifier: 1.0.0
+        version: 1.0.0
+  extensions/web-readability:
+    dependencies:
+      plugin-readable:
+        specifier: 2.0.0
+        version: 2.0.0
+packages:
+  core-lib@1.0.0: {}
+  plugin-readable@2.0.0: {}
+snapshots:
+  core-lib@1.0.0: {}
+  plugin-readable@2.0.0: {}
+`,
+    );
+    writeRepoFile(
+      repoRoot,
+      "scripts/lib/dependency-ownership.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        dependencies: {
+          "core-lib": { owner: "core:test", class: "core-runtime", risk: ["network"] },
+          "plugin-readable": {
+            owner: "plugin:web-readability",
+            class: "plugin-runtime",
+            risk: ["html"],
+          },
+          "removed-lib": { owner: "core:test", class: "core-runtime", risk: ["unused"] },
+        },
+      }),
+    );
+
+    const report = collectSbomRiskReport({ repoRoot });
+
+    expect(report.ownershipGaps).toEqual([]);
+    expect(report.staleOwnershipRecords).toEqual(["removed-lib"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: SBOM ownership records were reported as stale once a dependency moved out of the root importer into a bundled plugin workspace importer.
- Why it matters: this made the dependency-risk report point at the wrong cleanup target after plugin splits, including readability/PDF-style ownership records.
- What changed: stale ownership detection now checks all workspace production importers, while ownership-gap detection remains root-dependency-only.
- What did NOT change (scope boundary): no dependency graph, runtime behavior, plugin loading, or lockfile changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `staleOwnershipRecords` reused the root dependency name set, so ownership records for dependencies owned by plugin workspace importers looked stale after root split work.
- Missing detection / guardrail: no fixture covered an ownership record that is absent from the root importer but still present in another workspace importer.
- Contributing context (if known): the SBOM report started serving both root-dependency cleanup and plugin-split verification, but stale detection remained root-only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/sbom-risk-report.test.ts`
- Scenario the test should lock in: plugin workspace dependencies with ownership records are not stale, while records missing from every importer still are.
- Why this is the smallest reliable guardrail: it exercises the report logic directly with a tiny synthetic lockfile.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
ownership record -> not in root importer -> stale

After:
ownership record -> in any workspace prod importer -> live
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the focused SBOM report unit test.
2. Run the SBOM risk check against the current repo.
3. Run oxlint on the touched files.

### Expected

- Plugin importer dependencies with ownership records are not reported as stale.
- Actual stale records are still reported.
- SBOM risk check passes.

### Actual

- Focused test passed.
- Live SBOM risk check passed.
- Oxlint passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test test/scripts/sbom-risk-report.test.ts`; `pnpm deps:sbom-risk:check`; `pnpm exec oxlint scripts/sbom-risk-report.mjs test/scripts/sbom-risk-report.test.ts`
- Edge cases checked: ownership record present only in a plugin importer; ownership record absent from all importers.
- What you did **not** verify: full `pnpm check` / full `pnpm test`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
