### PR TITLE
Fix thinking validation runtime provider profiles

### DIFF
--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -26,6 +26,31 @@ export function modelKey(provider: string, model: string): string {
     : `${providerId}/${modelId}`;
 }
 
+export function stripOwnProviderPrefix(provider: string, model: string): string {
+  const normalizedProvider = normalizeProviderId(provider);
+  let trimmed = model.trim();
+  if (!normalizedProvider || !trimmed) {
+    return trimmed;
+  }
+  const prefix = `${normalizedProvider}/`;
+  while (normalizeLowercaseStringOrEmpty(trimmed).startsWith(prefix)) {
+    const stripped = trimmed.slice(prefix.length).trim();
+    if (!stripped) {
+      break;
+    }
+    trimmed = stripped;
+  }
+  return trimmed;
+}
+
+export function canonicalizeProviderModelId(provider: string, model: string): string {
+  const normalizedProvider = normalizeProviderId(provider);
+  return normalizeStaticProviderModelId(
+    normalizedProvider,
+    stripOwnProviderPrefix(normalizedProvider, model),
+  );
+}
+
 export function normalizeAnthropicModelId(model: string): string {
   const trimmed = model.trim();
   if (!trimmed) {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -402,6 +402,32 @@ describe("model-selection", () => {
         model: "kimi-code",
       });
     });
+
+    it("strips redundant own-provider prefixes from explicit override models", () => {
+      expect(
+        resolvePersistedOverrideModelRef({
+          defaultProvider: "anthropic",
+          overrideProvider: "anthropic",
+          overrideModel: "anthropic/anthropic/claude-opus-4-7",
+        }),
+      ).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      });
+    });
+
+    it("preserves vendor-prefixed models for wrapper override providers", () => {
+      expect(
+        resolvePersistedOverrideModelRef({
+          defaultProvider: "anthropic",
+          overrideProvider: "openrouter",
+          overrideModel: "anthropic/claude-opus-4-7",
+        }),
+      ).toEqual({
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4-7",
+      });
+    });
   });
 
   describe("resolvePersistedSelectedModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -42,6 +42,7 @@ import {
   type ModelAliasIndex,
   type ModelRefStatus,
 } from "./model-selection-shared.js";
+import { stripOwnProviderPrefix } from "./model-ref-shared.js";
 
 export type { ModelAliasIndex, ModelRef, ModelRefStatus };
 
@@ -84,8 +85,12 @@ export function resolvePersistedOverrideModelRef(params: {
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
   const defaultProvider = params.defaultProvider.trim();
-  const overrideProvider = params.overrideProvider?.trim();
-  const overrideModel = params.overrideModel?.trim();
+  const normalizedOverride = normalizeStoredOverrideModel({
+    providerOverride: params.overrideProvider,
+    modelOverride: params.overrideModel,
+  });
+  const overrideProvider = normalizedOverride.providerOverride;
+  const overrideModel = normalizedOverride.modelOverride;
   if (!overrideModel) {
     return null;
   }
@@ -179,12 +184,9 @@ export function normalizeStoredOverrideModel(params: {
     };
   }
 
-  const providerPrefix = `${providerOverride.toLowerCase()}/`;
   return {
     providerOverride,
-    modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
-      ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
-      : modelOverride,
+    modelOverride: stripOwnProviderPrefix(providerOverride, modelOverride),
   };
 }
 

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -17,6 +17,7 @@ vi.mock("../plugins/runtime.js", () => ({
 
 describe("ensureRuntimePluginsLoaded", () => {
   let ensureRuntimePluginsLoaded: typeof import("./runtime-plugins.js").ensureRuntimePluginsLoaded;
+  let tryEnsureRuntimePluginsLoaded: typeof import("./runtime-plugins.js").tryEnsureRuntimePluginsLoaded;
 
   beforeEach(async () => {
     hoisted.resolveRuntimePluginRegistry.mockReset();
@@ -24,7 +25,9 @@ describe("ensureRuntimePluginsLoaded", () => {
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("default");
     vi.resetModules();
-    ({ ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js"));
+    ({ ensureRuntimePluginsLoaded, tryEnsureRuntimePluginsLoaded } = await import(
+      "./runtime-plugins.js"
+    ));
   });
 
   it("does not reactivate plugins when a process already has an active registry", async () => {
@@ -83,5 +86,19 @@ describe("ensureRuntimePluginsLoaded", () => {
         allowGatewaySubagentBinding: true,
       },
     });
+  });
+
+  it("allows best-effort callers to continue when plugin activation fails", async () => {
+    hoisted.resolveRuntimePluginRegistry.mockImplementation(() => {
+      throw new Error("broken plugin");
+    });
+
+    expect(
+      tryEnsureRuntimePluginsLoaded({
+        config: {} as never,
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe(false);
+    expect(hoisted.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,13 +1,19 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveRuntimePluginRegistry } from "../plugins/loader.js";
 import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
 import { resolveUserPath } from "../utils.js";
 
-export function ensureRuntimePluginsLoaded(params: {
+type RuntimePluginsLoadParams = {
   config?: OpenClawConfig;
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
-}): void {
+};
+
+const log = createSubsystemLogger("agents/runtime-plugins");
+
+export function ensureRuntimePluginsLoaded(params: RuntimePluginsLoadParams): void {
   const workspaceDir =
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)
@@ -25,4 +31,16 @@ export function ensureRuntimePluginsLoaded(params: {
       : undefined,
   };
   resolveRuntimePluginRegistry(loadOptions);
+}
+
+export function tryEnsureRuntimePluginsLoaded(params: RuntimePluginsLoadParams): boolean {
+  try {
+    ensureRuntimePluginsLoaded(params);
+    return true;
+  } catch (err) {
+    log.warn("runtime plugin activation failed; continuing with current registry", {
+      error: formatErrorMessage(err),
+    });
+    return false;
+  }
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,6 +13,7 @@ import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
+import { stripOwnProviderPrefix } from "../../agents/model-ref-shared.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
@@ -205,7 +206,7 @@ function buildFallbackSelectionState(params: {
 }): FallbackSelectionState {
   return {
     providerOverride: params.provider,
-    modelOverride: params.model,
+    modelOverride: stripOwnProviderPrefix(params.provider, params.model),
     modelOverrideSource: "auto",
     authProfileOverride: params.authProfileId,
     authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -366,7 +366,11 @@ export async function handleDirectiveOnly(
     if (directives.hasFastDirective && directives.fastMode !== undefined) {
       sessionEntry.fastMode = directives.fastMode;
     }
-    if (shouldRemapUnsupportedThinkLevel && remappedUnsupportedThinkLevel) {
+    if (
+      shouldRemapUnsupportedThinkLevel &&
+      remappedUnsupportedThinkLevel &&
+      sessionEntry.thinkingLevel === nextThinkLevel
+    ) {
       sessionEntry.thinkingLevel = remappedUnsupportedThinkLevel;
     }
     if (

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -777,6 +777,46 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     });
   });
 
+  it("does not persist unsupported remaps for default-derived thinking levels", async () => {
+    const sessionEntry = createSessionEntry();
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/fast on"),
+        sessionEntry,
+        currentThinkLevel: "xhigh",
+        defaultModel: "claude-opus-4-7",
+        model: "claude-opus-4-7",
+      }),
+    );
+
+    expect(result?.text).toContain(
+      "Thinking level set to high (xhigh not supported for anthropic/claude-opus-4-7).",
+    );
+    expect(sessionEntry.fastMode).toBe(true);
+    expect(sessionEntry.thinkingLevel).toBeUndefined();
+  });
+
+  it("persists unsupported remaps for explicit stored thinking levels", async () => {
+    const sessionEntry = createSessionEntry({ thinkingLevel: "xhigh" });
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/fast on"),
+        sessionEntry,
+        currentThinkLevel: "xhigh",
+        defaultModel: "claude-opus-4-7",
+        model: "claude-opus-4-7",
+      }),
+    );
+
+    expect(result?.text).toContain(
+      "Thinking level set to high (xhigh not supported for anthropic/claude-opus-4-7).",
+    );
+    expect(sessionEntry.fastMode).toBe(true);
+    expect(sessionEntry.thinkingLevel).toBe("high");
+  });
+
   it("does not request a live restart when /model mutates an active session", async () => {
     const directives = parseInlineDirectives("/model openai/gpt-4o");
     const sessionEntry = createSessionEntry();

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   buildGetReplyCtx,
@@ -17,10 +17,14 @@ registerGetReplyRuntimeOverrides(mocks);
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 let loadConfigMock: typeof import("../../config/config.js").loadConfig;
+let tryEnsureRuntimePluginsLoadedMock: typeof import("../../agents/runtime-plugins.js").tryEnsureRuntimePluginsLoaded;
 
 async function loadGetReplyRuntimeForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
   ({ loadConfig: loadConfigMock } = await import("../../config/config.js"));
+  ({ tryEnsureRuntimePluginsLoaded: tryEnsureRuntimePluginsLoadedMock } = await import(
+    "../../agents/runtime-plugins.js"
+  ));
 }
 
 describe("getReplyFromConfig configOverride", () => {
@@ -30,6 +34,7 @@ describe("getReplyFromConfig configOverride", () => {
     mocks.resolveReplyDirectives.mockReset();
     mocks.initSessionState.mockReset();
     vi.mocked(loadConfigMock).mockReset();
+    vi.mocked(tryEnsureRuntimePluginsLoadedMock).mockClear();
 
     vi.mocked(loadConfigMock).mockReturnValue({});
     mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
@@ -63,5 +68,26 @@ describe("getReplyFromConfig configOverride", () => {
     } as OpenClawConfig);
 
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
+  });
+
+  it("activates runtime plugins before directive handling", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+      },
+    } as OpenClawConfig;
+    mocks.resolveReplyDirectives.mockImplementation(async () => {
+      expect(tryEnsureRuntimePluginsLoadedMock).toHaveBeenCalledWith({
+        config: expect.objectContaining({
+          agents: cfg.agents,
+        }),
+        workspaceDir: "/tmp/workspace",
+      });
+      return { kind: "reply", reply: { text: "ok" } };
+    });
+
+    await getReplyFromConfig(buildGetReplyCtx(), undefined, cfg);
   });
 });

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -24,6 +24,11 @@ vi.mock("../../agents/model-selection.js", async () => {
   };
 });
 
+vi.mock("../../agents/runtime-plugins.js", () => ({
+  ensureRuntimePluginsLoaded: vi.fn(),
+  tryEnsureRuntimePluginsLoaded: vi.fn(() => true),
+}));
+
 vi.mock("../../agents/timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 60000),
 }));

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -5,6 +5,7 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
+import { tryEnsureRuntimePluginsLoaded } from "../../agents/runtime-plugins.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
@@ -227,6 +228,12 @@ export async function getReplyFromConfig(
       });
   const workspaceDir = workspace.dir;
   const agentDir = resolveAgentDir(cfg, agentId);
+  if (!useFastTestRuntime) {
+    tryEnsureRuntimePluginsLoaded({
+      config: cfg,
+      workspaceDir,
+    });
+  }
   const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
   const configuredTypingSeconds =
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -159,6 +159,34 @@ describe("listThinkingLevels", () => {
     ]);
   });
 
+  it("strips own-provider prefixes before provider thinking profile lookup", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ provider, context }) =>
+      provider === "anthropic" && context.modelId === "claude-opus-4-7"
+        ? { levels: [{ id: "off" }, { id: "xhigh" }, { id: "max" }] }
+        : undefined,
+    );
+
+    expect(listThinkingLevels("anthropic", "anthropic/anthropic/claude-opus-4-7")).toContain(
+      "xhigh",
+    );
+    expect(providerRuntimeMocks.resolveProviderThinkingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        context: expect.objectContaining({ modelId: "claude-opus-4-7" }),
+      }),
+    );
+  });
+
+  it("keeps other-provider prefixes intact for provider thinking profile lookup", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ provider, context }) =>
+      provider === "anthropic" && context.modelId === "claude-opus-4-7"
+        ? { levels: [{ id: "off" }, { id: "xhigh" }] }
+        : undefined,
+    );
+
+    expect(listThinkingLevels("anthropic", "claude-cli/claude-opus-4-7")).not.toContain("xhigh");
+  });
+
   it("uses provider thinking profiles ahead of legacy hooks", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "low", label: "on" }],

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
+import { canonicalizeProviderModelId } from "../agents/model-ref-shared.js";
 import {
   BASE_THINKING_LEVELS,
   normalizeThinkLevel,
@@ -63,8 +64,11 @@ function resolveThinkingPolicyContext(params: {
 }) {
   const providerRaw = normalizeOptionalString(params.provider);
   const normalizedProvider = providerRaw ? normalizeProviderId(providerRaw) : "";
-  const modelId = normalizeOptionalString(params.model) ?? "";
-  const modelKey = normalizeOptionalLowercaseString(params.model) ?? "";
+  const rawModelId = normalizeOptionalString(params.model) ?? "";
+  const modelId = normalizedProvider
+    ? canonicalizeProviderModelId(normalizedProvider, rawModelId)
+    : rawModelId;
+  const modelKey = normalizeOptionalLowercaseString(modelId) ?? "";
   const candidate = params.catalog?.find(
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
   );

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { applySessionsPatchToStore } from "./sessions-patch.js";
+
+const tryEnsureRuntimePluginsLoadedMock = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock("../agents/runtime-plugins.js", () => ({
+  tryEnsureRuntimePluginsLoaded: tryEnsureRuntimePluginsLoadedMock,
+}));
 
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.5";
 const KIMI_SUBAGENT_KEY = "agent:kimi:subagent:child";
@@ -105,6 +111,10 @@ function createAllowlistedAnthropicModelCfg(): OpenClawConfig {
 }
 
 describe("gateway sessions patch", () => {
+  beforeEach(() => {
+    tryEnsureRuntimePluginsLoadedMock.mockClear();
+  });
+
   test("persists thinkingLevel=off (does not clear)", async () => {
     const entry = expectPatchOk(
       await runPatch({
@@ -112,6 +122,10 @@ describe("gateway sessions patch", () => {
       }),
     );
     expect(entry.thinkingLevel).toBe("off");
+    expect(tryEnsureRuntimePluginsLoadedMock).toHaveBeenCalledWith({
+      config: EMPTY_CFG,
+      workspaceDir: expect.any(String),
+    });
   });
 
   test("clears thinkingLevel when patch sets null", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
+  normalizeStoredOverrideModel,
   resolveAllowedModelRef,
   resolveDefaultModelForAgent,
   resolveSubagentConfiguredModelSelection,
 } from "../agents/model-selection.js";
+import { tryEnsureRuntimePluginsLoaded } from "../agents/runtime-plugins.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
   formatThinkingLevels,
@@ -435,8 +437,16 @@ export async function applySessionsPatchToStore(params: {
   }
 
   if (next.thinkingLevel) {
-    const effectiveProvider = next.providerOverride ?? resolvedDefault.provider;
-    const effectiveModel = next.modelOverride ?? resolvedDefault.model;
+    tryEnsureRuntimePluginsLoaded({
+      config: cfg,
+      workspaceDir: resolveAgentWorkspaceDir(cfg, sessionAgentId),
+    });
+    const normalizedOverride = normalizeStoredOverrideModel({
+      providerOverride: next.providerOverride,
+      modelOverride: next.modelOverride,
+    });
+    const effectiveProvider = normalizedOverride.providerOverride ?? resolvedDefault.provider;
+    const effectiveModel = normalizedOverride.modelOverride ?? resolvedDefault.model;
     const thinkingLevel = normalizeThinkLevel(next.thinkingLevel);
     if (!thinkingLevel) {
       delete next.thinkingLevel;

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -142,6 +142,25 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.modelOverrideSource).toBe("auto");
   });
 
+  it("strips own-provider prefixes before persisting model overrides", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-5b",
+      updatedAt: Date.now() - 5_000,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "anthropic",
+        model: "anthropic/claude-opus-4-7",
+      },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-opus-4-7");
+  });
+
   it("sets liveModelSwitchPending only when explicitly requested", () => {
     const entry: SessionEntry = {
       sessionId: "sess-5",

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,4 +1,5 @@
 import type { SessionEntry } from "../config/sessions.js";
+import { stripOwnProviderPrefix } from "../agents/model-ref-shared.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export type ModelOverrideSelection = {
@@ -16,6 +17,8 @@ export function applyModelOverrideToSessionEntry(params: {
   markLiveSwitchPending?: boolean;
 }): { updated: boolean } {
   const { entry, selection, profileOverride } = params;
+  const selectionProvider = selection.provider;
+  const selectionModel = stripOwnProviderPrefix(selection.provider, selection.model);
   const profileOverrideSource = params.profileOverrideSource ?? "user";
   const selectionSource = params.selectionSource ?? "user";
   let updated = false;
@@ -37,13 +40,13 @@ export function applyModelOverrideToSessionEntry(params: {
       updated = true;
     }
   } else {
-    if (entry.providerOverride !== selection.provider) {
-      entry.providerOverride = selection.provider;
+    if (entry.providerOverride !== selectionProvider) {
+      entry.providerOverride = selectionProvider;
       updated = true;
       selectionUpdated = true;
     }
-    if (entry.modelOverride !== selection.model) {
-      entry.modelOverride = selection.model;
+    if (entry.modelOverride !== selectionModel) {
+      entry.modelOverride = selectionModel;
       updated = true;
       selectionUpdated = true;
     }
@@ -60,8 +63,8 @@ export function applyModelOverrideToSessionEntry(params: {
   const runtimeProvider = normalizeOptionalString(entry.modelProvider) ?? "";
   const runtimePresent = runtimeModel.length > 0 || runtimeProvider.length > 0;
   const runtimeAligned =
-    runtimeModel === selection.model &&
-    (runtimeProvider.length === 0 || runtimeProvider === selection.provider);
+    runtimeModel === selectionModel &&
+    (runtimeProvider.length === 0 || runtimeProvider === selectionProvider);
   if (runtimePresent && (selectionUpdated || !runtimeAligned)) {
     if (entry.model !== undefined) {
       delete entry.model;


### PR DESCRIPTION
## Summary
- activate runtime plugin profiles before get-reply and sessions.patch thinking validation, with best-effort fallback on plugin load failures
- canonicalize own-provider-prefixed model ids before thinking policy lookup and persisted override reads/writes
- avoid persisting unsupported thinking downgrades when the value was only default-derived

## Tests
- pnpm exec vitest run src/agents/runtime-plugins.test.ts src/auto-reply/thinking.test.ts src/agents/model-selection.test.ts src/sessions/model-overrides.test.ts src/gateway/sessions-patch.test.ts src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/get-reply.config-override.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/auto-reply/reply/get-reply.message-hooks.test.ts src/commands/agent.test.ts src/agents/agent-command.live-model-switch.test.ts src/tui/embedded-backend.test.ts
- git diff --check

Fixes #70776
May also address #69440