### PR TITLE
fix: disable validateAnthropicTurns for strict OpenAI-compatible transports

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -212,7 +212,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
     expect(policy.applyGoogleTurnOrdering).toBe(true);
     expect(policy.validateGeminiTurns).toBe(true);
-    expect(policy.validateAnthropicTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(false);
   }
 
   it("enables sanitizeToolCallIds for Anthropic provider", () => {
@@ -489,7 +489,7 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.applyGoogleTurnOrdering).toBe(true);
     expect(policy.validateGeminiTurns).toBe(true);
-    expect(policy.validateAnthropicTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(false);
   });
 
   it("keeps OpenRouter on its existing turn-validation path", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -116,7 +116,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
       : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
-    ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),
+    ...(isAnthropic ? { validateAnthropicTurns: true } : {}),
     ...(isGoogle || isAnthropic ? { allowSyntheticToolResults: true } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #71407 — DeepSeek thinking mode + tool calls = HTTP 400.

DeepSeek API requires `reasoning_content` to be passed back in all subsequent requests during tool-call loops. The `validateAnthropicTurns` policy flag was enabled for all strict OpenAI-compatible providers (openai-completions modelApi), which includes DeepSeek, Cerebras, xAI, Mistral, and others. When enabled, `stripDanglingAnthropicToolUses` drops thinking blocks from assistant messages when tool calls lack matching tool results — which strips the `reasoning_content` that DeepSeek needs.

**The fix:** Remove `isStrictOpenAiCompatible` from the `validateAnthropicTurns` condition in `buildUnownedProviderTransportReplayFallback`. This flag is only meaningful for Anthropic-family transports (anthropic-messages, bedrock-converse-stream) where the dangling-tool-use API rule applies. OpenAI-compatible providers handle dangling tool calls through their own transform layers (`transformTransportMessages`, pi-ai `transformMessages`).

**Changes:**
- `src/agents/transcript-policy.ts:119`: restrict `validateAnthropicTurns` to `isAnthropic` only (was `isAnthropic || isStrictOpenAiCompatible`)
- `src/agents/transcript-policy.test.ts`: update two test expectations for the unowned fallback path

## Test plan
- [x] `transcript-policy.test.ts` — all 29 tests pass
- [x] `pi-embedded-helpers.validate-turns.test.ts` — all 31 tests pass
- [x] Provider-owned policies (MiniMax, Bedrock, etc.) unaffected — verified in test matrix
- [x] DeepSeek tool-call + reasoning round-trips should no longer produce HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)