### PR TITLE
fix(webchat): persist chat queue to localStorage with drain-on-reconnect

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,7 +1,7 @@
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
-import { persistChatQueue as persistQueue, restoreChatQueue as restoreQueue } from "./chat-queue-persistence.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
+import { persistChatQueue as persistQueue } from "./chat-queue-persistence.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand, refreshSlashCommands } from "./chat/slash-commands.ts";

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,4 +1,5 @@
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
+import { persistChatQueue as persistQueue, restoreChatQueue as restoreQueue } from "./chat-queue-persistence.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
@@ -133,6 +134,7 @@ function enqueueChatMessage(
       localCommandName: localCommand?.name,
     },
   ];
+  persistQueue(host.sessionKey, host.chatQueue);
 }
 
 function enqueuePendingRunMessage(
@@ -157,6 +159,7 @@ function enqueuePendingRunMessage(
       pendingRunId,
     },
   ];
+  persistQueue(host.sessionKey, host.chatQueue);
 }
 
 async function sendChatMessageNow(
@@ -197,7 +200,7 @@ async function sendChatMessageNow(
   // Force scroll after sending to ensure viewport is at bottom for incoming stream
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);
   if (ok && !host.chatRunId) {
-    void flushChatQueue(host);
+    void flushChatQueueInternal(host);
   }
   if (ok && opts?.refreshSessions && runId) {
     host.refreshSessionsAfterChat.add(runId);
@@ -256,6 +259,7 @@ export async function steerQueuedChatMessage(host: ChatHost, id: string) {
   host.chatQueue = host.chatQueue.map((entry) =>
     entry.id === id ? { ...entry, kind: "steered", pendingRunId: activeRunId } : entry,
   );
+  persistQueue(host.sessionKey, host.chatQueue);
   const runId = await sendSteerChatMessage(
     host as unknown as ChatState,
     message,
@@ -263,6 +267,7 @@ export async function steerQueuedChatMessage(host: ChatHost, id: string) {
   );
   if (!runId) {
     host.chatQueue = host.chatQueue.map((entry) => (entry.id === id ? item : entry));
+    persistQueue(host.sessionKey, host.chatQueue);
     return;
   }
   setLastActiveSessionKey(
@@ -272,7 +277,7 @@ export async function steerQueuedChatMessage(host: ChatHost, id: string) {
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
 }
 
-async function flushChatQueue(host: ChatHost) {
+async function flushChatQueueInternal(host: ChatHost) {
   if (!host.connected || isChatBusy(host)) {
     return;
   }
@@ -282,6 +287,7 @@ async function flushChatQueue(host: ChatHost) {
   }
   const next = host.chatQueue[nextIndex];
   host.chatQueue = host.chatQueue.filter((_, index) => index !== nextIndex);
+  persistQueue(host.sessionKey, host.chatQueue);
   let ok = false;
   try {
     if (next.localCommandName) {
@@ -298,14 +304,16 @@ async function flushChatQueue(host: ChatHost) {
   }
   if (!ok) {
     host.chatQueue = [next, ...host.chatQueue];
+    persistQueue(host.sessionKey, host.chatQueue);
   } else if (host.chatQueue.length > 0) {
     // Continue draining — local commands don't block on server response
-    void flushChatQueue(host);
+    void flushChatQueueInternal(host);
   }
 }
 
 export function removeQueuedMessage(host: ChatHost, id: string) {
   host.chatQueue = host.chatQueue.filter((item) => item.id !== id);
+  persistQueue(host.sessionKey, host.chatQueue);
 }
 
 export function clearPendingQueueItemsForRun(host: ChatHost, runId: string | undefined) {
@@ -313,6 +321,11 @@ export function clearPendingQueueItemsForRun(host: ChatHost, runId: string | und
     return;
   }
   host.chatQueue = host.chatQueue.filter((item) => item.pendingRunId !== runId);
+  persistQueue(host.sessionKey, host.chatQueue);
+}
+
+export function flushChatQueue(host: ChatHost): void {
+  void flushChatQueueInternal(host);
 }
 
 export async function handleSendChat(

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -328,9 +328,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         // The interrupted run will never emit its terminal event now that the
         // old client is gone, so resume any deferred commands after hello.
         shutdownHost.resumeChatQueueAfterReconnect = false;
-        void flushChatQueueForEvent(
-          host as unknown as Parameters<typeof flushChatQueueForEvent>[0],
-        );
+        flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);
       }
       void subscribeSessions(host as unknown as SessionsState);
       void loadAssistantIdentity(host as unknown as AssistantIdentityState);

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -1,3 +1,5 @@
+import { flushChatQueue } from "./app-chat.ts";
+import type { ChatHost } from "./app-chat.ts";
 import { connectGateway } from "./app-gateway.ts";
 import {
   startLogsPolling,
@@ -15,9 +17,10 @@ import {
   syncTabWithLocation,
   syncThemeWithSettings,
 } from "./app-settings.ts";
-import { flushChatQueue, restoreChatQueue } from "./chat-queue-persistence.ts";
+import { restoreChatQueue } from "./chat-queue-persistence.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
+import type { ChatQueueItem } from "./ui-types.ts";
 
 type LifecycleHost = {
   basePath: string;
@@ -56,13 +59,13 @@ export function handleConnected(host: LifecycleHost) {
   const connectGeneration = ++host.connectGeneration;
   // Restore persisted chat queue from localStorage when reconnecting, then drain it.
   if (host.sessionKey && Array.isArray(host.chatQueue)) {
-    const restored = restoreChatQueue(host.sessionKey, host.chatQueue as any[]);
+    const restored = restoreChatQueue(host.sessionKey, host.chatQueue as ChatQueueItem[]);
     if (restored !== host.chatQueue) {
-      (host.chatQueue as any[]) = restored;
+      (host.chatQueue as ChatQueueItem[]) = restored;
     }
     // Trigger drain if chat is idle and items were restored.
     if (restored.length > 0 && host.connected) {
-      flushChatQueue(host as any);
+      flushChatQueue(host as unknown as ChatHost);
     }
   }
   host.basePath = inferBasePath();

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -15,6 +15,7 @@ import {
   syncTabWithLocation,
   syncThemeWithSettings,
 } from "./app-settings.ts";
+import { flushChatQueue, restoreChatQueue } from "./chat-queue-persistence.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
 
@@ -42,6 +43,8 @@ type LifecycleHost = {
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStream: string | null;
+  chatQueue: unknown[];
+  sessionKey: string;
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];
@@ -51,6 +54,17 @@ type LifecycleHost = {
 
 export function handleConnected(host: LifecycleHost) {
   const connectGeneration = ++host.connectGeneration;
+  // Restore persisted chat queue from localStorage when reconnecting, then drain it.
+  if (host.sessionKey && Array.isArray(host.chatQueue)) {
+    const restored = restoreChatQueue(host.sessionKey, host.chatQueue as any[]);
+    if (restored !== host.chatQueue) {
+      (host.chatQueue as any[]) = restored;
+    }
+    // Trigger drain if chat is idle and items were restored.
+    if (restored.length > 0 && host.connected) {
+      flushChatQueue(host as any);
+    }
+  }
   host.basePath = inferBasePath();
   applySettingsFromUrl(host as unknown as Parameters<typeof applySettingsFromUrl>[0]);
   const bootstrapReady = loadControlUiBootstrapConfig(host);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -7,7 +7,6 @@ import {
 } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
-import { restoreChatQueue } from "./chat-queue-persistence.ts";
 import { refreshChat } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM } from "./app-defaults.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
@@ -23,6 +22,7 @@ import {
 } from "./app-render.helpers.ts";
 import { warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { restoreChatQueue } from "./chat-queue-persistence.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
@@ -121,9 +121,10 @@ import {
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
-import "./components/dashboard-header.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import "./components/dashboard-header.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
+import type { ChatQueueItem } from "./ui-types.ts";
 import { isRenderableControlUiAvatarUrl } from "./views/agents-utils.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
@@ -1489,9 +1490,9 @@ export function renderApp(state: AppViewState) {
                 state.chatRunId = null;
                 state.chatQueue = [];
                 // Restore persisted queue for the new session (if any).
-                const restoredQueue = restoreChatQueue(next, state.chatQueue as any[]);
+                const restoredQueue = restoreChatQueue(next, state.chatQueue as ChatQueueItem[]);
                 if (restoredQueue.length > 0) {
-                  state.chatQueue = restoredQueue as any;
+                  state.chatQueue = restoredQueue as ChatQueueItem[];
                 }
                 state.resetToolStream();
                 state.applySettings({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
+import { restoreChatQueue } from "./chat-queue-persistence.ts";
 import { refreshChat } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM } from "./app-defaults.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
@@ -1487,6 +1488,11 @@ export function renderApp(state: AppViewState) {
                 state.chatStream = null;
                 state.chatRunId = null;
                 state.chatQueue = [];
+                // Restore persisted queue for the new session (if any).
+                const restoredQueue = restoreChatQueue(next, state.chatQueue as any[]);
+                if (restoredQueue.length > 0) {
+                  state.chatQueue = restoredQueue as any;
+                }
                 state.resetToolStream();
                 state.applySettings({
                   ...state.settings,

--- a/ui/src/ui/chat-queue-persistence.ts
+++ b/ui/src/ui/chat-queue-persistence.ts
@@ -9,7 +9,9 @@ export const CHAT_QUEUE_TTL_MS = 86_400_000; // 24 hours
  * queue is empty to avoid stale entries accumulating across sessions. */
 export function persistChatQueue(sessionKey: string, queue: ChatQueueItem[]): void {
   const storage = getSafeLocalStorage();
-  if (!storage) return;
+  if (!storage) {
+    return;
+  }
   try {
     const key = `${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`;
     if (queue.length === 0) {
@@ -34,10 +36,14 @@ export function restoreChatQueue(
   currentQueue: ChatQueueItem[],
 ): ChatQueueItem[] {
   const storage = getSafeLocalStorage();
-  if (!storage) return currentQueue;
+  if (!storage) {
+    return currentQueue;
+  }
   try {
     const raw = storage.getItem(`${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`);
-    if (!raw) return currentQueue;
+    if (!raw) {
+      return currentQueue;
+    }
     const parsed = JSON.parse(raw) as { items: ChatQueueItem[]; ts: number };
     if (Date.now() - parsed.ts > CHAT_QUEUE_TTL_MS) {
       storage.removeItem(`${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`);

--- a/ui/src/ui/chat-queue-persistence.ts
+++ b/ui/src/ui/chat-queue-persistence.ts
@@ -1,0 +1,55 @@
+import { getSafeLocalStorage } from "../local-storage.ts";
+import type { ChatQueueItem } from "./ui-types.ts";
+
+const CHAT_QUEUE_STORAGE_KEY_PREFIX = "oc.chatqueue:";
+
+export const CHAT_QUEUE_TTL_MS = 86_400_000; // 24 hours
+
+/** Persist the current chat queue for the active session. Removes the key when the
+ * queue is empty to avoid stale entries accumulating across sessions. */
+export function persistChatQueue(sessionKey: string, queue: ChatQueueItem[]): void {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+  try {
+    const key = `${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`;
+    if (queue.length === 0) {
+      // Drain complete — remove the stale entry so localStorage doesn't grow indefinitely.
+      storage.removeItem(key);
+      return;
+    }
+    const value = JSON.stringify({ items: queue, ts: Date.now() });
+    storage.setItem(key, value);
+  } catch {
+    // Best-effort: localStorage may be unavailable (e.g. private browsing).
+  }
+}
+
+/**
+ * Restore a persisted chat queue for the given session, merging with any
+ * items already in the in-memory queue (de-duplicated by id).
+ * Items older than 24 hours are dropped.
+ */
+export function restoreChatQueue(
+  sessionKey: string,
+  currentQueue: ChatQueueItem[],
+): ChatQueueItem[] {
+  const storage = getSafeLocalStorage();
+  if (!storage) return currentQueue;
+  try {
+    const raw = storage.getItem(`${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`);
+    if (!raw) return currentQueue;
+    const parsed = JSON.parse(raw) as { items: ChatQueueItem[]; ts: number };
+    if (Date.now() - parsed.ts > CHAT_QUEUE_TTL_MS) {
+      storage.removeItem(`${CHAT_QUEUE_STORAGE_KEY_PREFIX}${sessionKey}`);
+      return currentQueue;
+    }
+    const existingIds = new Set(currentQueue.map((i) => i.id));
+    const newItems = parsed.items.filter((i) => !existingIds.has(i.id));
+    if (newItems.length > 0) {
+      return [...currentQueue, ...newItems];
+    }
+    return currentQueue;
+  } catch {
+    return currentQueue;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **#51549** — WebChat loses message queue, conversation history, and draft on browser refresh.

### Problem

The `chatQueue` (pending messages queued while the agent is busy) was stored as a pure in-memory array. On browser refresh or session switch, the array was recreated empty and all queued messages were permanently lost.

### Solution

Persists `chatQueue` to `localStorage` on every mutation, with automatic restore on reconnect or session switch.

### Changes

**New file: `ui/src/ui/chat-queue-persistence.ts`**
- `persistChatQueue(sessionKey, queue)`: saves queue to localStorage; removes the key when the queue is empty (avoids stale entry accumulation)
- `restoreChatQueue(sessionKey, currentQueue)`: loads from localStorage with 24h TTL, merges with in-memory queue (de-duplicated by message id)

**`ui/src/ui/app-chat.ts`**
- Calls `persistQueue(host.sessionKey, host.chatQueue)` after every `chatQueue` mutation: enqueue, dequeue, steer, drain
- Exports `flushChatQueue` wrapper for use by lifecycle hook

**`ui/src/ui/app-lifecycle.ts`**
- `handleConnected`: restores queue from localStorage and triggers drain if items were recovered and chat is idle

**`ui/src/ui/app-render.ts`**
- `onSessionKeyChange`: restores queue for the newly selected session

### Notes

- Session-store rotation/recovery fixes are handled in **PR #71328** (separate, focused PR)
- The `rotateSessionFile` ordering issue noted in review was already fixed in #71328
- The `await in sync function` compilation error in `store-load.ts` was caused by the dropped session-store changes and is not present in this version

Fixes #51549
