### PR TITLE
chore(changelog): dedupe #66884 entry into 2026.4.24 (Unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 Docs: https://docs.openclaw.ai
 
-## Unreleased
-
-### Changes
-
-### Fixes
-
-- CI/release-checks: pass workflow inputs and matrix values through step environment variables instead of embedding them directly into `run:` shell commands, reducing template-injection surface in the cross-OS release-check workflow. (#66884) Thanks @alexlomt.
-- fix(ci): harden release checks workflow inputs (#66884). Thanks @alexlomt
-
 ## 2026.4.24 (Unreleased)
 
 ### Breaking
@@ -263,6 +254,7 @@ Docs: https://docs.openclaw.ai
 - Memory search: apply session visibility and agent-to-agent policy to session transcript hits, and keep `corpus=sessions` ranking scoped to session collections before result limiting. (#70761) Thanks @nefainl.
 - Agents/sessions: stop session write-lock timeouts from entering model failover, so local lock contention surfaces directly instead of cascading across providers. (#68700) Thanks @MonkeyLeeT.
 - Auto-reply: run inbound reply delivery through `message_sending` hooks so plugins can transform or cancel generated replies before they are sent. (#70118) Thanks @jzakirov.
+- CI/release-checks: pass workflow inputs and matrix values through step environment variables instead of embedding them directly into `run:` shell commands, reducing template-injection surface in the cross-OS release-check workflow. (#66884) Thanks @alexlomt.
 
 ## 2026.4.23
 


### PR DESCRIPTION
## Summary

- Remove the stray top-level `## Unreleased` section introduced when #66884 landed.
- Consolidate the #66884 changelog line under `## 2026.4.24 (Unreleased) > ### Fixes`, matching the active release block used by the rest of the file.

## Why

PR #66884 shipped two duplicate entries for itself: one written during `/prepare-pr`, and a second one auto-inserted during the push-time rebase step. The auto-insertion did not recognize `## 2026.4.24 (Unreleased)` as the active block, so it synthesized a new top-level `## Unreleased` section and appended a PR-title-style line there. This PR cleans that up — no code change.

## Test plan

- [x] `grep -c "#66884" CHANGELOG.md` returns `1`
- [x] Only one Unreleased header remains (`## 2026.4.24 (Unreleased)`)
- [x] Diff is CHANGELOG-only