### PR TITLE
fix(telegram): add comprehensive logging for outbound sendMessage failures

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -113,6 +113,9 @@ export async function sendTelegramText(
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   },
 ): Promise<number> {
+  // Log the attempt to send a message
+  runtime.log?.(`telegram attempting to send message to chat=${chatId}, text length=${text.length}`);
+  
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
     thread: opts?.thread,
@@ -126,6 +129,7 @@ export async function sendTelegramText(
   const fallbackText = opts?.plainText ?? text;
   const hasFallbackText = fallbackText.trim().length > 0;
   const sendPlainFallback = async () => {
+    runtime.log?.(`telegram sending message with plain text fallback to chat=${chatId}`);
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,
@@ -145,8 +149,11 @@ export async function sendTelegramText(
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      const errorMsg = "telegram sendMessage failed: empty formatted text and empty plain fallback";
+      runtime.log?.(errorMsg);
+      throw new Error(errorMsg);
     }
+    runtime.log?.(`telegram formatted text is empty, sending plain text fallback to chat=${chatId}`);
     return await sendPlainFallback();
   }
   try {
@@ -173,11 +180,13 @@ export async function sendTelegramText(
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
       if (!hasFallbackText) {
+        runtime.log?.(`telegram formatted send failed with no fallback available: ${errText}`);
         throw err;
       }
       runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
       return await sendPlainFallback();
     }
+    runtime.log?.(`telegram sendMessage failed for chat=${chatId}: ${errText}`);
     throw err;
   }
 }

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -108,9 +108,11 @@ export function resolveTelegramConversationRoute(params: {
   const threadBindingConversationId =
     params.replyThreadId != null
       ? `${params.chatId}:topic:${params.replyThreadId}`
-      : !params.isGroup
-        ? String(params.chatId)
-        : undefined;
+      : params.resolvedThreadId != null
+        ? `${params.chatId}:topic:${params.resolvedThreadId}`
+        : !params.isGroup
+          ? String(params.chatId)
+          : undefined;
   if (threadBindingConversationId) {
     const runtimeRoute = resolveRuntimeConversationBindingRoute({
       route,


### PR DESCRIPTION
This PR addresses issue #71299 by adding comprehensive logging to the Telegram plugin's outbound sendMessage functionality. Currently, the plugin silently drops outbound messages without any logging, making it extremely difficult to diagnose issues.

The changes include:
- Logging all sendMessage attempts with chat ID and text length
- Logging plain text fallback attempts
- Logging specific error conditions (empty formatted text, parse errors)
- Logging general sendMessage failures with detailed error information
- Improving conversation route resolution for forum topics

These changes will help operators identify when and why Telegram messages are failing to send, enabling faster debugging and resolution of issues.

Fixes #71299