### PR TITLE
fix(codex): respect command approval decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/sessions: recover main-agent turns interrupted by a gateway restart from stale transcript-lock evidence, avoiding stuck `status: "running"` sessions without broad post-boot transcript scans. Fixes #70555. Thanks @bitloi.
+- Codex approvals: keep command approval responses within Codex app-server `availableDecisions`, including deny/cancel fallbacks for prompts that do not offer `decline`. (#71338) Thanks @Lucenx9.
 - Plugins/Google Meet: include live Chrome-node readiness in `googlemeet setup` and document the Parallels recovery checks, so stale node tokens or disconnected VM browsers are visible before an agent opens a meeting. Thanks @steipete.
 - Codex approvals: compact home-directory permission paths to `~` without repeating them as a separate high-risk warning, while preserving filesystem root and wildcard host warnings. Thanks @steipete.
 - Context engine: keep safeguard compaction checks active after context-engine windowing and for `ownsCompaction` engines, so large transcripts can compact before prompt submission instead of waiting for provider overflow. Fixes #71325. Thanks @steipete.

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -775,6 +775,43 @@ describe("Codex app-server approval bridge", () => {
     ).toEqual({
       decision: "decline",
     });
+    expect(
+      buildApprovalResponse("item/commandExecution/requestApproval", undefined, "approved-once"),
+    ).toEqual({
+      decision: "accept",
+    });
+    expect(
+      buildApprovalResponse("item/commandExecution/requestApproval", undefined, "approved-session"),
+    ).toEqual({
+      decision: "acceptForSession",
+    });
+    expect(
+      buildApprovalResponse(
+        "item/commandExecution/requestApproval",
+        { availableDecisions: ["cancel"] },
+        "approved-once",
+      ),
+    ).toEqual({
+      decision: "cancel",
+    });
+    expect(
+      buildApprovalResponse(
+        "item/commandExecution/requestApproval",
+        { availableDecisions: ["accept", "cancel"] },
+        "denied",
+      ),
+    ).toEqual({
+      decision: "cancel",
+    });
+    expect(
+      buildApprovalResponse(
+        "item/commandExecution/requestApproval",
+        { availableDecisions: ["decline"] },
+        "cancelled",
+      ),
+    ).toEqual({
+      decision: "decline",
+    });
     expect(buildApprovalResponse("item/fileChange/requestApproval", undefined, "denied")).toEqual({
       decision: "decline",
     });

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -757,6 +757,24 @@ describe("Codex app-server approval bridge", () => {
         },
       },
     });
+    expect(
+      buildApprovalResponse(
+        "item/commandExecution/requestApproval",
+        { availableDecisions: ["decline"] },
+        "approved-once",
+      ),
+    ).toEqual({
+      decision: "decline",
+    });
+    expect(
+      buildApprovalResponse(
+        "item/commandExecution/requestApproval",
+        { availableDecisions: ["decline"] },
+        "approved-session",
+      ),
+    ).toEqual({
+      decision: "decline",
+    });
     expect(buildApprovalResponse("item/fileChange/requestApproval", undefined, "denied")).toEqual({
       decision: "decline",
     });

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -273,7 +273,7 @@ function commandApprovalDecision(
       return amendmentDecision;
     }
   }
-  return "accept";
+  return hasAvailableDecision(requestParams, "accept") ? "accept" : "decline";
 }
 
 function fileChangeApprovalDecision(outcome: AppServerApprovalOutcome): JsonValue {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -259,10 +259,10 @@ function commandApprovalDecision(
   outcome: AppServerApprovalOutcome,
 ): JsonValue {
   if (outcome === "cancelled") {
-    return "cancel";
+    return commandRejectionDecision(requestParams, "cancel");
   }
   if (outcome === "denied" || outcome === "unavailable") {
-    return "decline";
+    return commandRejectionDecision(requestParams, "decline");
   }
   if (outcome === "approved-session") {
     if (hasAvailableDecision(requestParams, "acceptForSession")) {
@@ -273,7 +273,9 @@ function commandApprovalDecision(
       return amendmentDecision;
     }
   }
-  return hasAvailableDecision(requestParams, "accept") ? "accept" : "decline";
+  return hasAvailableDecision(requestParams, "accept")
+    ? "accept"
+    : commandRejectionDecision(requestParams, "decline");
 }
 
 function fileChangeApprovalDecision(outcome: AppServerApprovalOutcome): JsonValue {
@@ -516,6 +518,24 @@ function findAvailableCommandAmendmentDecision(
       (isJsonObject(entry.acceptWithExecpolicyAmendment) ||
         isJsonObject(entry.applyNetworkPolicyAmendment)),
   );
+}
+
+function commandRejectionDecision(
+  requestParams: JsonObject | undefined,
+  preferred: "decline" | "cancel",
+): JsonValue {
+  const available = requestParams?.availableDecisions;
+  if (!Array.isArray(available)) {
+    return preferred;
+  }
+  if (available.includes(preferred)) {
+    return preferred;
+  }
+  const alternate = preferred === "decline" ? "cancel" : "decline";
+  if (available.includes(alternate)) {
+    return alternate;
+  }
+  return preferred;
 }
 
 function approvalResolutionMessage(outcome: AppServerApprovalOutcome): string {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Codex command approvals could return `"accept"` even when app-server supplied an `availableDecisions` list that did not include `"accept"`.
- Why it matters: The bridge should not synthesize a response outside Codex's advertised decision contract; invalid approval responses can fail downstream or grant a shape Codex did not offer for that prompt.
- What changed: `commandApprovalDecision` now only falls back to `"accept"` when it is available, or when no `availableDecisions` list is provided. Otherwise it fails closed with `"decline"`.
- What did NOT change (scope boundary): Session approvals still prefer `acceptForSession` or a provided amendment decision when available; file-change and permission approval response mapping is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The command approval mapper treated `"accept"` as an unconditional fallback after handling session/amendment cases.
- Missing detection / guardrail: Existing tests covered available `"accept"` and amendment decisions, but not the case where `availableDecisions` is present and excludes `"accept"`.
- Contributing context (if known): Codex app-server exposes `availableDecisions` as the ordered set of decisions the client may present for that approval prompt.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/approval-bridge.test.ts`
- Scenario the test should lock in: command approvals with `availableDecisions: ["decline"]` should not synthesize `"accept"` for either turn-scoped or session-scoped approval outcomes.
- Why this is the smallest reliable guardrail: The bug is isolated to pure response mapping in `buildApprovalResponse` / `commandApprovalDecision`.
- Existing test that already covers this (if any): Existing response-family tests covered allowed `"accept"` and amendment decisions, but not fail-closed unavailable accept.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Codex command approval prompts with a restrictive `availableDecisions` list now fail closed with `"decline"` instead of returning a decision Codex did not advertise.

## Diagram (if applicable)

N/A

```text
Before:
availableDecisions=["decline"] + approved outcome -> "accept"

After:
availableDecisions=["decline"] + approved outcome -> "decline"
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: This narrows command approval behavior by preventing unavailable `"accept"` decisions from being returned; mitigation is fail-closed `"decline"` when Codex did not offer `"accept"`.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Codex app-server
- Relevant config (redacted): N/A

### Steps

1. Call `buildApprovalResponse("item/commandExecution/requestApproval", { availableDecisions: ["decline"] }, "approved-once")`.
2. Call `buildApprovalResponse("item/commandExecution/requestApproval", { availableDecisions: ["decline"] }, "approved-session")`.
3. Run the approval bridge unit test.

### Expected

- Both restrictive-decision cases return `{ decision: "decline" }`.
- Existing available `"accept"` and amendment-decision mappings still pass.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unavailable `"accept"` fails closed for turn-scoped and session-scoped command approval outcomes.
- Edge cases checked: existing `"accept"`, execpolicy amendment, network policy amendment, file change, and permission response-family tests still pass.
- What you did **not** verify: Live Codex app-server runtime approval UI; this is covered at the mapper/unit level.

Commands run:

```sh
corepack pnpm -s vitest extensions/codex/src/app-server/approval-bridge.test.ts --run
corepack pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/approval-bridge.ts extensions/codex/src/app-server/approval-bridge.test.ts
corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/codex/src/app-server/approval-bridge.ts extensions/codex/src/app-server/approval-bridge.test.ts
corepack pnpm -s tsgo:extensions:test
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: If Codex sends an unexpectedly restrictive decision list, OpenClaw will deny rather than approve the command.
  - Mitigation: This is intentional fail-closed behavior and only applies when Codex explicitly did not advertise `"accept"`.
