### PR TITLE
fix: use non-empty placeholder in dropThinkingBlocks to prevent Bedrock ValidationException

### DIFF
--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -58,6 +58,10 @@ describe("dropThinkingBlocks", () => {
     const { assistant } = dropSingleAssistantContent([
       { type: "thinking", thinking: "internal-only" },
     ]);
-    expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+    // The placeholder must be non-empty so downstream provider converters
+    // (Bedrock convertMessages, Anthropic convertAnthropicMessages) do not
+    // filter it out and leave an empty content array, which would trigger a
+    // Bedrock ValidationException.
+    expect(assistant.content).toEqual([{ type: "text", text: "[thinking]" }]);
   });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -13,11 +13,26 @@ export function isAssistantMessageWithContent(message: AgentMessage): message is
 }
 
 /**
+ * Placeholder text used when all content blocks in an assistant message were
+ * thinking-only.  This must be a **non-empty** string because downstream
+ * provider converters (Bedrock `convertMessages`, Anthropic
+ * `convertAnthropicMessages`) filter out text blocks whose
+ * `text.trim().length === 0`, which would leave the assistant message with an
+ * empty `content` array and trigger a Bedrock `ValidationException`:
+ *
+ *   "The content field in the Message object at messages.N is empty."
+ *
+ * Using a visible placeholder keeps the turn intact across all providers.
+ */
+const THINKING_DROPPED_PLACEHOLDER = "[thinking]";
+
+/**
  * Strip all `type: "thinking"` content blocks from assistant messages.
  *
  * If an assistant message becomes empty after stripping, it is replaced with
- * a synthetic `{ type: "text", text: "" }` block to preserve turn structure
- * (some providers require strict user/assistant alternation).
+ * a synthetic text block containing {@link THINKING_DROPPED_PLACEHOLDER} to
+ * preserve turn structure (some providers require strict user/assistant
+ * alternation and reject empty content arrays).
  *
  * Returns the original array reference when nothing was changed (callers can
  * use reference equality to skip downstream work).
@@ -45,8 +60,11 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
       continue;
     }
     // Preserve the assistant turn even if all blocks were thinking-only.
+    // The placeholder MUST be non-empty — see THINKING_DROPPED_PLACEHOLDER.
     const content =
-      nextContent.length > 0 ? nextContent : [{ type: "text", text: "" } as AssistantContentBlock];
+      nextContent.length > 0
+        ? nextContent
+        : [{ type: "text", text: THINKING_DROPPED_PLACEHOLDER } as AssistantContentBlock];
     out.push({ ...msg, content });
   }
   return touched ? out : messages;


### PR DESCRIPTION
## Problem

When `dropThinkingBlocks` strips all thinking content from an assistant message, it replaces the content with a synthetic text block to preserve turn structure. Previously this placeholder used an empty string:

```ts
{ type: "text", text: "" }
```

However, both Bedrock's `convertMessages` and Anthropic's `convertAnthropicMessages` (in `@mariozechner/pi-ai`) filter out text blocks where `text.trim().length === 0`:

```ts
// Bedrock convertMessages
case "text":
    if (c.text.trim().length === 0) continue; // ← filters empty placeholder

// Anthropic convertAnthropicMessages  
if (block.type === "text") {
    if (block.text.trim().length > 0) blocks.push({...}); // ← skips empty
    continue;
}
```

This causes the assistant message's content array to become empty after filtering, which triggers a **Bedrock `ValidationException`**:

> The content field in the Message object at messages.N is empty. Add a ContentBlock object to the content field and try again.

### Reproduction

1. Start a conversation with extended thinking enabled on Bedrock (e.g. `claude-opus-4-6`)
2. Have a multi-turn conversation where an assistant response contains **only** thinking blocks (no text, no tool calls)
3. Continue the conversation so `dropThinkingBlocks` runs on that historical message
4. The next API call fails with the validation error above

### Observed in production

```
[agent/embedded] embedded run agent end: isError=true
  model=global.anthropic.claude-opus-4-6-v1 provider=amazon-bedrock
  error=Validation error: The content field in the Message object at messages.16 is empty.
```

## Fix

Use `"[thinking]"` as the placeholder text so it survives downstream empty-text filters across all providers.

## Changes

- `src/agents/pi-embedded-runner/thinking.ts` — Replace empty string placeholder with `"[thinking]"` and add a named constant with documentation
- `src/agents/pi-embedded-runner/thinking.test.ts` — Update test expectation to match new placeholder