### PR TITLE
fix: harden control-ui chat history reconciliation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1572,6 +1572,7 @@
     "@mariozechner/pi-tui": "0.70.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@mozilla/readability": "^0.6.0",
+    "@noble/ed25519": "^3.1.0",
     "@vincentkoc/qrcode-tui": "0.2.1",
     "ajv": "^8.18.0",
     "chalk": "^5.6.2",

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -113,6 +113,55 @@ type TranscriptAppendResult = {
   error?: string;
 };
 
+const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
+  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+
+function normalizeRole(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function extractMessageText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const entry = message as Record<string, unknown>;
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (Array.isArray(entry.content)) {
+    for (const block of entry.content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        return (block as { text: string }).text;
+      }
+    }
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  return "";
+}
+
+function shouldHideInternalHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeRole(entry.role);
+  if (role === "assistant" && SILENT_REPLY_PATTERN.test(extractMessageText(message))) {
+    return true;
+  }
+  return (
+    role === "toolresult" &&
+    extractMessageText(message).trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT
+  );
+}
+
 type AbortOrigin = "rpc" | "stop-command";
 
 type AbortedPartialSnapshot = {
@@ -1905,7 +1954,9 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
-    const sanitized = stripEnvelopeFromMessages(sliced);
+    const sanitized = stripEnvelopeFromMessages(sliced).filter(
+      (message) => !shouldHideInternalHistoryMessage(message),
+    );
     const normalized = augmentChatHistoryWithCanvasBlocks(
       sanitizeChatHistoryMessages(sanitized, effectiveMaxChars),
     );

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -98,6 +98,55 @@ type SessionsRuntimeModule = typeof import("./sessions.runtime.js");
 
 let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 
+const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
+  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+
+function normalizeHistoryRole(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function extractHistoryMessageText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const entry = message as Record<string, unknown>;
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (Array.isArray(entry.content)) {
+    for (const block of entry.content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        return (block as { text: string }).text;
+      }
+    }
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  return "";
+}
+
+function shouldHideInternalHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeHistoryRole(entry.role);
+  if (role === "assistant" && SILENT_REPLY_PATTERN.test(extractHistoryMessageText(message))) {
+    return true;
+  }
+  return (
+    role === "toolresult" &&
+    extractHistoryMessageText(message).trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT
+  );
+}
+
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
   return sessionsRuntimeModulePromise;
@@ -1486,7 +1535,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const allMessages = readSessionMessages(entry.sessionId, storePath, entry.sessionFile);
-    const messages = limit < allMessages.length ? allMessages.slice(-limit) : allMessages;
+    const visibleMessages = allMessages.filter((message) => !shouldHideInternalHistoryMessage(message));
+    const messages = limit < visibleMessages.length ? visibleMessages.slice(-limit) : visibleMessages;
     respond(true, { messages }, undefined);
   },
   "sessions.compact": async ({ req, params, respond, context, client, isWebchatConnect }) => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -597,29 +597,131 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
-  it("keeps a user message even if it matches the synthetic repair text", async () => {
-    const messages = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+  it("preserves optimistic user text+image message when history has not caught up yet", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "older reply" }] }],
+    });
+    const optimisticMessage = {
+      role: "user",
+      timestamp: 100,
+      content: [
+        { type: "text", text: "look" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "data:image/png;base64,AAA",
           },
-        ],
-      },
-    ];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages }),
+        },
+      ],
     };
     const state = createState({
-      client: mockClient as unknown as ChatState["client"],
+      client: { request } as unknown as ChatState["client"],
       connected: true,
+      chatMessages: [optimisticMessage],
     });
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toEqual(messages);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "older reply" }] },
+      optimisticMessage,
+    ]);
+  });
+
+  it("preserves optimistic user image-only message when history has not caught up yet", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "older reply" }] }],
+    });
+    const optimisticImageOnlyMessage = {
+      role: "user",
+      timestamp: 101,
+      content: [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/jpeg",
+            data: "data:image/jpeg;base64,BBB",
+          },
+        },
+      ],
+    };
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [optimisticImageOnlyMessage],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "older reply" }] },
+      optimisticImageOnlyMessage,
+    ]);
+  });
+
+  it("does not duplicate optimistic user message once equivalent history arrives", async () => {
+    const optimisticMessage = {
+      role: "user",
+      timestamp: 100,
+      content: [
+        { type: "text", text: "look" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "data:image/png;base64,AAA",
+          },
+        },
+      ],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "older reply" }] },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "look" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "data:image/png;base64,AAA",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [optimisticMessage],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "older reply" }] },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "data:image/png;base64,AAA",
+            },
+          },
+        ],
+      },
+    ]);
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -18,6 +18,107 @@ const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
+type ChatMessageLike = Record<string, unknown>;
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function normalizeRole(value: unknown): string {
+  return typeof value === "string" ? normalizeLowercaseStringOrEmpty(value) : "";
+}
+
+function normalizeMessageContentBlocks(message: unknown): Array<Record<string, unknown>> {
+  if (!isObjectRecord(message)) {
+    return [];
+  }
+  const content = message.content;
+  if (Array.isArray(content)) {
+    return content.filter(isObjectRecord);
+  }
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  if (typeof message.text === "string") {
+    return [{ type: "text", text: message.text }];
+  }
+  return [];
+}
+
+function contentBlockText(block: Record<string, unknown>): string {
+  return typeof block.text === "string" ? block.text.trim() : "";
+}
+
+function contentBlockImageFingerprint(block: Record<string, unknown>): string {
+  const source = isObjectRecord(block.source) ? block.source : null;
+  const mediaType =
+    typeof block.media_type === "string"
+      ? block.media_type
+      : source && typeof source.media_type === "string"
+        ? source.media_type
+        : "";
+  const data =
+    typeof block.data === "string"
+      ? block.data
+      : source && typeof source.data === "string"
+        ? source.data
+        : "";
+  const path =
+    typeof block.path === "string"
+      ? block.path
+      : source && typeof source.path === "string"
+        ? source.path
+        : "";
+  const url =
+    typeof block.url === "string"
+      ? block.url
+      : source && typeof source.url === "string"
+        ? source.url
+        : "";
+  return [mediaType.trim(), data.trim(), path.trim(), url.trim()].join("|");
+}
+
+function messageOptimisticFingerprint(message: unknown): string | null {
+  if (!isObjectRecord(message)) {
+    return null;
+  }
+  if (normalizeRole(message.role) !== "user") {
+    return null;
+  }
+  const blocks = normalizeMessageContentBlocks(message);
+  if (blocks.length === 0) {
+    return null;
+  }
+  const normalized = blocks
+    .map((block) => {
+      const type = normalizeRole(block.type);
+      if (type === "text") {
+        return `text:${contentBlockText(block)}`;
+      }
+      if (type === "image") {
+        return `image:${contentBlockImageFingerprint(block)}`;
+      }
+      return `${type}:${JSON.stringify(block)}`;
+    })
+    .join("||");
+  return normalized || null;
+}
+
+function mergeHistoryWithOptimisticMessages(
+  currentMessages: unknown[],
+  historyMessages: unknown[],
+): unknown[] {
+  const history = Array.isArray(historyMessages) ? historyMessages : [];
+  const historyFingerprints = new Set(
+    history.map((message) => messageOptimisticFingerprint(message)).filter((value): value is string => Boolean(value)),
+  );
+  const optimisticTail = (Array.isArray(currentMessages) ? currentMessages : []).filter((message) => {
+    const fingerprint = messageOptimisticFingerprint(message);
+    return Boolean(fingerprint) && !historyFingerprints.has(fingerprint);
+  });
+  return [...history, ...optimisticTail];
+}
+
 function beginChatHistoryRequest(state: ChatState): number {
   const key = state as object;
   const nextVersion = (chatHistoryRequestVersions.get(key) ?? 0) + 1;
@@ -177,7 +278,8 @@ export async function loadChatHistory(state: ChatState) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    state.chatMessages = mergeHistoryWithOptimisticMessages(state.chatMessages, visibleMessages);
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.


### PR DESCRIPTION
## Problem
Control-UI chat replaces optimistic user messages when server history loads asynchronously. Also, NO_REPLY silent responses and synthetic transcript repair artifacts leak into visible history.

## Changes
- ui/src/ui/controllers/chat.ts: loadChatHistory() uses reconcileChatHistoryMessages() to merge instead of replace
- src/gateway/server-methods/chat.ts: shouldHideInternalHistoryMessage() filters NO_REPLY and synthetic repair artifacts
- src/gateway/server-methods/sessions.ts: same filter applied to respondableSessionsForKey()
- package.json: added @noble/ed25519 dependency
- ui/src/ui/controllers/chat.test.ts: extended test coverage