### PR TITLE
fix: respect NO_PROXY in browser navigation SSRF guard

### DIFF
--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -3,8 +3,7 @@ import {
   matchesHostnameAllowlist,
   normalizeHostname,
 } from "openclaw/plugin-sdk/browser-security-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
+import { hasProxyEnvConfigured, matchesNoProxy } from "../infra/net/proxy-env.js";
 import {
   isPrivateNetworkAllowedByPolicy,
   resolvePinnedHostnameWithPolicy,
@@ -18,6 +17,10 @@ const SAFE_NON_NETWORK_URLS = new Set(["about:blank"]);
 function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
   // Keep non-network navigation explicit; about:blank is the only allowed bootstrap URL.
   return SAFE_NON_NETWORK_URLS.has(parsed.href);
+}
+
+function normalizeNavigationUrl(url: string): string {
+  return url.trim();
 }
 
 export class InvalidBrowserNavigationUrlError extends Error {
@@ -85,7 +88,7 @@ export async function assertBrowserNavigationAllowed(
     lookupFn?: LookupFn;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
-  const rawUrl = normalizeOptionalString(opts.url) ?? "";
+  const rawUrl = normalizeNavigationUrl(opts.url);
   if (!rawUrl) {
     throw new InvalidBrowserNavigationUrlError("url is required");
   }
@@ -108,11 +111,18 @@ export async function assertBrowserNavigationAllowed(
 
   // Browser network stacks may apply env proxy routing at connect-time, which
   // can bypass strict destination-binding intent from pre-navigation DNS checks.
-  // In strict mode, fail closed unless private-network navigation is explicitly
-  // enabled by policy.
-  if (hasProxyEnvConfigured() && !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy)) {
+  // In strict mode, fail closed unless:
+  //   1. Private-network navigation is explicitly enabled by policy, OR
+  //   2. The target URL matches NO_PROXY, meaning the proxy will not be used
+  //      for this request and SSRF checks remain enforceable.
+  if (
+    hasProxyEnvConfigured() &&
+    !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&
+    !matchesNoProxy(rawUrl)
+  ) {
     throw new InvalidBrowserNavigationUrlError(
-      "Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set",
+      "Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set. " +
+        "Set NO_PROXY to bypass the proxy for browser targets, or set browser.ssrfPolicy.dangerouslyAllowPrivateNetwork to true.",
     );
   }
 
@@ -150,7 +160,7 @@ export async function assertBrowserNavigationResultAllowed(
     lookupFn?: LookupFn;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
-  const rawUrl = normalizeOptionalString(opts.url) ?? "";
+  const rawUrl = normalizeNavigationUrl(opts.url);
   if (!rawUrl) {
     return;
   }

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -115,6 +115,16 @@ export async function assertBrowserNavigationAllowed(
   //   1. Private-network navigation is explicitly enabled by policy, OR
   //   2. The target URL matches NO_PROXY, meaning the proxy will not be used
   //      for this request and SSRF checks remain enforceable.
+  //
+  // Security note: matchesNoProxy mirrors undici's EnvHttpProxyAgent semantics.
+  // Chromium has its own NO_PROXY parser which may diverge on edge cases (e.g.
+  // leading-dot handling, wildcard syntax, IPv6 bracket forms). In the unlikely
+  // event Chromium's bypass logic is stricter than undici's (i.e. Chromium still
+  // routes through the proxy for a URL that matchesNoProxy considers bypassed),
+  // the SSRF gap could theoretically reopen. In practice, the overlap is high
+  // for common patterns (*, hostname, .domain, IP:port) and the
+  // resolvePinnedHostnameWithPolicy check below provides a secondary guard
+  // against private-IP destinations after Node-side DNS resolution.
   if (
     hasProxyEnvConfigured() &&
     !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&

--- a/extensions/browser/src/infra/net/proxy-env.ts
+++ b/extensions/browser/src/infra/net/proxy-env.ts
@@ -1,1 +1,1 @@
-export { hasProxyEnvConfigured } from "openclaw/plugin-sdk/browser-security-runtime";
+export { hasProxyEnvConfigured, matchesNoProxy } from "openclaw/plugin-sdk/browser-security-runtime";

--- a/src/plugin-sdk/browser-security-runtime.ts
+++ b/src/plugin-sdk/browser-security-runtime.ts
@@ -5,7 +5,7 @@ export {
   openFileWithinRoot,
   writeFileFromPathWithinRoot,
 } from "../infra/fs-safe.js";
-export { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
+export { hasProxyEnvConfigured, matchesNoProxy } from "../infra/net/proxy-env.js";
 export {
   SsrFBlockedError,
   isBlockedHostnameOrIp,


### PR DESCRIPTION
## Summary

Browser navigation is blocked with "strict browser SSRF policy cannot be enforced while env proxy variables are set" when `HTTP_PROXY`/`HTTPS_PROXY` are configured in the gateway environment — even for normal public URLs that don't go through the proxy.

## Root Cause

The navigation guard in `assertBrowserNavigationAllowed()` checks `hasProxyEnvConfigured()` as a blanket block. When proxy env vars exist and `dangerouslyAllowPrivateNetwork` isn't enabled, **all** browser navigation is rejected. The guard doesn't consider `NO_PROXY`, which tells the network stack to bypass the proxy for matching URLs.

## Fix

1. Export `matchesNoProxy` from `plugin-sdk/browser-security-runtime` (already implemented in `src/infra/net/proxy-env.ts`)
2. Re-export it in the browser extension's `proxy-env.ts`
3. In the navigation guard, add a `!matchesNoProxy(url)` check: if the target URL matches `NO_PROXY`, the proxy won't route that traffic, so SSRF IP-based checks remain enforceable

## Workaround for users

Users can now add browser targets to `NO_PROXY`:

```bash
export NO_PROXY="localhost,127.0.0.1,docs.openclaw.ai"
```

Or use `*` to bypass proxy for all browser traffic while keeping it for provider requests (which use their own fetch path).

## Error message improvement

Updated the error message to suggest `NO_PROXY` as a fix:

> Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set. Set NO_PROXY to bypass the proxy for browser targets, or set browser.ssrfPolicy.dangerouslyAllowPrivateNetwork to true.

Fixes #71358