### PR TITLE
fix(daemon): harden launchd restart handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/cron: deliver text-only isolated cron and heartbeat announce output from the canonical final assistant text once, avoiding duplicate Discord posts when streamed block payloads and the final answer contain the same content. Fixes #71406. Thanks @alexgross21.
+- macOS Gateway: wait for launchd to reload the exited Gateway LaunchAgent before bootstrapping repair fallback, preventing config-triggered restarts from leaving the service not loaded. Fixes #45178. Thanks @vincentkoc.
 - Control UI/WebChat: hide heartbeat prompts, `HEARTBEAT_OK` acknowledgments, and internal-only runtime context turns from visible chat history while leaving the underlying transcript intact. Fixes #71381. Thanks @gerald1950ggg-ai.
 - Control UI/chat: keep optimistic user and assistant tail messages visible when a final history refresh briefly returns an older snapshot, preventing message cards from flash-disappearing until the next refresh. Fixes #71371. Thanks @WolvenRA.
 - Talk/TTS: resolve configured extension speech providers from the active runtime registry before provider-list discovery, so Talk mode no longer rejects valid plugin speech providers as unsupported.

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -63,6 +63,11 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
 
     const [, args] = spawnMock.mock.calls[0] as [string, string[]];
     expect(args[7]).toBe("ai.openclaw.gateway");
+    expect(args[1]).toContain('if launchctl print "$service_target" >/dev/null 2>&1; then');
+    expect(args[1]).toContain("reason=launchd-auto-reload");
+    expect(args[1]).toContain("print_retry_count=$((print_retry_count - 1))");
+    expect(args[1]).toContain("sleep 0.2");
+    expect(args[1]).toContain('if launchctl bootstrap "$domain" "$plist_path"; then');
     expect(args[1]).toContain('if launchctl start "$label"; then');
     expect(args[1]).not.toContain('basename "$service_target"');
   });

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -22,6 +22,9 @@ export type LaunchdRestartTarget = {
   serviceTarget: string;
 };
 
+const START_AFTER_EXIT_PRINT_RETRY_COUNT = 15;
+const START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS = 0.2;
+
 function assertValidLaunchAgentLabel(label: string): string {
   const trimmed = label.trim();
   if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
@@ -116,28 +119,36 @@ exit "$status"
 `;
   }
 
+  const verifyLaunchdReload = `print_retry_count="${START_AFTER_EXIT_PRINT_RETRY_COUNT}"
+while [ "$print_retry_count" -gt 0 ]; do
+  if launchctl print "$service_target" >/dev/null 2>&1; then
+    printf '[%s] openclaw restart done source=launchd-handoff mode=${mode} reason=launchd-auto-reload\\n' "$(date -u +%FT%TZ)" >&2
+    exit 0
+  fi
+  print_retry_count=$((print_retry_count - 1))
+  sleep ${START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS}
+done
+`;
+
   // Restart is explicit operator intent; undo any previous `launchctl disable`.
   return `service_target="$1"
 domain="$2"
 plist_path="$3"
 ${waitForCallerPid}
+${verifyLaunchdReload}
 status=0
 launchctl enable "$service_target"
-if launchctl start "$label"; then
-  status=0
-else
-  status=$?
-  if launchctl bootstrap "$domain" "$plist_path"; then
-    if launchctl start "$label"; then
-      status=0
-    else
-      launchctl kickstart -k "$service_target"
-      status=$?
-    fi
+if launchctl bootstrap "$domain" "$plist_path"; then
+  if launchctl start "$label"; then
+    status=0
   else
     launchctl kickstart -k "$service_target"
     status=$?
   fi
+else
+  status=$?
+  launchctl kickstart -k "$service_target"
+  status=$?
 fi
 if [ "$status" -eq 0 ]; then
   printf '[%s] openclaw restart done source=launchd-handoff mode=${mode}\\n' "$(date -u +%FT%TZ)" >&2


### PR DESCRIPTION
## Summary

- Problem: config-triggered macOS Gateway restarts can exit cleanly before launchd has re-materialized the LaunchAgent, leaving the service not loaded.
- Why it matters: once launchd no longer sees the job, `KeepAlive` cannot recover the Gateway and users fall back to `doctor --repair` or manual bootstrap.
- What changed: the detached `start-after-exit` handoff now waits for `launchctl print` to confirm launchd auto-reloaded the job before running the repair/bootstrap fallback.
- What did NOT change (scope boundary): this does not rewrite the broader stop/update/ThrottleInterval flows tracked in related reports.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45178
- Related #45892
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `start-after-exit` trusted launchd to restore the exited Gateway immediately, then fell into repair paths without first distinguishing “launchd is still reloading” from “the service is gone”.
- Missing detection / guardrail: no bounded `launchctl print` verification window before bootstrap/kickstart fallback.
- Contributing context: #45892 had the right narrow fix shape, but it was dirty against current `main`; this reapplies the behavior on top of current launchd logging and label validation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/launchd-restart-handoff.test.ts`
- Scenario the test should lock in: `start-after-exit` probes `launchctl print`, waits briefly, and only then bootstraps/kickstarts repair fallback.
- Why this is the smallest reliable guardrail: the bug is in generated detached shell behavior, and the existing test already inspects that script.
- Existing test that already covers this (if any): existing handoff tests covered PID waiting and label passing, not the reload probe.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

macOS config-triggered Gateway restarts should recover more reliably when launchd is slow to re-register the LaunchAgent after the old process exits.

## Diagram (if applicable)

```text
Before:
config restart -> old gateway exits -> handoff immediately repairs -> launchd race can leave service not loaded

After:
config restart -> old gateway exits -> handoff waits for launchd print -> repair fallback only if still missing
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS launchd path, reviewed from source
- Runtime/container: Node 22+ repo workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway LaunchAgent
- Relevant config (redacted): default `ai.openclaw.gateway` LaunchAgent

### Steps

1. Trigger a config-driven Gateway restart on macOS.
2. Let the old Gateway process exit under launchd supervision.
3. Observe the detached handoff behavior.

### Expected

- The handoff waits for launchd to show the service with `launchctl print` before deciding repair is required.
- If the service remains missing, it enables/bootstrap/kickstarts the LaunchAgent fallback.

### Actual

- Before this change, the handoff did not include the bounded `launchctl print` reload window.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/daemon/launchd-restart-handoff.test.ts` passed once after the macOS code/test edit.
- Edge cases checked: invalid launchd label guard remains unchanged; kickstart mode remains the explicit operator path.
- What you did **not** verify: live macOS launchd restart, because this environment is not the affected LaunchAgent host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: waiting for `launchctl print` delays fallback repair by up to roughly 3 seconds.
  - Mitigation: the wait only runs in detached `start-after-exit` mode after the old PID exits, and it avoids unnecessary bootstrap/kickstart while launchd is already recovering.
