### PR TITLE
refactor: centralize model catalog normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups and warn non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata. Thanks @vincentkoc.
 - Plugins/setup: derive generic provider setup choices from descriptor-safe `setup.providers[].authMethods` before falling back to setup runtime. Thanks @vincentkoc.
 - Plugins/setup: surface manifest provider auth choices directly in provider setup flow before falling back to setup runtime or install-catalog choices. Thanks @vincentkoc.
+- Models/catalog: centralize manifest model catalog normalization behind a shared `src/model-catalog` contract so future provider index, cache, onboarding, and listing consumers reuse the same validation and row refs. (#71360) Thanks @shakkernerd.
 - Plugins/manifest: add a `modelCatalog` contract for provider-owned model rows, aliases, suppression rules, and discovery mode metadata without loading plugin runtime. (#71342) Thanks @shakkernerd.
 - Plugins/setup: warn when descriptor-only setup plugins still ship ignored setup runtime entries, keeping `setup.requiresRuntime: false` semantics explicit without breaking existing metadata. Thanks @vincentkoc.
 - Plugins/channels: use manifest `channelConfigs` for read-only external channel discovery when no setup entry is available or setup descriptors declare runtime unnecessary. Thanks @vincentkoc.

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -1,0 +1,24 @@
+export {
+  buildModelCatalogMergeKey,
+  buildModelCatalogRef,
+  normalizeModelCatalogProviderId,
+} from "./refs.js";
+export {
+  normalizeModelCatalog,
+  normalizeModelCatalogProviderRows,
+  normalizeModelCatalogRows,
+} from "./normalize.js";
+export type {
+  ModelCatalog,
+  ModelCatalogAlias,
+  ModelCatalogCost,
+  ModelCatalogDiscovery,
+  ModelCatalogInput,
+  ModelCatalogModel,
+  ModelCatalogProvider,
+  ModelCatalogSource,
+  ModelCatalogStatus,
+  ModelCatalogSuppression,
+  ModelCatalogTieredCost,
+  NormalizedModelCatalogRow,
+} from "./types.js";

--- a/src/model-catalog/normalize.test.ts
+++ b/src/model-catalog/normalize.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelCatalogMergeKey,
+  buildModelCatalogRef,
+  normalizeModelCatalog,
+  normalizeModelCatalogRows,
+} from "./index.js";
+
+describe("model catalog normalization", () => {
+  it("normalizes catalog ownership, aliases, suppressions, and row fields", () => {
+    const catalog = normalizeModelCatalog(
+      {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses",
+            headers: {
+              "x-provider": "openai",
+            },
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                api: "openai-completions",
+                baseUrl: "https://proxy.example/v1",
+                headers: {
+                  "x-model": "gpt-5.4",
+                },
+                input: ["text", "image", "document", "audio"],
+                reasoning: true,
+                contextWindow: 256000,
+                contextTokens: 200000,
+                maxTokens: 128000,
+                cost: {
+                  input: 1.25,
+                  output: 10,
+                  cacheRead: 0.125,
+                  tieredPricing: [
+                    {
+                      input: 1.25,
+                      output: 10,
+                      cacheRead: 0.125,
+                      cacheWrite: 1.25,
+                      range: [0, 256000],
+                    },
+                    {
+                      input: 1,
+                      output: 2,
+                      range: [0, 1000],
+                    },
+                  ],
+                },
+                compat: {
+                  supportsTools: true,
+                  supportsStore: "yes",
+                  unknownFlag: true,
+                },
+                status: "preview",
+                statusReason: "rolling out",
+                replaces: ["gpt-5.3"],
+                replacedBy: "gpt-5.5",
+                tags: ["default"],
+              },
+              {
+                id: "",
+              },
+            ],
+          },
+          anthropic: {
+            models: [{ id: "claude-sonnet-4.6" }],
+          },
+        },
+        aliases: {
+          "azure-openai-responses": {
+            provider: "openai",
+            api: "azure-openai-responses",
+          },
+          "anthropic-alias": {
+            provider: "anthropic",
+          },
+        },
+        suppressions: [
+          {
+            provider: "azure-openai-responses",
+            model: "gpt-5.3-codex-spark",
+            reason: "not available",
+          },
+        ],
+        discovery: {
+          openai: "static",
+          anthropic: "static",
+          bad: "unknown",
+        },
+      },
+      { ownedProviders: new Set(["openai"]) },
+    );
+
+    expect(catalog).toEqual({
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-responses",
+          headers: {
+            "x-provider": "openai",
+          },
+          models: [
+            {
+              id: "gpt-5.4",
+              name: "GPT-5.4",
+              api: "openai-completions",
+              baseUrl: "https://proxy.example/v1",
+              headers: {
+                "x-model": "gpt-5.4",
+              },
+              input: ["text", "image", "document"],
+              reasoning: true,
+              contextWindow: 256000,
+              contextTokens: 200000,
+              maxTokens: 128000,
+              cost: {
+                input: 1.25,
+                output: 10,
+                cacheRead: 0.125,
+                tieredPricing: [
+                  {
+                    input: 1.25,
+                    output: 10,
+                    cacheRead: 0.125,
+                    cacheWrite: 1.25,
+                    range: [0, 256000],
+                  },
+                ],
+              },
+              compat: {
+                supportsTools: true,
+              },
+              status: "preview",
+              statusReason: "rolling out",
+              replaces: ["gpt-5.3"],
+              replacedBy: "gpt-5.5",
+              tags: ["default"],
+            },
+          ],
+        },
+      },
+      aliases: {
+        "azure-openai-responses": {
+          provider: "openai",
+          api: "azure-openai-responses",
+        },
+      },
+      suppressions: [
+        {
+          provider: "azure-openai-responses",
+          model: "gpt-5.3-codex-spark",
+          reason: "not available",
+        },
+      ],
+      discovery: {
+        openai: "static",
+      },
+    });
+  });
+
+  it("builds normalized rows with provider defaults and stable refs", () => {
+    const rows = normalizeModelCatalogRows({
+      source: "manifest",
+      providers: {
+        OpenAI: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-responses",
+          headers: {
+            "x-provider": "openai",
+          },
+          models: [
+            {
+              id: "GPT-5.4",
+              headers: {
+                "x-model": "gpt-5.4",
+              },
+              input: ["image"],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        provider: "openai",
+        id: "GPT-5.4",
+        ref: "openai/GPT-5.4",
+        mergeKey: "openai::gpt-5.4",
+        name: "GPT-5.4",
+        source: "manifest",
+        input: ["image"],
+        reasoning: false,
+        status: "available",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        headers: {
+          "x-provider": "openai",
+          "x-model": "gpt-5.4",
+        },
+      },
+    ]);
+    expect(buildModelCatalogRef("OpenAI", "GPT-5.4")).toBe("openai/GPT-5.4");
+    expect(buildModelCatalogMergeKey("OpenAI", "GPT-5.4")).toBe("openai::gpt-5.4");
+  });
+});

--- a/src/model-catalog/normalize.ts
+++ b/src/model-catalog/normalize.ts
@@ -1,0 +1,473 @@
+import { MODEL_APIS, type ModelApi, type ModelCompatConfig } from "../config/types.models.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { normalizeTrimmedStringList } from "../shared/string-normalization.js";
+import { isRecord } from "../utils.js";
+import {
+  buildModelCatalogMergeKey,
+  buildModelCatalogRef,
+  normalizeModelCatalogProviderId,
+} from "./refs.js";
+import type {
+  ModelCatalog,
+  ModelCatalogAlias,
+  ModelCatalogCost,
+  ModelCatalogDiscovery,
+  ModelCatalogInput,
+  ModelCatalogModel,
+  ModelCatalogProvider,
+  ModelCatalogSource,
+  ModelCatalogStatus,
+  ModelCatalogSuppression,
+  ModelCatalogTieredCost,
+  NormalizedModelCatalogRow,
+} from "./types.js";
+
+const MODEL_CATALOG_INPUTS = new Set(["text", "image", "document"]);
+const MODEL_CATALOG_DISCOVERY_MODES = new Set(["static", "refreshable", "runtime"]);
+const MODEL_CATALOG_STATUSES = new Set(["available", "preview", "deprecated", "disabled"]);
+const MODEL_CATALOG_APIS = new Set<string>(MODEL_APIS);
+const DEFAULT_MODEL_INPUT: ModelCatalogInput[] = ["text"];
+const DEFAULT_MODEL_STATUS: ModelCatalogStatus = "available";
+
+export type { NormalizedModelCatalogRow } from "./types.js";
+
+function normalizeSafeRecordKey(value: unknown): string {
+  const key = normalizeOptionalString(value) ?? "";
+  return key && !isBlockedObjectKey(key) ? key : "";
+}
+
+function normalizeStringMap(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const normalized: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = normalizeSafeRecordKey(rawKey);
+    const mapValue = normalizeOptionalString(rawValue) ?? "";
+    if (key && mapValue) {
+      normalized[key] = mapValue;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function mergeStringMaps(
+  base: Record<string, string> | undefined,
+  override: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!base && !override) {
+    return undefined;
+  }
+  return { ...base, ...override };
+}
+
+function normalizeModelCatalogApi(value: unknown): ModelApi | undefined {
+  const api = normalizeOptionalString(value) ?? "";
+  return MODEL_CATALOG_APIS.has(api) ? (api as ModelApi) : undefined;
+}
+
+function normalizeModelCatalogInputs(value: unknown): ModelCatalogInput[] | undefined {
+  const inputs = normalizeTrimmedStringList(value).filter((input): input is ModelCatalogInput =>
+    MODEL_CATALOG_INPUTS.has(input),
+  );
+  return inputs.length > 0 ? inputs : undefined;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function normalizePositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function normalizeModelCatalogTieredCost(value: unknown): ModelCatalogTieredCost[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized: ModelCatalogTieredCost[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry) || !Array.isArray(entry.range)) {
+      continue;
+    }
+    const input = normalizeNonNegativeNumber(entry.input);
+    const output = normalizeNonNegativeNumber(entry.output);
+    const cacheRead = normalizeNonNegativeNumber(entry.cacheRead);
+    const cacheWrite = normalizeNonNegativeNumber(entry.cacheWrite);
+    if (
+      input === undefined ||
+      output === undefined ||
+      cacheRead === undefined ||
+      cacheWrite === undefined ||
+      entry.range.length < 1 ||
+      entry.range.length > 2
+    ) {
+      continue;
+    }
+    const rangeValues = entry.range.map((rangeValue) => normalizeNonNegativeNumber(rangeValue));
+    if (rangeValues.some((rangeValue) => rangeValue === undefined)) {
+      continue;
+    }
+    normalized.push({
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      range:
+        rangeValues.length === 1
+          ? ([rangeValues[0]] as [number])
+          : ([rangeValues[0], rangeValues[1]] as [number, number]),
+    });
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeModelCatalogCost(value: unknown): ModelCatalogCost | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const input = normalizeNonNegativeNumber(value.input);
+  const output = normalizeNonNegativeNumber(value.output);
+  const cacheRead = normalizeNonNegativeNumber(value.cacheRead);
+  const cacheWrite = normalizeNonNegativeNumber(value.cacheWrite);
+  const tieredPricing = normalizeModelCatalogTieredCost(value.tieredPricing);
+  const cost = {
+    ...(input !== undefined ? { input } : {}),
+    ...(output !== undefined ? { output } : {}),
+    ...(cacheRead !== undefined ? { cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+    ...(tieredPricing ? { tieredPricing } : {}),
+  } satisfies ModelCatalogCost;
+  return Object.keys(cost).length > 0 ? cost : undefined;
+}
+
+function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const compat: Record<string, unknown> = {};
+  const booleanFields = [
+    "supportsStore",
+    "supportsPromptCacheKey",
+    "supportsDeveloperRole",
+    "supportsReasoningEffort",
+    "supportsUsageInStreaming",
+    "supportsTools",
+    "supportsStrictMode",
+    "requiresStringContent",
+    "requiresToolResultName",
+    "requiresAssistantAfterToolResult",
+    "requiresThinkingAsText",
+    "nativeWebSearchTool",
+    "requiresMistralToolIds",
+    "requiresOpenAiAnthropicToolPayload",
+  ] as const;
+  for (const field of booleanFields) {
+    if (typeof value[field] === "boolean") {
+      compat[field] = value[field];
+    }
+  }
+
+  const stringFields = ["toolSchemaProfile", "toolCallArgumentsEncoding"] as const;
+  for (const field of stringFields) {
+    const normalized = normalizeOptionalString(value[field]) ?? "";
+    if (normalized) {
+      compat[field] = normalized;
+    }
+  }
+
+  const stringListFields = [
+    "visibleReasoningDetailTypes",
+    "supportedReasoningEfforts",
+    "unsupportedToolSchemaKeywords",
+  ] as const;
+  for (const field of stringListFields) {
+    const normalized = normalizeTrimmedStringList(value[field]);
+    if (normalized.length > 0) {
+      compat[field] = normalized;
+    }
+  }
+
+  const maxTokensField = normalizeOptionalString(value.maxTokensField) ?? "";
+  if (maxTokensField === "max_completion_tokens" || maxTokensField === "max_tokens") {
+    compat.maxTokensField = maxTokensField;
+  }
+
+  const thinkingFormat = normalizeOptionalString(value.thinkingFormat) ?? "";
+  if (
+    thinkingFormat === "openai" ||
+    thinkingFormat === "openrouter" ||
+    thinkingFormat === "deepseek" ||
+    thinkingFormat === "zai" ||
+    thinkingFormat === "qwen" ||
+    thinkingFormat === "qwen-chat-template"
+  ) {
+    compat.thinkingFormat = thinkingFormat;
+  }
+
+  return Object.keys(compat).length > 0 ? (compat as ModelCompatConfig) : undefined;
+}
+
+function normalizeModelCatalogStatus(value: unknown): ModelCatalogStatus | undefined {
+  const status = normalizeOptionalString(value) ?? "";
+  return MODEL_CATALOG_STATUSES.has(status) ? (status as ModelCatalogStatus) : undefined;
+}
+
+function normalizeModelCatalogModel(value: unknown): ModelCatalogModel | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const id = normalizeOptionalString(value.id) ?? "";
+  if (!id) {
+    return undefined;
+  }
+  const name = normalizeOptionalString(value.name) ?? "";
+  const api = normalizeModelCatalogApi(value.api);
+  const baseUrl = normalizeOptionalString(value.baseUrl) ?? "";
+  const headers = normalizeStringMap(value.headers);
+  const input = normalizeModelCatalogInputs(value.input);
+  const reasoning = typeof value.reasoning === "boolean" ? value.reasoning : undefined;
+  const contextWindow = normalizePositiveNumber(value.contextWindow);
+  const contextTokens = normalizePositiveInteger(value.contextTokens);
+  const maxTokens = normalizePositiveNumber(value.maxTokens);
+  const cost = normalizeModelCatalogCost(value.cost);
+  const compat = normalizeModelCatalogCompat(value.compat);
+  const status = normalizeModelCatalogStatus(value.status);
+  const statusReason = normalizeOptionalString(value.statusReason) ?? "";
+  const replaces = normalizeTrimmedStringList(value.replaces);
+  const replacedBy = normalizeOptionalString(value.replacedBy) ?? "";
+  const tags = normalizeTrimmedStringList(value.tags);
+  return {
+    id,
+    ...(name ? { name } : {}),
+    ...(api ? { api } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(headers ? { headers } : {}),
+    ...(input ? { input } : {}),
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+    ...(contextTokens !== undefined ? { contextTokens } : {}),
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+    ...(cost ? { cost } : {}),
+    ...(compat ? { compat } : {}),
+    ...(status ? { status } : {}),
+    ...(statusReason ? { statusReason } : {}),
+    ...(replaces.length > 0 ? { replaces } : {}),
+    ...(replacedBy ? { replacedBy } : {}),
+    ...(tags.length > 0 ? { tags } : {}),
+  };
+}
+
+function normalizeModelCatalogProvider(value: unknown): ModelCatalogProvider | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const models = Array.isArray(value.models)
+    ? value.models
+        .map((entry) => normalizeModelCatalogModel(entry))
+        .filter((entry): entry is ModelCatalogModel => Boolean(entry))
+    : [];
+  if (models.length === 0) {
+    return undefined;
+  }
+  const baseUrl = normalizeOptionalString(value.baseUrl) ?? "";
+  const api = normalizeModelCatalogApi(value.api);
+  const headers = normalizeStringMap(value.headers);
+  return {
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(api ? { api } : {}),
+    ...(headers ? { headers } : {}),
+    models,
+  };
+}
+
+function normalizeModelCatalogProviders(
+  value: unknown,
+  ownedProviders: ReadonlySet<string>,
+): Record<string, ModelCatalogProvider> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const providers: Record<string, ModelCatalogProvider> = {};
+  for (const [rawProviderId, rawProvider] of Object.entries(value)) {
+    const providerId = normalizeSafeRecordKey(rawProviderId);
+    if (!providerId || !ownedProviders.has(providerId)) {
+      continue;
+    }
+    const provider = normalizeModelCatalogProvider(rawProvider);
+    if (provider) {
+      providers[providerId] = provider;
+    }
+  }
+  return Object.keys(providers).length > 0 ? providers : undefined;
+}
+
+function normalizeModelCatalogAliases(
+  value: unknown,
+  ownedProviders: ReadonlySet<string>,
+): Record<string, ModelCatalogAlias> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const aliases: Record<string, ModelCatalogAlias> = {};
+  for (const [rawAlias, rawTarget] of Object.entries(value)) {
+    const alias = normalizeSafeRecordKey(rawAlias);
+    if (!alias || !isRecord(rawTarget)) {
+      continue;
+    }
+    const provider = normalizeOptionalString(rawTarget.provider) ?? "";
+    if (!provider || !ownedProviders.has(provider)) {
+      continue;
+    }
+    const api = normalizeModelCatalogApi(rawTarget.api);
+    const baseUrl = normalizeOptionalString(rawTarget.baseUrl) ?? "";
+    aliases[alias] = {
+      provider,
+      ...(api ? { api } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+    };
+  }
+  return Object.keys(aliases).length > 0 ? aliases : undefined;
+}
+
+function normalizeModelCatalogSuppressions(value: unknown): ModelCatalogSuppression[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const suppressions: ModelCatalogSuppression[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const provider = normalizeOptionalString(entry.provider) ?? "";
+    const model = normalizeOptionalString(entry.model) ?? "";
+    if (!provider || !model) {
+      continue;
+    }
+    const reason = normalizeOptionalString(entry.reason) ?? "";
+    suppressions.push({
+      provider,
+      model,
+      ...(reason ? { reason } : {}),
+    });
+  }
+  return suppressions.length > 0 ? suppressions : undefined;
+}
+
+function normalizeModelCatalogDiscovery(
+  value: unknown,
+  ownedProviders: ReadonlySet<string>,
+): Record<string, ModelCatalogDiscovery> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const discovery: Record<string, ModelCatalogDiscovery> = {};
+  for (const [rawProviderId, rawMode] of Object.entries(value)) {
+    const providerId = normalizeSafeRecordKey(rawProviderId);
+    const mode = normalizeOptionalString(rawMode) ?? "";
+    if (providerId && ownedProviders.has(providerId) && MODEL_CATALOG_DISCOVERY_MODES.has(mode)) {
+      discovery[providerId] = mode as ModelCatalogDiscovery;
+    }
+  }
+  return Object.keys(discovery).length > 0 ? discovery : undefined;
+}
+
+export function normalizeModelCatalog(
+  value: unknown,
+  params: { ownedProviders: ReadonlySet<string> },
+): ModelCatalog | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const providers = normalizeModelCatalogProviders(value.providers, params.ownedProviders);
+  const aliases = normalizeModelCatalogAliases(value.aliases, params.ownedProviders);
+  const suppressions = normalizeModelCatalogSuppressions(value.suppressions);
+  const discovery = normalizeModelCatalogDiscovery(value.discovery, params.ownedProviders);
+  const catalog = {
+    ...(providers ? { providers } : {}),
+    ...(aliases ? { aliases } : {}),
+    ...(suppressions ? { suppressions } : {}),
+    ...(discovery ? { discovery } : {}),
+  } satisfies ModelCatalog;
+  return Object.keys(catalog).length > 0 ? catalog : undefined;
+}
+
+function normalizeStringList(value: unknown): string[] | undefined {
+  const normalized = normalizeTrimmedStringList(value);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function normalizeModelCatalogProviderRows(params: {
+  provider: string;
+  providerCatalog: ModelCatalogProvider;
+  source: ModelCatalogSource;
+}): NormalizedModelCatalogRow[] {
+  const provider = normalizeModelCatalogProviderId(params.provider);
+  if (!provider || !Array.isArray(params.providerCatalog.models)) {
+    return [];
+  }
+  const providerApi = normalizeModelCatalogApi(params.providerCatalog.api);
+  const providerBaseUrl = normalizeOptionalString(params.providerCatalog.baseUrl) ?? "";
+  const providerHeaders = normalizeStringMap(params.providerCatalog.headers);
+  const rows: NormalizedModelCatalogRow[] = [];
+
+  for (const model of params.providerCatalog.models) {
+    const id = normalizeOptionalString(model.id) ?? "";
+    if (!id) {
+      continue;
+    }
+    const api = normalizeModelCatalogApi(model.api) ?? providerApi;
+    const baseUrl = normalizeOptionalString(model.baseUrl) ?? providerBaseUrl;
+    const headers = mergeStringMaps(providerHeaders, normalizeStringMap(model.headers));
+    const contextWindow = normalizePositiveNumber(model.contextWindow);
+    const contextTokens = normalizePositiveInteger(model.contextTokens);
+    const maxTokens = normalizePositiveNumber(model.maxTokens);
+    const cost = normalizeModelCatalogCost(model.cost);
+    const compat = normalizeModelCatalogCompat(model.compat);
+    const statusReason = normalizeOptionalString(model.statusReason) ?? "";
+    const replacedBy = normalizeOptionalString(model.replacedBy) ?? "";
+    const replaces = normalizeStringList(model.replaces);
+    const tags = normalizeStringList(model.tags);
+    rows.push({
+      provider,
+      id,
+      ref: buildModelCatalogRef(provider, id),
+      mergeKey: buildModelCatalogMergeKey(provider, id),
+      name: normalizeOptionalString(model.name) || id,
+      source: params.source,
+      input: normalizeModelCatalogInputs(model.input) ?? [...DEFAULT_MODEL_INPUT],
+      reasoning: typeof model.reasoning === "boolean" ? model.reasoning : false,
+      status: normalizeModelCatalogStatus(model.status) ?? DEFAULT_MODEL_STATUS,
+      ...(api ? { api } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(headers ? { headers } : {}),
+      ...(contextWindow !== undefined ? { contextWindow } : {}),
+      ...(contextTokens !== undefined ? { contextTokens } : {}),
+      ...(maxTokens !== undefined ? { maxTokens } : {}),
+      ...(cost ? { cost } : {}),
+      ...(compat ? { compat } : {}),
+      ...(statusReason ? { statusReason } : {}),
+      ...(replaces ? { replaces } : {}),
+      ...(replacedBy ? { replacedBy } : {}),
+      ...(tags ? { tags } : {}),
+    });
+  }
+
+  return rows.toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
+}
+
+export function normalizeModelCatalogRows(params: {
+  providers: Record<string, ModelCatalogProvider>;
+  source: ModelCatalogSource;
+}): NormalizedModelCatalogRow[] {
+  return Object.entries(params.providers)
+    .flatMap(([provider, providerCatalog]) =>
+      normalizeModelCatalogProviderRows({ provider, providerCatalog, source: params.source }),
+    )
+    .toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
+}

--- a/src/model-catalog/refs.ts
+++ b/src/model-catalog/refs.ts
@@ -1,0 +1,13 @@
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+
+export function normalizeModelCatalogProviderId(provider: string): string {
+  return normalizeLowercaseStringOrEmpty(provider);
+}
+
+export function buildModelCatalogRef(provider: string, modelId: string): string {
+  return `${normalizeModelCatalogProviderId(provider)}/${modelId}`;
+}
+
+export function buildModelCatalogMergeKey(provider: string, modelId: string): string {
+  return `${normalizeModelCatalogProviderId(provider)}::${normalizeLowercaseStringOrEmpty(modelId)}`;
+}

--- a/src/model-catalog/types.ts
+++ b/src/model-catalog/types.ts
@@ -1,0 +1,97 @@
+import type { ModelApi, ModelCompatConfig } from "../config/types.models.js";
+
+export type ModelCatalogInput = "text" | "image" | "document";
+export type ModelCatalogDiscovery = "static" | "refreshable" | "runtime";
+export type ModelCatalogStatus = "available" | "preview" | "deprecated" | "disabled";
+export type ModelCatalogSource =
+  | "manifest"
+  | "provider-index"
+  | "cache"
+  | "config"
+  | "runtime-refresh";
+
+export type ModelCatalogTieredCost = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  range: [number, number] | [number];
+};
+
+export type ModelCatalogCost = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  tieredPricing?: ModelCatalogTieredCost[];
+};
+
+export type ModelCatalogModel = {
+  id: string;
+  name?: string;
+  api?: ModelApi;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  input?: ModelCatalogInput[];
+  reasoning?: boolean;
+  contextWindow?: number;
+  contextTokens?: number;
+  maxTokens?: number;
+  cost?: ModelCatalogCost;
+  compat?: ModelCompatConfig;
+  status?: ModelCatalogStatus;
+  statusReason?: string;
+  replaces?: string[];
+  replacedBy?: string;
+  tags?: string[];
+};
+
+export type ModelCatalogProvider = {
+  baseUrl?: string;
+  api?: ModelApi;
+  headers?: Record<string, string>;
+  models: ModelCatalogModel[];
+};
+
+export type ModelCatalogAlias = {
+  provider: string;
+  api?: ModelApi;
+  baseUrl?: string;
+};
+
+export type ModelCatalogSuppression = {
+  provider: string;
+  model: string;
+  reason?: string;
+};
+
+export type ModelCatalog = {
+  providers?: Record<string, ModelCatalogProvider>;
+  aliases?: Record<string, ModelCatalogAlias>;
+  suppressions?: ModelCatalogSuppression[];
+  discovery?: Record<string, ModelCatalogDiscovery>;
+};
+
+export type NormalizedModelCatalogRow = {
+  provider: string;
+  id: string;
+  ref: string;
+  mergeKey: string;
+  name: string;
+  source: ModelCatalogSource;
+  input: ModelCatalogInput[];
+  reasoning: boolean;
+  status: ModelCatalogStatus;
+  api?: ModelApi;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  contextWindow?: number;
+  contextTokens?: number;
+  maxTokens?: number;
+  cost?: ModelCatalogCost;
+  compat?: ModelCompatConfig;
+  statusReason?: string;
+  replaces?: string[];
+  replacedBy?: string;
+  tags?: string[];
+};

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -3,9 +3,21 @@ import path from "node:path";
 import JSON5 from "json5";
 import type { ChannelConfigRuntimeSchema } from "../channels/plugins/types.config.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { MODEL_APIS, type ModelApi, type ModelCompatConfig } from "../config/types.models.js";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import {
+  normalizeModelCatalog,
+  type ModelCatalog,
+  type ModelCatalogAlias,
+  type ModelCatalogCost,
+  type ModelCatalogDiscovery,
+  type ModelCatalogInput,
+  type ModelCatalogModel,
+  type ModelCatalogProvider,
+  type ModelCatalogStatus,
+  type ModelCatalogSuppression,
+  type ModelCatalogTieredCost,
+} from "../model-catalog/index.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeTrimmedStringList } from "../shared/string-normalization.js";
@@ -43,71 +55,16 @@ export type PluginManifestModelSupport = {
   modelPatterns?: string[];
 };
 
-export type PluginManifestModelCatalogInput = "text" | "image" | "document";
-export type PluginManifestModelCatalogDiscovery = "static" | "refreshable" | "runtime";
-export type PluginManifestModelCatalogStatus = "available" | "preview" | "deprecated" | "disabled";
-
-export type PluginManifestModelCatalogTieredCost = {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  range: [number, number] | [number];
-};
-
-export type PluginManifestModelCatalogCost = {
-  input?: number;
-  output?: number;
-  cacheRead?: number;
-  cacheWrite?: number;
-  tieredPricing?: PluginManifestModelCatalogTieredCost[];
-};
-
-export type PluginManifestModelCatalogModel = {
-  id: string;
-  name?: string;
-  api?: ModelApi;
-  baseUrl?: string;
-  headers?: Record<string, string>;
-  input?: PluginManifestModelCatalogInput[];
-  reasoning?: boolean;
-  contextWindow?: number;
-  contextTokens?: number;
-  maxTokens?: number;
-  cost?: PluginManifestModelCatalogCost;
-  compat?: ModelCompatConfig;
-  status?: PluginManifestModelCatalogStatus;
-  statusReason?: string;
-  replaces?: string[];
-  replacedBy?: string;
-  tags?: string[];
-};
-
-export type PluginManifestModelCatalogProvider = {
-  baseUrl?: string;
-  api?: ModelApi;
-  headers?: Record<string, string>;
-  models: PluginManifestModelCatalogModel[];
-};
-
-export type PluginManifestModelCatalogAlias = {
-  provider: string;
-  api?: ModelApi;
-  baseUrl?: string;
-};
-
-export type PluginManifestModelCatalogSuppression = {
-  provider: string;
-  model: string;
-  reason?: string;
-};
-
-export type PluginManifestModelCatalog = {
-  providers?: Record<string, PluginManifestModelCatalogProvider>;
-  aliases?: Record<string, PluginManifestModelCatalogAlias>;
-  suppressions?: PluginManifestModelCatalogSuppression[];
-  discovery?: Record<string, PluginManifestModelCatalogDiscovery>;
-};
+export type PluginManifestModelCatalogInput = ModelCatalogInput;
+export type PluginManifestModelCatalogDiscovery = ModelCatalogDiscovery;
+export type PluginManifestModelCatalogStatus = ModelCatalogStatus;
+export type PluginManifestModelCatalogTieredCost = ModelCatalogTieredCost;
+export type PluginManifestModelCatalogCost = ModelCatalogCost;
+export type PluginManifestModelCatalogModel = ModelCatalogModel;
+export type PluginManifestModelCatalogProvider = ModelCatalogProvider;
+export type PluginManifestModelCatalogAlias = ModelCatalogAlias;
+export type PluginManifestModelCatalogSuppression = ModelCatalogSuppression;
+export type PluginManifestModelCatalog = ModelCatalog;
 
 export type PluginManifestProviderEndpoint = {
   /**
@@ -416,30 +373,6 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
-function isSafeManifestRecordKey(key: string): boolean {
-  return key !== "__proto__" && key !== "constructor" && key !== "prototype";
-}
-
-function normalizeSafeRecordKey(value: unknown): string {
-  const key = normalizeOptionalString(value) ?? "";
-  return key && isSafeManifestRecordKey(key) ? key : "";
-}
-
-function normalizeStringMap(value: unknown): Record<string, string> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const normalized: Record<string, string> = {};
-  for (const [rawKey, rawValue] of Object.entries(value)) {
-    const key = normalizeSafeRecordKey(rawKey);
-    const strValue = normalizeOptionalString(rawValue) ?? "";
-    if (key && strValue) {
-      normalized[key] = strValue;
-    }
-  }
-  return Object.keys(normalized).length > 0 ? normalized : undefined;
-}
-
 const MEDIA_UNDERSTANDING_CAPABILITIES = new Set(["image", "audio", "video"]);
 
 function normalizeMediaUnderstandingCapabilityRecord(
@@ -671,350 +604,6 @@ function normalizeManifestModelSupport(value: unknown): PluginManifestModelSuppo
   } satisfies PluginManifestModelSupport;
 
   return Object.keys(modelSupport).length > 0 ? modelSupport : undefined;
-}
-
-const MODEL_CATALOG_INPUTS = new Set(["text", "image", "document"]);
-const MODEL_CATALOG_DISCOVERY_MODES = new Set(["static", "refreshable", "runtime"]);
-const MODEL_CATALOG_STATUSES = new Set(["available", "preview", "deprecated", "disabled"]);
-const MODEL_CATALOG_APIS = new Set<string>(MODEL_APIS);
-
-function normalizeModelCatalogApi(value: unknown): ModelApi | undefined {
-  const api = normalizeOptionalString(value) ?? "";
-  return MODEL_CATALOG_APIS.has(api) ? (api as ModelApi) : undefined;
-}
-
-function normalizeModelCatalogInputs(
-  value: unknown,
-): PluginManifestModelCatalogInput[] | undefined {
-  const inputs = normalizeTrimmedStringList(value).filter(
-    (input): input is PluginManifestModelCatalogInput => MODEL_CATALOG_INPUTS.has(input),
-  );
-  return inputs.length > 0 ? inputs : undefined;
-}
-
-function normalizeModelCatalogNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
-}
-
-function normalizeModelCatalogPositiveNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
-}
-
-function normalizeModelCatalogPositiveInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
-}
-
-function normalizeModelCatalogTieredCost(
-  value: unknown,
-): PluginManifestModelCatalogTieredCost[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const normalized: PluginManifestModelCatalogTieredCost[] = [];
-  for (const entry of value) {
-    if (!isRecord(entry)) {
-      continue;
-    }
-    const input = normalizeModelCatalogNumber(entry.input);
-    const output = normalizeModelCatalogNumber(entry.output);
-    const cacheRead = normalizeModelCatalogNumber(entry.cacheRead);
-    const cacheWrite = normalizeModelCatalogNumber(entry.cacheWrite);
-    if (
-      input === undefined ||
-      output === undefined ||
-      cacheRead === undefined ||
-      cacheWrite === undefined ||
-      !Array.isArray(entry.range)
-    ) {
-      continue;
-    }
-    if (entry.range.length < 1 || entry.range.length > 2) {
-      continue;
-    }
-    const rangeValues = entry.range.map((rangeValue) => normalizeModelCatalogNumber(rangeValue));
-    if (rangeValues.some((rangeValue) => rangeValue === undefined)) {
-      continue;
-    }
-    const range =
-      rangeValues.length === 1
-        ? ([rangeValues[0]] as [number])
-        : ([rangeValues[0], rangeValues[1]] as [number, number]);
-    if (!range) {
-      continue;
-    }
-    normalized.push({
-      input,
-      output,
-      cacheRead,
-      cacheWrite,
-      range,
-    });
-  }
-  return normalized.length > 0 ? normalized : undefined;
-}
-
-function normalizeModelCatalogCost(value: unknown): PluginManifestModelCatalogCost | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const input = normalizeModelCatalogNumber(value.input);
-  const output = normalizeModelCatalogNumber(value.output);
-  const cacheRead = normalizeModelCatalogNumber(value.cacheRead);
-  const cacheWrite = normalizeModelCatalogNumber(value.cacheWrite);
-  const tieredPricing = normalizeModelCatalogTieredCost(value.tieredPricing);
-  const cost = {
-    ...(input !== undefined ? { input } : {}),
-    ...(output !== undefined ? { output } : {}),
-    ...(cacheRead !== undefined ? { cacheRead } : {}),
-    ...(cacheWrite !== undefined ? { cacheWrite } : {}),
-    ...(tieredPricing ? { tieredPricing } : {}),
-  } satisfies PluginManifestModelCatalogCost;
-  return Object.keys(cost).length > 0 ? cost : undefined;
-}
-
-function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const compat: Record<string, unknown> = {};
-  const booleanFields = [
-    "supportsStore",
-    "supportsPromptCacheKey",
-    "supportsDeveloperRole",
-    "supportsReasoningEffort",
-    "supportsUsageInStreaming",
-    "supportsTools",
-    "supportsStrictMode",
-    "requiresStringContent",
-    "requiresToolResultName",
-    "requiresAssistantAfterToolResult",
-    "requiresThinkingAsText",
-    "nativeWebSearchTool",
-    "requiresMistralToolIds",
-    "requiresOpenAiAnthropicToolPayload",
-  ] as const;
-  for (const field of booleanFields) {
-    if (typeof value[field] === "boolean") {
-      compat[field] = value[field];
-    }
-  }
-
-  const stringFields = ["toolSchemaProfile", "toolCallArgumentsEncoding"] as const;
-  for (const field of stringFields) {
-    const normalized = normalizeOptionalString(value[field]) ?? "";
-    if (normalized) {
-      compat[field] = normalized;
-    }
-  }
-
-  const stringListFields = [
-    "visibleReasoningDetailTypes",
-    "supportedReasoningEfforts",
-    "unsupportedToolSchemaKeywords",
-  ] as const;
-  for (const field of stringListFields) {
-    const normalized = normalizeTrimmedStringList(value[field]);
-    if (normalized.length > 0) {
-      compat[field] = normalized;
-    }
-  }
-
-  const maxTokensField = normalizeOptionalString(value.maxTokensField) ?? "";
-  if (maxTokensField === "max_completion_tokens" || maxTokensField === "max_tokens") {
-    compat.maxTokensField = maxTokensField;
-  }
-
-  const thinkingFormat = normalizeOptionalString(value.thinkingFormat) ?? "";
-  if (
-    thinkingFormat === "openai" ||
-    thinkingFormat === "openrouter" ||
-    thinkingFormat === "deepseek" ||
-    thinkingFormat === "zai" ||
-    thinkingFormat === "qwen" ||
-    thinkingFormat === "qwen-chat-template"
-  ) {
-    compat.thinkingFormat = thinkingFormat;
-  }
-
-  return Object.keys(compat).length > 0 ? (compat as ModelCompatConfig) : undefined;
-}
-
-function normalizeModelCatalogStatus(value: unknown): PluginManifestModelCatalogStatus | undefined {
-  const status = normalizeOptionalString(value) ?? "";
-  return MODEL_CATALOG_STATUSES.has(status)
-    ? (status as PluginManifestModelCatalogStatus)
-    : undefined;
-}
-
-function normalizeModelCatalogModel(value: unknown): PluginManifestModelCatalogModel | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const id = normalizeOptionalString(value.id) ?? "";
-  if (!id) {
-    return undefined;
-  }
-  const name = normalizeOptionalString(value.name) ?? "";
-  const api = normalizeModelCatalogApi(value.api);
-  const baseUrl = normalizeOptionalString(value.baseUrl) ?? "";
-  const headers = normalizeStringMap(value.headers);
-  const input = normalizeModelCatalogInputs(value.input);
-  const reasoning = typeof value.reasoning === "boolean" ? value.reasoning : undefined;
-  const contextWindow = normalizeModelCatalogPositiveNumber(value.contextWindow);
-  const contextTokens = normalizeModelCatalogPositiveInteger(value.contextTokens);
-  const maxTokens = normalizeModelCatalogPositiveNumber(value.maxTokens);
-  const cost = normalizeModelCatalogCost(value.cost);
-  const compat = normalizeModelCatalogCompat(value.compat);
-  const status = normalizeModelCatalogStatus(value.status);
-  const statusReason = normalizeOptionalString(value.statusReason) ?? "";
-  const replaces = normalizeTrimmedStringList(value.replaces);
-  const replacedBy = normalizeOptionalString(value.replacedBy) ?? "";
-  const tags = normalizeTrimmedStringList(value.tags);
-  return {
-    id,
-    ...(name ? { name } : {}),
-    ...(api ? { api } : {}),
-    ...(baseUrl ? { baseUrl } : {}),
-    ...(headers ? { headers } : {}),
-    ...(input ? { input } : {}),
-    ...(reasoning !== undefined ? { reasoning } : {}),
-    ...(contextWindow !== undefined ? { contextWindow } : {}),
-    ...(contextTokens !== undefined ? { contextTokens } : {}),
-    ...(maxTokens !== undefined ? { maxTokens } : {}),
-    ...(cost ? { cost } : {}),
-    ...(compat ? { compat } : {}),
-    ...(status ? { status } : {}),
-    ...(statusReason ? { statusReason } : {}),
-    ...(replaces.length > 0 ? { replaces } : {}),
-    ...(replacedBy ? { replacedBy } : {}),
-    ...(tags.length > 0 ? { tags } : {}),
-  };
-}
-
-function normalizeModelCatalogProviders(
-  value: unknown,
-  ownedProviders: ReadonlySet<string>,
-): Record<string, PluginManifestModelCatalogProvider> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const providers: Record<string, PluginManifestModelCatalogProvider> = {};
-  for (const [rawProviderId, rawProvider] of Object.entries(value)) {
-    const providerId = normalizeSafeRecordKey(rawProviderId);
-    if (!providerId || !ownedProviders.has(providerId) || !isRecord(rawProvider)) {
-      continue;
-    }
-    const models = Array.isArray(rawProvider.models)
-      ? rawProvider.models
-          .map((entry) => normalizeModelCatalogModel(entry))
-          .filter((entry): entry is PluginManifestModelCatalogModel => Boolean(entry))
-      : [];
-    if (models.length === 0) {
-      continue;
-    }
-    const baseUrl = normalizeOptionalString(rawProvider.baseUrl) ?? "";
-    const api = normalizeModelCatalogApi(rawProvider.api);
-    const headers = normalizeStringMap(rawProvider.headers);
-    providers[providerId] = {
-      ...(baseUrl ? { baseUrl } : {}),
-      ...(api ? { api } : {}),
-      ...(headers ? { headers } : {}),
-      models,
-    };
-  }
-  return Object.keys(providers).length > 0 ? providers : undefined;
-}
-
-function normalizeModelCatalogAliases(
-  value: unknown,
-  ownedProviders: ReadonlySet<string>,
-): Record<string, PluginManifestModelCatalogAlias> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const aliases: Record<string, PluginManifestModelCatalogAlias> = {};
-  for (const [rawAlias, rawTarget] of Object.entries(value)) {
-    const alias = normalizeSafeRecordKey(rawAlias);
-    if (!alias || !isRecord(rawTarget)) {
-      continue;
-    }
-    const provider = normalizeOptionalString(rawTarget.provider) ?? "";
-    if (!provider || !ownedProviders.has(provider)) {
-      continue;
-    }
-    const api = normalizeModelCatalogApi(rawTarget.api);
-    const baseUrl = normalizeOptionalString(rawTarget.baseUrl) ?? "";
-    aliases[alias] = {
-      provider,
-      ...(api ? { api } : {}),
-      ...(baseUrl ? { baseUrl } : {}),
-    };
-  }
-  return Object.keys(aliases).length > 0 ? aliases : undefined;
-}
-
-function normalizeModelCatalogSuppressions(
-  value: unknown,
-): PluginManifestModelCatalogSuppression[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const suppressions: PluginManifestModelCatalogSuppression[] = [];
-  for (const entry of value) {
-    if (!isRecord(entry)) {
-      continue;
-    }
-    const provider = normalizeOptionalString(entry.provider) ?? "";
-    const model = normalizeOptionalString(entry.model) ?? "";
-    if (!provider || !model) {
-      continue;
-    }
-    const reason = normalizeOptionalString(entry.reason) ?? "";
-    suppressions.push({
-      provider,
-      model,
-      ...(reason ? { reason } : {}),
-    });
-  }
-  return suppressions.length > 0 ? suppressions : undefined;
-}
-
-function normalizeModelCatalogDiscovery(
-  value: unknown,
-  ownedProviders: ReadonlySet<string>,
-): Record<string, PluginManifestModelCatalogDiscovery> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const discovery: Record<string, PluginManifestModelCatalogDiscovery> = {};
-  for (const [rawProviderId, rawMode] of Object.entries(value)) {
-    const providerId = normalizeSafeRecordKey(rawProviderId);
-    const mode = normalizeOptionalString(rawMode) ?? "";
-    if (providerId && ownedProviders.has(providerId) && MODEL_CATALOG_DISCOVERY_MODES.has(mode)) {
-      discovery[providerId] = mode as PluginManifestModelCatalogDiscovery;
-    }
-  }
-  return Object.keys(discovery).length > 0 ? discovery : undefined;
-}
-
-function normalizeManifestModelCatalog(
-  value: unknown,
-  ownedProviders: ReadonlySet<string>,
-): PluginManifestModelCatalog | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const providers = normalizeModelCatalogProviders(value.providers, ownedProviders);
-  const aliases = normalizeModelCatalogAliases(value.aliases, ownedProviders);
-  const suppressions = normalizeModelCatalogSuppressions(value.suppressions);
-  const discovery = normalizeModelCatalogDiscovery(value.discovery, ownedProviders);
-  const modelCatalog = {
-    ...(providers ? { providers } : {}),
-    ...(aliases ? { aliases } : {}),
-    ...(suppressions ? { suppressions } : {}),
-    ...(discovery ? { discovery } : {}),
-  } satisfies PluginManifestModelCatalog;
-  return Object.keys(modelCatalog).length > 0 ? modelCatalog : undefined;
 }
 
 function normalizeManifestProviderEndpoints(
@@ -1326,7 +915,9 @@ export function loadPluginManifest(
   const providers = normalizeTrimmedStringList(raw.providers);
   const providerDiscoveryEntry = normalizeOptionalString(raw.providerDiscoveryEntry);
   const modelSupport = normalizeManifestModelSupport(raw.modelSupport);
-  const modelCatalog = normalizeManifestModelCatalog(raw.modelCatalog, new Set(providers));
+  const modelCatalog = normalizeModelCatalog(raw.modelCatalog, {
+    ownedProviders: new Set(providers),
+  });
   const providerEndpoints = normalizeManifestProviderEndpoints(raw.providerEndpoints);
   const cliBackends = normalizeTrimmedStringList(raw.cliBackends);
   const syntheticAuthRefs = normalizeTrimmedStringList(raw.syntheticAuthRefs);


### PR DESCRIPTION
This PR is the next slice after #71342 in the manifest model catalog work. It creates a dedicated `src/model-catalog` component and moves catalog semantics out of the plugin manifest loader.

This does not change `models list`, onboarding, configure, provider loading, cache behavior, or runtime refresh behavior.

What changed:
- Added `src/model-catalog/types.ts` as the canonical home for model catalog types.
- Added `src/model-catalog/refs.ts` for stable model refs and merge keys.
- Added `src/model-catalog/normalize.ts` for catalog validation and normalization.
- Added `src/model-catalog/index.ts` as the deliberate export surface.
- Updated `src/plugins/manifest.ts` so manifest model catalog types are aliases to the shared catalog types.
- Updated manifest parsing to delegate `modelCatalog` normalization to `normalizeModelCatalog(...)`.
- Added focused tests for the shared normalizer.

Why:
- #71342 added `modelCatalog` to plugin manifests.
- Without this PR, catalog semantics would stay inside `src/plugins/manifest.ts`, then get copied again into Provider Index, cache, onboarding, and `models list`.
- This PR makes `src/model-catalog` the single owner of catalog shape, validation, refs, and row normalization before later PRs start consuming catalog data.

Contract behavior kept:
- Provider catalog rows are scoped to owned providers.
- Alias targets must be owned providers.
- Suppressions remain cross-provider.
- Invalid APIs, input modalities, discovery modes, status values, token fields, pricing tiers, and compat fields are filtered consistently.
- Provider defaults merge into normalized rows, with model-level overrides.
- `document` input is preserved.
- Stable row identifiers are available through `ref` and `mergeKey`.

Verification:
- `pnpm test src/model-catalog/normalize.test.ts`
- `pnpm test src/plugins/manifest-registry.test.ts`
- `pnpm check:changed`
