### PR TITLE
fix: use cmd.exe /c start on Windows for browser open

### DIFF
--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -34,9 +34,11 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
   }
 
   if (platform === "win32") {
+    // Use rundll32 url.dll to open URLs safely on Windows without cmd.exe
+    // shell parsing issues (& % < > etc. in URLs are handled correctly).
     return {
-      argv: ["cmd.exe", "/c", "start", ""],
-      command: "cmd.exe",
+      argv: ["rundll32", "url.dll,FileProtocolHandler"],
+      command: "rundll32",
     };
   }
 

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -35,8 +35,8 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
 
   if (platform === "win32") {
     return {
-      argv: ["explorer.exe"],
-      command: "explorer.exe",
+      argv: ["cmd.exe", "/c", "start", ""],
+      command: "cmd.exe",
     };
   }
 


### PR DESCRIPTION
## Summary

`openclaw dashboard` on Windows prints "Opened in your browser" but no browser actually opens. The `openUrl` function uses `explorer.exe` which silently fails to open URLs on some Windows configurations.\n\n## Root Cause\n\nThe win32 branch in `resolveBrowserOpenCommand()` used `explorer.exe` as the browser launcher. While `explorer.exe` can sometimes open URLs, it doesn't reliably work across all Windows configurations — the process exits successfully even when no browser launches.\n\n## Fix\n\nSwitch to `cmd.exe /c start \"\" <url>` which is the standard Windows idiom for opening URLs in the default browser. The empty string after `start` is required to prevent cmd from interpreting the URL as a window title.\n\n## Before\n\n```ts\nif (platform === \"win32\") {\n  return { argv: [\"explorer.exe\"], command: \"explorer.exe\" };\n}\n```\n\n## After\n\n```ts\nif (platform === \"win32\") {\n  return { argv: [\"cmd.exe\", \"/c\", \"start\", \"\"], command: \"cmd.exe\" };\n}\n```\n\nFixes #71098