### PR TITLE
fix(moonshot): disable thinking for incompatible tool replay

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
@@ -66,6 +66,82 @@ describe("applyExtraParamsToAgent Moonshot", () => {
     expect(payload.tool_choice).toEqual({ type: "tool", name: "read" });
   });
 
+  it("disables thinking when replayed Anthropic tool_use lacks reasoning_content", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "low",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_123",
+                name: "read",
+                input: { path: "README.md" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("disables thinking when replayed OpenAI tool_calls lacks reasoning_content", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "low",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_123",
+                type: "function",
+                function: { name: "read", arguments: '{"path":"README.md"}' },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("keeps thinking enabled when replayed tool calls include reasoning_content", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "low",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            reasoning_content: "I should inspect the file before answering.",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_123",
+                name: "read",
+                input: { path: "README.md" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "enabled" });
+  });
+
   it("respects explicit Moonshot thinking param from model config", () => {
     const payload = runExtraParamsPayloadCase({
       provider: "moonshot",

--- a/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
@@ -67,6 +67,37 @@ function isPinnedToolChoice(toolChoice: unknown): boolean {
   return typeValue === "tool" || typeValue === "function";
 }
 
+function hasAssistantToolUseWithoutReasoningContent(messages: unknown): boolean {
+  if (!Array.isArray(messages)) {
+    return false;
+  }
+
+  return messages.some((message) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      return false;
+    }
+    const msg = message as Record<string, unknown>;
+    if (msg.role !== "assistant") {
+      return false;
+    }
+
+    const hasReasoningContent =
+      typeof msg.reasoning_content === "string" && msg.reasoning_content.length > 0;
+    const hasOpenAiToolCalls = Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0;
+    const hasAnthropicToolUse =
+      Array.isArray(msg.content) &&
+      msg.content.some(
+        (block) =>
+          Boolean(block) &&
+          typeof block === "object" &&
+          !Array.isArray(block) &&
+          (block as Record<string, unknown>).type === "tool_use",
+      );
+
+    return (hasOpenAiToolCalls || hasAnthropicToolUse) && !hasReasoningContent;
+  });
+}
+
 export function resolveMoonshotThinkingType(params: {
   configuredThinking: unknown;
   thinkingLevel?: ThinkLevel;
@@ -112,6 +143,14 @@ export function createMoonshotThinkingWrapper(
           payloadObj.thinking = { type: "disabled" };
           effectiveThinkingType = "disabled";
         }
+      }
+
+      if (
+        effectiveThinkingType === "enabled" &&
+        hasAssistantToolUseWithoutReasoningContent(payloadObj.messages)
+      ) {
+        payloadObj.thinking = { type: "disabled" };
+        effectiveThinkingType = "disabled";
       }
 
       // thinking.keep is only valid on kimi-k2.6 when thinking is enabled. Gate


### PR DESCRIPTION
## Summary

Moonshot/Kimi rejects follow-up requests when `thinking` is enabled and replayed assistant tool-use messages do not contain `reasoning_content`:

```text
LLM request rejected: thinking is enabled but reasoning_content is missing in assistant tool call message at index {N}
```

This can happen when OpenClaw replays older or provider-normalized assistant tool-call turns that have `tool_use` / `tool_calls` but no Kimi reasoning metadata. The request is invalid for Moonshot thinking mode, even though the same history is valid when thinking is disabled.

This PR makes the Moonshot thinking wrapper detect that incompatible replay shape and set `thinking: { type: "disabled" }` for that request only. Normal thinking behavior is preserved when there are no replayed assistant tool calls, or when the tool-call message already has `reasoning_content`.

## Why this shape

- Does not fabricate hidden reasoning metadata.
- Preserves thinking for compatible requests.
- Mirrors the existing provider-wrapper pattern that adapts generic OpenClaw thinking state to provider-specific transport constraints.
- Addresses the failure class described in #16952 while keeping the behavior scoped to Moonshot/Kimi payloads.

## Tests

```bash
npx pnpm@10.33.0 test -- src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
npx pnpm@10.33.0 exec oxfmt --check src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
```

Both pass locally.
