### PR TITLE
fix: restrict validateAnthropicTurns to Anthropic transports only

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -212,7 +212,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
     expect(policy.applyGoogleTurnOrdering).toBe(true);
     expect(policy.validateGeminiTurns).toBe(true);
-    expect(policy.validateAnthropicTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(false);
   }
 
   it("enables sanitizeToolCallIds for Anthropic provider", () => {
@@ -489,7 +489,7 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.applyGoogleTurnOrdering).toBe(true);
     expect(policy.validateGeminiTurns).toBe(true);
-    expect(policy.validateAnthropicTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(false);
   });
 
   it("keeps OpenRouter on its existing turn-validation path", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -116,7 +116,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
       : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
-    ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),
+    ...(isAnthropic ? { validateAnthropicTurns: true } : {}),
     ...(isGoogle || isAnthropic ? { allowSyntheticToolResults: true } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #71407

DeepSeek API requires `reasoning_content` to be passed back in subsequent requests during tool-call loops. The `validateAnthropicTurns` flag was enabled for all strict OpenAI-compatible providers, which includes DeepSeek. When enabled, `stripDanglingAnthropicToolUses` drops thinking blocks from assistant messages when tool calls lack matching tool results, stripping the `reasoning_content` that DeepSeek needs.

This change removes `isStrictOpenAiCompatible` from the `validateAnthropicTurns` condition so the flag only applies to Anthropic-family transports (anthropic-messages, bedrock-converse-stream). OpenAI-compatible providers handle dangling tool calls through their own transform layers.

## Changes

- `src/agents/transcript-policy.ts`: restrict `validateAnthropicTurns` to `isAnthropic` only
- `src/agents/transcript-policy.test.ts`: update test expectations for the unowned fallback path

## Test plan

- [x] `transcript-policy.test.ts` — 29 tests pass
- [x] `validate-turns.test.ts` — 31 tests pass
- [x] Provider-owned policies (MiniMax, Bedrock, etc.) unaffected