### PR TITLE
docs: align Node minimum requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Model note: while many providers and models are supported, prefer a current flag
 
 ## Install (recommended)
 
-Runtime: **Node 24 (recommended) or Node 22.16+**.
+Runtime: **Node 24 (recommended) or Node 22.14+**.
 
 ```bash
 npm install -g openclaw@latest
@@ -109,7 +109,7 @@ OpenClaw Onboard installs the Gateway daemon (launchd/systemd user service) so i
 
 ## Quick start (TL;DR)
 
-Runtime: **Node 24 (recommended) or Node 22.16+**.
+Runtime: **Node 24 (recommended) or Node 22.14+**.
 
 Full beginner guide (auth, pairing, channels): [Getting started](https://docs.openclaw.ai/start/getting-started)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -288,7 +288,7 @@ OpenClaw's web interface (Gateway Control UI + HTTP endpoints) is intended for *
 
 ### Node.js Version
 
-OpenClaw requires **Node.js 22.12.0 or later** (LTS). This version includes important security patches:
+OpenClaw requires **Node.js 22.14.0 or later** (LTS). This version includes important security patches:
 
 - CVE-2025-59466: async_hooks DoS vulnerability
 - CVE-2026-21636: Permission model bypass vulnerability
@@ -296,7 +296,7 @@ OpenClaw requires **Node.js 22.12.0 or later** (LTS). This version includes impo
 Verify your Node.js version:
 
 ```bash
-node --version  # Should be v22.12.0 or later
+node --version  # Should be v22.14.0 or later
 ```
 
 ### Docker Security


### PR DESCRIPTION
## Summary

- align SECURITY.md with the runtime guard and package engine Node >=22.14.0 requirement
- align README quick-start runtime text with the same supported Node 22 floor

Fixes https://github.com/openclaw/openclaw/issues/59476
Supersedes https://github.com/openclaw/openclaw/pull/59478

## Validation

- pnpm check:changed
- git diff --check
- rg -n --glob '!docs/assets/install-script.svg' '22\\.12\\.0|22\\.16\\+' .\n- pnpm docs:list (pre-existing docs/AGENTS.md missing front matter remains)\n