### PR TITLE
fix(image): resolve configured provider models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Image tool: resolve configured provider-prefixed image models before rejecting them as unknown, preserving custom vision provider capability metadata for `imageModel` routing. Fixes #33185 and #70180.
 - MCP: retire one-shot embedded bundled MCP runtimes at run end, skip bundle-MCP startup when a runtime tool allowlist cannot reach bundle-MCP tools, and add `mcp.sessionIdleTtlMs` idle eviction for leaked session runtimes. Fixes #71106, #71110, #70389, and #70808.
 - Gateway/restart continuation: durably hand restart continuations to a session-delivery queue before deleting the restart sentinel, recover queued continuation work after crashy restarts, and fall back to a session-only wake when no channel route survives reboot. (#70780) Thanks @fuller-stack-dev.
 - Agents/tool-result pruning: harden the tool-result character estimator and context-pruning loops against malformed `{ type: "text" }` blocks created by void or undefined tool handler results, serializing non-string text payloads for size accounting so they cannot bypass trimming as zero-sized. Fixes #34979. (#51267) Thanks @cgdusek.

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -421,6 +421,71 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text", "image"]);
   });
 
+  it("propagates image input when configured model ids include the provider prefix", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("custom/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "custom",
+      id: "custom/vision-model",
+      input: ["text", "image"],
+    });
+  });
+
+  it("prefers provider-prefixed configured metadata over discovered text-only models", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "custom",
+      modelId: "vision-model",
+      templateModel: {
+        ...makeModel("vision-model"),
+        provider: "custom",
+        input: ["text"],
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("custom/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "custom",
+      id: "custom/vision-model",
+      input: ["text", "image"],
+    });
+  });
+
   it("keeps unknown fallback models text-only instead of borrowing image input from another configured model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -265,17 +265,18 @@ function findInlineModelMatch(params: {
   provider: string;
   modelId: string;
 }) {
+  const matchesModelId = (entry: { provider: string; id?: string }) =>
+    entry.id === params.modelId || entry.id === `${entry.provider}/${params.modelId}`;
   const inlineModels = buildInlineProviderModels(params.providers);
   const exact = inlineModels.find(
-    (entry) => entry.provider === params.provider && entry.id === params.modelId,
+    (entry) => entry.provider === params.provider && matchesModelId(entry),
   );
   if (exact) {
     return exact;
   }
   const normalizedProvider = normalizeProviderId(params.provider);
   return inlineModels.find(
-    (entry) =>
-      normalizeProviderId(entry.provider) === normalizedProvider && entry.id === params.modelId,
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && matchesModelId(entry),
   );
 }
 
@@ -306,6 +307,16 @@ function isModelsAddMetadataModel(params: {
   );
 }
 
+function findConfiguredProviderModel(
+  providerConfig: InlineProviderConfig | undefined,
+  provider: string,
+  modelId: string,
+) {
+  return providerConfig?.models?.find(
+    (candidate) => candidate.id === modelId || candidate.id === `${provider}/${modelId}`,
+  );
+}
+
 function applyConfiguredProviderOverrides(params: {
   provider: string;
   discoveredModel: ProviderRuntimeModel;
@@ -324,9 +335,9 @@ function applyConfiguredProviderOverrides(params: {
     };
   }
   const configuredModel =
-    providerConfig.models?.find((candidate) => candidate.id === modelId) ??
+    findConfiguredProviderModel(providerConfig, params.provider, modelId) ??
     (discoveredModel.id !== modelId
-      ? providerConfig.models?.find((candidate) => candidate.id === discoveredModel.id)
+      ? findConfiguredProviderModel(providerConfig, params.provider, discoveredModel.id)
       : undefined);
   const metadataOverrideModel =
     params.preferDiscoveredModelMetadata &&
@@ -546,7 +557,7 @@ function resolveConfiguredFallbackModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, cfg, agentDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -188,6 +188,56 @@ describe("describeImageWithModel", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("resolves custom provider image models from config when discovery misses", async () => {
+    discoverModelsMock.mockReturnValue({ find: vi.fn(() => null) });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "vllm",
+      model: "vllm/Qwen3.5",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "custom vision ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:1234/v1",
+              apiKey: "vllm-local", // pragma: allowlist secret
+              api: "openai-completions",
+              models: [
+                {
+                  id: "vllm/Qwen3.5",
+                  name: "Qwen3.5",
+                  input: ["text", "image"],
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      provider: "vllm",
+      model: "Qwen3.5",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "custom vision ok",
+      model: "vllm/Qwen3.5",
+    });
+    expect(completeMock).toHaveBeenCalledOnce();
+  });
+
   it("passes image prompt as system instructions for codex image requests", async () => {
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -6,8 +6,9 @@ import {
   requireApiKey,
   resolveApiKeyForProvider,
 } from "../agents/model-auth.js";
-import { normalizeModelRef } from "../agents/model-selection.js";
+import { normalizeModelRef, normalizeProviderId } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { buildInlineProviderModels } from "../agents/pi-embedded-runner/model.inline-provider.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
 import { registerProviderStreamForModel } from "../agents/provider-stream.js";
 import {
@@ -99,6 +100,21 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return Boolean(value) && typeof (value as { then?: unknown }).then === "function";
 }
 
+function resolveConfiguredImageModel(params: {
+  cfg: ImageDescriptionRequest["cfg"];
+  provider: string;
+  modelId: string;
+}): Model<Api> | undefined {
+  const configuredProviders = params.cfg?.models?.providers ?? {};
+  const normalizedProvider = normalizeProviderId(params.provider);
+  return buildInlineProviderModels(configuredProviders).find(
+    (entry) =>
+      (entry.provider === params.provider ||
+        normalizeProviderId(entry.provider) === normalizedProvider) &&
+      (entry.id === params.modelId || entry.id === `${entry.provider}/${params.modelId}`),
+  ) as Model<Api> | undefined;
+}
+
 function composeImageDescriptionPayloadHandlers(
   first: ProviderStreamOptions["onPayload"] | undefined,
   second: ProviderStreamOptions["onPayload"] | undefined,
@@ -141,7 +157,19 @@ async function resolveImageRuntime(params: {
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
-  const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
+  const registryModel = modelRegistry.find(
+    resolvedRef.provider,
+    resolvedRef.model,
+  ) as Model<Api> | null;
+  const configuredModel = resolveConfiguredImageModel({
+    cfg: params.cfg,
+    provider: resolvedRef.provider,
+    modelId: resolvedRef.model,
+  });
+  const model =
+    configuredModel?.input?.includes("image") && !registryModel?.input?.includes("image")
+      ? configuredModel
+      : (registryModel ?? configuredModel);
   if (!model) {
     throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
   }


### PR DESCRIPTION
## Summary

- Problem: `imageModel` routing could reject configured custom vision models with `Unknown model` when discovery did not return the row or returned text-only metadata.
- Why it matters: operators with configured providers such as vLLM, NVIDIA-compatible, iFlow, Ollama, or MiniMax could have valid `models.providers` image rows but still fail before the image request reached the provider.
- What changed: image understanding now falls back to configured provider rows, and shared model selection matches provider-prefixed configured ids such as `vllm/Qwen3.5` when the caller asks for provider `vllm`, model `Qwen3.5`.
- What did NOT change (scope boundary): no provider-specific endpoint behavior, auth format, or catalog discovery policy changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33185
- Closes #70180
- Related #51150
- Related #67406, #69648, #38816, #65431, #66625, #64111, #66758, #66017, #65832, #65450, #65283, #64628, #56417, #60280, #48234, #45240, #57059, #55170, #45277
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the image-understanding runtime required discovery to know the requested model before checking configured `models.providers` rows, and shared configured-model matching did not treat provider-prefixed ids as the same configured row for capability metadata.
- Missing detection / guardrail: there was no image-runtime test for a configured custom provider model when discovery misses, and no shared resolver test for provider-prefixed configured model ids carrying `input: ["text", "image"]`.
- Contributing context (if known): #51150 identified the same failing path but is currently conflicting with `main`; this PR keeps that direction and narrows it to the current resolver seams.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media-understanding/image.test.ts`, `src/agents/pi-embedded-runner/model.test.ts`
- Scenario the test should lock in: configured provider-prefixed image models remain image-capable when discovery misses or reports a text-only row.
- Why this is the smallest reliable guardrail: the bug lived at resolver seams, before provider network execution.
- Existing test that already covers this (if any): `src/agents/tools/image-tool.test.ts` covers the tool-side registry lookup added by the earlier main fix.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Configured custom vision models can be used by the image tool and media-understanding path instead of failing early with `Unknown model` when the configured provider row is valid.

## Diagram (if applicable)

```text
Before:
image tool -> discovery miss/text-only row -> Unknown model / no image support

After:
image tool -> discovery row or configured provider row -> image-capable model -> provider call
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: Node 22 / pnpm
- Model/provider: custom OpenAI-compatible configured provider
- Integration/channel (if any): image tool / media understanding
- Relevant config (redacted): `models.providers.<provider>.models[].id` with provider-prefixed image model id

### Steps

1. Configure a custom provider with an image-capable model id such as `vllm/Qwen3.5`.
2. Request the image model using provider `vllm` and model `Qwen3.5`.
3. Simulate discovery missing the row or returning text-only metadata.

### Expected

- OpenClaw resolves the configured image-capable model and calls the provider.

### Actual

- Before this PR, image understanding could throw `Unknown model` or reject the discovered text-only metadata before using the configured image row.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/media-understanding/image.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/tools/image-tool.test.ts` passed before rebasing this one-commit branch onto current `origin/main`.
- Edge cases checked: provider-prefixed configured ids, discovery miss, discovered text-only row repaired by configured image metadata, existing image-tool lookup coverage.
- What you did **not** verify: full `pnpm check:changed`; a separate local worktree already held the heavy-check lock, so I did not queue another repo gate after the rebase.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: configured metadata could mask stale discovery metadata for image capability.
  - Mitigation: the fallback only prefers configured metadata when it explicitly includes `image` and the discovered row does not.

Credit: builds on the investigation and direction in #51150 by @JaiminBhojani, which is currently conflicting with `main`.
