### PR TITLE
fix(codex): spawn app server through shell on Windows

### DIFF
--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexAppServerStdioSpawnOptions } from "./transport-stdio.js";
+
+describe("Codex app-server stdio transport", () => {
+  it("spawns through a shell on Windows so npm command shims resolve", () => {
+    const options = buildCodexAppServerStdioSpawnOptions({}, "win32");
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        detached: false,
+        shell: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    );
+  });
+
+  it("keeps non-Windows spawns direct and detached", () => {
+    const options = buildCodexAppServerStdioSpawnOptions({}, "darwin");
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        detached: true,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    );
+  });
+
+  it("applies environment overrides before clearing blocked keys", () => {
+    const options = buildCodexAppServerStdioSpawnOptions(
+      {
+        env: {
+          CODEX_HOME: "/tmp/openclaw-codex",
+          CODEX_TEST_CLEAR_ME: "remove",
+        },
+        clearEnv: ["CODEX_TEST_CLEAR_ME"],
+      },
+      "darwin",
+    );
+
+    expect(options.env?.CODEX_HOME).toBe("/tmp/openclaw-codex");
+    expect(options.env?.CODEX_TEST_CLEAR_ME).toBeUndefined();
+  });
+});

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -1,8 +1,19 @@
-import { spawn } from "node:child_process";
+import { spawn, type SpawnOptionsWithoutStdio } from "node:child_process";
 import type { CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
 export function createStdioTransport(options: CodexAppServerStartOptions): CodexAppServerTransport {
+  return spawn(
+    options.command,
+    options.args,
+    buildCodexAppServerStdioSpawnOptions(options, process.platform),
+  );
+}
+
+export function buildCodexAppServerStdioSpawnOptions(
+  options: Pick<CodexAppServerStartOptions, "env" | "clearEnv">,
+  platform: NodeJS.Platform,
+): SpawnOptionsWithoutStdio {
   const env = {
     ...process.env,
     ...options.env,
@@ -10,9 +21,11 @@ export function createStdioTransport(options: CodexAppServerStartOptions): Codex
   for (const key of options.clearEnv ?? []) {
     delete env[key];
   }
-  return spawn(options.command, options.args, {
+
+  return {
     env,
-    detached: process.platform !== "win32",
+    detached: platform !== "win32",
+    shell: platform === "win32",
     stdio: ["pipe", "pipe", "pipe"],
-  });
+  };
 }


### PR DESCRIPTION
## Summary

- Problem: Windows installs the Codex CLI as an npm `.cmd` shim, but the stdio transport spawned bare `codex` without a shell.
- Why it matters: Node returns `ENOENT` on Windows, causing every Codex harness dispatch to wait for fallback.
- What changed: the stdio transport now uses `shell: true` only on Windows and keeps direct detached spawning elsewhere.
- What did NOT change: non-Windows spawn behavior and the websocket transport are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71139
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Node's Windows process creation path does not resolve npm `.cmd` shims for a bare command unless the process is spawned through a shell.
- Missing detection / guardrail: the stdio transport did not have a platform-specific test for spawn options.
- Contributing context (if known): npm global installs of `@openai/codex` create `codex.cmd`, not `codex.exe`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/codex/src/app-server/transport-stdio.test.ts`
- Scenario the test should lock in: Windows uses shell spawning, non-Windows keeps direct detached spawning, and env clearing still applies.
- Why this is the smallest reliable guardrail: the bug is in spawn option assembly, so it can be covered without a Windows runner.
- Existing test that already covers this (if any): N/A

## User-visible / Behavior Changes

Windows Codex harness launches can resolve the npm `codex.cmd` shim instead of timing out and falling back.

## Diagram (if applicable)

```text
Before:
spawn("codex") on Windows -> ENOENT -> fallback after timeout

After:
spawn("codex", { shell: true }) on Windows -> npm shim resolves -> stdio harness starts
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: only the existing Codex stdio command path uses `shell: true`, and only on Windows. Non-Windows direct spawning is unchanged.

## Repro + Verification

### Environment

- OS: macOS for local tests; issue reproduces on Windows 11
- Runtime/container: Node 22
- Model/provider: Codex app-server transport
- Integration/channel (if any): Gateway agent harness
- Relevant config (redacted): Codex CLI installed through npm on Windows

### Steps

1. Install `@openai/codex` globally on Windows.
2. Dispatch work through the Codex app-server stdio harness.
3. Observe `spawn codex ENOENT` before this patch.

### Expected

- The Codex stdio transport starts through the npm shim on Windows.

### Actual

- Windows could not resolve bare `codex` and fell back after timeout.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: targeted stdio spawn-options test, `pnpm check:changed`
- Edge cases checked: non-Windows direct spawn and env clearing
- What you did not verify: manual Windows runtime dispatch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: Windows shell spawning can interpret command text differently than direct spawning.
  - Mitigation: the change is limited to Windows where `.cmd` shims need a shell; other platforms keep direct spawning.
