### PR TITLE
fix(google): omit systemInstruction/tools/toolConfig when cachedContent is used

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -175,16 +175,13 @@ describe("google transport stream", () => {
       throw new Error("Expected Google transport request body to be serialized JSON");
     }
     const payload = JSON.parse(requestBody) as Record<string, unknown>;
-    expect(payload.systemInstruction).toEqual({
-      parts: [{ text: "Follow policy." }],
-    });
     expect(payload.cachedContent).toBe("cachedContents/request-cache");
+    expect(payload.systemInstruction).toBeUndefined();
     expect(payload.generationConfig).toMatchObject({
       thinkingConfig: { includeThoughts: true, thinkingLevel: "HIGH" },
     });
-    expect(payload.toolConfig).toMatchObject({
-      functionCallingConfig: { mode: "AUTO" },
-    });
+    expect(payload.tools).toBeUndefined();
+    expect(payload.toolConfig).toBeUndefined();
     expect(result).toMatchObject({
       api: "google-generative-ai",
       provider: "google",
@@ -513,5 +510,44 @@ describe("google transport stream", () => {
     );
 
     expect(params.cachedContent).toBe("cachedContents/prebuilt-context");
+  });
+
+  it("omits prompt and tool request settings when cachedContent is used", () => {
+    const model = {
+      id: "gemini-2.5-pro",
+      name: "Gemini 2.5 Pro",
+      api: "google-generative-ai",
+      provider: "google",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    } satisfies Model<"google-generative-ai">;
+
+    const params = buildGoogleGenerativeAiParams(
+      model,
+      {
+        systemPrompt: "Follow policy.",
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parameters: { type: "object" },
+          },
+        ],
+      } as never,
+      {
+        cachedContent: "cachedContents/prebuilt-context",
+        toolChoice: "auto",
+      },
+    );
+
+    expect(params.cachedContent).toBe("cachedContents/prebuilt-context");
+    expect(params.systemInstruction).toBeUndefined();
+    expect(params.tools).toBeUndefined();
+    expect(params.toolConfig).toBeUndefined();
   });
 });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -481,7 +481,9 @@ export function buildGoogleGenerativeAiParams(
   if (Object.keys(generationConfig).length > 0) {
     params.generationConfig = generationConfig;
   }
-  if (context.systemPrompt) {
+  const usesCachedContent =
+    typeof params.cachedContent === "string" && params.cachedContent.length > 0;
+  if (!usesCachedContent && context.systemPrompt) {
     params.systemInstruction = {
       parts: [
         {
@@ -490,7 +492,7 @@ export function buildGoogleGenerativeAiParams(
       ],
     };
   }
-  if (context.tools?.length) {
+  if (!usesCachedContent && context.tools?.length) {
     params.tools = convertGoogleTools(context.tools);
     const toolChoice = mapToolChoice(options?.toolChoice);
     if (toolChoice) {

--- a/src/agents/pi-embedded-runner/google-prompt-cache.test.ts
+++ b/src/agents/pi-embedded-runner/google-prompt-cache.test.ts
@@ -80,6 +80,30 @@ function createCapturingStreamFn(result = "stream") {
   };
 }
 
+function createConflictingPayloadStreamFn(result = "stream") {
+  let capturedPayload: Record<string, unknown> | undefined;
+  const streamFn = vi.fn(
+    (
+      model: Parameters<StreamFn>[0],
+      _context: Parameters<StreamFn>[1],
+      options: Parameters<StreamFn>[2],
+    ) => {
+      const payload: Record<string, unknown> = {
+        systemInstruction: { parts: [{ text: "Follow policy." }] },
+        tools: [{ functionDeclarations: [{ name: "lookup" }] }],
+        toolConfig: { functionCallingConfig: { mode: "AUTO" } },
+      };
+      void options?.onPayload?.(payload, model);
+      capturedPayload = payload;
+      return result as never;
+    },
+  );
+  return {
+    streamFn,
+    getCapturedPayload: () => capturedPayload,
+  };
+}
+
 function preparePromptCacheStream(params: {
   fetchMock: ReturnType<typeof vi.fn>;
   now: number;
@@ -172,9 +196,39 @@ describe("google prompt cache", () => {
     expect(getCapturedPayload()).toMatchObject({
       cachedContent: "cachedContents/system-cache-1",
     });
+    expect(getCapturedPayload()?.systemInstruction).toBeUndefined();
+    expect(getCapturedPayload()?.tools).toBeUndefined();
+    expect(getCapturedPayload()?.toolConfig).toBeUndefined();
     expect(entries).toHaveLength(1);
     expect(entries[0]?.customType).toBe("openclaw.google-prompt-cache");
     expect((entries[0]?.data as { status?: string; cachedContent?: string })?.status).toBe("ready");
+  });
+
+  it("removes GenerateContent fields that conflict with managed cachedContent", async () => {
+    const now = 1_500_000;
+    const sessionManager = makeSessionManager();
+    const fetchMock = createCacheFetchMock({
+      name: "cachedContents/system-cache-conflict",
+      expireTime: new Date(now + 3_600_000).toISOString(),
+    });
+    const { streamFn: innerStreamFn, getCapturedPayload } = createConflictingPayloadStreamFn();
+
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now,
+      sessionManager,
+      streamFn: innerStreamFn,
+    });
+
+    void wrapped?.(
+      makeGoogleModel(),
+      { systemPrompt: "Follow policy.", messages: [] } as never,
+      {} as never,
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      cachedContent: "cachedContents/system-cache-conflict",
+    });
   });
 
   it("reuses a persisted cache entry without creating a second cache", async () => {

--- a/src/agents/pi-embedded-runner/google-prompt-cache.ts
+++ b/src/agents/pi-embedded-runner/google-prompt-cache.ts
@@ -407,6 +407,9 @@ export async function prepareGooglePromptCacheStreamFn(
       options,
       (payload) => {
         payload.cachedContent = cachedContent;
+        delete payload.systemInstruction;
+        delete payload.tools;
+        delete payload.toolConfig;
       },
     );
 }


### PR DESCRIPTION
## Problem

When the Google Generative AI transport layer sends a request with `cachedContent`, it also sends `systemInstruction`, `tools`, and `toolConfig` in the same request body. The Google API rejects this because `cachedContent` already references a cached context that contains these fields — sending them again causes a conflict error.

This caused the Gemini-based cron job (`openclaw cron run`) to fail with Google API errors.

## Fix

In `buildGoogleGenerativeAiParams()`, detect when `cachedContent` is present and skip setting `systemInstruction`, `tools`, and `toolConfig`:

- `src/agents/google-transport-stream.ts`: Add `usesCachedContent` guard before setting `systemInstruction` and `tools`/`toolConfig`
- `src/agents/pi-embedded-runner/google-prompt-cache.ts`: Same guard for prompt cache builder

## Test Changes

- Updated existing test expectations: `systemInstruction`, `tools`, `toolConfig` should be `undefined` when `cachedContent` is present
- Added new test case: "omits prompt and tool request settings when cachedContent is used"
- Added test for `google-prompt-cache.ts` ensuring cached content path skips system prompt injection

## Files Changed

- `src/agents/google-transport-stream.ts` — guard `systemInstruction` and `tools` behind `!usesCachedContent`
- `src/agents/google-transport-stream.test.ts` — update expectations + new test
- `src/agents/pi-embedded-runner/google-prompt-cache.ts` — guard system prompt injection
- `src/agents/pi-embedded-runner/google-prompt-cache.test.ts` — new test