### PR TITLE
fix(model): re-prefix nvidia/ on bare model ids (#71552)

### DIFF
--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -69,6 +69,9 @@ export function normalizeStaticProviderModelId(provider: string, model: string):
   if (provider === "openrouter" && !model.includes("/")) {
     return `openrouter/${model}`;
   }
+  if (provider === "nvidia" && !model.includes("/")) {
+    return `nvidia/${model}`;
+  }
   if (provider === "xai") {
     return normalizeNativeXaiModelId(model);
   }


### PR DESCRIPTION
## Summary

Fixes #71552 — Nvidia NIM models (e.g. `nvidia/nemotron-3-super-120b-a12b`) fail with HTTP 404 because `parseStaticModelRef()` strips the `nvidia/` prefix and `normalizeStaticProviderModelId()` has no re-prefix case for nvidia.

## Root Cause

`parseStaticModelRef()` splits the configured ref on the first `/` into `provider` + `modelRaw`. For `nvidia/nemotron-3-super-120b-a12b`, this yields `provider='nvidia'` and `modelRaw='nemotron-3-super-120b-a12b'`.

`normalizeStaticProviderModelId()` already re-prefixes bare model ids for `openrouter` (line 74), but had no equivalent case for `nvidia`. The Nvidia NIM API at `integrate.api.nvidia.com` expects the full vendor-prefixed id on the wire.

## Fix

Add the same `!model.includes('/')` guard for `nvidia` provider, mirroring the existing `openrouter` pattern. Models with inner slashes (e.g. `moonshotai/kimi-k2.5`) are unaffected since the guard only triggers when the slash was consumed by the parser.

## Testing

- `nvidia/nemotron-3-super-120b-a12b` → re-prefixed to `nvidia/nemotron-3-super-120b-a12b` ✅
- `moonshotai/kimi-k2.5` on nvidia provider → keeps inner slash, not re-prefixed ✅
- openrouter behavior unchanged ✅