### PR TITLE
fix(agents): prevent Bedrock replay death loop on empty assistant content

### DIFF
--- a/src/agents/pi-embedded-runner/replay-history.test.ts
+++ b/src/agents/pi-embedded-runner/replay-history.test.ts
@@ -1,0 +1,85 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { normalizeAssistantReplayContent } from "./replay-history.js";
+
+const FALLBACK_TEXT = "[assistant turn failed before producing content]";
+
+function bedrockAssistant(content: unknown): AgentMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "bedrock-converse-stream",
+    provider: "amazon-bedrock",
+    model: "anthropic.claude-3-haiku-20240307-v1:0",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "error",
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+function userMessage(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: 0 } as unknown as AgentMessage;
+}
+
+function openclawTranscriptAssistant(model: "delivery-mirror" | "gateway-injected"): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "channel mirror" }],
+    api: "openai-responses",
+    provider: "openclaw",
+    model,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+describe("normalizeAssistantReplayContent", () => {
+  it("converts assistant content: [] to a non-empty sentinel text block", () => {
+    const messages = [userMessage("hello"), bedrockAssistant([])];
+    const out = normalizeAssistantReplayContent(messages);
+    expect(out).not.toBe(messages);
+    const repaired = out[1] as AgentMessage & { content: { type: string; text: string }[] };
+    expect(repaired.content).toEqual([{ type: "text", text: FALLBACK_TEXT }]);
+  });
+
+  it("wraps legacy string assistant content as a single text block (regression)", () => {
+    const messages = [userMessage("hi"), bedrockAssistant("plain string content")];
+    const out = normalizeAssistantReplayContent(messages);
+    const wrapped = out[1] as AgentMessage & { content: { type: string; text: string }[] };
+    expect(wrapped.content).toEqual([{ type: "text", text: "plain string content" }]);
+  });
+
+  it("filters openclaw delivery-mirror and gateway-injected assistant messages from replay", () => {
+    const messages = [
+      userMessage("hello"),
+      openclawTranscriptAssistant("delivery-mirror"),
+      bedrockAssistant([{ type: "text", text: "real reply" }]),
+      openclawTranscriptAssistant("gateway-injected"),
+    ];
+    const out = normalizeAssistantReplayContent(messages);
+    expect(out).toHaveLength(2);
+    expect((out[0] as { role: string }).role).toBe("user");
+    expect((out[1] as { provider: string }).provider).toBe("amazon-bedrock");
+  });
+
+  it("returns the original array reference when nothing needs to change", () => {
+    const messages = [userMessage("hello"), bedrockAssistant([{ type: "text", text: "fine" }])];
+    const out = normalizeAssistantReplayContent(messages);
+    expect(out).toBe(messages);
+  });
+});

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -28,6 +28,7 @@ import {
   sanitizeToolUseResultPairing,
   stripToolResultDetails,
 } from "../session-transcript-repair.js";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../stream-message-shared.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import {
@@ -227,20 +228,65 @@ function stripStaleAssistantUsageBeforeLatestCompaction(messages: AgentMessage[]
   return touched ? out : messages;
 }
 
+// `provider:"openclaw"` assistant entries written by the channel-delivery
+// transcript mirror (`model:"delivery-mirror"`, see config/sessions/transcript.ts)
+// and by the Gateway transcript-inject helper (`model:"gateway-injected"`, see
+// gateway/server-methods/chat-transcript-inject.ts) are user-visible transcript
+// records, not model output. Replaying them to the actual provider duplicates
+// content and, on Bedrock or strict OpenAI-compatible providers, can also
+// trigger turn-ordering rejections.
+const TRANSCRIPT_ONLY_OPENCLAW_MODELS = new Set<string>(["delivery-mirror", "gateway-injected"]);
+
+function isTranscriptOnlyOpenclawAssistant(message: AgentMessage): boolean {
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  const provider = (message as { provider?: unknown }).provider;
+  const model = (message as { model?: unknown }).model;
+  return (
+    provider === "openclaw" &&
+    typeof model === "string" &&
+    TRANSCRIPT_ONLY_OPENCLAW_MODELS.has(model)
+  );
+}
+
 export function normalizeAssistantReplayContent(messages: AgentMessage[]): AgentMessage[] {
   let touched = false;
-  const out = [...messages];
-  for (let i = 0; i < out.length; i += 1) {
-    const message = out[i];
-    const replayContent = (message as { content?: unknown } | undefined)?.content;
-    if (!message || message.role !== "assistant" || typeof replayContent !== "string") {
+  const out: AgentMessage[] = [];
+  for (const message of messages) {
+    if (!message || message.role !== "assistant") {
+      out.push(message);
       continue;
     }
-    out[i] = {
-      ...message,
-      content: [{ type: "text", text: replayContent }],
-    };
-    touched = true;
+    if (isTranscriptOnlyOpenclawAssistant(message)) {
+      // Drop from the in-memory replay copy; the persisted JSONL keeps the
+      // entry so user-facing transcript surfaces are unchanged.
+      touched = true;
+      continue;
+    }
+    const replayContent = (message as { content?: unknown }).content;
+    if (typeof replayContent === "string") {
+      out.push({
+        ...message,
+        content: [{ type: "text", text: replayContent }],
+      });
+      touched = true;
+      continue;
+    }
+    if (Array.isArray(replayContent) && replayContent.length === 0) {
+      // Empty content arrays are the Bedrock-Converse replay poison: the
+      // provider validates that each assistant message carries at least one
+      // ContentBlock and rejects the whole request otherwise. Substitute a
+      // sentinel text block so replay succeeds and the failed turn is still
+      // visible to the model and to clients reading content.
+      out.push({
+        ...message,
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+      });
+      touched = true;
+      continue;
+    }
+    out.push(message);
   }
   return touched ? out : messages;
 }

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -97,4 +97,112 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.reason).toContain("failed to read session file");
     expect(warn).toHaveBeenCalledTimes(1);
   });
+
+  it("rewrites persisted assistant messages with empty content arrays", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const poisonedAssistantEntry = {
+      type: "message",
+      id: "msg-2",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [],
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        model: "anthropic.claude-3-haiku-20240307-v1:0",
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+        stopReason: "error",
+        errorMessage: "transient stream failure",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const warn = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedLines).toBe(0);
+    expect(result.rewrittenAssistantMessages).toBe(1);
+    expect(result.backupPath).toBeTruthy();
+    // Warn message must omit the "dropped 0 malformed line(s)" noise when
+    // nothing was dropped; only the rewrite count is reported.
+    expect(warn).toHaveBeenCalledTimes(1);
+    const warnMessage = warn.mock.calls[0]?.[0] as string;
+    expect(warnMessage).toContain("rewrote 1 assistant message(s)");
+    expect(warnMessage).not.toContain("dropped");
+
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedLines = repaired.trim().split("\n");
+    expect(repairedLines).toHaveLength(2);
+    const repairedEntry = JSON.parse(repairedLines[1]!) as {
+      message: { content: { type: string; text: string }[] };
+    };
+    expect(repairedEntry.message.content).toEqual([
+      { type: "text", text: "[assistant turn failed before producing content]" },
+    ]);
+  });
+
+  it("reports both drops and rewrites in the warn message when both occur", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const poisonedAssistantEntry = {
+      type: "message",
+      id: "msg-2",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [],
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        model: "anthropic.claude-3-haiku-20240307-v1:0",
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+        stopReason: "error",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n{"type":"message"`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const warn = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedLines).toBe(1);
+    expect(result.rewrittenAssistantMessages).toBe(1);
+    const warnMessage = warn.mock.calls[0]?.[0] as string;
+    expect(warnMessage).toContain("dropped 1 malformed line(s)");
+    expect(warnMessage).toContain("rewrote 1 assistant message(s)");
+  });
+
+  it("is a no-op on a session that was already repaired", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const healedEntry = {
+      type: "message",
+      id: "msg-2",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
+        api: "bedrock-converse-stream",
+        provider: "amazon-bedrock",
+        model: "anthropic.claude-3-haiku-20240307-v1:0",
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+        stopReason: "error",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(healedEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(false);
+    expect(result.rewrittenAssistantMessages ?? 0).toBe(0);
+    const after = await fs.readFile(file, "utf-8");
+    expect(after).toBe(original);
+  });
 });

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -1,12 +1,28 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { STREAM_ERROR_FALLBACK_TEXT } from "./stream-message-shared.js";
 
 type RepairReport = {
   repaired: boolean;
   droppedLines: number;
+  rewrittenAssistantMessages?: number;
   backupPath?: string;
   reason?: string;
 };
+
+// Persisted assistant entries with `content: []` (written by older builds when
+// a stream/provider error fired before any block was produced) are valid JSON
+// but not valid for AWS Bedrock Converse replay; rewriting them on disk lets a
+// poisoned session recover across gateway restarts instead of needing a fresh
+// session. The sentinel text is shared with stream-message-shared.ts and
+// replay-history.ts so a session repaired offline reads byte-identically to a
+// live stream-error turn — that byte-identity is what makes the repair pass
+// idempotent (a healed entry is then indistinguishable from a fresh one).
+
+type SessionMessageEntry = {
+  type: "message";
+  message: { role: "assistant"; content: unknown[] } & Record<string, unknown>;
+} & Record<string, unknown>;
 
 function isSessionHeader(entry: unknown): entry is { type: string; id: string } {
   if (!entry || typeof entry !== "object") {
@@ -14,6 +30,44 @@ function isSessionHeader(entry: unknown): entry is { type: string; id: string } 
   }
   const record = entry as { type?: unknown; id?: unknown };
   return record.type === "session" && typeof record.id === "string" && record.id.length > 0;
+}
+
+function isAssistantEntryWithEmptyContent(entry: unknown): entry is SessionMessageEntry {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  const message = record.message as { role?: unknown; content?: unknown };
+  if (message.role !== "assistant") {
+    return false;
+  }
+  return Array.isArray(message.content) && message.content.length === 0;
+}
+
+function rewriteAssistantEntryWithEmptyContent(entry: SessionMessageEntry): SessionMessageEntry {
+  return {
+    ...entry,
+    message: {
+      ...entry.message,
+      content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+    },
+  };
+}
+
+function buildRepairSummaryParts(droppedLines: number, rewrittenAssistantMessages: number): string {
+  const parts: string[] = [];
+  if (droppedLines > 0) {
+    parts.push(`dropped ${droppedLines} malformed line(s)`);
+  }
+  if (rewrittenAssistantMessages > 0) {
+    parts.push(`rewrote ${rewrittenAssistantMessages} assistant message(s)`);
+  }
+  // Caller only invokes this once at least one counter is non-zero, so the
+  // empty-array branch is unreachable in production. Kept for defensive output.
+  return parts.length > 0 ? parts.join(", ") : "no changes";
 }
 
 export async function repairSessionFileIfNeeded(params: {
@@ -41,13 +95,19 @@ export async function repairSessionFileIfNeeded(params: {
   const lines = content.split(/\r?\n/);
   const entries: unknown[] = [];
   let droppedLines = 0;
+  let rewrittenAssistantMessages = 0;
 
   for (const line of lines) {
     if (!line.trim()) {
       continue;
     }
     try {
-      const entry = JSON.parse(line);
+      const entry: unknown = JSON.parse(line);
+      if (isAssistantEntryWithEmptyContent(entry)) {
+        entries.push(rewriteAssistantEntryWithEmptyContent(entry));
+        rewrittenAssistantMessages += 1;
+        continue;
+      }
       entries.push(entry);
     } catch {
       droppedLines += 1;
@@ -65,7 +125,7 @@ export async function repairSessionFileIfNeeded(params: {
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
 
-  if (droppedLines === 0) {
+  if (droppedLines === 0 && rewrittenAssistantMessages === 0) {
     return { repaired: false, droppedLines: 0 };
   }
 
@@ -96,14 +156,16 @@ export async function repairSessionFileIfNeeded(params: {
     return {
       repaired: false,
       droppedLines,
+      rewrittenAssistantMessages,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
   }
 
   params.warn?.(
-    `session file repaired: dropped ${droppedLines} malformed line(s) (${path.basename(
-      sessionFile,
-    )})`,
+    `session file repaired: ${buildRepairSummaryParts(
+      droppedLines,
+      rewrittenAssistantMessages,
+    )} (${path.basename(sessionFile)})`,
   );
-  return { repaired: true, droppedLines, backupPath };
+  return { repaired: true, droppedLines, rewrittenAssistantMessages, backupPath };
 }

--- a/src/agents/stream-message-shared.test.ts
+++ b/src/agents/stream-message-shared.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  STREAM_ERROR_FALLBACK_TEXT,
+  buildStreamErrorAssistantMessage,
+} from "./stream-message-shared.js";
+
+const model = {
+  api: "bedrock-converse-stream",
+  provider: "amazon-bedrock",
+  id: "anthropic.claude-3-haiku-20240307-v1:0",
+};
+
+describe("buildStreamErrorAssistantMessage", () => {
+  it("never returns an empty content array", () => {
+    const message = buildStreamErrorAssistantMessage({
+      model,
+      errorMessage: "stream aborted by upstream host=internal.example.com",
+    });
+    expect(Array.isArray(message.content)).toBe(true);
+    expect(message.content.length).toBeGreaterThan(0);
+  });
+
+  it("places only the sentinel in content and never echoes the raw error text", () => {
+    const message = buildStreamErrorAssistantMessage({
+      model,
+      errorMessage: "stream aborted by upstream host=internal.example.com",
+    });
+    // Replay-visible content must be the canonical sentinel — replaying raw
+    // provider error strings could leak hostnames/metadata to the model and
+    // turn them into a prompt-injection surface.
+    expect(message.content).toEqual([{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }]);
+    expect(JSON.stringify(message.content)).not.toContain("internal.example.com");
+    // The detailed error remains available in the peer field for clients/UIs.
+    expect(message.errorMessage).toBe("stream aborted by upstream host=internal.example.com");
+    expect(message.stopReason).toBe("error");
+  });
+
+  it("uses the same sentinel when errorMessage is blank", () => {
+    const message = buildStreamErrorAssistantMessage({ model, errorMessage: "   " });
+    expect(message.content).toEqual([{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }]);
+    // Original errorMessage is preserved verbatim for clients that surface it.
+    expect(message.errorMessage).toBe("   ");
+  });
+});

--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -72,6 +72,23 @@ export function buildAssistantMessageWithZeroUsage(params: {
   });
 }
 
+// Single canonical sentinel placed in the `content` array of any assistant turn
+// that failed before the model produced its own content. AWS Bedrock Converse
+// rejects assistant messages with `content: []` during replay ("The content
+// field in the Message object at messages.N is empty."), which can persist into
+// the session file and trap subsequent turns in a validation-failure loop. The
+// raw provider error text is intentionally NOT placed in `content` because that
+// array is replayed back to the model on the next turn — provider error strings
+// can carry hostnames or upstream metadata, and replaying them as assistant
+// content opens a prompt-injection surface (CWE-200). The detailed error stays
+// in the peer `errorMessage` field, which clients/UIs read directly and
+// providers do not include in their wire payloads.
+//
+// This constant is the single source of truth used by replay normalization and
+// session-file repair as well, so a session repaired offline reads identically
+// to a live stream-error turn (and the repair pass remains idempotent).
+export const STREAM_ERROR_FALLBACK_TEXT = "[assistant turn failed before producing content]";
+
 export function buildStreamErrorAssistantMessage(params: {
   model: StreamModelDescriptor;
   errorMessage: string;
@@ -80,7 +97,7 @@ export function buildStreamErrorAssistantMessage(params: {
   return {
     ...buildAssistantMessageWithZeroUsage({
       model: params.model,
-      content: [],
+      content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
       stopReason: "error",
       timestamp: params.timestamp,
     }),


### PR DESCRIPTION
### Summary

- **Problem**: When a stream/provider error fires before any assistant content block is produced, OpenClaw persists `{"role":"assistant","content":[],...}` to the session JSONL via `buildStreamErrorAssistantMessage` (`src/agents/stream-message-shared.ts:75-90`). On the next turn, AWS Bedrock Converse rejects the replay with `"The content field in the Message object at messages.N is empty. Add a ContentBlock object to the content field and try again."` Each subsequent user message replays the same poisoned turn, so the session enters a death loop and a gateway restart does not help (the JSONL is already corrupt). Affected sessions reported in #71572 cover both embedded agent runs and Feishu channel delivery.
- **Root Cause**: Three transcript-hygiene gaps line up to make the failure permanent:
  1. `buildStreamErrorAssistantMessage` creates the error turn with `content: []` (line 84). For Bedrock Converse, an assistant message must contain at least one `ContentBlock`, so this entry is invalid the moment it is persisted.
  2. `normalizeAssistantReplayContent` in `src/agents/pi-embedded-runner/replay-history.ts` (line 230) only normalises legacy `string` content; it skips empty arrays entirely. It also forwards openclaw transcript-only mirror entries (`provider:"openclaw"`, `model:"delivery-mirror"` from `src/config/sessions/transcript.ts:128` and `model:"gateway-injected"` from `src/gateway/server-methods/chat-transcript-inject.ts:89`) to the actual provider, which duplicates content and, on strict providers, breaks turn-ordering rules.
  3. `repairSessionFileIfNeeded` in `src/agents/session-file-repair.ts` only drops malformed JSONL lines. The poisoned line is valid JSON, so repair leaves it untouched and the death loop survives every restart.
- **Fix**: Address each gap at its origin so a poisoned session cannot form, an in-flight session cannot replay poison even from older builds, and a session already poisoned on disk recovers without manual surgery.
  1. `buildStreamErrorAssistantMessage` now writes `[{type:"text", text: errorMessage || sentinel}]` so the persisted turn is replay-valid for Bedrock and remains useful for clients reading `content`.
  2. `normalizeAssistantReplayContent` now (a) drops openclaw `delivery-mirror` / `gateway-injected` assistant entries from the in-memory replay copy (the persisted JSONL is unchanged, so user-facing transcript surfaces stay intact) and (b) substitutes a sentinel text block for any assistant entry whose `content` is an empty array. Existing string-content wrapping behavior is preserved.
  3. `repairSessionFileIfNeeded` now also rewrites persisted assistant entries that have `content: []` to the sentinel text block, in addition to the existing malformed-JSONL drop. The rewrite is idempotent: a session with no empty-content entries returns `repaired:false` and bytes on disk are unchanged.
  - The sentinel string `[assistant turn failed before producing content]` is reused in all three call sites so a session repaired offline reads identically to a live stream-error turn. It is kept as a module-local constant in each file to avoid creating a cross-module coupling for one literal.
- **What changed**:
  - `src/agents/stream-message-shared.ts` — export `STREAM_ERROR_FALLBACK_TEXT`; `buildStreamErrorAssistantMessage` returns a non-empty text block instead of `content: []`.
  - `src/agents/pi-embedded-runner/replay-history.ts` — extend `normalizeAssistantReplayContent` to drop transcript-only openclaw assistant entries and to substitute the sentinel for empty content arrays; preserve original-array-reference fast path when nothing changes.
  - `src/agents/session-file-repair.ts` — extend `repairSessionFileIfNeeded` to detect-and-rewrite assistant entries with empty content; add `rewrittenAssistantMessages` to `RepairReport` (additive, optional); update warn message; combine drop and rewrite signals into the `repaired` flag.
  - `src/agents/stream-message-shared.test.ts` (new, co-located) — covers: never returns empty content; carries the error message verbatim in a single text block; falls back to sentinel when `errorMessage` is blank.
  - `src/agents/pi-embedded-runner/replay-history.test.ts` (new, co-located) — covers: empty assistant content array becomes sentinel; legacy string-content wrapping still works; `delivery-mirror` and `gateway-injected` are filtered from replay; original array reference returned when nothing changes.
  - `src/agents/session-file-repair.test.ts` — adds two cases: persisted assistant `content: []` is rewritten with backup; an already-repaired session is a no-op (idempotent).
- **What did NOT change (scope boundary)**:
  - No persisted JSONL entry is dropped from disk by repair. Mirror filtering happens only in the in-memory replay copy in `normalizeAssistantReplayContent`; UI/transcript history surfaces remain unaffected.
  - `errorMessage` field on the assistant message is preserved verbatim, including blank/whitespace input, so any client that reads `errorMessage` separately still sees the original payload.
  - `RepairReport` only gains an optional field (`rewrittenAssistantMessages?: number`); existing callers that ignore the return value or only read `repaired`/`droppedLines` are unaffected.
  - No changes to provider plugins, transcript-policy, image sanitization, tool-call repair, compaction, or session-file format/version.
  - The Ollama plugin has its own local `buildStreamErrorAssistantMessage` (`extensions/ollama/src/stream.ts:289`) that is intentionally left untouched here; it is provider-scoped and not in the Bedrock replay path. A separate change can mirror this fix once the plugin contract owners agree.

### Reproduction

1. Run an OpenClaw 2026.4.23 / 2026.4.25 gateway against AWS Bedrock Converse (e.g. `anthropic.claude-3-haiku` or any other Bedrock-hosted model).
2. From an embedded agent or Feishu channel, send a prompt that triggers a stream/provider error before the model emits any content block (network drop, transient `ValidationException`, or any error path that flows through `buildStreamErrorAssistantMessage`).
3. Observe the session JSONL: the new assistant entry has `"content": []`, `"stopReason": "error"`.
4. Send any next user message in the same session. The Bedrock SDK rejects with `"The content field in the Message object at messages.N is empty. Add a ContentBlock object to the content field and try again."`
5. Restart the gateway and retry — the same validation error fires because the JSONL is unchanged.

After this fix:

- Step 3 produces `"content": [{"type":"text","text": "<errorMessage or sentinel>"}]`, so the persisted turn is replay-valid.
- For sessions already poisoned by older builds, the session-file repair pass on the next load rewrites the empty-content entry to a sentinel text block (with backup) and the session resumes; rerunning repair is a no-op.
- Replay drops openclaw `delivery-mirror` / `gateway-injected` mirror entries from the provider request, removing a separate class of strict-provider rejections (see `replay-history.ts` line ~568 comment for the related assistant-first ordering case).

### Risk / Mitigation

- **Risk**: Changing `buildStreamErrorAssistantMessage` shape might affect downstream consumers that special-case `content.length === 0`.
  - **Mitigation**: All call sites surveyed (`src/agents/openai-ws-stream.ts:1284`, `src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts:49,78,119`) pass the value through to the agent loop's error event, which already iterates `content` defensively. The `errorMessage` field is preserved verbatim for clients that surface it separately. Unit test `stream-message-shared.test.ts` pins both behaviors.
- **Risk**: Filtering `delivery-mirror` / `gateway-injected` from replay could remove user-visible turns from the model's context.
  - **Mitigation**: These entries are transcript-only by design — `transcript.ts:264 isRedundantDeliveryMirror` and `chat-transcript-inject.ts` document them as channel-delivery / gateway-injection records, not model output. Persisted JSONL is unchanged, so transcript history surfaces (WebChat, TUI, REST, SSE) keep showing them. The strict-provider ordering fallback at `replay-history.ts:564-574` is unchanged and remains the safety net for any provider hooks that already rewrite ordering.
- **Risk**: Repair rewriting on-disk content could damage a session if the rewrite path crashes.
  - **Mitigation**: Repair already writes a `.bak-${pid}-${ts}` backup before any rewrite and uses an atomic `tmp → rename` swap. The new rewrite path reuses the same write/backup machinery; failure paths still clean up the tmp file and return `repaired:false` with a `reason`. Idempotency test ensures a second call is a no-op on a healed session.
- **Risk**: Adding `rewrittenAssistantMessages` to `RepairReport` could be a typed-API regression for external callers.
  - **Mitigation**: Field is optional (`?:`) and additive; all in-tree callers either ignore the return value or only read `repaired`/`droppedLines`/`reason`. No external consumers found in the repo.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agents (embedded runner / replay)
- [x] Session storage (file repair)
- [x] Provider replay (Bedrock Converse)