### PR TITLE
fix(codex): sanitize elicitation approval text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Agents/MCP: validate draft-2020-12 MCP tool output schemas with a draft-aware bundle-MCP client validator, so external MCP servers no longer fail catalog/tool execution with missing schema refs. Fixes #68772 and #70196. Thanks @mwiesen.
 - Dashboard/Windows: open Control UI and OAuth URLs through the system URL handler without `cmd.exe` parsing or PATH-based `rundll32` lookup, and reject non-HTTP browser-open inputs. Fixes #71098. Thanks @Sanjays2402.
 - Config/doctor: reject legacy `secretref-env:<ENV_VAR>` marker strings on SecretRef credential paths and migrate valid markers to structured env SecretRefs with `openclaw doctor --fix`. Fixes #51794. Thanks @halointellicore.
+- Plugin SDK/browser: export the resolved browser tab-cleanup config type through the browser profile facade, keeping SDK subpath contracts aligned.
 - Providers/OpenAI: separate API-key and Codex sign-in onboarding groups, and avoid replaying stale OpenAI Responses reasoning blocks after a model route switch.
 - Providers/OpenAI-compatible: forward `prompt_cache_key` on Completions requests only for providers that opt in with `compat.supportsPromptCacheKey`, keeping default proxy payloads unchanged. Fixes #69272.
 - Providers/OpenAI-compatible: skip null or non-object streaming chunks from custom providers instead of failing the turn after partial output. Fixes #51112.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google Meet: reuse existing Meet tabs and active sessions across harmless URL query differences, avoiding duplicate Chrome windows when agents retry a join. Thanks @steipete.
 - Plugins/Google Meet: tell agents to recover already-open Meet tabs after browser timeouts, and make the dev CLI release its build lock if compiler spawning fails. Thanks @steipete.
 - Gateway/sessions: recover main-agent turns interrupted by a gateway restart from stale transcript-lock evidence, avoiding stuck `status: "running"` sessions without broad post-boot transcript scans. Fixes #70555. Thanks @bitloi.
+- Codex approvals: sanitize MCP elicitation approval titles, descriptions, and display parameters before forwarding them to OpenClaw approval prompts. (#71343) Thanks @Lucenx9.
 - Codex approvals: keep command approval responses within Codex app-server `availableDecisions`, including deny/cancel fallbacks for prompts that do not offer `decline`. (#71338) Thanks @Lucenx9.
 - Codex harness: reject same-thread app-server notifications without `turnId` or `turn.id` after a bound turn starts, preventing unscoped events from mutating or completing the active reply. (#71317) Thanks @Lucenx9.
 - Plugins/Google Meet: include live Chrome-node readiness in `googlemeet setup` and document the Parallels recovery checks, so stale node tokens or disconnected VM browsers are visible before an agent opens a meeting. Thanks @steipete.

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -188,6 +188,184 @@ describe("Codex app-server elicitation bridge", () => {
     expect(approvalRequest.description).toContain("Repository: openclaw/openclaw");
   });
 
+  it("strips control and invisible formatting from approval display text", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-sanitized", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-sanitized", decision: "allow-once" });
+
+    await handleCodexAppServerElicitationRequest({
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        message: "Approve\u202e hidden",
+        serverName: "codex\u009b31m_apps__github",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          connector_name: "GitHub\nInjected: approve",
+          tool_title: "\u001b]8;;https://evil.example\u001b\\Visible tool\u001b]8;;\u001b\\",
+          tool_description: "Creates\u0000 a\u202e pull request",
+          tool_params_display: [
+            {
+              name: "repo",
+              display_name: "Repository\u202e",
+              value: "\u001b]8;;https://evil.example\u001b\\openclaw/openclaw\u001b]8;;\u001b\\",
+            },
+          ],
+        },
+        requestedSchema: {
+          type: "object",
+          properties: {
+            approve: {
+              type: "boolean",
+              title: "Approve\u202e this tool call",
+              description: "Confirm\u009b31m access",
+            },
+          },
+          required: ["approve"],
+        },
+      },
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const approvalRequest = mockCallGatewayTool.mock.calls[0]?.[2] as {
+      title: string;
+      description: string;
+    };
+    expect(approvalRequest.title).toBe("Approve hidden");
+    expect(approvalRequest.description).toContain("GitHub Injected: approve");
+    expect(approvalRequest.description).toContain("Tool: Visible tool");
+    expect(approvalRequest.description).toContain("Repository: openclaw/openclaw");
+    expect(approvalRequest.description).toContain("- Approve this tool call: Confirm access");
+    expect(approvalRequest.description).not.toContain("https://evil.example");
+    expect(approvalRequest.description).not.toContain("\u001b");
+    expect(approvalRequest.description).not.toContain("\u009b");
+    expect(approvalRequest.description).not.toContain("\u202e");
+  });
+
+  it("falls back to stable names when display labels sanitize to empty", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-label-fallback", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-label-fallback", decision: "allow-once" });
+
+    await handleCodexAppServerElicitationRequest({
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        message: "Approve",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          connector_name: "App",
+          tool_params_display: [
+            {
+              name: "repo",
+              display_name: "\u202e",
+              value: "openclaw/openclaw",
+            },
+          ],
+        },
+        requestedSchema: {
+          type: "object",
+          properties: {
+            approve: {
+              type: "boolean",
+              title: "\u202e",
+              description: "Confirm access",
+            },
+          },
+          required: ["approve"],
+        },
+      },
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const approvalRequest = mockCallGatewayTool.mock.calls[0]?.[2] as {
+      description: string;
+    };
+    expect(approvalRequest.description).toContain("- repo: openclaw/openclaw");
+    expect(approvalRequest.description).toContain("- approve: Confirm access");
+    expect(approvalRequest.description).not.toContain("- field: Confirm access");
+  });
+
+  it("bounds deep approval display parameter values before forwarding them", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-bounded-params", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-bounded-params", decision: "allow-once" });
+
+    await handleCodexAppServerElicitationRequest({
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        message: "Approve",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          connector_name: "App",
+          tool_title: "Tool",
+          tool_params_display: [
+            {
+              name: "payload",
+              value: {
+                key0: { nested: { deeper: { secret: "hidden" } } },
+                key1: 1,
+                key2: 2,
+                key3: 3,
+                key4: 4,
+                key5: 5,
+                key6: 6,
+                key7: 7,
+                key8: 8,
+              },
+            },
+          ],
+        },
+      },
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const approvalRequest = mockCallGatewayTool.mock.calls[0]?.[2] as {
+      description: string;
+    };
+    expect(approvalRequest.description).toContain("payload");
+    expect(approvalRequest.description).toContain("key0");
+    expect(approvalRequest.description).not.toContain("key8");
+    expect(approvalRequest.description).not.toContain("hidden");
+  });
+
+  it("caps approval display parameter entries before forwarding them", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-capped-params", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-capped-params", decision: "allow-once" });
+
+    await handleCodexAppServerElicitationRequest({
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        message: "Approve",
+        serverName: "",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          connector_name: "App",
+          tool_params_display: Array.from({ length: 9 }, (_, index) => ({
+            name: `p${index}`,
+            value: index,
+          })),
+        },
+      },
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const approvalRequest = mockCallGatewayTool.mock.calls[0]?.[2] as {
+      description: string;
+    };
+    expect(approvalRequest.description).toContain("p0");
+    expect(approvalRequest.description).toContain("p7");
+    expect(approvalRequest.description).toContain("Additional parameters: 1 more");
+    expect(approvalRequest.description).not.toContain("p8");
+  });
+
   it("accepts approval elicitations with a null turn id when the thread matches", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-null-turn", status: "accepted" })

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -30,7 +30,28 @@ const MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY = "connector_name";
 const MCP_TOOL_APPROVAL_TOOL_TITLE_KEY = "tool_title";
 const MCP_TOOL_APPROVAL_TOOL_DESCRIPTION_KEY = "tool_description";
 const MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY = "tool_params_display";
+const MAX_DISPLAY_PARAM_ENTRIES = 8;
 const MAX_DISPLAY_PARAM_VALUE_LENGTH = 120;
+const MAX_DISPLAY_VALUE_ARRAY_ITEMS = 8;
+const MAX_DISPLAY_VALUE_OBJECT_KEYS = 8;
+const MAX_DISPLAY_VALUE_DEPTH = 3;
+const DISPLAY_TEXT_SCAN_MAX_LENGTH = 4096;
+const ANSI_OSC_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
+  "g",
+);
+const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
+  "g",
+);
+const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
+const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
+  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
+  "gu",
+);
+const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
+  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
+);
 
 export async function handleCodexAppServerElicitationRequest(params: {
   requestParams: JsonValue | undefined;
@@ -97,14 +118,15 @@ function readBridgeableApprovalElicitation(
     return undefined;
   }
 
-  const title = readString(requestParams, "message") ?? "Codex MCP tool approval";
+  const title =
+    sanitizeDisplayText(readString(requestParams, "message") ?? "") || "Codex MCP tool approval";
   return {
     title,
     description: buildApprovalDescription({
       title,
       meta: requestParams._meta,
       requestedSchema,
-      serverName: readString(requestParams, "serverName"),
+      serverName: sanitizeOptionalDisplayText(readString(requestParams, "serverName")),
     }),
     requestedSchema,
     meta: requestParams._meta,
@@ -117,13 +139,20 @@ function buildApprovalDescription(params: {
   requestedSchema: JsonObject;
   serverName: string | undefined;
 }): string {
-  const summaryLines = [
-    readString(params.meta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY) &&
-      `App: ${readString(params.meta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY)}`,
-    readString(params.meta, MCP_TOOL_APPROVAL_TOOL_TITLE_KEY) &&
-      `Tool: ${readString(params.meta, MCP_TOOL_APPROVAL_TOOL_TITLE_KEY)}`,
-    params.serverName && `MCP server: ${params.serverName}`,
+  const connectorName = sanitizeOptionalDisplayText(
+    readString(params.meta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY),
+  );
+  const toolTitle = sanitizeOptionalDisplayText(
+    readString(params.meta, MCP_TOOL_APPROVAL_TOOL_TITLE_KEY),
+  );
+  const toolDescription = sanitizeOptionalDisplayText(
     readString(params.meta, MCP_TOOL_APPROVAL_TOOL_DESCRIPTION_KEY),
+  );
+  const summaryLines = [
+    connectorName && `App: ${connectorName}`,
+    toolTitle && `Tool: ${toolTitle}`,
+    params.serverName && `MCP server: ${params.serverName}`,
+    toolDescription,
   ].filter((line): line is string => Boolean(line));
   const paramLines = readDisplayParamLines(params.meta);
   const propertyLines = readPropertyDescriptionLines(params.requestedSchema);
@@ -145,8 +174,11 @@ function readPropertyDescriptionLines(requestedSchema: JsonObject): string[] {
       if (!schema) {
         return undefined;
       }
-      const propTitle = readString(schema, "title") ?? name;
-      const description = readString(schema, "description");
+      const propTitle =
+        sanitizeDisplayText(readString(schema, "title") ?? "") ||
+        sanitizeDisplayText(name) ||
+        "field";
+      const description = sanitizeOptionalDisplayText(readString(schema, "description"));
       return description ? `- ${propTitle}: ${description}` : `- ${propTitle}`;
     })
     .filter((line): line is string => Boolean(line));
@@ -157,26 +189,105 @@ function readDisplayParamLines(meta: JsonObject): string[] {
   if (!Array.isArray(displayParams)) {
     return [];
   }
-  return displayParams
+  const lines = displayParams
+    .slice(0, MAX_DISPLAY_PARAM_ENTRIES)
     .map((entry) => {
       const param = isJsonObject(entry) ? entry : undefined;
       if (!param) {
         return undefined;
       }
-      const name = readString(param, "display_name") ?? readString(param, "name");
+      const name =
+        sanitizeOptionalDisplayText(readString(param, "display_name")) ??
+        sanitizeOptionalDisplayText(readString(param, "name"));
       if (!name) {
         return undefined;
       }
       return `- ${name}: ${formatDisplayParamValue(param.value)}`;
     })
     .filter((line): line is string => Boolean(line));
+  const remaining = displayParams.length - MAX_DISPLAY_PARAM_ENTRIES;
+  return remaining > 0 ? [...lines, `- Additional parameters: ${remaining} more`] : lines;
 }
 
 function formatDisplayParamValue(value: JsonValue | undefined): string {
-  const formatted = typeof value === "string" ? value : JSON.stringify(value ?? null);
-  return formatted.length <= MAX_DISPLAY_PARAM_VALUE_LENGTH
-    ? formatted
-    : `${formatted.slice(0, MAX_DISPLAY_PARAM_VALUE_LENGTH - 3)}...`;
+  const formatted = typeof value === "string" ? value : formatDisplayJsonValue(value ?? null);
+  return truncateDisplayText(sanitizeDisplayText(formatted), MAX_DISPLAY_PARAM_VALUE_LENGTH);
+}
+
+function formatDisplayJsonValue(value: JsonValue, depth = MAX_DISPLAY_VALUE_DEPTH): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(truncateDisplayText(sanitizeDisplayText(value), 80));
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    if (depth <= 0) {
+      return "[truncated]";
+    }
+    const parts: string[] = [];
+    const limit = Math.min(value.length, MAX_DISPLAY_VALUE_ARRAY_ITEMS);
+    for (let i = 0; i < limit; i += 1) {
+      parts.push(formatDisplayJsonValue(value[i] ?? null, depth - 1));
+    }
+    if (value.length > MAX_DISPLAY_VALUE_ARRAY_ITEMS) {
+      parts.push("...");
+    }
+    return `[${parts.join(",")}]`;
+  }
+  if (typeof value === "object") {
+    if (depth <= 0) {
+      return "{truncated}";
+    }
+    const parts: string[] = [];
+    let count = 0;
+    let truncated = false;
+    for (const key in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) {
+        continue;
+      }
+      if (count >= MAX_DISPLAY_VALUE_OBJECT_KEYS) {
+        truncated = true;
+        break;
+      }
+      const safeKey = truncateDisplayText(sanitizeDisplayText(key), 80);
+      parts.push(
+        `${JSON.stringify(safeKey)}:${formatDisplayJsonValue(value[key] ?? null, depth - 1)}`,
+      );
+      count += 1;
+    }
+    if (truncated) {
+      parts.push("...");
+    }
+    return `{${parts.join(",")}}`;
+  }
+  return "null";
+}
+
+function sanitizeOptionalDisplayText(value: string | undefined): string | undefined {
+  const sanitized = value === undefined ? "" : sanitizeDisplayText(value);
+  return sanitized || undefined;
+}
+
+function sanitizeDisplayText(value: string): string {
+  const scanned = value.slice(0, DISPLAY_TEXT_SCAN_MAX_LENGTH);
+  const clipped = value.length > DISPLAY_TEXT_SCAN_MAX_LENGTH;
+  const sanitized = scanned
+    .replace(ANSI_OSC_SEQUENCE_RE, "")
+    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
+    .replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "")
+    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
+    .replace(CONTROL_CHARACTER_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return clipped ? `${sanitized}...` : sanitized;
+}
+
+function truncateDisplayText(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
 async function requestPluginApprovalOutcome(params: {

--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -1,11 +1,24 @@
 import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
-import {
-  clearMemoryEmbeddingProviders,
-  registerMemoryEmbeddingProvider,
-} from "../../../../src/plugins/memory-embedding-providers.js";
 import { createEmbeddingProvider } from "./embeddings.js";
+
+const mockEmbeddingRegistry = vi.hoisted(() => ({
+  adapters: [] as MemoryEmbeddingProviderAdapter[],
+}));
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
+  DEFAULT_LOCAL_MODEL: "nomic-embed-text",
+  createLocalEmbeddingProvider: async () => {
+    throw new Error("local embedding provider is not used by these tests");
+  },
+  getMemoryEmbeddingProvider: (id: string) =>
+    mockEmbeddingRegistry.adapters.find((adapter) => adapter.id === id),
+  listMemoryEmbeddingProviders: () => [...mockEmbeddingRegistry.adapters],
+  listRegisteredMemoryEmbeddingProviderAdapters: () => [...mockEmbeddingRegistry.adapters],
+  listRegisteredMemoryEmbeddingProviders: () =>
+    mockEmbeddingRegistry.adapters.map((adapter) => ({ adapter })),
+}));
 
 const missingBedrockCredentialsError = new Error(
   'No API key found for provider "bedrock". AWS credentials are not available.',
@@ -50,6 +63,17 @@ function createMissingCredentialsAdapter(
     },
     ...overrides,
   };
+}
+
+function clearMemoryEmbeddingProviders(): void {
+  mockEmbeddingRegistry.adapters = [];
+}
+
+function registerMemoryEmbeddingProvider(adapter: MemoryEmbeddingProviderAdapter): void {
+  mockEmbeddingRegistry.adapters = mockEmbeddingRegistry.adapters.filter(
+    (candidate) => candidate.id !== adapter.id,
+  );
+  mockEmbeddingRegistry.adapters.push(adapter);
 }
 
 describe("createEmbeddingProvider", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Codex MCP elicitation approval descriptions used app/tool display metadata directly, including parameter labels/values and schema titles/descriptions.
- Why it matters: Those fields are human-facing approval text; terminal controls, C1 controls, bidi/invisible formatting, or embedded newlines can make the approval prompt render differently from the underlying text.
- What changed: Elicitation approval display text now strips ANSI/OSC/C1 controls and invisible formatting controls, collapses whitespace, bounds scan length before regex cleanup, and continues truncating parameter values.
- What did NOT change (scope boundary): Structured MCP elicitation content, approval decisions, and response mapping are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The elicitation bridge built approval descriptions from MCP display metadata without applying the display-text sanitization used by other Codex approval previews.
- Missing detection / guardrail: Tests covered truncation and normal display metadata, but not terminal controls, bidi/invisible formatting, or newline injection in approval text.
- Contributing context (if known): MCP app/tool metadata is used to help the operator understand what they are approving, so it is display text rather than structured policy input.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/elicitation-bridge.test.ts`
- Scenario the test should lock in: MCP approval display metadata containing OSC-8 links, C1 controls, bidi controls, NULs, and newlines is sanitized before being sent to `plugin.approval.request`.
- Why this is the smallest reliable guardrail: The vulnerable behavior is the pure bridge formatting path before the gateway approval request.
- Existing test that already covers this (if any): Existing tests covered normal current Codex MCP approval display fields and length truncation only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Codex MCP approval prompts may show sanitized single-line versions of app/tool display fields when those fields contain terminal controls, bidi/invisible formatting, or embedded newlines. Normal readable labels and parameter values are preserved.

## Diagram (if applicable)

N/A

```text
Before:
MCP display metadata -> approval description (raw controls/newlines)

After:
MCP display metadata -> display sanitizer -> approval description
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Codex app-server MCP elicitation approval bridge
- Relevant config (redacted): N/A

### Steps

1. Build an MCP approval elicitation whose `message`, `serverName`, `_meta.tool_*`, `tool_params_display`, and schema title/description contain terminal controls or bidi/invisible characters.
2. Route it through `handleCodexAppServerElicitationRequest`.
3. Inspect the `plugin.approval.request` payload.

### Expected

- Visible labels and values remain understandable.
- OSC URLs, ESC/C1 controls, bidi controls, NULs, and newline injection do not appear in the approval title/description.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: OSC-8 link label preservation without URL/control bytes, C1 control cleanup, bidi/invisible cleanup, NUL cleanup, newline collapse, existing current MCP approval behavior.
- Edge cases checked: display parameter names/values, tool title/description, server name, request title, schema property title/description.
- What you did **not** verify: Live app-server UI rendering; this PR covers the bridge payload sent to the approval gateway method.

Commands run:

```sh
corepack pnpm -s vitest extensions/codex/src/app-server/elicitation-bridge.test.ts --run
corepack pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts
corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts
corepack pnpm -s tsgo:extensions:test
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Display text with intentional line breaks is collapsed into a single line in approval prompts.
  - Mitigation: These fields are compact approval-summary labels/values, not free-form content; collapsing prevents prompt spoofing while preserving readable text.
