### PR TITLE
fix(whatsapp): use sender lid for group ack reactions

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
@@ -93,6 +93,31 @@ describe("maybeSendAckReaction", () => {
     },
   );
 
+  it("uses sender LID as participant for group ack reactions when JID is unavailable", async () => {
+    await runAckReaction({
+      msg: createMessage({
+        from: "1234567890@g.us",
+        conversationId: "1234567890@g.us",
+        chatType: "group",
+        chatId: "1234567890@g.us",
+        sender: { lid: "alice@lid", name: "Alice" },
+        wasMentioned: true,
+      }),
+      sessionKey: "whatsapp:default:group:1234567890@g.us",
+      conversationId: "1234567890@g.us",
+    });
+
+    expect(hoisted.sendReactionWhatsApp).toHaveBeenCalledWith(
+      "1234567890@g.us",
+      "msg-1",
+      "👀",
+      expect.objectContaining({
+        fromMe: false,
+        participant: "alice@lid",
+      }),
+    );
+  });
+
   it("suppresses ack reactions when reactionLevel is off", async () => {
     await runAckReaction({
       cfg: createConfig("off"),

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
@@ -72,7 +72,7 @@ export async function maybeSendAckReaction(params: {
   sendReactionWhatsApp(params.msg.chatId, params.msg.id, emoji, {
     verbose: params.verbose,
     fromMe: false,
-    participant: sender.jid ?? undefined,
+    participant: sender.jid ?? sender.lid ?? undefined,
     accountId: params.accountId,
     cfg: params.cfg,
   }).catch((err) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: WhatsApp group ack reactions only passed `sender.jid` as the Baileys reaction participant.
- Why it matters: modern WhatsApp group messages can identify the sender only by LID (`@lid`), so ack reactions may silently not render when the participant is omitted.
- What changed: ack reactions now fall back to `sender.lid` when `sender.jid` is unavailable, with a unit regression test for group LID senders.
- What did NOT change (scope boundary): direct-message reactions, reaction gating, ack emoji config, and Baileys send logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: ack reaction participant selection only considered the legacy WhatsApp JID identity, but inbound identity normalization may place LID-only participants in `sender.lid`.
- Missing detection / guardrail: there was no regression test covering group ack reactions where the sender has only a LID participant.
- Contributing context (if known): Baileys group reactions require the participant key to match the original group message sender; DMs do not need this participant.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts`
- Scenario the test should lock in: group ack reaction with `sender.lid` and no `sender.jid` passes the LID as `participant`.
- Why this is the smallest reliable guardrail: the bug is in the local ack-reaction option construction before the Baileys send call.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

WhatsApp group ack reactions are more reliable for LID-only group senders. No config changes.

## Diagram (if applicable)

```text
Before:
[group message from LID-only sender] -> participant undefined -> reaction may not render

After:
[group message from LID-only sender] -> participant sender.lid -> reaction targets original sender
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp / Baileys
- Relevant config (redacted): `channels.whatsapp.ackReaction.emoji` enabled; group ack path using `group: "mentions"`

### Steps

1. Construct a WhatsApp group inbound message with `sender: { lid: "alice@lid" }` and no `sender.jid`.
2. Call `maybeSendAckReaction` with ack reactions enabled and the message marked as mentioned.
3. Inspect the mocked `sendReactionWhatsApp` options.

### Expected

- The reaction options include `participant: "alice@lid"`.

### Actual

- Before this patch the participant would be `undefined`; after this patch it is `"alice@lid"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unit regression for LID-only group ack participant; existing ack reaction gating tests still pass.
- Edge cases checked: direct-message behavior still sends no participant; reactionLevel `off` still suppresses ack reactions; account-level override test still passes.
- What you did **not** verify: live WhatsApp/Baileys group delivery from this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: LID fallback could affect only group reaction key construction when JID is absent.
  - Mitigation: keep JID precedence unchanged and only use LID as fallback; unit test covers the new fallback.

Validation run locally:

- `corepack pnpm -s vitest extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts --run`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts`
- `corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts`
- `corepack pnpm -s tsgo:extensions:test`
