### PR TITLE
fix(agents): handle iq* quant suffixes in splitTrailingAuthProfile

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -88,4 +88,20 @@ describe("splitTrailingAuthProfile", () => {
       model: "lmstudio-mb-pro/gemma-4-31b@8bit",
     });
   });
+
+  it("keeps @iq* quant suffixes (LM Studio) in model ids", () => {
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq3_xxs")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq3_xxs",
+    });
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq4_xs")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq4_xs",
+    });
+  });
+
+  it("supports auth profiles after @iq* quant suffixes", () => {
+    expect(splitTrailingAuthProfile("lmstudio/qwen3.6-27b@iq3_xxs@work")).toEqual({
+      model: "lmstudio/qwen3.6-27b@iq3_xxs",
+      profile: "work",
+    });
+  });
 });

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -26,12 +26,13 @@ export function splitTrailingAuthProfile(raw: string): {
   }
 
   // Keep local model quant suffixes (common in LM Studio/Ollama catalogs) as part
-  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0) which would
-  // otherwise be misinterpreted as an auth profile delimiter.
+  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0 or
+  // qwen3.6-27b@iq3_xxs) which would otherwise be misinterpreted as an auth
+  // profile delimiter.
   //
   // If an auth profile is needed, it can still be specified as a second suffix:
   //   lmstudio/foo@q8_0@work
-  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
+  if (/^(?:q\d+(?:_[a-z0-9]+)*|i(?:q\d+(?:_[a-z0-9]+)*)?|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -32,7 +32,7 @@ export function splitTrailingAuthProfile(raw: string): {
   //
   // If an auth profile is needed, it can still be specified as a second suffix:
   //   lmstudio/foo@q8_0@work
-  if (/^(?:q\d+(?:_[a-z0-9]+)*|i(?:q\d+(?:_[a-z0-9]+)*)?|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
+  if (/^(?:q\d+(?:_[a-z0-9]+)*|iq\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };


### PR DESCRIPTION
## Fixes openclaw/openclaw#71474

### Problem
LM Studio uses '@' in model names to denote quant variants (e.g. `qwen3.6-27b@iq3_xxs`, `qwen3.6-27b@iq4_xs`). OpenClaw's `splitTrailingAuthProfile` function incorrectly treats `iq*` suffixes as auth profile delimiters, truncating the model name at '@'.

Result:
- `/model lmstudio/qwen3.6-27b@iq3_xxs` → error "model not allowed: lmstudio/qwen3.6-27b"  
- LM Studio receives truncated name `qwen3.6-27b` and picks a random quant

### Root cause
The quant-suffix regex only covered `q*` (e.g. `q8_0`, `q4_k_xl`) and `*bit` patterns, but not `i*` prefixed quants like `iq3_xxs`, `iq4_xs` that LM Studio uses.

### Fix
Extend the quant-suffix regex in `splitTrailingAuthProfile` to also match `i`-prefixed quant suffixes:

```diff
- if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(...))
+ if (/^(?:q\d+(?:_[a-z0-9]+)*|i(?:q\d+(?:_[a-z0-9]+)*)?|\d+bit)(?:@|$)/i.test(...))
```

The `i` branch handles both standalone `i*` and `iq*` quant formats. Auth profiles can still be appended as a second `@` suffix (e.g. `...@iq3_xxs@work`).

### Test additions
- Covers `iq3_xxs` and `iq4_xs` LM Studio quant suffixes
- Covers auth profile after `@iq*` suffix