### PR TITLE
fix: detect Tailscale runtime state even when config mode is off

### DIFF
--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -90,17 +90,17 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     all: params.opts.all,
   });
   const updateTimeoutMs = params.opts.all ? 6500 : 2500;
-  // Always attempt to resolve the tailnet hostname, even when the config
-  // mode is "off".  This lets `openclaw status` surface the actual
-  // Tailscale runtime state (e.g. "off · Running · host.tailnet") so
-  // users can see that the daemon is connected even if they haven't
-  // configured the gateway to use it.  The call is cheap (1.2 s
-  // timeout) and only happens during status scans.
-  const tailscaleDnsPromise = params
-    .getTailnetHostname((cmd, args) =>
-      runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
-    )
-    .catch(() => null);
+  // Attempt to resolve the tailnet hostname even when the config mode is
+  // "off", so `openclaw status` can surface the actual Tailscale runtime
+  // state (e.g. "off · host.tailnet").  The cold-start skip guard is
+  // respected to keep the fast path instant for fresh/no-channel runs.
+  const tailscaleDnsPromise = skipColdStartNetworkChecks
+    ? Promise.resolve<string | null>(null)
+    : params
+        .getTailnetHostname((cmd, args) =>
+          runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+        )
+        .catch(() => null);
   const updatePromise = skipColdStartNetworkChecks
     ? Promise.resolve(buildColdStartUpdateResult())
     : params.getUpdateCheckResult({

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -90,14 +90,17 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
     all: params.opts.all,
   });
   const updateTimeoutMs = params.opts.all ? 6500 : 2500;
-  const tailscaleDnsPromise =
-    tailscaleMode === "off"
-      ? Promise.resolve<string | null>(null)
-      : params
-          .getTailnetHostname((cmd, args) =>
-            runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
-          )
-          .catch(() => null);
+  // Always attempt to resolve the tailnet hostname, even when the config
+  // mode is "off".  This lets `openclaw status` surface the actual
+  // Tailscale runtime state (e.g. "off · Running · host.tailnet") so
+  // users can see that the daemon is connected even if they haven't
+  // configured the gateway to use it.  The call is cheap (1.2 s
+  // timeout) and only happens during status scans.
+  const tailscaleDnsPromise = params
+    .getTailnetHostname((cmd, args) =>
+      runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),
+    )
+    .catch(() => null);
   const updatePromise = skipColdStartNetworkChecks
     ? Promise.resolve(buildColdStartUpdateResult())
     : params.getUpdateCheckResult({


### PR DESCRIPTION
## Summary

`openclaw status` shows "Tailscale: off" even when the Tailscale CLI is installed and reports an active tailnet connection. The status display reads the **config** value (`gateway.tailscale.mode`), not the actual runtime state.

## Root Cause

In `status.scan.bootstrap-shared.ts`, when `tailscaleMode === "off"` (the default when unset), the code skipped the `getTailnetHostname` call entirely:

```ts
const tailscaleDnsPromise =
  tailscaleMode === "off"
    ? Promise.resolve<string | null>(null)  // ← always null
    : params.getTailnetHostname(...);
```

This meant the DNS name was never resolved, so the display layer had no runtime data to show.

## Fix

Always attempt the tailnet hostname lookup during status scans, regardless of the config mode. The call already has a 1.2s timeout and runs concurrently with other checks, so there's no performance impact. When Tailscale is running but not configured, the existing `includeDnsNameWhenOff` display path can now show the actual hostname.

## Before

```
│ Tailscale │ off │
```

## After (when Tailscale is running but not configured)

```
│ Tailscale │ off · host.tailnet │
```

Fixes #71123