### PR TITLE
fix(agents): preserve LM Studio IQ quant model refs

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -71,11 +71,18 @@ describe("splitTrailingAuthProfile", () => {
     expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0")).toEqual({
       model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
     });
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq3_xxs")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq3_xxs",
+    });
   });
 
   it("supports auth profiles after @q* quant suffixes", () => {
     expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0@work")).toEqual({
       model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
+      profile: "work",
+    });
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq4_xs@work")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq4_xs",
       profile: "work",
     });
   });

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -26,12 +26,13 @@ export function splitTrailingAuthProfile(raw: string): {
   }
 
   // Keep local model quant suffixes (common in LM Studio/Ollama catalogs) as part
-  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0) which would
-  // otherwise be misinterpreted as an auth profile delimiter.
+  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0 or
+  // qwen3.6-27b@iq3_xxs) which would otherwise be misinterpreted as an auth
+  // profile delimiter.
   //
   // If an auth profile is needed, it can still be specified as a second suffix:
   //   lmstudio/foo@q8_0@work
-  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
+  if (/^(?:i?q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -883,6 +883,17 @@ describe("model-selection", () => {
       });
     });
 
+    it("preserves LM Studio IQ quant suffixes in model ids", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "lmstudio/qwen3.6-27b@iq3_xxs",
+        defaultProvider: "openai",
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "lmstudio",
+        model: "qwen3.6-27b@iq3_xxs",
+      });
+    });
+
     it("splits trailing profile suffix after OpenRouter preset paths", () => {
       const resolved = resolveModelRefFromString({
         raw: "openrouter/@preset/kimi-2-5@work",


### PR DESCRIPTION
## Summary

- Problem: LM Studio model ids such as `qwen3.6-27b@iq3_xxs` were parsed as `qwen3.6-27b` plus an auth profile suffix.
- Why it matters: `/model lmstudio/...@iq*` could fail allowlist validation, and configured LM Studio IQ quant variants could lose the exact quant id before inference.
- What changed: Treat `@iq*` local quant suffixes like the existing `@q*` / `@4bit` suffixes and keep them in the model id. Added regression coverage for direct profile splitting and model selection resolution.
- What did NOT change (scope boundary): No LM Studio runtime transport, preload, auth-profile, or catalog discovery behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71474
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `splitTrailingAuthProfile` already protected common local quant suffixes like `@q8_0` and `@4bit`, but did not include LM Studio IQ quant suffixes such as `@iq3_xxs`.
- Missing detection / guardrail: Existing tests covered `@q*` and bit-depth suffixes, but not `@iq*` model ids from LM Studio.
- Contributing context (if known): LM Studio can expose multiple quants for the same base model by adding IQ suffixes to the model key.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-ref-profile.test.ts`, `src/agents/model-selection.test.ts`
- Scenario the test should lock in: `lmstudio/qwen3.6-27b@iq3_xxs` resolves to provider `lmstudio` and model `qwen3.6-27b@iq3_xxs`, not a truncated model plus profile suffix.
- Why this is the smallest reliable guardrail: The truncation happens in the shared model-ref/profile parser before LM Studio runtime code sees the selected model.
- Existing test that already covers this (if any): Existing tests covered `@q8_0`, `@4bit`, and profile suffixes but not `@iq*`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

LM Studio users can select and run IQ quant model ids containing `@iq*`, for example `lmstudio/qwen3.6-27b@iq3_xxs`, without the quant suffix being stripped as an auth profile.

## Diagram (if applicable)

```text
Before:
/model lmstudio/qwen3.6-27b@iq3_xxs -> lmstudio/qwen3.6-27b + profile iq3_xxs -> model not allowed

After:
/model lmstudio/qwen3.6-27b@iq3_xxs -> lmstudio/qwen3.6-27b@iq3_xxs -> exact configured model
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11 local checkout
- Runtime/container: Node test runner through repo scripts
- Model/provider: LM Studio model refs with `@iq*` suffixes
- Integration/channel (if any): `/model` / shared agent model selection
- Relevant config (redacted): N/A

### Steps

1. Parse `lmstudio/qwen3.6-27b@iq3_xxs` through shared model selection.
2. Parse `lmstudio/qwen3.6-27b@iq4_xs@work` through auth-profile splitting.
3. Verify the first `@iq*` suffix stays in the model id and a second suffix can still be used as an auth profile.

### Expected

- `@iq3_xxs` and `@iq4_xs` remain part of the LM Studio model id.
- A second suffix such as `@work` still resolves as the auth profile override.

### Actual

- Covered by the new regression tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```sh
pnpm test src/agents/model-ref-profile.test.ts src/agents/model-selection.test.ts
# Test Files  1 passed (1), Tests 13 passed (13)
# Test Files  1 passed (1), Tests 90 passed (90)

pnpm exec oxfmt --check --threads=1 src/agents/model-ref-profile.ts src/agents/model-ref-profile.test.ts src/agents/model-selection.test.ts
# All matched files use the correct format.

pnpm check:changed
# exit 0
```

## Human Verification (required)

- Verified scenarios: Shared parser preserves `@iq3_xxs`; shared model selection resolves `lmstudio/qwen3.6-27b@iq3_xxs` to the exact model id; second suffix auth profile still works after `@iq4_xs`.
- Edge cases checked: Existing `@q8_0`, `@4bit`, `@8bit`, dated suffix, and profile suffix tests still pass.
- What you did **not** verify: I did not run a live LM Studio server.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A user could previously intend `@iq3_xxs` as an auth profile name.
  - Mitigation: This matches the existing local-quant handling for `@q*`; users can still specify auth profiles as a second suffix, for example `lmstudio/model@iq3_xxs@work`.