### PR TITLE
fix(agents): preserve opaque reasoning ids from Copilot Responses proxy

### DIFF
--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -160,8 +160,13 @@ function isReplayableReasoningType(value: unknown): value is "reasoning" | `reas
 }
 
 function toReplayableReasoningId(value: unknown): string | null {
-  const id = toNonEmptyString(value);
-  return id && id.startsWith("rs_") ? id : null;
+  // Accept any non-empty id. OpenAI direct returns ids like "rs_...", but
+  // GitHub Copilot's Responses proxy returns opaque encrypted/base64 ids that
+  // do not share that prefix. Dropping non-"rs_" ids caused the server-side
+  // continuation check to fail with HTTP 400 "Encrypted content item_id did
+  // not match the target item id" when re-sending reasoning items in a
+  // multi-turn conversation against Copilot-hosted gpt-5.x models.
+  return toNonEmptyString(value);
 }
 
 function toReasoningSignature(value: unknown): ReplayableReasoningSignature | null {

--- a/src/agents/openai-ws-stream.e2e.test.ts
+++ b/src/agents/openai-ws-stream.e2e.test.ts
@@ -166,7 +166,9 @@ function extractReasoningText(item: { summary?: unknown; content?: unknown }): s
 function toExpectedReasoningSignature(item: { id?: string; type: string }) {
   return {
     type: item.type,
-    ...(typeof item.id === "string" && item.id.startsWith("rs_") ? { id: item.id } : {}),
+    // Accept any non-empty id, not just "rs_*". Copilot-hosted Responses
+    // returns opaque encrypted ids that must be threaded back as-is.
+    ...(typeof item.id === "string" && item.id.length > 0 ? { id: item.id } : {}),
   };
 }
 

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -619,7 +619,13 @@ describe("convertMessagesToInputItems", () => {
     expect(items[0]).toMatchObject({ type: "reasoning", id: "rs_summary" });
   });
 
-  it("drops reasoning replay ids that do not match OpenAI reasoning ids", () => {
+  it("preserves arbitrary reasoning ids (Copilot returns opaque non-rs_ ids)", () => {
+    // Regression: previously we dropped any reasoning id that did not start
+    // with "rs_". GitHub Copilot's hosted Responses proxy returns opaque,
+    // base64-shaped ids that must be re-sent verbatim on the next turn,
+    // otherwise the upstream rejects continuation with HTTP 400 "Encrypted
+    // content item_id did not match the target item id".
+    const opaqueId = "cAkF5s7bPI/vmV4ynEfGnazJ076eYI+abcdef=="; // Copilot-style opaque id
     const msg = {
       role: "assistant" as const,
       content: [
@@ -628,7 +634,44 @@ describe("convertMessagesToInputItems", () => {
           thinking: "internal reasoning...",
           thinkingSignature: JSON.stringify({
             type: "reasoning",
-            id: "  bad-id  ",
+            id: opaqueId,
+          }),
+        },
+        { type: "text" as const, text: "Here is my answer." },
+      ],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "github-copilot",
+      model: "gpt-5.5",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toEqual([
+      {
+        type: "reasoning",
+        id: opaqueId,
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Here is my answer.",
+      },
+    ]);
+  });
+
+  it("drops reasoning replay ids that are empty after trimming", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [
+        {
+          type: "thinking" as const,
+          thinking: "internal reasoning...",
+          thinkingSignature: JSON.stringify({
+            type: "reasoning",
+            id: "   ", // whitespace-only -> dropped
           }),
         },
         { type: "text" as const, text: "Here is my answer." },

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -39,7 +39,12 @@ function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature
   }
   const id = typeof candidate.id === "string" ? candidate.id : "";
   const type = typeof candidate.type === "string" ? candidate.type : "";
-  if (!id.startsWith("rs_")) {
+  // Accept any non-empty id. OpenAI direct emits "rs_..." prefixes, but
+  // Copilot-hosted Responses (e.g. gpt-5.x) returns opaque encrypted ids that
+  // must still be threaded back as-is on subsequent turns; otherwise the
+  // upstream rejects continuation with HTTP 400 "Encrypted content item_id
+  // did not match the target item id".
+  if (!id) {
     return null;
   }
   if (type === "reasoning" || type.startsWith("reasoning.")) {


### PR DESCRIPTION
Fixes #71333.

### What

Stop dropping the reasoning item id when it does not start with `rs_`.

OpenAI's direct Responses API uses ids like `rs_abc123`. The previous code:

```ts
function toReplayableReasoningId(value: unknown): string | null {
  const id = toNonEmptyString(value);
  return id && id.startsWith("rs_") ? id : null;
}
```

assumed that format everywhere. GitHub Copilot's hosted Responses proxy (used for `gpt-5.x`) instead returns opaque, encrypted/base64-shaped ids without the `rs_` prefix. We were stripping those ids before replaying the reasoning item on the next turn, which made the upstream reject continuation with:

```
HTTP 400 The encrypted content for item rs_<…> could not be verified.
Reason: Encrypted content item_id did not match the target item id.
```

Because that 400 then put the `github-copilot` provider into cooldown, the user-visible symptom was "I selected gpt-5.5 and a fallback model answered."

### Why this is safe

- The Responses spec does not mandate any particular id shape; it is server-defined and meant to be threaded back verbatim, alongside `encrypted_content`, on the next request. Both OpenAI direct (`rs_*`) and Copilot (opaque) ids satisfy that contract; only the format differs.
- Empty / whitespace-only ids are still dropped — the only path the previous code actually needed to defend against.
- `store: true` is **not** an alternative on Copilot (the endpoint returns `unsupported_value` for that param), so client-side replay is the only continuation mechanism for that provider.

### Changes

- `src/agents/openai-ws-message-conversion.ts` — `toReplayableReasoningId` now returns any non-empty trimmed string.
- `src/agents/pi-embedded-helpers/openai.ts` — `parseReasoningSignature` no longer requires `id.startsWith("rs_")`.
- `src/agents/openai-ws-stream.test.ts` — replace the now-stale "drops non-`rs_` ids" test with two:
  - new regression test `preserves arbitrary reasoning ids (Copilot returns opaque non-rs_ ids)` — uses a Copilot-style opaque id and asserts it is preserved;
  - reworded `drops reasoning replay ids that are empty after trimming` — keeps the intentional drop behavior for whitespace-only ids.
- `src/agents/openai-ws-stream.e2e.test.ts` — relax the `toExpectedReasoningSignature` test helper to mirror the new acceptance rule (any non-empty id), so the e2e expectations stay consistent with the production code.

### Verification

- `pnpm exec tsc --noEmit -p tsconfig.json` ✅
- `pnpm lint` (oxlint type-aware, 5742 files / 136 rules) ✅
- Targeted vitest run for `src/agents/openai-ws-stream.test.ts` was attempted locally but the full agent test surface is heavy on this machine; relying on CI for the full suite. The change is narrow (one predicate) and covered by the new + updated unit tests.
- Manual repro against `https://api.enterprise.githubcopilot.com/v1/responses` with a Copilot device-flow token:
  - turn 1 returns reasoning item with opaque id + `encrypted_content`;
  - turn 2 succeeds when the opaque id is replayed verbatim, fails with the exact reported 400 when the id is stripped.

### Risk

Very low. The relaxed predicate is `id is non-empty after trim` — strictly broader than `id.startsWith("rs_")`. Any existing `rs_*` id continues to round-trip unchanged. No production data path other than reasoning replay is affected.
