### PR TITLE
perf(cli): trim gateway status startup work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Google Meet: let realtime Meet sessions consult the full OpenClaw agent for deeper answers while staying in the live voice loop. Thanks @steipete.
 - Gateway/VoiceClaw: add a realtime brain WebSocket endpoint backed by Gemini Live, with owner-auth gating and async OpenClaw tool handoff. (#70938) Thanks @yagudaev.
 - Providers/DeepSeek: add DeepSeek V4 Flash and V4 Pro to the bundled catalog and make V4 Flash the onboarding default. Thanks @lsdsjy.
+- CLI/Gateway: make `gateway status` start faster by skipping plugin loading on the read-only status path. (#71364) Thanks @andyylin.
 
 ### Fixes
 

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -57,10 +57,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     exact: true,
     policy: {
       routeConfigGuard: "always",
-      // `gateway status` is a built-in daemon/RPC health path. Loading the
-      // full plugin registry here eagerly scans and validates every channel
-      // plugin before the command can even connect to the already-running
-      // gateway, which makes this frequently-used status check painfully slow.
       loadPlugins: "never",
     },
     route: { id: "gateway-status" },

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -55,7 +55,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["gateway", "status"],
     exact: true,
-    policy: { routeConfigGuard: "always" },
+    policy: {
+      routeConfigGuard: "always",
+      // `gateway status` is a built-in daemon/RPC health path. Loading the
+      // full plugin registry here eagerly scans and validates every channel
+      // plugin before the command can even connect to the already-running
+      // gateway, which makes this frequently-used status check painfully slow.
+      loadPlugins: "never",
+    },
     route: { id: "gateway-status" },
   },
   {

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -43,7 +43,7 @@ export async function probeGatewayStatus(opts: {
       },
       async () => {
         const { probeGateway } = await loadProbeGatewayModule();
-        const probe = await probeGateway({
+        const probeOpts = {
           url: opts.url,
           auth: {
             token: opts.token,
@@ -51,13 +51,26 @@ export async function probeGatewayStatus(opts: {
           },
           tlsFingerprint: opts.tlsFingerprint,
           timeoutMs: opts.timeoutMs,
-          includeDetails: opts.requireRpc === true,
-          detailLevel: opts.requireRpc === true ? "full" : "none",
-        });
-        return probe;
+          includeDetails: false,
+        };
+        if (opts.requireRpc) {
+          const { callGateway } = await import("../../gateway/call.js");
+          await callGateway({
+            url: opts.url,
+            token: opts.token,
+            password: opts.password,
+            tlsFingerprint: opts.tlsFingerprint,
+            method: "status",
+            timeoutMs: opts.timeoutMs,
+            ...(opts.configPath ? { configPath: opts.configPath } : {}),
+          });
+          const authProbe = await probeGateway(probeOpts).catch(() => null);
+          return { ok: true as const, authProbe };
+        }
+        return await probeGateway(probeOpts);
       },
     );
-    const auth = result.auth;
+    const auth = "auth" in result ? result.auth : result.authProbe?.auth;
     if (result.ok) {
       return {
         ok: true,
@@ -66,9 +79,7 @@ export async function probeGatewayStatus(opts: {
           kind === "read"
             ? auth?.capability && auth.capability !== "unknown"
               ? auth.capability
-              : // A successful detailed probe performs read RPCs, so it proves read access
-                // even when hello metadata cannot recover richer scope metadata.
-                "read_only"
+              : "read_only"
             : auth?.capability,
         auth,
       } as const;

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -42,32 +42,8 @@ export async function probeGatewayStatus(opts: {
         enabled: opts.json !== true,
       },
       async () => {
-        if (opts.requireRpc) {
-          const { callGateway } = await import("../../gateway/call.js");
-          await callGateway({
-            url: opts.url,
-            token: opts.token,
-            password: opts.password,
-            tlsFingerprint: opts.tlsFingerprint,
-            method: "status",
-            timeoutMs: opts.timeoutMs,
-            ...(opts.configPath ? { configPath: opts.configPath } : {}),
-          });
-          const { probeGateway } = await loadProbeGatewayModule();
-          const authProbe = await probeGateway({
-            url: opts.url,
-            auth: {
-              token: opts.token,
-              password: opts.password,
-            },
-            tlsFingerprint: opts.tlsFingerprint,
-            timeoutMs: opts.timeoutMs,
-            includeDetails: false,
-          }).catch(() => null);
-          return { ok: true as const, authProbe };
-        }
         const { probeGateway } = await loadProbeGatewayModule();
-        return await probeGateway({
+        const probe = await probeGateway({
           url: opts.url,
           auth: {
             token: opts.token,
@@ -75,12 +51,13 @@ export async function probeGatewayStatus(opts: {
           },
           tlsFingerprint: opts.tlsFingerprint,
           timeoutMs: opts.timeoutMs,
-          includeDetails: false,
+          includeDetails: opts.requireRpc === true,
+          detailLevel: opts.requireRpc === true ? "full" : "none",
         });
+        return probe;
       },
     );
-    const auth =
-      "auth" in result ? result.auth : "authProbe" in result ? result.authProbe?.auth : undefined;
+    const auth = result.auth;
     if (result.ok) {
       return {
         ok: true,
@@ -89,8 +66,8 @@ export async function probeGatewayStatus(opts: {
           kind === "read"
             ? auth?.capability && auth.capability !== "unknown"
               ? auth.capability
-              : // The status RPC proves read access even when a follow-up hello probe
-                // cannot recover richer scope metadata.
+              : // A successful detailed probe performs read RPCs, so it proves read access
+                // even when hello metadata cannot recover richer scope metadata.
                 "read_only"
             : auth?.capability,
         auth,

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -207,6 +207,7 @@ describe("gatherDaemonStatus", () => {
     expect(status.gateway?.probeUrl).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.url).toBe("wss://127.0.0.1:19001");
     expect(status.rpc?.ok).toBe(true);
+    expect(inspectGatewayRestart).not.toHaveBeenCalled();
   });
 
   it("forwards requireRpc and configPath to the daemon probe", async () => {
@@ -542,7 +543,12 @@ describe("gatherDaemonStatus", () => {
     expect(status.rpc).toBeUndefined();
   });
 
-  it("surfaces stale gateway listener pids from restart health inspection", async () => {
+  it("surfaces stale gateway listener pids from restart health inspection when probe fails", async () => {
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: false,
+      url: "ws://127.0.0.1:19001",
+      error: "timeout",
+    });
     inspectGatewayRestart.mockResolvedValueOnce({
       runtime: { status: "running", pid: 8000 },
       portUsage: {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -207,13 +207,18 @@ async function loadDaemonConfigContext(
     resolveStateDir(mergedDaemonEnv as NodeJS.ProcessEnv),
   );
 
-  const cliIO = createConfigIO({ env: process.env, configPath: cliConfigPath });
+  const cliIO = createConfigIO({
+    env: process.env,
+    configPath: cliConfigPath,
+    pluginValidation: "skip",
+  });
   const sharesDaemonConfigContext = !serviceEnv && cliConfigPath === daemonConfigPath;
   const daemonIO = sharesDaemonConfigContext
     ? cliIO
     : createConfigIO({
         env: mergedDaemonEnv,
         configPath: daemonConfigPath,
+        pluginValidation: "skip",
       });
 
   const cliSnapshotPromise = cliIO.readConfigFileSnapshot().catch(() => null);
@@ -444,7 +449,7 @@ export async function gatherDaemonStatus(
     rpcAuthWarning = undefined;
   }
   const health =
-    opts.probe && loaded
+    opts.probe && loaded && rpc?.ok !== true
       ? await loadRestartHealthModule()
           .then(({ inspectGatewayRestart }) =>
             inspectGatewayRestart({

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1142,7 +1142,9 @@ async function finalizeReadConfigSnapshotInternalResult(
   return result;
 }
 
-export function createConfigIO(overrides: ConfigIoDeps = {}) {
+export function createConfigIO(
+  overrides: ConfigIoDeps & { pluginValidation?: "full" | "skip" } = {},
+) {
   const deps = normalizeDeps(overrides);
   const configPath = resolveConfigPathForDeps(deps);
 
@@ -1258,7 +1260,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       if (preValidationDuplicates.length > 0) {
         throw new DuplicateAgentDirError(preValidationDuplicates);
       }
-      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, {
+        env: deps.env,
+        pluginValidation: overrides.pluginValidation,
+      });
       if (!validated.ok) {
         observeLoadConfigSnapshot({
           ...createConfigFileSnapshot({
@@ -1434,7 +1439,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const legacyResolution = resolveLegacyConfigForRead(resolvedConfigRaw, effectiveParsed);
       const effectiveConfigRaw = legacyResolution.effectiveConfigRaw;
       fallbackSourceConfig = coerceConfig(effectiveConfigRaw);
-      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, {
+        env: deps.env,
+        pluginValidation: overrides.pluginValidation,
+      });
       if (!validated.ok) {
         return await finalizeReadConfigSnapshotInternalResult(deps, {
           snapshot: createConfigFileSnapshot({

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -708,21 +708,29 @@ type ValidateConfigWithPluginsResult =
 
 export function validateConfigObjectWithPlugins(
   raw: unknown,
-  params?: { env?: NodeJS.ProcessEnv },
+  params?: { env?: NodeJS.ProcessEnv; pluginValidation?: "full" | "skip" },
 ): ValidateConfigWithPluginsResult {
-  return validateConfigObjectWithPluginsBase(raw, { applyDefaults: true, env: params?.env });
+  return validateConfigObjectWithPluginsBase(raw, {
+    applyDefaults: true,
+    env: params?.env,
+    pluginValidation: params?.pluginValidation ?? "full",
+  });
 }
 
 export function validateConfigObjectRawWithPlugins(
   raw: unknown,
-  params?: { env?: NodeJS.ProcessEnv },
+  params?: { env?: NodeJS.ProcessEnv; pluginValidation?: "full" | "skip" },
 ): ValidateConfigWithPluginsResult {
-  return validateConfigObjectWithPluginsBase(raw, { applyDefaults: false, env: params?.env });
+  return validateConfigObjectWithPluginsBase(raw, {
+    applyDefaults: false,
+    env: params?.env,
+    pluginValidation: params?.pluginValidation ?? "full",
+  });
 }
 
 function validateConfigObjectWithPluginsBase(
   raw: unknown,
-  opts: { applyDefaults: boolean; env?: NodeJS.ProcessEnv },
+  opts: { applyDefaults: boolean; env?: NodeJS.ProcessEnv; pluginValidation?: "full" | "skip" },
 ): ValidateConfigWithPluginsResult {
   const base = opts.applyDefaults ? validateConfigObject(raw) : validateConfigObjectRaw(raw);
   if (!base.ok) {
@@ -730,6 +738,14 @@ function validateConfigObjectWithPluginsBase(
   }
 
   const config = base.config;
+  if (opts.pluginValidation === "skip") {
+    return {
+      ok: true,
+      config,
+      warnings: [],
+    };
+  }
+
   const issues: ConfigValidationIssue[] = [];
   const warnings: ConfigValidationIssue[] = [];
   const hasExplicitPluginsConfig =


### PR DESCRIPTION
## Summary
- skip plugin registry/config-schema validation on the `gateway status` read-only path
- reuse the lightweight gateway probe for `--require-rpc` instead of opening a second gateway client
- avoid restart-health ownership checks when the connectivity probe already succeeded

## Verification
- `pnpm exec vitest run src/cli/command-path-policy.test.ts src/cli/route.test.ts src/cli/daemon-cli/status.gather.test.ts src/config/validation.channel-metadata.test.ts src/config/io.write-config.test.ts`
- `pnpm tsgo:core`
- `pnpm build`
- `node --import tsx scripts/bench-cli-startup.ts --case gatewayStatusJson --runs 5 --warmup 1 --json --output .artifacts/after3-gateway-status-json.json`

## Benchmark
On the rpi5 checkout with a live local gateway:
- before: `gateway status --json` avg ~5021ms / p50 ~4994ms / RSS avg ~365.6MB
- after: `gateway status --json` avg ~4172ms / p50 ~4151ms / RSS avg ~353.9MB

This is a modest but real cut (~17% avg, ~12MB RSS) without weakening config writes or full validation paths.
