### PR TITLE
Fix subagent recovery and session state reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: keep optimistic user and assistant tail messages visible when a final history refresh briefly returns an older snapshot, preventing message cards from flash-disappearing until the next refresh. Fixes #71371. Thanks @WolvenRA.
 - Talk/TTS: resolve configured extension speech providers from the active runtime registry before provider-list discovery, so Talk mode no longer rejects valid plugin speech providers as unsupported.
 - Sessions/subagents: stop stale ended runs and old store-only child reverse links from reappearing in `childSessions`, while keeping live descendants and recently-ended children visible. Fixes #57920.
+- Subagents: recover child sessions after recoverable wait transport failures without exposing an extra wait state, and keep terminal lifecycle timer ordering deterministic. (#71423) Thanks @ZiPengWei.
 - Subagents: stop stale unended runs from counting as active or pending forever, while preserving restart-aborted recovery for recoverable child sessions. Fixes #71252. Thanks @hclsys.
 - Gateway/tools: allow `POST /tools/invoke` to reach plugin-backed catalog tools such as `browser` when no core implementation exists, while still preferring built-in tools for real core names. Thanks @chat2way.
 - Browser/security: require `operator.admin` for the `browser.request` gateway method, matching the host/browser-node control authority exposed by that route. Thanks @RichardCao.

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -892,6 +892,33 @@ describe("normalizeFeishuTarget", () => {
   });
 });
 
+describe("feishuPlugin.messaging.resolveDeliveryTarget", () => {
+  it("routes direct conversations to user targets", () => {
+    expect(
+      feishuPlugin.messaging?.resolveDeliveryTarget?.({
+        conversationId: "ou_123",
+      }),
+    ).toEqual({ to: "user:ou_123" });
+  });
+
+  it("routes group conversations to chat targets", () => {
+    expect(
+      feishuPlugin.messaging?.resolveDeliveryTarget?.({
+        conversationId: "oc_123",
+      }),
+    ).toEqual({ to: "chat:oc_123" });
+  });
+
+  it("routes topic conversations to parent chat plus thread id", () => {
+    expect(
+      feishuPlugin.messaging?.resolveDeliveryTarget?.({
+        conversationId: "oc_123:topic:omt_456",
+        parentConversationId: "oc_123",
+      }),
+    ).toEqual({ to: "chat:oc_123", threadId: "omt_456" });
+  });
+});
+
 describe("looksLikeFeishuId", () => {
   it("accepts provider-prefixed user targets", () => {
     expect(looksLikeFeishuId("feishu:user:ou_123")).toBe(true);

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1134,6 +1134,20 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       setupWizard: feishuSetupWizard,
       messaging: {
         normalizeTarget: (raw) => normalizeFeishuTarget(raw) ?? undefined,
+        resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {
+          const directId = parseFeishuDirectConversationId(conversationId);
+          if (directId) {
+            return { to: `user:${directId}` };
+          }
+          const parsed = parseFeishuConversationId({ conversationId, parentConversationId });
+          if (parsed?.topicId) {
+            return {
+              to: `chat:${parentConversationId?.trim() || parsed.chatId}`,
+              threadId: parsed.topicId,
+            };
+          }
+          return { to: `chat:${parsed?.chatId ?? conversationId.trim()}` };
+        },
         resolveSessionConversation: ({ kind, rawId }) =>
           resolveFeishuSessionConversation({ kind, rawId }),
         resolveOutboundSessionRoute: (params) => resolveFeishuOutboundSessionRoute(params),

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -7,6 +7,7 @@ vi.mock("../gateway/call.js", () => ({
 
 import {
   __testing,
+  isRecoverableAgentWaitError,
   readLatestAssistantReply,
   readLatestAssistantReplySnapshot,
   waitForAgentRun,
@@ -149,6 +150,18 @@ describe("waitForAgentRun", () => {
       status: "timeout",
       error: "gateway timeout while waiting",
     });
+  });
+
+  it("maps transport-close wait failures to interrupted status", async () => {
+    callGatewayMock.mockRejectedValue(new Error("gateway closed (1006): transport close"));
+
+    const result = await waitForAgentRun({ runId: "run-interrupted", timeoutMs: 500 });
+
+    expect(result).toEqual({
+      status: "interrupted",
+      error: "gateway closed (1006): transport close",
+    });
+    expect(isRecoverableAgentWaitError(result.error)).toBe(true);
   });
 
   it("preserves pending agent.wait status", async () => {

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -152,13 +152,13 @@ describe("waitForAgentRun", () => {
     });
   });
 
-  it("maps transport-close wait failures to interrupted status", async () => {
+  it("keeps transport-close wait failures as errors for generic callers", async () => {
     callGatewayMock.mockRejectedValue(new Error("gateway closed (1006): transport close"));
 
     const result = await waitForAgentRun({ runId: "run-interrupted", timeoutMs: 500 });
 
     expect(result).toEqual({
-      status: "interrupted",
+      status: "error",
       error: "gateway closed (1006): transport close",
     });
     expect(isRecoverableAgentWaitError(result.error)).toBe(true);

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -18,7 +18,7 @@ export type AssistantReplySnapshot = {
 };
 
 export type AgentWaitResult = {
-  status: "ok" | "timeout" | "error" | "pending" | "interrupted";
+  status: "ok" | "timeout" | "error" | "pending";
   error?: string;
   startedAt?: number;
   endedAt?: number;
@@ -165,11 +165,7 @@ export async function waitForAgentRun(params: {
   } catch (err) {
     const error = formatErrorMessage(err);
     return {
-      status: error.includes("gateway timeout")
-        ? "timeout"
-        : isRecoverableAgentWaitError(error)
-          ? "interrupted"
-          : "error",
+      status: error.includes("gateway timeout") ? "timeout" : "error",
       error,
     };
   }

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -18,7 +18,7 @@ export type AssistantReplySnapshot = {
 };
 
 export type AgentWaitResult = {
-  status: "ok" | "timeout" | "error" | "pending";
+  status: "ok" | "timeout" | "error" | "pending" | "interrupted";
   error?: string;
   startedAt?: number;
   endedAt?: number;
@@ -47,6 +47,28 @@ function normalizeAgentWaitResult(
     startedAt: typeof wait?.startedAt === "number" ? wait.startedAt : undefined,
     endedAt: typeof wait?.endedAt === "number" ? wait.endedAt : undefined,
   };
+}
+
+const RECOVERABLE_AGENT_WAIT_ERROR_PATTERNS: readonly RegExp[] = [
+  /gateway closed \(1006/i,
+  /transport close/i,
+  /connection loss/i,
+  /connection closed/i,
+  /gateway not connected/i,
+  /no active .* listener/i,
+  /socket hang up/i,
+  /\b(ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|EHOSTUNREACH|ENETUNREACH)\b/i,
+];
+
+export function isRecoverableAgentWaitError(error: string | undefined): boolean {
+  const message = error?.trim();
+  if (!message) {
+    return false;
+  }
+  if (message.includes("gateway timeout")) {
+    return false;
+  }
+  return RECOVERABLE_AGENT_WAIT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function normalizePendingRunIds(runIds: Iterable<string>): string[] {
@@ -143,7 +165,11 @@ export async function waitForAgentRun(params: {
   } catch (err) {
     const error = formatErrorMessage(err);
     return {
-      status: error.includes("gateway timeout") ? "timeout" : "error",
+      status: error.includes("gateway timeout")
+        ? "timeout"
+        : isRecoverableAgentWaitError(error)
+          ? "interrupted"
+          : "error",
       error,
     };
   }

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as sessions from "../config/sessions.js";
 import * as gateway from "../gateway/call.js";
 import * as sessionUtils from "../gateway/session-utils.fs.js";
-import { recoverOrphanedSubagentSessions } from "./subagent-orphan-recovery.js";
+import * as announceDelivery from "./subagent-announce-delivery.js";
+import {
+  recoverOrphanedSubagentSessions,
+  scheduleOrphanRecovery,
+} from "./subagent-orphan-recovery.js";
 import * as subagentRegistrySteerRuntime from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
@@ -28,8 +32,19 @@ vi.mock("../gateway/session-utils.fs.js", () => ({
   readSessionMessages: vi.fn(() => []),
 }));
 
+vi.mock("./subagent-announce-delivery.js", () => ({
+  deliverSubagentAnnouncement: vi.fn(async () => ({ delivered: true, path: "direct" })),
+  isInternalAnnounceRequesterSession: vi.fn(() => false),
+  loadRequesterSessionEntry: vi.fn(() => ({ entry: {} })),
+}));
+
+vi.mock("./subagent-announce-origin.js", () => ({
+  resolveAnnounceOrigin: vi.fn((entry, requesterOrigin) => requesterOrigin),
+}));
+
 vi.mock("./subagent-registry-steer-runtime.js", () => ({
   replaceSubagentRunAfterSteer: vi.fn(() => true),
+  finalizeInterruptedSubagentRun: vi.fn(async () => 1),
 }));
 
 function createTestRunRecord(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
@@ -84,10 +99,12 @@ function getResumeMessage() {
 
 describe("subagent-orphan-recovery", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -262,6 +279,13 @@ describe("subagent-orphan-recovery", () => {
 
     expect(result.recovered).toBe(0);
     expect(result.failed).toBe(1);
+    expect(result.failedRuns).toEqual([
+      expect.objectContaining({
+        runId: "run-1",
+        childSessionKey: "agent:main:subagent:test-session-1",
+        error: "gateway unavailable",
+      }),
+    ]);
 
     // abortedLastRun flag should NOT be cleared on failure,
     // so the next restart can retry the recovery
@@ -369,6 +393,38 @@ describe("subagent-orphan-recovery", () => {
     expect(message).toContain("config changes from your previous run were already applied");
   });
 
+  it("announces recovery-in-progress once when a later retry is attempting resume", async () => {
+    mockSingleAbortedSession();
+
+    const activeRuns = createActiveRuns(createTestRunRecord());
+    const notifiedRecoverySessionKeys = new Set<string>();
+
+    await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      attemptNumber: 2,
+      maxAttempts: 4,
+      notifiedRecoverySessionKeys,
+    });
+
+    expect(announceDelivery.deliverSubagentAnnouncement).toHaveBeenCalledOnce();
+    expect(announceDelivery.deliverSubagentAnnouncement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterSessionKey: "agent:main:quietchat:direct:+1234567890",
+        triggerMessage: expect.stringContaining("Automatic recovery is already in progress"),
+      }),
+    );
+    expect(notifiedRecoverySessionKeys).toEqual(new Set(["agent:main:subagent:test-session-1"]));
+
+    await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      attemptNumber: 3,
+      maxAttempts: 4,
+      notifiedRecoverySessionKeys,
+    });
+
+    expect(announceDelivery.deliverSubagentAnnouncement).toHaveBeenCalledOnce();
+  });
+
   it("prevents duplicate resume when updateSessionStore fails", async () => {
     vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "new-run" } as never);
     vi.mocked(sessions.updateSessionStore).mockRejectedValue(new Error("write failed"));
@@ -428,5 +484,42 @@ describe("subagent-orphan-recovery", () => {
     expect(second.skipped).toBe(1);
     expect(gateway.callGateway).toHaveBeenCalledOnce();
     expect(sessions.updateSessionStore).toHaveBeenCalledOnce();
+  });
+
+  it("finalizes interrupted runs with a readable failure after recovery retries are exhausted", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    });
+    vi.mocked(gateway.callGateway).mockRejectedValue(new Error("service restart"));
+
+    const activeRuns = createActiveRuns(createTestRunRecord());
+
+    scheduleOrphanRecovery({
+      getActiveRuns: () => activeRuns,
+      delayMs: 1,
+      maxRetries: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(2);
+    await Promise.resolve();
+
+    expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        childSessionKey: "agent:main:subagent:test-session-1",
+        error: expect.stringContaining("Automatic recovery failed after 2 attempts"),
+      }),
+    );
+    expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("service restart"),
+      }),
+    );
   });
 });

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -81,7 +81,7 @@ function buildRecoveryProgressPrompt(params: {
     params.task.length > maxTaskLen ? `${params.task.slice(0, maxTaskLen)}...` : params.task;
   return (
     `A spawned subagent task was interrupted by a gateway restart or connection loss. ` +
-    `Automatic recovery is already in progress for \"${taskLabel}\" ` +
+    `Automatic recovery is already in progress for "${taskLabel}" ` +
     `(retry ${params.attemptNumber}/${params.maxAttempts}). ` +
     `Send one brief update now in your normal voice: say the task was interrupted, ` +
     `you are automatically resuming/retrying it, and you will report back when it either continues or truly fails. ` +

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -20,8 +20,19 @@ import {
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { readSessionMessages } from "../gateway/session-utils.fs.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { replaceSubagentRunAfterSteer } from "./subagent-registry-steer-runtime.js";
+import { buildAnnounceIdempotencyKey } from "./announce-idempotency.js";
+import {
+  deliverSubagentAnnouncement,
+  isInternalAnnounceRequesterSession,
+  loadRequesterSessionEntry,
+} from "./subagent-announce-delivery.js";
+import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
+import {
+  finalizeInterruptedSubagentRun,
+  replaceSubagentRunAfterSteer,
+} from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const log = createSubsystemLogger("subagent-orphan-recovery");
@@ -60,6 +71,75 @@ function buildResumeMessage(task: string, lastHumanMessage?: string): string {
   return message;
 }
 
+function buildRecoveryProgressPrompt(params: {
+  task: string;
+  attemptNumber: number;
+  maxAttempts: number;
+}): string {
+  const maxTaskLen = 160;
+  const taskLabel =
+    params.task.length > maxTaskLen ? `${params.task.slice(0, maxTaskLen)}...` : params.task;
+  return (
+    `A spawned subagent task was interrupted by a gateway restart or connection loss. ` +
+    `Automatic recovery is already in progress for \"${taskLabel}\" ` +
+    `(retry ${params.attemptNumber}/${params.maxAttempts}). ` +
+    `Send one brief update now in your normal voice: say the task was interrupted, ` +
+    `you are automatically resuming/retrying it, and you will report back when it either continues or truly fails. ` +
+    `Do not say the task has failed.`
+  );
+}
+
+async function announceRecoveryInProgress(params: {
+  runRecord: SubagentRunRecord;
+  attemptNumber: number;
+  maxAttempts: number;
+}): Promise<boolean> {
+  const requesterSessionKey = params.runRecord.requesterSessionKey?.trim();
+  if (!requesterSessionKey) {
+    return false;
+  }
+
+  const requesterOrigin = params.runRecord.requesterOrigin;
+  const requesterIsSubagent = isInternalAnnounceRequesterSession(requesterSessionKey);
+  let directOrigin = requesterOrigin;
+  if (!requesterIsSubagent) {
+    const { entry } = loadRequesterSessionEntry(requesterSessionKey);
+    directOrigin = resolveAnnounceOrigin(entry, requesterOrigin);
+  }
+
+  const prompt = buildRecoveryProgressPrompt({
+    task: params.runRecord.label || params.runRecord.task,
+    attemptNumber: params.attemptNumber,
+    maxAttempts: params.maxAttempts,
+  });
+
+  try {
+    const delivery = await deliverSubagentAnnouncement({
+      requesterSessionKey,
+      announceId: `${params.runRecord.runId}:recovery-progress`,
+      triggerMessage: prompt,
+      steerMessage: prompt,
+      summaryLine: params.runRecord.label || params.runRecord.task,
+      requesterSessionOrigin: requesterOrigin,
+      requesterOrigin,
+      completionDirectOrigin: requesterOrigin,
+      directOrigin,
+      sourceSessionKey: params.runRecord.childSessionKey,
+      sourceTool: "subagent_orphan_recovery",
+      targetRequesterSessionKey: requesterSessionKey,
+      requesterIsSubagent,
+      expectsCompletionMessage: false,
+      bestEffortDeliver: true,
+      directIdempotencyKey: buildAnnounceIdempotencyKey(
+        `${params.runRecord.runId}:recovery-progress`,
+      ),
+    });
+    return delivery.delivered;
+  } catch {
+    return false;
+  }
+}
+
 function extractMessageText(msg: unknown): string | undefined {
   if (!msg || typeof msg !== "object") {
     return undefined;
@@ -95,7 +175,7 @@ async function resumeOrphanedSession(params: {
   configChangeHint?: string;
   originalRunId: string;
   originalRun: SubagentRunRecord;
-}): Promise<boolean> {
+}): Promise<{ resumed: boolean; error?: string }> {
   let resumeMessage = buildResumeMessage(params.task, params.lastHumanMessage);
   if (params.configChangeHint) {
     resumeMessage += params.configChangeHint;
@@ -122,13 +202,14 @@ async function resumeOrphanedSession(params: {
       log.warn(
         `resumed orphaned session ${params.sessionKey} but remap failed (old run already removed); treating resume as accepted to avoid duplicate restarts`,
       );
-      return true;
+      return { resumed: true };
     }
     log.info(`resumed orphaned session: ${params.sessionKey}`);
-    return true;
+    return { resumed: true };
   } catch (err) {
-    log.warn(`failed to resume orphaned session ${params.sessionKey}: ${String(err)}`);
-    return false;
+    const error = formatErrorMessage(err);
+    log.warn(`failed to resume orphaned session ${params.sessionKey}: ${error}`);
+    return { resumed: false, error };
   }
 }
 
@@ -147,9 +228,28 @@ export async function recoverOrphanedSubagentSessions(params: {
   getActiveRuns: () => Map<string, SubagentRunRecord>;
   /** Persisted across retries so already-resumed sessions are not resumed again. */
   resumedSessionKeys?: Set<string>;
-}): Promise<{ recovered: number; failed: number; skipped: number }> {
-  const result = { recovered: 0, failed: 0, skipped: 0 };
+  /** Human-visible attempt number for this recovery pass. */
+  attemptNumber?: number;
+  /** Total recovery attempts before giving up. */
+  maxAttempts?: number;
+  /** Persisted across retries so recovery-in-progress notices stay deduped. */
+  notifiedRecoverySessionKeys?: Set<string>;
+}): Promise<{
+  recovered: number;
+  failed: number;
+  skipped: number;
+  failedRuns: Array<{ runId: string; childSessionKey: string; error?: string }>;
+}> {
+  const result = {
+    recovered: 0,
+    failed: 0,
+    skipped: 0,
+    failedRuns: [] as Array<{ runId: string; childSessionKey: string; error?: string }>,
+  };
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
+  const attemptNumber = Math.max(1, params.attemptNumber ?? 1);
+  const maxAttempts = Math.max(attemptNumber, params.maxAttempts ?? attemptNumber);
+  const notifiedRecoverySessionKeys = params.notifiedRecoverySessionKeys ?? new Set<string>();
   const configChangePattern = /openclaw\.json|openclaw gateway restart|config\.patch/i;
 
   try {
@@ -218,11 +318,22 @@ export async function recoverOrphanedSubagentSessions(params: {
           return typeof text === "string" && configChangePattern.test(text);
         });
 
+        if (attemptNumber > 1 && !notifiedRecoverySessionKeys.has(childSessionKey)) {
+          const notified = await announceRecoveryInProgress({
+            runRecord,
+            attemptNumber,
+            maxAttempts,
+          });
+          if (notified) {
+            notifiedRecoverySessionKeys.add(childSessionKey);
+          }
+        }
+
         // Resume the session with the original task context.
         // We intentionally do NOT clear abortedLastRun before attempting
         // the resume — if callGateway fails (e.g. gateway still booting),
         // the flag stays true so the next restart can retry.
-        const resumed = await resumeOrphanedSession({
+        const resumeResult = await resumeOrphanedSession({
           sessionKey: childSessionKey,
           task: runRecord.task,
           lastHumanMessage: extractMessageText(lastHumanMessage),
@@ -233,7 +344,7 @@ export async function recoverOrphanedSubagentSessions(params: {
           originalRun: runRecord,
         });
 
-        if (resumed) {
+        if (resumeResult.resumed) {
           resumedSessionKeys.add(childSessionKey);
           // Only clear the aborted flag after confirmed successful resume.
           try {
@@ -257,10 +368,21 @@ export async function recoverOrphanedSubagentSessions(params: {
             `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
           );
           result.failed++;
+          result.failedRuns.push({
+            runId,
+            childSessionKey,
+            error: resumeResult.error,
+          });
         }
       } catch (err) {
-        log.warn(`error processing orphaned session ${childSessionKey}: ${String(err)}`);
+        const error = formatErrorMessage(err);
+        log.warn(`error processing orphaned session ${childSessionKey}: ${error}`);
         result.failed++;
+        result.failedRuns.push({
+          runId,
+          childSessionKey,
+          error,
+        });
       }
     }
   } catch (err) {
@@ -285,6 +407,18 @@ const MAX_RECOVERY_RETRIES = 3;
 /** Backoff multiplier between retries (exponential). */
 const RETRY_BACKOFF_MULTIPLIER = 2;
 
+function buildRecoveryFailureMessage(params: { attempts: number; error?: string }): string {
+  const base =
+    `Subagent run was interrupted by a gateway restart or connection loss. ` +
+    `Automatic recovery failed after ${params.attempts} attempt${params.attempts === 1 ? "" : "s"}. ` +
+    `Please retry.`;
+  const detail = params.error?.trim();
+  if (!detail) {
+    return base;
+  }
+  return `${base} (${detail})`;
+}
+
 /**
  * Schedule orphan recovery after a delay, with retry logic.
  * The delay gives the gateway time to fully bootstrap after restart.
@@ -299,10 +433,17 @@ export function scheduleOrphanRecovery(params: {
   const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
 
   const resumedSessionKeys = new Set<string>();
+  const notifiedRecoverySessionKeys = new Set<string>();
 
   const attemptRecovery = (attempt: number, delay: number) => {
     setTimeout(() => {
-      void recoverOrphanedSubagentSessions({ ...params, resumedSessionKeys })
+      void recoverOrphanedSubagentSessions({
+        ...params,
+        resumedSessionKeys,
+        attemptNumber: attempt + 1,
+        maxAttempts: maxRetries + 1,
+        notifiedRecoverySessionKeys,
+      })
         .then((result) => {
           if (result.failed > 0 && attempt < maxRetries) {
             const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
@@ -310,7 +451,24 @@ export function scheduleOrphanRecovery(params: {
               `orphan recovery had ${result.failed} failure(s); retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
             );
             attemptRecovery(attempt + 1, nextDelay);
+            return;
           }
+          if (result.failedRuns.length === 0) {
+            return;
+          }
+          const attempts = attempt + 1;
+          void Promise.allSettled(
+            result.failedRuns.map((run) =>
+              finalizeInterruptedSubagentRun({
+                runId: run.runId,
+                childSessionKey: run.childSessionKey,
+                error: buildRecoveryFailureMessage({
+                  attempts,
+                  error: run.error,
+                }),
+              }),
+            ),
+          );
         })
         .catch((err) => {
           if (attempt < maxRetries) {

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -1,3 +1,4 @@
+import { getAgentRunContext } from "../infra/agent-events.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import {
   countActiveDescendantRunsFromRuns,
@@ -45,6 +46,15 @@ export function getSubagentRunByChildSessionKey(childSessionKey: string): Subage
     getSubagentRunsSnapshotForRead(subagentRuns),
     childSessionKey,
   );
+}
+
+export function isSubagentRunLive(
+  entry: Pick<SubagentRunRecord, "runId" | "endedAt"> | null | undefined,
+): boolean {
+  if (!entry || typeof entry.endedAt === "number") {
+    return false;
+  }
+  return Boolean(getAgentRunContext(entry.runId));
 }
 
 export function getSessionDisplaySubagentRunByChildSessionKey(

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -116,15 +116,12 @@ export function createSubagentRunManager(params: {
       if (wait.status === "pending") {
         return;
       }
-      if (wait.status === "interrupted") {
-        const recoverable = isRecoverableAgentWaitError(wait.error);
-        if (recoverable) {
-          log.info("subagent wait interrupted; scheduling recovery", {
-            runId,
-            childSessionKey: expectedEntry?.childSessionKey ?? entry?.childSessionKey,
-            error: wait.error,
-          });
-        }
+      if (wait.status === "error" && isRecoverableAgentWaitError(wait.error)) {
+        log.info("subagent wait interrupted; scheduling recovery", {
+          runId,
+          childSessionKey: expectedEntry?.childSessionKey ?? entry?.childSessionKey,
+          error: wait.error,
+        });
         params.scheduleOrphanRecovery({ delayMs: 1_000 });
         const scheduledEntry = entry;
         setTimeout(() => {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -6,7 +6,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
-import { waitForAgentRun } from "./run-wait.js";
+import { isRecoverableAgentWaitError, waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
 import {
@@ -30,6 +30,7 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const log = createSubsystemLogger("agents/subagent-registry");
+const RECOVERABLE_WAIT_RETRY_DELAY_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 25 : 5_000;
 
 function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
@@ -75,6 +76,7 @@ export function createSubagentRunManager(params: {
   resumeSubagentRun(runId: string): void;
   clearPendingLifecycleError(runId: string): void;
   resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: number): number;
+  scheduleOrphanRecovery(args?: { delayMs?: number; maxRetries?: number }): void;
   notifyContextEngineSubagentEnded(args: {
     childSessionKey: string;
     reason: "completed" | "deleted" | "released";
@@ -112,6 +114,29 @@ export function createSubagentRunManager(params: {
         return;
       }
       if (wait.status === "pending") {
+        return;
+      }
+      if (wait.status === "interrupted") {
+        const recoverable = isRecoverableAgentWaitError(wait.error);
+        if (recoverable) {
+          log.info("subagent wait interrupted; scheduling recovery", {
+            runId,
+            childSessionKey: expectedEntry?.childSessionKey ?? entry?.childSessionKey,
+            error: wait.error,
+          });
+        }
+        params.scheduleOrphanRecovery({ delayMs: 1_000 });
+        const scheduledEntry = entry;
+        setTimeout(() => {
+          if (!scheduledEntry) {
+            return;
+          }
+          const current = params.runs.get(runId);
+          if (!current || current !== scheduledEntry || typeof current.endedAt === "number") {
+            return;
+          }
+          void waitForSubagentCompletion(runId, waitTimeoutMs, scheduledEntry);
+        }, RECOVERABLE_WAIT_RETRY_DELAY_MS).unref?.();
         return;
       }
       let mutated = false;

--- a/src/agents/subagent-registry-steer-runtime.ts
+++ b/src/agents/subagent-registry-steer-runtime.ts
@@ -10,14 +10,32 @@ export type ReplaceSubagentRunAfterSteerParams = {
 
 type ReplaceSubagentRunAfterSteerFn = (params: ReplaceSubagentRunAfterSteerParams) => boolean;
 
+type FinalizeInterruptedSubagentRunParams = {
+  runId?: string;
+  childSessionKey?: string;
+  error: string;
+  endedAt?: number;
+};
+
+type FinalizeInterruptedSubagentRunFn = (
+  params: FinalizeInterruptedSubagentRunParams,
+) => Promise<number>;
+
 let replaceSubagentRunAfterSteerImpl: ReplaceSubagentRunAfterSteerFn | null = null;
+let finalizeInterruptedSubagentRunImpl: FinalizeInterruptedSubagentRunFn | null = null;
 
 export function configureSubagentRegistrySteerRuntime(params: {
   replaceSubagentRunAfterSteer: ReplaceSubagentRunAfterSteerFn;
+  finalizeInterruptedSubagentRun?: FinalizeInterruptedSubagentRunFn;
 }) {
   replaceSubagentRunAfterSteerImpl = params.replaceSubagentRunAfterSteer;
+  finalizeInterruptedSubagentRunImpl = params.finalizeInterruptedSubagentRun ?? null;
 }
 
 export function replaceSubagentRunAfterSteer(params: ReplaceSubagentRunAfterSteerParams) {
   return replaceSubagentRunAfterSteerImpl?.(params) ?? false;
+}
+
+export async function finalizeInterruptedSubagentRun(params: FinalizeInterruptedSubagentRunParams) {
+  return (await finalizeInterruptedSubagentRunImpl?.(params)) ?? 0;
 }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -378,7 +378,7 @@ describe("subagent registry seam flow", () => {
 
     const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
       mocks.onAgentEvent.mock.calls.length - 1
-    ] as
+    ] as unknown as
       | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
       | undefined;
     const lifecycleHandler = lastOnAgentEventCall?.[0];

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -10,6 +10,7 @@ const waitForFast = <T>(callback: () => T | Promise<T>) =>
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   onAgentEvent: vi.fn(() => noop),
+  getAgentRunContext: vi.fn(() => undefined),
   loadConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
     session: { mainKey: "main", scope: "per-sender" as const },
@@ -36,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   onSubagentEnded: vi.fn(async () => {}),
   runSubagentEnded: vi.fn(async () => {}),
   resolveAgentTimeoutMs: vi.fn(() => 1_000),
+  scheduleOrphanRecovery: vi.fn(),
 }));
 
 vi.mock("../gateway/call.js", () => ({
@@ -43,6 +45,7 @@ vi.mock("../gateway/call.js", () => ({
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
+  getAgentRunContext: mocks.getAgentRunContext,
   onAgentEvent: mocks.onAgentEvent,
 }));
 
@@ -98,6 +101,10 @@ vi.mock("./timeout.js", () => ({
   resolveAgentTimeoutMs: mocks.resolveAgentTimeoutMs,
 }));
 
+vi.mock("./subagent-orphan-recovery.js", () => ({
+  scheduleOrphanRecovery: mocks.scheduleOrphanRecovery,
+}));
+
 describe("subagent registry seam flow", () => {
   let mod: typeof import("./subagent-registry.js");
 
@@ -110,6 +117,7 @@ describe("subagent registry seam flow", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
     mocks.onAgentEvent.mockReturnValue(noop);
+    mocks.getAgentRunContext.mockReturnValue(undefined);
     mocks.loadConfig.mockReturnValue({
       agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
       session: { mainKey: "main", scope: "per-sender" as const },
@@ -128,6 +136,7 @@ describe("subagent registry seam flow", () => {
     mocks.resolveContextEngine.mockResolvedValue({
       onSubagentEnded: mocks.onSubagentEnded,
     });
+    mocks.scheduleOrphanRecovery.mockReset();
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return {
@@ -158,6 +167,129 @@ describe("subagent registry seam flow", () => {
     mod.__testing.setDepsForTest();
     mod.resetSubagentRegistryForTests({ persist: false });
     vi.useRealTimers();
+  });
+
+  it("schedules orphan recovery instead of terminally failing on recoverable wait transport errors", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        throw new Error("gateway closed (1006): transport close");
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-interrupted-wait",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "resume after transport close",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(mocks.scheduleOrphanRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ delayMs: 1_000 }),
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-interrupted-wait");
+    expect(run?.endedAt).toBeUndefined();
+    expect(run?.outcome).toBeUndefined();
+  });
+
+  it("reconciles stale active runs from persisted terminal session state during sweep", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    const persistedStartedAt = Date.parse("2026-03-24T11:58:00Z");
+    const persistedEndedAt = persistedStartedAt + 111;
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: persistedEndedAt,
+        status: "done",
+        startedAt: persistedStartedAt,
+        endedAt: persistedEndedAt,
+        runtimeMs: 111,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-stale-terminal",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "settle from persisted terminal state",
+      cleanup: "keep",
+    });
+
+    vi.setSystemTime(new Date("2026-03-24T12:02:00Z"));
+    await mod.__testing.sweepOnceForTests();
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          childRunId: "run-stale-terminal",
+          outcome: expect.objectContaining({ status: "ok", endedAt: persistedEndedAt }),
+        }),
+      );
+    });
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-stale-terminal");
+    expect(run?.endedAt).toBe(persistedEndedAt);
+    expect(run?.outcome).toMatchObject({
+      status: "ok",
+      endedAt: persistedEndedAt,
+    });
+    expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+  });
+
+  it("requeues orphan recovery instead of keeping restart-aborted stale runs stuck as running", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: 333,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-stale-aborted",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "resume after restart",
+      cleanup: "keep",
+    });
+
+    vi.setSystemTime(new Date("2026-03-24T12:02:00Z"));
+    await mod.__testing.sweepOnceForTests();
+
+    await waitForFast(() => {
+      expect(mocks.scheduleOrphanRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ delayMs: 1_000 }),
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-stale-aborted");
+    expect(run?.endedAt).toBeUndefined();
+    expect(run?.outcome).toBeUndefined();
   });
 
   it("completes a registered run across timing persistence, lifecycle status, and announce cleanup", async () => {
@@ -224,6 +356,68 @@ describe("subagent registry seam flow", () => {
     });
 
     expect(mocks.persistSubagentRunsToDisk).toHaveBeenCalled();
+  });
+
+  it("suppresses stale timeout announces when the same child run later finishes successfully", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-then-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout retry",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-then-ok",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1_000, aborted: true },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    lifecycleHandler?.({
+      runId: "run-timeout-then-ok",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1_250 },
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childRunId: "run-timeout-then-ok",
+        outcome: expect.objectContaining({
+          status: "ok",
+          endedAt: 1_250,
+        }),
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
   it("deletes delete-mode completion runs when announce cleanup gives up after retry limit", async () => {
@@ -499,6 +693,60 @@ describe("subagent registry seam flow", () => {
     await waitForFast(async () => {
       await expect(fs.access(attachmentsDir)).rejects.toMatchObject({ code: "ENOENT" });
     });
+  });
+
+  it("announces readable failure when an interrupted run is finalized", async () => {
+    mod.addSubagentRunForTests({
+      runId: "run-interrupted",
+      childSessionKey: "agent:main:subagent:interrupted",
+      controllerSessionKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "quietchat", accountId: "acct-interrupted" },
+      requesterDisplayKey: "main",
+      task: "recover interrupted subagent",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      spawnMode: "run",
+      createdAt: 1,
+      startedAt: 1,
+      sessionStartedAt: 1,
+      accumulatedRuntimeMs: 0,
+      cleanupHandled: false,
+    });
+
+    const updated = await mod.finalizeInterruptedSubagentRun({
+      runId: "run-interrupted",
+      error:
+        "Subagent run was interrupted by a gateway restart or connection loss. Automatic recovery failed after 2 attempts. Please retry.",
+      endedAt: 2,
+    });
+
+    expect(updated).toBe(1);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          childRunId: "run-interrupted",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: { channel: "quietchat", accountId: "acct-interrupted" },
+          outcome: expect.objectContaining({
+            status: "error",
+            error: expect.stringContaining("Automatic recovery failed after 2 attempts"),
+          }),
+        }),
+      );
+    });
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-interrupted");
+    expect(run?.outcome).toEqual({
+      status: "error",
+      error:
+        "Subagent run was interrupted by a gateway restart or connection loss. Automatic recovery failed after 2 attempts. Please retry.",
+      startedAt: 1,
+      endedAt: 2,
+      elapsedMs: 1,
+    });
+    expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
   it("removes attachments for released delete-mode runs", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1,9 +1,15 @@
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+  type SessionEntry,
+} from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
-import { onAgentEvent } from "../infra/agent-events.js";
+import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { registerPendingSpawnedChildrenQuery } from "../infra/outbound/pending-spawn-query.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { importRuntimeModule } from "../shared/runtime-import.js";
@@ -166,10 +172,103 @@ const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
  * subsequent lifecycle `start` / `end` can cancel premature failure announces.
  */
 const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
+/**
+ * Embedded runs can also surface an intermediate lifecycle `end` with
+ * `aborted=true` just before the runtime automatically retries the same run.
+ * Give that timeout a short grace window so the parent does not get a stale
+ * `timed out` completion right before the eventual success.
+ */
+const LIFECYCLE_TIMEOUT_RETRY_GRACE_MS = 15_000;
 /** Absolute TTL for session-mode runs after cleanup completes (no archiveAtMs). */
 const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
-/** Absolute TTL for orphaned pendingLifecycleError entries. */
-const PENDING_ERROR_TTL_MS = 5 * 60_000; // 5 minutes
+/** Absolute TTL for orphaned pendingLifecycleError / pendingLifecycleTimeout entries. */
+const PENDING_LIFECYCLE_TERMINAL_TTL_MS = 5 * 60_000; // 5 minutes
+/** Grace period before treating a "running" subagent without a live run context as stale. */
+const STALE_ACTIVE_SUBAGENT_GRACE_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 1_000 : 60_000;
+
+function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.trim().toLowerCase();
+  for (const [key, entry] of Object.entries(store)) {
+    if (key.trim().toLowerCase() === normalized) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function loadSubagentSessionEntry(
+  childSessionKey: string,
+  storeCache: Map<string, Record<string, SessionEntry>>,
+): SessionEntry | undefined {
+  const key = childSessionKey.trim();
+  if (!key) {
+    return undefined;
+  }
+  const agentId = resolveAgentIdFromSessionKey(key);
+  const storePath = resolveStorePath(loadConfig().session?.store, { agentId });
+  let store = storeCache.get(storePath);
+  if (!store) {
+    store = loadSessionStore(storePath);
+    storeCache.set(storePath, store);
+  }
+  return findSessionEntryByKey(store, key);
+}
+
+function resolveCompletionFromSessionEntry(
+  sessionEntry: SessionEntry | undefined,
+  fallbackEndedAt: number,
+): {
+  endedAt: number;
+  outcome: SubagentRunOutcome;
+  reason: SubagentLifecycleEndedReason;
+} | null {
+  const status = sessionEntry?.status;
+  const endedAt =
+    typeof sessionEntry?.endedAt === "number" && Number.isFinite(sessionEntry.endedAt)
+      ? sessionEntry.endedAt
+      : fallbackEndedAt;
+
+  if (status === "done") {
+    return {
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  if (status === "timeout") {
+    return {
+      endedAt,
+      outcome: { status: "timeout" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  if (status === "failed") {
+    return {
+      endedAt,
+      outcome: { status: "error", error: "session completed before registry settled" },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+    };
+  }
+  if (status === "killed") {
+    return {
+      endedAt,
+      outcome: { status: "error", error: "subagent run terminated" },
+      reason: SUBAGENT_ENDED_REASON_KILLED,
+    };
+  }
+  if (status !== "running" && typeof sessionEntry?.endedAt === "number") {
+    return {
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  return null;
+}
 
 function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
   contextEngineInitPromise ??= importRuntimeModule<ContextEngineInitModule>(
@@ -254,6 +353,13 @@ const pendingLifecycleErrorByRunId = new Map<
     error?: string;
   }
 >();
+const pendingLifecycleTimeoutByRunId = new Map<
+  string,
+  {
+    timer: NodeJS.Timeout;
+    endedAt: number;
+  }
+>();
 
 function clearPendingLifecycleError(runId: string) {
   const pending = pendingLifecycleErrorByRunId.get(runId);
@@ -271,7 +377,24 @@ function clearAllPendingLifecycleErrors() {
   pendingLifecycleErrorByRunId.clear();
 }
 
+function clearPendingLifecycleTimeout(runId: string) {
+  const pending = pendingLifecycleTimeoutByRunId.get(runId);
+  if (!pending) {
+    return;
+  }
+  clearTimeout(pending.timer);
+  pendingLifecycleTimeoutByRunId.delete(runId);
+}
+
+function clearAllPendingLifecycleTimeouts() {
+  for (const pending of pendingLifecycleTimeoutByRunId.values()) {
+    clearTimeout(pending.timer);
+  }
+  pendingLifecycleTimeoutByRunId.clear();
+}
+
 function schedulePendingLifecycleError(params: { runId: string; endedAt: number; error?: string }) {
+  clearPendingLifecycleTimeout(params.runId);
   clearPendingLifecycleError(params.runId);
   const timer = setTimeout(() => {
     const pending = pendingLifecycleErrorByRunId.get(params.runId);
@@ -304,6 +427,41 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
     timer,
     endedAt: params.endedAt,
     error: params.error,
+  });
+}
+
+function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: number }) {
+  clearPendingLifecycleError(params.runId);
+  clearPendingLifecycleTimeout(params.runId);
+  const timer = setTimeout(() => {
+    const pending = pendingLifecycleTimeoutByRunId.get(params.runId);
+    if (!pending || pending.timer !== timer) {
+      return;
+    }
+    pendingLifecycleTimeoutByRunId.delete(params.runId);
+    const entry = subagentRuns.get(params.runId);
+    if (!entry) {
+      return;
+    }
+    if (entry.outcome?.status === "ok") {
+      return;
+    }
+    void completeSubagentRun({
+      runId: params.runId,
+      endedAt: pending.endedAt,
+      outcome: {
+        status: "timeout",
+      },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      sendFarewell: true,
+      accountId: entry.requesterOrigin?.accountId,
+      triggerCleanup: true,
+    });
+  }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
+  timer.unref?.();
+  pendingLifecycleTimeoutByRunId.set(params.runId, {
+    timer,
+    endedAt: params.endedAt,
   });
 }
 
@@ -576,8 +734,69 @@ async function sweepSubagentRuns() {
   sweepInProgress = true;
   try {
     const now = Date.now();
+    const storeCache = new Map<string, Record<string, SessionEntry>>();
     let mutated = false;
     for (const [runId, entry] of subagentRuns.entries()) {
+      if (typeof entry.endedAt !== "number") {
+        const hasLiveRunContext = Boolean(getAgentRunContext(runId));
+        const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);
+        if (!hasLiveRunContext && activeAgeMs >= STALE_ACTIVE_SUBAGENT_GRACE_MS) {
+          const orphanReason = resolveSubagentRunOrphanReason({
+            entry,
+            storeCache,
+          });
+          if (orphanReason) {
+            if (
+              reconcileOrphanedRun({
+                runId,
+                entry,
+                reason: orphanReason,
+                source: "resume",
+                runs: subagentRuns,
+                resumedRuns,
+              })
+            ) {
+              mutated = true;
+            }
+            continue;
+          }
+
+          const sessionEntry = loadSubagentSessionEntry(entry.childSessionKey, storeCache);
+          const completion = resolveCompletionFromSessionEntry(sessionEntry, now);
+          if (completion) {
+            await completeSubagentRun({
+              runId,
+              endedAt: completion.endedAt,
+              outcome: completion.outcome,
+              reason: completion.reason,
+              sendFarewell: true,
+              accountId: entry.requesterOrigin?.accountId,
+              triggerCleanup: true,
+            });
+            continue;
+          }
+
+          if (sessionEntry?.abortedLastRun === true) {
+            scheduleSubagentOrphanRecovery({ delayMs: 1_000 });
+            continue;
+          }
+
+          await completeSubagentRun({
+            runId,
+            endedAt: now,
+            outcome: {
+              status: "error",
+              error: "subagent run lost active execution context",
+            },
+            reason: SUBAGENT_ENDED_REASON_ERROR,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
+          });
+          continue;
+        }
+      }
+
       // Session-mode runs have no archiveAtMs — apply absolute TTL after cleanup completes.
       // Use cleanupCompletedAt (not endedAt) to avoid interrupting deferred cleanup flows.
       if (!entry.archiveAtMs) {
@@ -633,8 +852,13 @@ async function sweepSubagentRuns() {
     }
     // Sweep orphaned pendingLifecycleError entries (absolute TTL).
     for (const [runId, pending] of pendingLifecycleErrorByRunId.entries()) {
-      if (now - pending.endedAt > PENDING_ERROR_TTL_MS) {
+      if (now - pending.endedAt > PENDING_LIFECYCLE_TERMINAL_TTL_MS) {
         clearPendingLifecycleError(runId);
+      }
+    }
+    for (const [runId, pending] of pendingLifecycleTimeoutByRunId.entries()) {
+      if (now - pending.endedAt > PENDING_LIFECYCLE_TERMINAL_TTL_MS) {
+        clearPendingLifecycleTimeout(runId);
       }
     }
 
@@ -669,6 +893,7 @@ function ensureListener() {
       }
       if (phase === "start") {
         clearPendingLifecycleError(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId);
         const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
         if (startedAt) {
           entry.startedAt = startedAt;
@@ -692,14 +917,19 @@ function ensureListener() {
         });
         return;
       }
+      if (evt.data?.aborted) {
+        schedulePendingLifecycleTimeout({
+          runId: evt.runId,
+          endedAt,
+        });
+        return;
+      }
       clearPendingLifecycleError(evt.runId);
-      const outcome: SubagentRunOutcome = evt.data?.aborted
-        ? { status: "timeout" }
-        : { status: "ok" };
+      clearPendingLifecycleTimeout(evt.runId);
       await completeSubagentRun({
         runId: evt.runId,
         endedAt,
-        outcome,
+        outcome: { status: "ok" },
         reason: SUBAGENT_ENDED_REASON_COMPLETE,
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
@@ -727,6 +957,7 @@ const subagentRunManager = createSubagentRunManager({
   resumeSubagentRun,
   clearPendingLifecycleError,
   resolveSubagentWaitTimeoutMs,
+  scheduleOrphanRecovery: (args) => scheduleSubagentOrphanRecovery(args),
   notifyContextEngineSubagentEnded,
   completeCleanupBookkeeping,
   completeSubagentRun,
@@ -734,6 +965,7 @@ const subagentRunManager = createSubagentRunManager({
 
 configureSubagentRegistrySteerRuntime({
   replaceSubagentRunAfterSteer: (params) => subagentRunManager.replaceSubagentRunAfterSteer(params),
+  finalizeInterruptedSubagentRun: async (params) => await finalizeInterruptedSubagentRun(params),
 });
 
 export function markSubagentRunForSteerRestart(runId: string) {
@@ -768,6 +1000,7 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   resumedRuns.clear();
   endedHookInFlightRunIds.clear();
   clearAllPendingLifecycleErrors();
+  clearAllPendingLifecycleTimeouts();
   contextEngineInitPromise = null;
   contextEngineRegistryPromise = null;
   runtimePluginsPromise = null;
@@ -788,6 +1021,9 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
 }
 
 export const __testing = {
+  async sweepOnceForTests() {
+    await sweepSubagentRuns();
+  },
   setDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
     subagentRegistryDeps = overrides
       ? {
@@ -804,6 +1040,57 @@ export function addSubagentRunForTests(entry: SubagentRunRecord) {
 
 export function releaseSubagentRun(runId: string) {
   subagentRunManager.releaseSubagentRun(runId);
+}
+
+export async function finalizeInterruptedSubagentRun(params: {
+  runId?: string;
+  childSessionKey?: string;
+  error: string;
+  endedAt?: number;
+}): Promise<number> {
+  const runIds = new Set<string>();
+  if (typeof params.runId === "string" && params.runId.trim()) {
+    runIds.add(params.runId.trim());
+  }
+  if (typeof params.childSessionKey === "string" && params.childSessionKey.trim()) {
+    const childSessionKey = params.childSessionKey.trim();
+    for (const [runId, entry] of subagentRuns.entries()) {
+      if (entry.childSessionKey === childSessionKey) {
+        runIds.add(runId);
+      }
+    }
+  }
+  if (runIds.size === 0) {
+    return 0;
+  }
+
+  const endedAt =
+    typeof params.endedAt === "number" && Number.isFinite(params.endedAt)
+      ? params.endedAt
+      : Date.now();
+  let updated = 0;
+  for (const runId of runIds) {
+    clearPendingLifecycleError(runId);
+    clearPendingLifecycleTimeout(runId);
+    const entry = subagentRuns.get(runId);
+    if (!entry || typeof entry.cleanupCompletedAt === "number") {
+      continue;
+    }
+    await completeSubagentRun({
+      runId,
+      endedAt,
+      outcome: {
+        status: "error",
+        error: params.error,
+      },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+      sendFarewell: true,
+      accountId: entry.requesterOrigin?.accountId,
+      triggerCleanup: true,
+    });
+    updated += 1;
+  }
+  return updated;
 }
 
 export function resolveRequesterForChildSession(childSessionKey: string): {

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -252,8 +252,8 @@ export async function waitForAgentJob(params: {
       snapshot: AgentRunSnapshot,
       delayMs: number,
     ) => {
-      const clearTimer = kind === "error" ? clearPendingErrorTimer : clearPendingTimeoutTimer;
-      clearTimer();
+      clearPendingErrorTimer();
+      clearPendingTimeoutTimer();
       const effectiveDelay = Math.max(1, Math.min(Math.floor(delayMs), 2_147_483_647));
       const timerRef = setTimeout(() => {
         const latest = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -7,10 +7,18 @@ const AGENT_RUN_CACHE_TTL_MS = 10 * 60_000;
  * subsequent `start` event can cancel premature terminal snapshots.
  */
 const AGENT_RUN_ERROR_RETRY_GRACE_MS = 15_000;
+/**
+ * Some embedded runtimes emit an intermediate lifecycle `end` with
+ * `aborted=true` immediately before retrying the same run. Hold timeout
+ * snapshots briefly so `agent.wait` does not resolve to a stale timeout when a
+ * final success is about to arrive.
+ */
+const AGENT_RUN_TIMEOUT_RETRY_GRACE_MS = 15_000;
 
 const agentRunCache = new Map<string, AgentRunSnapshot>();
 const agentRunStarts = new Map<string, number>();
 const pendingAgentRunErrors = new Map<string, PendingAgentRunError>();
+const pendingAgentRunTimeouts = new Map<string, PendingAgentRunTerminal>();
 let agentRunListenerStarted = false;
 
 type AgentRunSnapshot = {
@@ -22,11 +30,13 @@ type AgentRunSnapshot = {
   ts: number;
 };
 
-type PendingAgentRunError = {
+type PendingAgentRunTerminal = {
   snapshot: AgentRunSnapshot;
   dueAt: number;
   timer: NodeJS.Timeout;
 };
+
+type PendingAgentRunError = PendingAgentRunTerminal;
 
 function pruneAgentRunCache(now = Date.now()) {
   for (const [runId, entry] of agentRunCache) {
@@ -50,7 +60,17 @@ function clearPendingAgentRunError(runId: string) {
   pendingAgentRunErrors.delete(runId);
 }
 
+function clearPendingAgentRunTimeout(runId: string) {
+  const pending = pendingAgentRunTimeouts.get(runId);
+  if (!pending) {
+    return;
+  }
+  clearTimeout(pending.timer);
+  pendingAgentRunTimeouts.delete(runId);
+}
+
 function schedulePendingAgentRunError(snapshot: AgentRunSnapshot) {
+  clearPendingAgentRunTimeout(snapshot.runId);
   clearPendingAgentRunError(snapshot.runId);
   const dueAt = Date.now() + AGENT_RUN_ERROR_RETRY_GRACE_MS;
   const timer = setTimeout(() => {
@@ -65,8 +85,35 @@ function schedulePendingAgentRunError(snapshot: AgentRunSnapshot) {
   pendingAgentRunErrors.set(snapshot.runId, { snapshot, dueAt, timer });
 }
 
+function schedulePendingAgentRunTimeout(snapshot: AgentRunSnapshot) {
+  clearPendingAgentRunError(snapshot.runId);
+  clearPendingAgentRunTimeout(snapshot.runId);
+  const dueAt = Date.now() + AGENT_RUN_TIMEOUT_RETRY_GRACE_MS;
+  const timer = setTimeout(() => {
+    const pending = pendingAgentRunTimeouts.get(snapshot.runId);
+    if (!pending) {
+      return;
+    }
+    pendingAgentRunTimeouts.delete(snapshot.runId);
+    recordAgentRunSnapshot(pending.snapshot);
+  }, AGENT_RUN_TIMEOUT_RETRY_GRACE_MS);
+  timer.unref?.();
+  pendingAgentRunTimeouts.set(snapshot.runId, { snapshot, dueAt, timer });
+}
+
 function getPendingAgentRunError(runId: string) {
   const pending = pendingAgentRunErrors.get(runId);
+  if (!pending) {
+    return undefined;
+  }
+  return {
+    snapshot: pending.snapshot,
+    dueAt: pending.dueAt,
+  };
+}
+
+function getPendingAgentRunTimeout(runId: string) {
+  const pending = pendingAgentRunTimeouts.get(runId);
   if (!pending) {
     return undefined;
   }
@@ -113,6 +160,7 @@ function ensureAgentRunListener() {
       const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
       agentRunStarts.set(evt.runId, startedAt ?? Date.now());
       clearPendingAgentRunError(evt.runId);
+      clearPendingAgentRunTimeout(evt.runId);
       // A new start means this run is active again (or retried). Drop stale
       // terminal snapshots so waiters don't resolve from old state.
       agentRunCache.delete(evt.runId);
@@ -131,7 +179,12 @@ function ensureAgentRunListener() {
       schedulePendingAgentRunError(snapshot);
       return;
     }
+    if (snapshot.status === "timeout") {
+      schedulePendingAgentRunTimeout(snapshot);
+      return;
+    }
     clearPendingAgentRunError(evt.runId);
+    clearPendingAgentRunTimeout(evt.runId);
     recordAgentRunSnapshot(snapshot);
   });
 }
@@ -160,6 +213,7 @@ export async function waitForAgentJob(params: {
   return await new Promise((resolve) => {
     let settled = false;
     let pendingErrorTimer: NodeJS.Timeout | undefined;
+    let pendingTimeoutTimer: NodeJS.Timeout | undefined;
     let onAbort: (() => void) | undefined;
 
     const clearPendingErrorTimer = () => {
@@ -170,6 +224,14 @@ export async function waitForAgentJob(params: {
       pendingErrorTimer = undefined;
     };
 
+    const clearPendingTimeoutTimer = () => {
+      if (!pendingTimeoutTimer) {
+        return;
+      }
+      clearTimeout(pendingTimeoutTimer);
+      pendingTimeoutTimer = undefined;
+    };
+
     const finish = (entry: AgentRunSnapshot | null) => {
       if (settled) {
         return;
@@ -177,6 +239,7 @@ export async function waitForAgentJob(params: {
       settled = true;
       clearTimeout(timer);
       clearPendingErrorTimer();
+      clearPendingTimeoutTimer();
       unsubscribe();
       if (onAbort) {
         signal?.removeEventListener("abort", onAbort);
@@ -184,13 +247,15 @@ export async function waitForAgentJob(params: {
       resolve(entry);
     };
 
-    const scheduleErrorFinish = (
+    const scheduleTerminalFinish = (
+      kind: "error" | "timeout",
       snapshot: AgentRunSnapshot,
-      delayMs = AGENT_RUN_ERROR_RETRY_GRACE_MS,
+      delayMs: number,
     ) => {
-      clearPendingErrorTimer();
+      const clearTimer = kind === "error" ? clearPendingErrorTimer : clearPendingTimeoutTimer;
+      clearTimer();
       const effectiveDelay = Math.max(1, Math.min(Math.floor(delayMs), 2_147_483_647));
-      pendingErrorTimer = setTimeout(() => {
+      const timerRef = setTimeout(() => {
         const latest = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
         if (latest) {
           finish(latest);
@@ -199,13 +264,36 @@ export async function waitForAgentJob(params: {
         recordAgentRunSnapshot(snapshot);
         finish(snapshot);
       }, effectiveDelay);
-      pendingErrorTimer.unref?.();
+      timerRef.unref?.();
+      if (kind === "error") {
+        pendingErrorTimer = timerRef;
+      } else {
+        pendingTimeoutTimer = timerRef;
+      }
+    };
+
+    const scheduleErrorFinish = (
+      snapshot: AgentRunSnapshot,
+      delayMs = AGENT_RUN_ERROR_RETRY_GRACE_MS,
+    ) => {
+      scheduleTerminalFinish("error", snapshot, delayMs);
+    };
+
+    const scheduleTimeoutFinish = (
+      snapshot: AgentRunSnapshot,
+      delayMs = AGENT_RUN_TIMEOUT_RETRY_GRACE_MS,
+    ) => {
+      scheduleTerminalFinish("timeout", snapshot, delayMs);
     };
 
     if (!ignoreCachedSnapshot) {
-      const pending = getPendingAgentRunError(runId);
-      if (pending) {
-        scheduleErrorFinish(pending.snapshot, pending.dueAt - Date.now());
+      const pendingError = getPendingAgentRunError(runId);
+      if (pendingError) {
+        scheduleErrorFinish(pendingError.snapshot, pendingError.dueAt - Date.now());
+      }
+      const pendingTimeout = getPendingAgentRunTimeout(runId);
+      if (pendingTimeout) {
+        scheduleTimeoutFinish(pendingTimeout.snapshot, pendingTimeout.dueAt - Date.now());
       }
     }
 
@@ -219,6 +307,7 @@ export async function waitForAgentJob(params: {
       const phase = evt.data?.phase;
       if (phase === "start") {
         clearPendingErrorTimer();
+        clearPendingTimeoutTimer();
         return;
       }
       if (phase !== "end" && phase !== "error") {
@@ -236,6 +325,10 @@ export async function waitForAgentJob(params: {
       });
       if (phase === "error") {
         scheduleErrorFinish(snapshot);
+        return;
+      }
+      if (snapshot.status === "timeout") {
+        scheduleTimeoutFinish(snapshot);
         return;
       }
       recordAgentRunSnapshot(snapshot);

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -54,17 +54,32 @@ describe("waitForAgentJob", () => {
     return waitPromise;
   }
 
-  it("maps lifecycle end events with aborted=true to timeout", async () => {
-    const snapshot = await runLifecycleScenario({
-      runIdPrefix: "run-timeout",
-      startedAt: 100,
-      endedAt: 200,
-      aborted: true,
-    });
-    expect(snapshot).not.toBeNull();
-    expect(snapshot?.status).toBe("timeout");
-    expect(snapshot?.startedAt).toBe(100);
-    expect(snapshot?.endedAt).toBe(200);
+  it("maps lifecycle end events with aborted=true to timeout after the retry grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 100 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", endedAt: 200, aborted: true },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.status).toBe("timeout");
+      expect(snapshot?.startedAt).toBe(100);
+      expect(snapshot?.endedAt).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps non-aborted lifecycle end events as ok", async () => {
@@ -77,6 +92,36 @@ describe("waitForAgentJob", () => {
     expect(snapshot?.status).toBe("ok");
     expect(snapshot?.startedAt).toBe(300);
     expect(snapshot?.endedAt).toBe(400);
+  });
+
+  it("ignores transient aborted end events when the same run later succeeds", async () => {
+    const runId = `run-timeout-retry-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 500 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 500, endedAt: 600, aborted: true },
+    });
+
+    queueMicrotask(() => {
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 500, endedAt: 700 },
+      });
+    });
+
+    const snapshot = await waitPromise;
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.status).toBe("ok");
+    expect(snapshot?.startedAt).toBe(500);
+    expect(snapshot?.endedAt).toBe(700);
   });
 
   it("can ignore cached snapshots and wait for fresh lifecycle events", async () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -124,6 +124,74 @@ describe("waitForAgentJob", () => {
     expect(snapshot?.endedAt).toBe(700);
   });
 
+  it("lets a later aborted timeout replace a pending lifecycle error", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-then-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 800 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", startedAt: 800, endedAt: 900, error: "transient error" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 800, endedAt: 1_000, aborted: true },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await waitPromise;
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.status).toBe("timeout");
+      expect(snapshot?.startedAt).toBe(800);
+      expect(snapshot?.endedAt).toBe(1_000);
+      expect(snapshot?.error).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets a later lifecycle error replace a pending aborted timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-then-error-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_100 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 1_100, endedAt: 1_200, aborted: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", startedAt: 1_100, endedAt: 1_300, error: "final error" },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await waitPromise;
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.status).toBe("error");
+      expect(snapshot?.startedAt).toBe(1_100);
+      expect(snapshot?.endedAt).toBe(1_300);
+      expect(snapshot?.error).toBe("final error");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("can ignore cached snapshots and wait for fresh lifecycle events", async () => {
     const runId = `run-ignore-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     emitAgentEvent({

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -72,6 +72,8 @@ function buildGatewaySessionSnapshot(params: {
     modelProvider: sessionRow.modelProvider,
     model: sessionRow.model,
     status: sessionRow.status,
+    subagentRunState: sessionRow.subagentRunState,
+    hasActiveSubagentRun: sessionRow.hasActiveSubagentRun,
     startedAt: sessionRow.startedAt,
     endedAt: sessionRow.endedAt,
     runtimeMs: sessionRow.runtimeMs,

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/subagent-registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 import { listSessionsFromStore } from "./session-utils.js";
 
 function createModelDefaultsConfig(params: {
@@ -118,6 +119,7 @@ function listSingleSession(params: {
 describe("listSessionsFromStore search", () => {
   afterEach(() => {
     resetSubagentRegistryForTests({ persist: false });
+    resetAgentRunContextForTest();
   });
 
   const baseCfg = {
@@ -494,6 +496,9 @@ describe("listSessionsFromStore search", () => {
           startedAt: now - 4_000,
           model: "anthropic/claude-sonnet-4-6",
         });
+        registerAgentRunContext("run-child-live", {
+          sessionKey: "agent:main:subagent:child-live",
+        });
 
         const result = listSingleSession({
           cfg: createAnthropicContext1mConfig(),
@@ -544,6 +549,9 @@ describe("listSessionsFromStore search", () => {
           createdAt: now - 5_000,
           startedAt: now - 4_000,
           model: "openai/gpt-5.4",
+        });
+        registerAgentRunContext("run-child-live-new-model", {
+          sessionKey: "agent:main:subagent:child-live-stale-transcript",
         });
 
         const result = listSingleSession({

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/subagent-registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withEnv } from "../test-utils/env.js";
 import {
@@ -19,9 +20,11 @@ import {
 describe("listSessionsFromStore subagent metadata", () => {
   afterEach(() => {
     resetSubagentRegistryForTests({ persist: false });
+    resetAgentRunContextForTest();
   });
   beforeEach(() => {
     resetSubagentRegistryForTests({ persist: false });
+    resetAgentRunContextForTest();
   });
 
   const cfg = {
@@ -69,6 +72,9 @@ describe("listSessionsFromStore subagent metadata", () => {
       createdAt: now - 10_000,
       startedAt: now - 9_000,
       model: "openai/gpt-5.4",
+    });
+    registerAgentRunContext("run-parent", {
+      sessionKey: "agent:main:subagent:parent",
     });
     addSubagentRunForTests({
       runId: "run-child",
@@ -135,6 +141,49 @@ describe("listSessionsFromStore subagent metadata", () => {
     const failed = result.sessions.find((session) => session.key === "agent:main:subagent:failed");
     expect(failed?.status).toBe("failed");
     expect(failed?.runtimeMs).toBe(5_000);
+  });
+
+  test("does not show stale registry-only subagent runs as actively running", () => {
+    const now = Date.now();
+    const childSessionKey = "agent:main:subagent:stale-display";
+    const store: Record<string, SessionEntry> = {
+      [childSessionKey]: {
+        sessionId: "sess-stale-display",
+        updatedAt: now - 250,
+        spawnedBy: "agent:main:main",
+        status: "done",
+        startedAt: now - 4_000,
+        endedAt: now - 500,
+        runtimeMs: 3_500,
+      } as SessionEntry,
+    };
+
+    addSubagentRunForTests({
+      runId: "run-stale-display",
+      childSessionKey,
+      controllerSessionKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "stale display task",
+      cleanup: "keep",
+      createdAt: now - 5_000,
+      startedAt: now - 4_000,
+      model: "openai/gpt-5.4",
+    });
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    const row = result.sessions.find((session) => session.key === childSessionKey);
+    expect(row?.status).toBe("done");
+    expect(row?.subagentRunState).toBe("historical");
+    expect(row?.hasActiveSubagentRun).toBe(false);
+    expect(row?.endedAt).toBe(now - 500);
+    expect(row?.runtimeMs).toBe(3_500);
   });
 
   test("does not keep childSessions attached to a stale older controller row", () => {
@@ -522,6 +571,9 @@ describe("listSessionsFromStore subagent metadata", () => {
       accumulatedRuntimeMs: 120_000,
       model: "openai/gpt-5.4",
     });
+    registerAgentRunContext("run-followup-new", {
+      sessionKey: "agent:main:subagent:followup",
+    });
 
     const result = listSessionsFromStore({
       cfg,
@@ -592,7 +644,7 @@ describe("listSessionsFromStore subagent metadata", () => {
     });
   });
 
-  test("uses persisted active subagent runs when the local worker only has terminal snapshots", async () => {
+  test("prefers persisted terminal session state when only stale active subagent snapshots remain", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-utils-subagent-"));
     const stateDir = path.join(tempRoot, "state");
     fs.mkdirSync(stateDir, { recursive: true });
@@ -662,10 +714,12 @@ describe("listSessionsFromStore subagent metadata", () => {
         },
       );
 
-      expect(row?.status).toBe("running");
+      expect(row?.status).toBe("done");
+      expect(row?.subagentRunState).toBe("historical");
+      expect(row?.hasActiveSubagentRun).toBe(false);
       expect(row?.startedAt).toBe(now - 9_000);
-      expect(row?.endedAt).toBeUndefined();
-      expect(row?.runtimeMs).toBeGreaterThanOrEqual(9_000);
+      expect(row?.endedAt).toBe(now - 1_800);
+      expect(row?.runtimeMs).toBe(100);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -23,6 +23,7 @@ import {
   getSessionDisplaySubagentRunByChildSessionKey,
   getSubagentSessionRuntimeMs,
   getSubagentSessionStartedAt,
+  isSubagentRunLive,
   listSubagentRunsForController,
   resolveSubagentSessionStatus,
 } from "../agents/subagent-registry-read.js";
@@ -1256,10 +1257,51 @@ export function buildGatewaySessionRow(params: {
   const subagentOwner =
     normalizeOptionalString(subagentRun?.controllerSessionKey) ||
     normalizeOptionalString(subagentRun?.requesterSessionKey);
-  const subagentStatus = subagentRun ? resolveSubagentSessionStatus(subagentRun) : undefined;
-  const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
-  const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
-  const subagentRuntimeMs = subagentRun ? resolveSessionRuntimeMs(subagentRun, now) : undefined;
+  const liveSubagentRunActive = isSubagentRunLive(subagentRun);
+  const persistedSessionStatus = entry?.status;
+  const persistedSessionEndedAt = entry?.endedAt;
+  const persistedSessionStartedAt = entry?.startedAt;
+  const persistedSessionRuntimeMs = entry?.runtimeMs;
+  const subagentRunState = subagentRun
+    ? liveSubagentRunActive
+      ? "active"
+      : typeof subagentRun.endedAt === "number" ||
+          persistedSessionStatus === "done" ||
+          persistedSessionStatus === "failed" ||
+          persistedSessionStatus === "killed" ||
+          persistedSessionStatus === "timeout" ||
+          typeof persistedSessionEndedAt === "number"
+        ? "historical"
+        : "interrupted"
+    : undefined;
+  const subagentStatus = subagentRun
+    ? liveSubagentRunActive
+      ? resolveSubagentSessionStatus(subagentRun)
+      : persistedSessionStatus === "running"
+        ? undefined
+        : (persistedSessionStatus ??
+          (typeof subagentRun.endedAt === "number"
+            ? resolveSubagentSessionStatus(subagentRun)
+            : undefined))
+    : undefined;
+  const subagentStartedAt = subagentRun
+    ? liveSubagentRunActive
+      ? getSubagentSessionStartedAt(subagentRun)
+      : (persistedSessionStartedAt ?? getSubagentSessionStartedAt(subagentRun))
+    : undefined;
+  const subagentEndedAt = subagentRun
+    ? liveSubagentRunActive
+      ? subagentRun.endedAt
+      : (persistedSessionEndedAt ?? subagentRun.endedAt)
+    : undefined;
+  const subagentRuntimeMs = subagentRun
+    ? liveSubagentRunActive
+      ? resolveSessionRuntimeMs(subagentRun, now)
+      : (persistedSessionRuntimeMs ??
+        (typeof subagentRun.endedAt === "number"
+          ? resolveSessionRuntimeMs(subagentRun, now)
+          : undefined))
+    : undefined;
   const selectedModel = entry?.modelOverride?.trim()
     ? resolveSessionModelRef(cfg, entry, sessionAgentId)
     : null;
@@ -1403,6 +1445,8 @@ export function buildGatewaySessionRow(params: {
     totalTokensFresh,
     estimatedCostUsd,
     status: subagentRun ? subagentStatus : entry?.status,
+    subagentRunState,
+    hasActiveSubagentRun: subagentRun ? liveSubagentRunActive : undefined,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,
     endedAt: subagentRun ? subagentEndedAt : entry?.endedAt,
     runtimeMs: subagentRun ? subagentRuntimeMs : entry?.runtimeMs,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -23,6 +23,8 @@ export type GatewayThinkingLevelOption = {
 
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";
 
+export type SubagentRunState = "active" | "interrupted" | "historical";
+
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
@@ -62,6 +64,8 @@ export type GatewaySessionRow = {
   totalTokensFresh?: boolean;
   estimatedCostUsd?: number;
   status?: SessionRunStatus;
+  subagentRunState?: SubagentRunState;
+  hasActiveSubagentRun?: boolean;
   startedAt?: number;
   endedAt?: number;
   runtimeMs?: number;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -376,6 +376,7 @@ export type AgentsFilesSetResult = {
 };
 
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";
+export type SubagentRunState = "active" | "interrupted" | "historical";
 
 export type SessionCompactionCheckpointReason =
   | "manual"
@@ -431,6 +432,8 @@ export type GatewaySessionRow = {
   totalTokens?: number;
   totalTokensFresh?: boolean;
   status?: SessionRunStatus;
+  subagentRunState?: SubagentRunState;
+  hasActiveSubagentRun?: boolean;
   startedAt?: number;
   endedAt?: number;
   runtimeMs?: number;


### PR DESCRIPTION
## Summary
- Mark recoverable `agent.wait` connection interruptions as `interrupted` instead of treating them as terminal failures
- Improve orphan recovery with retry progress messaging, clearer failure finalization, and more readable terminal errors
- Reconcile registry and gateway session state so subagent runs are surfaced as `active`, `interrupted`, or `historical`
- Add Feishu delivery target resolution for direct chats, group chats, and topic threads

## Validation
- `pnpm exec vitest run src/agents/run-wait.test.ts src/agents/subagent-orphan-recovery.test.ts src/agents/subagent-registry.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-utils.subagent.test.ts extensions/feishu/src/channel.test.ts`
- 8 test files passed, 224 tests passed
