### PR TITLE
fix: suppress silent cron exec completion noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Docs: https://docs.openclaw.ai
 - Browser/startup: deduplicate concurrent lazy-start calls per profile so simultaneous browser tool requests no longer race into duplicate Chrome launches and `PortInUseError`. (#61772) Thanks @sukhdeepjohar.
 - Browser/profiles: recover from stale Chromium `Singleton*` profile locks after crashes or host moves by clearing dead/foreign locks and retrying launch once. Thanks @seanc-dev.
 - Browser/existing-session: keep Chrome MCP status probes transport-only and ephemeral, and retry stale cached Playwright attaches once so idle profile checks no longer poison the next real attach. (#57245) Thanks @josephbergvinson.
+- Cron/exec: suppress automatic background exec completion wakes only for silent cron jobs with `delivery.mode="none"` while keeping webhook and announce runs observable. (#71391) Thanks @goldmar.
 - Reply media: allow sandboxed replies to deliver OpenClaw-managed `media/outbound` and `media/tool-*` attachments without treating them as sandbox escapes, while keeping alias-escape checks on the managed media root. Fixes #71138. Thanks @mayor686, @truffle-dev, and @neeravmakwana.
 - CLI/agent: keep `openclaw agent --json` stdout reserved for the JSON response by routing gateway, plugin, and embedded-fallback diagnostics to stderr before execution starts. Fixes #71319.
 - Agents/Gemini: retry reasoning-only, empty, and planning-only Gemini turns instead of letting sessions silently stall. Fixes #71074. (#71362) Thanks @neeravmakwana.

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { TerminationReason } from "../process/supervisor/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.js";
 import { createSessionSlug as createSessionSlugId } from "./session-slug.js";
 
@@ -51,6 +52,7 @@ export interface ProcessSession {
   tail: string;
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | number | null;
+  exitReason?: TerminationReason;
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
@@ -68,6 +70,7 @@ export interface FinishedSession {
   status: ProcessStatus;
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | number | null;
+  exitReason?: TerminationReason;
   aggregated: string;
   tail: string;
   truncated: boolean;
@@ -150,10 +153,12 @@ export function markExited(
   exitCode: number | null,
   exitSignal: NodeJS.Signals | number | null,
   status: ProcessStatus,
+  exitReason?: TerminationReason,
 ) {
   session.exited = true;
   session.exitCode = exitCode;
   session.exitSignal = exitSignal;
+  session.exitReason = exitReason;
   session.tail = tail(session.aggregated, 2000);
   moveToFinished(session, status);
 }
@@ -209,6 +214,7 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     status,
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
+    exitReason: session.exitReason,
     aggregated: session.aggregated,
     tail: session.tail,
     truncated: session.truncated,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -148,6 +148,7 @@ let executeNodeHostCommand: typeof import("./bash-tools.exec-host-node.js").exec
 
 type MockNodeInvokeParams = {
   command?: string;
+  params?: Record<string, unknown>;
 };
 
 describe("executeNodeHostCommand", () => {
@@ -271,6 +272,36 @@ describe("executeNodeHostCommand", () => {
           approved: true,
           approvalDecision: "allow-once",
           systemRunPlan: preparedPlan,
+        }),
+      }),
+    );
+  });
+
+  it("suppresses node completion events when notifyOnExit is disabled", async () => {
+    requiresExecApprovalMock.mockReturnValue(false);
+
+    await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+      notifyOnExit: false,
+    });
+
+    expect(callGatewayToolMock).toHaveBeenNthCalledWith(
+      2,
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({
+        command: "system.run",
+        params: expect.objectContaining({
+          suppressNotifyOnExit: true,
         }),
       }),
     );

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -53,6 +53,7 @@ export type ExecuteNodeHostCommandParams = {
   approvalRunningNoticeMs: number;
   warnings: string[];
   notifySessionKey?: string;
+  notifyOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
 
@@ -228,7 +229,8 @@ export async function executeNodeHostCommand(
             ? "allow-once"
             : (approvalDecision ?? undefined),
         runId: runId ?? undefined,
-        suppressNotifyOnExit: suppressNotifyOnExit === true ? true : undefined,
+        suppressNotifyOnExit:
+          suppressNotifyOnExit === true || params.notifyOnExit === false ? true : undefined,
       },
       idempotencyKey: crypto.randomUUID(),
     }) satisfies Record<string, unknown>;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -2,6 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const supervisorMock = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
 
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: requestHeartbeatNowMock,
@@ -11,20 +14,36 @@ vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: enqueueSystemEventMock,
 }));
 
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    spawn: supervisorMock.spawn,
+  }),
+}));
+
+let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
 let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
 let emitExecSystemEvent: typeof import("./bash-tools.exec-runtime.js").emitExecSystemEvent;
 let formatExecFailureReason: typeof import("./bash-tools.exec-runtime.js").formatExecFailureReason;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
+let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
 
 beforeAll(async () => {
+  ({ markBackgrounded } = await import("./bash-process-registry.js"));
   ({
     buildExecExitOutcome,
     detectCursorKeyMode,
     emitExecSystemEvent,
     formatExecFailureReason,
     resolveExecTarget,
+    runExecProcess,
   } = await import("./bash-tools.exec-runtime.js"));
+});
+
+beforeEach(() => {
+  requestHeartbeatNowMock.mockClear();
+  enqueueSystemEventMock.mockClear();
+  supervisorMock.spawn.mockReset();
 });
 
 describe("detectCursorKeyMode", () => {
@@ -292,6 +311,84 @@ describe("resolveExecTarget", () => {
     ).toThrow(
       "exec host not allowed (requested gateway; configured host is node; set tools.exec.host=gateway or auto to allow this override).",
     );
+  });
+});
+
+describe("exec notifyOnExit suppression", () => {
+  async function runBackgroundedExit(params: {
+    reason: "manual-cancel" | "overall-timeout";
+    stdout?: string;
+  }) {
+    supervisorMock.spawn.mockImplementationOnce(
+      async (input: { onStdout?: (chunk: string) => void }) => {
+        if (params.stdout) {
+          input.onStdout?.(params.stdout);
+        }
+        return {
+          runId: "run-1",
+          startedAtMs: Date.now(),
+          pid: 123,
+          wait: async () => {
+            await new Promise((resolve) => setImmediate(resolve));
+            return {
+              reason: params.reason,
+              exitCode: null,
+              exitSignal: "SIGKILL",
+              durationMs: 10,
+              stdout: "",
+              stderr: "",
+              timedOut: params.reason === "overall-timeout",
+              noOutputTimedOut: false,
+            };
+          },
+          cancel: vi.fn(),
+        };
+      },
+    );
+
+    const run = await runExecProcess({
+      command: "sleep 999",
+      workdir: "/tmp",
+      env: {},
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: true,
+      notifyOnExitEmptySuccess: false,
+      sessionKey: "agent:main:main",
+      timeoutSec: null,
+    });
+    markBackgrounded(run.session);
+    return await run.promise;
+  }
+
+  it("keeps manual-cancelled no-output background execs silent", async () => {
+    const outcome = await runBackgroundedExit({ reason: "manual-cancel" });
+
+    expect(outcome.status).toBe("failed");
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies for manual-cancelled background execs with output", async () => {
+    await runBackgroundedExit({ reason: "manual-cancel", stdout: "partial output\n" });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("partial output"),
+      expect.objectContaining({ sessionKey: "agent:main:main" }),
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalled();
+  });
+
+  it("still notifies for no-output background exec timeouts", async () => {
+    await runBackgroundedExit({ reason: "overall-timeout" });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("Exec failed"),
+      expect.objectContaining({ sessionKey: "agent:main:main" }),
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalled();
   });
 });
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -291,6 +291,9 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const output = compactNotifyOutput(
     tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
   );
+  if (status === "failed" && session.exitReason === "manual-cancel" && !output) {
+    return;
+  }
   if (status === "completed" && !output && session.notifyOnExitEmptySuccess !== true) {
     return;
   }
@@ -783,7 +786,7 @@ export async function runExecProcess(opts: {
         timeoutSec: opts.timeoutSec,
       });
 
-      markExited(session, exit.exitCode, exit.exitSignal, outcome.status);
+      markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);
       maybeNotifyOnExit(session, outcome.status);
       if (!session.child && session.stdin) {
         session.stdin.destroyed = true;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1628,6 +1628,7 @@ export function createExecTool(
           approvalRunningNoticeMs,
           warnings,
           notifySessionKey,
+          notifyOnExit,
           trustedSafeBinDirs,
         });
       }

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -109,7 +109,10 @@ export type RunEmbeddedPiAgentParams = {
   bootstrapPromptWarningSignaturesSeen?: string[];
   /** Last shown bootstrap truncation warning signature for this session. */
   bootstrapPromptWarningSignature?: string;
-  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+  execOverrides?: Pick<
+    ExecToolDefaults,
+    "host" | "security" | "ask" | "node" | "notifyOnExit" | "notifyOnExitEmptySuccess"
+  >;
   bashElevated?: ExecElevatedDefaults;
   timeoutMs: number;
   runId: string;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -69,6 +69,7 @@ export function createCronPromptExecutor(params: {
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
   messageChannel: string | undefined;
+  deliveryRequested: boolean;
   resolvedDelivery: {
     accountId?: string;
     to?: string;
@@ -196,6 +197,12 @@ export function createCronPromptExecutor(params: {
           bootstrapContextMode: params.agentPayload?.lightContext ? "lightweight" : undefined,
           bootstrapContextRunKind: "cron",
           toolsAllow: params.agentPayload?.toolsAllow,
+          execOverrides: params.deliveryRequested
+            ? undefined
+            : {
+                notifyOnExit: false,
+                notifyOnExitEmptySuccess: false,
+              },
           runId: params.cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: params.toolPolicy.requireExplicitMessageTarget,
           disableMessageTool: params.toolPolicy.disableMessageTool,
@@ -263,6 +270,7 @@ export async function executeCronRun(params: {
   isAborted: () => boolean;
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
+  deliveryRequested: boolean;
   runStartedAt?: number;
 }): Promise<CronExecutionResult> {
   const resolvedVerboseLevel: VerboseLevel =
@@ -286,6 +294,7 @@ export async function executeCronRun(params: {
     thinkLevel: params.thinkLevel,
     timeoutMs: params.timeoutMs,
     messageChannel: params.resolvedDelivery.channel,
+    deliveryRequested: params.deliveryRequested,
     resolvedDelivery: params.resolvedDelivery,
     toolPolicy: params.toolPolicy,
     skillsSnapshot: params.skillsSnapshot,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -69,7 +69,7 @@ export function createCronPromptExecutor(params: {
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
   messageChannel: string | undefined;
-  deliveryRequested: boolean;
+  suppressExecNotifyOnExit: boolean;
   resolvedDelivery: {
     accountId?: string;
     to?: string;
@@ -197,12 +197,12 @@ export function createCronPromptExecutor(params: {
           bootstrapContextMode: params.agentPayload?.lightContext ? "lightweight" : undefined,
           bootstrapContextRunKind: "cron",
           toolsAllow: params.agentPayload?.toolsAllow,
-          execOverrides: params.deliveryRequested
-            ? undefined
-            : {
+          execOverrides: params.suppressExecNotifyOnExit
+            ? {
                 notifyOnExit: false,
                 notifyOnExitEmptySuccess: false,
-              },
+              }
+            : undefined,
           runId: params.cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: params.toolPolicy.requireExplicitMessageTarget,
           disableMessageTool: params.toolPolicy.disableMessageTool,
@@ -270,7 +270,7 @@ export async function executeCronRun(params: {
   isAborted: () => boolean;
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
-  deliveryRequested: boolean;
+  suppressExecNotifyOnExit: boolean;
   runStartedAt?: number;
 }): Promise<CronExecutionResult> {
   const resolvedVerboseLevel: VerboseLevel =
@@ -294,7 +294,7 @@ export async function executeCronRun(params: {
     thinkLevel: params.thinkLevel,
     timeoutMs: params.timeoutMs,
     messageChannel: params.resolvedDelivery.channel,
-    deliveryRequested: params.deliveryRequested,
+    suppressExecNotifyOnExit: params.suppressExecNotifyOnExit,
     resolvedDelivery: params.resolvedDelivery,
     toolPolicy: params.toolPolicy,
     skillsSnapshot: params.skillsSnapshot,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -241,6 +241,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       thinkLevel: undefined,
       timeoutMs: 60_000,
       messageChannel: "messagechat",
+      deliveryRequested: false,
       toolPolicy: {
         requireExplicitMessageTarget: false,
         disableMessageTool: false,
@@ -267,6 +268,48 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     await expectMessageToolEnabledForPlan({
       requested: false,
       mode: "none",
+    });
+  });
+
+  it('suppresses automatic exec completion notifications when delivery.mode is "none"', async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "none",
+      channel: "topicchat",
+      to: "room#42",
+      threadId: 42,
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "topicchat",
+      to: "room#42",
+      threadId: 42,
+      accountId: undefined,
+      error: undefined,
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({
+        mode: "none",
+        channel: "topicchat",
+        to: "room#42",
+        threadId: 42,
+      }),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      disableMessageTool: false,
+      forceMessageTool: true,
+      messageChannel: "topicchat",
+      messageTo: "room#42",
+      messageThreadId: 42,
+      execOverrides: {
+        notifyOnExit: false,
+        notifyOnExitEmptySuccess: false,
+      },
     });
   });
 
@@ -412,6 +455,19 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       channel: "messagechat",
       to: "123",
     });
+  });
+
+  it("keeps automatic exec completion notifications when announce delivery is active", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob(),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.execOverrides).toBeUndefined();
   });
 
   it("disables the message tool when webhook delivery is active", async () => {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -241,7 +241,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       thinkLevel: undefined,
       timeoutMs: 60_000,
       messageChannel: "messagechat",
-      deliveryRequested: false,
+      suppressExecNotifyOnExit: true,
       toolPolicy: {
         requireExplicitMessageTarget: false,
         disableMessageTool: false,
@@ -464,6 +464,26 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     await runCronIsolatedAgentTurn({
       ...makeParams(),
       job: makeAnnounceMessageToolJob(),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.execOverrides).toBeUndefined();
+  });
+
+  it("keeps automatic exec completion notifications when webhook delivery is active", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "webhook",
+      to: "https://example.invalid/cron",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({
+        mode: "webhook",
+        to: "https://example.invalid/cron",
+      }),
     });
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -977,6 +977,7 @@ export async function runCronIsolatedAgentTurn(params: {
       isAborted,
       thinkLevel: prepared.context.thinkLevel,
       timeoutMs: prepared.context.timeoutMs,
+      deliveryRequested: prepared.context.deliveryRequested,
     });
     if (isAborted()) {
       return prepared.context.withRunSession({ status: "error", error: abortReason() });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -408,6 +408,7 @@ type PreparedCronRunContext = {
   deliveryPlan: CronDeliveryPlan;
   resolvedDelivery: ResolvedCronDeliveryTarget;
   deliveryRequested: boolean;
+  suppressExecNotifyOnExit: boolean;
   toolPolicy: ReturnType<typeof resolveCronToolPolicy>;
   skillsSnapshot: SkillSnapshot;
   liveSelection: CronLiveSelection;
@@ -696,6 +697,7 @@ async function prepareCronRunContext(params: {
       deliveryPlan,
       resolvedDelivery,
       deliveryRequested,
+      suppressExecNotifyOnExit: deliveryPlan.mode === "none",
       toolPolicy,
       skillsSnapshot,
       liveSelection,
@@ -977,7 +979,7 @@ export async function runCronIsolatedAgentTurn(params: {
       isAborted,
       thinkLevel: prepared.context.thinkLevel,
       timeoutMs: prepared.context.timeoutMs,
-      deliveryRequested: prepared.context.deliveryRequested,
+      suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
     });
     if (isAborted()) {
       return prepared.context.withRunSession({ status: "error", error: abortReason() });


### PR DESCRIPTION
## Summary
- suppress automatic background exec completion wakes for silent isolated cron jobs (delivery.mode=none)
- keep explicit message-tool sends intact for silent cron jobs with Telegram/topic targets
- preserve exec notifications for real timeouts/failures with output while keeping manual no-output cancellations quiet
- propagate notifyOnExit=false through node-host exec paths as suppressNotifyOnExit

## Tests
- pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts
- pnpm test src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec-host-node.test.ts
- targeted oxfmt --check on touched files (from Codex run)
- pnpm check:changed passed typecheck/lint/guards and many selected shards, then was stopped after hanging for several minutes in unrelated vitest.extension-whatsapp.config.ts

No gateway restart or deployment performed.