### PR TITLE
fix: enable incomplete-turn recovery for Gemini turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Gemini: retry reasoning-only, empty, and planning-only Gemini turns instead of letting sessions silently stall. Fixes #71074. (#71362) Thanks @neeravmakwana.
 - Exec approvals: allow bare command-name allowlist patterns to match PATH-resolved executable basenames without trusting `./tool` or absolute path-selected binaries. Fixes #71315. Thanks @chen-zhang-cs-code and @dengluozhang.
 - Config/recovery: skip whole-file last-known-good rollback when invalidity is scoped to `plugins.entries.*`, preserving unrelated user settings during plugin schema or host-version skew. Fixes #71289. Thanks @jalehman.
 - Agents/tools: keep resolved reply-run configs from being overwritten by stale runtime snapshots, and let empty web runtime metadata fall back to configured provider auto-detection so standard and queued turns expose the same tool set. Fixes #71355. Thanks @c-g14.

--- a/src/agents/execution-contract.ts
+++ b/src/agents/execution-contract.ts
@@ -14,7 +14,7 @@ import { resolveAgentExecutionContract, resolveSessionAgentIds } from "./agent-s
  * bare names. The adversarial review in #64227 flagged this as a quality
  * gap on completion-gate criterion 1.
  */
-function stripProviderPrefix(modelId: string): string {
+export function stripProviderPrefix(modelId: string): string {
   const normalizedModelId = modelId.trim();
   const match = /^([^/:]+)[/:](.+)$/.exec(normalizedModelId);
   return (match?.[2] ?? normalizedModelId).toLowerCase();

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -735,6 +735,33 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
+  it("detects reasoning-only Gemini turns from signed thinking blocks", () => {
+    const retryInstruction = resolveReasoningOnlyRetryInstruction({
+      provider: "google",
+      modelId: "gemini-2.5-pro",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "google",
+          model: "gemini-2.5-pro",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({ id: "gemini_rs_helper", type: "reasoning" }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+  });
+
   it("treats exact NO_REPLY as a deliberate silent assistant reply", () => {
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
       payloadCount: 0,
@@ -916,6 +943,28 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
   });
 
+  it("detects generic empty Gemini turns without visible text", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "google-vertex",
+      modelId: "google/gemini-3.1-flash",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "google-vertex",
+          model: "gemini-3.1-flash",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
   it("does not retry generic empty GPT turns after side effects", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "openai",
@@ -983,6 +1032,21 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toBeUndefined();
     expect(result.meta.livenessState).toBe("working");
+  });
+
+  it("detects replay-safe planning-only Gemini turns", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "google-gemini-cli",
+      modelId: "gemini-3.1-pro",
+      prompt: "Please inspect the code, make the change, and run the checks.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
+      }),
+    });
+
+    expect(retryInstruction).toContain("Do not restate the plan");
   });
 
   it("does not misclassify a direct answer that says 'i'm not going to' as planning-only", () => {

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -2,7 +2,10 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import type { EmbeddedPiExecutionContract } from "../../../config/types.agent-defaults.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
-import { isStrictAgenticSupportedProviderModel } from "../../execution-contract.js";
+import {
+  isStrictAgenticSupportedProviderModel,
+  stripProviderPrefix,
+} from "../../execution-contract.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 import { assessLastAssistantMessage } from "../thinking.js";
 import type { EmbeddedRunLivenessState } from "../types.js";
@@ -83,7 +86,7 @@ const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google-antigravity",
   "google-gemini-cli",
 ]);
-const GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN = /^gemini(?:[.-]|$)/i;
+const GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN = /^gemini(?:[.-]|$)/;
 const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
 const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2;
 // Allow one immediate continuation plus one follow-up continuation before
@@ -405,12 +408,6 @@ function shouldApplyPlanningOnlyRetryGuard(params: {
     provider: params.provider,
     modelId: params.modelId,
   });
-}
-
-function stripProviderPrefix(modelId: string): string {
-  const normalizedModelId = modelId.trim();
-  const match = /^([^/:]+)[/:](.+)$/.exec(normalizedModelId);
-  return (match?.[2] ?? normalizedModelId).toLowerCase();
 }
 
 function isIncompleteTurnRecoverySupportedProviderModel(params: {

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -77,6 +77,13 @@ const SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES = new Set([
   "glob",
   "ls",
 ]);
+const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
+  "google",
+  "google-vertex",
+  "google-antigravity",
+  "google-gemini-cli",
+]);
+const GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN = /^gemini(?:[.-]|$)/i;
 const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
 const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2;
 // Allow one immediate continuation plus one follow-up continuation before
@@ -394,10 +401,36 @@ function shouldApplyPlanningOnlyRetryGuard(params: {
   if (params.executionContract === "strict-agentic") {
     return true;
   }
-  return isStrictAgenticSupportedProviderModel({
+  return isIncompleteTurnRecoverySupportedProviderModel({
     provider: params.provider,
     modelId: params.modelId,
   });
+}
+
+function stripProviderPrefix(modelId: string): string {
+  const normalizedModelId = modelId.trim();
+  const match = /^([^/:]+)[/:](.+)$/.exec(normalizedModelId);
+  return (match?.[2] ?? normalizedModelId).toLowerCase();
+}
+
+function isIncompleteTurnRecoverySupportedProviderModel(params: {
+  provider?: string;
+  modelId?: string;
+}): boolean {
+  if (
+    isStrictAgenticSupportedProviderModel({
+      provider: params.provider,
+      modelId: params.modelId,
+    })
+  ) {
+    return true;
+  }
+  const provider = normalizeLowercaseStringOrEmpty(params.provider ?? "");
+  if (!GEMINI_INCOMPLETE_TURN_PROVIDER_IDS.has(provider)) {
+    return false;
+  }
+  const modelId = typeof params.modelId === "string" ? params.modelId : "";
+  return GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN.test(stripProviderPrefix(modelId));
 }
 
 function normalizeAckPrompt(text: string): string {


### PR DESCRIPTION
Fixes #71074.

## Root cause
`resolvePlanningOnlyRetryInstruction`, `resolveReasoningOnlyRetryInstruction`, and `resolveEmptyResponseRetryInstruction` all depended on a guard that only recognized strict-agentic GPT-5 OpenAI lanes. Gemini provider/model pairs were excluded, so reasoning-only, empty-response, and planning-only Gemini turns could terminate silently without the retry nudge path.

## What changed
- Added a dedicated incomplete-turn support guard in `run/incomplete-turn.ts` that keeps existing strict-agentic support and additionally allows Gemini lanes for:
  - `google`
  - `google-vertex`
  - `google-antigravity`
  - `google-gemini-cli`
- Gemini matching is runtime-enforced by provider + model id (`gemini*`, including prefixed ids like `google/gemini-3.1-flash`).
- Wired the guard into the existing incomplete-turn retry and ack fast-path entry points without changing strict-agentic contract activation.
- Added targeted regression tests for Gemini reasoning-only, empty-response, and planning-only retry detection.

## Why this is safe
- Scope is narrow: only incomplete-turn retry eligibility changes.
- Existing strict-agentic contract defaults and execution contract resolution remain unchanged.
- Non-matching providers/models still follow existing behavior.
- Replay-safety and side-effect checks are unchanged; retries are still blocked after mutating/side-effect activity.

## Security/runtime controls unchanged
- No auth, permission, or transport policy changes.
- No change to strict-agentic enforcement criteria.
- No change to side-effect/replay invalidation controls.
- No behavior depends only on prompt wording; provider/model eligibility remains runtime-checked.

## Focused self-review
- Verified test helper defaults still align with production defaults for the touched path (retry limits and guard behavior unchanged outside Gemini eligibility).
- Verified no config default changes were introduced, so docs/help/generated artifacts do not need updates.
- Verified the new behavior is runtime-gated by provider/model checks rather than prompt text.

## Tests run
- `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- `pnpm check:changed`

## AI assistance
- AI-assisted implementation and review; all changes were manually validated with the commands above.

Made with [Cursor](https://cursor.com)