### PR TITLE
test(browser): cover tilde edge cases for executablePath

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -168,6 +168,32 @@ describe("browser config", () => {
     expect(resolved.executablePath).toBeUndefined();
   });
 
+  it("expands a bare ~ executablePath to the OS home directory", () => {
+    const resolved = resolveBrowserConfig({
+      executablePath: "~",
+    });
+
+    expect(resolved.executablePath).toBe(path.resolve(os.homedir()));
+  });
+
+  it("expands a Windows-style ~\\ executablePath to the OS home directory", () => {
+    const resolved = resolveBrowserConfig({
+      executablePath: "~\\AppData\\Local\\Chromium\\chrome.exe",
+    });
+
+    expect(resolved.executablePath).toBe(
+      path.resolve(os.homedir(), "AppData/Local/Chromium/chrome.exe"),
+    );
+  });
+
+  it("does not expand executablePath values where ~ is not the home prefix", () => {
+    const resolved = resolveBrowserConfig({
+      executablePath: "/opt/~chromium/chrome",
+    });
+
+    expect(resolved.executablePath).toBe("/opt/~chromium/chrome");
+  });
+
   it("normalizes invalid browser tab cleanup numbers to defaults", () => {
     const resolved = resolveBrowserConfig({
       tabCleanup: {

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -176,15 +176,22 @@ describe("browser config", () => {
     expect(resolved.executablePath).toBe(path.resolve(os.homedir()));
   });
 
-  it("expands a Windows-style ~\\ executablePath to the OS home directory", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "~\\AppData\\Local\\Chromium\\chrome.exe",
-    });
+  // Windows-only: on POSIX path.resolve treats `\` as a literal character,
+  // so "~\foo" cannot resolve to "$HOME/foo". The helper's regex still matches
+  // a leading `~\` on every platform; we only assert the resolved form where
+  // the OS path module agrees.
+  (process.platform === "win32" ? it : it.skip)(
+    "expands a Windows-style ~\\ executablePath to the OS home directory",
+    () => {
+      const resolved = resolveBrowserConfig({
+        executablePath: "~\\AppData\\Local\\Chromium\\chrome.exe",
+      });
 
-    expect(resolved.executablePath).toBe(
-      path.resolve(os.homedir(), "AppData/Local/Chromium/chrome.exe"),
-    );
-  });
+      expect(resolved.executablePath).toBe(
+        path.resolve(os.homedir(), "AppData/Local/Chromium/chrome.exe"),
+      );
+    },
+  );
 
   it("does not expand executablePath values where ~ is not the home prefix", () => {
     const resolved = resolveBrowserConfig({


### PR DESCRIPTION
## Summary

  Adds three test cases for `browser.executablePath` tilde expansion that the original fix in 95a2c9b
  supports but does not assert:

  - bare `~` expands to the home directory
  - Windows-style `~\AppData\...` expands correctly under `$HOME`
  - a stray `~` mid-path (e.g. `/opt/~chromium/chrome`) is preserved verbatim — guards the regex anchor
  `/^~(?=$|[\\/])/` against accidental relaxation

  ## Why

  The current tests cover `~/path` and non-tilde paths, but the helper's regex was deliberately written
  to also accept bare `~` and `~\` while rejecting embedded `~`. Pinning that contract prevents
  regressions if someone later "simplifies" the regex.

  ## Test plan

  - [x] Three new vitest cases added in `extensions/browser/src/browser/config.test.ts`
  - [x] No production code changes — tests only