### PR TITLE
fix(diagnostics): trust internal trace parents

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-79b0499ec6b587ce25c13bdd179b9991f9442a6bdd0d4fa29b1422368b8ec91c  plugin-sdk-api-baseline.json
-dd6d8405647f9ff013e79bddf7a3c5d507af5c574b87ae51dca7b284fb0476d9  plugin-sdk-api-baseline.jsonl
+de45c43666bf66e92efa3bce5c4ab594965f06e2d90a0ab4f28c828003bfa4d5  plugin-sdk-api-baseline.json
+cecafd3632c3c81fca7982e0d4c7655da8561ca0fb4b34890270baa11bccaaa7  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d5bad55d588ecafab1298a2a79578ce13becced8bc33d2b8543161ab528feca4  plugin-sdk-api-baseline.json
-373ded33d5ecc61229de5179827182f0c6f805a804e1f0666cf2da68301153be  plugin-sdk-api-baseline.jsonl
+ec8ef8a49d237a2f4bf326f3be42df09d645f0bdbe746d2bb538992496f2e179  plugin-sdk-api-baseline.json
+9c0e68adbabe5deac0bcc3526d9b2b0931f420d9a95796428ba4250d25ec7f55  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-ec8ef8a49d237a2f4bf326f3be42df09d645f0bdbe746d2bb538992496f2e179  plugin-sdk-api-baseline.json
-9c0e68adbabe5deac0bcc3526d9b2b0931f420d9a95796428ba4250d25ec7f55  plugin-sdk-api-baseline.jsonl
+0727db9032440a211131502f46782f3e7ef339b2f8cfb78c16e762dfa7aa9387  plugin-sdk-api-baseline.json
+afaecc1586f8472447771f4e0748411b00441e070a73189bec829715a694d1cd  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4ec3d17954a3b25debd0b38121ec625b8cbfd0957b59d7a42c62616dcf57b49e  plugin-sdk-api-baseline.json
-226e9d7ff1ea2858f63ae4b278855de27892ad82e7892d923fc87a4de3e3b85c  plugin-sdk-api-baseline.jsonl
+f6d9588737310773031e744b6726ba80a9ca742205db335aae95fbd1e2925dc8  plugin-sdk-api-baseline.json
+a4c86fe92b7bea538f33139e9b57cfada766b7d504323c2e20a7ca205994be44  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-de45c43666bf66e92efa3bce5c4ab594965f06e2d90a0ab4f28c828003bfa4d5  plugin-sdk-api-baseline.json
-cecafd3632c3c81fca7982e0d4c7655da8561ca0fb4b34890270baa11bccaaa7  plugin-sdk-api-baseline.jsonl
+4ec3d17954a3b25debd0b38121ec625b8cbfd0957b59d7a42c62616dcf57b49e  plugin-sdk-api-baseline.json
+226e9d7ff1ea2858f63ae4b278855de27892ad82e7892d923fc87a4de3e3b85c  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0727db9032440a211131502f46782f3e7ef339b2f8cfb78c16e762dfa7aa9387  plugin-sdk-api-baseline.json
-afaecc1586f8472447771f4e0748411b00441e070a73189bec829715a694d1cd  plugin-sdk-api-baseline.jsonl
+edd42b4048dc10092000bff95bd677685c81989d9c120d6c8d1836218e5b302a  plugin-sdk-api-baseline.json
+71f6eb6b72fff1289104895a3760a2c1122b1c157b9f8a68892da1a23b672ed7  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-edd42b4048dc10092000bff95bd677685c81989d9c120d6c8d1836218e5b302a  plugin-sdk-api-baseline.json
-71f6eb6b72fff1289104895a3760a2c1122b1c157b9f8a68892da1a23b672ed7  plugin-sdk-api-baseline.jsonl
+79b0499ec6b587ce25c13bdd179b9991f9442a6bdd0d4fa29b1422368b8ec91c  plugin-sdk-api-baseline.json
+dd6d8405647f9ff013e79bddf7a3c5d507af5c574b87ae51dca7b284fb0476d9  plugin-sdk-api-baseline.jsonl

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -111,7 +111,10 @@ vi.mock("@opentelemetry/semantic-conventions", () => ({
   ATTR_SERVICE_NAME: "service.name",
 }));
 
-import { emitTrustedDiagnosticEvent } from "../../../src/infra/diagnostic-events.js";
+import {
+  emitTrustedDiagnosticEvent,
+  onInternalDiagnosticEvent,
+} from "../../../src/infra/diagnostic-events.js";
 import type { OpenClawPluginServiceContext } from "../api.js";
 import { emitDiagnosticEvent } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
@@ -167,6 +170,7 @@ function createOtelContext(
     },
     logger: createLogger(),
     stateDir: OTEL_TEST_STATE_DIR,
+    internalDiagnostics: { onEvent: onInternalDiagnosticEvent },
   };
 }
 

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -517,13 +517,11 @@ describe("diagnostics-otel service", () => {
       },
     });
 
-    expect(emitCall?.attributes).toMatchObject({
-      "openclaw.traceFlags": "01",
-    });
     expect(emitCall?.attributes).toEqual(
       expect.not.objectContaining({
         "openclaw.traceId": expect.anything(),
         "openclaw.spanId": expect.anything(),
+        "openclaw.traceFlags": expect.anything(),
       }),
     );
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -111,6 +111,7 @@ vi.mock("@opentelemetry/semantic-conventions", () => ({
   ATTR_SERVICE_NAME: "service.name",
 }));
 
+import { emitTrustedDiagnosticEvent } from "../../../src/infra/diagnostic-events.js";
 import type { OpenClawPluginServiceContext } from "../api.js";
 import { emitDiagnosticEvent } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
@@ -122,6 +123,7 @@ const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
 const SPAN_ID = "00f067aa0ba902b7";
 const CHILD_SPAN_ID = "1111111111111111";
 const GRANDCHILD_SPAN_ID = "2222222222222222";
+const TOOL_SPAN_ID = "3333333333333333";
 const PROTO_KEY = "__proto__";
 const MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS = 4096;
 const OTEL_TRUNCATED_SUFFIX_MAX_CHARS = 20;
@@ -174,11 +176,13 @@ function createTraceOnlyContext(endpoint: string): OpenClawPluginServiceContext 
 
 async function emitAndCaptureLog(
   event: Omit<Extract<Parameters<typeof emitDiagnosticEvent>[0], { type: "log.record" }>, "type">,
+  options: { trusted?: boolean } = {},
 ) {
   const service = createDiagnosticsOtelService();
   const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { logs: true });
   await service.start(ctx);
-  emitDiagnosticEvent({
+  const emit = options.trusted ? emitTrustedDiagnosticEvent : emitDiagnosticEvent;
+  emit({
     type: "log.record",
     ...event,
   });
@@ -499,7 +503,7 @@ describe("diagnostics-otel service", () => {
     }
   });
 
-  test("attaches diagnostic trace context to exported logs", async () => {
+  test("does not attach untrusted diagnostic trace context to exported logs", async () => {
     const emitCall = await emitAndCaptureLog({
       level: "INFO",
       message: "traceable log",
@@ -522,6 +526,24 @@ describe("diagnostics-otel service", () => {
         "openclaw.spanId": expect.anything(),
       }),
     );
+    expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
+    expect(emitCall?.context).toBeUndefined();
+  });
+
+  test("attaches trusted diagnostic trace context to exported logs", async () => {
+    const emitCall = await emitAndCaptureLog(
+      {
+        level: "INFO",
+        message: "traceable log",
+        trace: {
+          traceId: TRACE_ID,
+          spanId: SPAN_ID,
+          traceFlags: "01",
+        },
+      },
+      { trusted: true },
+    );
+
     expect(telemetryState.tracer.setSpanContext).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -814,6 +836,75 @@ describe("diagnostics-otel service", () => {
     });
     expect(toolSpan?.end).toHaveBeenCalledWith(expect.any(Number));
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
+    await service.stop?.(ctx);
+  });
+
+  test("parents trusted diagnostic lifecycle spans from explicit parent ids", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitTrustedDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      outcome: "completed",
+      durationMs: 100,
+      trace: {
+        traceId: TRACE_ID,
+        spanId: CHILD_SPAN_ID,
+        parentSpanId: SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    emitTrustedDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      durationMs: 80,
+      trace: {
+        traceId: TRACE_ID,
+        spanId: GRANDCHILD_SPAN_ID,
+        parentSpanId: CHILD_SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      runId: "run-1",
+      toolName: "read",
+      durationMs: 20,
+      errorCategory: "TypeError",
+      trace: {
+        traceId: TRACE_ID,
+        spanId: TOOL_SPAN_ID,
+        parentSpanId: GRANDCHILD_SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    await flushDiagnosticEvents();
+
+    expect(telemetryState.tracer.setSpanContext).toHaveBeenCalledTimes(3);
+    expect(telemetryState.tracer.setSpanContext.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({ traceId: TRACE_ID, spanId: SPAN_ID }),
+      expect.objectContaining({ traceId: TRACE_ID, spanId: CHILD_SPAN_ID }),
+      expect.objectContaining({ traceId: TRACE_ID, spanId: GRANDCHILD_SPAN_ID }),
+    ]);
+
+    const parentBySpanName = Object.fromEntries(
+      telemetryState.tracer.startSpan.mock.calls.map((call) => [
+        call[0],
+        (call[2] as { spanContext?: { spanId?: string } } | undefined)?.spanContext?.spanId,
+      ]),
+    );
+    expect(parentBySpanName).toMatchObject({
+      "openclaw.run": SPAN_ID,
+      "openclaw.model.call": CHILD_SPAN_ID,
+      "openclaw.tool.execution": GRANDCHILD_SPAN_ID,
+    });
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -16,6 +16,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import type {
+  DiagnosticEventMetadata,
   DiagnosticEventPayload,
   DiagnosticTraceContext,
   OpenClawPluginService,
@@ -24,7 +25,6 @@ import {
   isValidDiagnosticSpanId,
   isValidDiagnosticTraceFlags,
   isValidDiagnosticTraceId,
-  isTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   redactSensitiveText,
 } from "../api.js";
@@ -340,35 +340,31 @@ function contextForTraceContext(traceContext: DiagnosticTraceContext | undefined
   });
 }
 
-function contextForDiagnosticSpanParent(
-  traceContext: DiagnosticTraceContext | undefined,
-  options: { fallbackToSpanId?: boolean } = {},
-) {
+function contextForDiagnosticSpanParent(traceContext: DiagnosticTraceContext | undefined) {
   const normalized = normalizeTraceContext(traceContext);
-  const parentSpanId =
-    normalized?.parentSpanId ?? (options.fallbackToSpanId ? normalized?.spanId : undefined);
-  if (!normalized || !parentSpanId) {
+  if (!normalized?.parentSpanId) {
     return undefined;
   }
   return trace.setSpanContext(otelContextApi.active(), {
     traceId: normalized.traceId,
-    spanId: parentSpanId,
+    spanId: normalized.parentSpanId,
     traceFlags: traceFlagsToOtel(normalized.traceFlags),
     isRemote: true,
   });
 }
 
-function contextForTrustedTraceContext(evt: DiagnosticEventPayload) {
-  return isTrustedDiagnosticEvent(evt) ? contextForTraceContext(evt.trace) : undefined;
+function contextForTrustedTraceContext(
+  evt: DiagnosticEventPayload,
+  metadata: DiagnosticEventMetadata,
+) {
+  return metadata.trusted ? contextForTraceContext(evt.trace) : undefined;
 }
 
 function contextForTrustedDiagnosticSpanParent(
   evt: DiagnosticEventPayload,
-  options: { fallbackToSpanId?: boolean } = {},
+  metadata: DiagnosticEventMetadata,
 ) {
-  return isTrustedDiagnosticEvent(evt)
-    ? contextForDiagnosticSpanParent(evt.trace, options)
-    : undefined;
+  return metadata.trusted ? contextForDiagnosticSpanParent(evt.trace) : undefined;
 }
 
 function addTraceAttributes(
@@ -616,7 +612,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       });
 
       let recordLogRecord:
-        | ((evt: Extract<DiagnosticEventPayload, { type: "log.record" }>) => void)
+        | ((
+            evt: Extract<DiagnosticEventPayload, { type: "log.record" }>,
+            metadata: DiagnosticEventMetadata,
+          ) => void)
         | undefined;
       if (logsEnabled) {
         let logRecordExportFailureLastReportedAt = Number.NEGATIVE_INFINITY;
@@ -635,7 +634,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           processors: [logProcessor],
         });
         const otelLogger = logProvider.getLogger("openclaw");
-        recordLogRecord = (evt) => {
+        recordLogRecord = (evt, metadata) => {
           try {
             const logLevelName = evt.level || "INFO";
             const severityNumber = logSeverityMap[logLevelName] ?? (9 as SeverityNumber);
@@ -658,7 +657,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             if (evt.code?.functionName) {
               assignOtelLogAttribute(attributes, "code.function", evt.code.functionName);
             }
-            addTraceAttributes(attributes, evt.trace);
+            if (metadata.trusted) {
+              addTraceAttributes(attributes, evt.trace);
+            }
 
             const logRecord: LogRecord = {
               body: normalizeOtelLogString(evt.message || "log", MAX_OTEL_LOG_BODY_CHARS),
@@ -667,7 +668,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               attributes: redactOtelAttributes(attributes),
               timestamp: evt.ts,
             };
-            const logContext = contextForTrustedTraceContext(evt);
+            const logContext = contextForTrustedTraceContext(evt, metadata);
             if (logContext) {
               logRecord.context = logContext;
             }
@@ -751,7 +752,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         };
       };
 
-      const recordModelUsage = (evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>) => {
+      const recordModelUsage = (
+        evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>,
+        metadata: DiagnosticEventMetadata,
+      ) => {
         const attrs = {
           "openclaw.channel": evt.channel ?? "unknown",
           "openclaw.provider": evt.provider ?? "unknown",
@@ -810,7 +814,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         };
 
         const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         span.end(evt.ts);
@@ -1029,6 +1033,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordRunCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "run.completed" }>,
+        metadata: DiagnosticEventMetadata,
       ) => {
         const attrs: Record<string, string | number> = {
           "openclaw.outcome": evt.outcome,
@@ -1050,7 +1055,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.errorCategory"] = lowCardinalityAttr(evt.errorCategory, "other");
         }
         const span = spanWithDuration("openclaw.run", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         if (evt.outcome === "error") {
@@ -1073,6 +1078,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordModelCallCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "model.call.completed" }>,
+        metadata: DiagnosticEventMetadata,
       ) => {
         modelCallDurationHistogram.record(evt.durationMs, modelCallMetricAttrs(evt));
         if (!tracesEnabled) {
@@ -1097,7 +1103,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.model.call", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         span.end(evt.ts);
@@ -1105,6 +1111,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordModelCallError = (
         evt: Extract<DiagnosticEventPayload, { type: "model.call.error" }>,
+        metadata: DiagnosticEventMetadata,
       ) => {
         modelCallDurationHistogram.record(evt.durationMs, {
           ...modelCallMetricAttrs(evt),
@@ -1133,7 +1140,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.model.call", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         span.setStatus({
@@ -1145,6 +1152,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordToolExecutionCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.completed" }>,
+        metadata: DiagnosticEventMetadata,
       ) => {
         const attrs = {
           "openclaw.toolName": evt.toolName,
@@ -1166,7 +1174,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         span.end(evt.ts);
@@ -1174,6 +1182,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordToolExecutionError = (
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.error" }>,
+        metadata: DiagnosticEventMetadata,
       ) => {
         const attrs = {
           "openclaw.toolName": evt.toolName,
@@ -1200,7 +1209,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
-          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          parentContext: contextForTrustedDiagnosticSpanParent(evt, metadata),
           endTimeMs: evt.ts,
         });
         span.setStatus({
@@ -1258,90 +1267,92 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
       };
 
-      unsubscribe = onInternalDiagnosticEvent((evt: DiagnosticEventPayload) => {
-        try {
-          switch (evt.type) {
-            case "model.usage":
-              recordModelUsage(evt);
-              return;
-            case "webhook.received":
-              recordWebhookReceived(evt);
-              return;
-            case "webhook.processed":
-              recordWebhookProcessed(evt);
-              return;
-            case "webhook.error":
-              recordWebhookError(evt);
-              return;
-            case "message.queued":
-              recordMessageQueued(evt);
-              return;
-            case "message.processed":
-              recordMessageProcessed(evt);
-              return;
-            case "message.delivery.started":
-              recordMessageDeliveryStarted(evt);
-              return;
-            case "message.delivery.completed":
-              recordMessageDeliveryCompleted(evt);
-              return;
-            case "message.delivery.error":
-              recordMessageDeliveryError(evt);
-              return;
-            case "queue.lane.enqueue":
-              recordLaneEnqueue(evt);
-              return;
-            case "queue.lane.dequeue":
-              recordLaneDequeue(evt);
-              return;
-            case "session.state":
-              recordSessionState(evt);
-              return;
-            case "session.stuck":
-              recordSessionStuck(evt);
-              return;
-            case "run.attempt":
-              recordRunAttempt(evt);
-              return;
-            case "diagnostic.heartbeat":
-              recordHeartbeat(evt);
-              return;
-            case "run.completed":
-              recordRunCompleted(evt);
-              return;
-            case "model.call.completed":
-              recordModelCallCompleted(evt);
-              return;
-            case "model.call.error":
-              recordModelCallError(evt);
-              return;
-            case "tool.execution.completed":
-              recordToolExecutionCompleted(evt);
-              return;
-            case "tool.execution.error":
-              recordToolExecutionError(evt);
-              return;
-            case "exec.process.completed":
-              recordExecProcessCompleted(evt);
-              return;
-            case "log.record":
-              recordLogRecord?.(evt);
-              return;
-            case "tool.loop":
-            case "tool.execution.started":
-            case "run.started":
-            case "model.call.started":
-            case "diagnostic.memory.sample":
-            case "diagnostic.memory.pressure":
-            case "payload.large":
-              return;
+      unsubscribe = onInternalDiagnosticEvent(
+        (evt: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) => {
+          try {
+            switch (evt.type) {
+              case "model.usage":
+                recordModelUsage(evt, metadata);
+                return;
+              case "webhook.received":
+                recordWebhookReceived(evt);
+                return;
+              case "webhook.processed":
+                recordWebhookProcessed(evt);
+                return;
+              case "webhook.error":
+                recordWebhookError(evt);
+                return;
+              case "message.queued":
+                recordMessageQueued(evt);
+                return;
+              case "message.processed":
+                recordMessageProcessed(evt);
+                return;
+              case "message.delivery.started":
+                recordMessageDeliveryStarted(evt);
+                return;
+              case "message.delivery.completed":
+                recordMessageDeliveryCompleted(evt);
+                return;
+              case "message.delivery.error":
+                recordMessageDeliveryError(evt);
+                return;
+              case "queue.lane.enqueue":
+                recordLaneEnqueue(evt);
+                return;
+              case "queue.lane.dequeue":
+                recordLaneDequeue(evt);
+                return;
+              case "session.state":
+                recordSessionState(evt);
+                return;
+              case "session.stuck":
+                recordSessionStuck(evt);
+                return;
+              case "run.attempt":
+                recordRunAttempt(evt);
+                return;
+              case "diagnostic.heartbeat":
+                recordHeartbeat(evt);
+                return;
+              case "run.completed":
+                recordRunCompleted(evt, metadata);
+                return;
+              case "model.call.completed":
+                recordModelCallCompleted(evt, metadata);
+                return;
+              case "model.call.error":
+                recordModelCallError(evt, metadata);
+                return;
+              case "tool.execution.completed":
+                recordToolExecutionCompleted(evt, metadata);
+                return;
+              case "tool.execution.error":
+                recordToolExecutionError(evt, metadata);
+                return;
+              case "exec.process.completed":
+                recordExecProcessCompleted(evt);
+                return;
+              case "log.record":
+                recordLogRecord?.(evt, metadata);
+                return;
+              case "tool.loop":
+              case "tool.execution.started":
+              case "run.started":
+              case "model.call.started":
+              case "diagnostic.memory.sample":
+              case "diagnostic.memory.pressure":
+              case "payload.large":
+                return;
+            }
+          } catch (err) {
+            ctx.logger.error(
+              `diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`,
+            );
           }
-        } catch (err) {
-          ctx.logger.error(
-            `diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`,
-          );
-        }
-      });
+        },
+      );
 
       if (logsEnabled) {
         ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/Protobuf)");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -25,7 +25,6 @@ import {
   isValidDiagnosticSpanId,
   isValidDiagnosticTraceFlags,
   isValidDiagnosticTraceId,
-  onInternalDiagnosticEvent,
   redactSensitiveText,
 } from "../api.js";
 
@@ -1267,92 +1266,96 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
       };
 
-      unsubscribe = onInternalDiagnosticEvent(
-        (evt: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) => {
-          try {
-            switch (evt.type) {
-              case "model.usage":
-                recordModelUsage(evt, metadata);
-                return;
-              case "webhook.received":
-                recordWebhookReceived(evt);
-                return;
-              case "webhook.processed":
-                recordWebhookProcessed(evt);
-                return;
-              case "webhook.error":
-                recordWebhookError(evt);
-                return;
-              case "message.queued":
-                recordMessageQueued(evt);
-                return;
-              case "message.processed":
-                recordMessageProcessed(evt);
-                return;
-              case "message.delivery.started":
-                recordMessageDeliveryStarted(evt);
-                return;
-              case "message.delivery.completed":
-                recordMessageDeliveryCompleted(evt);
-                return;
-              case "message.delivery.error":
-                recordMessageDeliveryError(evt);
-                return;
-              case "queue.lane.enqueue":
-                recordLaneEnqueue(evt);
-                return;
-              case "queue.lane.dequeue":
-                recordLaneDequeue(evt);
-                return;
-              case "session.state":
-                recordSessionState(evt);
-                return;
-              case "session.stuck":
-                recordSessionStuck(evt);
-                return;
-              case "run.attempt":
-                recordRunAttempt(evt);
-                return;
-              case "diagnostic.heartbeat":
-                recordHeartbeat(evt);
-                return;
-              case "run.completed":
-                recordRunCompleted(evt, metadata);
-                return;
-              case "model.call.completed":
-                recordModelCallCompleted(evt, metadata);
-                return;
-              case "model.call.error":
-                recordModelCallError(evt, metadata);
-                return;
-              case "tool.execution.completed":
-                recordToolExecutionCompleted(evt, metadata);
-                return;
-              case "tool.execution.error":
-                recordToolExecutionError(evt, metadata);
-                return;
-              case "exec.process.completed":
-                recordExecProcessCompleted(evt);
-                return;
-              case "log.record":
-                recordLogRecord?.(evt, metadata);
-                return;
-              case "tool.loop":
-              case "tool.execution.started":
-              case "run.started":
-              case "model.call.started":
-              case "diagnostic.memory.sample":
-              case "diagnostic.memory.pressure":
-              case "payload.large":
-                return;
-            }
-          } catch (err) {
-            ctx.logger.error(
-              `diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`,
-            );
+      const subscribe = ctx.internalDiagnostics?.onEvent;
+      if (!subscribe) {
+        ctx.logger.error("diagnostics-otel: internal diagnostics capability unavailable");
+        return;
+      }
+
+      unsubscribe = subscribe((evt: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) => {
+        try {
+          switch (evt.type) {
+            case "model.usage":
+              recordModelUsage(evt, metadata);
+              return;
+            case "webhook.received":
+              recordWebhookReceived(evt);
+              return;
+            case "webhook.processed":
+              recordWebhookProcessed(evt);
+              return;
+            case "webhook.error":
+              recordWebhookError(evt);
+              return;
+            case "message.queued":
+              recordMessageQueued(evt);
+              return;
+            case "message.processed":
+              recordMessageProcessed(evt);
+              return;
+            case "message.delivery.started":
+              recordMessageDeliveryStarted(evt);
+              return;
+            case "message.delivery.completed":
+              recordMessageDeliveryCompleted(evt);
+              return;
+            case "message.delivery.error":
+              recordMessageDeliveryError(evt);
+              return;
+            case "queue.lane.enqueue":
+              recordLaneEnqueue(evt);
+              return;
+            case "queue.lane.dequeue":
+              recordLaneDequeue(evt);
+              return;
+            case "session.state":
+              recordSessionState(evt);
+              return;
+            case "session.stuck":
+              recordSessionStuck(evt);
+              return;
+            case "run.attempt":
+              recordRunAttempt(evt);
+              return;
+            case "diagnostic.heartbeat":
+              recordHeartbeat(evt);
+              return;
+            case "run.completed":
+              recordRunCompleted(evt, metadata);
+              return;
+            case "model.call.completed":
+              recordModelCallCompleted(evt, metadata);
+              return;
+            case "model.call.error":
+              recordModelCallError(evt, metadata);
+              return;
+            case "tool.execution.completed":
+              recordToolExecutionCompleted(evt, metadata);
+              return;
+            case "tool.execution.error":
+              recordToolExecutionError(evt, metadata);
+              return;
+            case "exec.process.completed":
+              recordExecProcessCompleted(evt);
+              return;
+            case "log.record":
+              recordLogRecord?.(evt, metadata);
+              return;
+            case "tool.loop":
+            case "tool.execution.started":
+            case "run.started":
+            case "model.call.started":
+            case "diagnostic.memory.sample":
+            case "diagnostic.memory.pressure":
+            case "payload.large":
+              return;
           }
-        },
-      );
+        } catch (err) {
+          ctx.logger.error(
+            `diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`,
+          );
+        }
+      });
 
       if (logsEnabled) {
         ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/Protobuf)");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -24,6 +24,7 @@ import {
   isValidDiagnosticSpanId,
   isValidDiagnosticTraceFlags,
   isValidDiagnosticTraceId,
+  isTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   redactSensitiveText,
 } from "../api.js";
@@ -339,6 +340,37 @@ function contextForTraceContext(traceContext: DiagnosticTraceContext | undefined
   });
 }
 
+function contextForDiagnosticSpanParent(
+  traceContext: DiagnosticTraceContext | undefined,
+  options: { fallbackToSpanId?: boolean } = {},
+) {
+  const normalized = normalizeTraceContext(traceContext);
+  const parentSpanId =
+    normalized?.parentSpanId ?? (options.fallbackToSpanId ? normalized?.spanId : undefined);
+  if (!normalized || !parentSpanId) {
+    return undefined;
+  }
+  return trace.setSpanContext(otelContextApi.active(), {
+    traceId: normalized.traceId,
+    spanId: parentSpanId,
+    traceFlags: traceFlagsToOtel(normalized.traceFlags),
+    isRemote: true,
+  });
+}
+
+function contextForTrustedTraceContext(evt: DiagnosticEventPayload) {
+  return isTrustedDiagnosticEvent(evt) ? contextForTraceContext(evt.trace) : undefined;
+}
+
+function contextForTrustedDiagnosticSpanParent(
+  evt: DiagnosticEventPayload,
+  options: { fallbackToSpanId?: boolean } = {},
+) {
+  return isTrustedDiagnosticEvent(evt)
+    ? contextForDiagnosticSpanParent(evt.trace, options)
+    : undefined;
+}
+
 function addTraceAttributes(
   attributes: Record<string, string | number | boolean>,
   traceContext: DiagnosticTraceContext | undefined,
@@ -635,7 +667,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               attributes: redactOtelAttributes(attributes),
               timestamp: evt.ts,
             };
-            const logContext = contextForTraceContext(evt.trace);
+            const logContext = contextForTrustedTraceContext(evt);
             if (logContext) {
               logRecord.context = logContext;
             }
@@ -777,8 +809,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.tokens.total": usage.total ?? 0,
         };
 
-        const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
-        span.end();
+        const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
+          endTimeMs: evt.ts,
+        });
+        span.end(evt.ts);
       };
 
       const recordWebhookReceived = (
@@ -1015,6 +1050,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.errorCategory"] = lowCardinalityAttr(evt.errorCategory, "other");
         }
         const span = spanWithDuration("openclaw.run", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
           endTimeMs: evt.ts,
         });
         if (evt.outcome === "error") {
@@ -1061,6 +1097,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.model.call", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
           endTimeMs: evt.ts,
         });
         span.end(evt.ts);
@@ -1096,6 +1133,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.model.call", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
           endTimeMs: evt.ts,
         });
         span.setStatus({
@@ -1128,6 +1166,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
           endTimeMs: evt.ts,
         });
         span.end(evt.ts);
@@ -1161,6 +1200,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           contentCapturePolicy,
         );
         const span = spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
+          parentContext: contextForTrustedDiagnosticSpanParent(evt),
           endTimeMs: evt.ts,
         });
         span.setStatus({

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -92,7 +92,7 @@ export function applyLocalOxlintPolicy(args, env, hostResources) {
     insertBeforeSeparator(nextArgs, "--report-unused-disable-directives-severity", "error");
   }
 
-  if (shouldThrottleLocalHeavyChecks(nextEnv, hostResources)) {
+  if (shouldThrottleLocalHeavyChecks(nextEnv, hostResources) && !hasFlag(nextArgs, "--threads")) {
     insertBeforeSeparator(nextArgs, "--threads=1");
   }
 

--- a/src/agents/pi-embedded-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.model-diagnostic-events.ts
@@ -1,7 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { diagnosticErrorCategory } from "../../../infra/diagnostic-error-metadata.js";
 import {
-  emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   type DiagnosticEventInput,
 } from "../../../infra/diagnostic-events.js";
 import {
@@ -122,14 +122,14 @@ async function* observeModelCallIterator<T>(
       yield next.value;
     }
     terminalEmitted = true;
-    emitDiagnosticEvent({
+    emitTrustedDiagnosticEvent({
       type: "model.call.completed",
       ...eventBase,
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {
     terminalEmitted = true;
-    emitDiagnosticEvent({
+    emitTrustedDiagnosticEvent({
       type: "model.call.error",
       ...eventBase,
       durationMs: Date.now() - startedAt,
@@ -139,7 +139,7 @@ async function* observeModelCallIterator<T>(
   } finally {
     if (!terminalEmitted) {
       await safeReturnIterator(iterator);
-      emitDiagnosticEvent({
+      emitTrustedDiagnosticEvent({
         type: "model.call.error",
         ...eventBase,
         durationMs: Date.now() - startedAt,
@@ -194,7 +194,7 @@ function observeModelCallResult(
       startedAt,
     );
   }
-  emitDiagnosticEvent({
+  emitTrustedDiagnosticEvent({
     type: "model.call.completed",
     ...eventBase,
     durationMs: Date.now() - startedAt,
@@ -210,7 +210,7 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
     const callId = ctx.nextCallId();
     const trace = freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace));
     const eventBase = baseModelCallEvent(ctx, callId, trace);
-    emitDiagnosticEvent({
+    emitTrustedDiagnosticEvent({
       type: "model.call.started",
       ...eventBase,
     });
@@ -222,7 +222,7 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
         return result.then(
           (resolved) => observeModelCallResult(resolved, eventBase, startedAt),
           (err) => {
-            emitDiagnosticEvent({
+            emitTrustedDiagnosticEvent({
               type: "model.call.error",
               ...eventBase,
               durationMs: Date.now() - startedAt,
@@ -234,7 +234,7 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
       }
       return observeModelCallResult(result, eventBase, startedAt);
     } catch (err) {
-      emitDiagnosticEvent({
+      emitTrustedDiagnosticEvent({
         type: "model.call.error",
         ...eventBase,
         durationMs: Date.now() - startedAt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -9,7 +9,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
-import { emitDiagnosticEvent } from "../../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import {
   createDiagnosticTraceContext,
   createChildDiagnosticTraceContext,
@@ -649,7 +649,7 @@ export async function runEmbeddedAttempt(
         : {}),
       trace: runTrace,
     };
-    emitDiagnosticEvent({
+    emitTrustedDiagnosticEvent({
       type: "run.started",
       ...diagnosticRunBase,
     });
@@ -660,7 +660,7 @@ export async function runEmbeddedAttempt(
         return;
       }
       diagnosticRunCompleted = true;
-      emitDiagnosticEvent({
+      emitTrustedDiagnosticEvent({
         type: "run.completed",
         ...diagnosticRunBase,
         durationMs: Date.now() - diagnosticRunStartedAt,
@@ -673,7 +673,7 @@ export async function runEmbeddedAttempt(
       : (() => {
           const allTools = createOpenClawCodingTools({
             agentId: sessionAgentId,
-            ...buildEmbeddedAttemptToolRunContext({ ...params, trace: diagnosticTrace }),
+            ...buildEmbeddedAttemptToolRunContext({ ...params, trace: runTrace }),
             exec: {
               ...params.execOverrides,
               elevated: params.bashElevated,

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -391,7 +391,12 @@ describe("before_tool_call loop detection behavior", () => {
         paramsSummary: {
           kind: "object",
         },
-        trace,
+        trace: {
+          traceId: trace.traceId,
+          parentSpanId: trace.spanId,
+          spanId: expect.any(String),
+          traceFlags: trace.traceFlags,
+        },
       });
       expect(emitted[0]?.trace).not.toBe(trace);
       expect(Object.isFrozen(emitted[0]?.trace)).toBe(true);

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -4,10 +4,11 @@ import {
   diagnosticHttpStatusCode,
 } from "../infra/diagnostic-error-metadata.js";
 import {
-  emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   type DiagnosticToolParamsSummary,
 } from "../infra/diagnostic-events.js";
 import {
+  createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
@@ -456,16 +457,19 @@ export function wrapToolWithBeforeToolCallHook(
         }
       }
       const normalizedToolName = normalizeToolName(toolName || "tool");
+      const trace = ctx?.trace
+        ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace))
+        : undefined;
       const eventBase = {
         ...(ctx?.runId && { runId: ctx.runId }),
         ...(ctx?.sessionKey && { sessionKey: ctx.sessionKey }),
         ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
-        ...(ctx?.trace && { trace: freezeDiagnosticTraceContext(ctx.trace) }),
+        ...(trace && { trace }),
         toolName: normalizedToolName,
         ...(toolCallId && { toolCallId }),
         paramsSummary: summarizeToolParams(outcome.params),
       };
-      emitDiagnosticEvent({
+      emitTrustedDiagnosticEvent({
         type: "tool.execution.started",
         ...eventBase,
       });
@@ -480,7 +484,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolCallId,
           result,
         });
-        emitDiagnosticEvent({
+        emitTrustedDiagnosticEvent({
           type: "tool.execution.completed",
           ...eventBase,
           durationMs,
@@ -489,7 +493,7 @@ export function wrapToolWithBeforeToolCallHook(
       } catch (err) {
         const cause = unwrapErrorCause(err);
         const errorCode = diagnosticHttpStatusCode(cause);
-        emitDiagnosticEvent({
+        emitTrustedDiagnosticEvent({
           type: "tool.execution.error",
           ...eventBase,
           durationMs: Date.now() - startedAt,

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -440,7 +440,7 @@ function loadSkillEntries(
     const suspicious = childDirs.length > limits.maxCandidatesPerRoot;
 
     const maxCandidates = Math.max(0, limits.maxSkillsLoadedPerSource);
-    const limitedChildren = childDirs.slice().sort().slice(0, maxCandidates);
+    const limitedChildren = childDirs.toSorted().slice(0, maxCandidates);
 
     if (suspicious) {
       skillsLogger.warn("Skills root looks suspiciously large, truncating discovery.", {

--- a/src/agents/subagent-list.ts
+++ b/src/agents/subagent-list.ts
@@ -126,8 +126,8 @@ export function buildLatestSubagentRunIndex(
     }
     childSessionsByController.set(controllerSessionKey, [childSessionKey]);
   }
-  for (const childSessions of childSessionsByController.values()) {
-    childSessions.sort();
+  for (const [controllerSessionKey, childSessions] of childSessionsByController) {
+    childSessionsByController.set(controllerSessionKey, childSessions.toSorted());
   }
 
   return {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -16,8 +16,11 @@ import {
 import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
-import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -1433,10 +1436,14 @@ export async function runReplyAgent(params: {
         config: cfg,
       });
       const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      emitDiagnosticEvent({
+      emitTrustedDiagnosticEvent({
         type: "model.usage",
         ...(runResult.diagnosticTrace
-          ? { trace: freezeDiagnosticTraceContext(runResult.diagnosticTrace) }
+          ? {
+              trace: freezeDiagnosticTraceContext(
+                createChildDiagnosticTraceContext(runResult.diagnosticTrace),
+              ),
+            }
           : {}),
         sessionKey,
         sessionId: followupRun.run.sessionId,

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -174,6 +174,36 @@ describe("diagnostic-events", () => {
     delete state.trustedEvents;
   });
 
+  it("isolates trusted event trace context from listener mutation", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const trace = createDiagnosticTraceContext({
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+    });
+    const seen: Array<{ traceId: string | undefined; trusted: boolean }> = [];
+    onInternalDiagnosticEvent((event) => {
+      (event.trace as { traceId: string }).traceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    });
+    onInternalDiagnosticEvent((event, metadata) => {
+      seen.push({ traceId: event.trace?.traceId, trusted: metadata.trusted });
+    });
+
+    emitTrustedDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      trace,
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(seen).toEqual([{ traceId: trace.traceId, trusted: true }]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("listener error type=model.call.started seq=1: TypeError"),
+    );
+  });
+
   it("drops prototype-pollution keys during event enrichment", () => {
     const eventInput = Object.assign(Object.create(null), {
       type: "message.queued",

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -223,6 +223,31 @@ describe("diagnostic-events", () => {
     );
   });
 
+  it("isolates nested diagnostic payloads from listener mutation", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const seen: Array<{ total: number | undefined; trusted: boolean }> = [];
+    onInternalDiagnosticEvent((event) => {
+      if (event.type === "model.usage") {
+        event.usage.total = 0;
+      }
+    });
+    onInternalDiagnosticEvent((event, metadata) => {
+      if (event.type === "model.usage") {
+        seen.push({ total: event.usage.total, trusted: metadata.trusted });
+      }
+    });
+
+    emitTrustedDiagnosticEvent({
+      type: "model.usage",
+      usage: { total: 42 },
+    });
+
+    expect(seen).toEqual([{ total: 42, trusted: true }]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("listener error type=model.usage seq=1: TypeError"),
+    );
+  });
+
   it("drops prototype-pollution keys during event enrichment", () => {
     const eventInput = Object.assign(Object.create(null), {
       type: "message.queued",

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -3,7 +3,6 @@ import {
   emitDiagnosticEvent,
   emitTrustedDiagnosticEvent,
   isDiagnosticsEnabled,
-  isTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -119,16 +118,12 @@ describe("diagnostic-events", () => {
 
   it("marks only internal trusted diagnostic emissions as trusted", async () => {
     const events: Array<{
-      event: Parameters<typeof isTrustedDiagnosticEvent>[0];
       metadataTrusted: boolean;
-      trusted: boolean;
       type: string;
     }> = [];
     onInternalDiagnosticEvent((event, metadata) => {
       events.push({
-        event,
         metadataTrusted: metadata.trusted,
-        trusted: isTrustedDiagnosticEvent(event),
         type: event.type,
       });
     });
@@ -146,17 +141,37 @@ describe("diagnostic-events", () => {
     });
 
     await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(
-      events.map(({ metadataTrusted, trusted, type }) => ({ metadataTrusted, trusted, type })),
-    ).toEqual([
-      { metadataTrusted: false, trusted: false, type: "message.queued" },
-      { metadataTrusted: true, trusted: true, type: "model.call.started" },
+    expect(events).toEqual([
+      { metadataTrusted: false, type: "message.queued" },
+      { metadataTrusted: true, type: "model.call.started" },
     ]);
+  });
 
-    const trustedEvent = events[1]?.event;
-    resetDiagnosticEventsForTest();
-    expect(trustedEvent).toBeDefined();
-    expect(trustedEvent ? isTrustedDiagnosticEvent(trustedEvent) : false).toBe(false);
+  it("does not derive trust from mutable global diagnostic state", async () => {
+    const stateKey = Symbol.for("openclaw.diagnosticEventsState");
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    const state = globalStore[stateKey] as Record<string, unknown>;
+    state.trustedEvents = { has: () => true };
+    const events: boolean[] = [];
+    onInternalDiagnosticEvent((_event, metadata) => {
+      events.push(metadata.trusted);
+    });
+
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(Object.getOwnPropertyDescriptor(globalStore, stateKey)).toMatchObject({
+      configurable: false,
+      writable: false,
+    });
+    expect(events).toEqual([false]);
+    delete state.trustedEvents;
   });
 
   it("drops prototype-pollution keys during event enrichment", () => {
@@ -170,7 +185,7 @@ describe("diagnostic-events", () => {
       enumerable: true,
       value: { polluted: true },
     });
-    const events: Array<Parameters<typeof isTrustedDiagnosticEvent>[0]> = [];
+    const events: Array<Parameters<Parameters<typeof onInternalDiagnosticEvent>[0]>[0]> = [];
     onInternalDiagnosticEvent((event) => {
       events.push(event);
     });

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   isDiagnosticsEnabled,
+  isTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -113,6 +115,40 @@ describe("diagnostic-events", () => {
     });
 
     expect(events).toEqual([{ trace, type: "message.queued" }]);
+  });
+
+  it("marks only internal trusted diagnostic emissions as trusted", async () => {
+    const events: Array<{
+      event: Parameters<typeof isTrustedDiagnosticEvent>[0];
+      trusted: boolean;
+      type: string;
+    }> = [];
+    onInternalDiagnosticEvent((event) => {
+      events.push({ event, trusted: isTrustedDiagnosticEvent(event), type: event.type });
+    });
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      source: "plugin",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events.map(({ trusted, type }) => ({ trusted, type }))).toEqual([
+      { trusted: false, type: "message.queued" },
+      { trusted: true, type: "model.call.started" },
+    ]);
+
+    const trustedEvent = events[1]?.event;
+    resetDiagnosticEventsForTest();
+    expect(trustedEvent).toBeDefined();
+    expect(trustedEvent ? isTrustedDiagnosticEvent(trustedEvent) : false).toBe(false);
   });
 
   it("dispatches high-frequency tool and model lifecycle events asynchronously", async () => {

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -147,12 +147,12 @@ describe("diagnostic-events", () => {
     ]);
   });
 
-  it("does not derive trust from mutable global diagnostic state", async () => {
-    const stateKey = Symbol.for("openclaw.diagnosticEventsState");
+  it("does not expose mutable diagnostic state on a global symbol", async () => {
     const globalStore = globalThis as Record<PropertyKey, unknown>;
-    const state = globalStore[stateKey] as Record<string, unknown>;
-    state.trustedEvents = { has: () => true };
     const events: boolean[] = [];
+    globalStore[Symbol.for("openclaw.diagnosticEventsState")] = {
+      listeners: new Set([() => events.push(true)]),
+    };
     onInternalDiagnosticEvent((_event, metadata) => {
       events.push(metadata.trusted);
     });
@@ -166,12 +166,31 @@ describe("diagnostic-events", () => {
     });
 
     await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(Object.getOwnPropertyDescriptor(globalStore, stateKey)).toMatchObject({
-      configurable: false,
-      writable: false,
-    });
     expect(events).toEqual([false]);
-    delete state.trustedEvents;
+    delete globalStore[Symbol.for("openclaw.diagnosticEventsState")];
+  });
+
+  it("keeps trusted internal events off the public diagnostic stream", async () => {
+    const publicEvents: string[] = [];
+    const internalEvents: Array<{ trusted: boolean; type: string }> = [];
+    onDiagnosticEvent((event) => {
+      publicEvents.push(event.type);
+    });
+    onInternalDiagnosticEvent((event, metadata) => {
+      internalEvents.push({ trusted: metadata.trusted, type: event.type });
+    });
+
+    emitTrustedDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(publicEvents).toEqual([]);
+    expect(internalEvents).toEqual([{ trusted: true, type: "model.call.started" }]);
   });
 
   it("isolates trusted event trace context from listener mutation", async () => {

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -120,11 +120,17 @@ describe("diagnostic-events", () => {
   it("marks only internal trusted diagnostic emissions as trusted", async () => {
     const events: Array<{
       event: Parameters<typeof isTrustedDiagnosticEvent>[0];
+      metadataTrusted: boolean;
       trusted: boolean;
       type: string;
     }> = [];
-    onInternalDiagnosticEvent((event) => {
-      events.push({ event, trusted: isTrustedDiagnosticEvent(event), type: event.type });
+    onInternalDiagnosticEvent((event, metadata) => {
+      events.push({
+        event,
+        metadataTrusted: metadata.trusted,
+        trusted: isTrustedDiagnosticEvent(event),
+        type: event.type,
+      });
     });
 
     emitDiagnosticEvent({
@@ -140,15 +146,42 @@ describe("diagnostic-events", () => {
     });
 
     await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(events.map(({ trusted, type }) => ({ trusted, type }))).toEqual([
-      { trusted: false, type: "message.queued" },
-      { trusted: true, type: "model.call.started" },
+    expect(
+      events.map(({ metadataTrusted, trusted, type }) => ({ metadataTrusted, trusted, type })),
+    ).toEqual([
+      { metadataTrusted: false, trusted: false, type: "message.queued" },
+      { metadataTrusted: true, trusted: true, type: "model.call.started" },
     ]);
 
     const trustedEvent = events[1]?.event;
     resetDiagnosticEventsForTest();
     expect(trustedEvent).toBeDefined();
     expect(trustedEvent ? isTrustedDiagnosticEvent(trustedEvent) : false).toBe(false);
+  });
+
+  it("drops prototype-pollution keys during event enrichment", () => {
+    const eventInput = Object.assign(Object.create(null), {
+      type: "message.queued",
+      source: "plugin",
+      constructor: "blocked",
+      prototype: "blocked",
+    }) as Parameters<typeof emitDiagnosticEvent>[0] & Record<string, unknown>;
+    Object.defineProperty(eventInput, "__proto__", {
+      enumerable: true,
+      value: { polluted: true },
+    });
+    const events: Array<Parameters<typeof isTrustedDiagnosticEvent>[0]> = [];
+    onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitDiagnosticEvent(eventInput);
+
+    expect(events).toHaveLength(1);
+    expect(Object.hasOwn(events[0] ?? {}, "__proto__")).toBe(false);
+    expect(Object.hasOwn(events[0] ?? {}, "constructor")).toBe(false);
+    expect(Object.hasOwn(events[0] ?? {}, "prototype")).toBe(false);
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
   });
 
   it("dispatches high-frequency tool and model lifecycle events asynchronously", async () => {

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -193,6 +193,27 @@ describe("diagnostic-events", () => {
     expect(internalEvents).toEqual([{ trusted: true, type: "model.call.started" }]);
   });
 
+  it("isolates diagnostic metadata from listener mutation", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const seen: boolean[] = [];
+    onInternalDiagnosticEvent((_event, metadata) => {
+      (metadata as { trusted: boolean }).trusted = true;
+    });
+    onInternalDiagnosticEvent((_event, metadata) => {
+      seen.push(metadata.trusted);
+    });
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      source: "plugin",
+    });
+
+    expect(seen).toEqual([false]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("listener error type=message.queued seq=1: TypeError"),
+    );
+  });
+
   it("isolates trusted event trace context from listener mutation", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const trace = createDiagnosticTraceContext({

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -374,14 +374,18 @@ type DiagnosticEventListener = (
   metadata: DiagnosticEventMetadata,
 ) => void;
 
+type QueuedDiagnosticEvent = {
+  event: DiagnosticEventPayload;
+  metadata: DiagnosticEventMetadata;
+};
+
 type DiagnosticEventsGlobalState = {
   enabled: boolean;
   seq: number;
   listeners: Set<DiagnosticEventListener>;
   dispatchDepth: number;
-  asyncQueue: DiagnosticEventPayload[];
+  asyncQueue: QueuedDiagnosticEvent[];
   asyncDrainScheduled: boolean;
-  trustedEvents: WeakSet<DiagnosticEventPayload>;
 };
 
 const MAX_ASYNC_DIAGNOSTIC_EVENTS = 10_000;
@@ -398,25 +402,46 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "model.call.error",
   "log.record",
 ]);
+const DIAGNOSTIC_EVENTS_STATE_KEY = Symbol.for("openclaw.diagnosticEventsState");
+
+function isDiagnosticEventsGlobalState(value: unknown): value is DiagnosticEventsGlobalState {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<DiagnosticEventsGlobalState>;
+  return (
+    typeof candidate.enabled === "boolean" &&
+    typeof candidate.seq === "number" &&
+    candidate.listeners instanceof Set &&
+    typeof candidate.dispatchDepth === "number" &&
+    Array.isArray(candidate.asyncQueue) &&
+    typeof candidate.asyncDrainScheduled === "boolean"
+  );
+}
 
 function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
   const globalStore = globalThis as typeof globalThis & {
-    __openclawDiagnosticEventsState?: DiagnosticEventsGlobalState;
+    [DIAGNOSTIC_EVENTS_STATE_KEY]?: DiagnosticEventsGlobalState;
   };
-  if (!globalStore.__openclawDiagnosticEventsState) {
-    globalStore.__openclawDiagnosticEventsState = {
-      enabled: true,
-      seq: 0,
-      listeners: new Set<DiagnosticEventListener>(),
-      dispatchDepth: 0,
-      asyncQueue: [],
-      asyncDrainScheduled: false,
-      trustedEvents: new WeakSet<DiagnosticEventPayload>(),
-    };
+  const existing = globalStore[DIAGNOSTIC_EVENTS_STATE_KEY];
+  if (isDiagnosticEventsGlobalState(existing)) {
+    return existing;
   }
-  globalStore.__openclawDiagnosticEventsState.trustedEvents ??=
-    new WeakSet<DiagnosticEventPayload>();
-  return globalStore.__openclawDiagnosticEventsState;
+  const state = {
+    enabled: true,
+    seq: 0,
+    listeners: new Set<DiagnosticEventListener>(),
+    dispatchDepth: 0,
+    asyncQueue: [],
+    asyncDrainScheduled: false,
+  } satisfies DiagnosticEventsGlobalState;
+  Object.defineProperty(globalStore, DIAGNOSTIC_EVENTS_STATE_KEY, {
+    configurable: false,
+    enumerable: false,
+    value: state,
+    writable: false,
+  });
+  return state;
 }
 
 export function isDiagnosticsEnabled(config?: OpenClawConfig): boolean {
@@ -434,6 +459,7 @@ export function areDiagnosticsEnabledForProcess(): boolean {
 function dispatchDiagnosticEvent(
   state: DiagnosticEventsGlobalState,
   enriched: DiagnosticEventPayload,
+  metadata: DiagnosticEventMetadata,
 ): void {
   if (state.dispatchDepth > 100) {
     console.error(
@@ -444,9 +470,6 @@ function dispatchDiagnosticEvent(
 
   state.dispatchDepth += 1;
   try {
-    const metadata: DiagnosticEventMetadata = {
-      trusted: state.trustedEvents.has(enriched),
-    };
     for (const listener of state.listeners) {
       try {
         listener(enriched, metadata);
@@ -476,8 +499,8 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
   setImmediate(() => {
     state.asyncDrainScheduled = false;
     const batch = state.asyncQueue.splice(0);
-    for (const event of batch) {
-      dispatchDiagnosticEvent(state, event);
+    for (const entry of batch) {
+      dispatchDiagnosticEvent(state, entry.event, entry.metadata);
     }
     if (state.asyncQueue.length > 0) {
       scheduleAsyncDiagnosticDrain(state);
@@ -488,7 +511,6 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
 function enrichDiagnosticEvent(
   state: DiagnosticEventsGlobalState,
   event: DiagnosticEventInput,
-  trusted: boolean,
 ): DiagnosticEventPayload {
   const enriched = {} as DiagnosticEventPayload & Record<string, unknown>;
   for (const [key, value] of Object.entries(event as Record<string, unknown>)) {
@@ -500,9 +522,6 @@ function enrichDiagnosticEvent(
   state.seq += 1;
   enriched.seq = state.seq;
   enriched.ts = Date.now();
-  if (trusted) {
-    state.trustedEvents.add(enriched);
-  }
   return enriched;
 }
 
@@ -512,18 +531,19 @@ function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: bool
     return;
   }
 
-  const enriched = enrichDiagnosticEvent(state, event, trusted);
+  const enriched = enrichDiagnosticEvent(state, event);
+  const metadata: DiagnosticEventMetadata = { trusted };
 
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
       return;
     }
-    state.asyncQueue.push(enriched);
+    state.asyncQueue.push({ event: enriched, metadata });
     scheduleAsyncDiagnosticDrain(state);
     return;
   }
 
-  dispatchDiagnosticEvent(state, enriched);
+  dispatchDiagnosticEvent(state, enriched, metadata);
 }
 
 export function emitDiagnosticEvent(event: DiagnosticEventInput) {
@@ -532,10 +552,6 @@ export function emitDiagnosticEvent(event: DiagnosticEventInput) {
 
 export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
   emitDiagnosticEventWithTrust(event, true);
-}
-
-export function isTrustedDiagnosticEvent(event: DiagnosticEventPayload): boolean {
-  return getDiagnosticEventsState().trustedEvents.has(event);
 }
 
 export function onInternalDiagnosticEvent(listener: DiagnosticEventListener): () => void {
@@ -563,5 +579,4 @@ export function resetDiagnosticEventsForTest(): void {
   state.dispatchDepth = 0;
   state.asyncQueue = [];
   state.asyncDrainScheduled = false;
-  state.trustedEvents = new WeakSet<DiagnosticEventPayload>();
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -464,11 +464,27 @@ function dispatchDiagnosticEvent(
 }
 
 function cloneDiagnosticEventForListener(event: DiagnosticEventPayload): DiagnosticEventPayload {
-  const cloned = { ...event } as DiagnosticEventPayload & Record<string, unknown>;
-  if (event.trace) {
-    cloned.trace = Object.freeze({ ...event.trace });
+  return deepFreezeDiagnosticValue(structuredClone(event)) as DiagnosticEventPayload;
+}
+
+function deepFreezeDiagnosticValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
   }
-  return Object.freeze(cloned) as DiagnosticEventPayload;
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreezeDiagnosticValue(item, seen);
+    }
+    return Object.freeze(value);
+  }
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    deepFreezeDiagnosticValue(nested, seen);
+  }
+  return Object.freeze(value);
 }
 
 function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -472,7 +472,7 @@ function dispatchDiagnosticEvent(
   try {
     for (const listener of state.listeners) {
       try {
-        listener(enriched, metadata);
+        listener(cloneDiagnosticEventForListener(enriched), metadata);
       } catch (err) {
         const errorMessage =
           err instanceof Error
@@ -489,6 +489,14 @@ function dispatchDiagnosticEvent(
   } finally {
     state.dispatchDepth -= 1;
   }
+}
+
+function cloneDiagnosticEventForListener(event: DiagnosticEventPayload): DiagnosticEventPayload {
+  const cloned = { ...event } as DiagnosticEventPayload & Record<string, unknown>;
+  if (event.trace) {
+    cloned.trace = Object.freeze({ ...event.trace });
+  }
+  return Object.freeze(cloned) as DiagnosticEventPayload;
 }
 
 function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -388,6 +388,8 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "log.record",
 ]);
 
+let trustedDiagnosticEvents = new WeakSet<DiagnosticEventPayload>();
+
 function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
   const globalStore = globalThis as typeof globalThis & {
     __openclawDiagnosticEventsState?: DiagnosticEventsGlobalState;
@@ -468,7 +470,7 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
   });
 }
 
-export function emitDiagnosticEvent(event: DiagnosticEventInput) {
+function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: boolean) {
   const state = getDiagnosticEventsState();
   if (!state.enabled) {
     return;
@@ -480,6 +482,10 @@ export function emitDiagnosticEvent(event: DiagnosticEventInput) {
     ts: Date.now(),
   } satisfies DiagnosticEventPayload;
 
+  if (trusted) {
+    trustedDiagnosticEvents.add(enriched);
+  }
+
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
       return;
@@ -490,6 +496,18 @@ export function emitDiagnosticEvent(event: DiagnosticEventInput) {
   }
 
   dispatchDiagnosticEvent(state, enriched);
+}
+
+export function emitDiagnosticEvent(event: DiagnosticEventInput) {
+  emitDiagnosticEventWithTrust(event, false);
+}
+
+export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
+  emitDiagnosticEventWithTrust(event, true);
+}
+
+export function isTrustedDiagnosticEvent(event: DiagnosticEventPayload): boolean {
+  return trustedDiagnosticEvents.has(event);
 }
 
 export function onInternalDiagnosticEvent(
@@ -519,4 +537,5 @@ export function resetDiagnosticEventsForTest(): void {
   state.dispatchDepth = 0;
   state.asyncQueue = [];
   state.asyncDrainScheduled = false;
+  trustedDiagnosticEvents = new WeakSet<DiagnosticEventPayload>();
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -365,9 +365,9 @@ export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
     : never
   : never;
 
-export type DiagnosticEventMetadata = {
+export type DiagnosticEventMetadata = Readonly<{
   trusted: boolean;
-};
+}>;
 
 type DiagnosticEventListener = (
   evt: DiagnosticEventPayload,
@@ -444,7 +444,7 @@ function dispatchDiagnosticEvent(
   try {
     for (const listener of state.listeners) {
       try {
-        listener(cloneDiagnosticEventForListener(enriched), metadata);
+        listener(cloneDiagnosticEventForListener(enriched), Object.freeze({ ...metadata }));
       } catch (err) {
         const errorMessage =
           err instanceof Error

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -402,46 +402,18 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "model.call.error",
   "log.record",
 ]);
-const DIAGNOSTIC_EVENTS_STATE_KEY = Symbol.for("openclaw.diagnosticEventsState");
 
-function isDiagnosticEventsGlobalState(value: unknown): value is DiagnosticEventsGlobalState {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as Partial<DiagnosticEventsGlobalState>;
-  return (
-    typeof candidate.enabled === "boolean" &&
-    typeof candidate.seq === "number" &&
-    candidate.listeners instanceof Set &&
-    typeof candidate.dispatchDepth === "number" &&
-    Array.isArray(candidate.asyncQueue) &&
-    typeof candidate.asyncDrainScheduled === "boolean"
-  );
-}
+const diagnosticEventsState: DiagnosticEventsGlobalState = {
+  enabled: true,
+  seq: 0,
+  listeners: new Set<DiagnosticEventListener>(),
+  dispatchDepth: 0,
+  asyncQueue: [],
+  asyncDrainScheduled: false,
+};
 
 function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
-  const globalStore = globalThis as typeof globalThis & {
-    [DIAGNOSTIC_EVENTS_STATE_KEY]?: DiagnosticEventsGlobalState;
-  };
-  const existing = globalStore[DIAGNOSTIC_EVENTS_STATE_KEY];
-  if (isDiagnosticEventsGlobalState(existing)) {
-    return existing;
-  }
-  const state = {
-    enabled: true,
-    seq: 0,
-    listeners: new Set<DiagnosticEventListener>(),
-    dispatchDepth: 0,
-    asyncQueue: [],
-    asyncDrainScheduled: false,
-  } satisfies DiagnosticEventsGlobalState;
-  Object.defineProperty(globalStore, DIAGNOSTIC_EVENTS_STATE_KEY, {
-    configurable: false,
-    enumerable: false,
-    value: state,
-    writable: false,
-  });
-  return state;
+  return diagnosticEventsState;
 }
 
 export function isDiagnosticsEnabled(config?: OpenClawConfig): boolean {
@@ -571,8 +543,8 @@ export function onInternalDiagnosticEvent(listener: DiagnosticEventListener): ()
 }
 
 export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => void): () => void {
-  return onInternalDiagnosticEvent((event) => {
-    if (event.type === "log.record") {
+  return onInternalDiagnosticEvent((event, metadata) => {
+    if (metadata.trusted || event.type === "log.record") {
       return;
     }
     listener(event);

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DiagnosticTraceContext } from "./diagnostic-trace-context.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
 
 export type DiagnosticSessionState = "idle" | "processing" | "waiting";
 
@@ -364,13 +365,23 @@ export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
     : never
   : never;
 
+export type DiagnosticEventMetadata = {
+  trusted: boolean;
+};
+
+type DiagnosticEventListener = (
+  evt: DiagnosticEventPayload,
+  metadata: DiagnosticEventMetadata,
+) => void;
+
 type DiagnosticEventsGlobalState = {
   enabled: boolean;
   seq: number;
-  listeners: Set<(evt: DiagnosticEventPayload) => void>;
+  listeners: Set<DiagnosticEventListener>;
   dispatchDepth: number;
   asyncQueue: DiagnosticEventPayload[];
   asyncDrainScheduled: boolean;
+  trustedEvents: WeakSet<DiagnosticEventPayload>;
 };
 
 const MAX_ASYNC_DIAGNOSTIC_EVENTS = 10_000;
@@ -388,8 +399,6 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "log.record",
 ]);
 
-let trustedDiagnosticEvents = new WeakSet<DiagnosticEventPayload>();
-
 function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
   const globalStore = globalThis as typeof globalThis & {
     __openclawDiagnosticEventsState?: DiagnosticEventsGlobalState;
@@ -398,12 +407,15 @@ function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
     globalStore.__openclawDiagnosticEventsState = {
       enabled: true,
       seq: 0,
-      listeners: new Set<(evt: DiagnosticEventPayload) => void>(),
+      listeners: new Set<DiagnosticEventListener>(),
       dispatchDepth: 0,
       asyncQueue: [],
       asyncDrainScheduled: false,
+      trustedEvents: new WeakSet<DiagnosticEventPayload>(),
     };
   }
+  globalStore.__openclawDiagnosticEventsState.trustedEvents ??=
+    new WeakSet<DiagnosticEventPayload>();
   return globalStore.__openclawDiagnosticEventsState;
 }
 
@@ -432,9 +444,12 @@ function dispatchDiagnosticEvent(
 
   state.dispatchDepth += 1;
   try {
+    const metadata: DiagnosticEventMetadata = {
+      trusted: state.trustedEvents.has(enriched),
+    };
     for (const listener of state.listeners) {
       try {
-        listener(enriched);
+        listener(enriched, metadata);
       } catch (err) {
         const errorMessage =
           err instanceof Error
@@ -470,21 +485,34 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
   });
 }
 
+function enrichDiagnosticEvent(
+  state: DiagnosticEventsGlobalState,
+  event: DiagnosticEventInput,
+  trusted: boolean,
+): DiagnosticEventPayload {
+  const enriched = {} as DiagnosticEventPayload & Record<string, unknown>;
+  for (const [key, value] of Object.entries(event as Record<string, unknown>)) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
+    enriched[key] = value;
+  }
+  state.seq += 1;
+  enriched.seq = state.seq;
+  enriched.ts = Date.now();
+  if (trusted) {
+    state.trustedEvents.add(enriched);
+  }
+  return enriched;
+}
+
 function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: boolean) {
   const state = getDiagnosticEventsState();
   if (!state.enabled) {
     return;
   }
 
-  const enriched = {
-    ...event,
-    seq: (state.seq += 1),
-    ts: Date.now(),
-  } satisfies DiagnosticEventPayload;
-
-  if (trusted) {
-    trustedDiagnosticEvents.add(enriched);
-  }
+  const enriched = enrichDiagnosticEvent(state, event, trusted);
 
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
@@ -507,12 +535,10 @@ export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
 }
 
 export function isTrustedDiagnosticEvent(event: DiagnosticEventPayload): boolean {
-  return trustedDiagnosticEvents.has(event);
+  return getDiagnosticEventsState().trustedEvents.has(event);
 }
 
-export function onInternalDiagnosticEvent(
-  listener: (evt: DiagnosticEventPayload) => void,
-): () => void {
+export function onInternalDiagnosticEvent(listener: DiagnosticEventListener): () => void {
   const state = getDiagnosticEventsState();
   state.listeners.add(listener);
   return () => {
@@ -537,5 +563,5 @@ export function resetDiagnosticEventsForTest(): void {
   state.dispatchDepth = 0;
   state.asyncQueue = [];
   state.asyncDrainScheduled = false;
-  trustedDiagnosticEvents = new WeakSet<DiagnosticEventPayload>();
+  state.trustedEvents = new WeakSet<DiagnosticEventPayload>();
 }

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -4,11 +4,7 @@
 export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
 export type { DiagnosticEventMetadata } from "../infra/diagnostic-events.js";
 export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
-export {
-  emitDiagnosticEvent,
-  onDiagnosticEvent,
-  onInternalDiagnosticEvent,
-} from "../infra/diagnostic-events.js";
+export { emitDiagnosticEvent, onDiagnosticEvent } from "../infra/diagnostic-events.js";
 export {
   createChildDiagnosticTraceContext,
   createDiagnosticTraceContext,

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -2,10 +2,10 @@
 // Keep this list additive and scoped to the bundled diagnostics-otel surface.
 
 export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
+export type { DiagnosticEventMetadata } from "../infra/diagnostic-events.js";
 export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export {
   emitDiagnosticEvent,
-  isTrustedDiagnosticEvent,
   onDiagnosticEvent,
   onInternalDiagnosticEvent,
 } from "../infra/diagnostic-events.js";

--- a/src/plugin-sdk/diagnostics-otel.ts
+++ b/src/plugin-sdk/diagnostics-otel.ts
@@ -5,6 +5,7 @@ export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
 export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export {
   emitDiagnosticEvent,
+  isTrustedDiagnosticEvent,
   onDiagnosticEvent,
   onInternalDiagnosticEvent,
 } from "../infra/diagnostic-events.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -37,9 +37,6 @@ export {
   emitDiagnosticEvent,
   isDiagnosticsEnabled,
   onDiagnosticEvent,
-  onInternalDiagnosticEvent,
-  resetDiagnosticEventsForTest,
-  setDiagnosticsEnabledForProcess,
 } from "../infra/diagnostic-events.js";
 export * from "../infra/diagnostic-flags.js";
 export * from "../infra/env.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -31,7 +31,16 @@ export async function drainPendingDeliveries(opts: DrainPendingDeliveriesOptions
 export * from "../infra/backoff.js";
 export * from "../infra/channel-activity.js";
 export * from "../infra/dedupe.js";
-export * from "../infra/diagnostic-events.js";
+export type * from "../infra/diagnostic-events.js";
+export {
+  areDiagnosticsEnabledForProcess,
+  emitDiagnosticEvent,
+  isDiagnosticsEnabled,
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
+} from "../infra/diagnostic-events.js";
 export * from "../infra/diagnostic-flags.js";
 export * from "../infra/env.js";
 export * from "../infra/errors.js";

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -189,6 +189,7 @@ export type PluginServiceRegistration = {
   pluginName?: string;
   service: OpenClawPluginService;
   source: string;
+  origin: PluginOrigin;
   rootDir?: string;
 };
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1198,6 +1198,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       pluginName: record.name,
       service,
       source: record.source,
+      origin: record.origin,
       rootDir: record.rootDir,
     });
   };

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -17,10 +17,10 @@ vi.mock("../logging/subsystem.js", () => ({
 import { STATE_DIR } from "../config/paths.js";
 import { startPluginServices } from "./services.js";
 
-function createRegistry(services: OpenClawPluginService[]) {
+function createRegistry(services: OpenClawPluginService[], pluginId = "plugin:test") {
   const registry = createEmptyPluginRegistry();
   registry.services = services.map((service) => ({
-    pluginId: "plugin:test",
+    pluginId,
     service,
     source: "test",
     rootDir: "/plugins/test-plugin",
@@ -172,5 +172,27 @@ describe("startPluginServices", () => {
     );
     expect(stopOk).toHaveBeenCalledOnce();
     expect(stopThrows).toHaveBeenCalledOnce();
+  });
+
+  it("grants internal diagnostics only to the bundled diagnostics OTEL service", async () => {
+    const contexts: OpenClawPluginServiceContext[] = [];
+    const diagnosticsService = createTrackingService("diagnostics-otel", { contexts });
+    await startPluginServices({
+      registry: createRegistry([diagnosticsService], "diagnostics-otel"),
+      config: createServiceConfig(),
+    });
+
+    expect(contexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
+
+    const untrustedContexts: OpenClawPluginServiceContext[] = [];
+    const untrustedService = createTrackingService("diagnostics-otel", {
+      contexts: untrustedContexts,
+    });
+    await startPluginServices({
+      registry: createRegistry([untrustedService], "plugin:test"),
+      config: createServiceConfig(),
+    });
+
+    expect(untrustedContexts[0]?.internalDiagnostics).toBeUndefined();
   });
 });

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginOrigin } from "./plugin-origin.types.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import type { OpenClawPluginService, OpenClawPluginServiceContext } from "./types.js";
 
@@ -17,12 +18,17 @@ vi.mock("../logging/subsystem.js", () => ({
 import { STATE_DIR } from "../config/paths.js";
 import { startPluginServices } from "./services.js";
 
-function createRegistry(services: OpenClawPluginService[], pluginId = "plugin:test") {
+function createRegistry(
+  services: OpenClawPluginService[],
+  pluginId = "plugin:test",
+  origin: PluginOrigin = "workspace",
+) {
   const registry = createEmptyPluginRegistry();
   registry.services = services.map((service) => ({
     pluginId,
     service,
     source: "test",
+    origin,
     rootDir: "/plugins/test-plugin",
   })) as typeof registry.services;
   return registry;
@@ -178,7 +184,7 @@ describe("startPluginServices", () => {
     const contexts: OpenClawPluginServiceContext[] = [];
     const diagnosticsService = createTrackingService("diagnostics-otel", { contexts });
     await startPluginServices({
-      registry: createRegistry([diagnosticsService], "diagnostics-otel"),
+      registry: createRegistry([diagnosticsService], "diagnostics-otel", "bundled"),
       config: createServiceConfig(),
     });
 
@@ -189,7 +195,7 @@ describe("startPluginServices", () => {
       contexts: untrustedContexts,
     });
     await startPluginServices({
-      registry: createRegistry([untrustedService], "plugin:test"),
+      registry: createRegistry([untrustedService], "diagnostics-otel", "workspace"),
       config: createServiceConfig(),
     });
 

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -26,7 +26,8 @@ function createServiceContext(params: {
     workspaceDir: params.workspaceDir,
     stateDir: STATE_DIR,
     logger: createPluginLogger(),
-    ...(params.service?.pluginId === "diagnostics-otel" &&
+    ...(params.service?.origin === "bundled" &&
+    params.service.pluginId === "diagnostics-otel" &&
     params.service.service.id === "diagnostics-otel"
       ? { internalDiagnostics: { onEvent: onInternalDiagnosticEvent } }
       : {}),

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -1,6 +1,8 @@
 import { STATE_DIR } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { onInternalDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
 import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
@@ -17,12 +19,17 @@ function createPluginLogger(): PluginLogger {
 function createServiceContext(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
+  service?: PluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   return {
     config: params.config,
     workspaceDir: params.workspaceDir,
     stateDir: STATE_DIR,
     logger: createPluginLogger(),
+    ...(params.service?.pluginId === "diagnostics-otel" &&
+    params.service.service.id === "diagnostics-otel"
+      ? { internalDiagnostics: { onEvent: onInternalDiagnosticEvent } }
+      : {}),
   };
 }
 
@@ -39,13 +46,13 @@ export async function startPluginServices(params: {
     id: string;
     stop?: () => void | Promise<void>;
   }> = [];
-  const serviceContext = createServiceContext({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-  });
-
   for (const entry of params.registry.services) {
     const service = entry.service;
+    const serviceContext = createServiceContext({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      service: entry,
+    });
     try {
       await service.start(serviceContext);
       running.push({

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -27,6 +27,10 @@ import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hook-types.js";
 import type { ImageGenerationProvider } from "../image-generation/types.js";
+import type {
+  DiagnosticEventMetadata,
+  DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import type { ProviderUsageSnapshot } from "../infra/provider-usage.types.js";
 import type { MediaUnderstandingProvider } from "../media-understanding/types.js";
 import type { MusicGenerationProvider } from "../music-generation/types.js";
@@ -1971,6 +1975,11 @@ export type OpenClawPluginServiceContext = {
   workspaceDir?: string;
   stateDir: string;
   logger: PluginLogger;
+  internalDiagnostics?: {
+    onEvent: (
+      listener: (event: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) => void,
+    ) => () => void;
+  };
 };
 
 /** Background service registered by a plugin during `register(api)`. */

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -251,6 +251,19 @@ describe("local-heavy-check-runtime", () => {
     ]);
   });
 
+  it("honors an explicit oxlint thread count", () => {
+    const { args } = applyLocalOxlintPolicy(["--threads=8"], makeEnv(), ROOMY_HOST);
+
+    expect(args).toEqual([
+      "--threads=8",
+      "--type-aware",
+      "--tsconfig",
+      "tsconfig.oxlint.json",
+      "--report-unused-disable-directives-severity",
+      "error",
+    ]);
+  });
+
   it("allows forcing full-speed oxlint runs on roomy hosts", () => {
     const { args } = applyLocalOxlintPolicy(
       [],


### PR DESCRIPTION
## Summary

- Problem: plugin-emittable diagnostic events can carry syntactically valid trace IDs, and OTEL must not treat those traces as trusted parent context.
- Why it matters: accepting untrusted diagnostic trace context as span/log parentage enables trace poisoning and cross-plugin correlation confusion.
- What changed: added internal trusted diagnostic emission, parented OTEL spans/log context only from trusted events, and made run/model/tool/usage core diagnostics emit trusted child traces.
- What did NOT change (scope boundary): public `emitDiagnosticEvent` remains untrusted; plugins can still receive/use diagnostic trace fields for correlation but cannot make OTEL parent spans from them.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/70424
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: diagnostic trace context was just data; the OTEL exporter had no provenance signal to distinguish core-created runtime events from plugin/public diagnostic events.
- Missing detection / guardrail: no test locked that public/plugin-emitted trace context must not become OTEL parent context while trusted core events can still build the trace tree.
- Contributing context: trace context helpers are intentionally available through the diagnostics SDK, so trust cannot live on the trace object itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/diagnostic-events.test.ts`, `extensions/diagnostics-otel/src/service.test.ts`, `src/agents/pi-tools.before-tool-call.e2e.test.ts`
- Scenario the test should lock in: public diagnostic events stay untrusted; trusted core events parent OTEL spans/log contexts from explicit parent span IDs; tool execution events use child trace contexts without leaking parameter values.
- Why this is the smallest reliable guardrail: it covers the event bus provenance seam and the OTEL sink where spoofing mattered.
- Existing test that already covers this (if any): existing diagnostics-otel tests covered untrusted public trace context; this expands them for trusted parentage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
plugin event trace -> OTEL could not distinguish provenance

After:
public emitDiagnosticEvent -> untrusted trace -> no OTEL parent context
core emitTrustedDiagnosticEvent -> trusted child trace -> OTEL parent context
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): diagnostics-otel
- Relevant config (redacted): diagnostics OTEL traces/logs enabled in tests

### Steps

1. Emit a public diagnostic event with trace context.
2. Emit a trusted internal diagnostic event with explicit parent span ID.
3. Start diagnostics-otel and inspect span/log parent context behavior.

### Expected

- Public/plugin events never parent OTEL spans/log records.
- Trusted core events parent spans from validated parent IDs.

### Actual

- Matches expected after this change.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm plugin-sdk:api:check`
  - `pnpm test src/infra/diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts src/agents/pi-tools.before-tool-call.e2e.test.ts`
  - `pnpm lint:core && pnpm lint:extensions && pnpm check:import-cycles && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/pi-embedded-runner/run/attempt.model-diagnostic-events.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-tools.before-tool-call.e2e.test.ts src/agents/pi-tools.before-tool-call.ts`
  - `pnpm test:extensions` reached QA after all earlier extension projects passed; QA initially failed because sparse checkout omitted `qa/scenarios`; after adding sparse paths, `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/docker-harness.test.ts extensions/qa-lab/src/lab-server.test.ts` passed.
- Edge cases checked: untrusted public events with valid trace IDs; trusted log records; trusted run/model/tool parent IDs; child tool trace immutability and parameter redaction.
- What you did **not** verify: full `pnpm check:changed` completion, because the fresh worktree hit a check self-lock at `lint:core`; direct equivalent lanes listed above were run instead.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: exposing `isTrustedDiagnosticEvent` on the diagnostics-otel SDK seam could be mistaken for an authorization primitive.
  - Mitigation: it is read-only and backed by an internal `WeakSet`; public `emitDiagnosticEvent` cannot forge trust.
