### PR TITLE
fix(openai): replay DeepSeek tool reasoning_content

### DIFF
--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -72,9 +72,9 @@ export function resolveOpenAICompletionsCompatDefaults(
   const isZai =
     endpointClass === "zai-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "zai"));
-  const isDeepSeek =
-    endpointClass === "deepseek-native" ||
-    (isDefaultRoute && isDefaultRouteProvider(input.provider, "deepseek"));
+  const providerOrFamilyIsDeepSeek =
+    isDefaultRouteProvider(input.provider, "deepseek") || knownProviderFamily === "deepseek";
+  const isDeepSeek = endpointClass === "deepseek-native" || providerOrFamilyIsDeepSeek;
   const isNonStandard =
     endpointClass === "cerebras-native" ||
     endpointClass === "chutes-native" ||

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -72,9 +72,13 @@ export function resolveOpenAICompletionsCompatDefaults(
   const isZai =
     endpointClass === "zai-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "zai"));
-  const providerOrFamilyIsDeepSeek =
-    isDefaultRouteProvider(input.provider, "deepseek") || knownProviderFamily === "deepseek";
-  const isDeepSeek = endpointClass === "deepseek-native" || providerOrFamilyIsDeepSeek;
+  const isDeepSeek =
+    endpointClass === "deepseek-native" ||
+    (isDefaultRoute && isDefaultRouteProvider(input.provider, "deepseek")) ||
+    // `knownProviderFamily` may come from a model-id heuristic for custom/local
+    // providers, e.g. Ollama-hosted `deepseek-*` models. Known proxy providers
+    // such as OpenRouter keep their own family and thinking format.
+    knownProviderFamily === "deepseek";
   const isNonStandard =
     endpointClass === "cerebras-native" ||
     endpointClass === "chutes-native" ||

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1535,6 +1535,61 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("keeps OpenRouter-hosted DeepSeek models on OpenRouter thinking format", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "deepseek/deepseek-r1",
+        name: "DeepSeek R1",
+        api: "openai-completions",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        messages: [
+          { role: "user", content: "call a tool", timestamp: 1 },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "openrouter",
+            model: "deepseek/deepseek-r1",
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 2,
+          },
+        ],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup data",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+      { reasoning: "high" } as never,
+    ) as {
+      messages?: Array<Record<string, unknown>>;
+      reasoning?: unknown;
+      reasoning_effort?: unknown;
+    };
+
+    expect(params.reasoning).toEqual({ effort: "high" });
+    expect(params).not.toHaveProperty("reasoning_effort");
+    expect(params.messages?.[1]).not.toHaveProperty("reasoning_content");
+  });
+
   it("does not add DeepSeek reasoning_content when thinking is disabled", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1468,6 +1468,122 @@ describe("openai transport stream", () => {
     expect(params.messages?.[0]?.content).toBe("Stable prefix\nDynamic suffix");
   });
 
+  it("adds blank reasoning_content to DeepSeek thinking tool-call replay payloads", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "ollama/deepseek-v4-flash-cn-think",
+        name: "DeepSeek V4 Flash Think",
+        api: "openai-completions",
+        provider: "ollama",
+        baseUrl: "http://localhost:11434/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        messages: [
+          { role: "user", content: "call a tool", timestamp: 1 },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "ollama",
+            model: "ollama/deepseek-v4-flash-cn-think",
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 2,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup data",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+      { reasoning: "high" } as never,
+    ) as { messages?: Array<Record<string, unknown>> };
+
+    expect(params.messages?.[1]).toMatchObject({
+      role: "assistant",
+      reasoning_content: "",
+      tool_calls: [
+        {
+          id: "call_1",
+          type: "function",
+          function: { name: "lookup", arguments: "{}" },
+        },
+      ],
+    });
+  });
+
+  it("does not add DeepSeek reasoning_content when thinking is disabled", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "ollama/deepseek-v4-flash-cn-think",
+        name: "DeepSeek V4 Flash Think",
+        api: "openai-completions",
+        provider: "ollama",
+        baseUrl: "http://localhost:11434/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        messages: [
+          { role: "user", content: "call a tool", timestamp: 1 },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "ollama",
+            model: "ollama/deepseek-v4-flash-cn-think",
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 2,
+          },
+        ],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup data",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+      { reasoning: "off" } as never,
+    ) as { messages?: Array<Record<string, unknown>> };
+
+    expect(params.messages?.[1]).not.toHaveProperty("reasoning_content");
+  });
+
   it("uses shared stream reasoning as OpenAI completions effort", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1614,6 +1614,21 @@ function convertTools(
   }));
 }
 
+function ensureDeepSeekToolCallReasoningContent(messages: unknown[]): void {
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+      continue;
+    }
+    if (!("reasoning_content" in record)) {
+      record.reasoning_content = "";
+    }
+  }
+}
+
 function extractGoogleThoughtSignature(toolCall: unknown): string | undefined {
   const tc = toolCall as Record<string, unknown> | undefined;
   if (!tc) {
@@ -1722,6 +1737,23 @@ export function buildOpenAICompletionsParams(
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
+  const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
+  const resolvedCompletionsReasoningEffort = completionsReasoningEffort
+    ? resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: completionsReasoningEffort,
+        fallbackMap: compat.reasoningEffortMap,
+      })
+    : undefined;
+  if (
+    compat.thinkingFormat === "deepseek" &&
+    model.reasoning &&
+    completionsReasoningEffort !== "none" &&
+    completionsReasoningEffort !== "off" &&
+    resolvedCompletionsReasoningEffort
+  ) {
+    ensureDeepSeekToolCallReasoningContent(messages as unknown[]);
+  }
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const params: Record<string, unknown> = {
     model: model.id,
@@ -1755,14 +1787,6 @@ export function buildOpenAICompletionsParams(
   } else if (hasToolHistory(context.messages)) {
     params.tools = [];
   }
-  const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
-  const resolvedCompletionsReasoningEffort = completionsReasoningEffort
-    ? resolveOpenAIReasoningEffortForModel({
-        model,
-        effort: completionsReasoningEffort,
-        fallbackMap: compat.reasoningEffortMap,
-      })
-    : undefined;
   if (
     compat.thinkingFormat === "openrouter" &&
     model.reasoning &&

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -343,9 +343,6 @@ export function resolveProviderEndpoint(
 
 function resolveKnownProviderFamily(provider: string | undefined, modelId?: string | null): string {
   const normalizedModelId = normalizeOptionalLowercaseString(modelId);
-  if (normalizedModelId?.includes("deepseek")) {
-    return "deepseek";
-  }
   switch (provider) {
     case "openai":
     case "openai-codex":
@@ -383,6 +380,12 @@ function resolveKnownProviderFamily(provider: string | undefined, modelId?: stri
     case "together":
       return "together";
     default:
+      // Only use model-id family detection for unknown/custom provider IDs. Known
+      // providers such as OpenRouter must keep their provider-owned compat rules
+      // even when serving DeepSeek-family models.
+      if (normalizedModelId?.includes("deepseek")) {
+        return "deepseek";
+      }
       return provider || "unknown";
   }
 }

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -341,7 +341,11 @@ export function resolveProviderEndpoint(
   return { endpointClass: "custom", hostname: host };
 }
 
-function resolveKnownProviderFamily(provider: string | undefined): string {
+function resolveKnownProviderFamily(provider: string | undefined, modelId?: string | null): string {
+  const normalizedModelId = normalizeOptionalLowercaseString(modelId);
+  if (normalizedModelId?.includes("deepseek")) {
+    return "deepseek";
+  }
   switch (provider) {
     case "openai":
     case "openai-codex":
@@ -584,7 +588,7 @@ export function resolveProviderRequestPolicy(
     policy,
     endpointClass,
     usesConfiguredBaseUrl,
-    knownProviderFamily: resolveKnownProviderFamily(provider || undefined),
+    knownProviderFamily: resolveKnownProviderFamily(provider || undefined, input.modelId),
     attributionProvider,
     attributionHeaders,
     allowsHiddenAttribution:


### PR DESCRIPTION
Fixes #71455.

## Summary
- detect DeepSeek-family OpenAI-compatible models by model id, so Ollama/custom hosted `deepseek-*` models get DeepSeek thinking compat
- inject blank `reasoning_content: ""` on assistant messages with replayed `tool_calls` when DeepSeek thinking mode is active
- preserve the disabled-thinking path without adding `reasoning_content`

## Test plan
- `pnpm test src/agents/openai-transport-stream.test.ts extensions/deepseek/index.test.ts`