### PR TITLE
fix(memory): retry rename on EBUSY and fall back to copyFile on Windows

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -28,8 +28,8 @@ async function renameWithRetry(src: string, dest: string): Promise<void> {
 export async function moveMemoryIndexFiles(sourceBase: string, targetBase: string): Promise<void> {
   const suffixes = ["", "-wal", "-shm"];
   for (const suffix of suffixes) {
-    const source = ${sourceBase};
-    const target = ${targetBase};
+    const source = `${sourceBase}${suffix}`;
+    const target = `${targetBase}${suffix}`;
     try {
       await renameWithRetry(source, target);
     } catch (err) {
@@ -42,17 +42,17 @@ export async function moveMemoryIndexFiles(sourceBase: string, targetBase: strin
 
 export async function removeMemoryIndexFiles(basePath: string): Promise<void> {
   const suffixes = ["", "-wal", "-shm"];
-  await Promise.all(suffixes.map((suffix) => fs.rm(${basePath}, { force: true })));
+  await Promise.all(suffixes.map((suffix) => fs.rm(`${basePath}${suffix}`, { force: true })));
 }
 
 export async function swapMemoryIndexFiles(targetPath: string, tempPath: string): Promise<void> {
-  const backupPath = ${targetPath}.backup-;
+  const backupPath = `${targetPath}.backup-${randomUUID()}`;
   await moveMemoryIndexFiles(targetPath, backupPath);
   try {
     await moveMemoryIndexFiles(tempPath, targetPath);
   } catch (err) {
     await moveMemoryIndexFiles(backupPath, targetPath);
-    throw err;
+    thror err;
   }
   await removeMemoryIndexFiles(backupPath);
 }

--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -1,13 +1,37 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 
+const RENAME_MAX_RETRIES = 3;
+const RENAME_BASE_DELAY_MS = 50;
+
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+  for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
+    try {
+      await fs.rename(src, dest);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EBUSY" && attempt < RENAME_MAX_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, RENAME_BASE_DELAY_MS * 2 ** attempt));
+        continue;
+      }
+      if (code === "EPERM" || code === "EEXIST") {
+        await fs.copyFile(src, dest);
+        await fs.unlink(src).catch(() => {});
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
 export async function moveMemoryIndexFiles(sourceBase: string, targetBase: string): Promise<void> {
   const suffixes = ["", "-wal", "-shm"];
   for (const suffix of suffixes) {
-    const source = `${sourceBase}${suffix}`;
-    const target = `${targetBase}${suffix}`;
+    const source = ${sourceBase};
+    const target = ${targetBase};
     try {
-      await fs.rename(source, target);
+      await renameWithRetry(source, target);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         throw err;
@@ -18,11 +42,11 @@ export async function moveMemoryIndexFiles(sourceBase: string, targetBase: strin
 
 export async function removeMemoryIndexFiles(basePath: string): Promise<void> {
   const suffixes = ["", "-wal", "-shm"];
-  await Promise.all(suffixes.map((suffix) => fs.rm(`${basePath}${suffix}`, { force: true })));
+  await Promise.all(suffixes.map((suffix) => fs.rm(${basePath}, { force: true })));
 }
 
 export async function swapMemoryIndexFiles(targetPath: string, tempPath: string): Promise<void> {
-  const backupPath = `${targetPath}.backup-${randomUUID()}`;
+  const backupPath = ${targetPath}.backup-;
   await moveMemoryIndexFiles(targetPath, backupPath);
   try {
     await moveMemoryIndexFiles(tempPath, targetPath);


### PR DESCRIPTION
## Fix for Issue #64187: Windows EBUSY in memory atomic-reindex

Windows file locks cause s.rename() to fail with EBUSY when the SQLite file is held by another process (e.g. the gateway itself). This was already fixed for the cron store in commit 5f0a92; this PR applies the same pattern to the memory atomic-reindex path in manager-atomic-reindex.ts.

### Changes
- Added enameWithRetry() helper that:  - Retries s.rename() up to 3 times with exponential backoff on EBUSY  - Falls back to copyFile + unlink on EPERM/EEXIST (Windows atomic-replace failure)
- Replaced direct s.rename() call in moveMemoryIndexFiles() with enameWithRetry()`n
### Root cause (from #64187)
The gateway process holds an exclusive lock on main.sqlite. When the file watcher triggers a concurrent sync, the rename-based atomic swap fails with EBUSY because Windows mandatory file locks reject concurrent access to the same file.

Fixes #64187

---

*Contributor: jujitao (via OpenClaw agent)*