### PR TITLE
fix(exec): match bare allowlist command names

### DIFF
--- a/src/infra/exec-allowlist-matching.test.ts
+++ b/src/infra/exec-allowlist-matching.test.ts
@@ -10,7 +10,7 @@ describe("exec allowlist matching", () => {
 
   it("handles wildcard and path matching semantics", () => {
     const cases: Array<{ entries: ExecAllowlistEntry[]; expectedPattern: string | null }> = [
-      { entries: [{ pattern: "RG" }], expectedPattern: null },
+      { entries: [{ pattern: "not-rg" }], expectedPattern: null },
       { entries: [{ pattern: "/opt/**/rg" }], expectedPattern: "/opt/**/rg" },
       { entries: [{ pattern: "/opt/*/rg" }], expectedPattern: null },
     ];
@@ -18,6 +18,11 @@ describe("exec allowlist matching", () => {
       const match = matchAllowlist(entries, baseResolution);
       expect(match?.pattern ?? null).toBe(expectedPattern);
     }
+  });
+
+  it("matches bare command names against the resolved executable basename", () => {
+    expect(matchAllowlist([{ pattern: "rg" }], baseResolution)?.pattern).toBe("rg");
+    expect(matchAllowlist([{ pattern: "homebrew" }], baseResolution)).toBeNull();
   });
 
   it("matches bare wildcard patterns against arbitrary resolved executables", () => {

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -315,6 +315,24 @@ function matchArgPattern(argPattern: string, argv: string[], platform?: string |
   }
 }
 
+function allowlistPatternHasPathSelector(pattern: string): boolean {
+  return pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
+}
+
+function matchesExecutableBasenamePattern(
+  pattern: string,
+  resolution: ExecutableResolution,
+): boolean {
+  const candidates = new Set<string>();
+  if (resolution.executableName) {
+    candidates.add(resolution.executableName);
+  }
+  if (resolution.resolvedPath) {
+    candidates.add(path.basename(resolution.resolvedPath));
+  }
+  return [...candidates].some((candidate) => matchesExecAllowlistPattern(pattern, candidate));
+}
+
 export function matchAllowlist(
   entries: ExecAllowlistEntry[],
   resolution: ExecutableResolution | null,
@@ -348,11 +366,10 @@ export function matchAllowlist(
     if (!pattern) {
       continue;
     }
-    const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
-    if (!hasPath) {
-      continue;
-    }
-    if (!matchesExecAllowlistPattern(pattern, resolvedPath)) {
+    const patternMatches = allowlistPatternHasPathSelector(pattern)
+      ? matchesExecAllowlistPattern(pattern, resolvedPath)
+      : pattern !== "*" && matchesExecutableBasenamePattern(pattern, resolution);
+    if (!patternMatches) {
       continue;
     }
     if (!useArgPattern) {


### PR DESCRIPTION
## Summary

- Closes #71315.
- Allows non-path exec allowlist patterns like `ls` or `gbrain` to match the resolved executable basename instead of being silently skipped.
- Preserves existing path/glob matching and the special bare `*` wildcard handling.
- Adds regression coverage for bare command-name allowlist matching.

## Test plan

- [x] `pnpm exec node scripts/run-vitest.mjs run src/infra/exec-allowlist-matching.test.ts`
- [x] `pnpm exec node scripts/run-vitest.mjs run src/infra/exec-approvals-config.test.ts src/infra/exec-approvals-analysis.test.ts src/infra/exec-approvals-allow-always.test.ts`
- [x] `pnpm exec oxlint src/infra/exec-command-resolution.ts src/infra/exec-allowlist-matching.test.ts`
- [x] `pnpm exec oxfmt --check src/infra/exec-command-resolution.ts src/infra/exec-allowlist-matching.test.ts`
- [x] `pnpm check:import-cycles`
- [ ] `pnpm check` currently passes typecheck and full oxlint locally, then fails in `check-no-runtime-action-load-config.mjs` on Windows by trying to scan `F:\F:\openclaw\extensions`.