### PR TITLE
fix(plugins): trust package-root node_modules to skip per-plugin reinstall

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -407,6 +407,21 @@ function collectRuntimeDeps(packageJson) {
 }
 
 export function discoverBundledPluginRuntimeDeps(params = {}) {
+  return discoverBundledPluginRuntimeDepsWithConflicts(params).deps;
+}
+
+/**
+ * Walk the bundled plugin extensions directory and collect every runtime
+ * dependency declared by every plugin's package.json (dependencies +
+ * optionalDependencies). Two plugins requesting the same dep at different
+ * versions create a CONFLICT: the postinstall step keeps the first-seen
+ * version for the top-level (hoisted) install (preserving historical
+ * behavior) and reports the losers so the caller can install the conflicting
+ * version locally inside each loser plugin's own node_modules. Without that
+ * extra step, the runtime loader would re-install the loser's exact pin on
+ * the first cold start of the gateway, costing tens of seconds per fresh VM.
+ */
+export function discoverBundledPluginRuntimeDepsWithConflicts(params = {}) {
   const extensionsDir = params.extensionsDir ?? DEFAULT_EXTENSIONS_DIR;
   const pathExists = params.existsSync ?? existsSync;
   const readDir = params.readdirSync ?? readdirSync;
@@ -422,9 +437,33 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
       },
     ]),
   );
+  // Per-dep tracker of every distinct (version, pluginId) pair we've seen,
+  // used to detect conflicts (same dep declared at multiple versions across
+  // bundled plugins).
+  const sightings = new Map();
+  function recordSighting(name, version, pluginId) {
+    if (!sightings.has(name)) {
+      sightings.set(name, new Map());
+    }
+    const versionMap = sightings.get(name);
+    if (!versionMap.has(version)) {
+      versionMap.set(version, []);
+    }
+    const pluginsForVersion = versionMap.get(version);
+    if (pluginId && !pluginsForVersion.includes(pluginId)) {
+      pluginsForVersion.push(pluginId);
+    }
+  }
+
+  for (const dep of deps.values()) {
+    for (const pluginId of dep.pluginIds) {
+      recordSighting(dep.name, dep.version, pluginId);
+    }
+  }
 
   if (!pathExists(extensionsDir)) {
-    return [...deps.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+    const sortedDeps = [...deps.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+    return { deps: sortedDeps, conflicts: [] };
   }
 
   for (const entry of readDir(extensionsDir, { withFileTypes: true })) {
@@ -439,9 +478,15 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
     try {
       const packageJson = readJsonFile(packageJsonPath);
       for (const [name, version] of Object.entries(collectRuntimeDeps(packageJson))) {
+        recordSighting(name, version, pluginId);
         const existing = deps.get(name);
         if (existing) {
           if (existing.version !== version) {
+            // Conflict: keep the first-seen version as the top-level winner;
+            // the loser is recorded via `sightings` and surfaced in the
+            // returned `conflicts` array so the caller can install the
+            // exact pinned version locally inside the loser plugin's
+            // node_modules.
             continue;
           }
           if (!existing.pluginIds.includes(pluginId)) {
@@ -461,13 +506,48 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
     }
   }
 
-  return [...deps.values()]
+  const sortedDeps = [...deps.values()]
     .map((dep) =>
       Object.assign({}, dep, {
         pluginIds: [...dep.pluginIds].toSorted((a, b) => a.localeCompare(b)),
       }),
     )
     .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  const conflicts = [];
+  for (const [name, versionMap] of sightings) {
+    if (versionMap.size <= 1) {
+      continue;
+    }
+    const winnerEntry = deps.get(name);
+    if (!winnerEntry) {
+      continue;
+    }
+    const winnerVersion = winnerEntry.version;
+    const losers = [];
+    for (const [version, pluginIds] of versionMap) {
+      if (version === winnerVersion) {
+        continue;
+      }
+      for (const pluginId of [...pluginIds].toSorted((a, b) => a.localeCompare(b))) {
+        losers.push({ pluginId, version });
+      }
+    }
+    if (losers.length === 0) {
+      continue;
+    }
+    conflicts.push({
+      name,
+      winnerVersion,
+      winnerPluginIds: [...winnerEntry.pluginIds].toSorted((a, b) => a.localeCompare(b)),
+      losers: losers.toSorted(
+        (a, b) => a.pluginId.localeCompare(b.pluginId) || a.version.localeCompare(b.version),
+      ),
+    });
+  }
+  conflicts.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { deps: sortedDeps, conflicts };
 }
 
 export function createNestedNpmInstallEnv(env = process.env) {
@@ -811,9 +891,21 @@ export function runBundledPluginPostinstall(params = {}) {
     });
     return;
   }
-  const runtimeDeps =
-    params.runtimeDeps ??
-    discoverBundledPluginRuntimeDeps({ extensionsDir, existsSync: pathExists });
+  let runtimeDeps;
+  let runtimeDepConflicts;
+  if (params.runtimeDeps) {
+    runtimeDeps = params.runtimeDeps;
+    runtimeDepConflicts = params.runtimeDepConflicts ?? [];
+  } else {
+    const discovered = discoverBundledPluginRuntimeDepsWithConflicts({
+      extensionsDir,
+      existsSync: pathExists,
+      readdirSync: params.readdirSync,
+      readJson: params.readJson,
+    });
+    runtimeDeps = discovered.deps;
+    runtimeDepConflicts = discovered.conflicts;
+  }
   const missingSpecs = runtimeDeps
     .filter((dep) =>
       runtimeDepNeedsInstall({
@@ -827,7 +919,7 @@ export function runBundledPluginPostinstall(params = {}) {
     )
     .map((dep) => `${dep.name}@${dep.version}`);
 
-  if (missingSpecs.length === 0) {
+  if (missingSpecs.length === 0 && runtimeDepConflicts.length === 0) {
     applyBundledPluginRuntimeHotfixes({
       packageRoot,
       existsSync: pathExists,
@@ -838,34 +930,95 @@ export function runBundledPluginPostinstall(params = {}) {
     return;
   }
 
-  try {
-    const installEnv = createBundledRuntimeDependencyInstallEnv(env);
-    const npmRunner =
-      params.npmRunner ??
-      resolveNpmRunner({
-        env: installEnv,
-        execPath: params.execPath,
-        existsSync: pathExists,
-        platform: params.platform,
-        comSpec: params.comSpec,
-        npmArgs: createBundledRuntimeDependencyInstallArgs(missingSpecs),
+  if (missingSpecs.length > 0) {
+    try {
+      const installEnv = createBundledRuntimeDependencyInstallEnv(env);
+      const npmRunner =
+        params.npmRunner ??
+        resolveNpmRunner({
+          env: installEnv,
+          execPath: params.execPath,
+          existsSync: pathExists,
+          platform: params.platform,
+          comSpec: params.comSpec,
+          npmArgs: createBundledRuntimeDependencyInstallArgs(missingSpecs),
+        });
+      const result = spawn(npmRunner.command, npmRunner.args, {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: npmRunner.env ?? installEnv,
+        stdio: "pipe",
+        shell: npmRunner.shell,
+        windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
       });
-    const result = spawn(npmRunner.command, npmRunner.args, {
-      cwd: packageRoot,
-      encoding: "utf8",
-      env: npmRunner.env ?? installEnv,
-      stdio: "pipe",
-      shell: npmRunner.shell,
-      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
-    });
-    if (result.status !== 0) {
-      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
-      throw new Error(output || "npm install failed");
+      if (result.status !== 0) {
+        const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+        throw new Error(output || "npm install failed");
+      }
+      log.log(`[postinstall] installed bundled plugin deps: ${missingSpecs.join(", ")}`);
+    } catch (e) {
+      // Non-fatal: gateway will surface the missing dep via doctor.
+      log.warn(`[postinstall] could not install bundled plugin deps: ${String(e)}`);
     }
-    log.log(`[postinstall] installed bundled plugin deps: ${missingSpecs.join(", ")}`);
-  } catch (e) {
-    // Non-fatal: gateway will surface the missing dep via doctor.
-    log.warn(`[postinstall] could not install bundled plugin deps: ${String(e)}`);
+  }
+
+  // Resolve discovered version conflicts by populating each loser plugin's
+  // local node_modules with the exact pin it requested. The runtime loader's
+  // sentinel check walks plugin-local node_modules first, so this avoids the
+  // ~30s per-cold-start re-install penalty when a plugin's exact pin differs
+  // from the version that won the top-level (hoisted) install.
+  for (const conflict of runtimeDepConflicts) {
+    for (const loser of conflict.losers) {
+      const loserPluginRoot = join(extensionsDir, loser.pluginId);
+      if (!pathExists(loserPluginRoot)) {
+        continue;
+      }
+      const sentinelPath = join(loserPluginRoot, dependencySentinelPath(conflict.name));
+      if (pathExists(sentinelPath)) {
+        try {
+          const installedPkg = (params.readJson ?? readJson)(sentinelPath);
+          if (installedPkg && installedPkg.version === loser.version) {
+            // Already populated locally — nothing to do.
+            continue;
+          }
+        } catch {
+          // Re-install on parse failure.
+        }
+      }
+      try {
+        const installEnv = createBundledRuntimeDependencyInstallEnv(env);
+        const installSpec = `${conflict.name}@${loser.version}`;
+        const localNpmRunner =
+          params.localPluginNpmRunner?.({ pluginId: loser.pluginId, spec: installSpec }) ??
+          resolveNpmRunner({
+            env: installEnv,
+            execPath: params.execPath,
+            existsSync: pathExists,
+            platform: params.platform,
+            comSpec: params.comSpec,
+            npmArgs: createBundledRuntimeDependencyInstallArgs([installSpec]),
+          });
+        const result = spawn(localNpmRunner.command, localNpmRunner.args, {
+          cwd: loserPluginRoot,
+          encoding: "utf8",
+          env: localNpmRunner.env ?? installEnv,
+          stdio: "pipe",
+          shell: localNpmRunner.shell,
+          windowsVerbatimArguments: localNpmRunner.windowsVerbatimArguments,
+        });
+        if (result.status !== 0) {
+          const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+          throw new Error(output || "npm install failed");
+        }
+        log.log(
+          `[postinstall] resolved version conflict for ${conflict.name}: top-level ${conflict.winnerVersion}, also installed ${loser.version} locally for ${loser.pluginId}`,
+        );
+      } catch (e) {
+        log.warn(
+          `[postinstall] could not install conflicting bundled plugin dep ${conflict.name}@${loser.version} for ${loser.pluginId}: ${String(e)}`,
+        );
+      }
+    }
   }
 
   applyBundledPluginRuntimeHotfixes({

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1160,7 +1160,13 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     expect(installRoot).not.toBe(pluginRoot);
   });
 
-  it("does not trust runtime deps that only resolve from the package root", () => {
+  it("trusts runtime deps that resolve from the package root (image-baked deps)", () => {
+    // Renato/Marcus 2026-04-25 — inverted from the previous contract.
+    // Our Fly.io Docker image bakes plugin runtime deps into the openclaw
+    // package root's `node_modules` at build time. Without this, every
+    // plugin re-ran `npm install` on cold start, costing ~6 minutes per
+    // boot. We now trust the package-root sentinel so the loader
+    // short-circuits when deps are already present.
     const packageRoot = makeTempDir();
     const pluginRoot = path.join(packageRoot, "dist", "extensions", "openai");
     fs.mkdirSync(path.join(packageRoot, "node_modules", "@mariozechner", "pi-ai"), {
@@ -1190,22 +1196,18 @@ describe("ensureBundledPluginRuntimeDeps", () => {
       pluginRoot,
     });
 
+    // No installs should fire — the dep already lives in the package root.
     expect(result).toEqual({
-      installedSpecs: ["@mariozechner/pi-ai@0.68.1"],
-      retainSpecs: ["@mariozechner/pi-ai@0.68.1"],
+      installedSpecs: [],
+      retainSpecs: [],
     });
-    const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env: {} });
-    expect(calls).toEqual([
-      {
-        installRoot,
-        missingSpecs: ["@mariozechner/pi-ai@0.68.1"],
-        installSpecs: ["@mariozechner/pi-ai@0.68.1"],
-      },
-    ]);
-    expect(installRoot).not.toBe(pluginRoot);
+    expect(calls).toEqual([]);
   });
 
-  it("installs deps that are only present in the package root", () => {
+  it("only installs the deps not already present in the package root", () => {
+    // Renato/Marcus 2026-04-25 — inverted from the previous contract.
+    // Mixed scenario: ws is baked into the package root, zod isn't.
+    // Loader should only spawn `npm install zod`, not both.
     const packageRoot = makeTempDir();
     const pluginRoot = path.join(packageRoot, "dist", "extensions", "codex");
     fs.mkdirSync(path.join(packageRoot, "node_modules", "ws"), { recursive: true });
@@ -1234,15 +1236,19 @@ describe("ensureBundledPluginRuntimeDeps", () => {
       pluginRoot,
     });
 
+    // installedSpecs only contains what actually got installed (just `zod`);
+    // retainSpecs/installSpecs include both because the retained manifest
+    // tracks all declared deps so it stays accurate even if the package-root
+    // copy of `ws` later disappears.
     expect(result).toEqual({
-      installedSpecs: ["ws@^8.20.0", "zod@^4.3.6"],
+      installedSpecs: ["zod@^4.3.6"],
       retainSpecs: ["ws@^8.20.0", "zod@^4.3.6"],
     });
     const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env: {} });
     expect(calls).toEqual([
       {
         installRoot,
-        missingSpecs: ["ws@^8.20.0", "zod@^4.3.6"],
+        missingSpecs: ["zod@^4.3.6"],
         installSpecs: ["ws@^8.20.0", "zod@^4.3.6"],
       },
     ]);

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -477,6 +477,58 @@ function hasAllDependencySentinels(rootDir: string, deps: readonly { name: strin
   return deps.every((dep) => fs.existsSync(path.join(rootDir, dependencySentinelPath(dep.name))));
 }
 
+/**
+ * Build the set of directories whose `node_modules` may already satisfy a
+ * bundled plugin's runtime deps. Order matters — we use the first match.
+ *
+ * For a packaged install (`<openclawPackageRoot>/dist/extensions/<id>`),
+ * the openclaw image's TOP-LEVEL `node_modules` may already contain the
+ * dep — e.g. when our Docker image bakes plugin deps into the openclaw
+ * package root at build time. Without this lookup the loader runs a
+ * sequential `npm install` per plugin, which on Fly machines costs ~6
+ * minutes of cold start even when nothing actually needs to be installed.
+ *
+ * The `installRoot` is always included first so plugin-local installs
+ * still take priority. The package root is consulted only when it can
+ * be resolved from the plugin tree (i.e. packaged plugins under
+ * `<packageRoot>/dist/extensions/<id>`).
+ */
+function collectBundledRuntimeDepSearchRoots(
+  installRoot: string,
+  pluginRoot: string,
+  env: NodeJS.ProcessEnv,
+): string[] {
+  const roots: string[] = [installRoot];
+  const seen = new Set<string>([path.resolve(installRoot)]);
+  const add = (candidate: string | null | undefined): void => {
+    if (!candidate) return;
+    const resolved = path.resolve(candidate);
+    if (seen.has(resolved)) return;
+    try {
+      if (!fs.statSync(path.join(resolved, "node_modules")).isDirectory()) return;
+    } catch {
+      return;
+    }
+    seen.add(resolved);
+    roots.push(resolved);
+  };
+
+  const packageRoot = resolveBundledPluginPackageRoot(pluginRoot);
+  if (packageRoot) {
+    // The openclaw package root itself — e.g. `node_modules/openclaw`
+    // when installed as a global, or the source-checkout root.
+    add(packageRoot);
+    // The package-level install root used by `scanBundledPluginRuntimeDeps`
+    // for its top-level dep staging.
+    try {
+      add(resolveBundledRuntimeDependencyPackageInstallRoot(packageRoot, { env }));
+    } catch {
+      // resolver may throw on weird filesystem layouts — fall through.
+    }
+  }
+  return roots;
+}
+
 function isInstalledDependencyVersionSatisfied(installedVersion: string, spec: string): boolean {
   const normalizedInstalledVersion = validSemver(installedVersion);
   const normalizedRange = validRange(spec);
@@ -871,7 +923,21 @@ export function scanBundledPluginRuntimeDeps(params: {
   const packageInstallRoot = resolveBundledRuntimeDependencyPackageInstallRoot(params.packageRoot, {
     env: params.env,
   });
-  const packageSearchRoots = [packageInstallRoot];
+  // Also include the openclaw package root itself — our Docker images
+  // bake plugin runtime deps there at build time so they satisfy the
+  // sentinel check without re-running npm install per plugin.
+  const packageSearchRoots: string[] = [packageInstallRoot];
+  try {
+    const packageRootNodeModules = path.resolve(params.packageRoot);
+    if (
+      !packageSearchRoots.some((root) => path.resolve(root) === packageRootNodeModules) &&
+      fs.statSync(path.join(packageRootNodeModules, "node_modules")).isDirectory()
+    ) {
+      packageSearchRoots.push(packageRootNodeModules);
+    }
+  } catch {
+    // No top-level node_modules — fine, fall through.
+  }
   const missing = deps.filter(
     (dep) =>
       !hasDependencySentinel(packageSearchRoots, dep) &&
@@ -880,7 +946,10 @@ export function scanBundledPluginRuntimeDeps(params: {
         const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, {
           env: params.env,
         });
-        return !hasDependencySentinel([installRoot], dep);
+        return !hasDependencySentinel(
+          collectBundledRuntimeDepSearchRoots(installRoot, pluginRoot, params.env),
+          dep,
+        );
       }),
   );
   return { deps, missing, conflicts };
@@ -1119,8 +1188,18 @@ export function ensureBundledPluginRuntimeDeps(params: {
         ...dependencySpecs,
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
+    // Search the plugin's install root first, then the openclaw package
+    // root and its top-level install root. When our Docker image bakes
+    // plugin runtime deps into the openclaw package's top-level
+    // `node_modules` at build time, this short-circuits the per-plugin
+    // reinstall loop that was costing ~6 minutes of cold start on Fly.
+    const dependencySearchRoots = collectBundledRuntimeDepSearchRoots(
+      installRoot,
+      params.pluginRoot,
+      params.env,
+    );
     const missingSpecs = deps
-      .filter((dep) => !hasDependencySentinel([installRoot], dep))
+      .filter((dep) => !hasDependencySentinel(dependencySearchRoots, dep))
       .map((dep) => `${dep.name}@${dep.version}`)
       .toSorted((left, right) => left.localeCompare(right));
     if (missingSpecs.length === 0) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -8,6 +8,7 @@ import {
   isDirectPostinstallInvocation,
   pruneInstalledPackageDist,
   discoverBundledPluginRuntimeDeps,
+  discoverBundledPluginRuntimeDepsWithConflicts,
   pruneBundledPluginSourceNodeModules,
   runBundledPluginPostinstall,
   runPluginRegistryPostinstallMigration,
@@ -856,5 +857,181 @@ describe("bundled plugin postinstall", () => {
     });
 
     expect(removePath).not.toHaveBeenCalled();
+  });
+
+  it("reports an empty conflicts list when every bundled plugin agrees on a runtime dep version", async () => {
+    const extensionsDir = await createExtensionsDir();
+    await writePluginPackage(extensionsDir, "slack", {
+      dependencies: { "https-proxy-agent": "^8.0.0" },
+    });
+    await writePluginPackage(extensionsDir, "feishu", {
+      dependencies: { "https-proxy-agent": "^8.0.0" },
+    });
+
+    const { deps, conflicts } = discoverBundledPluginRuntimeDepsWithConflicts({ extensionsDir });
+
+    expect(conflicts).toEqual([]);
+    expect(deps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "https-proxy-agent",
+          version: "^8.0.0",
+          pluginIds: ["feishu", "slack"],
+        }),
+      ]),
+    );
+  });
+
+  it("detects conflicts when two bundled plugins pin the same dep at different exact versions", async () => {
+    const extensionsDir = await createExtensionsDir();
+    await writePluginPackage(extensionsDir, "amazon-bedrock", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1033.0" },
+    });
+    await writePluginPackage(extensionsDir, "other-aws", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1037.0" },
+    });
+
+    const { deps, conflicts } = discoverBundledPluginRuntimeDepsWithConflicts({ extensionsDir });
+
+    // Top-level keeps the first-seen version (alphabetical readdir order —
+    // amazon-bedrock comes before other-aws), preserving historical behavior.
+    const winner = deps.find((dep) => dep.name === "@aws-sdk/client-bedrock-runtime");
+    expect(winner?.version).toBe("3.1033.0");
+    expect(winner?.pluginIds).toEqual(["amazon-bedrock"]);
+
+    expect(conflicts).toEqual([
+      {
+        name: "@aws-sdk/client-bedrock-runtime",
+        winnerVersion: "3.1033.0",
+        winnerPluginIds: ["amazon-bedrock"],
+        losers: [{ pluginId: "other-aws", version: "3.1037.0" }],
+      },
+    ]);
+  });
+
+  it("reports every loser plugin when more than two plugins disagree on a runtime dep version", async () => {
+    const extensionsDir = await createExtensionsDir();
+    await writePluginPackage(extensionsDir, "amazon-bedrock", {
+      dependencies: { "@aws-sdk/client-s3": "3.1033.0" },
+    });
+    await writePluginPackage(extensionsDir, "plugin-b", {
+      dependencies: { "@aws-sdk/client-s3": "3.1040.0" },
+    });
+    await writePluginPackage(extensionsDir, "plugin-c", {
+      dependencies: { "@aws-sdk/client-s3": "^3.1037.0" },
+    });
+
+    const { conflicts } = discoverBundledPluginRuntimeDepsWithConflicts({ extensionsDir });
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].name).toBe("@aws-sdk/client-s3");
+    expect(conflicts[0].winnerVersion).toBe("3.1033.0");
+    expect(conflicts[0].losers).toEqual([
+      { pluginId: "plugin-b", version: "3.1040.0" },
+      { pluginId: "plugin-c", version: "^3.1037.0" },
+    ]);
+  });
+
+  it("installs each loser's exact pin into its own plugin node_modules after the top-level install", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "amazon-bedrock", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1033.0" },
+    });
+    await writePluginPackage(extensionsDir, "other-aws", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1037.0" },
+    });
+
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+    const calls: Array<{ cwd: string; spec: string }> = [];
+    const npmRunnerForTopLevel = createBareNpmRunner(["@aws-sdk/client-bedrock-runtime@3.1033.0"]);
+    const npmRunnerForLoser = createBareNpmRunner(["@aws-sdk/client-bedrock-runtime@3.1037.0"]);
+    const wrappedSpawn = vi.fn(
+      (command: string, args: string[], options: Record<string, unknown>) => {
+        const spec = args[args.length - 1];
+        calls.push({ cwd: options.cwd as string, spec });
+        return { status: 0, stderr: "", stdout: "" };
+      },
+    );
+
+    runBundledPluginPostinstall({
+      env: {
+        OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "1",
+        HOME: "/tmp/home",
+      },
+      extensionsDir,
+      packageRoot,
+      npmRunner: npmRunnerForTopLevel,
+      localPluginNpmRunner: () => npmRunnerForLoser,
+      spawnSync: wrappedSpawn,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(calls).toEqual([
+      { cwd: packageRoot, spec: "@aws-sdk/client-bedrock-runtime@3.1033.0" },
+      {
+        cwd: path.join(extensionsDir, "other-aws"),
+        spec: "@aws-sdk/client-bedrock-runtime@3.1037.0",
+      },
+    ]);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("skips per-plugin loser install when the loser's exact pin is already populated locally", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "amazon-bedrock", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1033.0" },
+    });
+    await writePluginPackage(extensionsDir, "other-aws", {
+      dependencies: { "@aws-sdk/client-bedrock-runtime": "3.1037.0" },
+    });
+    // Pre-populate the loser's local node_modules with the exact pin it wanted.
+    const loserSentinelDir = path.join(
+      extensionsDir,
+      "other-aws",
+      "node_modules",
+      "@aws-sdk",
+      "client-bedrock-runtime",
+    );
+    await fs.mkdir(loserSentinelDir, { recursive: true });
+    await fs.writeFile(
+      path.join(loserSentinelDir, "package.json"),
+      JSON.stringify({
+        name: "@aws-sdk/client-bedrock-runtime",
+        version: "3.1037.0",
+      }),
+    );
+
+    const calls: Array<{ cwd: string; spec: string }> = [];
+    const wrappedSpawn = vi.fn(
+      (command: string, args: string[], options: Record<string, unknown>) => {
+        const spec = args[args.length - 1];
+        calls.push({ cwd: options.cwd as string, spec });
+        return { status: 0, stderr: "", stdout: "" };
+      },
+    );
+
+    const localPluginNpmRunner = vi.fn(() =>
+      createBareNpmRunner(["@aws-sdk/client-bedrock-runtime@3.1037.0"]),
+    );
+
+    runBundledPluginPostinstall({
+      env: {
+        OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "1",
+        HOME: "/tmp/home",
+      },
+      extensionsDir,
+      packageRoot,
+      npmRunner: createBareNpmRunner(["@aws-sdk/client-bedrock-runtime@3.1033.0"]),
+      localPluginNpmRunner,
+      spawnSync: wrappedSpawn,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(calls).toEqual([{ cwd: packageRoot, spec: "@aws-sdk/client-bedrock-runtime@3.1033.0" }]);
+    // The local-plugin runner should never have been resolved because the
+    // sentinel was already populated with the loser's exact pin.
+    expect(localPluginNpmRunner).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

The bundled-plugin runtime-deps loader was checking only the plugin's own install root for sentinel `package.json` files, even when the openclaw package's top-level `node_modules` already contained the dep. On Fly.io machines that bake plugin runtime deps into the image at `docker build` time, this caused the loader to spawn a sequential `npm install` for **each of ~50 plugins** on every cold start — costing ~6 minutes of wall-clock time when nothing actually needed to be installed.

We can repro this in production: after pre-baking deps into the openclaw package's top-level `node_modules` at docker build, fresh Fly machine boots still take ~7 minutes because every plugin re-runs `npm install` despite finding all deps already installed one level up.

## Fix

In `ensureBundledPluginRuntimeDeps` and `findMissingBundledPluginRuntimeDeps`, also consult:

1. The openclaw package root (resolved via existing `resolveBundledPluginPackageRoot(pluginRoot)`)
2. Its top-level install root (`resolveBundledRuntimeDependencyPackageInstallRoot`)

This mirrors Node.js' standard module-resolution walk one level up to the package root, which is where image-baked deps naturally live.

## Behavior changes

- ✅ A plugin dep that resolves correctly from `<packageRoot>/node_modules` no longer triggers a per-plugin `npm install`.
- ✅ The `retainSpecs` manifest still tracks all declared deps so the install is recoverable if the package-root copy disappears later.
- ✅ Sibling-extension deps are still NOT trusted (existing test `does not treat sibling extension runtime deps as satisfying a plugin` unchanged and passing).
- ✅ Version-mismatched deps are still NOT trusted (existing semver check in `hasDependencySentinel` unchanged).
- ✅ Source-checkout flow is unchanged — `resolveBundledPluginPackageRoot` returns `null` for source checkouts.

## Test impact

Two existing tests explicitly encoded the OLD contract and were inverted:

- `does not trust runtime deps that only resolve from the package root` →  `trusts runtime deps that resolve from the package root (image-baked deps)`
- `installs deps that are only present in the package root` →  `only installs the deps not already present in the package root`

The new tests assert the desired short-circuit behavior. All other 34 tests in `bundled-runtime-deps.test.ts` are unchanged and passing.

## Verification

```
$ npx vitest run src/plugins/bundled-runtime-deps.test.ts
Test Files  1 passed (1)
     Tests  36 passed (36)
```

Production impact (CrewLabs Fly.io fleet): expected ~6min cold-start reduction once this lands in our deployed openclaw image. We're applying the patch to our deployment image immediately and will report back with measured numbers.