### PR TITLE
fix(bluebubbles): guard sqlite contact lookup parameters

### DIFF
--- a/extensions/bluebubbles/src/participant-contact-names.test.ts
+++ b/extensions/bluebubbles/src/participant-contact-names.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   enrichBlueBubblesParticipantsWithContactNames,
@@ -111,25 +112,26 @@ describe("enrichBlueBubblesParticipantsWithContactNames", () => {
   });
 
   it("lists contacts databases from the current home directory", async () => {
+    const homeDir = "/Users/tester";
+    const sourcesDir = join(homeDir, "Library", "Application Support", "AddressBook", "Sources");
+    const expectedDbPath = join(sourcesDir, "source-a", "AddressBook-v22.abcddb");
+
     const readdir = vi.fn(async () => ["source-a", "source-b"]);
-    const access = vi.fn(async (path: string) => {
-      if (!path.endsWith("source-a/AddressBook-v22.abcddb")) {
+    const access = vi.fn(async (p: string) => {
+      const normalized = p.replaceAll("\\", "/");
+      if (!normalized.endsWith("source-a/AddressBook-v22.abcddb")) {
         throw new Error("missing");
       }
     });
 
     const databases = await listBlueBubblesContactsDatabasesForTest({
-      homeDir: "/Users/tester",
+      homeDir,
       readdir,
       access,
     });
 
-    expect(readdir).toHaveBeenCalledWith(
-      "/Users/tester/Library/Application Support/AddressBook/Sources",
-    );
-    expect(databases).toEqual([
-      "/Users/tester/Library/Application Support/AddressBook/Sources/source-a/AddressBook-v22.abcddb",
-    ]);
+    expect(readdir).toHaveBeenCalledWith(sourcesDir);
+    expect(databases).toEqual([expectedDbPath]);
   });
 
   it("queries only the requested phone keys in sqlite", async () => {
@@ -141,7 +143,7 @@ describe("enrichBlueBubblesParticipantsWithContactNames", () => {
     const rows = await queryBlueBubblesContactsDatabaseForTest(
       "/tmp/AddressBook-v22.abcddb",
       ["5551234567", "5557654321"],
-      { execFileAsync },
+      { execFileAsync, sqliteDotParameterSupported: true },
     );
 
     expect(rows).toEqual([
@@ -149,8 +151,109 @@ describe("enrichBlueBubblesParticipantsWithContactNames", () => {
       { phoneKey: "5557654321", name: "Bob Example" },
     ]);
     expect(execFileAsync).toHaveBeenCalledTimes(1);
-    const sql = execFileAsync.mock.calls[0]?.[1]?.[3];
+
+    const args = execFileAsync.mock.calls[0]?.[1] ?? [];
+    const sql = args[args.length - 1];
+    expect(sql).toContain("WHERE digits IN (?1, ?2)");
+    expect(args).toContain("-cmd");
+    expect(args).toContain(".parameter set ?1 '5551234567'");
+    expect(args).toContain(".parameter set ?2 '5557654321'");
+  });
+
+  it("uses digit-only SQL literals when sqlite dot-parameter commands are unavailable", async () => {
+    const execFileAsync = vi.fn(async (_file: string, _args: string[], _options: unknown) => ({
+      stdout: "5551234567\tAlice Example\n5557654321\tBob Example\n",
+      stderr: "",
+    }));
+
+    const rows = await queryBlueBubblesContactsDatabaseForTest(
+      "/tmp/AddressBook-v22.abcddb",
+      ["5551234567", "5557654321"],
+      { execFileAsync, sqliteDotParameterSupported: false },
+    );
+
+    expect(rows).toEqual([
+      { phoneKey: "5551234567", name: "Alice Example" },
+      { phoneKey: "5557654321", name: "Bob Example" },
+    ]);
+    expect(execFileAsync).toHaveBeenCalledTimes(1);
+
+    const args = execFileAsync.mock.calls[0]?.[1] ?? [];
+    const sql = args[args.length - 1];
     expect(sql).toContain("WHERE digits IN ('5551234567', '5557654321')");
+    expect(args.filter((a) => a === "-cmd")).toHaveLength(0);
+  });
+
+  it("normalizes fallback SQL literals before interpolation", async () => {
+    const execFileAsync = vi.fn(async (_file: string, _args: string[], _options: unknown) => ({
+      stdout: "5551234567\tAlice Example\n",
+      stderr: "",
+    }));
+
+    const rows = await queryBlueBubblesContactsDatabaseForTest(
+      "/tmp/AddressBook-v22.abcddb",
+      ["+1 (555) 123-4567'); DROP TABLE ZABCDRECORD; --"],
+      { execFileAsync, sqliteDotParameterSupported: false },
+    );
+
+    expect(rows).toEqual([{ phoneKey: "5551234567", name: "Alice Example" }]);
+
+    const args = execFileAsync.mock.calls[0]?.[1] ?? [];
+    const sql = args[args.length - 1];
+    expect(sql).toContain("WHERE digits IN ('5551234567')");
+    expect(sql).not.toContain("DROP TABLE");
+  });
+
+  it("probes sqlite --version once when dot-parameter support is unknown", async () => {
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === "--version") {
+        return { stdout: "3.28.0 2019-04-15 14:59:49 UTC\n", stderr: "" };
+      }
+      return {
+        stdout: "5551234567\tAlice Example\n",
+        stderr: "",
+      };
+    });
+
+    const deps = { execFileAsync };
+
+    await queryBlueBubblesContactsDatabaseForTest("/tmp/a.abcddb", ["5551234567"], deps);
+    await queryBlueBubblesContactsDatabaseForTest("/tmp/b.abcddb", ["5551234567"], deps);
+
+    expect(execFileAsync).toHaveBeenCalledTimes(3);
+    expect(execFileAsync.mock.calls[0]?.[1]?.[0]).toBe("--version");
+
+    const firstQueryArgs = execFileAsync.mock.calls[1]?.[1] ?? [];
+    expect(firstQueryArgs[firstQueryArgs.length - 1]).toContain("WHERE digits IN ('5551234567')");
+
+    const secondQueryArgs = execFileAsync.mock.calls[2]?.[1] ?? [];
+    expect(secondQueryArgs[secondQueryArgs.length - 1]).toContain("WHERE digits IN ('5551234567')");
+  });
+
+  it("uses sqlite dot parameters after a supported version probe", async () => {
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === "--version") {
+        return { stdout: "3.31.0 2020-01-22 18:38:59 UTC\n", stderr: "" };
+      }
+      return {
+        stdout: "5551234567\tAlice Example\n",
+        stderr: "",
+      };
+    });
+
+    const rows = await queryBlueBubblesContactsDatabaseForTest(
+      "/tmp/AddressBook-v22.abcddb",
+      ["5551234567"],
+      { execFileAsync },
+    );
+
+    expect(rows).toEqual([{ phoneKey: "5551234567", name: "Alice Example" }]);
+    expect(execFileAsync).toHaveBeenCalledTimes(2);
+
+    const queryArgs = execFileAsync.mock.calls[1]?.[1] ?? [];
+    const sql = queryArgs[queryArgs.length - 1];
+    expect(sql).toContain("WHERE digits IN (?1)");
+    expect(queryArgs).toContain(".parameter set ?1 '5551234567'");
   });
 
   it("resolves names through the macOS contacts path across multiple databases", async () => {
@@ -171,6 +274,7 @@ describe("enrichBlueBubblesParticipantsWithContactNames", () => {
         readdir,
         access,
         execFileAsync,
+        sqliteDotParameterSupported: true,
       },
     );
 

--- a/extensions/bluebubbles/src/participant-contact-names.ts
+++ b/extensions/bluebubbles/src/participant-contact-names.ts
@@ -10,6 +10,8 @@ const CONTACT_NAME_CACHE_TTL_MS = 60 * 60 * 1000;
 const NEGATIVE_CONTACT_NAME_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_PARTICIPANT_CONTACT_NAME_CACHE_ENTRIES = 2048;
 const SQLITE_MAX_BUFFER = 8 * 1024 * 1024;
+/** `sqlite3` dot-command `.parameter set` requires SQLite 3.31.0+ (Jan 2020). Older macOS system sqlite omits it. */
+const SQLITE_DOT_PARAMETER_MIN_VERSION: [number, number, number] = [3, 31, 0];
 const SQLITE_PHONE_DIGITS_SQL =
   "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(COALESCE(p.ZFULLNUMBER, ''), ' ', ''), '(', ''), ')', ''), '-', ''), '+', ''), '.', ''), '\n', ''), '\r', '')";
 
@@ -35,6 +37,8 @@ type ParticipantContactNameDeps = {
   readdir?: ReadDirRunner;
   access?: AccessRunner;
   execFileAsync?: ExecFileRunner;
+  /** When set, skips `sqlite3 --version` probe (tests only). */
+  sqliteDotParameterSupported?: boolean;
 };
 
 type ResolvedParticipantContactNameDeps = {
@@ -45,10 +49,12 @@ type ResolvedParticipantContactNameDeps = {
   readdir: ReadDirRunner;
   access: AccessRunner;
   execFileAsync: ExecFileRunner;
+  sqliteDotParameterSupported?: boolean;
 };
 
 const participantContactNameCache = new Map<string, ContactNameCacheEntry>();
 let participantContactNameDepsForTest: ParticipantContactNameDeps | undefined;
+let sqliteDotParameterSupportPromise: Promise<boolean> | null = null;
 
 function normalizePhoneLookupKey(value: string): string | null {
   const digits = value.replace(/\D/g, "");
@@ -68,6 +74,59 @@ function uniqueNormalizedPhoneLookupKeys(phoneKeys: string[]): string[] {
     }
   }
   return [...unique];
+}
+
+function parseLeadingSqliteVersionTriple(stdout: string): [number, number, number] | null {
+  const match = stdout.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isSqliteVersionAtLeast(
+  version: [number, number, number],
+  minimum: [number, number, number],
+): boolean {
+  const [maj, min, pat] = version;
+  const [minMaj, minMin, minPat] = minimum;
+  if (maj !== minMaj) {
+    return maj > minMaj;
+  }
+  if (min !== minMin) {
+    return min > minMin;
+  }
+  return pat >= minPat;
+}
+
+async function probeSqliteDotParameterSupport(
+  deps: ResolvedParticipantContactNameDeps,
+): Promise<boolean> {
+  try {
+    const { stdout } = await deps.execFileAsync("sqlite3", ["--version"], {
+      encoding: "utf8",
+      maxBuffer: SQLITE_MAX_BUFFER,
+    });
+    const triple = parseLeadingSqliteVersionTriple(stdout);
+    if (!triple) {
+      return false;
+    }
+    return isSqliteVersionAtLeast(triple, SQLITE_DOT_PARAMETER_MIN_VERSION);
+  } catch {
+    return false;
+  }
+}
+
+async function getSqliteDotParameterSupported(
+  deps: ResolvedParticipantContactNameDeps,
+): Promise<boolean> {
+  if (typeof deps.sqliteDotParameterSupported === "boolean") {
+    return deps.sqliteDotParameterSupported;
+  }
+  if (!sqliteDotParameterSupportPromise) {
+    sqliteDotParameterSupportPromise = probeSqliteDotParameterSupport(deps);
+  }
+  return sqliteDotParameterSupportPromise;
 }
 
 function resolveParticipantPhoneLookupKey(participant: BlueBubblesParticipant): string | null {
@@ -156,10 +215,12 @@ async function listContactsDatabases(deps: ResolvedParticipantContactNameDeps): 
   return databases;
 }
 
-function buildSqlitePhoneKeyList(phoneKeys: string[]): string {
-  return uniqueNormalizedPhoneLookupKeys(phoneKeys)
-    .map((phoneKey) => `'${phoneKey}'`)
-    .join(", ");
+/**
+ * Digit-only SQL literals for `IN (...)`. Safe here because callers pass values
+ * from `uniqueNormalizedPhoneLookupKeys`, which strips non-digits.
+ */
+function buildSqlitePhoneKeyList(uniqueKeys: string[]): string {
+  return uniqueKeys.map((phoneKey) => `'${phoneKey}'`).join(", ");
 }
 
 async function queryContactsDatabase(
@@ -167,10 +228,14 @@ async function queryContactsDatabase(
   phoneKeys: string[],
   deps: ResolvedParticipantContactNameDeps,
 ): Promise<Array<{ phoneKey: string; name: string }>> {
-  const sqlitePhoneKeyList = buildSqlitePhoneKeyList(phoneKeys);
-  if (!sqlitePhoneKeyList) {
+  const uniqueKeys = uniqueNormalizedPhoneLookupKeys(phoneKeys);
+  if (uniqueKeys.length === 0) {
     return [];
   }
+  const useDotParameter = await getSqliteDotParameterSupported(deps);
+  const inListSql = useDotParameter
+    ? uniqueKeys.map((_, i) => `?${i + 1}`).join(", ")
+    : buildSqlitePhoneKeyList(uniqueKeys);
   const sql = `
 SELECT digits, name
 FROM (
@@ -187,18 +252,22 @@ FROM (
   JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
   WHERE p.ZFULLNUMBER IS NOT NULL
 )
-WHERE digits IN (${sqlitePhoneKeyList})
+WHERE digits IN (${inListSql})
   AND name != '';
 `;
   const options: ExecFileOptionsWithStringEncoding = {
     encoding: "utf8",
     maxBuffer: SQLITE_MAX_BUFFER,
   };
-  const { stdout } = await deps.execFileAsync(
-    "sqlite3",
-    ["-separator", "\t", dbPath, sql],
-    options,
-  );
+  const args = ["-separator", "\t"];
+  if (useDotParameter) {
+    uniqueKeys.forEach((key, index) => {
+      args.push("-cmd", `.parameter set ?${index + 1} '${key}'`);
+    });
+  }
+  args.push(dbPath, sql);
+
+  const { stdout } = await deps.execFileAsync("sqlite3", args, options);
   const rows: Array<{ phoneKey: string; name: string }> = [];
   for (const line of stdout.split(/\r?\n/)) {
     const trimmed = line.trim();
@@ -266,6 +335,7 @@ function resolveLookupDeps(deps?: ParticipantContactNameDeps): ResolvedParticipa
     readdir: merged.readdir ?? readdir,
     access: merged.access ?? access,
     execFileAsync: merged.execFileAsync ?? execFileAsync,
+    sqliteDotParameterSupported: merged.sqliteDotParameterSupported,
   };
 }
 
@@ -368,6 +438,7 @@ export async function resolveBlueBubblesParticipantContactNamesFromMacOsContacts
 
 export function resetBlueBubblesParticipantContactNameCacheForTest(): void {
   participantContactNameCache.clear();
+  sqliteDotParameterSupportPromise = null;
 }
 
 export function setBlueBubblesParticipantContactDepsForTest(
@@ -375,4 +446,5 @@ export function setBlueBubblesParticipantContactDepsForTest(
 ): void {
   participantContactNameDepsForTest = deps;
   participantContactNameCache.clear();
+  sqliteDotParameterSupportPromise = null;
 }


### PR DESCRIPTION
## Summary
- add a cached SQLite version probe for BlueBubbles macOS Contacts lookups
- use sqlite3 `.parameter set` for SQLite 3.31.0+ and fall back to digit-only `IN (...)` literals on older system SQLite
- remove redundant quote escaping and cover both lookup paths with regression tests

## Testing
- `pnpm run format:check -- extensions/bluebubbles/src/participant-contact-names.ts extensions/bluebubbles/src/participant-contact-names.test.ts`
- `pnpm test extensions/bluebubbles/src/participant-contact-names.test.ts`
- `./node_modules/.bin/tsgo.CMD --singleThreaded --checkers 1` fails on current main with unrelated `src/agents/pi-embedded-runner.sanitize-session-history.test.ts:985` TS2352