### PR TITLE
docs(cron): clarify isolated session context

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -86,6 +86,8 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
 
 **Main session** jobs enqueue a system event and optionally wake the heartbeat (`--wake now` or `--wake next-heartbeat`). **Isolated** jobs run a dedicated agent turn with a fresh session. **Custom sessions** (`session:xxx`) persist context across runs, enabling workflows like daily standups that build on previous summaries.
 
+For isolated jobs, “fresh session” means a new transcript/session id for each run. OpenClaw may carry safe preferences such as thinking/fast/verbose settings, labels, and explicit user-selected model/auth overrides, but it does not inherit ambient conversation context from an older cron row: channel/group routing, send or queue policy, elevation, origin, or ACP runtime binding. Use `current` or `session:<id>` when a recurring job should deliberately build on the same conversation context.
+
 For isolated jobs, runtime teardown now includes best-effort browser cleanup for that cron session. Cleanup failures are ignored so the actual cron result still wins.
 
 Isolated cron runs also dispose any bundled MCP runtime instances created for the job through the shared runtime-cleanup path. This matches how main-session and custom-session MCP clients are torn down, so isolated cron jobs do not leak stdio child processes or long-lived MCP connections across runs.
@@ -116,7 +118,7 @@ Model-selection precedence for isolated jobs is:
 
 1. Gmail hook model override (when the run came from Gmail and that override is allowed)
 2. Per-job payload `model`
-3. Stored cron session model override
+3. User-selected stored cron session model override
 4. Agent/default model selection
 
 Fast mode follows the resolved live selection too. If the selected model config
@@ -124,10 +126,11 @@ has `params.fastMode`, isolated cron uses that by default. A stored session
 `fastMode` override still wins over config in either direction.
 
 If an isolated run hits a live model-switch handoff, cron retries with the
-switched provider/model and persists that live selection before retrying. When
-the switch also carries a new auth profile, cron persists that auth profile
-override too. Retries are bounded: after the initial attempt plus 2 switch
-retries, cron aborts instead of looping forever.
+switched provider/model and persists that live selection for the active run
+before retrying. When the switch also carries a new auth profile, cron persists
+that auth profile override for the active run too. Retries are bounded: after
+the initial attempt plus 2 switch retries, cron aborts instead of looping
+forever.
 
 ## Delivery and output
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -33,6 +33,11 @@ Note: `--session` supports `main`, `isolated`, `current`, and `session:<id>`.
 Use `current` to bind to the active session at creation time, or `session:<id>` for
 an explicit persistent session key.
 
+Note: `--session isolated` creates a fresh transcript/session id for each run.
+Safe preferences and explicit user-selected model/auth overrides can carry, but
+ambient conversation context does not: channel/group routing, send/queue policy,
+elevation, origin, and ACP runtime binding are reset for the new isolated run.
+
 Note: for one-shot CLI jobs, offset-less `--at` datetimes are treated as UTC unless you also pass
 `--tz <iana>`, which interprets that local wall-clock time in the given timezone.
 
@@ -59,17 +64,17 @@ model override with no explicit per-job fallback list no longer appends the
 agent primary as a hidden extra retry target.
 
 Note: isolated cron model precedence is Gmail-hook override first, then per-job
-`--model`, then any stored cron-session model override, then the normal
-agent/default selection.
+`--model`, then any user-selected stored cron-session model override, then the
+normal agent/default selection.
 
 Note: isolated cron fast mode follows the resolved live model selection. Model
 config `params.fastMode` applies by default, but a stored session `fastMode`
 override still wins over config.
 
 Note: if an isolated run throws `LiveSessionModelSwitchError`, cron persists the
-switched provider/model (and switched auth profile override when present) before
-retrying. The outer retry loop is bounded to 2 switch retries after the initial
-attempt, then aborts instead of looping forever.
+switched provider/model (and switched auth profile override when present) for
+the active run before retrying. The outer retry loop is bounded to 2 switch
+retries after the initial attempt, then aborts instead of looping forever.
 
 Note: failure notifications use `delivery.failureDestination` first, then
 global `cron.failureDestination`, and finally fall back to the job's primary

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -101,6 +101,14 @@ Isolated cron runs also create session entries/transcripts, and they have dedica
 - `cron.sessionRetention` (default `24h`) prunes old isolated cron run sessions from the session store (`false` disables).
 - `cron.runLog.maxBytes` + `cron.runLog.keepLines` prune `~/.openclaw/cron/runs/<jobId>.jsonl` files (defaults: `2_000_000` bytes and `2000` lines).
 
+When cron force-creates a new isolated run session, it sanitizes the previous
+`cron:<jobId>` session entry before writing the new row. It carries safe
+preferences such as thinking/fast/verbose settings, labels, and explicit
+user-selected model/auth overrides. It drops ambient conversation context such
+as channel/group routing, send or queue policy, elevation, origin, and ACP
+runtime binding so a fresh isolated run cannot inherit stale delivery or
+runtime authority from an older run.
+
 ---
 
 ## Session keys (`sessionKey`)

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -400,7 +400,7 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.authProfileOverrideCompactionCount).toBe(3);
     });
 
-    it("preserves session context for stale non-isolated rollovers", () => {
+    it("preserves ambient session context for non-isolated expiration rollovers", () => {
       const result = resolveWithStoredEntry({
         entry: {
           sessionId: "existing-session-id-321",

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -9,9 +9,7 @@ import { loadSessionStore } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
-type FreshCronSessionSanitizeMode = "isolated-force-new" | "stale-rollover";
-
-const FRESH_CRON_SAFE_PREFERENCE_FIELDS = [
+const FRESH_CRON_CARRIED_PREFERENCE_FIELDS = [
   "heartbeatTaskState",
   "chatType",
   "thinkingLevel",
@@ -25,7 +23,7 @@ const FRESH_CRON_SAFE_PREFERENCE_FIELDS = [
   "displayName",
 ] as const satisfies readonly (keyof SessionEntry)[];
 
-const STALE_SESSION_CONTEXT_PRESERVED_FIELDS = [
+const AMBIENT_SESSION_CONTEXT_FIELDS = [
   "elevatedLevel",
   "groupActivation",
   "groupActivationNeedsSystemIntro",
@@ -87,13 +85,13 @@ function preserveUserAuthOverride(target: SessionEntry, entry: SessionEntry): vo
 
 function sanitizeFreshCronSessionEntry(
   entry: SessionEntry,
-  mode: FreshCronSessionSanitizeMode,
+  options: { preserveAmbientContext: boolean },
 ): SessionEntry {
   const next = {} as SessionEntry;
 
-  copySessionFields(next, entry, FRESH_CRON_SAFE_PREFERENCE_FIELDS);
-  if (mode === "stale-rollover") {
-    copySessionFields(next, entry, STALE_SESSION_CONTEXT_PRESERVED_FIELDS);
+  copySessionFields(next, entry, FRESH_CRON_CARRIED_PREFERENCE_FIELDS);
+  if (options.preserveAmbientContext) {
+    copySessionFields(next, entry, AMBIENT_SESSION_CONTEXT_FIELDS);
   }
   preserveNonAutoModelOverride(next, entry);
   preserveUserAuthOverride(next, entry);
@@ -159,10 +157,7 @@ export function resolveCronSession(params: {
 
   const baseEntry = entry
     ? isNewSession
-      ? sanitizeFreshCronSessionEntry(
-          entry,
-          params.forceNew ? "isolated-force-new" : "stale-rollover",
-        )
+      ? sanitizeFreshCronSessionEntry(entry, { preserveAmbientContext: !params.forceNew })
       : entry
     : undefined;
 


### PR DESCRIPTION
## Summary

- Problem: the cron isolated-session fix used clearer code behavior than the docs explained.
- Why it matters: operators need to know exactly what “fresh isolated session” carries vs resets.
- What changed: renamed the cron sanitizer terms to ambient context, documented isolated cron context reset semantics in cron CLI/reference docs.
- What did NOT change: runtime behavior from #71340; this is wording/refactor plus docs.

## Change Type (select all)

- [x] Refactor required for the fix
- [x] Docs

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Related #71340
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/session.test.ts`
- Scenario the test should lock in: isolated force-new runs drop ambient context while non-isolated expiration rollovers preserve it.
- Why this is the smallest reliable guardrail: the behavior is owned by `resolveCronSession`.
- Existing test that already covers this: `preserves ambient session context for non-isolated expiration rollovers`; force-new drop assertions in the fresh cron session test.
- If no new test is added, why not: behavior coverage already exists; this PR clarifies naming/docs.

## User-visible / Behavior Changes

Docs clarify that `--session isolated` creates a fresh transcript/session id and does not inherit channel/group routing, send/queue policy, elevation, origin, or ACP runtime binding from an older cron row. Safe preferences and explicit user-selected model/auth overrides can carry.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm
- Model/provider: N/A
- Integration/channel (if any): cron isolated sessions
- Relevant config (redacted): N/A

### Steps

1. Review `resolveCronSession` force-new and expiration rollover paths.
2. Review cron/session docs for isolated-session wording.
3. Run changed gate.

### Expected

- Docs accurately describe isolated cron session context behavior.
- Existing cron session tests stay green.

### Actual

- `pnpm check:changed` passed.

## Evidence

- [x] Failing test/log before + passing after

`pnpm check:changed` passed locally.

## Human Verification (required)

- Verified scenarios: renamed code path still preserves force-new vs non-isolated rollover behavior; docs match the field boundary.
- Edge cases checked: user-selected model/auth override wording; live model switch persistence wording.
- What you did **not** verify: full repository test sweep; not needed for docs/naming-only follow-up.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
