### PR TITLE
fix(configure): clear deselected model fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,7 @@ Docs: https://docs.openclaw.ai
 - Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local credentials are current. Fixes #71256. (#71332) Thanks @matthiasjanke and @neeravmakwana.
 - CLI backends: compact OpenClaw transcripts after over-budget CLI turns and reseed fresh CLI sessions from the compacted transcript instead of stale external resume state. Fixes #68329. (#71916) Thanks @obviyus.
 - Telegram: keep default tool progress messages visible when answer preview streaming is disabled. (#71825) Thanks @VACInc.
+- Configure/models: clear deselected model fallbacks when updating the model picker allowlist, including provider-scoped setup flows. (#71596) Thanks @rubencu.
 
 ## 2026.4.24
 

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -198,6 +198,52 @@ describe("promptAuthConfig", () => {
     });
   });
 
+  it("resolves fallback aliases before scoped allowlist pruning", async () => {
+    vi.clearAllMocks();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("token");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.5",
+              fallbacks: ["mini"],
+            },
+            models: {
+              "openai/gpt-5.5": { alias: "GPT" },
+              "openai/gpt-5.4-mini": { alias: "mini" },
+              "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+            },
+          },
+        },
+      },
+    });
+    mocks.promptModelAllowlist.mockResolvedValue({
+      models: ["openai/gpt-5.5"],
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4-mini"],
+    });
+    mocks.resolveProviderPluginChoice.mockReturnValue({
+      provider: { id: "openai", label: "OpenAI", auth: [] },
+      method: { id: "setup-token", label: "setup-token", kind: "token" },
+      wizard: {
+        modelAllowlist: {
+          allowedKeys: ["openai/gpt-5.5", "openai/gpt-5.4-mini"],
+          initialSelections: ["openai/gpt-5.5"],
+        },
+      },
+    });
+
+    const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
+
+    expect(result.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+    });
+    expect(result.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": { alias: "GPT" },
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+    });
+  });
+
   it("scopes the allowlist picker to the selected provider when available", async () => {
     mocks.promptAuthChoiceGrouped.mockResolvedValue("openai-api-key");
     mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("openai");

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -177,10 +177,12 @@ export async function promptAuthConfig(
       preferredProvider,
     });
     if (allowlistSelection.models) {
+      next = applyModelFallbacksFromSelection(next, allowlistSelection.models, {
+        scopeKeys: allowlistSelection.scopeKeys,
+      });
       next = applyModelAllowlist(next, allowlistSelection.models, {
         scopeKeys: allowlistSelection.scopeKeys,
       });
-      next = applyModelFallbacksFromSelection(next, allowlistSelection.models);
     }
   }
 

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -434,6 +434,179 @@ describe("promptModelAllowlist", () => {
       "openai/gpt-5.4-mini",
     ]);
   });
+
+  it("seeds existing model fallbacks into unscoped allowlist selections", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+      },
+    ]);
+
+    const multiselect = vi.fn(async (params) => params.initialValues ?? []);
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          models: {
+            "openai/gpt-5.5": { alias: "gpt" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({ config, prompter });
+    const call = multiselect.mock.calls[0]?.[0];
+    expect(call?.options.map((option: { value: string }) => option.value)).toEqual([
+      "openai/gpt-5.5",
+      "anthropic/claude-sonnet-4-6",
+    ]);
+    expect(call?.initialValues).toEqual(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]);
+    expect(result.models).toEqual(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("resolves bare fallback seeds against the primary model provider", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.5",
+      },
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.5",
+      },
+      {
+        provider: "openai",
+        id: "claude-sonnet-4-6",
+        name: "Wrong provider",
+      },
+    ]);
+
+    const multiselect = vi.fn(async (params) => params.initialValues ?? []);
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({ config, prompter });
+    const call = multiselect.mock.calls[0]?.[0];
+
+    expect(call?.initialValues).toEqual([
+      "anthropic/claude-opus-4-6",
+      "anthropic/claude-sonnet-4-6",
+    ]);
+    expect(result.models).toEqual(["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("keeps the no-catalog allowlist prompt blank when no allowlist exists", async () => {
+    loadModelCatalog.mockResolvedValue([]);
+
+    const text = vi.fn(async (params) => params.initialValue ?? "");
+    const prompter = makePrompter({ text });
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({ config, prompter });
+
+    expect(text.mock.calls[0]?.[0]?.initialValue).toBe("");
+    expect(result).toEqual({});
+  });
+
+  it("shows existing fallbacks in the no-catalog allowlist prompt when an allowlist exists", async () => {
+    loadModelCatalog.mockResolvedValue([]);
+
+    const text = vi.fn(async (params) => params.initialValue ?? "");
+    const prompter = makePrompter({ text });
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          models: {
+            "openai/gpt-5.5": { alias: "gpt" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({ config, prompter });
+
+    expect(text.mock.calls[0]?.[0]?.initialValue).toBe(
+      "openai/gpt-5.5, anthropic/claude-sonnet-4-6",
+    );
+    expect(result.models).toEqual(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("keeps provider-scoped fallback supplements within scope", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+      },
+      {
+        provider: "openai",
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+      },
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.5",
+      },
+    ]);
+
+    const multiselect = vi.fn(async (params) => params.initialValues ?? []);
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "openai",
+    });
+
+    const call = multiselect.mock.calls[0]?.[0];
+    expect(call?.options.map((option: { value: string }) => option.value)).toEqual([
+      "openai/gpt-5.5",
+      "openai/gpt-5.4",
+    ]);
+    expect(call?.initialValues).toEqual(["openai/gpt-5.5"]);
+    expect(result).toEqual({
+      models: ["openai/gpt-5.5"],
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4"],
+    });
+  });
 });
 
 describe("runtime model picker visibility", () => {
@@ -599,6 +772,186 @@ describe("applyModelFallbacksFromSelection", () => {
       fallbacks: ["anthropic/claude-sonnet-4-6"],
     });
     expect(next.agents?.defaults?.model).not.toHaveProperty("primary");
+  });
+
+  it("does not write an empty model object for singleton default selections", () => {
+    const config = {
+      agents: {
+        defaults: {},
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5"]);
+    expect(next).toBe(config);
+  });
+
+  it("clears existing fallbacks when only the primary remains selected", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["anthropic/claude-opus-4-6"]);
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-opus-4-6",
+    });
+  });
+
+  it("drops malformed fallback refs instead of preserving raw strings", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["openai/"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5"]);
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+    });
+  });
+
+  it("preserves hidden fallbacks during unscoped selections", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["claude-cli/claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5"]);
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+      fallbacks: ["claude-cli/claude-sonnet-4-6"],
+    });
+  });
+
+  it("preserves out-of-scope fallbacks during scoped selections", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5"], {
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4"],
+    });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+      fallbacks: ["anthropic/claude-sonnet-4-6"],
+    });
+  });
+
+  it("removes scoped fallbacks for empty scoped selections", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["openai/gpt-5.5", "google/gemini-3-pro-preview"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, [], {
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4"],
+    });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-opus-4-6",
+      fallbacks: ["google/gemini-3-pro-preview"],
+    });
+  });
+
+  it("does not add new scoped fallbacks when the primary is outside scope", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["openai/gpt-5.5"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5", "openai/gpt-5.4"], {
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4"],
+    });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-opus-4-6",
+      fallbacks: ["openai/gpt-5.5"],
+    });
+  });
+
+  it("removes existing scoped fallback aliases when deselected", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["mini"],
+          },
+          models: {
+            "openai/gpt-5.4-mini": { alias: "mini" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(config, ["openai/gpt-5.5"], {
+      scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4-mini"],
+    });
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+    });
+  });
+
+  it("canonicalizes existing scoped fallback aliases when kept selected", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["mini"],
+          },
+          models: {
+            "openai/gpt-5.4-mini": { alias: "mini" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = applyModelFallbacksFromSelection(
+      config,
+      ["openai/gpt-5.5", "openai/gpt-5.4-mini"],
+      {
+        scopeKeys: ["openai/gpt-5.5", "openai/gpt-5.4-mini"],
+      },
+    );
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+      fallbacks: ["openai/gpt-5.4-mini"],
+    });
   });
 
   it("keeps existing fallbacks when the primary is not selected", () => {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -933,16 +933,14 @@ export function applyModelFallbacksFromSelection(
     scopeKeySet && !includesResolvedPrimary
       ? rawSelectedFallbacks.filter((key) => existingFallbackSet.has(key))
       : rawSelectedFallbacks;
-  const fallbacks = scopeKeySet
-    ? mergeScopedFallbackSelection({
-        existingFallbacks,
-        selectedFallbacks,
-        scopeKeySet,
-      })
-    : mergeUnscopedFallbackSelection({
-        existingFallbacks,
-        selectedFallbacks,
-      });
+  const preserveExistingFallback = scopeKeySet
+    ? (fallback: string) => !scopeKeySet.has(fallback)
+    : (fallback: string) => !isModelPickerVisibleModelRef(fallback);
+  const fallbacks = mergeFallbackSelection({
+    existingFallbacks,
+    selectedFallbacks,
+    preserveExistingFallback,
+  });
   const nextModel = {
     ...preservedModelFields,
     ...(existingPrimary != null ? { primary: existingPrimary } : {}),
@@ -973,41 +971,16 @@ export function applyModelFallbacksFromSelection(
   };
 }
 
-function mergeScopedFallbackSelection(params: {
+function mergeFallbackSelection(params: {
   existingFallbacks: string[];
   selectedFallbacks: string[];
-  scopeKeySet: Set<string>;
+  preserveExistingFallback: (fallback: string) => boolean;
 }): string[] {
   const selected = new Set(params.selectedFallbacks);
   const fallbacks: string[] = [];
   for (const fallback of params.existingFallbacks) {
-    if (!params.scopeKeySet.has(fallback)) {
+    if (params.preserveExistingFallback(fallback)) {
       fallbacks.push(fallback);
-      continue;
-    }
-    if (selected.delete(fallback)) {
-      fallbacks.push(fallback);
-    }
-  }
-  for (const fallback of params.selectedFallbacks) {
-    if (selected.has(fallback)) {
-      fallbacks.push(fallback);
-    }
-  }
-  return fallbacks;
-}
-
-function mergeUnscopedFallbackSelection(params: {
-  existingFallbacks: string[];
-  selectedFallbacks: string[];
-}): string[] {
-  const selected = new Set(params.selectedFallbacks);
-  const fallbacks: string[] = [];
-  for (const fallback of params.existingFallbacks) {
-    if (!isModelPickerVisibleModelRef(fallback)) {
-      fallbacks.push(fallback);
-      // Defensive: future callers may pass a hidden fallback in the selected list.
-      selected.delete(fallback);
       continue;
     }
     if (selected.delete(fallback)) {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -9,12 +9,17 @@ import {
 import {
   buildAllowedModelSet,
   buildModelAliasIndex,
+  type ModelAliasIndex,
   modelKey,
   normalizeProviderId,
   resolveConfiguredModelRef,
+  resolveModelRefFromString,
 } from "../agents/model-selection.js";
 import { formatTokenK } from "../commands/models/shared.js";
-import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 import { resolveOwningPluginIdsForProvider } from "../plugins/providers.js";
@@ -119,6 +124,48 @@ function normalizeModelKeys(values: string[]): string[] {
     next.push(value);
   }
   return next;
+}
+
+function resolveFallbackModelKey(params: {
+  cfg: OpenClawConfig;
+  raw: string;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): string | undefined {
+  const raw = normalizeOptionalString(params.raw);
+  if (!raw) {
+    return undefined;
+  }
+  const resolved = resolveModelRefFromString({
+    cfg: params.cfg,
+    raw,
+    defaultProvider: params.defaultProvider,
+    aliasIndex: params.aliasIndex,
+  });
+  if (!resolved) {
+    return undefined;
+  }
+  return modelKey(resolved.ref.provider, resolved.ref.model);
+}
+
+function resolveFallbackModelKeys(params: {
+  cfg: OpenClawConfig;
+  rawFallbacks: string[];
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): string[] {
+  return normalizeModelKeys(
+    params.rawFallbacks
+      .map((raw) =>
+        resolveFallbackModelKey({
+          cfg: params.cfg,
+          raw,
+          defaultProvider: params.defaultProvider,
+          aliasIndex: params.aliasIndex,
+        }),
+      )
+      .filter((key): key is string => Boolean(key)),
+  );
 }
 
 function resolveModelRouteHint(provider: string): string | undefined {
@@ -615,14 +662,29 @@ export async function promptModelAllowlist(params: {
     defaultModel: DEFAULT_MODEL,
   });
   const resolvedKey = modelKey(resolved.provider, resolved.model);
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  const fallbackAliasIndex =
+    resolved.provider === DEFAULT_PROVIDER
+      ? aliasIndex
+      : buildModelAliasIndex({
+          cfg,
+          defaultProvider: resolved.provider,
+        });
+  const fallbackKeys = resolveFallbackModelKeys({
+    cfg,
+    rawFallbacks: resolveAgentModelFallbackValues(cfg.agents?.defaults?.model),
+    defaultProvider: resolved.provider,
+    aliasIndex: fallbackAliasIndex,
+  });
   const initialSeeds = normalizeModelKeys([
     ...existingKeys,
     resolvedKey,
+    ...fallbackKeys,
     ...(params.initialSelections ?? []),
   ]);
-  const initialKeys = allowedKeySet
-    ? initialSeeds.filter((key) => allowedKeySet.has(key))
-    : initialSeeds.filter(isModelPickerVisibleModelRef);
 
   const allowlistProgress = params.prompter.progress("Loading available models");
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
@@ -632,11 +694,13 @@ export async function promptModelAllowlist(params: {
     allowlistProgress.stop();
   }
   if (catalog.length === 0 && allowedKeys.length === 0) {
+    const noCatalogInitialKeys =
+      existingKeys.length > 0 ? normalizeModelKeys([...existingKeys, ...fallbackKeys]) : [];
     const raw = await params.prompter.text({
       message:
         params.message ??
         "Allowlist models (comma-separated provider/model; blank to keep current)",
-      initialValue: existingKeys.join(", "),
+      initialValue: noCatalogInitialKeys.join(", "),
       placeholder: "provider/model, other-provider/model",
     });
     const parsed = (raw ?? "")
@@ -649,10 +713,6 @@ export async function promptModelAllowlist(params: {
     return { models: normalizeModelKeys(parsed) };
   }
 
-  const aliasIndex = buildModelAliasIndex({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-  });
   const hasAuth = createProviderAuthChecker({ cfg, agentDir: params.agentDir });
   const matchesPreferredProvider = preferredProvider
     ? createPreferredProviderMatcher({
@@ -678,12 +738,20 @@ export async function promptModelAllowlist(params: {
     : preferredProvider
       ? filteredCatalog.map((entry) => modelKey(entry.provider, entry.id))
       : undefined;
+  const scopeKeySet = scopeKeys ? new Set(scopeKeys) : null;
+  const selectableInitialSeeds =
+    scopeKeySet && !allowedKeySet
+      ? initialSeeds.filter((key) => scopeKeySet.has(key))
+      : initialSeeds;
+  const initialKeys = allowedKeySet
+    ? initialSeeds.filter((key) => allowedKeySet.has(key))
+    : selectableInitialSeeds.filter(isModelPickerVisibleModelRef);
 
   for (const entry of filteredCatalog) {
     addModelSelectOption({ entry, options, seen, aliasIndex, hasAuth });
   }
 
-  const supplementalKeys = (allowedKeySet ? allowedKeys : existingKeys).filter(
+  const supplementalKeys = (allowedKeySet ? allowedKeys : selectableInitialSeeds).filter(
     isModelPickerVisibleModelRef,
   );
   for (const key of supplementalKeys) {
@@ -813,9 +881,12 @@ export function applyModelAllowlist(
 export function applyModelFallbacksFromSelection(
   cfg: OpenClawConfig,
   selection: string[],
+  opts: { scopeKeys?: string[] } = {},
 ): OpenClawConfig {
   const normalized = normalizeModelKeys(selection);
-  if (normalized.length <= 1) {
+  const scopeKeys = opts.scopeKeys ? normalizeModelKeys(opts.scopeKeys) : [];
+  const scopeKeySet = scopeKeys.length > 0 ? new Set(scopeKeys) : null;
+  if (normalized.length === 0 && !scopeKeySet) {
     return cfg;
   }
 
@@ -825,7 +896,8 @@ export function applyModelFallbacksFromSelection(
     defaultModel: DEFAULT_MODEL,
   });
   const resolvedKey = modelKey(resolved.provider, resolved.model);
-  if (!normalized.includes(resolvedKey)) {
+  const includesResolvedPrimary = normalized.includes(resolvedKey);
+  if (!includesResolvedPrimary && !scopeKeySet) {
     return cfg;
   }
 
@@ -837,20 +909,115 @@ export function applyModelFallbacksFromSelection(
       : existingModel && typeof existingModel === "object"
         ? existingModel.primary
         : undefined;
+  const preservedModelFields =
+    existingModel && typeof existingModel === "object"
+      ? (({ fallbacks: _oldFallbacks, ...rest }) => rest)(existingModel)
+      : {};
 
-  const fallbacks = normalized.filter((key) => key !== resolvedKey);
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: resolved.provider,
+  });
+  const existingFallbacks =
+    existingModel && typeof existingModel === "object" && Array.isArray(existingModel.fallbacks)
+      ? resolveFallbackModelKeys({
+          cfg,
+          rawFallbacks: existingModel.fallbacks,
+          defaultProvider: resolved.provider,
+          aliasIndex,
+        })
+      : [];
+  const existingFallbackSet = new Set(existingFallbacks);
+  const rawSelectedFallbacks = normalized.filter((key) => key !== resolvedKey);
+  const selectedFallbacks =
+    scopeKeySet && !includesResolvedPrimary
+      ? rawSelectedFallbacks.filter((key) => existingFallbackSet.has(key))
+      : rawSelectedFallbacks;
+  const fallbacks = scopeKeySet
+    ? mergeScopedFallbackSelection({
+        existingFallbacks,
+        selectedFallbacks,
+        scopeKeySet,
+      })
+    : mergeUnscopedFallbackSelection({
+        existingFallbacks,
+        selectedFallbacks,
+      });
+  const nextModel = {
+    ...preservedModelFields,
+    ...(existingPrimary != null ? { primary: existingPrimary } : {}),
+    ...(fallbacks.length > 0 ? { fallbacks } : {}),
+  };
+  if (Object.keys(nextModel).length === 0) {
+    if (!defaults || !Object.hasOwn(defaults, "model")) {
+      return cfg;
+    }
+    const { model: _ignoredModel, ...restDefaults } = defaults;
+    return {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        defaults: restDefaults,
+      },
+    };
+  }
   return {
     ...cfg,
     agents: {
       ...cfg.agents,
       defaults: {
         ...defaults,
-        model: {
-          ...(typeof existingModel === "object" ? existingModel : undefined),
-          ...(existingPrimary != null ? { primary: existingPrimary } : {}),
-          fallbacks,
-        },
+        model: nextModel,
       },
     },
   };
+}
+
+function mergeScopedFallbackSelection(params: {
+  existingFallbacks: string[];
+  selectedFallbacks: string[];
+  scopeKeySet: Set<string>;
+}): string[] {
+  const selected = new Set(params.selectedFallbacks);
+  const fallbacks: string[] = [];
+  for (const fallback of params.existingFallbacks) {
+    if (!params.scopeKeySet.has(fallback)) {
+      fallbacks.push(fallback);
+      continue;
+    }
+    if (selected.delete(fallback)) {
+      fallbacks.push(fallback);
+    }
+  }
+  for (const fallback of params.selectedFallbacks) {
+    if (selected.has(fallback)) {
+      fallbacks.push(fallback);
+    }
+  }
+  return fallbacks;
+}
+
+function mergeUnscopedFallbackSelection(params: {
+  existingFallbacks: string[];
+  selectedFallbacks: string[];
+}): string[] {
+  const selected = new Set(params.selectedFallbacks);
+  const fallbacks: string[] = [];
+  for (const fallback of params.existingFallbacks) {
+    if (!isModelPickerVisibleModelRef(fallback)) {
+      fallbacks.push(fallback);
+      // Defensive: future callers may pass a hidden fallback in the selected list.
+      selected.delete(fallback);
+      continue;
+    }
+    if (selected.delete(fallback)) {
+      fallbacks.push(fallback);
+    }
+  }
+  for (const fallback of params.selectedFallbacks) {
+    if (selected.has(fallback)) {
+      fallbacks.push(fallback);
+    }
+  }
+  return fallbacks;
 }


### PR DESCRIPTION
## Summary

AI-assisted: Codex authored the patch, ran local validation, and ran `codex review --base origin/main` after rebasing.

- Problem: configure/model allowlist updates could leave stale `agents.defaults.model.fallbacks` after a user deselected fallback models.
- Why it matters: the gateway could still fail over to models the user intentionally removed from the picker.
- What changed: the model picker now seeds existing fallback refs into visible selections, applies fallback reconciliation before allowlist pruning, clears deselected visible fallbacks, and preserves scoped, out-of-scope, hidden, and alias-backed fallback entries correctly.
- What did NOT change (scope boundary): no provider catalog, auth credential, runtime failover policy, or config schema behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: configure applied the allowlist without reconciling `agents.defaults.model.fallbacks` for singleton or scoped selections, so stale fallback refs survived after users removed them from the picker. In scoped provider flows, fallback aliases also needed to be resolved before allowlist pruning could remove their alias metadata.
- Missing detection / guardrail: tests did not cover deselecting all visible fallbacks, scoped provider selections, no-catalog allowlist prompts, or alias-backed fallback removal.
- Contributing context (if known): this surfaced while configuring GPT-5.5 routes, where stale fallback candidates made the gateway continue attempting models that were no longer selected.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/model-picker.test.ts`, `src/commands/configure.gateway-auth.prompt-auth-config.test.ts`
- Scenario the test should lock in: selecting only the primary clears visible fallbacks; scoped provider updates remove only in-scope fallbacks; hidden/out-of-scope fallbacks are preserved; fallback aliases are resolved before allowlist pruning.
- Why this is the smallest reliable guardrail: these tests exercise the pure picker/config merge helpers and the configure ordering that caused the stale fallback state.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw configure` and provider auth setup now keep `agents.defaults.model.fallbacks` aligned with the model allowlist selection. Deselecting a visible fallback removes it from fallback routing; hidden legacy refs and out-of-scope provider fallbacks are preserved.

## Diagram (if applicable)

```text
Before:
[select only primary] -> [allowlist updated] -> [old fallbacks still configured]

After:
[select only primary] -> [fallbacks reconciled] -> [allowlist updated] -> [stale fallback removed]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node via pnpm, local repo commands
- Model/provider: OpenAI/OpenAI Codex model refs in config tests
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model.primary` with one or more `fallbacks`, plus `agents.defaults.models` aliases

### Steps

1. Start with `agents.defaults.model` containing a primary model and fallback refs.
2. Run the configure/provider allowlist path and select only the primary or remove an in-scope fallback.
3. Inspect the resulting config or fallback candidates.

### Expected

- Visible deselected fallbacks are removed from `agents.defaults.model.fallbacks`.
- Hidden or out-of-scope fallback refs remain intact.
- Alias-backed fallback refs are resolved before allowlist pruning.

### Actual

- Before this fix, stale fallback refs could remain configured after the picker selection removed them.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

User logs showed the gateway still attempting stale fallback candidates after configure changes. Added regression coverage now passes for singleton, scoped, alias, no-catalog, and hidden legacy fallback cases.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused picker/configure tests, changed-surface tests, typecheck/lint/guard lanes, and local `codex review --base origin/main` after rebasing.
- Edge cases checked: singleton primary selection, scoped provider allowlists, empty scoped selections, fallback aliases, hidden legacy runtime refs, out-of-scope fallbacks, and no-catalog allowlist prompts.
- What you did **not** verify: a live Telegram/gateway round trip with real GPT-5.5 credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations were open when this body was updated.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: fallback reconciliation could remove a fallback the user expected to keep.
  - Mitigation: scoped updates preserve out-of-scope fallbacks, unscoped updates preserve hidden legacy runtime refs, and tests cover both paths.