### PR TITLE
fix(config): avoid plugin-local last-good rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/recovery: skip whole-file last-known-good rollback when invalidity is scoped to `plugins.entries.*`, preserving unrelated user settings during plugin schema or host-version skew. Fixes #71289. Thanks @jalehman.
 - Compaction: honor explicit `agents.defaults.compaction.keepRecentTokens` for manual `/compact`, re-distill safeguard summaries instead of snowballing previous summaries, and enable safeguard summary quality checks by default. Fixes #71357. Thanks @WhiteGiverMa.
 - Sessions: honor configured `session.maintenance` settings during load-time maintenance instead of falling back to default entry caps. Fixes #71356. Thanks @comolago.
 - Browser/sandbox: pass the resolved `browser.ssrfPolicy` into sandbox browser bridges and refresh cached bridges when the effective policy changes, so sandboxed browser navigation honors private-network opt-ins. Fixes #45153 and #57055. Thanks @jzakirov, @zuoanCo, and @kybrcore.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,7 @@ export {
 export type { ConfigWriteNotification } from "./io.js";
 export { ConfigMutationConflictError, mutateConfigFile, replaceConfigFile } from "./mutate.js";
 export * from "./paths.js";
+export * from "./recovery-policy.js";
 export * from "./runtime-overrides.js";
 export * from "./types.js";
 export {

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -347,6 +347,121 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("does not restore stale last-known-good for plugin schema evolution issues", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      const staleSnapshot = await makeSnapshot(configPath, {
+        gateway: { mode: "local" },
+        agents: { defaults: { model: "sonnet-4.6" } },
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: { compactionMode: "legacy" },
+            },
+          },
+        },
+      });
+      await expect(
+        promoteConfigSnapshotToLastKnownGood({
+          deps,
+          snapshot: staleSnapshot,
+          logger: deps.logger,
+        }),
+      ).resolves.toBe(true);
+
+      const activeConfig = {
+        gateway: { mode: "local" },
+        agents: { defaults: { model: "gpt-5.4" } },
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: { compactionMode: "adaptive", cacheAwareCompaction: true },
+            },
+          },
+        },
+      };
+      const active = await writeConfigRaw(configPath, activeConfig);
+      const restored = await recoverConfigFromLastKnownGood({
+        deps,
+        snapshot: {
+          ...staleSnapshot,
+          raw: active.raw,
+          parsed: active.parsed,
+          valid: false,
+          issues: [
+            {
+              path: "plugins.entries.lossless-claw.config.cacheAwareCompaction",
+              message: "invalid config: must NOT have additional properties",
+            },
+          ],
+        },
+        reason: "reload-invalid-config",
+      });
+
+      expect(restored).toBe(false);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(active.raw);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Config last-known-good recovery skipped"),
+      );
+    });
+  });
+
+  it("does not restore stale last-known-good for plugin minHostVersion skew issues", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath } = makeDeps(home);
+      const staleSnapshot = await makeSnapshot(configPath, {
+        gateway: { mode: "local" },
+        plugins: {
+          entries: {
+            feishu: { enabled: false },
+          },
+        },
+      });
+      await expect(
+        promoteConfigSnapshotToLastKnownGood({
+          deps,
+          snapshot: staleSnapshot,
+          logger: deps.logger,
+        }),
+      ).resolves.toBe(true);
+
+      const activeConfig = {
+        gateway: { mode: "local" },
+        agents: { defaults: { model: "gpt-5.4" } },
+        plugins: {
+          entries: {
+            feishu: { enabled: true, config: { appId: "feishu-app" } },
+            whatsapp: { enabled: true, config: { account: "primary" } },
+          },
+        },
+      };
+      const active = await writeConfigRaw(configPath, activeConfig);
+      const restored = await recoverConfigFromLastKnownGood({
+        deps,
+        snapshot: {
+          ...staleSnapshot,
+          raw: active.raw,
+          parsed: active.parsed,
+          valid: false,
+          issues: [
+            {
+              path: "plugins.entries.feishu",
+              message:
+                "plugin feishu: plugin requires OpenClaw >=2026.4.23, but this host is 2026.4.22; skipping load",
+            },
+          ],
+        },
+        reason: "reload-invalid-config",
+      });
+
+      expect(restored).toBe(false);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(active.raw);
+      expect(JSON5.parse(active.raw)).toEqual(activeConfig);
+    });
+  });
+
   it("refuses to promote redacted secret placeholders", async () => {
     await withSuiteHome(async (home) => {
       const warn = vi.fn();

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -7,6 +7,10 @@ import {
   type ConfigObserveAuditRecord,
 } from "./io.audit.js";
 import { resolveStateDir } from "./paths.js";
+import {
+  isPluginLocalInvalidConfigSnapshot,
+  shouldAttemptLastKnownGoodRecovery,
+} from "./recovery-policy.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
 export type ObserveRecoveryDeps = {
@@ -1012,6 +1016,14 @@ export async function recoverConfigFromLastKnownGood(params: {
 }): Promise<boolean> {
   const { deps, snapshot } = params;
   if (!snapshot.exists || typeof snapshot.raw !== "string") {
+    return false;
+  }
+  if (!shouldAttemptLastKnownGoodRecovery(snapshot)) {
+    if (isPluginLocalInvalidConfigSnapshot(snapshot)) {
+      deps.logger.warn(
+        `Config last-known-good recovery skipped: invalidity is scoped to plugin entries (${params.reason})`,
+      );
+    }
     return false;
   }
   const healthState = await readConfigHealthState(deps);

--- a/src/config/recovery-policy.test.ts
+++ b/src/config/recovery-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPluginLocalInvalidConfigSnapshot,
+  shouldAttemptLastKnownGoodRecovery,
+} from "./recovery-policy.js";
+import type { ConfigFileSnapshot } from "./types.openclaw.js";
+
+type PolicySnapshot = Pick<ConfigFileSnapshot, "valid" | "issues" | "legacyIssues">;
+
+function snapshot(params: Partial<PolicySnapshot>): PolicySnapshot {
+  return {
+    valid: false,
+    issues: [],
+    legacyIssues: [],
+    ...params,
+  };
+}
+
+describe("config recovery policy", () => {
+  it("skips whole-file recovery for issues scoped only to plugin entries", () => {
+    const current = snapshot({
+      issues: [
+        {
+          path: "plugins.entries.feishu",
+          message: "plugin requires newer host",
+        },
+        {
+          path: "plugins.entries.lossless-claw.config.cacheAwareCompaction",
+          message: "invalid config: must NOT have additional properties",
+        },
+      ],
+    });
+
+    expect(isPluginLocalInvalidConfigSnapshot(current)).toBe(true);
+    expect(shouldAttemptLastKnownGoodRecovery(current)).toBe(false);
+  });
+
+  it("keeps recovery enabled for mixed plugin and root config invalidity", () => {
+    const current = snapshot({
+      issues: [
+        { path: "plugins.entries.feishu", message: "plugin requires newer host" },
+        { path: "gateway.mode", message: "Expected string" },
+      ],
+    });
+
+    expect(isPluginLocalInvalidConfigSnapshot(current)).toBe(false);
+    expect(shouldAttemptLastKnownGoodRecovery(current)).toBe(true);
+  });
+
+  it("keeps recovery enabled for ambiguous plugin collection issues", () => {
+    const current = snapshot({
+      issues: [{ path: "plugins.entries", message: "Expected object" }],
+    });
+
+    expect(isPluginLocalInvalidConfigSnapshot(current)).toBe(false);
+    expect(shouldAttemptLastKnownGoodRecovery(current)).toBe(true);
+  });
+
+  it("keeps recovery enabled when legacy config issues are present", () => {
+    const current = snapshot({
+      issues: [{ path: "plugins.entries.feishu", message: "plugin requires newer host" }],
+      legacyIssues: [{ path: "heartbeat", message: "Use agents.defaults.heartbeat" }],
+    });
+
+    expect(isPluginLocalInvalidConfigSnapshot(current)).toBe(false);
+    expect(shouldAttemptLastKnownGoodRecovery(current)).toBe(true);
+  });
+});

--- a/src/config/recovery-policy.ts
+++ b/src/config/recovery-policy.ts
@@ -1,0 +1,35 @@
+import type { ConfigFileSnapshot, ConfigValidationIssue } from "./types.openclaw.js";
+
+const PLUGIN_ENTRY_PATH_PREFIX = "plugins.entries.";
+
+function isPluginEntryIssue(issue: ConfigValidationIssue): boolean {
+  const path = issue.path.trim();
+  if (!path.startsWith(PLUGIN_ENTRY_PATH_PREFIX)) {
+    return false;
+  }
+  return path.slice(PLUGIN_ENTRY_PATH_PREFIX.length).trim().length > 0;
+}
+
+/**
+ * Returns true when an invalid config snapshot is scoped entirely to plugin entries.
+ */
+export function isPluginLocalInvalidConfigSnapshot(
+  snapshot: Pick<ConfigFileSnapshot, "valid" | "issues" | "legacyIssues">,
+): boolean {
+  if (snapshot.valid || snapshot.legacyIssues.length > 0 || snapshot.issues.length === 0) {
+    return false;
+  }
+  return snapshot.issues.every(isPluginEntryIssue);
+}
+
+/**
+ * Decides whether whole-file last-known-good recovery is safe for a snapshot.
+ */
+export function shouldAttemptLastKnownGoodRecovery(
+  snapshot: Pick<ConfigFileSnapshot, "valid" | "issues" | "legacyIssues">,
+): boolean {
+  if (snapshot.valid) {
+    return false;
+  }
+  return !isPluginLocalInvalidConfigSnapshot(snapshot);
+}

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -727,6 +727,62 @@ describe("startGatewayConfigReloader", () => {
     await reloader.stop();
   });
 
+  it("skips last-known-good recovery for plugin-local invalid reloads", async () => {
+    const activeConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      agents: { defaults: { model: "gpt-5.4" } },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { compactionMode: "adaptive", cacheAwareCompaction: true },
+          },
+        },
+      },
+    };
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      raw: `${JSON.stringify(activeConfig, null, 2)}\n`,
+      parsed: activeConfig,
+      sourceConfig: activeConfig,
+      runtimeConfig: activeConfig,
+      config: activeConfig,
+      issues: [
+        {
+          path: "plugins.entries.lossless-claw.config.cacheAwareCompaction",
+          message: "invalid config: must NOT have additional properties",
+        },
+      ],
+      hash: "plugin-skew-1",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(invalidSnapshot);
+    const recoverSnapshot = vi.fn(async () => true);
+    const promoteSnapshot = vi.fn(async () => true);
+    const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot, {
+      recoverSnapshot,
+      promoteSnapshot,
+    });
+
+    watcher.emit("change");
+    await vi.runAllTimersAsync();
+
+    expect(recoverSnapshot).not.toHaveBeenCalled();
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(onHotReload).not.toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(promoteSnapshot).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      "config reload recovery skipped after invalid-config: invalidity is scoped to plugin entries",
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("config reload skipped (invalid config):"),
+    );
+
+    await reloader.stop();
+  });
+
   it("promotes valid external config edits after they are accepted", async () => {
     const acceptedSnapshot = makeSnapshot({
       config: {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -7,6 +7,7 @@ import type {
   ConfigWriteNotification,
   GatewayReloadMode,
 } from "../config/config.js";
+import { shouldAttemptLastKnownGoodRecovery } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { isPlainObject } from "../utils.js";
 import {
@@ -220,6 +221,12 @@ export function startGatewayConfigReloader(opts: {
     reason: string,
   ): Promise<ConfigFileSnapshot | null> => {
     if (!opts.recoverSnapshot) {
+      return null;
+    }
+    if (!shouldAttemptLastKnownGoodRecovery(snapshot)) {
+      opts.log.warn(
+        `config reload recovery skipped after ${reason}: invalidity is scoped to plugin entries`,
+      );
       return null;
     }
     const recovered = await opts.recoverSnapshot(snapshot, reason);

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -8,6 +8,16 @@ vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: vi.fn(),
   recoverConfigFromLastKnownGood: vi.fn(),
   recoverConfigFromJsonRootSuffix: vi.fn(),
+  shouldAttemptLastKnownGoodRecovery: vi.fn((snapshot: ConfigFileSnapshot) => {
+    if (snapshot.valid) {
+      return false;
+    }
+    return !(
+      snapshot.legacyIssues.length === 0 &&
+      snapshot.issues.length > 0 &&
+      snapshot.issues.every((issue) => issue.path.startsWith("plugins.entries."))
+    );
+  }),
   writeConfigFile: vi.fn(),
 }));
 
@@ -107,6 +117,62 @@ describe("gateway startup config recovery", () => {
       `Invalid config at ${configPath}.\ngateway.mode: Expected 'local' or 'remote'\nRun "openclaw doctor --fix" to repair, then retry.`,
     );
 
+    expect(recoveryNotice.enqueueConfigRecoveryNotice).not.toHaveBeenCalled();
+  });
+
+  it("does not restore last-known-good for plugin-local startup invalidity", async () => {
+    const invalidSnapshot = buildTestConfigSnapshot({
+      path: configPath,
+      exists: true,
+      raw: `${JSON.stringify({
+        gateway: { mode: "local" },
+        plugins: {
+          entries: {
+            feishu: { enabled: true },
+          },
+        },
+      })}\n`,
+      parsed: {
+        gateway: { mode: "local" },
+        plugins: {
+          entries: {
+            feishu: { enabled: true },
+          },
+        },
+      },
+      valid: false,
+      config: {
+        gateway: { mode: "local" },
+        plugins: {
+          entries: {
+            feishu: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      issues: [
+        {
+          path: "plugins.entries.feishu",
+          message:
+            "plugin feishu: plugin requires OpenClaw >=2026.4.23, but this host is 2026.4.22; skipping load",
+        },
+      ],
+      legacyIssues: [],
+    });
+    vi.mocked(configIo.readConfigFileSnapshot).mockResolvedValueOnce(invalidSnapshot);
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await expect(
+      loadGatewayStartupConfigSnapshot({
+        minimalTestGateway: true,
+        log,
+      }),
+    ).rejects.toThrow(`Invalid config at ${configPath}.`);
+
+    expect(configIo.recoverConfigFromLastKnownGood).not.toHaveBeenCalled();
+    expect(configIo.recoverConfigFromJsonRootSuffix).toHaveBeenCalledWith(invalidSnapshot);
+    expect(log.warn).toHaveBeenCalledWith(
+      `gateway: last-known-good recovery skipped for plugin-local config invalidity: ${configPath}`,
+    );
     expect(recoveryNotice.enqueueConfigRecoveryNotice).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -9,6 +9,7 @@ import {
   readConfigFileSnapshot,
   recoverConfigFromLastKnownGood,
   recoverConfigFromJsonRootSuffix,
+  shouldAttemptLastKnownGoodRecovery,
   writeConfigFile,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
@@ -70,10 +71,18 @@ export async function loadGatewayStartupConfigSnapshot(params: {
   }
   if (configSnapshot.exists) {
     if (!configSnapshot.valid) {
-      const recovered = await recoverConfigFromLastKnownGood({
-        snapshot: configSnapshot,
-        reason: "startup-invalid-config",
-      });
+      const canRecoverFromLastKnownGood = shouldAttemptLastKnownGoodRecovery(configSnapshot);
+      const recovered = canRecoverFromLastKnownGood
+        ? await recoverConfigFromLastKnownGood({
+            snapshot: configSnapshot,
+            reason: "startup-invalid-config",
+          })
+        : false;
+      if (!canRecoverFromLastKnownGood) {
+        params.log.warn(
+          `gateway: last-known-good recovery skipped for plugin-local config invalidity: ${configSnapshot.path}`,
+        );
+      }
       if (recovered) {
         wroteConfig = true;
         params.log.warn(


### PR DESCRIPTION
## Summary

Fixes #71289.

Prevents plugin-local validation failures from triggering whole-file last-known-good recovery. This preserves `openclaw.json` during plugin schema evolution / `minHostVersion` skew windows while keeping last-known-good recovery intact for true base config corruption.

## What changed

- Added a shared recovery policy that classifies invalid snapshots scoped only to `plugins.entries.*` as plugin-local.
- Made startup, hot reload, and direct recovery helper paths consult that policy before restoring `.last-good`.
- Kept parse failures and non-plugin/base config invalidity on the existing recovery path.
- Added regression coverage for plugin schema evolution and plugin `minHostVersion` skew so stale `.last-good` snapshots do not clobber active config.

## Verification

- `pnpm tsgo`
- `pnpm check:test-types`
- `pnpm test src/config/io.observe-recovery.test.ts src/gateway/config-reload.test.ts src/gateway/server-startup-config.recovery.test.ts`
- `pnpm test src/config/config.plugin-validation.test.ts src/config/io.observe-recovery.test.ts src/gateway/config-reload.test.ts src/gateway/server-startup-config.recovery.test.ts`
