### PR TITLE
fix(auth): clarify Codex OAuth region failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Control UI/chat: collapse assistant token/model context details behind an explicit Context disclosure and show full dates in message footers, making historical transcript timing clear without noisy default metadata. (#71337) Thanks @BunsDev.
+- OpenAI/Codex OAuth: explain `unsupported_country_region_territory` token-exchange failures with a proxy/region hint instead of surfacing a generic OAuth error. Fixes #51175.
 - Telegram: remove the startup persisted-offset `getUpdates` preflight so polling restarts do not self-conflict before the runner starts. Fixes #69304. (#69779) Thanks @chinar-amrutkar.
 - Telegram: keep the polling stall watchdog active even when grammY reports the runner as not running while its task is still pending, so a rebuilt transport cannot leave `getUpdates` silent until a manual gateway restart. Fixes #69064. Thanks @LDLoeb.
 - Browser/Playwright: ignore benign already-handled route races during guarded navigation so browser-page tasks no longer fail when Playwright tears down a route mid-flight. (#68708) Thanks @Steady-ai.

--- a/src/plugins/provider-openai-codex-oauth.test.ts
+++ b/src/plugins/provider-openai-codex-oauth.test.ts
@@ -181,6 +181,28 @@ describe("loginOpenAICodexOAuth", () => {
     );
   });
 
+  it("explains OpenAI unsupported region token exchange failures", async () => {
+    mocks.loginOpenAICodex.mockRejectedValue(new Error("403 unsupported_country_region_territory"));
+
+    const { prompter, spin } = createPrompter();
+    const runtime = createRuntime();
+    await expect(
+      loginOpenAICodexOAuth({
+        prompter,
+        runtime,
+        isRemote: false,
+        openUrl: async () => {},
+      }),
+    ).rejects.toThrow(/unsupported_region/i);
+
+    expect(spin.stop).toHaveBeenCalledWith("OpenAI OAuth failed");
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("HTTPS_PROXY"));
+    expect(prompter.note).toHaveBeenCalledWith(
+      "Trouble with OAuth? See https://docs.openclaw.ai/start/faq",
+      "OAuth help",
+    );
+  });
+
   it("passes manual code input hook for remote oauth flows", async () => {
     const creds = createCodexCredentials();
     mocks.loginOpenAICodex.mockImplementation(async (opts: CodexLoginOptions) => {

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -15,7 +15,10 @@ const openAICodexOAuthOriginator = "openclaw";
 const localManualFallbackDelayMs = 15_000;
 const localManualFallbackGraceMs = 1_000;
 
-type OpenAICodexOAuthFailureCode = "callback_timeout" | "callback_validation_failed";
+type OpenAICodexOAuthFailureCode =
+  | "callback_timeout"
+  | "callback_validation_failed"
+  | "unsupported_region";
 
 function waitForDelayOrLoginSettle(params: {
   delayMs: number;
@@ -54,6 +57,16 @@ function createOpenAICodexOAuthError(
 
 function rewriteOpenAICodexOAuthError(error: unknown): Error {
   const message = formatErrorMessage(error);
+  if (/unsupported_country_region_territory/i.test(message)) {
+    return createOpenAICodexOAuthError(
+      "unsupported_region",
+      [
+        "OpenAI rejected the token exchange for this country, region, or network route.",
+        "If you normally use a proxy, verify HTTPS_PROXY, HTTP_PROXY, or ALL_PROXY is set for the OpenClaw process and then retry `openclaw models auth login --provider openai-codex`.",
+      ].join(" "),
+      error,
+    );
+  }
   if (/state mismatch|missing authorization code/i.test(message)) {
     return createOpenAICodexOAuthError("callback_validation_failed", message, error);
   }


### PR DESCRIPTION
## Summary

- Detect OpenAI `unsupported_country_region_territory` failures from the Codex OAuth token exchange.
- Rewrite that opaque provider response into a stable `unsupported_region` OAuth error with proxy/region guidance.
- Add regression coverage and a changelog entry.

Fixes https://github.com/openclaw/openclaw/issues/51175

## Validation

- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/plugins/provider-openai-codex-oauth.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed`
