### PR TITLE
Update copyright year to 2025–2026

### DIFF
--- a/apps/macos/Sources/OpenClaw/AboutSettings.swift
+++ b/apps/macos/Sources/OpenClaw/AboutSettings.swift
@@ -77,7 +77,7 @@ struct AboutSettings: View {
                 }
             }
 
-            Text("© 2025 Peter Steinberger — MIT License.")
+            Text("© 2025–2026 Peter Steinberger — MIT License.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 4)


### PR DESCRIPTION
> 🤖 **AI-assisted PR** — see disclosure section below per CONTRIBUTING.md.

Tiny tweak: the About panel reads `© 2025 …` but the app's currently shipping in 2026 (e.g. v2026.4.22). Updates the visible copyright in `apps/macos/Sources/OpenClaw/AboutSettings.swift` from `© 2025` to `© 2025–2026`.

Used an en-dash for the year range to match the existing em-dash typography on the same line.

---

## AI-assisted disclosure

Per the project's [AI/Vibe-Coded PRs guidance](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md#aivibe-coded-prs-welcome-):

- [x] **Marked as AI-assisted** (banner above + this section)
- [x] **Tooling:** Claude (Sonnet 4.6 → Opus 4.7) via Claude Code; GitHub API used to fork, branch, commit, and open the PR
- [x] **Degree of testing: untested locally.** One-character substitution inside a `SwiftUI Text("...")` view — no logic change, no new symbols, no surrounding-view changes. No Swift build performed.
- [x] **I understand what the code does:** it changes the visible copyright string in the macOS app's About settings panel. That's the entirety of the change.
- [ ] Codex review not run.
- [x] Will resolve any bot review conversations after they post.

## Before / After

**Before** (currently shipping, e.g. v2026.4.22):
> © 2025 Peter Steinberger — MIT License.

**After** (this PR):
> © 2025–2026 Peter Steinberger — MIT License.

About-panel screenshot of the "before" state attached as a comment below.

## Note on CI

CI is red, but the failing checks (`ExecAllowlistMatcher.swift:17` and `ExecApprovals.swift:621` — SwiftFormat `wrapMultilineStatementBraces`) are present on `main` itself at HEAD (`c070509b`) and are unrelated to this PR. Not patching those per CONTRIBUTING guidance on known-main-CI failures.

## Scope

This is a one-character fix to a user-visible string. If maintainers consider it closer to drive-by polish than a small fix, happy to close — no attachment.
