### PR TITLE
fix(bonjour): suppress Windows arp-poll console flash via windowsHide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1734,7 +1734,8 @@
       }
     },
     "patchedDependencies": {
-      "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch"
+      "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch",
+      "@homebridge/ciao@1.3.6": "patches/@homebridge__ciao@1.3.6.patch"
     }
   }
 }

--- a/patches/@homebridge__ciao@1.3.6.patch
+++ b/patches/@homebridge__ciao@1.3.6.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/NetworkManager.js b/lib/NetworkManager.js
+index d13c3f249d8f3a55bec35a7af663db56a8df8772..c453cc92cfa7ee09a16f0b21e0f4489dc0849235 100644
+--- a/lib/NetworkManager.js
++++ b/lib/NetworkManager.js
+@@ -425,7 +425,7 @@ class NetworkManager extends events_1.EventEmitter {
+     static getWindowsNetworkInterfaces() {
+         // does not return loopback interface
+         return new Promise((resolve, reject) => {
+-            child_process_1.default.exec("arp -a | findstr /C:\"---\"", (error, stdout) => {
++            child_process_1.default.exec("arp -a | findstr /C:\"---\"", { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     reject(error);
+                     return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ overrides:
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
 patchedDependencies:
+  '@homebridge/ciao@1.3.6':
+    hash: af447fe8d0b060406e8dbdd36ee169c01e3cc5ded5a353a8a2de1ad97867eaa9
+    path: patches/@homebridge__ciao@1.3.6.patch
   '@whiskeysockets/baileys@7.0.0-rc.9':
     hash: 23ec8efe1484afa57c51b96955ba331d1467521a8e676a18c2690da7e70a6201
     path: patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
@@ -305,7 +308,7 @@ importers:
     dependencies:
       '@homebridge/ciao':
         specifier: ^1.3.6
-        version: 1.3.6
+        version: 1.3.6(patch_hash=af447fe8d0b060406e8dbdd36ee169c01e3cc5ded5a353a8a2de1ad97867eaa9)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -8758,7 +8761,7 @@ snapshots:
 
   '@hapi/hoek@9.3.0': {}
 
-  '@homebridge/ciao@1.3.6':
+  '@homebridge/ciao@1.3.6(patch_hash=af447fe8d0b060406e8dbdd36ee169c01e3cc5ded5a353a8a2de1ad97867eaa9)':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3


### PR DESCRIPTION
## Problem

On Windows, `@homebridge/ciao` polls for network interfaces by calling `arp -a | findstr /C:"---"` every few seconds. Because `child_process.exec` defaults to `windowsHide: false`, each poll spawns a brief visible `cmd.exe` window, causing a distracting console flash for users running OpenClaw in the background.

## Fix

Pass `{ windowsHide: true }` to the `exec` call in `NetworkManager.getWindowsNetworkInterfaces()` via a pnpm patch. This is the standard Node.js option to suppress the console window for spawned processes on Windows.

**Patch:** `patches/@homebridge__ciao@1.3.6.patch` — one-line change, no logic touched.

Related issue: #71492