### PR TITLE
fix(control-ui): persist assistant avatar override locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ changelog/fragments/
 
 # Local scratch workspace
 .tmp/
+.vmux*
 .artifacts/
 test/fixtures/openclaw-vitest-unit-report.json
 analysis/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Quick Settings: persist the assistant avatar override to browser local storage (mirroring the user avatar) so uploaded image data URLs no longer fail config validation with "Too big: expected string to have <=200 characters". Also lift the gateway-side `ui.assistant.avatar` length cap to match the user avatar size budget for non-UI clients writing the field directly. Thanks @BunsDev.
 - Browser/CDP: make readiness diagnostics use the same discovery-first fallback as reachability for bare `ws://` Browserless and Browserbase CDP URLs. Fixes #69532.
 - ACP/OpenCode: update the bundled acpx runtime to 0.6.0 and cover the OpenCode ACP bind path in Docker live tests.
 - Browser/existing-session: support per-profile Chrome MCP command/args, map `cdpUrl` to `--browserUrl` or `--wsEndpoint`, and avoid combining endpoint flags with `--userDataDir`. Fixes #47879, #48037, and #62706. Thanks @puneet1409, @zhehao, and @madkow1001.

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -878,7 +878,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               },
               avatar: {
                 type: "string",
-                maxLength: 200,
+                maxLength: 2000000,
                 title: "Assistant Avatar",
                 description:
                   "Assistant avatar image source used in UI surfaces (URL, path, or data URI depending on runtime support). Use trusted assets and consistent branding dimensions for clean rendering.",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -457,7 +457,7 @@ export const OpenClawSchema = z
         assistant: z
           .object({
             name: z.string().max(50).optional(),
-            avatar: z.string().max(200).optional(),
+            avatar: z.string().max(2_000_000).optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/assistant-identity.test.ts
+++ b/src/gateway/assistant-identity.test.ts
@@ -40,4 +40,17 @@ describe("resolveAssistantIdentity avatar normalization", () => {
 
     expect(resolveAssistantIdentity({ cfg, workspaceDir: "" }).avatar).toBe("avatars/openclaw.png");
   });
+
+  it("preserves long image data URLs without truncating past 200 chars", () => {
+    const dataUrl = `data:image/png;base64,${"A".repeat(50_000)}`;
+    const cfg: OpenClawConfig = {
+      ui: {
+        assistant: {
+          avatar: dataUrl,
+        },
+      },
+    };
+
+    expect(resolveAssistantIdentity({ cfg, workspaceDir: "" }).avatar).toBe(dataUrl);
+  });
 });

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -11,7 +11,10 @@ import {
 } from "../shared/avatar-policy.js";
 
 const MAX_ASSISTANT_NAME = 50;
-const MAX_ASSISTANT_AVATAR = 200;
+// Image-bearing avatars (data: URLs, paths) need to round-trip through
+// coerceIdentityValue without truncation. Sized to match
+// MAX_LOCAL_USER_IMAGE_AVATAR / AVATAR_MAX_BYTES expansion.
+const MAX_ASSISTANT_AVATAR = 2_000_000;
 const MAX_ASSISTANT_EMOJI = 16;
 
 export const DEFAULT_ASSISTANT_IDENTITY: AssistantIdentity = {

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -56,10 +56,6 @@
   min-width: 0;
 }
 
-.qs-stack--wide {
-  grid-column: span 2;
-}
-
 /* ── Card ── */
 
 .qs-card {
@@ -83,7 +79,38 @@
 }
 
 .qs-card--personal {
-  grid-column: span 2;
+  grid-column: 1 / -1;
+}
+
+.qs-personal-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  align-items: start;
+  gap: 16px;
+  padding: 14px 16px 16px;
+}
+
+.qs-personal-body .qs-identity-grid {
+  padding: 0;
+}
+
+.qs-personal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.qs-personal-form .qs-row {
+  padding: 0;
+}
+
+.qs-personal-form .qs-row + .qs-row {
+  border-top: none;
+}
+
+.qs-personal-form .qs-personal-actions {
+  padding: 0;
 }
 
 .qs-card__header {
@@ -1055,20 +1082,14 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .qs-card--personal,
-  .qs-stack--wide {
-    grid-column: span 1;
+  .qs-personal-body {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 760px) {
   .qs-grid {
     grid-template-columns: 1fr;
-  }
-
-  .qs-card--personal,
-  .qs-stack--wide {
-    grid-column: 1 / -1;
   }
 }
 

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -82,35 +82,9 @@
   grid-column: 1 / -1;
 }
 
-.qs-personal-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-  align-items: start;
-  gap: 16px;
+.qs-card--personal .qs-identity-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding: 14px 16px 16px;
-}
-
-.qs-personal-body .qs-identity-grid {
-  padding: 0;
-}
-
-.qs-personal-form {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-width: 0;
-}
-
-.qs-personal-form .qs-row {
-  padding: 0;
-}
-
-.qs-personal-form .qs-row + .qs-row {
-  border-top: none;
-}
-
-.qs-personal-form .qs-personal-actions {
-  padding: 0;
 }
 
 .qs-card__header {
@@ -352,12 +326,35 @@
 
 .qs-identity-card__repair {
   display: grid;
-  gap: 6px;
+  gap: 8px;
   margin-top: 10px;
 }
 
 .qs-identity-card__repair .btn {
   width: fit-content;
+}
+
+.qs-identity-card__repair .qs-field {
+  gap: 4px;
+}
+
+.qs-identity-card__repair .qs-row__label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.qs-identity-card__repair .qs-field__input {
+  font-size: 0.78rem;
+  padding: 6px 9px;
+}
+
+.qs-identity-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .qs-identity-card__repair .muted {
@@ -1081,14 +1078,14 @@
   .qs-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .qs-personal-body {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 760px) {
   .qs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .qs-card--personal .qs-identity-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/ui/src/styles/config-quick.test.ts
+++ b/ui/src/styles/config-quick.test.ts
@@ -18,7 +18,7 @@ describe("config-quick styles", () => {
 
   it("includes the stacked quick-settings density layout", () => {
     expect(css).toContain(".qs-stack");
-    expect(css).toContain(".qs-stack--wide");
+    expect(css).toContain(".qs-personal-body");
     expect(css).toContain("grid-template-columns: repeat(3, minmax(0, 1fr));");
     expect(css).toContain("grid-template-columns: repeat(2, minmax(0, 1fr));");
     expect(css).toContain("@media (max-width: 760px)");

--- a/ui/src/styles/config-quick.test.ts
+++ b/ui/src/styles/config-quick.test.ts
@@ -18,7 +18,7 @@ describe("config-quick styles", () => {
 
   it("includes the stacked quick-settings density layout", () => {
     expect(css).toContain(".qs-stack");
-    expect(css).toContain(".qs-personal-body");
+    expect(css).toContain(".qs-identity-card__actions");
     expect(css).toContain("grid-template-columns: repeat(3, minmax(0, 1fr));");
     expect(css).toContain("grid-template-columns: repeat(2, minmax(0, 1fr));");
     expect(css).toContain("@media (max-width: 760px)");

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
-import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
+import { refreshChat } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM } from "./app-defaults.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
@@ -1038,49 +1038,23 @@ export function renderApp(state: AppViewState) {
             assistantAvatarOverride,
             assistantAvatarUploadBusy: state.assistantAvatarUploadBusy,
             assistantAvatarUploadError: state.assistantAvatarUploadError,
-            onAssistantAvatarOverrideChange: async (dataUrl) => {
-              state.assistantAvatarUploadBusy = true;
+            onAssistantAvatarOverrideChange: (dataUrl) => {
+              setAssistantAvatarOverride(state, dataUrl);
+              state.chatAvatarUrl = dataUrl;
+              state.chatAvatarSource = dataUrl;
+              state.chatAvatarStatus = "data";
+              state.chatAvatarReason = null;
               state.assistantAvatarUploadError = null;
               requestHostUpdate?.();
-              try {
-                await setAssistantAvatarOverride(state, dataUrl);
-                state.assistantAvatar = dataUrl;
-                state.assistantAvatarSource = dataUrl;
-                state.assistantAvatarStatus = "data";
-                state.assistantAvatarReason = null;
-                state.chatAvatarUrl = dataUrl;
-                state.chatAvatarSource = dataUrl;
-                state.chatAvatarStatus = "data";
-                state.chatAvatarReason = null;
-                await loadConfig(state);
-                await state.loadAssistantIdentity();
-                await refreshChatAvatar(state);
-              } catch (err) {
-                state.assistantAvatarUploadError = err instanceof Error ? err.message : String(err);
-              } finally {
-                state.assistantAvatarUploadBusy = false;
-                requestHostUpdate?.();
-              }
             },
-            onAssistantAvatarClearOverride: async () => {
-              state.assistantAvatarUploadBusy = true;
+            onAssistantAvatarClearOverride: () => {
+              setAssistantAvatarOverride(state, null);
+              state.chatAvatarUrl = null;
+              state.chatAvatarSource = null;
+              state.chatAvatarStatus = null;
+              state.chatAvatarReason = null;
               state.assistantAvatarUploadError = null;
               requestHostUpdate?.();
-              try {
-                await setAssistantAvatarOverride(state, null);
-                state.chatAvatarUrl = null;
-                state.chatAvatarSource = null;
-                state.chatAvatarStatus = null;
-                state.chatAvatarReason = null;
-                await loadConfig(state);
-                await state.loadAssistantIdentity();
-                await refreshChatAvatar(state);
-              } catch (err) {
-                state.assistantAvatarUploadError = err instanceof Error ? err.message : String(err);
-              } finally {
-                state.assistantAvatarUploadBusy = false;
-                requestHostUpdate?.();
-              }
             },
             basePath: state.basePath ?? "",
             configObject: configObj,

--- a/ui/src/ui/assistant-identity.test.ts
+++ b/ui/src/ui/assistant-identity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAssistantIdentity } from "./assistant-identity.ts";
+
+describe("normalizeAssistantIdentity", () => {
+  it("preserves long image data URLs without truncating past 200 chars", () => {
+    const dataUrl = `data:image/png;base64,${"A".repeat(50_000)}`;
+    expect(normalizeAssistantIdentity({ avatar: dataUrl }).avatar).toBe(dataUrl);
+  });
+
+  it("preserves same-origin Control UI avatar routes", () => {
+    expect(normalizeAssistantIdentity({ avatar: "/avatar/main" }).avatar).toBe("/avatar/main");
+  });
+
+  it("keeps short text avatars", () => {
+    expect(normalizeAssistantIdentity({ avatar: "PS" }).avatar).toBe("PS");
+    expect(normalizeAssistantIdentity({ avatar: "🦞" }).avatar).toBe("🦞");
+  });
+
+  it("drops sentence-like text that exceeds the text-avatar limit", () => {
+    const longText = "this is a description, not an emoji or url ".repeat(4);
+    expect(normalizeAssistantIdentity({ avatar: longText }).avatar).toBeNull();
+  });
+
+  it("drops avatars containing newlines", () => {
+    expect(normalizeAssistantIdentity({ avatar: "line1\nline2" }).avatar).toBeNull();
+  });
+});

--- a/ui/src/ui/assistant-identity.ts
+++ b/ui/src/ui/assistant-identity.ts
@@ -1,8 +1,18 @@
 import { coerceIdentityValue } from "../../../src/shared/assistant-identity-values.js";
 
 const MAX_ASSISTANT_NAME = 50;
-const MAX_ASSISTANT_AVATAR = 200;
+// Short text/emoji avatars (e.g. "A", "PS", "🦞"). Anything longer that is not
+// a renderable image URL is dropped during normalization.
+const MAX_ASSISTANT_TEXT_AVATAR = 64;
+// Image-bearing avatars (data: URLs, same-origin Control UI routes). Sized to
+// match MAX_LOCAL_USER_IMAGE_AVATAR so an uploaded image data URL survives
+// round-tripping through config without truncation.
+const MAX_ASSISTANT_IMAGE_AVATAR = 2_000_000;
 const MAX_ASSISTANT_AVATAR_SOURCE = 500;
+const MAX_ASSISTANT_AVATAR_REASON = 200;
+// Mirrors agents-utils.CONTROL_UI_AVATAR_URL_RE — duplicated locally to keep
+// this module free of UI view imports (avoids an import cycle).
+const RENDERABLE_AVATAR_URL_RE = /^(data:image\/|\/(?!\/))/i;
 
 export const DEFAULT_ASSISTANT_NAME = "Assistant";
 export const DEFAULT_ASSISTANT_AVATAR = "A";
@@ -16,11 +26,25 @@ export type AssistantIdentity = {
   avatarReason?: string | null;
 };
 
+function normalizeAssistantAvatar(value: string | null | undefined): string | null {
+  const trimmed = coerceIdentityValue(value ?? undefined, MAX_ASSISTANT_IMAGE_AVATAR);
+  if (!trimmed) {
+    return null;
+  }
+  if (RENDERABLE_AVATAR_URL_RE.test(trimmed)) {
+    return trimmed;
+  }
+  if (/[\r\n]/.test(trimmed)) {
+    return null;
+  }
+  return trimmed.length <= MAX_ASSISTANT_TEXT_AVATAR ? trimmed : null;
+}
+
 export function normalizeAssistantIdentity(
   input?: Partial<AssistantIdentity> | null,
 ): AssistantIdentity {
   const name = coerceIdentityValue(input?.name, MAX_ASSISTANT_NAME) ?? DEFAULT_ASSISTANT_NAME;
-  const avatar = coerceIdentityValue(input?.avatar ?? undefined, MAX_ASSISTANT_AVATAR) ?? null;
+  const avatar = normalizeAssistantAvatar(input?.avatar);
   const avatarSource =
     coerceIdentityValue(input?.avatarSource ?? undefined, MAX_ASSISTANT_AVATAR_SOURCE) ?? null;
   const avatarStatus =
@@ -31,7 +55,7 @@ export function normalizeAssistantIdentity(
       ? input.avatarStatus
       : null;
   const avatarReason =
-    coerceIdentityValue(input?.avatarReason ?? undefined, MAX_ASSISTANT_AVATAR) ?? null;
+    coerceIdentityValue(input?.avatarReason ?? undefined, MAX_ASSISTANT_AVATAR_REASON) ?? null;
   const agentId =
     typeof input?.agentId === "string" && input.agentId.trim() ? input.agentId.trim() : null;
   return { agentId, name, avatar, avatarSource, avatarStatus, avatarReason };

--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -1,45 +1,42 @@
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadLocalAssistantIdentity } from "../storage.ts";
 import { setAssistantAvatarOverride } from "./assistant-identity.ts";
 
 describe("setAssistantAvatarOverride", () => {
-  it("writes the assistant avatar override through config.patch", async () => {
-    const request = vi.fn().mockResolvedValue({});
-
-    await setAssistantAvatarOverride(
-      {
-        client: { request } as never,
-        connected: true,
-        applySessionKey: "agent:main",
-        configSnapshot: { hash: "config-hash" },
-      },
-      "data:image/png;base64,YXZhdGFy",
-    );
-
-    expect(request).toHaveBeenCalledWith("config.patch", {
-      baseHash: "config-hash",
-      raw: JSON.stringify({ ui: { assistant: { avatar: "data:image/png;base64,YXZhdGFy" } } }),
-      sessionKey: "agent:main",
-      note: "Assistant avatar override updated from Control UI.",
-    });
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it("clears the assistant avatar override through config.patch", async () => {
-    const request = vi.fn().mockResolvedValue({});
+  it("persists the assistant avatar locally and mirrors the user avatar pattern", () => {
+    const state: Parameters<typeof setAssistantAvatarOverride>[0] = {};
 
-    await setAssistantAvatarOverride(
-      {
-        client: { request } as never,
-        connected: true,
-        configSnapshot: { hash: "config-hash" },
-      },
-      null,
-    );
+    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
 
-    expect(request).toHaveBeenCalledWith("config.patch", {
-      baseHash: "config-hash",
-      raw: JSON.stringify({ ui: { assistant: { avatar: null } } }),
-      sessionKey: undefined,
-      note: "Assistant avatar override cleared from Control UI.",
-    });
+    expect(state.assistantAvatar).toBe("data:image/png;base64,YXZhdGFy");
+    expect(state.assistantAvatarSource).toBe("data:image/png;base64,YXZhdGFy");
+    expect(state.assistantAvatarStatus).toBe("data");
+    expect(state.assistantAvatarReason).toBeNull();
+    expect(loadLocalAssistantIdentity().avatar).toBe("data:image/png;base64,YXZhdGFy");
+  });
+
+  it("clears the local override", () => {
+    const state: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAvatar: "data:image/png;base64,YXZhdGFy",
+      assistantAvatarSource: "data:image/png;base64,YXZhdGFy",
+      assistantAvatarStatus: "data",
+    };
+    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
+
+    setAssistantAvatarOverride(state, null);
+
+    expect(state.assistantAvatarSource).toBeNull();
+    expect(state.assistantAvatarStatus).toBeNull();
+    expect(state.assistantAvatarReason).toBeNull();
+    expect(loadLocalAssistantIdentity().avatar).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -1,5 +1,6 @@
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { loadLocalAssistantIdentity, saveLocalAssistantIdentity } from "../storage.ts";
 
 export type AssistantIdentityState = {
   client: GatewayBrowserClient | null;
@@ -14,10 +15,10 @@ export type AssistantIdentityState = {
 };
 
 export type AssistantAvatarOverrideState = {
-  client: GatewayBrowserClient | null;
-  connected: boolean;
-  applySessionKey?: string;
-  configSnapshot?: { hash?: string | null } | null;
+  assistantAvatar?: string | null;
+  assistantAvatarSource?: string | null;
+  assistantAvatarStatus?: "none" | "local" | "remote" | "data" | null;
+  assistantAvatarReason?: string | null;
 };
 
 export async function loadAssistantIdentity(
@@ -41,28 +42,32 @@ export async function loadAssistantIdentity(
     state.assistantAvatarStatus = normalized.avatarStatus ?? null;
     state.assistantAvatarReason = normalized.avatarReason ?? null;
     state.assistantAgentId = normalized.agentId ?? null;
+    // Local override always wins — same pattern as the user avatar.
+    const localAvatar = loadLocalAssistantIdentity().avatar;
+    if (localAvatar) {
+      state.assistantAvatar = localAvatar;
+      state.assistantAvatarSource = localAvatar;
+      state.assistantAvatarStatus = "data";
+      state.assistantAvatarReason = null;
+    }
   } catch {
     // Ignore errors; keep last known identity.
   }
 }
 
-export async function setAssistantAvatarOverride(
+export function setAssistantAvatarOverride(
   state: AssistantAvatarOverrideState,
   avatar: string | null,
 ) {
-  if (!state.client || !state.connected) {
-    throw new Error("Gateway is not connected.");
+  saveLocalAssistantIdentity({ avatar });
+  if (avatar) {
+    state.assistantAvatar = avatar;
+    state.assistantAvatarSource = avatar;
+    state.assistantAvatarStatus = "data";
+    state.assistantAvatarReason = null;
+  } else {
+    state.assistantAvatarSource = null;
+    state.assistantAvatarStatus = null;
+    state.assistantAvatarReason = null;
   }
-  const baseHash = state.configSnapshot?.hash;
-  if (!baseHash) {
-    throw new Error("Config hash missing; refresh and retry.");
-  }
-  await state.client.request("config.patch", {
-    baseHash,
-    raw: JSON.stringify({ ui: { assistant: { avatar } } }),
-    sessionKey: state.applySessionKey,
-    note: avatar
-      ? "Assistant avatar override updated from Control UI."
-      : "Assistant avatar override cleared from Control UI.",
-  });
 }

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -6,6 +6,7 @@ import {
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
 import { resolveControlUiAuthCandidates } from "../control-ui-auth.ts";
 import { normalizeBasePath } from "../navigation.ts";
+import { loadLocalAssistantIdentity } from "../storage.ts";
 
 export type ControlUiBootstrapState = {
   basePath: string;
@@ -79,6 +80,14 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     state.assistantAvatarStatus = normalized.avatarStatus ?? null;
     state.assistantAvatarReason = normalized.avatarReason ?? null;
     state.assistantAgentId = normalized.agentId ?? null;
+    // Local override always wins — same pattern as the user avatar.
+    const localAvatar = loadLocalAssistantIdentity().avatar;
+    if (localAvatar) {
+      state.assistantAvatar = localAvatar;
+      state.assistantAvatarSource = localAvatar;
+      state.assistantAvatarStatus = "data";
+      state.assistantAvatarReason = null;
+    }
     state.serverVersion = parsed.serverVersion ?? null;
     state.localMediaPreviewRoots = Array.isArray(parsed.localMediaPreviewRoots)
       ? parsed.localMediaPreviewRoots.filter((value): value is string => typeof value === "string")

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -1,6 +1,7 @@
 const SETTINGS_KEY_PREFIX = "openclaw.control.settings.v1:";
 const LEGACY_SETTINGS_KEY = "openclaw.control.settings.v1";
 const LOCAL_USER_IDENTITY_KEY = "openclaw.control.user.v1";
+const LOCAL_ASSISTANT_IDENTITY_KEY = "openclaw.control.assistant.v1";
 const LEGACY_TOKEN_SESSION_KEY = "openclaw.control.token.v1";
 const TOKEN_SESSION_KEY_PREFIX = "openclaw.control.token.v1:";
 const MAX_SCOPED_SESSION_ENTRIES = 10;
@@ -304,6 +305,36 @@ export function saveLocalUserIdentity(next: LocalUserIdentity) {
       return;
     }
     storage?.setItem(LOCAL_USER_IDENTITY_KEY, JSON.stringify(normalized));
+  } catch {
+    // best-effort — quota exceeded or security restrictions should not
+    // prevent in-memory identity updates from being applied
+  }
+}
+
+export type LocalAssistantIdentity = { avatar: string | null };
+
+export function loadLocalAssistantIdentity(): LocalAssistantIdentity {
+  const storage = getSafeLocalStorage();
+  try {
+    const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+    if (!raw) {
+      return { avatar: null };
+    }
+    const parsed = JSON.parse(raw) as Partial<LocalAssistantIdentity>;
+    return { avatar: typeof parsed.avatar === "string" ? parsed.avatar : null };
+  } catch {
+    return { avatar: null };
+  }
+}
+
+export function saveLocalAssistantIdentity(next: LocalAssistantIdentity) {
+  const storage = getSafeLocalStorage();
+  try {
+    if (!next.avatar) {
+      storage?.removeItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+      return;
+    }
+    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({ avatar: next.avatar }));
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory identity updates from being applied

--- a/ui/src/ui/views/config-quick.test.ts
+++ b/ui/src/ui/views/config-quick.test.ts
@@ -67,7 +67,7 @@ describe("renderQuickSettings", () => {
 
     render(renderQuickSettings(createProps()), container);
 
-    expect(container.querySelectorAll(".qs-stack")).toHaveLength(3);
+    expect(container.querySelectorAll(".qs-stack")).toHaveLength(2);
     expect(container.querySelector(".qs-card--personal")).not.toBeNull();
     expect(container.querySelectorAll(".qs-card--span-all")).toHaveLength(1);
   });

--- a/ui/src/ui/views/config-quick.ts
+++ b/ui/src/ui/views/config-quick.ts
@@ -631,7 +631,7 @@ function renderPersonalCard(props: QuickSettingsProps) {
   return html`
     <div class="qs-card qs-card--personal">
       ${renderCardHeader(icons.image, "Personal")}
-      <div class="qs-card__body">
+      <div class="qs-card__body qs-personal-body">
         <div class="qs-identity-grid">
           <section class="qs-identity-card" aria-label="Your local chat identity">
             ${renderLocalUserAvatarPreview(props.userAvatar)}
@@ -709,42 +709,44 @@ function renderPersonalCard(props: QuickSettingsProps) {
             </div>
           </section>
         </div>
-        <div class="qs-row">
-          <label class="qs-field">
-            <span class="qs-row__label">Avatar text / emoji</span>
-            <input
-              class="qs-field__input"
-              type="text"
-              maxlength="16"
-              .value=${avatarText}
-              placeholder="JD or 🦞"
-              @input=${(e: Event) => {
-                const value = (e.target as HTMLInputElement).value;
-                props.onUserAvatarChange?.(value.trim() ? value : null);
+        <div class="qs-personal-form">
+          <div class="qs-row">
+            <label class="qs-field">
+              <span class="qs-row__label">Avatar text / emoji</span>
+              <input
+                class="qs-field__input"
+                type="text"
+                maxlength="16"
+                .value=${avatarText}
+                placeholder="JD or 🦞"
+                @input=${(e: Event) => {
+                  const value = (e.target as HTMLInputElement).value;
+                  props.onUserAvatarChange?.(value.trim() ? value : null);
+                }}
+              />
+            </label>
+          </div>
+          <div class="qs-personal-actions">
+            <label class="btn btn--sm">
+              Choose image
+              <input
+                type="file"
+                accept="image/*"
+                hidden
+                @change=${(e: Event) => handleLocalUserAvatarFileSelect(e, props)}
+              />
+            </label>
+            <button
+              type="button"
+              class="btn btn--sm btn--ghost"
+              ?disabled=${!identity.avatar}
+              @click=${() => {
+                props.onUserAvatarChange?.(null);
               }}
-            />
-          </label>
-        </div>
-        <div class="qs-personal-actions">
-          <label class="btn btn--sm">
-            Choose image
-            <input
-              type="file"
-              accept="image/*"
-              hidden
-              @change=${(e: Event) => handleLocalUserAvatarFileSelect(e, props)}
-            />
-          </label>
-          <button
-            type="button"
-            class="btn btn--sm btn--ghost"
-            ?disabled=${!identity.avatar}
-            @click=${() => {
-              props.onUserAvatarChange?.(null);
-            }}
-          >
-            Clear avatar
-          </button>
+            >
+              Clear avatar
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -977,10 +979,6 @@ function renderStack(...cards: TemplateResult[]) {
   return html`<div class="qs-stack">${cards}</div>`;
 }
 
-function renderWideStack(...cards: TemplateResult[]) {
-  return html`<div class="qs-stack qs-stack--wide">${cards}</div>`;
-}
-
 // ── Main render ──
 
 export function renderQuickSettings(props: QuickSettingsProps) {
@@ -995,9 +993,9 @@ export function renderQuickSettings(props: QuickSettingsProps) {
 
       <div class="qs-grid">
         ${renderStack(renderModelCard(props), renderSecurityCard(props))}
-        ${renderPersonalCard(props)}
-        ${renderStack(renderChannelsCard(props), renderAutomationsCard(props))}
-        ${renderWideStack(renderAppearanceCard(props))} ${renderPresetsCard(props)}
+        ${renderChannelsCard(props)}
+        ${renderStack(renderAppearanceCard(props), renderAutomationsCard(props))}
+        ${renderPersonalCard(props)} ${renderPresetsCard(props)}
       </div>
 
       ${renderConnectionFooter(props)}

--- a/ui/src/ui/views/config-quick.ts
+++ b/ui/src/ui/views/config-quick.ts
@@ -631,7 +631,7 @@ function renderPersonalCard(props: QuickSettingsProps) {
   return html`
     <div class="qs-card qs-card--personal">
       ${renderCardHeader(icons.image, "Personal")}
-      <div class="qs-card__body qs-personal-body">
+      <div class="qs-card__body">
         <div class="qs-identity-grid">
           <section class="qs-identity-card" aria-label="Your local chat identity">
             ${renderLocalUserAvatarPreview(props.userAvatar)}
@@ -639,6 +639,44 @@ function renderPersonalCard(props: QuickSettingsProps) {
               <div class="qs-identity-card__eyebrow">User</div>
               <div class="qs-identity-card__title">${LOCAL_USER_LABEL}</div>
               <div class="qs-identity-card__sub">Avatar is browser-local</div>
+              <div class="qs-identity-card__repair">
+                <label class="qs-field">
+                  <span class="qs-row__label">Avatar text / emoji</span>
+                  <input
+                    class="qs-field__input"
+                    type="text"
+                    maxlength="16"
+                    .value=${avatarText}
+                    placeholder="JD or 🦞"
+                    @input=${(e: Event) => {
+                      const value = (e.target as HTMLInputElement).value;
+                      props.onUserAvatarChange?.(value.trim() ? value : null);
+                    }}
+                  />
+                </label>
+                <div class="qs-identity-card__actions">
+                  <label class="btn btn--sm">
+                    Choose image
+                    <input
+                      type="file"
+                      accept="image/*"
+                      hidden
+                      @change=${(e: Event) => handleLocalUserAvatarFileSelect(e, props)}
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    class="btn btn--sm btn--ghost"
+                    ?disabled=${!identity.avatar}
+                    @click=${() => {
+                      props.onUserAvatarChange?.(null);
+                    }}
+                  >
+                    Clear avatar
+                  </button>
+                </div>
+                <div class="muted">Stored in this browser only.</div>
+              </div>
             </div>
           </section>
           <section
@@ -667,34 +705,36 @@ function renderPersonalCard(props: QuickSettingsProps) {
               ${canOverrideAssistantAvatar
                 ? html`
                     <div class="qs-identity-card__repair">
-                      <label class="btn btn--sm">
-                        ${props.assistantAvatarUploadBusy
-                          ? "Saving..."
-                          : assistantAvatarOverride
-                            ? "Replace image"
-                            : "Choose image"}
-                        <input
-                          type="file"
-                          accept="image/*"
-                          hidden
-                          ?disabled=${props.assistantAvatarUploadBusy === true}
-                          @change=${(e: Event) => handleAssistantAvatarFileSelect(e, props)}
-                        />
-                      </label>
-                      ${assistantAvatarOverride
-                        ? html`
-                            <button
-                              type="button"
-                              class="btn btn--sm btn--ghost"
-                              ?disabled=${props.assistantAvatarUploadBusy === true}
-                              @click=${() => {
-                                void props.onAssistantAvatarClearOverride?.();
-                              }}
-                            >
-                              Clear override
-                            </button>
-                          `
-                        : nothing}
+                      <div class="qs-identity-card__actions">
+                        <label class="btn btn--sm">
+                          ${props.assistantAvatarUploadBusy
+                            ? "Saving..."
+                            : assistantAvatarOverride
+                              ? "Replace image"
+                              : "Choose image"}
+                          <input
+                            type="file"
+                            accept="image/*"
+                            hidden
+                            ?disabled=${props.assistantAvatarUploadBusy === true}
+                            @change=${(e: Event) => handleAssistantAvatarFileSelect(e, props)}
+                          />
+                        </label>
+                        ${assistantAvatarOverride
+                          ? html`
+                              <button
+                                type="button"
+                                class="btn btn--sm btn--ghost"
+                                ?disabled=${props.assistantAvatarUploadBusy === true}
+                                @click=${() => {
+                                  void props.onAssistantAvatarClearOverride?.();
+                                }}
+                              >
+                                Clear override
+                              </button>
+                            `
+                          : nothing}
+                      </div>
                       <div class="muted">
                         Stores a Control UI override. Clear it to return to IDENTITY.md.
                       </div>
@@ -708,45 +748,6 @@ function renderPersonalCard(props: QuickSettingsProps) {
                 : nothing}
             </div>
           </section>
-        </div>
-        <div class="qs-personal-form">
-          <div class="qs-row">
-            <label class="qs-field">
-              <span class="qs-row__label">Avatar text / emoji</span>
-              <input
-                class="qs-field__input"
-                type="text"
-                maxlength="16"
-                .value=${avatarText}
-                placeholder="JD or 🦞"
-                @input=${(e: Event) => {
-                  const value = (e.target as HTMLInputElement).value;
-                  props.onUserAvatarChange?.(value.trim() ? value : null);
-                }}
-              />
-            </label>
-          </div>
-          <div class="qs-personal-actions">
-            <label class="btn btn--sm">
-              Choose image
-              <input
-                type="file"
-                accept="image/*"
-                hidden
-                @change=${(e: Event) => handleLocalUserAvatarFileSelect(e, props)}
-              />
-            </label>
-            <button
-              type="button"
-              class="btn btn--sm btn--ghost"
-              ?disabled=${!identity.avatar}
-              @click=${() => {
-                props.onUserAvatarChange?.(null);
-              }}
-            >
-              Clear avatar
-            </button>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Mirrors the user-avatar pattern: assistant avatar uploads now persist to `localStorage` instead of routing through `config.patch` → `ui.assistant.avatar`. The Quick Settings uploader stops failing with `invalid config: ui.assistant.avatar: Too big: expected string to have <=200 characters` when the data URL exceeds the schema cap.
- Bootstrap (`control-ui-bootstrap.ts`) and `loadAssistantIdentity` overlay the local override on top of the gateway-resolved identity so the override always wins — same precedence rule the chat already uses for the user avatar.
- Lifts the gateway-side `ui.assistant.avatar` zod cap from `200` → `2_000_000` to match the user-avatar size budget for non-Control-UI clients (agents.list identity etc.) writing the field directly. UI assistant-identity normalizer split into a 64-char text branch and a 2 MB image-URL/path branch, mirroring `user-identity.ts`.
- Collapses the avatar upload handler in `app-render.ts` from a 44-line async/`loadConfig`/`loadAssistantIdentity` dance into a synchronous setter.
- `.gitignore`: ignore `.vmux*` worktree paths.
- Changelog entry under `### Fixes` with `Thanks @BunsDev` attribution.

## Security review

- **XSS**: Same surface as the existing user-avatar upload (`<input type=file>` → `FileReader.readAsDataURL` → `<img src=data:…>`). SVG-as-image is sandboxed by browsers; no script execution path. No new vector.
- **Quota**: 1.5 MB upload cap (already enforced) → ~2 MB after base64. localStorage typically allows 5–10 MB per origin. `try/catch` covers `QuotaExceededError`. Same as user avatar.
- **Server attack surface**: Net reduction — one fewer authenticated `config.patch` path writing to gateway config.
- **Privacy**: Avatar data stays client-side. Improvement over the round-trip-to-gateway model.
- **Auth bypass / prompt injection**: N/A — purely client-side persistence; no auth or prompt surfaces touched.

## Test plan

- [x] `pnpm test:changed` (4,737 tests across gateway / runtime-config / ui lanes — green)
- [x] `pnpm tsgo:core` and `pnpm check:test-types` clean on touched files
- [x] `pnpm lint:core` clean
- [x] `pnpm build` clean (UI bundle + gateway artifacts regenerated)
- [x] New unit coverage:
  - `ui/src/ui/assistant-identity.test.ts` — data-URL passthrough, path passthrough, short-text accept, long-text reject, newline reject
  - `ui/src/ui/controllers/assistant-identity.test.ts` — local persistence + clear-override
  - `src/gateway/assistant-identity.test.ts` — 50 KB+ data URL passthrough through `coerceIdentityValue`
- [x] Manual: Quick Settings → Personal → Assistant avatar uploader, picked an image, confirmed it renders without the 200-char rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)