### PR TITLE
fix: detect stale subagent runs that exceed timeout threshold

### DIFF
--- a/src/agents/subagent-list.ts
+++ b/src/agents/subagent-list.ts
@@ -129,11 +129,21 @@ export function createPendingDescendantCounter(runsSnapshot?: Map<string, Subage
   };
 }
 
+/** Default staleness threshold: matches DEFAULT_AGENT_TIMEOUT_SECONDS (48 h). */
+const STALE_RUN_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
 export function isActiveSubagentRun(
   entry: SubagentRunRecord,
   pendingDescendantCount: (sessionKey: string) => number,
-) {
-  return !entry.endedAt || pendingDescendantCount(entry.childSessionKey) > 0;
+): boolean {
+  if (entry.endedAt) {
+    return pendingDescendantCount(entry.childSessionKey) > 0;
+  }
+  const startedAt = entry.startedAt ?? entry.createdAt;
+  if (startedAt && Date.now() - startedAt > STALE_RUN_THRESHOLD_MS) {
+    return false;
+  }
+  return pendingDescendantCount(entry.childSessionKey) > 0 || !entry.endedAt;
 }
 
 function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendants?: number }) {
@@ -143,6 +153,10 @@ function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendan
     return `active (waiting on ${pendingDescendants} ${childLabel})`;
   }
   if (!entry.endedAt) {
+    const startedAt = entry.startedAt ?? entry.createdAt;
+    if (startedAt && Date.now() - startedAt > STALE_RUN_THRESHOLD_MS) {
+      return "stale";
+    }
     return "running";
   }
   const status = entry.outcome?.status ?? "done";


### PR DESCRIPTION
## Summary

Subagent runs that have been running longer than their expected timeout are now detected and excluded from the active count.

### Changes
- Added `STALE_RUN_THRESHOLD_MS` constant (48 hours, matching `DEFAULT_AGENT_TIMEOUT_SECONDS`)
- Updated `isActiveSubagentRun()` to check elapsed time against the threshold — runs exceeding it are no longer considered active
- Updated `resolveRunStatus()` to report stale runs as `"stale"` instead of `"running"` in CLI output

### Before
Runs that exceeded their timeout were permanently listed as "running" in `openclaw subagents` output because the only end condition was `endedAt` being set.

### After
After 48 hours without completion, runs are automatically classified as stale and excluded from the active count.

### Testing
- Verified the diff compiles against the existing type definitions (`SubagentRunRecord.startedAt`, `createdAt`, `endedAt`)
- No new dependencies introduced
- Change is limited to `subagent-list.ts` (16 additions, 2 deletions)

Closes #71252
