### PR TITLE
test(cli-runner): bound argv length for large Claude system prompts (#71600)

### DIFF
--- a/src/agents/cli-runner.system-prompt-argv-bound.test.ts
+++ b/src/agents/cli-runner.system-prompt-argv-bound.test.ts
@@ -114,6 +114,11 @@ describe("claude-cli system prompt argv length bound (#71600)", () => {
 
     await executePreparedCliRun(buildLargeSystemPromptContext(largeSystemPrompt));
 
+    // Pin that the spawn was actually reached so the inside-mock capture
+    // is meaningful. Otherwise capturedArgv stays [] and the assertions
+    // below would pass under "mock never ran" instead of "argv stayed
+    // bounded".
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
     expect(capturedArgv.length).toBeGreaterThan(0);
     expect(joinedArgvLength(capturedArgv)).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
 
@@ -150,6 +155,12 @@ describe("claude-cli system prompt argv length bound (#71600)", () => {
     });
 
     await executePreparedCliRun(buildLargeSystemPromptContext(largeSystemPrompt));
+
+    // Make the inside-mock assertions meaningful: if the supervisor was
+    // never reached, the inside-mock expects above never run, systemPromptPath
+    // stays "", and `fs.access("")` rejects for a different reason — the
+    // test would pass for the wrong reason.
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
 
     // Temp file is cleaned up after the run.
     await expect(fs.access(systemPromptPath)).rejects.toMatchObject({ code: "ENOENT" });

--- a/src/agents/cli-runner.system-prompt-argv-bound.test.ts
+++ b/src/agents/cli-runner.system-prompt-argv-bound.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __testing as replyRunTesting } from "../auto-reply/reply/reply-run-registry.js";
+import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import {
+  createManagedRun,
+  restoreCliRunnerPrepareTestDeps,
+  supervisorSpawnMock,
+} from "./cli-runner.test-support.js";
+import { resetClaudeLiveSessionsForTest } from "./cli-runner/claude-live-session.js";
+import { executePreparedCliRun } from "./cli-runner/execute.js";
+import type { PreparedCliRunContext } from "./cli-runner/types.js";
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  resetClaudeLiveSessionsForTest();
+  replyRunTesting.resetReplyRunRegistry();
+  restoreCliRunnerPrepareTestDeps();
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  resetClaudeLiveSessionsForTest();
+  replyRunTesting.resetReplyRunRegistry();
+});
+
+// Windows enforces a hard ~32,767-char command-line limit (CreateProcessW
+// MAX_COMMAND_LINE). A claude-cli backend that inlines the system prompt via
+// `--append-system-prompt` blows past it as soon as workspace context
+// approaches that size, and Node's child_process.spawn surfaces the failure
+// as `spawn ENAMETOOLONG` long before Claude Code starts. f7b71abf48
+// ("fix(agents): pass Claude system prompt via file") routes the prompt
+// through `--append-system-prompt-file <path>` whenever the backend exposes
+// `systemPromptFileArg`, sidestepping the limit entirely. This test pins
+// that boundary: with a system prompt large enough to break the inline path
+// on Windows, the argv that reaches the supervisor must stay well below the
+// OS limit and the prompt body must never appear in argv.
+//
+// Regression target: https://github.com/openclaw/openclaw/issues/71600
+const WINDOWS_COMMAND_LINE_LIMIT = 32_767;
+
+function buildLargeSystemPromptContext(systemPrompt: string): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    modelArg: "--model",
+    sessionArg: "--session-id",
+    sessionMode: "always" as const,
+    systemPromptFileArg: "--append-system-prompt-file",
+    systemPromptWhen: "first" as const,
+    serialize: true,
+  };
+  return {
+    params: {
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 1_000,
+      runId: "run-system-prompt-argv-bound",
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: true,
+      pluginId: "anthropic",
+    },
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: {},
+    modelId: "sonnet",
+    normalizedModel: "sonnet",
+    systemPrompt,
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+function joinedArgvLength(argv: string[]): number {
+  // Windows treats the joined command line as a single string separated by
+  // spaces. This mirrors what CreateProcessW measures against the limit;
+  // small over-counts from quoting are fine for a defensive bound.
+  return argv.join(" ").length;
+}
+
+describe("claude-cli system prompt argv length bound (#71600)", () => {
+  it("keeps argv under the Windows command-line limit even with a 40k-char system prompt", async () => {
+    // 40k chars: typical workspace-context-heavy prompt that broke the inline
+    // path on Windows in #71600. Use a non-repeating-but-deterministic payload
+    // so any leak into argv is detectable by substring search.
+    const largeSystemPrompt = `BEGIN-PROMPT-MARKER ${"x".repeat(40_000)} END-PROMPT-MARKER`;
+
+    let capturedArgv: string[] = [];
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      capturedArgv = input.argv ?? [];
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await executePreparedCliRun(buildLargeSystemPromptContext(largeSystemPrompt));
+
+    expect(capturedArgv.length).toBeGreaterThan(0);
+    expect(joinedArgvLength(capturedArgv)).toBeLessThan(WINDOWS_COMMAND_LINE_LIMIT);
+
+    // Defense: even if argv length stayed under the limit by accident (e.g.
+    // truncation, placeholder substitution), the prompt body itself must
+    // never appear in argv. The file-based path is the only correct way to
+    // ship it.
+    const argvText = capturedArgv.join(" ");
+    expect(argvText).not.toContain("BEGIN-PROMPT-MARKER");
+    expect(argvText).not.toContain("END-PROMPT-MARKER");
+  });
+
+  it("uses --append-system-prompt-file with a temp path for the large prompt", async () => {
+    const largeSystemPrompt = `LARGE-PROMPT-MARKER ${"y".repeat(40_000)}`;
+
+    let systemPromptPath = "";
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      const idx = input.argv?.indexOf("--append-system-prompt-file") ?? -1;
+      expect(idx).toBeGreaterThanOrEqual(0);
+      systemPromptPath = input.argv?.[idx + 1] ?? "";
+      expect(systemPromptPath).toContain("openclaw-cli-system-prompt-");
+      await expect(fs.readFile(systemPromptPath, "utf-8")).resolves.toBe(largeSystemPrompt);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await executePreparedCliRun(buildLargeSystemPromptContext(largeSystemPrompt));
+
+    // Temp file is cleaned up after the run.
+    await expect(fs.access(systemPromptPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Why

`f7b71abf48` ("fix(agents): pass Claude system prompt via file") routes the Claude CLI system prompt through `--append-system-prompt-file <path>` whenever the backend exposes `systemPromptFileArg`. That fix unblocks the Windows-specific `spawn ENAMETOOLONG` reported in [#71600](https://github.com/openclaw/openclaw/issues/71600), where workspace-scale system prompts (~41k chars) blow past Windows' `CreateProcessW` MAX_COMMAND_LINE limit (~32,767 chars).

Existing coverage in `cli-runner.spawn.test.ts` ("passes Claude system prompts through a file instead of argv") asserts the file path appears in argv and the prompt body doesn't, but uses a small hardcoded prompt. It doesn't pin the actual regression target — the **argv length** staying under Windows' OS limit when the prompt is workspace-scale.

## What this adds

A focused regression test in `src/agents/cli-runner.system-prompt-argv-bound.test.ts`:

1. **Length bound**: with a 40k-char system prompt, the joined argv reaching the supervisor stays under 32,767 chars.
2. **Defense-in-depth**: the prompt body itself (`BEGIN-PROMPT-MARKER`/`END-PROMPT-MARKER` sentinels) never appears anywhere in argv.

This way, a future change that bypasses the file path — even one where argv length stays bounded by accident (truncation, placeholder substitution) — will still fail (2).

## Verified

Locally flipped the test backend config from `systemPromptFileArg: "--append-system-prompt-file"` to `systemPromptArg: "--append-system-prompt"` (simulating the pre-fix state). Both cases fail under the broken config: the runtime falls back to inlining the prompt and argv blows past the 32k threshold. Restoring the file arg returns both cases to green.

Pure test addition; no production code change. No changelog entry.

## Verification

- `pnpm test src/agents/cli-runner.system-prompt-argv-bound.test.ts` → 2/2 pass
- `pnpm format` + `pnpm lint` → clean on the touched file
- Doesn't affect #71600 itself; the fix is already on main from `f7b71abf48` and will land in the next release. This locks the bound so it can't quietly regress again.