### PR TITLE
test(cron): lock cleanupBundleMcpOnRunEnd gating against sessionTarget

### DIFF
--- a/src/cron/isolated-agent/run.bundle-mcp-cleanup.test.ts
+++ b/src/cron/isolated-agent/run.bundle-mcp-cleanup.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeIsolatedAgentTurnJob, makeIsolatedAgentTurnParams } from "./run.suite-helpers.js";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  resolveAgentConfigMock,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  resolveCronSessionMock,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+  updateSessionStoreMock,
+} from "./run.test-harness.js";
+
+// Lock in the cron-side gating from cb16d22780 ("fix(cron): retire bundled mcp
+// runtimes"): the cron isolated-agent run-executor must pass
+// cleanupBundleMcpOnRunEnd=true to runEmbeddedPiAgent for ephemeral isolated
+// jobs, and false for jobs bound to a persistent custom session. Without this
+// gate, isolated cron fires either accumulate bundled-MCP subprocesses (when
+// false) or kill long-lived persistent-session MCP state on every run (when
+// true). The dispose call itself is covered at the runEmbeddedPiAgent level
+// in pi-embedded-runner.e2e.test.ts; this asserts the upstream decision.
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeSuccessfulRunResult(provider = "openai", model = "gpt-5.4") {
+  return {
+    result: {
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          model,
+          provider,
+          usage: { input: 10, output: 5 },
+        },
+      },
+    },
+    provider,
+    model,
+    attempts: [],
+  };
+}
+
+describe("runCronIsolatedAgentTurn — cleanupBundleMcpOnRunEnd gating", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-5.4" },
+    });
+    resolveAgentConfigMock.mockReturnValue(undefined);
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    resolveCronSessionMock.mockReturnValue(makeCronSession());
+
+    // Passthrough so the embedded runner mock actually receives the call.
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue(makeSuccessfulRunResult().result);
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("requests bundled-MCP cleanup for an isolated cron run", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({ sessionTarget: "isolated" }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+      | { cleanupBundleMcpOnRunEnd?: boolean; trigger?: string }
+      | undefined;
+    expect(call?.trigger).toBe("cron");
+    expect(call?.cleanupBundleMcpOnRunEnd).toBe(true);
+  });
+
+  it("does NOT request bundled-MCP cleanup when bound to a persistent custom session", async () => {
+    // session:* targets bind the cron run to a long-lived session whose MCP
+    // runtime is shared across runs; tearing it down here would force every
+    // fire to repay subprocess startup cost and lose warm tool state.
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({ sessionTarget: "session:agent:main:main" }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+      | { cleanupBundleMcpOnRunEnd?: boolean }
+      | undefined;
+    expect(call?.cleanupBundleMcpOnRunEnd).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

`cb16d22780` ("fix(cron): retire bundled mcp runtimes") added a one-line gate in `src/cron/isolated-agent/run-executor.ts`:

```ts
cleanupBundleMcpOnRunEnd: params.job.sessionTarget === "isolated",
```

Coverage for the dispose call itself lives at the `runEmbeddedPiAgent` level (`src/agents/pi-embedded-runner.e2e.test.ts`), but the cron-side decision — *which jobs request the cleanup* — has no direct test. A refactor of `run-executor.ts` could silently regress in either direction:

- Drop or invert the check → isolated cron fires leak bundled-MCP subprocesses again (the original [#68623](https://github.com/openclaw/openclaw/issues/68623) symptom).
- Hardcode to `true` → persistent-session MCP state gets torn down on every cron fire, forcing cold-start subprocess cost on every run.

## What this adds

Two cron-level assertions in `src/cron/isolated-agent/run.bundle-mcp-cleanup.test.ts`, using the existing `run.test-harness` mock seam:

1. `sessionTarget: "isolated"` → `runEmbeddedPiAgent` receives `cleanupBundleMcpOnRunEnd: true`.
2. `sessionTarget: "session:agent:main:main"` → `runEmbeddedPiAgent` receives `cleanupBundleMcpOnRunEnd: false`.

## Verified

Locally flipped `run-executor.ts` to `cleanupBundleMcpOnRunEnd: true` (always on) and to `cleanupBundleMcpOnRunEnd: false` (always off) — the persistent-session and isolated assertions failed respectively. Both directions are caught.

Pure test addition; no production code change. No changelog entry.

## Verification

- `pnpm test src/cron/isolated-agent/` → 232/232 pass (including the 2 new cases)
- `pnpm format` + `pnpm lint` → clean on the touched file
- `pnpm tsgo:core:test` → clean on the touched file (some pre-existing UI typeerrors in `ui/src/ui/views/agents-*` surfaced; unrelated to this change, not in any path I edit)