### PR TITLE
fix(embedded): normalize string content to ContentBlock[] for non-compliant providers

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -21,6 +21,7 @@ import {
   extractThinkingFromTaggedStream,
   extractThinkingFromTaggedText,
   formatReasoningMessage,
+  normalizeAgentMessageContent,
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
@@ -175,6 +176,10 @@ export function handleMessageStart(
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
   }
+
+  // Normalize string content to ContentBlock[] for providers like MiniMax that
+  // don't follow the Anthropic/OpenAI SDK convention (#67933).
+  normalizeAgentMessageContent(msg);
 
   // KNOWN: Resetting at `text_end` is unsafe (late/duplicate end events).
   // ASSUME: `message_start` is the only reliable boundary for “new assistant message begins”.
@@ -385,6 +390,10 @@ export function handleMessageEnd(
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
   }
+
+  // Final normalize in case the provider only delivers string content at the
+  // end of the message stream (#67933).
+  normalizeAgentMessageContent(msg);
 
   const assistantMessage = msg;
   ctx.noteLastAssistant(assistantMessage);

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -10,6 +10,28 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
 }
 
 /**
+ * Normalize message content to ContentBlock[] for providers that return plain strings.
+ *
+ * Anthropic/OpenAI SDKs return `content` as `ContentBlock[]`, but some providers
+ * (e.g. MiniMax) return it as a plain `string`. Downstream code assumes arrays
+ * and calls `.flatMap()`, `.filter()`, `.map()` directly, causing TypeErrors.
+ *
+ * This helper mutates the message in place for efficiency, matching the pattern
+ * already used in `proxy-stream-wrappers.ts` for system/developer messages.
+ */
+export function normalizeAgentMessageContent(msg: AgentMessage): void {
+  if (!msg || typeof msg !== "object") {
+    return;
+  }
+  const rawContent = (msg as { content?: unknown }).content;
+  if (typeof rawContent === "string") {
+    (msg as { content: Array<{ type: "text"; text: string }> }).content = [
+      { type: "text", text: rawContent },
+    ];
+  }
+}
+
+/**
  * Strip malformed Minimax tool invocations that leak into text content.
  * Minimax sometimes embeds tool calls as XML in text blocks instead of
  * proper structured tool calls. This removes:


### PR DESCRIPTION
## Summary

Fixes #67933.

MiniMax (and potentially other providers) return `assistantMsg.content` as a plain **string** instead of `ContentBlock[]`. Downstream code assumes arrays and calls `.flatMap()`, `.filter()`, `.map()` directly, causing `TypeError: assistantMsg.content.flatMap is not a function` at runtime.

## Changes

- Add `normalizeAgentMessageContent()` helper in `pi-embedded-utils.ts` that converts string content to `[{type: 'text', text: string}]` in place.
- Call the helper in both `handleMessageStart` and `handleMessageEnd` so providers that deliver content early or late are both covered.
- The pattern matches the existing normalize logic already used in `proxy-stream-wrappers.ts` for system/developer messages.

## Testing

- Manual: verified that synthetic assistant messages with `content: "string"` are normalized before downstream processing.
- Existing tests for `extractAssistantText`, `extractAssistantThinking`, and `promoteThinkingTagsToBlocks` already handle both string and array inputs defensively, so no regressions expected.

## Scope

This is a targeted fix for the embedded agent runtime path. A broader audit of all `message.content` array accesses across the codebase could be done as follow-up, but this addresses the reported crash in #67933.