### PR TITLE
[codex] Fix Codex Responses payload compatibility

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -948,6 +948,137 @@ describe("openai transport stream", () => {
     expect(params.reasoning).toEqual({ effort: "medium", summary: "auto" });
   });
 
+  it("uses top-level instructions and strips unsupported fields for Codex responses", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        cacheRetention: "long",
+        maxTokens: 1024,
+        serviceTier: "auto",
+        sessionId: "session-123",
+        temperature: 0.2,
+      },
+      {
+        openclaw_session_id: "session-123",
+        openclaw_turn_id: "turn-123",
+      },
+    ) as Record<string, unknown> & {
+      input?: Array<{ role?: string }>;
+      instructions?: string;
+      tools?: unknown[];
+    };
+
+    expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
+    expect(
+      params.input?.some((item) => item.role === "system" || item.role === "developer"),
+    ).toBe(false);
+    expect(params.tools).toHaveLength(1);
+
+    for (const field of [
+      "metadata",
+      "store",
+      "temperature",
+      "max_output_tokens",
+      "prompt_cache_key",
+      "prompt_cache_retention",
+      "service_tier",
+    ]) {
+      expect(params).not.toHaveProperty(field);
+    }
+  });
+
+  it("allows priority service_tier for Codex responses", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        serviceTier: "priority",
+      },
+    ) as { service_tier?: unknown };
+
+    expect(params.service_tier).toBe("priority");
+  });
+
+  it("re-strips unsupported Codex responses fields after payload mutation", () => {
+    const params = __testing.finalizeOpenAIResponsesPayload(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        input: [],
+        instructions: "system",
+        max_output_tokens: 1024,
+        metadata: { openclaw_session_id: "session-123" },
+        model: "gpt-5.4",
+        prompt_cache_key: "session-123",
+        prompt_cache_retention: "24h",
+        service_tier: "auto",
+        store: false,
+        stream: true,
+        temperature: 0.2,
+      } as never,
+    ) as Record<string, unknown>;
+
+    expect(params.instructions).toBe("system");
+    for (const field of [
+      "metadata",
+      "store",
+      "temperature",
+      "max_output_tokens",
+      "prompt_cache_key",
+      "prompt_cache_retention",
+      "service_tier",
+    ]) {
+      expect(params).not.toHaveProperty(field);
+    }
+  });
+
   it.each([
     {
       label: "openai",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -728,7 +728,10 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        params = mergeTransportMetadata(params, turnState?.metadata);
+        params = finalizeOpenAIResponsesPayload(
+          model,
+          mergeTransportMetadata(params, turnState?.metadata),
+        ) as typeof params;
         const responseStream = (await client.responses.create(
           params as never,
           options?.signal ? { signal: options.signal } : undefined,
@@ -828,12 +831,80 @@ function raiseMinimalReasoningForResponsesWebSearch(params: {
   return params.effort;
 }
 
+const CODEX_RESPONSES_DEFAULT_INSTRUCTIONS = "You are Codex. Follow the user's instructions.";
+
+const CODEX_RESPONSES_UNSUPPORTED_FIELDS = [
+  "metadata",
+  "store",
+  "temperature",
+  "max_output_tokens",
+  "prompt_cache_key",
+  "prompt_cache_retention",
+] as const satisfies readonly (keyof OpenAIResponsesRequestParams)[];
+
+type CodexResponsesUnsupportedField = (typeof CODEX_RESPONSES_UNSUPPORTED_FIELDS)[number];
+
+type OpenAICodexResponsesRequestParams = Omit<
+  OpenAIResponsesRequestParams,
+  CodexResponsesUnsupportedField
+> & {
+  instructions: string;
+};
+
+const CODEX_RESPONSES_ALLOWED_SERVICE_TIERS = new Set<
+  NonNullable<ResponseCreateParamsStreaming["service_tier"]>
+>(["priority"]);
+
+function isOpenAICodexResponsesModel(model: Model<Api>): boolean {
+  return model.provider === "openai-codex" && model.api === "openai-codex-responses";
+}
+
+function buildOpenAICodexResponsesInstructions(context: Context): string {
+  return sanitizeTransportPayloadText(
+    stripSystemPromptCacheBoundary(context.systemPrompt || CODEX_RESPONSES_DEFAULT_INSTRUCTIONS),
+  );
+}
+
+function sanitizeOpenAICodexResponsesPayload<
+  T extends OpenAIResponsesRequestParams | OpenAICodexResponsesRequestParams,
+>(payload: T): T {
+  const sanitized = { ...payload } as T &
+    Partial<Record<CodexResponsesUnsupportedField, unknown>> & {
+      service_tier?: ResponseCreateParamsStreaming["service_tier"];
+    };
+
+  for (const field of CODEX_RESPONSES_UNSUPPORTED_FIELDS) {
+    delete sanitized[field];
+  }
+
+  if (
+    sanitized.service_tier !== undefined &&
+    !CODEX_RESPONSES_ALLOWED_SERVICE_TIERS.has(
+      sanitized.service_tier as NonNullable<ResponseCreateParamsStreaming["service_tier"]>,
+    )
+  ) {
+    delete sanitized.service_tier;
+  }
+
+  return sanitized as T;
+}
+
+function finalizeOpenAIResponsesPayload(
+  model: Model<Api>,
+  payload: OpenAIResponsesRequestParams | OpenAICodexResponsesRequestParams,
+): OpenAIResponsesRequestParams | OpenAICodexResponsesRequestParams {
+  return isOpenAICodexResponsesModel(model)
+    ? sanitizeOpenAICodexResponsesPayload(payload)
+    : payload;
+}
+
 export function buildOpenAIResponsesParams(
   model: Model<Api>,
   context: Context,
   options: OpenAIResponsesOptions | undefined,
   metadata?: Record<string, string>,
 ) {
+  const isCodexResponses = isOpenAICodexResponsesModel(model);
   const compat = getCompat(model as OpenAIModeModel);
   const supportsDeveloperRole =
     typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;
@@ -841,27 +912,43 @@ export function buildOpenAIResponsesParams(
     model,
     context,
     new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]),
-    { supportsDeveloperRole },
+    { includeSystemPrompt: !isCodexResponses, supportsDeveloperRole },
   );
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
   });
-  const params: OpenAIResponsesRequestParams = {
+  const baseParams = {
     model: model.id,
     input: messages,
-    stream: true,
-    prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
-    prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-    ...(metadata ? { metadata } : {}),
+    stream: true as const,
   };
-  if (options?.maxTokens) {
-    params.max_output_tokens = options.maxTokens;
+  const params: OpenAIResponsesRequestParams | OpenAICodexResponsesRequestParams =
+    isCodexResponses
+      ? {
+          ...baseParams,
+          instructions: buildOpenAICodexResponsesInstructions(context),
+        }
+      : {
+          ...baseParams,
+          prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
+          prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
+          ...(metadata ? { metadata } : {}),
+        };
+  if (options?.maxTokens && !isCodexResponses) {
+    (params as OpenAIResponsesRequestParams).max_output_tokens = options.maxTokens;
   }
-  if (options?.temperature !== undefined) {
-    params.temperature = options.temperature;
+  if (options?.temperature !== undefined && !isCodexResponses) {
+    (params as OpenAIResponsesRequestParams).temperature = options.temperature;
   }
-  if (options?.serviceTier !== undefined && payloadPolicy.allowsServiceTier) {
+  if (
+    options?.serviceTier !== undefined &&
+    payloadPolicy.allowsServiceTier &&
+    (!isCodexResponses ||
+      CODEX_RESPONSES_ALLOWED_SERVICE_TIERS.has(
+        options.serviceTier as NonNullable<ResponseCreateParamsStreaming["service_tier"]>,
+      ))
+  ) {
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
@@ -907,7 +994,7 @@ export function buildOpenAIResponsesParams(
     }
   }
   applyOpenAIResponsesPayloadPolicy(params as Record<string, unknown>, payloadPolicy);
-  return params;
+  return finalizeOpenAIResponsesPayload(model, params);
 }
 
 export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
@@ -1566,6 +1653,7 @@ type OpenAIResponsesRequestParams = {
   model: string;
   input: ResponseInput;
   stream: true;
+  instructions?: string;
   prompt_cache_key?: string;
   prompt_cache_retention?: "24h";
   metadata?: Record<string, string>;
@@ -1829,5 +1917,6 @@ function mapStopReason(reason: string | null) {
 
 export const __testing = {
   buildOpenAICompletionsClientConfig,
+  finalizeOpenAIResponsesPayload,
   processOpenAICompletionsStream,
 };


### PR DESCRIPTION
## Summary

- Route `openai-codex-responses` system prompts through top-level `instructions` instead of replaying them in the Responses `input` array.
- Strip Codex-incompatible Responses payload fields (`metadata`, `store`, `temperature`, `max_output_tokens`, `prompt_cache_key`, and `prompt_cache_retention`) through a central constant.
- Re-apply Codex payload sanitation after payload hooks and transport metadata merging so unsupported fields cannot be reintroduced.
- Keep `service_tier` gated for Codex Responses, allowing only `priority`.

## Why

The ChatGPT Codex Responses endpoint rejects several payload fields that are valid on native OpenAI Responses routes. When those fields are forwarded unchanged, Codex-backed models such as `gpt-5.4` can fail before streaming starts.

## Validation

- Added regression coverage for top-level Codex `instructions`, unsupported field stripping, `priority` service tier handling, and post-hook payload re-sanitization.
- Ran `prettier --debug-check` against the modified source and test files.
