### PR TITLE
fix(skills): honor legacy clawdbot metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/OpenAI: separate API-key and Codex sign-in onboarding groups, and avoid replaying stale OpenAI Responses reasoning blocks after a model route switch.
+- Skills: honor legacy `metadata.clawdbot` requirements and installer hints when `metadata.openclaw` is absent, so older skills no longer appear ready when required binaries are missing. Fixes #71323. Thanks @chen-zhang-cs-code.
 - Browser/config: expand `~` in `browser.executablePath` before Chromium launch, so home-relative custom browser paths no longer fail with `ENOENT`. Fixes #67264. Thanks @Quratulain-bilal.
 - Telegram/streaming: hide tool-progress status updates by default while keeping explicit `streaming.preview.toolProgress` opt-in support for edited preview messages. Fixes #71320. Thanks @neeravmakwana.
 - Gateway/sessions: copy the oversized `sessions.json` to a rotation backup before the atomic rewrite instead of renaming the live store away, so a crash during rotation keeps the existing session-to-transcript mapping authoritative. Fixes #68229. Thanks @jjjojoj.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -203,6 +203,11 @@ Fields under `metadata.openclaw`:
 - `primaryEnv` — env var name associated with `skills.entries.<name>.apiKey`.
 - `install` — optional array of installer specs used by the macOS Skills UI (brew/node/go/uv/download).
 
+Legacy `metadata.clawdbot` blocks are still accepted when
+`metadata.openclaw` is absent, so older installed skills keep their dependency
+gates and installer hints. New and updated skills should use
+`metadata.openclaw`.
+
 Note on sandboxing:
 
 - `requires.bins` is checked on the **host** at skill load time.

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -14,6 +14,12 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
+async function createTempWorkspaceDir() {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
+  tempDirs.push(workspaceDir);
+  return workspaceDir;
+}
+
 function makeEntry(params: {
   name: string;
   source?: string;
@@ -94,6 +100,36 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.missing.config).toContain("browser.enabled");
     expect(skill?.install[0]?.id).toBe("brew");
   });
+
+  it("honors legacy clawdbot skill metadata requirements and install hints", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "legacy-skill"),
+      name: "legacy-skill",
+      description: "Legacy metadata",
+      metadata:
+        '{"clawdbot":{"requires":{"bins":["fakebin"]},"install":[{"id":"brew","kind":"brew","formula":"fakebin","bins":["fakebin"],"label":"Install fakebin"}]}}',
+    });
+
+    const report = withEnv({ PATH: "" }, () =>
+      buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+      }),
+    );
+    const skill = report.skills.find((entry) => entry.name === "legacy-skill");
+
+    expect(skill).toBeDefined();
+    expect(skill?.eligible).toBe(false);
+    expect(skill?.requirements.bins).toEqual(["fakebin"]);
+    expect(skill?.missing.bins).toEqual(["fakebin"]);
+    expect(skill?.install[0]).toMatchObject({
+      id: "brew",
+      kind: "brew",
+      label: "Install fakebin",
+      bins: ["fakebin"],
+    });
+  });
+
   it("respects OS-gated skills", async () => {
     const entry = makeEntry({
       name: "os-skill",

--- a/src/compat/legacy-names.test.ts
+++ b/src/compat/legacy-names.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { LEGACY_MANIFEST_KEYS, MANIFEST_KEY, PROJECT_NAME } from "./legacy-names.js";
+
+describe("compat/legacy-names", () => {
+  it("keeps the current manifest key primary while exposing legacy fallbacks", () => {
+    expect(PROJECT_NAME).toBe("openclaw");
+    expect(MANIFEST_KEY).toBe("openclaw");
+    expect(LEGACY_MANIFEST_KEYS).toEqual(["clawdbot"]);
+  });
+});

--- a/src/compat/legacy-names.ts
+++ b/src/compat/legacy-names.ts
@@ -1,6 +1,6 @@
 export const PROJECT_NAME = "openclaw" as const;
 
-export const LEGACY_PROJECT_NAMES = [] as const;
+export const LEGACY_PROJECT_NAMES = ["clawdbot"] as const;
 
 export const MANIFEST_KEY = PROJECT_NAME;
 

--- a/src/shared/frontmatter.test.ts
+++ b/src/shared/frontmatter.test.ts
@@ -59,6 +59,17 @@ describe("shared/frontmatter", () => {
     ).toEqual({ requires: { bins: ["op"] }, install: [] });
   });
 
+  test("resolveOpenClawManifestBlock prefers current manifest keys over legacy keys", () => {
+    expect(
+      resolveOpenClawManifestBlock({
+        frontmatter: {
+          metadata:
+            "{ openclaw: { requires: { bins: ['current'] } }, clawdbot: { requires: { bins: ['legacy'] } } }",
+        },
+      }),
+    ).toEqual({ requires: { bins: ["current"] } });
+  });
+
   test("resolveOpenClawManifestBlock returns undefined for invalid input", () => {
     expect(resolveOpenClawManifestBlock({ frontmatter: {} })).toBeUndefined();
     expect(

--- a/src/shared/frontmatter.test.ts
+++ b/src/shared/frontmatter.test.ts
@@ -49,6 +49,16 @@ describe("shared/frontmatter", () => {
     ).toEqual({ foo: 2 });
   });
 
+  test("resolveOpenClawManifestBlock reads legacy manifest keys", () => {
+    expect(
+      resolveOpenClawManifestBlock({
+        frontmatter: {
+          metadata: "{ clawdbot: { requires: { bins: ['op'] }, install: [] } }",
+        },
+      }),
+    ).toEqual({ requires: { bins: ["op"] }, install: [] });
+  });
+
   test("resolveOpenClawManifestBlock returns undefined for invalid input", () => {
     expect(resolveOpenClawManifestBlock({ frontmatter: {} })).toBeUndefined();
     expect(


### PR DESCRIPTION
## Summary
- accept legacy `metadata.clawdbot` manifest blocks alongside `metadata.openclaw`
- restore skill requirement checks and install hints for legacy SKILL.md metadata
- add parser and skill-status regression coverage

Closes #71323.

## Verification
- `pnpm exec oxfmt --check --threads=1 src/compat/legacy-names.ts src/shared/frontmatter.test.ts src/agents/skills.buildworkspaceskillstatus.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/skills.buildworkspaceskillstatus.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/shared/frontmatter.test.ts`
- `pnpm check:changed`
- `git diff --check`