### PR TITLE
fix(cli): route logs to stderr when --json is set on route-first path (#71319)

### DIFF
--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -23,7 +23,10 @@ async function prepareRoutedCommand(params: {
   const { VERSION } = await import("../version.js");
   await applyCliExecutionStartupPresentation({
     argv: params.argv,
-    routeLogsToStderrOnSuppress: false,
+    // Route logs to stderr in --json mode so scripts that capture stdout
+    // (e.g. `openclaw agent --json --message ...`) receive only the JSON
+    // envelope, not the plugin-registration / gateway lifecycle log noise
+    // that preaction-driven commands already redirect. (#71319)
     startupPolicy,
     showBanner: process.stdout.isTTY && !startupPolicy.suppressDoctorStdout,
     version: VERSION,


### PR DESCRIPTION
## Summary

Refs #71319.

\`src/cli/route.ts\` explicitly passed \`routeLogsToStderrOnSuppress: false\`, which kept plugin/gateway lifecycle logs on stdout even when the user invoked a command with \`--json\`. Scripted pipelines that capture stdout receive log noise as the payload instead of the JSON envelope — the reporter's real-world script posted:

> [plugins] openclaw-mem0: registered (...)
> completed

instead of the actual agent reply.

## Change

Remove the explicit \`false\` override in \`src/cli/route.ts\` so the route-first path uses the default behavior — the same default that \`src/cli/program/preaction.ts\` already relies on, which calls \`routeLogsToStderr()\` whenever \`suppressDoctorStdout\` is active. Single-line change plus a comment explaining why.

The previous explicit \`false\` was introduced in a21709d (refactor: share cli startup and routing helpers) which faithfully preserved the pre-refactor behavior, but that behavior was the bug.

## Scope

Intentionally narrow:
- Fixes the local-CLI / \`--local\` path where plugin registration fires in the CLI process itself.
- Does **not** fix the forwarded-over-WebSocket case where the plugin log originates in a separate gateway process and is streamed back over the wire. That forwarding sink is a separate concern and out of scope — will file a follow-up if the maintainer prefers to track it separately.

## Test plan

- \`pnpm oxlint src/cli/route.ts\` → 0 warnings, 0 errors
- Manual: before the fix, \`openclaw <route-first-command> --json 1>/tmp/out 2>/tmp/err\` puts plugin-registration lines in \`/tmp/out\`; after the fix, \`/tmp/out\` contains only the JSON envelope and \`/tmp/err\` receives the log noise.