### PR TITLE
fix(telegram): hide tool progress by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 
 - Providers/OpenAI: separate API-key and Codex sign-in onboarding groups, and avoid replaying stale OpenAI Responses reasoning blocks after a model route switch.
 - Browser/config: expand `~` in `browser.executablePath` before Chromium launch, so home-relative custom browser paths no longer fail with `ENOENT`. Fixes #67264. Thanks @Quratulain-bilal.
+- Telegram/streaming: hide tool-progress status updates by default while keeping explicit `streaming.preview.toolProgress` opt-in support for edited preview messages. Fixes #71320. Thanks @neeravmakwana.
 - Discord/subagents: preserve thread-bound completion delivery by keeping the requester-agent announce path primary and falling back to direct thread sends only when the announce produces no visible output. (#71064) Thanks @DolencLuka.
 - Browser/tool: give Chrome MCP existing-session manage calls a longer default timeout, pass explicit tool timeouts through tab management, and recover stale selected-page MCP sessions instead of forcing a manual reset. Thanks @steipete.
 - Browser/sandbox: clean up idle tracked tabs opened by primary-agent browser sessions, while preserving active tab reuse and lifecycle cleanup for subagents, cron, and ACP sessions. Fixes #71165. Thanks @dwbutler.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -273,7 +273,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - `channels.telegram.streaming` is `off | partial | block | progress` (default: `partial`)
     - `progress` maps to `partial` on Telegram (compat with cross-channel naming)
-    - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `true`). Set `false` to keep separate tool/progress messages.
+    - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `false`). Set `true` only when visible Telegram progress updates are desired.
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are auto-mapped
 
     For text-only replies:

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -176,7 +176,8 @@ Preview streaming can also include **tool-progress** updates — short status li
 
 Supported surfaces:
 
-- **Discord**, **Slack**, and **Telegram** stream tool-progress into the live preview edit.
+- **Discord** and **Slack** stream tool-progress into the live preview edit by default.
+- **Telegram** only streams tool-progress into the live preview edit when `streaming.preview.toolProgress` is explicitly enabled.
 - **Mattermost** already folds tool activity into its single draft preview post (see above).
 - Tool-progress edits follow the active preview streaming mode; they are skipped when preview streaming is `off` or when block streaming has taken over the message.
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -7,6 +7,7 @@ import {
   createSequencedTestDraftStream,
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
+import { renderTelegramHtmlText } from "./format.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -524,6 +525,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onItemEvent?.({ progressText: "read [label](tg://user?id=123)" });
       return { queuedFinal: false };
     });
 
@@ -533,7 +535,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { preview: { toolProgress: true } } },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith("Working…\n• tool: exec");
+    const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0];
+    expect(lastPreviewText).toBe("Working…\n• `tool: exec`\n• `read [label](tg://user?id=123)`");
+    expect(renderTelegramHtmlText(lastPreviewText ?? "")).not.toContain("<a ");
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -547,6 +547,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("bounds Telegram tool progress markdown preview formatting", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    const longProgress = `${"`".repeat(1000)}${"x".repeat(1000)}[label](tg://user?id=123)`;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onItemEvent?.({ progressText: longProgress });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { preview: { toolProgress: true } } },
+    });
+
+    const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
+    const progressLine = lastPreviewText.split("\n").at(1) ?? "";
+
+    expect(lastPreviewText.length).toBeLessThan(340);
+    expect(progressLine).toMatch(/^• `{10}/);
+    expect(progressLine).toContain("…");
+    expect(renderTelegramHtmlText(lastPreviewText)).not.toContain("<a ");
+  });
+
   it("keeps block streaming enabled when account config enables it", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -498,6 +498,51 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("suppresses Telegram tool progress by default", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onItemEvent?.({ progressText: "exec ls ~/Desktop" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          suppressDefaultToolProgressMessages: true,
+        }),
+      }),
+    );
+  });
+
+  it("streams Telegram tool progress only when explicitly enabled", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { preview: { toolProgress: true } } },
+    });
+
+    expect(draftStream.update).toHaveBeenCalledWith("Working…\n• tool: exec");
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          suppressDefaultToolProgressMessages: true,
+        }),
+      }),
+    );
+  });
+
   it("keeps block streaming enabled when account config enables it", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -207,6 +207,15 @@ function resolveTelegramReasoningLevel(params: {
   return "off";
 }
 
+function formatProgressAsMarkdownCode(text: string): string {
+  const maxBacktickRun = Math.max(
+    0,
+    ...Array.from(text.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const fence = "`".repeat(maxBacktickRun + 1);
+  return `${fence}${text}${fence}`;
+}
+
 export const dispatchTelegramMessage = async ({
   context,
   bot,
@@ -404,9 +413,10 @@ export const dispatchTelegramMessage = async ({
       return;
     }
     previewToolProgressLines = [...previewToolProgressLines, normalized].slice(-8);
-    const previewText = ["Working…", ...previewToolProgressLines.map((entry) => `• ${entry}`)].join(
-      "\n",
-    );
+    const previewText = [
+      "Working…",
+      ...previewToolProgressLines.map((entry) => `• ${formatProgressAsMarkdownCode(entry)}`),
+    ].join("\n");
     answerLane.lastPartialText = previewText;
     answerLane.stream.update(previewText);
   };

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -388,7 +388,7 @@ export const dispatchTelegramMessage = async ({
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
   const previewToolProgressEnabled =
-    Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg);
+    Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg, false);
   let previewToolProgressSuppressed = false;
   let previewToolProgressLines: string[] = [];
   const pushPreviewToolProgress = (line?: string) => {
@@ -966,7 +966,7 @@ export const dispatchTelegramMessage = async ({
                   previewToolProgressLines = [];
                 })
             : undefined,
-          suppressDefaultToolProgressMessages: previewToolProgressEnabled ? true : undefined,
+          suppressDefaultToolProgressMessages: true,
           onToolStart: async (payload) => {
             const toolName = payload.name?.trim();
             if (statusReactionController && toolName) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -207,13 +207,24 @@ function resolveTelegramReasoningLevel(params: {
   return "off";
 }
 
+const MAX_PROGRESS_MARKDOWN_TEXT_CHARS = 300;
+const MAX_PROGRESS_MARKDOWN_FENCE_CHARS = 10;
+
+function clipProgressMarkdownText(text: string): string {
+  if (text.length <= MAX_PROGRESS_MARKDOWN_TEXT_CHARS) {
+    return text;
+  }
+  return `${text.slice(0, MAX_PROGRESS_MARKDOWN_TEXT_CHARS - 1).trimEnd()}…`;
+}
+
 function formatProgressAsMarkdownCode(text: string): string {
+  const clipped = clipProgressMarkdownText(text);
   const maxBacktickRun = Math.max(
     0,
-    ...Array.from(text.matchAll(/`+/g), (match) => match[0].length),
+    ...Array.from(clipped.matchAll(/`+/g), (match) => match[0].length),
   );
-  const fence = "`".repeat(maxBacktickRun + 1);
-  return `${fence}${text}${fence}`;
+  const fence = "`".repeat(Math.min(maxBacktickRun + 1, MAX_PROGRESS_MARKDOWN_FENCE_CHARS));
+  return `${fence}${clipped}${fence}`;
 }
 
 export const dispatchTelegramMessage = async ({

--- a/extensions/telegram/src/config-ui-hints.ts
+++ b/extensions/telegram/src/config-ui-hints.ts
@@ -63,7 +63,7 @@ export const telegramChannelConfigUiHints = {
   },
   "streaming.preview.toolProgress": {
     label: "Telegram Draft Tool Progress",
-    help: "Show tool/progress activity in the live draft preview message (default: true). Set false to keep tool updates as separate messages.",
+    help: "Show tool/progress activity in the live draft preview message (default: false). Enable only when visible Telegram progress updates are desired.",
   },
   "retry.attempts": {
     label: "Telegram Retry Attempts",

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1636,7 +1636,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("delivers deterministic exec approval tool payloads for native commands", async () => {
+  it("delivers deterministic exec approval tool payloads for native commands with progress suppression", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -1663,7 +1663,13 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "NO_REPLY" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(firstToolResultPayload(dispatcher)).toEqual(


### PR DESCRIPTION
## Summary
- Fixes #71320 by making Telegram tool-progress preview updates opt-in instead of default-on.
- Suppresses the generic default tool/progress messages on Telegram so tool lifecycle status does not leak as separate chat messages.
- Updates Telegram docs, streaming docs, config UI hint text, and changelog to match the runtime default.

## Root Cause
Telegram enabled `resolveChannelStreamingPreviewToolProgress()` with the shared default of `true`, so tool/item/plan lifecycle events were turned into visible `Working…` preview text during normal Telegram replies. Disabling that path alone would have allowed the generic `Working:` progress messages to surface separately, so Telegram also needs to suppress default tool-progress message delivery at runtime.

## Why This Is Safe
The change is Telegram-scoped. Final assistant replies, block streaming, reasoning streaming, status reactions, media tool payloads, approval payloads, and error delivery continue to use the existing delivery paths. Users who intentionally want visible Telegram progress can still opt in with `channels.telegram.streaming.preview.toolProgress=true`, which keeps progress inside the edited preview message.

## Security / Runtime Controls Unchanged
This does not rely on prompt instructions. The suppression is enforced in the Telegram dispatch runtime via `suppressDefaultToolProgressMessages`, while the existing runtime filtering that still allows media, approval, and error payloads remains unchanged.

## Self-Review
- Test helper defaults match production defaults: empty Telegram config now suppresses progress in the regression test and production code.
- Config default documentation is aligned in Telegram docs, streaming docs, config UI hints, and changelog.
- Generated config docs were checked and did not change.

## Tests
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` (pass)
- `pnpm test:extension telegram` (pass)
- `pnpm config:docs:check` (pass)
- `git diff --check` (pass)
- `pnpm check:changed` (fails in unrelated extension-wide typecheck before reaching changed tests; errors are duplicate nested `@mariozechner/pi-ai` / `pi-agent-core` type identities in other extensions such as `extensions/amazon-bedrock-mantle`, `extensions/anthropic`, and `extensions/codex`)

Made with [Cursor](https://cursor.com)