### PR TITLE
fix(googlechat): preserve reply text after typing update failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Google Chat: preserve reply text when a typing indicator message is deleted or can no longer be updated, so media captions and first text chunks are resent instead of silently disappearing. (#71498) Thanks @colin-lgtm.
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Telegram: remove the startup persisted-offset `getUpdates` preflight so polling restarts do not self-conflict before the runner starts. Fixes #69304. (#69779) Thanks @chinar-amrutkar.
 - Telegram: keep the polling stall watchdog active even when grammY reports the runner as not running while its task is still pending, so a rebuilt transport cannot leave `getUpdates` silent until a manual gateway restart. Fixes #69064. Thanks @LDLoeb.

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -1,0 +1,156 @@
+import {
+  deliverTextOrMediaReply,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import {
+  deleteGoogleChatMessage,
+  sendGoogleChatMessage,
+  updateGoogleChatMessage,
+  uploadGoogleChatAttachment,
+} from "./api.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+
+export async function deliverGoogleChatReply(params: {
+  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string; replyToId?: string };
+  account: ResolvedGoogleChatAccount;
+  spaceId: string;
+  runtime: GoogleChatRuntimeEnv;
+  core: GoogleChatCoreRuntime;
+  config: OpenClawConfig;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  typingMessageName?: string;
+}): Promise<void> {
+  const { payload, account, spaceId, runtime, core, config, statusSink } = params;
+  // Clear this whenever the typing message is deleted or unavailable; otherwise
+  // text delivery can keep retrying a dead message and drop content.
+  let typingMessageName = params.typingMessageName;
+  const reply = resolveSendableOutboundReplyParts(payload);
+  const mediaCount = reply.mediaCount;
+  const hasMedia = reply.hasMedia;
+  const text = reply.text;
+  let firstTextChunk = true;
+  let suppressCaption = false;
+
+  if (hasMedia && typingMessageName) {
+    try {
+      await deleteGoogleChatMessage({
+        account,
+        messageName: typingMessageName,
+      });
+      typingMessageName = undefined;
+    } catch (err) {
+      runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+      if (typingMessageName) {
+        const fallbackText = reply.hasText
+          ? text
+          : mediaCount > 1
+            ? "Sent attachments."
+            : "Sent attachment.";
+        try {
+          await updateGoogleChatMessage({
+            account,
+            messageName: typingMessageName,
+            text: fallbackText,
+          });
+          suppressCaption = Boolean(text.trim());
+        } catch (updateErr) {
+          runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+          typingMessageName = undefined;
+        }
+      }
+    }
+  }
+
+  const chunkLimit = account.config.textChunkLimit ?? 4000;
+  const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
+  const sendTextMessage = async (chunk: string) => {
+    await sendGoogleChatMessage({
+      account,
+      space: spaceId,
+      text: chunk,
+      thread: payload.replyToId,
+    });
+  };
+  await deliverTextOrMediaReply({
+    payload,
+    text: suppressCaption ? "" : reply.text,
+    chunkText: (value) => core.channel.text.chunkMarkdownTextWithMode(value, chunkLimit, chunkMode),
+    sendText: async (chunk) => {
+      try {
+        if (firstTextChunk && typingMessageName) {
+          await updateGoogleChatMessage({
+            account,
+            messageName: typingMessageName,
+            text: chunk,
+          });
+        } else {
+          await sendTextMessage(chunk);
+        }
+        firstTextChunk = false;
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`Google Chat message send failed: ${String(err)}`);
+        if (firstTextChunk && typingMessageName) {
+          typingMessageName = undefined;
+          try {
+            await sendTextMessage(chunk);
+            statusSink?.({ lastOutboundAt: Date.now() });
+          } catch (fallbackErr) {
+            runtime.error?.(`Google Chat message fallback send failed: ${String(fallbackErr)}`);
+          } finally {
+            firstTextChunk = false;
+          }
+        }
+      }
+    },
+    sendMedia: async ({ mediaUrl, caption }) => {
+      try {
+        const loaded = await core.channel.media.fetchRemoteMedia({
+          url: mediaUrl,
+          maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+        });
+        const upload = await uploadAttachmentForReply({
+          account,
+          spaceId,
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+          filename: loaded.fileName ?? "attachment",
+        });
+        if (!upload.attachmentUploadToken) {
+          throw new Error("missing attachment upload token");
+        }
+        await sendGoogleChatMessage({
+          account,
+          space: spaceId,
+          text: caption,
+          thread: payload.replyToId,
+          attachments: [
+            { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
+          ],
+        });
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`Google Chat attachment send failed: ${String(err)}`);
+      }
+    },
+  });
+}
+
+async function uploadAttachmentForReply(params: {
+  account: ResolvedGoogleChatAccount;
+  spaceId: string;
+  buffer: Buffer;
+  contentType?: string;
+  filename: string;
+}) {
+  const { account, spaceId, buffer, contentType, filename } = params;
+  return await uploadGoogleChatAttachment({
+    account,
+    space: spaceId,
+    filename,
+    buffer,
+    contentType,
+  });
+}

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+
+const mocks = vi.hoisted(() => ({
+  deleteGoogleChatMessage: vi.fn(),
+  sendGoogleChatMessage: vi.fn(),
+  updateGoogleChatMessage: vi.fn(),
+  uploadGoogleChatAttachment: vi.fn(),
+}));
+
+vi.mock("./api.js", () => ({
+  deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  sendGoogleChatMessage: mocks.sendGoogleChatMessage,
+  updateGoogleChatMessage: mocks.updateGoogleChatMessage,
+  uploadGoogleChatAttachment: mocks.uploadGoogleChatAttachment,
+}));
+
+const account = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "inline",
+  config: {},
+} as ResolvedGoogleChatAccount;
+
+const config = {} as OpenClawConfig;
+
+function createCore(params?: {
+  chunks?: readonly string[];
+  media?: { buffer: Buffer; contentType?: string; fileName?: string };
+}) {
+  return {
+    channel: {
+      text: {
+        resolveChunkMode: vi.fn(() => "markdown"),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => params?.chunks ?? [text]),
+      },
+      media: {
+        fetchRemoteMedia: vi.fn(async () => params?.media ?? { buffer: Buffer.from("image") }),
+      },
+    },
+  } as unknown as GoogleChatCoreRuntime;
+}
+
+function createRuntime() {
+  return {
+    error: vi.fn(),
+    log: vi.fn(),
+  } satisfies GoogleChatRuntimeEnv;
+}
+
+let deliverGoogleChatReply: typeof import("./monitor-reply-delivery.js").deliverGoogleChatReply;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ deliverGoogleChatReply } = await import("./monitor-reply-delivery.js"));
+});
+
+describe("Google Chat reply delivery", () => {
+  it("resends the first text chunk as a new message when typing update fails", async () => {
+    const core = createCore({ chunks: ["first chunk", "second chunk"] });
+    const runtime = createRuntime();
+    const statusSink = vi.fn();
+    mocks.updateGoogleChatMessage.mockRejectedValueOnce(new Error("message not found"));
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/fallback" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "first chunk\n\nsecond chunk", replyToId: "spaces/AAA/threads/root" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      statusSink,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+      text: "first chunk",
+    });
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.sendGoogleChatMessage).toHaveBeenNthCalledWith(1, {
+      account,
+      space: "spaces/AAA",
+      text: "first chunk",
+      thread: "spaces/AAA/threads/root",
+    });
+    expect(mocks.sendGoogleChatMessage).toHaveBeenNthCalledWith(2, {
+      account,
+      space: "spaces/AAA",
+      text: "second chunk",
+      thread: "spaces/AAA/threads/root",
+    });
+    expect(statusSink).toHaveBeenCalledTimes(2);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat message send failed"),
+    );
+  });
+
+  it("does not update a deleted typing message before sending media with a caption", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
+    });
+    const runtime = createRuntime();
+    mocks.deleteGoogleChatMessage.mockResolvedValue(undefined);
+    mocks.uploadGoogleChatAttachment.mockResolvedValue({ attachmentUploadToken: "upload-token" });
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/media" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "https://example.invalid/reply.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+    });
+    expect(mocks.updateGoogleChatMessage).not.toHaveBeenCalled();
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption",
+      thread: "spaces/AAA/threads/root",
+      attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,7 +1,3 @@
-import {
-  deliverTextOrMediaReply,
-  resolveSendableOutboundReplyParts,
-} from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
 import {
@@ -10,15 +6,10 @@ import {
   resolveWebhookPath,
 } from "../runtime-api.js";
 import { type ResolvedGoogleChatAccount } from "./accounts.js";
-import {
-  downloadGoogleChatMedia,
-  deleteGoogleChatMessage,
-  sendGoogleChatMessage,
-  uploadGoogleChatAttachment,
-  updateGoogleChatMessage,
-} from "./api.js";
+import { downloadGoogleChatMedia, sendGoogleChatMessage } from "./api.js";
 import { type GoogleChatAudienceType } from "./auth.js";
 import { applyGoogleChatInboundAccessPolicy, isSenderAllowed } from "./monitor-access.js";
+import { deliverGoogleChatReply } from "./monitor-reply-delivery.js";
 import {
   handleGoogleChatWebhookRequest,
   registerGoogleChatWebhookTarget,
@@ -335,152 +326,6 @@ async function downloadAttachment(
     attachment.contentName,
   );
   return { path: saved.path, contentType: saved.contentType };
-}
-
-async function deliverGoogleChatReply(params: {
-  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string; replyToId?: string };
-  account: ResolvedGoogleChatAccount;
-  spaceId: string;
-  runtime: GoogleChatRuntimeEnv;
-  core: GoogleChatCoreRuntime;
-  config: OpenClawConfig;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
-  typingMessageName?: string;
-}): Promise<void> {
-  const { payload, account, spaceId, runtime, core, config, statusSink } = params;
-  // Use let so we can clear it after a successful delete — if we leave it set, sendText
-  // would try to updateGoogleChatMessage on an already-deleted message and silently drop
-  // all text content (the update error is caught before firstTextChunk flips to false).
-  let typingMessageName = params.typingMessageName;
-  const reply = resolveSendableOutboundReplyParts(payload);
-  const mediaCount = reply.mediaCount;
-  const hasMedia = reply.hasMedia;
-  const text = reply.text;
-  let firstTextChunk = true;
-  let suppressCaption = false;
-
-  if (hasMedia) {
-    if (typingMessageName) {
-      try {
-        await deleteGoogleChatMessage({
-          account,
-          messageName: typingMessageName,
-        });
-        // Clear after successful delete so the sendText path below does not attempt to
-        // update a message that no longer exists.
-        typingMessageName = undefined;
-      } catch (err) {
-        runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
-        // typingMessageName is still set here: the delete threw before the reset ran.
-        // The guard below satisfies TypeScript's conservative catch-block narrowing.
-        if (typingMessageName) {
-          const fallbackText = reply.hasText
-            ? text
-            : mediaCount > 1
-              ? "Sent attachments."
-              : "Sent attachment.";
-          try {
-            await updateGoogleChatMessage({
-              account,
-              messageName: typingMessageName,
-              text: fallbackText,
-            });
-            suppressCaption = Boolean(text.trim());
-          } catch (updateErr) {
-            runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
-            // Also clear here so sendText falls through to sendGoogleChatMessage
-            // instead of repeatedly retrying the unavailable message and dropping text.
-            typingMessageName = undefined;
-          }
-        }
-      }
-    }
-  }
-
-  const chunkLimit = account.config.textChunkLimit ?? 4000;
-  const chunkMode = core.channel.text.resolveChunkMode(config, "googlechat", account.accountId);
-  await deliverTextOrMediaReply({
-    payload,
-    text: suppressCaption ? "" : reply.text,
-    chunkText: (value) => core.channel.text.chunkMarkdownTextWithMode(value, chunkLimit, chunkMode),
-    sendText: async (chunk) => {
-      try {
-        if (firstTextChunk && typingMessageName) {
-          await updateGoogleChatMessage({
-            account,
-            messageName: typingMessageName,
-            text: chunk,
-          });
-        } else {
-          await sendGoogleChatMessage({
-            account,
-            space: spaceId,
-            text: chunk,
-            thread: payload.replyToId,
-          });
-        }
-        firstTextChunk = false;
-        statusSink?.({ lastOutboundAt: Date.now() });
-      } catch (err) {
-        runtime.error?.(`Google Chat message send failed: ${String(err)}`);
-        if (firstTextChunk && typingMessageName) {
-          // The updateGoogleChatMessage call failed. Clear both flags so
-          // subsequent chunks fall through to sendGoogleChatMessage instead of
-          // retrying the unavailable typing-indicator message and silently
-          // dropping all remaining text.
-          typingMessageName = undefined;
-          firstTextChunk = false;
-        }
-      }
-    },
-    sendMedia: async ({ mediaUrl, caption }) => {
-      try {
-        const loaded = await core.channel.media.fetchRemoteMedia({
-          url: mediaUrl,
-          maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
-        });
-        const upload = await uploadAttachmentForReply({
-          account,
-          spaceId,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-          filename: loaded.fileName ?? "attachment",
-        });
-        if (!upload.attachmentUploadToken) {
-          throw new Error("missing attachment upload token");
-        }
-        await sendGoogleChatMessage({
-          account,
-          space: spaceId,
-          text: caption,
-          thread: payload.replyToId,
-          attachments: [
-            { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
-          ],
-        });
-        statusSink?.({ lastOutboundAt: Date.now() });
-      } catch (err) {
-        runtime.error?.(`Google Chat attachment send failed: ${String(err)}`);
-      }
-    },
-  });
-}
-
-async function uploadAttachmentForReply(params: {
-  account: ResolvedGoogleChatAccount;
-  spaceId: string;
-  buffer: Buffer;
-  contentType?: string;
-  filename: string;
-}) {
-  const { account, spaceId, buffer, contentType, filename } = params;
-  return await uploadGoogleChatAttachment({
-    account,
-    space: spaceId,
-    filename,
-    buffer,
-    contentType,
-  });
 }
 
 export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => void {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -347,8 +347,11 @@ async function deliverGoogleChatReply(params: {
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
 }): Promise<void> {
-  const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
-    params;
+  const { payload, account, spaceId, runtime, core, config, statusSink } = params;
+  // Use let so we can clear it after a successful delete — if we leave it set, sendText
+  // would try to updateGoogleChatMessage on an already-deleted message and silently drop
+  // all text content (the update error is caught before firstTextChunk flips to false).
+  let typingMessageName = params.typingMessageName;
   const reply = resolveSendableOutboundReplyParts(payload);
   const mediaCount = reply.mediaCount;
   const hasMedia = reply.hasMedia;
@@ -363,22 +366,32 @@ async function deliverGoogleChatReply(params: {
           account,
           messageName: typingMessageName,
         });
+        // Clear after successful delete so the sendText path below does not attempt to
+        // update a message that no longer exists.
+        typingMessageName = undefined;
       } catch (err) {
         runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
-        const fallbackText = reply.hasText
-          ? text
-          : mediaCount > 1
-            ? "Sent attachments."
-            : "Sent attachment.";
-        try {
-          await updateGoogleChatMessage({
-            account,
-            messageName: typingMessageName,
-            text: fallbackText,
-          });
-          suppressCaption = Boolean(text.trim());
-        } catch (updateErr) {
-          runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+        // typingMessageName is still set here: the delete threw before the reset ran.
+        // The guard below satisfies TypeScript's conservative catch-block narrowing.
+        if (typingMessageName) {
+          const fallbackText = reply.hasText
+            ? text
+            : mediaCount > 1
+              ? "Sent attachments."
+              : "Sent attachment.";
+          try {
+            await updateGoogleChatMessage({
+              account,
+              messageName: typingMessageName,
+              text: fallbackText,
+            });
+            suppressCaption = Boolean(text.trim());
+          } catch (updateErr) {
+            runtime.error?.(`Google Chat typing update failed: ${String(updateErr)}`);
+            // Also clear here so sendText falls through to sendGoogleChatMessage
+            // instead of repeatedly retrying the unavailable message and dropping text.
+            typingMessageName = undefined;
+          }
         }
       }
     }
@@ -410,6 +423,14 @@ async function deliverGoogleChatReply(params: {
         statusSink?.({ lastOutboundAt: Date.now() });
       } catch (err) {
         runtime.error?.(`Google Chat message send failed: ${String(err)}`);
+        if (firstTextChunk && typingMessageName) {
+          // The updateGoogleChatMessage call failed. Clear both flags so
+          // subsequent chunks fall through to sendGoogleChatMessage instead of
+          // retrying the unavailable typing-indicator message and silently
+          // dropping all remaining text.
+          typingMessageName = undefined;
+          firstTextChunk = false;
+        }
       }
     },
     sendMedia: async ({ mediaUrl, caption }) => {


### PR DESCRIPTION
## Summary

- Problem: Google Chat typing placeholder cleanup/update failures can silently drop reply text, including media captions and the first text chunk after a failed placeholder update.
- Why it matters: users see incomplete Google Chat replies even though OpenClaw finished the response.
- What changed: moved Google Chat reply delivery into a narrow module, clears dead typing-message state, retries the current failed first chunk via `sendGoogleChatMessage`, and adds regression tests.
- What did NOT change (scope boundary): no Google Chat auth, routing, inbound policy, or core channel contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #71498
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: after the Google Chat typing indicator message was deleted or became unavailable, reply delivery could keep trying to update that dead message. On first text update failure, the failed chunk was not resent.
- Missing detection / guardrail: no seam-level regression coverage for typing-message cleanup/update failures in outbound Google Chat delivery.
- Contributing context: Google Chat uses a sent message as its typing indicator because reaction typing mode is not available with service-account auth.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/googlechat/src/monitor.reply-delivery.test.ts`
- Scenario the test should lock in: failed first typing-message update resends the same chunk as a new Google Chat message; deleting a typing message before media+caption does not leave a dead message name for caption delivery.
- Why this is the smallest reliable guardrail: the bug is entirely in reply delivery state handling; direct delivery tests avoid mocking the full monitor import graph.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Google Chat replies preserve text/captions when typing indicator cleanup or update fails; affected replies may send the text as a fresh message instead of updating the placeholder.

## Diagram (if applicable)

```text
Before:
typing message gone -> update first chunk fails -> first chunk disappears

After:
typing message gone -> update first chunk fails -> resend chunk as new message
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo checkout
- Model/provider: N/A
- Integration/channel (if any): Google Chat
- Relevant config (redacted): typing indicator message mode

### Steps

1. Simulate a Google Chat reply with a typing message name.
2. Make `updateGoogleChatMessage` fail for the first text chunk.
3. Verify the same chunk is resent through `sendGoogleChatMessage` and later chunks still deliver.

### Expected

- First chunk and later chunks are delivered.

### Actual

- Before this fix, the first failed chunk was dropped.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: first typing-message update failure; media+caption after successful typing-message delete; full Google Chat extension shard.
- Edge cases checked: fallback send failure logs and does not throw; subsequent chunks do not retry the dead typing message.
- What you did **not** verify: live Google Chat API delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: fallback can create a second message instead of editing the placeholder when the placeholder update fails.
  - Mitigation: only used after the update path has already failed; preserving reply text is more important than placeholder continuity.

Verification:
- `pnpm check:changed`
- `pnpm test extensions/googlechat`
