### PR TITLE
fix(memory-wiki): route bridge CLI through gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 - Browser/Linux: detect Chromium-based installs under `/opt/google`, `/opt/brave.com`, `/usr/lib/chromium`, and `/usr/lib/chromium-browser` before asking users to set `browser.executablePath`. (#48563) Thanks @lupuletic.
 - MCP/CLI: retire bundled MCP runtimes at the end of one-shot `openclaw agent` and `openclaw infer model run` gateway/local executions, so repeated scripted runs do not accumulate stdio MCP child processes. Fixes #71457.
+- Memory Wiki: route `wiki status`, `wiki doctor`, and `wiki bridge import` through the Gateway so CLI bridge checks see the same active memory plugin artifacts as runtime tools instead of reporting 0 artifacts or pruning bridge pages. Fixes #70181, #70842, #67979, #68828, #66082, #69019, #65722, #65976, #70242, and #68371.
 - OpenAI/Codex image generation: canonicalize legacy `openai-codex.baseUrl` values such as `https://chatgpt.com/backend-api` to the Codex Responses backend before calling `gpt-image-2`, matching the chat transport. Fixes #71460.
 - Control UI: make `/usage` use the fresh context snapshot for context percentage, and include cache-write tokens in the Usage overview cache-hit denominator. Fixes #47885. Thanks @imwyvern and @Ante042.
 - GitHub Copilot: preserve encrypted Responses reasoning item IDs during replay so Copilot can validate encrypted reasoning payloads across requests. (#71448) Thanks @a410979729-sys.

--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -68,6 +68,10 @@ Inspect current vault mode, health, and Obsidian CLI availability.
 Use this first when you are unsure whether the vault is initialized, bridge mode
 is healthy, or Obsidian integration is available.
 
+This command calls the Gateway so bridge mode reports the same exported memory
+artifacts that runtime wiki tools see. Start the Gateway first, or pass
+`--url` and `--token` when checking a remote Gateway.
+
 ### `wiki doctor`
 
 Run wiki health checks and surface configuration or vault problems.
@@ -77,6 +81,9 @@ Typical issues include:
 - bridge mode enabled without public memory artifacts
 - invalid or missing vault layout
 - missing external Obsidian CLI when Obsidian mode is expected
+
+Like `wiki status`, this command calls the Gateway in order to inspect the
+active runtime memory plugin state.
 
 ### `wiki init`
 
@@ -167,6 +174,10 @@ source pages.
 
 Use this in `bridge` mode when you want the latest exported memory artifacts
 pulled into the wiki vault.
+
+The import runs through the Gateway process. This keeps the CLI from seeing an
+empty standalone plugin registry and accidentally treating bridge-backed pages
+as removed.
 
 ### `wiki unsafe-local import`
 

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -63,7 +63,8 @@ Practical rule:
 
 If bridge mode reports zero exported artifacts, the active memory plugin is not
 currently exposing public bridge inputs yet. Run `openclaw wiki doctor` first,
-then confirm the active memory plugin supports public artifacts.
+then confirm the Gateway is running and the active memory plugin supports public
+artifacts.
 
 ## Vault modes
 
@@ -90,6 +91,10 @@ Bridge mode can index:
 - daily notes
 - memory root files
 - memory event logs
+
+Bridge status, doctor, and import commands call the Gateway so the CLI reads
+the same in-process memory capability as runtime wiki tools. For remote
+Gateways, pass the usual `--url` and `--token` options.
 
 ### `unsafe-local`
 

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -3,7 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerWikiCli, runWikiChatGptImport, runWikiChatGptRollback } from "./cli.js";
+import {
+  registerWikiCli,
+  runWikiBridgeImport,
+  runWikiChatGptImport,
+  runWikiChatGptRollback,
+  runWikiDoctor,
+  runWikiStatus,
+} from "./cli.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
 import { parseWikiMarkdown, renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -86,6 +93,19 @@ describe("memory-wiki cli", () => {
       "utf8",
     );
     return exportDir;
+  }
+
+  function createStdoutCapture() {
+    const writes: string[] = [];
+    return {
+      writes,
+      stdout: {
+        write: ((chunk: string | Uint8Array) => {
+          writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+          return true;
+        }) as NodeJS.WriteStream["write"],
+      },
+    };
   }
 
   it("registers apply synthesis and writes a synthesis page", async () => {
@@ -178,21 +198,113 @@ cli note
     expect(parsed.body).toContain("cli note");
   });
 
-  it("runs wiki doctor and sets a non-zero exit code when warnings exist", async () => {
-    const { rootDir, config } = await createCliVault({
+  it("loads wiki status through the gateway so bridge artifacts match runtime state", async () => {
+    const { config } = await createCliVault({
       config: {
         vaultMode: "bridge",
-        bridge: { enabled: false },
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+        },
+      },
+      initialize: true,
+    });
+    const callGateway = vi.fn(async () => ({
+      vaultMode: "bridge",
+      bridgePublicArtifactCount: 155,
+      warnings: [],
+    }));
+    const { stdout, writes } = createStdoutCapture();
+
+    const status = await runWikiStatus({
+      config,
+      gatewayOpts: { url: "ws://127.0.0.1:18789", token: "tok" },
+      json: true,
+      stdout,
+      callGateway,
+    });
+
+    expect(callGateway).toHaveBeenCalledWith(
+      "wiki.status",
+      expect.objectContaining({ url: "ws://127.0.0.1:18789", token: "tok", json: true }),
+      {},
+    );
+    expect(status.bridgePublicArtifactCount).toBe(155);
+    expect(writes.join("")).toContain('"bridgePublicArtifactCount": 155');
+  });
+
+  it("runs wiki doctor through the gateway and preserves non-zero exit behavior", async () => {
+    const { config } = await createCliVault({
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+        },
       },
     });
-    const program = new Command();
-    program.name("test");
-    registerWikiCli(program, config);
-    await fs.rm(rootDir, { recursive: true, force: true });
+    const callGateway = vi.fn(async () => ({
+      healthy: false,
+      warningCount: 1,
+      status: {
+        vaultMode: "bridge",
+      },
+      fixes: [{ code: "bridge-disabled", message: "Enable bridge mode." }],
+    }));
+    const { stdout, writes } = createStdoutCapture();
 
-    await program.parseAsync(["wiki", "doctor", "--json"], { from: "user" });
+    const report = await runWikiDoctor({
+      config,
+      json: true,
+      stdout,
+      callGateway,
+    });
 
+    expect(callGateway).toHaveBeenCalledWith("wiki.doctor", { json: true }, {});
+    expect(report.healthy).toBe(false);
     expect(process.exitCode).toBe(1);
+    expect(writes.join("")).toContain('"warningCount": 1');
+  });
+
+  it("runs wiki bridge import through the gateway to avoid CLI-only empty artifacts", async () => {
+    const { config } = await createCliVault({
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+        },
+      },
+      initialize: true,
+    });
+    const callGateway = vi.fn(async () => ({
+      importedCount: 3,
+      updatedCount: 1,
+      skippedCount: 2,
+      removedCount: 0,
+      artifactCount: 6,
+      workspaces: 2,
+      pagePaths: [],
+      indexesRefreshed: true,
+      indexUpdatedFiles: ["sources/a.md", "sources/b.md"],
+      indexRefreshReason: "synced" as const,
+    }));
+    const { stdout, writes } = createStdoutCapture();
+
+    const result = await runWikiBridgeImport({
+      config,
+      gatewayOpts: { url: "ws://127.0.0.1:18789", token: "tok" },
+      stdout,
+      callGateway,
+    });
+
+    expect(callGateway).toHaveBeenCalledWith(
+      "wiki.bridge.import",
+      expect.objectContaining({ url: "ws://127.0.0.1:18789", token: "tok" }),
+      {},
+    );
+    expect(result.artifactCount).toBe(6);
+    expect(writes.join("")).toContain("Bridge import synced 6 artifacts");
   });
 
   it("imports ChatGPT exports with dry-run, apply, and rollback", async () => {

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
+import {
+  addGatewayClientOptions,
+  callGatewayFromCli,
+  type GatewayRpcOpts,
+} from "openclaw/plugin-sdk/browser-node-runtime";
 import type { OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation } from "./apply.js";
 import {
@@ -26,20 +31,25 @@ import {
   runObsidianSearch,
 } from "./obsidian.js";
 import { getMemoryWikiPage, searchMemoryWiki } from "./query.js";
-import { syncMemoryWikiImportedSources } from "./source-sync.js";
+import {
+  syncMemoryWikiImportedSources,
+  type MemoryWikiImportedSourceSyncResult,
+} from "./source-sync.js";
 import {
   buildMemoryWikiDoctorReport,
+  type MemoryWikiDoctorReport,
+  type MemoryWikiStatus,
   renderMemoryWikiDoctor,
   renderMemoryWikiStatus,
   resolveMemoryWikiStatus,
 } from "./status.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
-type WikiStatusCommandOptions = {
+type WikiStatusCommandOptions = GatewayRpcOpts & {
   json?: boolean;
 };
 
-type WikiDoctorCommandOptions = {
+type WikiDoctorCommandOptions = GatewayRpcOpts & {
   json?: boolean;
 };
 
@@ -96,7 +106,7 @@ type WikiApplyMetadataCommandOptions = {
   status?: string;
 };
 
-type WikiBridgeImportCommandOptions = {
+type WikiBridgeImportCommandOptions = GatewayRpcOpts & {
   json?: boolean;
 };
 
@@ -201,6 +211,28 @@ function formatJsonOrText<T>(
   return json ? JSON.stringify(result, null, 2) : render(result);
 }
 
+async function callWikiGateway<T>(params: {
+  method: string;
+  gatewayOpts?: GatewayRpcOpts;
+  json?: boolean;
+  callGateway?: typeof callGatewayFromCli;
+}): Promise<T> {
+  const call = params.callGateway ?? callGatewayFromCli;
+  const result = await call(params.method, { ...params.gatewayOpts, json: params.json }, {});
+  if (result === undefined || result === null) {
+    throw new Error(
+      `${params.method} returned no result from the gateway (is the gateway running?)`,
+    );
+  }
+  return result as T;
+}
+
+function shouldUseGatewayBridgeRuntime(config: ResolvedMemoryWikiConfig): boolean {
+  return (
+    config.vaultMode === "bridge" && config.bridge.enabled && config.bridge.readMemoryArtifacts
+  );
+}
+
 async function runWikiCommandWithSummary<T>(params: {
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
@@ -252,13 +284,24 @@ function addWikiApplyMutationOptions<T extends Command>(command: T): T {
 export async function runWikiStatus(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  gatewayOpts?: GatewayRpcOpts;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
+  callGateway?: typeof callGatewayFromCli;
 }) {
-  await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
-  const status = await resolveMemoryWikiStatus(params.config, {
-    appConfig: params.appConfig,
-  });
+  const status = shouldUseGatewayBridgeRuntime(params.config)
+    ? await callWikiGateway<MemoryWikiStatus>({
+        method: "wiki.status",
+        gatewayOpts: params.gatewayOpts,
+        json: params.json,
+        callGateway: params.callGateway,
+      })
+    : await (async () => {
+        await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
+        return await resolveMemoryWikiStatus(params.config, {
+          appConfig: params.appConfig,
+        });
+      })();
   writeOutput(
     params.json ? JSON.stringify(status, null, 2) : renderMemoryWikiStatus(status),
     params.stdout,
@@ -269,15 +312,23 @@ export async function runWikiStatus(params: {
 export async function runWikiDoctor(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  gatewayOpts?: GatewayRpcOpts;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
+  callGateway?: typeof callGatewayFromCli;
 }) {
-  await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
-  const report = buildMemoryWikiDoctorReport(
-    await resolveMemoryWikiStatus(params.config, {
-      appConfig: params.appConfig,
-    }),
-  );
+  const report = shouldUseGatewayBridgeRuntime(params.config)
+    ? await callWikiGateway<MemoryWikiDoctorReport>({
+        method: "wiki.doctor",
+        gatewayOpts: params.gatewayOpts,
+        json: params.json,
+        callGateway: params.callGateway,
+      })
+    : buildMemoryWikiDoctorReport(
+        await resolveMemoryWikiStatus(params.config, {
+          appConfig: params.appConfig,
+        }),
+      );
   if (!report.healthy) {
     process.exitCode = 1;
   }
@@ -502,17 +553,26 @@ export async function runWikiApplyMetadata(params: {
 export async function runWikiBridgeImport(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  gatewayOpts?: GatewayRpcOpts;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
+  callGateway?: typeof callGatewayFromCli;
 }) {
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
     run: () =>
-      syncMemoryWikiImportedSources({
-        config: params.config,
-        appConfig: params.appConfig,
-      }),
+      shouldUseGatewayBridgeRuntime(params.config)
+        ? callWikiGateway<MemoryWikiImportedSourceSyncResult>({
+            method: "wiki.bridge.import",
+            gatewayOpts: params.gatewayOpts,
+            json: params.json,
+            callGateway: params.callGateway,
+          })
+        : syncMemoryWikiImportedSources({
+            config: params.config,
+            appConfig: params.appConfig,
+          }),
     render: (value) =>
       `Bridge import synced ${value.artifactCount} artifacts across ${value.workspaces} workspaces (${value.importedCount} new, ${value.updatedCount} updated, ${value.skippedCount} unchanged, ${value.removedCount} removed). Indexes ${value.indexesRefreshed ? `refreshed (${value.indexUpdatedFiles.length} files)` : `not refreshed (${value.indexRefreshReason})`}.`,
   });
@@ -671,21 +731,20 @@ export function registerWikiCli(
     : resolveMemoryWikiConfig(pluginConfig);
   const wiki = program.command("wiki").description("Inspect and initialize the memory wiki vault");
 
-  wiki
-    .command("status")
-    .description("Show wiki vault status")
-    .option("--json", "Print JSON")
-    .action(async (opts: WikiStatusCommandOptions) => {
-      await runWikiStatus({ config, appConfig, json: opts.json });
-    });
+  addGatewayClientOptions(
+    wiki.command("status").description("Show wiki vault status").option("--json", "Print JSON"),
+  ).action(async (opts: WikiStatusCommandOptions) => {
+    await runWikiStatus({ config, appConfig, gatewayOpts: opts, json: opts.json });
+  });
 
-  wiki
-    .command("doctor")
-    .description("Audit wiki vault setup and report actionable fixes")
-    .option("--json", "Print JSON")
-    .action(async (opts: WikiDoctorCommandOptions) => {
-      await runWikiDoctor({ config, appConfig, json: opts.json });
-    });
+  addGatewayClientOptions(
+    wiki
+      .command("doctor")
+      .description("Audit wiki vault setup and report actionable fixes")
+      .option("--json", "Print JSON"),
+  ).action(async (opts: WikiDoctorCommandOptions) => {
+    await runWikiDoctor({ config, appConfig, gatewayOpts: opts, json: opts.json });
+  });
 
   wiki
     .command("init")
@@ -814,13 +873,14 @@ export function registerWikiCli(
   const bridge = wiki
     .command("bridge")
     .description("Import public memory artifacts into the wiki vault");
-  bridge
-    .command("import")
-    .description("Sync bridge-backed memory artifacts into wiki source pages")
-    .option("--json", "Print JSON")
-    .action(async (opts: WikiBridgeImportCommandOptions) => {
-      await runWikiBridgeImport({ config, appConfig, json: opts.json });
-    });
+  addGatewayClientOptions(
+    bridge
+      .command("import")
+      .description("Sync bridge-backed memory artifacts into wiki source pages")
+      .option("--json", "Print JSON"),
+  ).action(async (opts: WikiBridgeImportCommandOptions) => {
+    await runWikiBridgeImport({ config, appConfig, gatewayOpts: opts, json: opts.json });
+  });
 
   const unsafeLocal = wiki
     .command("unsafe-local")


### PR DESCRIPTION
## Summary

- Route `openclaw wiki status`, `openclaw wiki doctor`, and `openclaw wiki bridge import` through Gateway RPC when Memory Wiki bridge mode is active.
- Keep the local/offline path for configs where bridge import is disabled or memory artifacts are not read.
- Document that active bridge CLI checks need a running Gateway and `--url`/`--token` for remote Gateways.

## Context

This keeps CLI bridge operations in the same process context as the runtime memory plugin, so `wiki bridge import` no longer sees an empty standalone plugin registry and prunes existing bridge-sourced pages.

Based on the Gateway-routing direction from https://github.com/openclaw/openclaw/pull/67208 by @moorsecopers99; this PR keeps the scope limited to Memory Wiki CLI routing and tests.

Fixes https://github.com/openclaw/openclaw/issues/70181
Fixes https://github.com/openclaw/openclaw/issues/70842
Fixes https://github.com/openclaw/openclaw/issues/67979
Fixes https://github.com/openclaw/openclaw/issues/68828
Fixes https://github.com/openclaw/openclaw/issues/66082
Fixes https://github.com/openclaw/openclaw/issues/69019
Fixes https://github.com/openclaw/openclaw/issues/65722
Fixes https://github.com/openclaw/openclaw/issues/65976
Fixes https://github.com/openclaw/openclaw/issues/70242
Fixes https://github.com/openclaw/openclaw/issues/68371

## Validation

- `OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/gateway.test.ts extensions/memory-wiki/src/status.test.ts` passed: 3 files, 20 tests.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/cli/wiki.md docs/plugins/memory-wiki.md extensions/memory-wiki/src/cli.ts extensions/memory-wiki/src/cli.test.ts` passed.
- `git diff --check` passed.
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed` is currently blocked by an unrelated extension typecheck error: `extensions/qa-lab/web/src/main.ts(1,8): error TS2882: Cannot find module or type declarations for side-effect import of './styles.css'.`
