### PR TITLE
fix(whatsapp): stop reconnecting quiet sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp: stop force-reconnecting quiet linked-device sessions solely because no inbound app messages arrived; the old 30-minute message-silence watchdog is now disabled unless a test/runtime override explicitly enables it.
 - Telegram/webhook: acknowledge validated webhook updates before running bot middleware, keeping slow agent turns from tripping Telegram delivery retries while preserving per-chat processing lanes. Fixes #71392.
 - MCP: retire one-shot embedded bundled MCP runtimes at run end, skip bundle-MCP startup when a runtime tool allowlist cannot reach bundle-MCP tools, and add `mcp.sessionIdleTtlMs` idle eviction for leaked session runtimes. Fixes #71106, #71110, #70389, and #70808.
 - Gateway/restart continuation: durably hand restart continuations to a session-delivery queue before deleting the restart sentinel, recover queued continuation work after crashy restarts, and fall back to a session-only wake when no channel route survives reboot. (#70780) Thanks @fuller-stack-dev.

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -147,6 +147,8 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
 
 - Gateway owns the WhatsApp socket and reconnect loop.
 - Outbound sends require an active WhatsApp listener for the target account.
+- Quiet linked-device sessions are not restarted solely because no inbound app
+  messages arrived; disconnects and Gateway health state drive recovery.
 - Status and broadcast chats are ignored (`@status`, `@broadcast`).
 - Direct chats use DM session rules (`session.dmScope`; default `main` collapses DMs to the agent main session).
 - Group sessions are isolated (`agent:<agentId>:whatsapp:group:<jid>`).

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -255,6 +255,39 @@ describe("web auto-reply connection", () => {
     }
   });
 
+  it("keeps quiet linked-device sessions connected by default", async () => {
+    vi.useFakeTimers();
+    try {
+      const sleep = vi.fn(async () => {});
+      const scripted = createScriptedWebListenerFactory();
+      const { controller, run } = startWebAutoReplyMonitor({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory: scripted.listenerFactory,
+        sleep,
+        heartbeatSeconds: 60,
+        watchdogCheckMs: 5,
+      });
+
+      await vi.waitFor(
+        () => {
+          expect(scripted.getListenerCount()).toBe(1);
+        },
+        { timeout: 250, interval: 2 },
+      );
+
+      await vi.advanceTimersByTimeAsync(31 * 60 * 1000);
+      await Promise.resolve();
+
+      expect(scripted.getListenerCount()).toBe(1);
+      expect(sleep).not.toHaveBeenCalled();
+
+      controller.abort();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("gives a reconnected listener a fresh watchdog window", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -180,7 +180,7 @@ export async function monitorWebChannel(
   };
   process.once("SIGINT", handleSigint);
 
-  const messageTimeoutMs = tuning.messageTimeoutMs ?? 30 * 60 * 1000;
+  const messageTimeoutMs = tuning.messageTimeoutMs ?? 0;
   const watchdogCheckMs = tuning.watchdogCheckMs ?? 60 * 1000;
   const controller = new WhatsAppConnectionController({
     accountId: account.accountId,

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -562,6 +562,10 @@ export class WhatsAppConnectionController {
       hooks.onHeartbeat?.(snapshot);
     }, this.heartbeatSeconds * 1000);
 
+    if (this.messageTimeoutMs <= 0) {
+      return;
+    }
+
     connection.watchdogTimer = setInterval(() => {
       const baselineAt = connection.lastInboundAt ?? connection.startedAt;
       const staleForMs = Date.now() - baselineAt;


### PR DESCRIPTION
## Summary

- Problem: WhatsApp linked-device sessions were force-reconnected after 30 minutes with no inbound app messages, even when the socket was otherwise healthy.
- Why it matters: quiet WhatsApp accounts hit noisy 499 reconnect cycles, missed-message windows, and credential-restore churn that looked like transport failure.
- What changed: the extension-local inbound-message silence watchdog is disabled by default; explicit test/runtime tuning can still enable it.
- What did NOT change (scope boundary): no Baileys auth storage, QR login, outbound delivery queue, or Gateway health-monitor policy changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70678
- Related #62258, #54332, #55246, #60337, #61326, #55030, #60378
- Related #63939 and #47513
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WhatsApp had an extension-local watchdog that used inbound app-message silence as a liveness signal (`lastInboundAt ?? startedAt`). Quiet linked-device sessions are normal, so this forced unnecessary 499 reconnects.
- Missing detection / guardrail: coverage proved explicit watchdog behavior, but not the production default for a quiet session with no inbound messages.
- Contributing context (if known): Gateway-level channel health has moved toward transport-backed liveness, but WhatsApp still had this older local app-message watchdog path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- Scenario the test should lock in: a quiet linked-device session remains on the same listener after 31 minutes when no explicit watchdog timeout override is set.
- Why this is the smallest reliable guardrail: the bug is the monitor/controller default wiring, not Baileys network behavior.
- Existing test that already covers this (if any): explicit watchdog reconnect tests still cover the opt-in timeout path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Quiet WhatsApp sessions no longer reconnect solely due to no inbound app messages. Actual disconnects and Gateway health state still drive recovery.

## Diagram (if applicable)

```text
Before:
quiet WhatsApp account -> 30m no inbound messages -> forced 499 reconnect

After:
quiet WhatsApp account -> no inbound messages -> remains connected unless transport/lifecycle closes
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp Web
- Relevant config (redacted): default WhatsApp monitor settings

### Steps

1. Start WhatsApp monitor with keepAlive enabled and no `messageTimeoutMs` override.
2. Leave the linked-device session quiet for longer than 30 minutes.
3. Observe whether a forced 499 reconnect is triggered solely by app-message silence.

### Expected

- No forced reconnect occurs from app-message silence alone.

### Actual

- Before this PR, the default 30-minute silence watchdog closed the connection with status 499.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts extensions/whatsapp/src/connection-controller.test.ts`
- Edge cases checked: default quiet-session behavior, explicit watchdog override still covered by existing reconnect tests, formatting/whitespace.
- What you did **not** verify: `pnpm check:changed`; multiple other worktrees already had `check:changed` / test lanes running, so I avoided queuing another heavy gate.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a genuinely stale but still-open WhatsApp socket may not be restarted by app-message silence alone.
  - Mitigation: reconnect still follows actual socket close/error paths, and Gateway health should use transport/lifecycle signals rather than ordinary inbound app messages.
