### PR TITLE
fix(channels): improve error logging for bundled channel entry loading failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/performance: scope Nodes polling to the active Nodes tab, debounce stale session-list reconciliation, and bound chat-side session refreshes so long-running dashboards avoid background reload churn. Thanks @BunsDev.
+- Plugins/channels: explain bundled channel entry files that reach the legacy plugin loader as setup-runtime loader mismatches instead of generic missing-register failures. Thanks @chinar-amrutkar.
 - Bonjour/Gateway: treat active ciao probing and fresh name-conflict renames as in-progress so the mDNS watchdog waits for probe settlement before retrying, preventing rapid re-advertise loops on Windows, WSL, and other multicast-hostile hosts. (#74778) Refs #74242. Thanks @fuller-stack-dev.
 - Providers/MiniMax: send a minimal Anthropic-compatible user fallback when message conversion filters a turn to an empty payload, so MiniMax M2.7 no longer returns `chat content is empty` after tool-heavy sessions. Fixes #74589. Thanks @neeravmakwana and @DerekEXS.
 - Tools/media: preserve implicit allow-all semantics from `tools.alsoAllow`-only policies when preconstructing built-in media generation and PDF tools, so configured media tools become live without forcing `tools.allow: ["*", ...]`. Fixes #77841. Thanks @trialanderrorstudios.

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -26,6 +26,58 @@ afterAll(() => {
 });
 
 describe("plugin loader CLI metadata", () => {
+  it.each([
+    {
+      id: "wrong-cli-channel-entry",
+      kind: "bundled-channel-entry",
+      error: "bundled channel entry requires setup-runtime loader",
+    },
+    {
+      id: "wrong-cli-channel-setup-entry",
+      kind: "bundled-channel-setup-entry",
+      error: "bundled channel setup entry requires setup-runtime loader",
+    },
+  ])(
+    "reports $kind loaded through CLI metadata legacy plugin path",
+    async ({ id, kind, error }) => {
+      useNoBundledPlugins();
+      const plugin = writePlugin({
+        id,
+        filename: `${id}.cjs`,
+        body: `module.exports = { id: ${JSON.stringify(id)}, kind: ${JSON.stringify(kind)} };`,
+      });
+      const errors: string[] = [];
+
+      const registry = await loadOpenClawPluginCliRegistry({
+        cache: false,
+        logger: {
+          info: () => {},
+          warn: () => {},
+          error: (msg: string) => errors.push(msg),
+          debug: () => {},
+        },
+        config: {
+          plugins: {
+            load: { paths: [plugin.file] },
+            allow: [id],
+          },
+        },
+      });
+
+      const loaded = registry.plugins.find((entry) => entry.id === id);
+      expect(loaded?.status).toBe("error");
+      expect(loaded?.error).toBe(error);
+      expect(
+        registry.diagnostics.some(
+          (diag) => diag.level === "error" && diag.pluginId === id && diag.message === error,
+        ),
+      ).toBe(true);
+      expect(errors).toEqual([
+        `[plugins] ${id} ${error}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+      ]);
+    },
+  );
+
   it("suppresses trust warning logs during CLI metadata loads", async () => {
     useNoBundledPlugins();
     const stateDir = makeTempDir();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3994,6 +3994,45 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(loaded?.error).toContain("export.default:object keys=default");
   });
 
+  it.each([
+    {
+      id: "wrong-channel-entry",
+      kind: "bundled-channel-entry",
+      error: "bundled channel entry requires setup-runtime loader",
+    },
+    {
+      id: "wrong-channel-setup-entry",
+      kind: "bundled-channel-setup-entry",
+      error: "bundled channel setup entry requires setup-runtime loader",
+    },
+  ])("reports $kind loaded through the legacy plugin loader", ({ id, kind, error }) => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id,
+      filename: `${id}.cjs`,
+      body: `module.exports = { id: ${JSON.stringify(id)}, kind: ${JSON.stringify(kind)} };`,
+    });
+    const errors: string[] = [];
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: [id],
+      },
+      options: {
+        logger: createErrorLogger(errors),
+      },
+    });
+
+    const loaded = registry.plugins.find((entry) => entry.id === id);
+    expect(loaded?.status).toBe("error");
+    expect(loaded?.error).toBe(error);
+    expectRegistryErrorDiagnostic({ registry, pluginId: id, message: error });
+    expect(errors).toEqual([
+      `[plugins] ${id} ${error}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+    ]);
+  });
+
   it("handles single-plugin channel, context engine, and cli validation", () => {
     useNoBundledPlugins();
     const scenarios = [

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -152,6 +152,7 @@ import type {
   OpenClawPluginApi,
   OpenClawPluginDefinition,
   OpenClawPluginModule,
+  PluginKind,
   PluginLogger,
   PluginRegistrationMode,
 } from "./types.js";
@@ -2340,10 +2341,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (typeof register !== "function") {
-        const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
-        const kind = resolvedModule.kind;
-        const isBundledChannelEntry = kind === "bundled-channel-entry";
-        const isBundledChannelSetupEntry = kind === "bundled-channel-setup-entry";
+        const kindStr = String(record.kind ?? "");
+        const isBundledChannelEntry =
+          kindStr === "bundled-channel-entry" ||
+          (Array.isArray(record.kind) && record.kind.includes("bundled-channel-entry" as PluginKind));
+        const isBundledChannelSetupEntry =
+          kindStr === "bundled-channel-setup-entry" ||
+          (Array.isArray(record.kind) && record.kind.includes("bundled-channel-setup-entry" as PluginKind));
         if (isBundledChannelEntry || isBundledChannelSetupEntry) {
           if (isBundledChannelSetupEntry) {
             pushPluginLoadError(
@@ -2809,10 +2813,13 @@ export async function loadOpenClawPluginCliRegistry(
     }
 
     if (typeof register !== "function") {
-      const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
-      const kind = resolvedModule.kind;
-      const isBundledChannelEntry = kind === "bundled-channel-entry";
-      const isBundledChannelSetupEntry = kind === "bundled-channel-setup-entry";
+      const kindStr = String(record.kind ?? "");
+      const isBundledChannelEntry =
+        kindStr === "bundled-channel-entry" ||
+        (Array.isArray(record.kind) && record.kind.includes("bundled-channel-entry" as PluginKind));
+      const isBundledChannelSetupEntry =
+        kindStr === "bundled-channel-setup-entry" ||
+        (Array.isArray(record.kind) && record.kind.includes("bundled-channel-setup-entry" as PluginKind));
       if (isBundledChannelEntry || isBundledChannelSetupEntry) {
         if (isBundledChannelSetupEntry) {
           logger.error(

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -152,7 +152,6 @@ import type {
   OpenClawPluginApi,
   OpenClawPluginDefinition,
   OpenClawPluginModule,
-  PluginKind,
   PluginLogger,
   PluginRegistrationMode,
 } from "./types.js";
@@ -1440,6 +1439,20 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   return {};
 }
 
+function kindIncludes(kind: unknown, target: string): boolean {
+  return kind === target || (Array.isArray(kind) && kind.includes(target));
+}
+
+function formatBundledChannelWrongLoaderError(kind: unknown): string | null {
+  if (kindIncludes(kind, "bundled-channel-setup-entry")) {
+    return "bundled channel setup entry requires setup-runtime loader";
+  }
+  if (kindIncludes(kind, "bundled-channel-entry")) {
+    return "bundled channel entry requires setup-runtime loader";
+  }
+  return null;
+}
+
 function pushDiagnostics(diagnostics: PluginDiagnostic[], append: PluginDiagnostic[]) {
   diagnostics.push(...append);
 }
@@ -2341,23 +2354,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (typeof register !== "function") {
-        const kindStr = String(record.kind ?? "");
-        const isBundledChannelEntry =
-          kindStr === "bundled-channel-entry" ||
-          (Array.isArray(record.kind) && record.kind.includes("bundled-channel-entry" as PluginKind));
-        const isBundledChannelSetupEntry =
-          kindStr === "bundled-channel-setup-entry" ||
-          (Array.isArray(record.kind) && record.kind.includes("bundled-channel-setup-entry" as PluginKind));
-        if (isBundledChannelEntry || isBundledChannelSetupEntry) {
-          if (isBundledChannelSetupEntry) {
-            pushPluginLoadError(
-              "bundled channel setup entry loaded via legacy plugin loader — use setup-runtime loader instead",
-            );
-          } else {
-            pushPluginLoadError(
-              "bundled channel entry loaded via legacy plugin loader — use setup-runtime loader instead",
-            );
-          }
+        const bundledChannelWrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
+        if (bundledChannelWrongLoaderError) {
+          logger.error(
+            `[plugins] ${record.id} ${bundledChannelWrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+          );
+          pushPluginLoadError(bundledChannelWrongLoaderError);
         } else {
           logger.error(`[plugins] ${record.id} missing register/activate export`);
           pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
@@ -2813,27 +2815,12 @@ export async function loadOpenClawPluginCliRegistry(
     }
 
     if (typeof register !== "function") {
-      const kindStr = String(record.kind ?? "");
-      const isBundledChannelEntry =
-        kindStr === "bundled-channel-entry" ||
-        (Array.isArray(record.kind) && record.kind.includes("bundled-channel-entry" as PluginKind));
-      const isBundledChannelSetupEntry =
-        kindStr === "bundled-channel-setup-entry" ||
-        (Array.isArray(record.kind) && record.kind.includes("bundled-channel-setup-entry" as PluginKind));
-      if (isBundledChannelEntry || isBundledChannelSetupEntry) {
-        if (isBundledChannelSetupEntry) {
-          logger.error(
-            `[plugins] ${record.id} is a bundled channel setup entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
-          );
-          pushPluginLoadError(
-            "bundled channel setup entry requires setup-runtime loader",
-          );
-        } else {
-          logger.error(
-            `[plugins] ${record.id} is a bundled channel entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
-          );
-          pushPluginLoadError("bundled channel entry requires setup-runtime loader");
-        }
+      const bundledChannelWrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
+      if (bundledChannelWrongLoaderError) {
+        logger.error(
+          `[plugins] ${record.id} ${bundledChannelWrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+        );
+        pushPluginLoadError(bundledChannelWrongLoaderError);
       } else {
         logger.error(`[plugins] ${record.id} missing register/activate export`);
         pushPluginLoadError(formatMissingPluginRegisterError(mod, env));

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2340,8 +2340,24 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (typeof register !== "function") {
-        logger.error(`[plugins] ${record.id} missing register/activate export`);
-        pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+        const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
+        const kind = resolvedModule.kind;
+        const isBundledChannelEntry = kind === "bundled-channel-entry";
+        const isBundledChannelSetupEntry = kind === "bundled-channel-setup-entry";
+        if (isBundledChannelEntry || isBundledChannelSetupEntry) {
+          if (isBundledChannelSetupEntry) {
+            pushPluginLoadError(
+              "bundled channel setup entry loaded via legacy plugin loader — use setup-runtime loader instead",
+            );
+          } else {
+            pushPluginLoadError(
+              "bundled channel entry loaded via legacy plugin loader — use setup-runtime loader instead",
+            );
+          }
+        } else {
+          logger.error(`[plugins] ${record.id} missing register/activate export`);
+          pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+        }
         continue;
       }
 
@@ -2793,8 +2809,28 @@ export async function loadOpenClawPluginCliRegistry(
     }
 
     if (typeof register !== "function") {
-      logger.error(`[plugins] ${record.id} missing register/activate export`);
-      pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+      const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
+      const kind = resolvedModule.kind;
+      const isBundledChannelEntry = kind === "bundled-channel-entry";
+      const isBundledChannelSetupEntry = kind === "bundled-channel-setup-entry";
+      if (isBundledChannelEntry || isBundledChannelSetupEntry) {
+        if (isBundledChannelSetupEntry) {
+          logger.error(
+            `[plugins] ${record.id} is a bundled channel setup entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+          );
+          pushPluginLoadError(
+            "bundled channel setup entry requires setup-runtime loader",
+          );
+        } else {
+          logger.error(
+            `[plugins] ${record.id} is a bundled channel entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+          );
+          pushPluginLoadError("bundled channel entry requires setup-runtime loader");
+        }
+      } else {
+        logger.error(`[plugins] ${record.id} missing register/activate export`);
+        pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

Improves error messaging when a bundled channel entry is incorrectly loaded via the legacy plugin loader instead of the bundled channel discovery path.

## Problem

When a bundled channel entry (e.g., Telegram setup runtime) is loaded via the wrong code path, users see a generic "missing register/activate export" error. This gives no indication of the actual problem or how to fix it.

## Solution

In `src/plugins/loader.ts`, when the `register` export is missing, check whether the module is a `bundled-channel-entry` and provide a specific error message:

- **Bundled channel entry via wrong loader:** `"bundled channel entry requires setup-runtime loader"`
- **Regular plugin missing export:** `"plugin export missing register/activate"`

Also removes an unused `loaderContext` parameter from `src/channels/plugins/bundled.ts`.

## Changes

- `src/plugins/loader.ts` — Detect `bundled-channel-entry` kind and emit actionable error
- `src/channels/plugins/bundled.ts` — Remove unused `loaderContext` parameter

Fixes #67380