### PR TITLE
feat: add manifest model catalog planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/setup: include `setup.providers[].envVars` in generic provider auth/env lookups and warn non-bundled plugins that still rely on deprecated `providerAuthEnvVars` compatibility metadata. Thanks @vincentkoc.
 - Plugins/setup: derive generic provider setup choices from descriptor-safe `setup.providers[].authMethods` before falling back to setup runtime. Thanks @vincentkoc.
 - Plugins/setup: surface manifest provider auth choices directly in provider setup flow before falling back to setup runtime or install-catalog choices. Thanks @vincentkoc.
+- Models/catalog: add a manifest catalog planner that produces stable manifest-sourced model rows and reports duplicate provider/model conflicts without loading provider runtime. (#71368) Thanks @shakkernerd.
 - Models/catalog: centralize manifest model catalog normalization behind a shared `src/model-catalog` contract so future provider index, cache, onboarding, and listing consumers reuse the same validation and row refs. (#71360) Thanks @shakkernerd.
 - Plugins/manifest: add a `modelCatalog` contract for provider-owned model rows, aliases, suppression rules, and discovery mode metadata without loading plugin runtime. (#71342) Thanks @shakkernerd.
 - Plugins/setup: warn when descriptor-only setup plugins still ship ignored setup runtime entries, keeping `setup.requiresRuntime: false` semantics explicit without breaking existing metadata. Thanks @vincentkoc.

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -8,6 +8,13 @@ export {
   normalizeModelCatalogProviderRows,
   normalizeModelCatalogRows,
 } from "./normalize.js";
+export { planManifestModelCatalogRows } from "./manifest-planner.js";
+export type {
+  ManifestModelCatalogPlan,
+  ManifestModelCatalogPlanEntry,
+  ManifestModelCatalogPlugin,
+  ManifestModelCatalogRegistry,
+} from "./manifest-planner.js";
 export type {
   ModelCatalog,
   ModelCatalogAlias,

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./normalize.js";
 export { planManifestModelCatalogRows } from "./manifest-planner.js";
 export type {
+  ManifestModelCatalogConflict,
   ManifestModelCatalogPlan,
   ManifestModelCatalogPlanEntry,
   ManifestModelCatalogPlugin,

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { planManifestModelCatalogRows } from "./index.js";
+
+describe("manifest model catalog planner", () => {
+  it("builds manifest rows from plugin-owned catalog providers", () => {
+    const plan = planManifestModelCatalogRows({
+      registry: {
+        plugins: [
+          {
+            id: "moonshot",
+            modelCatalog: {
+              providers: {
+                Moonshot: {
+                  api: "openai-responses",
+                  baseUrl: "https://api.moonshot.ai/v1",
+                  models: [
+                    {
+                      id: "kimi-k2.6",
+                      input: ["text", "image"],
+                      contextWindow: 256000,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(plan.entries).toEqual([
+      {
+        pluginId: "moonshot",
+        provider: "moonshot",
+        rows: [
+          {
+            provider: "moonshot",
+            id: "kimi-k2.6",
+            ref: "moonshot/kimi-k2.6",
+            mergeKey: "moonshot::kimi-k2.6",
+            name: "kimi-k2.6",
+            source: "manifest",
+            input: ["text", "image"],
+            reasoning: false,
+            status: "available",
+            api: "openai-responses",
+            baseUrl: "https://api.moonshot.ai/v1",
+            contextWindow: 256000,
+          },
+        ],
+      },
+    ]);
+    expect(plan.rows.map((row) => row.ref)).toEqual(["moonshot/kimi-k2.6"]);
+  });
+
+  it("filters providers before row planning", () => {
+    const plan = planManifestModelCatalogRows({
+      providerFilter: "openrouter",
+      registry: {
+        plugins: [
+          {
+            id: "moonshot",
+            modelCatalog: {
+              providers: {
+                moonshot: {
+                  models: [{ id: "kimi-k2.6" }],
+                },
+              },
+            },
+          },
+          {
+            id: "openrouter",
+            modelCatalog: {
+              providers: {
+                openrouter: {
+                  models: [{ id: "anthropic/claude-sonnet-4.6" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(plan.entries.map((entry) => entry.pluginId)).toEqual(["openrouter"]);
+    expect(plan.rows.map((row) => row.ref)).toEqual(["openrouter/anthropic/claude-sonnet-4.6"]);
+  });
+
+  it("keeps the first registry row for duplicate provider/model keys", () => {
+    const plan = planManifestModelCatalogRows({
+      registry: {
+        plugins: [
+          {
+            id: "z-first",
+            modelCatalog: {
+              providers: {
+                openai: {
+                  models: [{ id: "gpt-5.4", name: "First GPT-5.4" }],
+                },
+              },
+            },
+          },
+          {
+            id: "a-second",
+            modelCatalog: {
+              providers: {
+                openai: {
+                  models: [{ id: "GPT-5.4", name: "Second GPT-5.4" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(plan.entries).toHaveLength(2);
+    expect(plan.rows).toHaveLength(1);
+    expect(plan.rows[0]).toMatchObject({
+      mergeKey: "openai::gpt-5.4",
+      name: "First GPT-5.4",
+    });
+  });
+});

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -51,6 +51,7 @@ describe("manifest model catalog planner", () => {
       },
     ]);
     expect(plan.rows.map((row) => row.ref)).toEqual(["moonshot/kimi-k2.6"]);
+    expect(plan.conflicts).toEqual([]);
   });
 
   it("filters providers before row planning", () => {
@@ -84,9 +85,10 @@ describe("manifest model catalog planner", () => {
 
     expect(plan.entries.map((entry) => entry.pluginId)).toEqual(["openrouter"]);
     expect(plan.rows.map((row) => row.ref)).toEqual(["openrouter/anthropic/claude-sonnet-4.6"]);
+    expect(plan.conflicts).toEqual([]);
   });
 
-  it("keeps the first registry row for duplicate provider/model keys", () => {
+  it("reports duplicate provider/model keys and excludes conflicted rows", () => {
     const plan = planManifestModelCatalogRows({
       registry: {
         plugins: [
@@ -95,7 +97,10 @@ describe("manifest model catalog planner", () => {
             modelCatalog: {
               providers: {
                 openai: {
-                  models: [{ id: "gpt-5.4", name: "First GPT-5.4" }],
+                  models: [
+                    { id: "gpt-5.4", name: "First GPT-5.4" },
+                    { id: "gpt-5.5", name: "GPT-5.5" },
+                  ],
                 },
               },
             },
@@ -115,10 +120,20 @@ describe("manifest model catalog planner", () => {
     });
 
     expect(plan.entries).toHaveLength(2);
+    expect(plan.conflicts).toEqual([
+      {
+        mergeKey: "openai::gpt-5.4",
+        ref: "openai/gpt-5.4",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        firstPluginId: "z-first",
+        secondPluginId: "a-second",
+      },
+    ]);
     expect(plan.rows).toHaveLength(1);
     expect(plan.rows[0]).toMatchObject({
-      mergeKey: "openai::gpt-5.4",
-      name: "First GPT-5.4",
+      mergeKey: "openai::gpt-5.5",
+      name: "GPT-5.5",
     });
   });
 });

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -1,0 +1,94 @@
+import { normalizeModelCatalogProviderRows } from "./normalize.js";
+import { normalizeModelCatalogProviderId } from "./refs.js";
+import type { ModelCatalog, NormalizedModelCatalogRow } from "./types.js";
+
+export type ManifestModelCatalogPlugin = {
+  id: string;
+  modelCatalog?: Pick<ModelCatalog, "providers">;
+};
+
+export type ManifestModelCatalogRegistry = {
+  plugins: readonly ManifestModelCatalogPlugin[];
+};
+
+export type ManifestModelCatalogPlanEntry = {
+  pluginId: string;
+  provider: string;
+  rows: readonly NormalizedModelCatalogRow[];
+};
+
+export type ManifestModelCatalogPlan = {
+  rows: readonly NormalizedModelCatalogRow[];
+  entries: readonly ManifestModelCatalogPlanEntry[];
+};
+
+export function planManifestModelCatalogRows(params: {
+  registry: ManifestModelCatalogRegistry;
+  providerFilter?: string;
+}): ManifestModelCatalogPlan {
+  const providerFilter = params.providerFilter
+    ? normalizeModelCatalogProviderId(params.providerFilter)
+    : undefined;
+  const entries: ManifestModelCatalogPlanEntry[] = [];
+
+  for (const plugin of params.registry.plugins) {
+    for (const entry of planManifestModelCatalogPluginEntries({ plugin, providerFilter })) {
+      entries.push(entry);
+    }
+  }
+
+  const rows: NormalizedModelCatalogRow[] = [];
+  const seenMergeKeys = new Set<string>();
+  for (const entry of entries) {
+    for (const row of entry.rows) {
+      if (seenMergeKeys.has(row.mergeKey)) {
+        continue;
+      }
+      seenMergeKeys.add(row.mergeKey);
+      rows.push(row);
+    }
+  }
+
+  return {
+    entries,
+    rows: rows.toSorted(
+      (left, right) =>
+        left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
+    ),
+  };
+}
+
+function planManifestModelCatalogPluginEntries(params: {
+  plugin: ManifestModelCatalogPlugin;
+  providerFilter: string | undefined;
+}): ManifestModelCatalogPlanEntry[] {
+  const providers = params.plugin.modelCatalog?.providers;
+  if (!providers) {
+    return [];
+  }
+
+  return Object.entries(providers).flatMap(([provider, providerCatalog]) => {
+    const normalizedProvider = normalizeModelCatalogProviderId(provider);
+    if (
+      !normalizedProvider ||
+      (params.providerFilter && normalizedProvider !== params.providerFilter)
+    ) {
+      return [];
+    }
+    const rows = normalizeModelCatalogProviderRows({
+      provider: normalizedProvider,
+      providerCatalog,
+      source: "manifest",
+    });
+    if (rows.length === 0) {
+      return [];
+    }
+    return [
+      {
+        pluginId: params.plugin.id,
+        provider: normalizedProvider,
+        rows,
+      },
+    ];
+  });
+}

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -17,9 +17,19 @@ export type ManifestModelCatalogPlanEntry = {
   rows: readonly NormalizedModelCatalogRow[];
 };
 
+export type ManifestModelCatalogConflict = {
+  mergeKey: string;
+  ref: string;
+  provider: string;
+  modelId: string;
+  firstPluginId: string;
+  secondPluginId: string;
+};
+
 export type ManifestModelCatalogPlan = {
   rows: readonly NormalizedModelCatalogRow[];
   entries: readonly ManifestModelCatalogPlanEntry[];
+  conflicts: readonly ManifestModelCatalogConflict[];
 };
 
 export function planManifestModelCatalogRows(params: {
@@ -37,20 +47,36 @@ export function planManifestModelCatalogRows(params: {
     }
   }
 
-  const rows: NormalizedModelCatalogRow[] = [];
-  const seenMergeKeys = new Set<string>();
+  const rowCandidates: NormalizedModelCatalogRow[] = [];
+  const seenRows = new Map<string, { pluginId: string; row: NormalizedModelCatalogRow }>();
+  const conflicts = new Map<string, ManifestModelCatalogConflict>();
   for (const entry of entries) {
     for (const row of entry.rows) {
-      if (seenMergeKeys.has(row.mergeKey)) {
+      const seen = seenRows.get(row.mergeKey);
+      if (seen) {
+        if (!conflicts.has(row.mergeKey)) {
+          conflicts.set(row.mergeKey, {
+            mergeKey: row.mergeKey,
+            ref: seen.row.ref,
+            provider: seen.row.provider,
+            modelId: seen.row.id,
+            firstPluginId: seen.pluginId,
+            secondPluginId: entry.pluginId,
+          });
+        }
         continue;
       }
-      seenMergeKeys.add(row.mergeKey);
-      rows.push(row);
+      seenRows.set(row.mergeKey, { pluginId: entry.pluginId, row });
+      rowCandidates.push(row);
     }
   }
 
+  const conflictedMergeKeys = new Set(conflicts.keys());
+  const rows = rowCandidates.filter((row) => !conflictedMergeKeys.has(row.mergeKey));
+
   return {
     entries,
+    conflicts: [...conflicts.values()],
     rows: rows.toSorted(
       (left, right) =>
         left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),


### PR DESCRIPTION
## What changed

Adds the next model-catalog architecture slice: a pure manifest catalog planner under `src/model-catalog`.

This planner reads normalized `modelCatalog.providers` data from installed plugin manifest records and produces normalized catalog rows with `source: "manifest"`.

## Why

Previous PRs added the manifest contract and centralized model catalog normalization. This PR adds the next internal layer that lets core consume installed manifest catalog rows without loading provider runtime code.

That keeps the architecture moving toward:

- manifest-first provider/model metadata
- cheap catalog planning for list/picker surfaces
- runtime provider loading only for execution or explicit refresh
- one shared model catalog component instead of scattered command-specific parsing

## Behavior

No CLI behavior changes in this PR.

This is intentionally command-neutral. `models list`, onboarding, and provider pickers do not consume this planner yet.

## Implementation notes

- Adds `planManifestModelCatalogRows`.
- Accepts a small manifest-like registry shape instead of importing plugin runtime.
- Uses the shared model catalog normalizer for row shape and validation.
- Preserves registry order for duplicate provider/model precedence.
- Sorts final rows for stable output.

## Verification

- `pnpm test src/model-catalog/manifest-planner.test.ts`
- `pnpm check:changed`
