### PR TITLE
fix(reply-media): allow managed outbound paths during sandbox reply normalization

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -300,6 +300,29 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
+  it("keeps managed outbound media under the shared media root even with sandbox mapping", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/generated.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/generated.png",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/generated.png"],
+    });
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
   it("drops host-local media when shared outbound attachment policy rejects it", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
       new Error("Local media path is not under an allowed directory"),

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -282,6 +282,10 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("keeps managed generated media under the shared media root", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
     vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -159,6 +159,9 @@ export function createReplyMediaPathNormalizer(params: {
     if (!media) {
       return media;
     }
+    if (path.isAbsolute(media) && isManagedGlobalReplyMediaPath(media)) {
+      return media;
+    }
     assertMediaNotDataUrl(media);
     if (isPassThroughRemoteMediaSource(media)) {
       return media;


### PR DESCRIPTION
Fixes #71138

## Root cause
- Reply media normalization resolves local paths through sandbox mapping when a sandbox workspace is present.
- Managed outbound media files are staged under the shared state root (`.../media/outbound/...`), which is intentionally outside the sandbox workspace.
- Because sandbox remapping ran before managed-path detection, these already-staged files could be rejected with `Path escapes sandbox root` and dropped.

## What changed
- Added an early guard in `createReplyMediaPathNormalizer` to preserve absolute managed global media paths before sandbox remapping.
- Added regression coverage for the sandbox-present scenario to ensure managed outbound media paths are preserved.

## Why this is safe
- The change only short-circuits paths already recognized by the existing managed-path policy (`media/outbound` and `media/tool-*` under the configured shared media root).
- No new path classes are allowed; untrusted/local paths still follow the existing sandbox and outbound media access checks.

## Security/runtime controls unchanged
- Sandbox path validation for non-managed paths remains unchanged.
- Host-local MEDIA file URL blocking remains unchanged.
- Agent-scoped outbound media access policy and root enforcement remain unchanged.

## Tests run
- `pnpm test src/auto-reply/reply/reply-media-paths.test.ts`
- `pnpm test extensions/telegram/src/outbound-adapter.test.ts`

Made with [Cursor](https://cursor.com)