### PR TITLE
fix(models): reflect Claude CLI auth status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local Claude credentials are current. Fixes #71256. Thanks @matthiasjanke.
 - Packaged installs: preserve package-root runtime dependencies and their exported subpaths when bundled plugin runtime mirrors fall back to copying shared chunks, fixing Windows npm updates that could fail to load copied `dist` modules.
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Agents/heartbeat: stop injecting the heartbeat system prompt into non-heartbeat runs, preventing ordinary user replies from being suppressed as `HEARTBEAT_OK` acknowledgments. Fixes #69079. (#69278) Thanks @stainlu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: allow large live `stream-json` JSONL lines up to the existing per-turn raw limit, preventing large Telegram, WebChat, MCP, and image turns from aborting on the old stdout buffer cap. Fixes #71793, #71080, and #70766. (#71897) Thanks @chacher86, @shivamgrover21, and @tpjordan.
 - Agents/Claude CLI: unwrap nested Claude result envelopes in CLI JSON output so delegated agent responses surface as final text instead of raw result JSON. (#66819) Thanks @mraleko.
 - Agents/Claude CLI: apply the configured 1M context window override to eligible Claude CLI Opus and Sonnet models when `context1m` is enabled. (#70863) Thanks @bidadh.
+- Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local credentials are current. Fixes #71256. (#71332) Thanks @matthiasjanke and @neeravmakwana.
 
 ## 2026.4.24
 
@@ -353,7 +354,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local Claude credentials are current. Fixes #71256. Thanks @matthiasjanke.
 - Packaged installs: preserve package-root runtime dependencies and their exported subpaths when bundled plugin runtime mirrors fall back to copying shared chunks, fixing Windows npm updates that could fail to load copied `dist` modules.
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Agents/heartbeat: stop injecting the heartbeat system prompt into non-heartbeat runs, preventing ordinary user replies from being suppressed as `HEARTBEAT_OK` acknowledgments. Fixes #69079. (#69278) Thanks @stainlu.

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -306,6 +306,7 @@ describe("anthropic provider replay hooks", () => {
       apiKey: "access-token",
       source: "Claude CLI native auth",
       mode: "oauth",
+      expiresAt: 123,
     });
     expect(readClaudeCliCredentialsForRuntimeMock).toHaveBeenCalledTimes(1);
   });
@@ -329,6 +330,7 @@ describe("anthropic provider replay hooks", () => {
       apiKey: "bearer-token",
       source: "Claude CLI native auth",
       mode: "token",
+      expiresAt: 123,
     });
   });
 

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -332,6 +332,33 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
+  it("exposes Claude CLI auth as a runtime-only external profile", async () => {
+    readClaudeCliCredentialsForRuntimeMock.mockReset();
+    readClaudeCliCredentialsForRuntimeMock.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: "fresh-cli-access",
+      refresh: "fresh-cli-refresh",
+      expires: 123,
+    });
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(provider.resolveExternalAuthProfiles?.({} as never)).toEqual([
+      {
+        profileId: "anthropic:claude-cli",
+        credential: {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "fresh-cli-access",
+          refresh: "fresh-cli-refresh",
+          expires: 123,
+        },
+        persistence: "runtime-only",
+      },
+    ]);
+  });
+
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {
     readClaudeCliCredentialsForSetupMock.mockReset();
     readClaudeCliCredentialsForSetupMock.mockReturnValue({

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -332,33 +332,6 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
-  it("exposes Claude CLI auth as a runtime-only external profile", async () => {
-    readClaudeCliCredentialsForRuntimeMock.mockReset();
-    readClaudeCliCredentialsForRuntimeMock.mockReturnValue({
-      type: "oauth",
-      provider: "anthropic",
-      access: "fresh-cli-access",
-      refresh: "fresh-cli-refresh",
-      expires: 123,
-    });
-
-    const provider = await registerSingleProviderPlugin(anthropicPlugin);
-
-    expect(provider.resolveExternalAuthProfiles?.({} as never)).toEqual([
-      {
-        profileId: "anthropic:claude-cli",
-        credential: {
-          type: "oauth",
-          provider: "claude-cli",
-          access: "fresh-cli-access",
-          refresh: "fresh-cli-refresh",
-          expires: 123,
-        },
-        persistence: "runtime-only",
-      },
-    ]);
-  });
-
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {
     readClaudeCliCredentialsForSetupMock.mockReset();
     readClaudeCliCredentialsForSetupMock.mockReturnValue({

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -49,6 +49,7 @@
     }
   ],
   "contracts": {
+    "externalAuthProviders": ["claude-cli"],
     "mediaUnderstandingProviders": ["anthropic"]
   },
   "mediaUnderstandingProviderMetadata": {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -49,7 +49,6 @@
     }
   ],
   "contracts": {
-    "externalAuthProviders": ["claude-cli"],
     "mediaUnderstandingProviders": ["anthropic"]
   },
   "mediaUnderstandingProviderMetadata": {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -414,11 +414,13 @@ function resolveClaudeCliSyntheticAuth() {
         apiKey: credential.access,
         source: "Claude CLI native auth",
         mode: "oauth" as const,
+        expiresAt: credential.expires,
       }
     : {
         apiKey: credential.token,
         source: "Claude CLI native auth",
         mode: "token" as const,
+        expiresAt: credential.expires,
       };
 }
 

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -422,6 +422,26 @@ function resolveClaudeCliSyntheticAuth() {
       };
 }
 
+function resolveClaudeCliExternalAuthProfiles() {
+  const credential = claudeCliAuth.readClaudeCliCredentialsForRuntime();
+  if (!credential || credential.type !== "oauth") {
+    return [];
+  }
+  return [
+    {
+      profileId: "anthropic:claude-cli",
+      credential: {
+        type: "oauth" as const,
+        provider: CLAUDE_CLI_BACKEND_ID,
+        access: credential.access,
+        refresh: credential.refresh,
+        expires: credential.expires,
+      },
+      persistence: "runtime-only" as const,
+    },
+  ];
+}
+
 async function runAnthropicCliMigration(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const credential = claudeCliAuth.readClaudeCliCredentialsForSetup();
   if (!credential) {
@@ -587,6 +607,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
         ? resolveClaudeCliSyntheticAuth()
         : undefined,
+    resolveExternalAuthProfiles: () => resolveClaudeCliExternalAuthProfiles(),
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -422,26 +422,6 @@ function resolveClaudeCliSyntheticAuth() {
       };
 }
 
-function resolveClaudeCliExternalAuthProfiles() {
-  const credential = claudeCliAuth.readClaudeCliCredentialsForRuntime();
-  if (!credential || credential.type !== "oauth") {
-    return [];
-  }
-  return [
-    {
-      profileId: "anthropic:claude-cli",
-      credential: {
-        type: "oauth" as const,
-        provider: CLAUDE_CLI_BACKEND_ID,
-        access: credential.access,
-        refresh: credential.refresh,
-        expires: credential.expires,
-      },
-      persistence: "runtime-only" as const,
-    },
-  ];
-}
-
 async function runAnthropicCliMigration(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const credential = claudeCliAuth.readClaudeCliCredentialsForSetup();
   if (!credential) {
@@ -607,7 +587,6 @@ export function buildAnthropicProvider(): ProviderPlugin {
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
         ? resolveClaudeCliSyntheticAuth()
         : undefined,
-    resolveExternalAuthProfiles: () => resolveClaudeCliExternalAuthProfiles(),
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -1,16 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OAuthCredential } from "./auth-profiles/types.js";
-import type { ClaudeCliCredential } from "./cli-credentials.js";
 
-const { readClaudeCliCredentialsCachedMock, readCodexCliCredentialsCachedMock } = vi.hoisted(
-  () => ({
-    readClaudeCliCredentialsCachedMock: vi.fn<() => ClaudeCliCredential | null>(() => null),
-    readCodexCliCredentialsCachedMock: vi.fn<() => OAuthCredential | null>(() => null),
-  }),
-);
+const { readCodexCliCredentialsCachedMock } = vi.hoisted(() => ({
+  readCodexCliCredentialsCachedMock: vi.fn<() => OAuthCredential | null>(() => null),
+}));
 
 vi.mock("./cli-credentials.js", () => ({
-  readClaudeCliCredentialsCached: readClaudeCliCredentialsCachedMock,
+  readClaudeCliCredentialsCached: () => null,
   readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
   readMiniMaxCliCredentialsCached: () => null,
   resetCliCredentialCachesForTest: () => undefined,
@@ -63,8 +59,6 @@ describe("buildAuthHealthSummary", () => {
   });
 
   beforeEach(() => {
-    readClaudeCliCredentialsCachedMock.mockReset();
-    readClaudeCliCredentialsCachedMock.mockReturnValue(null);
     readCodexCliCredentialsCachedMock.mockReset();
     readCodexCliCredentialsCachedMock.mockReturnValue(null);
   });
@@ -144,15 +138,8 @@ describe("buildAuthHealthSummary", () => {
     expect(statuses["google:no-refresh"]).toBe("expired");
   });
 
-  it("uses fresh Claude CLI OAuth credentials for claude-cli profile health", () => {
+  it("uses runtime provider credentials for profile health", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
-    readClaudeCliCredentialsCachedMock.mockReturnValue({
-      type: "oauth",
-      provider: "anthropic",
-      access: "fresh-cli-access",
-      refresh: "fresh-cli-refresh",
-      expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
-    });
     const store = {
       version: 1,
       profiles: {
@@ -169,6 +156,17 @@ describe("buildAuthHealthSummary", () => {
     const summary = buildAuthHealthSummary({
       store,
       warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+      runtimeCredentialsByProvider: new Map([
+        [
+          "claude-cli",
+          {
+            type: "token",
+            provider: "claude-cli",
+            token: "fresh-cli-access",
+            expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+          },
+        ],
+      ]),
     });
 
     const profile = summary.profiles.find((entry) => entry.profileId === "anthropic:claude-cli");

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OAuthCredential } from "./auth-profiles/types.js";
+import type { ClaudeCliCredential } from "./cli-credentials.js";
 
-const { readCodexCliCredentialsCachedMock } = vi.hoisted(() => ({
-  readCodexCliCredentialsCachedMock: vi.fn<() => OAuthCredential | null>(() => null),
-}));
+const { readClaudeCliCredentialsCachedMock, readCodexCliCredentialsCachedMock } = vi.hoisted(
+  () => ({
+    readClaudeCliCredentialsCachedMock: vi.fn<() => ClaudeCliCredential | null>(() => null),
+    readCodexCliCredentialsCachedMock: vi.fn<() => OAuthCredential | null>(() => null),
+  }),
+);
 
 vi.mock("./cli-credentials.js", () => ({
-  readClaudeCliCredentialsCached: () => null,
+  readClaudeCliCredentialsCached: readClaudeCliCredentialsCachedMock,
   readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
   readMiniMaxCliCredentialsCached: () => null,
   resetCliCredentialCachesForTest: () => undefined,
@@ -59,6 +63,8 @@ describe("buildAuthHealthSummary", () => {
   });
 
   beforeEach(() => {
+    readClaudeCliCredentialsCachedMock.mockReset();
+    readClaudeCliCredentialsCachedMock.mockReturnValue(null);
     readCodexCliCredentialsCachedMock.mockReset();
     readCodexCliCredentialsCachedMock.mockReturnValue(null);
   });
@@ -136,6 +142,38 @@ describe("buildAuthHealthSummary", () => {
     const statuses = profileStatuses(summary);
 
     expect(statuses["google:no-refresh"]).toBe("expired");
+  });
+
+  it("uses fresh Claude CLI OAuth credentials for claude-cli profile health", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    readClaudeCliCredentialsCachedMock.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: "fresh-cli-access",
+      refresh: "fresh-cli-refresh",
+      expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+    });
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "oauth" as const,
+          provider: "claude-cli",
+          access: "stale-access",
+          refresh: "stale-refresh",
+          expires: now - 10_000,
+        },
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    const profile = summary.profiles.find((entry) => entry.profileId === "anthropic:claude-cli");
+    expect(profile?.status).toBe("ok");
+    expect(profile?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
   });
 
   it("does not let fresh .codex state override expired canonical health", () => {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { CLAUDE_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
 import {
   DEFAULT_OAUTH_REFRESH_MARGIN_MS,
   type AuthCredentialReasonCode,
@@ -9,7 +8,6 @@ import {
 import { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 import { resolveEffectiveOAuthCredential } from "./auth-profiles/effective-oauth.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
-import { readClaudeCliCredentialsCached } from "./cli-credentials.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 export type AuthProfileSource = "store";
@@ -103,46 +101,19 @@ function resolveOAuthStatus(
   return { status: "ok", remainingMs };
 }
 
-function resolveClaudeCliStatusCredential(params: {
-  profileId: string;
-  credential: AuthProfileCredential;
-}): AuthProfileCredential {
-  if (params.profileId !== CLAUDE_CLI_PROFILE_ID) {
-    return params.credential;
-  }
-  const cliCredential = readClaudeCliCredentialsCached({ allowKeychainPrompt: false });
-  if (!cliCredential) {
-    return params.credential;
-  }
-  if (cliCredential.type === "oauth") {
-    return {
-      type: "oauth",
-      provider: params.credential.provider,
-      access: cliCredential.access,
-      refresh: cliCredential.refresh,
-      expires: cliCredential.expires,
-    };
-  }
-  return {
-    type: "token",
-    provider: params.credential.provider,
-    token: cliCredential.token,
-    expires: cliCredential.expires,
-  };
-}
-
 function buildProfileHealth(params: {
   profileId: string;
   credential: AuthProfileCredential;
+  runtimeCredential?: AuthProfileCredential;
   store: AuthProfileStore;
   cfg?: OpenClawConfig;
   now: number;
   warnAfterMs: number;
 }): AuthProfileHealth {
-  const { profileId, credential, store, cfg, now, warnAfterMs } = params;
+  const { profileId, credential, runtimeCredential, store, cfg, now, warnAfterMs } = params;
   const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
   const source = resolveAuthProfileSource(profileId);
-  const healthCredential = resolveClaudeCliStatusCredential({ profileId, credential });
+  const healthCredential = runtimeCredential ?? credential;
   const provider = normalizeProviderId(healthCredential.provider);
 
   if (healthCredential.type === "api_key") {
@@ -227,6 +198,7 @@ export function buildAuthHealthSummary(params: {
   cfg?: OpenClawConfig;
   warnAfterMs?: number;
   providers?: string[];
+  runtimeCredentialsByProvider?: ReadonlyMap<string, AuthProfileCredential>;
 }): AuthHealthSummary {
   const now = Date.now();
   const warnAfterMs = params.warnAfterMs ?? DEFAULT_OAUTH_WARN_MS;
@@ -242,6 +214,9 @@ export function buildAuthHealthSummary(params: {
       buildProfileHealth({
         profileId,
         credential,
+        runtimeCredential: params.runtimeCredentialsByProvider?.get(
+          normalizeProviderId(credential.provider),
+        ),
         store: params.store,
         cfg: params.cfg,
         now,

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { CLAUDE_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
 import {
   DEFAULT_OAUTH_REFRESH_MARGIN_MS,
   type AuthCredentialReasonCode,
@@ -8,6 +9,7 @@ import {
 import { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 import { resolveEffectiveOAuthCredential } from "./auth-profiles/effective-oauth.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
+import { readClaudeCliCredentialsCached } from "./cli-credentials.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 export type AuthProfileSource = "store";
@@ -101,6 +103,34 @@ function resolveOAuthStatus(
   return { status: "ok", remainingMs };
 }
 
+function resolveClaudeCliStatusCredential(params: {
+  profileId: string;
+  credential: AuthProfileCredential;
+}): AuthProfileCredential {
+  if (params.profileId !== CLAUDE_CLI_PROFILE_ID) {
+    return params.credential;
+  }
+  const cliCredential = readClaudeCliCredentialsCached({ allowKeychainPrompt: false });
+  if (!cliCredential) {
+    return params.credential;
+  }
+  if (cliCredential.type === "oauth") {
+    return {
+      type: "oauth",
+      provider: params.credential.provider,
+      access: cliCredential.access,
+      refresh: cliCredential.refresh,
+      expires: cliCredential.expires,
+    };
+  }
+  return {
+    type: "token",
+    provider: params.credential.provider,
+    token: cliCredential.token,
+    expires: cliCredential.expires,
+  };
+}
+
 function buildProfileHealth(params: {
   profileId: string;
   credential: AuthProfileCredential;
@@ -112,9 +142,10 @@ function buildProfileHealth(params: {
   const { profileId, credential, store, cfg, now, warnAfterMs } = params;
   const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
   const source = resolveAuthProfileSource(profileId);
-  const provider = normalizeProviderId(credential.provider);
+  const healthCredential = resolveClaudeCliStatusCredential({ profileId, credential });
+  const provider = normalizeProviderId(healthCredential.provider);
 
-  if (credential.type === "api_key") {
+  if (healthCredential.type === "api_key") {
     return {
       profileId,
       provider,
@@ -125,9 +156,9 @@ function buildProfileHealth(params: {
     };
   }
 
-  if (credential.type === "token") {
+  if (healthCredential.type === "token") {
     const eligibility = evaluateStoredCredentialEligibility({
-      credential,
+      credential: healthCredential,
       now,
     });
     if (!eligibility.eligible) {
@@ -143,8 +174,8 @@ function buildProfileHealth(params: {
         label,
       };
     }
-    const expiryState = resolveTokenExpiryState(credential.expires, now);
-    const expiresAt = expiryState === "valid" ? credential.expires : undefined;
+    const expiryState = resolveTokenExpiryState(healthCredential.expires, now);
+    const expiresAt = expiryState === "valid" ? healthCredential.expires : undefined;
     if (!expiresAt) {
       return {
         profileId,
@@ -171,7 +202,7 @@ function buildProfileHealth(params: {
 
   const effectiveCredential = resolveEffectiveOAuthCredential({
     profileId,
-    credential,
+    credential: healthCredential,
   });
   const oauthWarnAfterMs = Math.max(warnAfterMs, DEFAULT_OAUTH_REFRESH_MARGIN_MS);
   const { status: rawStatus, remainingMs } = resolveOAuthStatus(

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -11,7 +11,7 @@ import {
   formatRemainingShort,
 } from "../../agents/auth-health.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
-import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
+import { ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import { resolveProviderEnvApiKeyCandidates } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -12,6 +12,7 @@ import {
 } from "../../agents/auth-health.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import { resolveProviderEnvApiKeyCandidates } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
@@ -29,6 +30,8 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../../config/model-input.js";
 import { getShellEnvAppliedKeys, shouldEnableShellEnvFallback } from "../../infra/shell-env.js";
+import type { ProviderSyntheticAuthResult } from "../../plugins/provider-external-auth.types.js";
+import { resolveProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic-auth.runtime.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -57,6 +60,14 @@ let listProbeRuntimePromise: Promise<ListProbeRuntime> | undefined;
 
 const DISPLAY_MODEL_PARSE_OPTIONS = { allowPluginNormalization: false } as const;
 
+type StatusSyntheticAuth = {
+  value: string;
+  source: string;
+  credential?: string;
+  mode?: ProviderSyntheticAuthResult["mode"];
+  expiresAt?: number;
+};
+
 function loadProviderUsageRuntime(): Promise<ProviderUsageRuntime> {
   providerUsageRuntimePromise ??= import("../../infra/provider-usage.js");
   return providerUsageRuntimePromise;
@@ -75,6 +86,56 @@ function loadTerminalTableRuntime(): Promise<TerminalTableRuntime> {
 function loadListProbeRuntime(): Promise<ListProbeRuntime> {
   listProbeRuntimePromise ??= import("./list.probe.js");
   return listProbeRuntimePromise;
+}
+
+function resolveProviderConfigForStatus(
+  cfg: Awaited<ReturnType<typeof loadModelsConfig>>,
+  provider: string,
+) {
+  const providers = cfg.models?.providers ?? {};
+  const direct = providers[provider];
+  if (direct) {
+    return direct;
+  }
+  const normalized = normalizeProviderId(provider);
+  return (
+    providers[normalized] ??
+    Object.entries(providers).find(([key]) => normalizeProviderId(key) === normalized)?.[1]
+  );
+}
+
+function syntheticAuthCredential(
+  provider: string,
+  auth: StatusSyntheticAuth,
+): AuthProfileCredential | undefined {
+  if (!auth.mode) {
+    return undefined;
+  }
+  if (auth.mode === "api-key") {
+    return {
+      type: "api_key",
+      provider,
+      key: auth.credential,
+    };
+  }
+  if (auth.mode === "token") {
+    return {
+      type: "token",
+      provider,
+      token: auth.credential,
+      expires: auth.expiresAt,
+    };
+  }
+  if (auth.expiresAt === undefined) {
+    return undefined;
+  }
+  return {
+    type: "oauth",
+    provider,
+    access: auth.credential ?? "",
+    refresh: "",
+    expires: auth.expiresAt,
+  };
 }
 
 export async function modelsStatusCommand(
@@ -185,14 +246,30 @@ export async function modelsStatusCommand(
       providersFromEnv.add(provider);
     }
   }
-  const syntheticAuthByProvider = new Map(
-    resolveRuntimeSyntheticAuthProviderRefs().map((provider) => [
-      normalizeProviderId(provider),
-      {
-        value: "plugin-owned",
-        source: "plugin synthetic auth",
+  const syntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
+  for (const provider of resolveRuntimeSyntheticAuthProviderRefs()) {
+    const normalized = normalizeProviderId(provider);
+    const resolved = resolveProviderSyntheticAuthWithPlugin({
+      provider: normalized,
+      config: cfg,
+      context: {
+        config: cfg,
+        provider: normalized,
+        providerConfig: resolveProviderConfigForStatus(cfg, normalized),
       },
-    ]),
+    });
+    syntheticAuthByProvider.set(normalized, {
+      value: "plugin-owned",
+      source: resolved?.source ?? "plugin synthetic auth",
+      credential: resolved?.apiKey,
+      mode: resolved?.mode,
+      expiresAt: resolved?.expiresAt,
+    });
+  }
+  const runtimeCredentialsByProvider = new Map(
+    Array.from(syntheticAuthByProvider.entries())
+      .map(([provider, auth]) => [provider, syntheticAuthCredential(provider, auth)] as const)
+      .filter((entry): entry is readonly [string, AuthProfileCredential] => Boolean(entry[1])),
   );
 
   const providers = Array.from(
@@ -325,6 +402,7 @@ export async function modelsStatusCommand(
     store,
     cfg,
     warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    runtimeCredentialsByProvider,
   });
   const oauthProfiles = authHealth.profiles.filter(
     (profile) => profile.type === "oauth" || profile.type === "token",

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -11,7 +11,7 @@ import {
   formatRemainingShort,
 } from "../../agents/auth-health.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
-import { ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import { resolveProviderEnvApiKeyCandidates } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -121,6 +121,7 @@ const mocks = vi.hoisted(() => {
     }),
     loadProviderUsageSummary: vi.fn().mockResolvedValue(undefined),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
+    resolveProviderSyntheticAuthWithPlugin: vi.fn().mockReturnValue(undefined),
   };
 });
 
@@ -210,6 +211,9 @@ vi.mock("../../infra/provider-usage.js", () => ({
 }));
 vi.mock("../../plugins/synthetic-auth.runtime.js", () => ({
   resolveRuntimeSyntheticAuthProviderRefs: mocks.resolveRuntimeSyntheticAuthProviderRefs,
+}));
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  resolveProviderSyntheticAuthWithPlugin: mocks.resolveProviderSyntheticAuthWithPlugin,
 }));
 
 import { modelsStatusCommand } from "./list.status-command.js";
@@ -427,6 +431,8 @@ describe("modelsStatusCommand auth overview", () => {
     const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
     const originalSyntheticImpl =
       mocks.resolveRuntimeSyntheticAuthProviderRefs.getMockImplementation();
+    const originalResolveSyntheticAuthImpl =
+      mocks.resolveProviderSyntheticAuthWithPlugin.getMockImplementation();
     mocks.loadConfig.mockReturnValue({
       agents: {
         defaults: {
@@ -439,6 +445,17 @@ describe("modelsStatusCommand auth overview", () => {
     });
     mocks.resolveEnvApiKey.mockImplementation(() => null);
     mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue(["codex", "unused-synthetic"]);
+    mocks.resolveProviderSyntheticAuthWithPlugin.mockImplementation(
+      ({ provider }: { provider: string }) =>
+        provider === "codex"
+          ? {
+              apiKey: "codex-runtime-token",
+              source: "codex-app-server",
+              mode: "token",
+              expiresAt: Date.now() + 60_000,
+            }
+          : undefined,
+    );
 
     try {
       await modelsStatusCommand({ json: true }, localRuntime as never);
@@ -453,13 +470,13 @@ describe("modelsStatusCommand auth overview", () => {
         expect.arrayContaining([
           expect.objectContaining({
             provider: "codex",
-            syntheticAuth: {
+            syntheticAuth: expect.objectContaining({
               value: "plugin-owned",
-              source: "plugin synthetic auth",
-            },
+              source: "codex-app-server",
+            }),
             effective: {
               kind: "synthetic",
-              detail: "plugin synthetic auth",
+              detail: "codex-app-server",
             },
           }),
         ]),
@@ -480,6 +497,13 @@ describe("modelsStatusCommand auth overview", () => {
         mocks.resolveRuntimeSyntheticAuthProviderRefs.mockImplementation(originalSyntheticImpl);
       } else {
         mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue([]);
+      }
+      if (originalResolveSyntheticAuthImpl) {
+        mocks.resolveProviderSyntheticAuthWithPlugin.mockImplementation(
+          originalResolveSyntheticAuthImpl,
+        );
+      } else {
+        mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue(undefined);
       }
     }
   });

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => {
     resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
     listAgentIds: vi.fn().mockReturnValue(["main", "jeremiah"]),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
+    ensureAuthProfileStoreWithoutExternalProfiles: vi.fn().mockReturnValue(store),
     listProfilesForProvider: vi.fn((s: typeof store, provider: string) => {
       return Object.entries(s.profiles)
         .filter(([, cred]) => cred.provider === provider)
@@ -146,7 +147,8 @@ vi.mock("../../agents/auth-profiles/profiles.js", () => ({
 }));
 vi.mock("../../agents/auth-profiles/store.js", () => ({
   ensureAuthProfileStore: mocks.ensureAuthProfileStore,
-  ensureAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles:
+    mocks.ensureAuthProfileStoreWithoutExternalProfiles,
 }));
 vi.mock("../../agents/auth-profiles/usage.js", () => ({
   resolveProfileUnusableUntilForDisplay: mocks.resolveProfileUnusableUntilForDisplay,
@@ -284,6 +286,8 @@ describe("modelsStatusCommand auth overview", () => {
     const payload = JSON.parse(String((runtime.log as Mock).mock.calls[0]?.[0]));
 
     expect(mocks.resolveOpenClawAgentDir).toHaveBeenCalled();
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalled();
+    expect(mocks.ensureAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
     expect(payload.defaultModel).toBe("anthropic/claude-opus-4-6");
     expect(payload.configPath).toBe("/tmp/openclaw-dev/openclaw.json");
     expect(payload.auth.storePath).toBe("/tmp/openclaw-agent/auth-profiles.json");

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -43,7 +43,6 @@ const mocks = vi.hoisted(() => {
     resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
     listAgentIds: vi.fn().mockReturnValue(["main", "jeremiah"]),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
-    ensureAuthProfileStoreWithoutExternalProfiles: vi.fn().mockReturnValue(store),
     listProfilesForProvider: vi.fn((s: typeof store, provider: string) => {
       return Object.entries(s.profiles)
         .filter(([, cred]) => cred.provider === provider)
@@ -147,8 +146,7 @@ vi.mock("../../agents/auth-profiles/profiles.js", () => ({
 }));
 vi.mock("../../agents/auth-profiles/store.js", () => ({
   ensureAuthProfileStore: mocks.ensureAuthProfileStore,
-  ensureAuthProfileStoreWithoutExternalProfiles:
-    mocks.ensureAuthProfileStoreWithoutExternalProfiles,
+  ensureAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStore,
 }));
 vi.mock("../../agents/auth-profiles/usage.js", () => ({
   resolveProfileUnusableUntilForDisplay: mocks.resolveProfileUnusableUntilForDisplay,
@@ -287,7 +285,6 @@ describe("modelsStatusCommand auth overview", () => {
 
     expect(mocks.resolveOpenClawAgentDir).toHaveBeenCalled();
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalled();
-    expect(mocks.ensureAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
     expect(payload.defaultModel).toBe("anthropic/claude-opus-4-6");
     expect(payload.configPath).toBe("/tmp/openclaw-dev/openclaw.json");
     expect(payload.auth.storePath).toBe("/tmp/openclaw-agent/auth-profiles.json");

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -12,6 +12,7 @@ export type ProviderSyntheticAuthResult = {
   apiKey: string;
   source: string;
   mode: Exclude<ModelProviderAuthMode, "aws-sdk">;
+  expiresAt?: number;
 };
 
 export type ProviderResolveExternalOAuthProfilesContext = {


### PR DESCRIPTION
## Summary

- Problem: `openclaw models status` could report `anthropic:claude-cli` as expired or expiring from a stale stored profile while Claude CLI native credentials were fresh enough for runtime use.
- Why it matters: users saw an auth health warning even though direct Claude CLI and OpenClaw Claude runtime paths still worked.
- What changed: auth health now evaluates the known Claude CLI profile against fresh native Claude CLI credentials for status only, without overlaying those credentials into the general auth store.
- What did NOT change (scope boundary): Claude CLI runtime execution, token refresh, credential persistence, provider selection policies, and plugin auth contracts are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71256
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `models status` built OAuth health from stale stored profile expiry data, while Claude CLI runtime auth was resolved separately through the native Claude CLI credential path.
- Missing detection / guardrail: there was no regression test proving `anthropic:claude-cli` health reflects fresh native Claude CLI credentials when the stored profile has drifted stale.
- Contributing context (if known): persisted `anthropic:claude-cli` profiles can drift from local Claude CLI credentials after the external CLI refreshes independently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/auth-health.test.ts`, `src/commands/models/list.status.test.ts`
- Scenario the test should lock in: `anthropic:claude-cli` health uses fresh native Claude CLI OAuth expiry for status while the status command keeps the no-external-profile store path.
- Why this is the smallest reliable guardrail: it covers the health/status mismatch without invoking a real Claude CLI binary or changing runtime credential resolution.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw models status` now reflects fresh local Claude CLI OAuth credentials when the stored `anthropic:claude-cli` profile is stale.

## Diagram (if applicable)

```text
Before:
models status -> stored claude-cli profile expiry -> stale warning

After:
models status -> auth health checks native Claude CLI expiry for claude-cli -> current status
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

Security/runtime controls unchanged: the fix reuses the existing Claude CLI credential reader only inside auth-health status evaluation and does not add an external auth profile, plugin contract, store overlay, persistence path, refresh path, network call, or command execution surface.

## Repro + Verification

### Environment

- OS: macOS local dev
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: Anthropic Claude CLI
- Integration/channel (if any): CLI models status
- Relevant config (redacted): stale `anthropic:claude-cli` stored profile plus fresh native Claude CLI OAuth credentials

### Steps

1. Have a stale stored `anthropic:claude-cli` profile.
2. Have fresh local Claude CLI OAuth credentials.
3. Run `openclaw models status`.

### Expected

- Status reflects the fresh Claude CLI native OAuth credential.

### Actual

- Before this fix, status could report the stale stored profile as expired or expiring.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified, and how:

- Verified scenarios: auth health reports a fresh status for a stale `anthropic:claude-cli` stored profile when native Claude CLI OAuth credentials are fresh; `models status` keeps using the no-external-profile store path.
- Edge cases checked: no external auth profile is added, so native Claude CLI credentials are not overlaid into `AuthProfileStore` and cannot be persisted by external-profile save filtering.
- What I did **not** verify: live Claude CLI login against a real host credential file.

Exact tests run:

- `pnpm test src/agents/auth-health.test.ts src/commands/models/list.status.test.ts extensions/anthropic/index.test.ts`
- `pnpm check:changed`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

AI-assisted: yes.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Claude CLI health could diverge from stored profile health for the fixed `anthropic:claude-cli` profile.
  - Mitigation: the override is scoped to the known Claude CLI profile id and only affects health/status calculation; runtime auth resolution and persisted store contents are unchanged.