### PR TITLE
fix(gateway): suppress transient network errors in uncaughtException handler (#71529)

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -252,7 +252,7 @@ export async function runCli(argv: string[] = process.argv) {
     const [
       { buildProgram },
       { runFatalErrorHooks },
-      { installUnhandledRejectionHandler },
+      { installUnhandledRejectionHandler, isTransientUnhandledRejectionError },
       { restoreTerminalState },
     ] = await Promise.all([
       import("./program.js"),
@@ -267,6 +267,13 @@ export async function runCli(argv: string[] = process.argv) {
     installUnhandledRejectionHandler();
 
     process.on("uncaughtException", (error) => {
+      if (isTransientUnhandledRejectionError(error)) {
+        console.warn(
+          "[openclaw] Non-fatal uncaught exception (continuing):",
+          formatUncaughtError(error),
+        );
+        return;
+      }
       console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
       for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
         console.error("[openclaw]", message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,10 @@ import { fileURLToPath } from "node:url";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientUnhandledRejectionError,
+} from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
   runCli: (argv: string[]) => Promise<void>;
@@ -86,6 +89,13 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientUnhandledRejectionError(error)) {
+      console.warn(
+        "[openclaw] Non-fatal uncaught exception (continuing):",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
       console.error("[openclaw]", message);


### PR DESCRIPTION
## Summary

Fixes #71529 — The gateway crashes with `EHOSTUNREACH` during transient network hiccups because the `uncaughtException` handler unconditionally calls `process.exit(1)`.

## Root Cause

The `unhandledRejection` handler already uses `isTransientUnhandledRejectionError()` to suppress transient network errors (EHOSTUNREACH, ECONNRESET, ETIMEDOUT, etc.) and continue running. However, the `uncaughtException` handler in both `src/index.ts` and `src/cli/run-main.ts` has no such check — it crashes for all errors.

When a socket `error` event fires synchronously (e.g., EHOSTUNREACH from the Telegram/SSRF module during a network hiccup), it surfaces as an `uncaughtException` rather than an `unhandledRejection`, bypassing the transient-error suppression and crashing the gateway.

## Fix

Apply the same `isTransientUnhandledRejectionError()` check to both `uncaughtException` handlers. Transient network errors are now logged as warnings and suppressed, matching the behavior of `unhandledRejection`.

## Files Changed

- `src/index.ts` — legacy CLI entry uncaughtException handler
- `src/cli/run-main.ts` — main CLI entry uncaughtException handler

## Testing

- Transient network error (EHOSTUNREACH) → logged as warning, gateway continues ✅
- Fatal errors (ERR_OUT_OF_MEMORY, etc.) → still crash with exit(1) ✅
- Existing `unhandled-rejections.test.ts` suite unaffected ✅