### PR TITLE
fix(config): make ModelProviderSchema.models optional to enable Ollama autodiscovery

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -356,7 +356,7 @@ export const ModelProviderSchema = z
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     request: ConfiguredModelProviderRequestSchema,
-    models: z.array(ModelDefinitionSchema),
+    models: z.array(ModelDefinitionSchema).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Problem

`ModelProviderSchema` requires `models` to be present in config. When Ollama is configured without an explicit `models` list (relying on autodiscovery via `/api/tags`), the schema rejects the config at parse time — even though the Ollama plugin already handles `models: undefined` gracefully via `Array.isArray(explicit?.models) && explicit.models.length > 0`.

## Fix

Mark `models` as `.optional()` in `ModelProviderSchema`. All existing callers that access `.models` directly already guard with `Array.isArray()` or `?? []`, so no runtime behavior changes.

Related issue: #70982