### PR TITLE
fix(browser): align browser profile SDK exports

### DIFF
--- a/extensions/browser/browser-profiles.ts
+++ b/extensions/browser/browser-profiles.ts
@@ -12,3 +12,4 @@ export {
   type ResolvedBrowserProfile,
   type ResolvedBrowserTabCleanupConfig,
 } from "./src/browser/config.js";
+export { DEFAULT_BROWSER_ACTION_TIMEOUT_MS } from "./src/browser/constants.js";

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -128,6 +128,7 @@ const BROWSER_HELPER_EXPORT_PARITY_CONTRACTS: readonly BrowserHelperExportParity
     extensionPath: "extensions/browser/browser-profiles.ts",
     expectedExports: [
       "DEFAULT_AI_SNAPSHOT_MAX_CHARS",
+      "DEFAULT_BROWSER_ACTION_TIMEOUT_MS",
       "DEFAULT_BROWSER_DEFAULT_PROFILE_NAME",
       "DEFAULT_BROWSER_EVALUATE_ENABLED",
       "DEFAULT_OPENCLAW_BROWSER_COLOR",


### PR DESCRIPTION
## Summary
- expose `DEFAULT_BROWSER_ACTION_TIMEOUT_MS` through the bundled browser profile public wrapper
- update the SDK subpath parity contract for the new browser action timeout export

## Validation
- `OPENCLAW_LOCAL_CHECK=0 OPENCLAW_VITEST_FS_MODULE_CACHE=0 pnpm test src/plugins/contracts/plugin-sdk-subpaths.test.ts`
