### PR TITLE
fix(agents): fail over generic unknown stream errors

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -130,14 +130,16 @@ OpenAI-compatible stop-reason errors such as `Unhandled stop reason: error`,
 `stop reason: error`, and `reason: error` are classified as timeout/failover
 signals.
 Provider-scoped generic server text can also land in that timeout bucket when
-the source matches a known transient pattern. For example, Anthropic bare
-`An unknown error occurred` and JSON `api_error` payloads with transient server
-text such as `internal server error`, `unknown error, 520`, `upstream error`,
-or `backend error` are treated as failover-worthy timeouts. OpenRouter-specific
-generic upstream text such as bare `Provider returned error` is also treated as
-timeout only when the provider context is actually OpenRouter. Generic internal
-fallback text such as `LLM request failed with an unknown error.` stays
-conservative and does not trigger failover by itself.
+the source matches a known transient pattern. For example, bare
+`An unknown error occurred` is treated as a timeout when provider context is
+present (except OpenRouter, which has separate handling), and Anthropic JSON
+`api_error` payloads with transient server text such as
+`internal server error`, `unknown error, 520`, `upstream error`, or
+`backend error` are also failover-worthy timeouts. OpenRouter-specific generic
+upstream text such as bare `Provider returned error` is treated as timeout only
+when the provider context is actually OpenRouter. Generic internal fallback
+text such as `LLM request failed with an unknown error.` stays conservative and
+does not trigger failover by itself.
 
 Some provider SDKs may otherwise sleep for a long `Retry-After` window before
 returning control to OpenClaw. For Stainless-based SDKs such as Anthropic and

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -450,6 +450,12 @@ describe("failover-error", () => {
     ).toBe("timeout");
     expect(
       resolveFailoverReasonFromError({
+        provider: "google",
+        message: "An unknown error occurred",
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
         provider: "openrouter",
         message: "Provider returned error",
       }),

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -743,6 +743,9 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("An unknown error occurred", { provider: "anthropic" })).toBe(
       "timeout",
     );
+    expect(classifyFailoverReason("An unknown error occurred", { provider: "google" })).toBe(
+      "timeout",
+    );
     expect(classifyFailoverReason("Provider returned error", { provider: "openrouter" })).toBe(
       "timeout",
     );

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -753,11 +753,18 @@ function isProvider(provider: string | undefined, match: string): boolean {
   return Boolean(normalized && normalized.includes(match));
 }
 
-function isAnthropicGenericUnknownError(raw: string, provider?: string): boolean {
-  return (
-    isProvider(provider, "anthropic") &&
-    (normalizeOptionalLowercaseString(raw)?.includes("an unknown error occurred") ?? false)
-  );
+function isProviderScopedGenericUnknownError(raw: string, provider?: string): boolean {
+  const normalizedMessage = normalizeOptionalLowercaseString(raw);
+  const normalizedProvider = normalizeOptionalLowercaseString(provider);
+  if (!normalizedMessage?.includes("an unknown error occurred")) {
+    return false;
+  }
+  if (!normalizedProvider) {
+    return false;
+  }
+  // OpenRouter uses this generic phrase for multiple upstream states and keeps
+  // an explicit provider-specific matcher ("Provider returned error").
+  return !normalizedProvider.includes("openrouter");
 }
 
 function isOpenRouterProviderReturnedError(raw: string, provider?: string): boolean {
@@ -833,7 +840,7 @@ function classifyFailoverClassificationFromMessage(
   if (isAuthErrorMessage(raw)) {
     return toReasonClassification("auth");
   }
-  if (isAnthropicGenericUnknownError(raw, provider)) {
+  if (isProviderScopedGenericUnknownError(raw, provider)) {
     return toReasonClassification("timeout");
   }
   if (isOpenRouterProviderReturnedError(raw, provider)) {


### PR DESCRIPTION
# fix(agents): fail over generic unknown stream errors for non-OpenRouter providers

## Summary

This fixes fallback classification for provider-scoped `"An unknown error occurred"` stream wrapper errors so non-OpenRouter providers (for example Google Gemini) can rotate to configured fallback models.

Fixes #71620.

## Root Cause

- `src/agents/transport-stream-shared.ts` throws `"An unknown error occurred"` for transport `stopReason === "error" | "aborted"` regardless of provider.
- `src/agents/pi-embedded-helpers/errors.ts` only classified that phrase as `timeout` when `provider` matched Anthropic.
- For providers like `google`, failover classification returned `null`, so fallback rotation was skipped and raw error text surfaced to users.

## What Changed

- Replaced Anthropic-only generic-unknown matcher with provider-scoped matcher:
  - classify `"An unknown error occurred"` as `timeout` when provider context exists and is not OpenRouter.
  - keep existing OpenRouter-specific handling (`"Provider returned error"`).
- Added regression assertions in:
  - `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - `src/agents/failover-error.test.ts`
- Updated failover docs in `docs/concepts/model-failover.md` to reflect current behavior.

## Validation

- `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts`
- `pnpm check:changed` (fails in this working tree due to unrelated pre-existing repo-wide typecheck errors; targeted touched-surface tests passed)

## Risk / Follow-up

- Risk is low and scoped to generic `"An unknown error occurred"` classification with provider context.
- OpenRouter remains conservative for this exact phrase and still relies on its explicit matcher path.

## AI-assisted

- [x] AI-assisted and manually reviewed.
