### PR TITLE
fix(cron): normalize flat legacy job rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Google video generation: download direct MLDev Veo `video.uri` results instead of passing them through the Files API path, fixing 404s after successful generation/polling. Fixes #71200. Thanks @panhaishan.
 - Google video generation: fall back to the REST `predictLongRunning` Veo endpoint for text-only SDK 404s while keeping reference image/video generation on the SDK path. Fixes #62309 and #63008. (#62343) Thanks @leoleedev.
 - MiniMax music generation: switch the bundled default model from the unsupported `music-2.5+` id to the current `music-2.6` API model. Fixes #64870 and addresses the music default from #62315. Thanks @noahclanman and @edwardzheng1.
+- Cron: hydrate flat legacy job rows with top-level `cron`, `tz`, `session`, and `message` fields into canonical schedule, target, and payload objects before startup recomputes run times. Fixes #43351.
 - Google media generation: strip a configured trailing `/v1beta` from Google music/video provider base URLs before calling the Google GenAI SDK, preventing doubled `/v1beta/v1beta` paths. Fixes #63240. (#63258) Thanks @Hybirdss.
 - Discord: restore direct-message voice-note preflight transcription and classify URL-only Ogg/Opus voice attachments as audio while skipping partial attachments without usable URLs. Fixes #61314 and #64803.
 - Google Chat: preserve reply text when a typing indicator message is deleted or can no longer be updated, so media captions and first text chunks are resent instead of silently disappearing. (#71498) Thanks @colin-lgtm.

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -405,6 +405,38 @@ describe("normalizeCronJobCreate", () => {
     expect(typeof normalized.name).toBe("string");
   });
 
+  it("normalizes flat legacy cron job rows", () => {
+    const normalized = normalizeCronJobCreate({
+      id: "dbus-watchdog-001",
+      name: "dbus-watchdog",
+      kind: "cron",
+      cron: "*/10 * * * *",
+      tz: "UTC",
+      session: "isolated",
+      message: "watch dbus",
+      tools: [" exec "],
+      enabled: true,
+      created_at: "2026-04-17T20:09:00Z",
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.schedule).toEqual({
+      kind: "cron",
+      expr: "*/10 * * * *",
+      tz: "UTC",
+    });
+    expect(normalized.sessionTarget).toBe("isolated");
+    expect(normalized.payload).toEqual({
+      kind: "agentTurn",
+      message: "watch dbus",
+      toolsAllow: ["exec"],
+    });
+    expect(normalized.kind).toBeUndefined();
+    expect(normalized.cron).toBeUndefined();
+    expect(normalized.tz).toBeUndefined();
+    expect(normalized.session).toBeUndefined();
+    expect(normalized.tools).toBeUndefined();
+  });
+
   it("maps top-level model/thinking/timeout into payload for legacy add params", () => {
     const normalized = normalizeCronJobCreate({
       name: "legacy root fields",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -144,6 +144,21 @@ function coerceSchedule(schedule: UnknownRecord) {
   return next;
 }
 
+function inferTopLevelSchedule(next: UnknownRecord): UnknownRecord | null {
+  const kindRaw = normalizeLowercaseStringOrEmpty(next.kind);
+  const kind = kindRaw === "at" || kindRaw === "every" || kindRaw === "cron" ? kindRaw : undefined;
+  const schedule: UnknownRecord = {};
+  if (kind) {
+    schedule.kind = kind;
+  }
+  for (const field of ["at", "atMs", "everyMs", "anchorMs", "expr", "cron", "tz", "staggerMs"]) {
+    if (field in next) {
+      schedule[field] = next[field];
+    }
+  }
+  return Object.keys(schedule).length > 0 ? coerceSchedule(schedule) : null;
+}
+
 function coercePayload(payload: UnknownRecord) {
   const next: UnknownRecord = { ...payload };
   const kindRaw = normalizeLowercaseStringOrEmpty(next.kind);
@@ -367,7 +382,9 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
     }
   }
   if (!("toolsAllow" in payload) || payload.toolsAllow === undefined) {
-    const toolsAllow = normalizeTrimmedStringArray(next.toolsAllow, { allowNull: true });
+    const toolsAllow =
+      normalizeTrimmedStringArray(next.toolsAllow, { allowNull: true }) ??
+      normalizeTrimmedStringArray(next.tools);
     if (toolsAllow !== undefined) {
       payload.toolsAllow = toolsAllow;
     }
@@ -393,6 +410,16 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.allowUnsafeExternalContent;
   delete next.message;
   delete next.text;
+  delete next.kind;
+  delete next.cron;
+  delete next.tz;
+  delete next.at;
+  delete next.atMs;
+  delete next.everyMs;
+  delete next.anchorMs;
+  delete next.staggerMs;
+  delete next.session;
+  delete next.tools;
   delete next.deliver;
   delete next.channel;
   delete next.to;
@@ -462,6 +489,11 @@ export function normalizeCronJobInput(
     } else {
       delete next.sessionTarget;
     }
+  } else if ("session" in base) {
+    const normalized = normalizeSessionTarget(base.session);
+    if (normalized) {
+      next.sessionTarget = normalized;
+    }
   }
 
   if ("wakeMode" in base) {
@@ -475,6 +507,11 @@ export function normalizeCronJobInput(
 
   if (isRecord(base.schedule)) {
     next.schedule = coerceSchedule(base.schedule);
+  } else if (!isRecord(next.schedule)) {
+    const inferredSchedule = inferTopLevelSchedule(next);
+    if (inferredSchedule) {
+      next.schedule = inferredSchedule;
+    }
   }
 
   if (!("payload" in next) || !isRecord(next.payload)) {

--- a/src/cron/service/store.load-missing-session-target.test.ts
+++ b/src/cron/service/store.load-missing-session-target.test.ts
@@ -30,6 +30,41 @@ function createStoreTestState(storePath: string) {
 }
 
 describe("cron service store load: missing sessionTarget", () => {
+  it("hydrates flat legacy cron rows before recomputing next runs", async () => {
+    const { storePath } = await makeStorePath();
+
+    await writeSingleJobStore(storePath, {
+      id: "legacy-flat-cron",
+      name: "dbus-watchdog",
+      kind: "cron",
+      cron: "*/10 * * * *",
+      tz: "UTC",
+      session: "isolated",
+      message: "watch dbus",
+      tools: ["exec"],
+      enabled: true,
+      created_at: "2026-04-17T20:09:00Z",
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state);
+
+    const job = findJobOrThrow(state, "legacy-flat-cron");
+    expect(job.schedule).toEqual({
+      kind: "cron",
+      expr: "*/10 * * * *",
+      tz: "UTC",
+    });
+    expect(job.sessionTarget).toBe("isolated");
+    expect(job.payload).toEqual({
+      kind: "agentTurn",
+      message: "watch dbus",
+      toolsAllow: ["exec"],
+    });
+    expect(job.state.nextRunAtMs).toEqual(expect.any(Number));
+    expect(() => assertSupportedJobSpec(job)).not.toThrow();
+  });
+
   it('defaults missing sessionTarget to "main" for systemEvent payloads', async () => {
     const { storePath } = await makeStorePath();
 


### PR DESCRIPTION
## Summary
- normalize stored flat legacy cron rows with top-level `cron`, `tz`, `session`, and `message` into canonical `schedule`, `sessionTarget`, and `payload`
- preserve legacy `tools` as `payload.toolsAllow` and remove the obsolete top-level flat fields from the normalized in-memory shape
- add regression coverage for both direct normalization and store-load recompute so startup/list paths do not crash on missing nested `.kind`

Fixes #43351.

Related to #38766 and #57640.

## Validation
- `pnpm test src/cron/normalize.test.ts src/cron/service/store.load-missing-session-target.test.ts src/cli/cron-cli/shared.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed`
