### PR TITLE
fix(agents): preserve LM Studio @iq* quant suffixes in model refs

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -67,15 +67,22 @@ describe("splitTrailingAuthProfile", () => {
     });
   });
 
-  it("keeps @q* quant suffixes in model ids", () => {
+  it("keeps @q* and @iq* quant suffixes in model ids", () => {
     expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0")).toEqual({
       model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
     });
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq3_xxs")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq3_xxs",
+    });
   });
 
-  it("supports auth profiles after @q* quant suffixes", () => {
+  it("supports auth profiles after @q* and @iq* quant suffixes", () => {
     expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0@work")).toEqual({
       model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
+      profile: "work",
+    });
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq3_xxs@work")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq3_xxs",
       profile: "work",
     });
   });

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -26,12 +26,14 @@ export function splitTrailingAuthProfile(raw: string): {
   }
 
   // Keep local model quant suffixes (common in LM Studio/Ollama catalogs) as part
-  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0) which would
-  // otherwise be misinterpreted as an auth profile delimiter.
+  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0 or
+  // qwen3.6-27b@iq3_xxs) which would otherwise be misinterpreted as an auth
+  // profile delimiter.
   //
   // If an auth profile is needed, it can still be specified as a second suffix:
   //   lmstudio/foo@q8_0@work
-  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
+  //   lmstudio/foo@iq3_xxs@work
+  if (/^(?:(?:i?q)\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -894,6 +894,28 @@ describe("model-selection", () => {
       });
     });
 
+    it("preserves LM Studio @iq* quant suffixes", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "lmstudio/qwen3.6-27b@iq3_xxs",
+        defaultProvider: "anthropic",
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "lmstudio",
+        model: "qwen3.6-27b@iq3_xxs",
+      });
+    });
+
+    it("splits trailing profile suffix after LM Studio @iq* quant suffixes", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "lmstudio/qwen3.6-27b@iq3_xxs@work",
+        defaultProvider: "anthropic",
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "lmstudio",
+        model: "qwen3.6-27b@iq3_xxs",
+      });
+    });
+
     it("strips profile suffix before alias resolution", () => {
       const index = {
         byAlias: new Map([

--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -72,6 +72,20 @@ describe("extractModelDirective", () => {
       expect(result.rawProfile).toBe("cf:default");
     });
 
+    it("keeps LM Studio @iq* quant suffixes inside model ids", () => {
+      const result = extractModelDirective("/model lmstudio/qwen3.6-27b@iq3_xxs");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("lmstudio/qwen3.6-27b@iq3_xxs");
+      expect(result.rawProfile).toBeUndefined();
+    });
+
+    it("allows profile overrides after LM Studio @iq* quant suffixes", () => {
+      const result = extractModelDirective("/model lmstudio/qwen3.6-27b@iq3_xxs@work");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("lmstudio/qwen3.6-27b@iq3_xxs");
+      expect(result.rawProfile).toBe("work");
+    });
+
     it("returns no directive for plain text", () => {
       const result = extractModelDirective("hello world");
       expect(result.hasDirective).toBe(false);


### PR DESCRIPTION
Fixes #71474

## Problem

LM Studio names imatrix-quant variants like `qwen3.6-27b@iq3_xxs` (note: `iq` prefix, not `q`). `splitTrailingAuthProfile` only special-cased `@q*` / `<n>bit` suffixes, so:

```
/model lmstudio/qwen3.6-27b@iq3_xxs
```

was parsed as `model="lmstudio/qwen3.6-27b"` + `profile="iq3_xxs"`, producing `GatewayRequestError: model not allowed: lmstudio/qwen3.6-27b` and (when it didn't fail) sending the truncated id to LM Studio, which then picked an arbitrary quant.

## Fix

Extend the protected quant pattern to allow an optional `i` prefix:

```diff
- /^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i
+ /^(?:(?:i?q)\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i
```

This keeps `@iq3_xxs`, `@iq4_xs`, etc. as part of the model id while still allowing an explicit auth profile via a second `@` suffix (e.g. `lmstudio/foo@iq3_xxs@work`).

## Tests

Added regression cases in:
- `src/agents/model-ref-profile.test.ts`
- `src/agents/model-selection.test.ts`
- `src/auto-reply/model.test.ts`

Verified the splitter against representative inputs:

| input | model | profile |
|---|---|---|
| `lmstudio/qwen3.6-27b@iq3_xxs` | `lmstudio/qwen3.6-27b@iq3_xxs` | — |
| `lmstudio-mb-pro/gemma-4-31b-it@q8_0` | …`@q8_0` | — |
| `lmstudio/qwen3.6-27b@iq3_xxs@work` | …`@iq3_xxs` | `work` |
| `openai/gpt-5@work` | `openai/gpt-5` | `work` |
| `openai/@cf/openai/gpt-oss-20b@cf:default` | `openai/@cf/openai/gpt-oss-20b` | `cf:default` |
