### PR TITLE
fix(acp): remove stale channel allowlist from zod validator

### DIFF
--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -109,7 +109,7 @@ describe("ACP binding cutover schema", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("rejects ACP bindings on unsupported channels", () => {
+  it("accepts ACP bindings on any non-empty channel", () => {
     const parsed = OpenClawSchema.safeParse({
       bindings: [
         {
@@ -117,6 +117,24 @@ describe("ACP binding cutover schema", () => {
           agentId: "codex",
           match: {
             channel: "slack",
+            accountId: "default",
+            peer: { kind: "channel", id: "C123456" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects ACP bindings with empty channel", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "  ",
             accountId: "default",
             peer: { kind: "channel", id: "C123456" },
           },

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -71,12 +71,11 @@ const AcpBindingSchema = z
       return;
     }
     const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    if (!channel) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["match", "channel"],
-        message:
-          'ACP bindings currently support only "discord", "telegram", and "feishu" channels.',
+        message: "ACP bindings require a non-empty channel.",
       });
       return;
     }


### PR DESCRIPTION
## Problem

The configured-binding-registry and ACP resolution pipeline on current `main` are **fully channel-agnostic**:

- `ConfiguredAcpBindingChannel` is widened to `ChannelId` (any string)
- `configured-binding-match.ts`, `configured-binding-compiler.ts`, `configured-binding-registry.ts` have zero references to discord/telegram/feishu
- `acp-configured-binding-consumer.ts` handles any channel
- `persistent-bindings.resolve.ts` delegates to the generic registry

However, **`zod-schema.agents.ts:74`** still has a stale 3-channel allowlist:

```typescript
if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
  // rejects everything else
}
```

This means any user trying to configure an ACP binding for a plugin channel (Bridge, Slack, Mattermost, Matrix, etc.) gets rejected at config validation, even though the entire runtime already supports it.

## Fix

Replace the allowlist with a non-empty channel check (2 lines changed in the validator).

## Test changes

- Flipped the old "rejects unsupported channels" test to verify plugin channels are now accepted
- Added an empty-channel rejection test

All 12 tests in `config.acp-binding-cutover.test.ts` pass.

## Context

This was the exact fix in #51560, which was closed by a maintainer who stated the work was "already implemented on main." The runtime is indeed ready, but this validator guard was missed. Issue #41988 was also closed as implemented, but this last gate remains.

Closes #41988
