### PR TITLE
fix: pass changed-check lock marker to lint

### DIFF
--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -68,6 +68,7 @@ export function createChangedCheckPlan(result, options = {}) {
     }
   };
   const addTypecheck = (name, args) => add(name, args, createSparseTsgoSkipEnv(baseEnv));
+  const addLint = (name, args) => add(name, args, baseEnv);
 
   add("conflict markers", ["check:no-conflict-markers"]);
 
@@ -109,7 +110,7 @@ export function createChangedCheckPlan(result, options = {}) {
 
   if (runAll) {
     addTypecheck("typecheck all", ["tsgo:all"]);
-    add("lint", ["lint"]);
+    addLint("lint", ["lint"]);
     add("runtime import cycles", ["check:import-cycles"]);
     return {
       commands,
@@ -135,16 +136,16 @@ export function createChangedCheckPlan(result, options = {}) {
   }
 
   if (lanes.core || lanes.coreTests) {
-    add("lint core", ["lint:core"]);
+    addLint("lint core", ["lint:core"]);
   }
   if (lanes.extensions || lanes.extensionTests) {
-    add("lint extensions", ["lint:extensions"]);
+    addLint("lint extensions", ["lint:extensions"]);
   }
   if (lanes.tooling) {
-    add("lint scripts", ["lint:scripts"]);
+    addLint("lint scripts", ["lint:scripts"]);
   }
   if (lanes.apps) {
-    add("lint apps", ["lint:apps"]);
+    addLint("lint apps", ["lint:apps"]);
   }
 
   if (lanes.core || lanes.extensions) {

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -122,6 +122,26 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
+  it("passes the parent heavy-check lock marker to lint commands", () => {
+    const result = detectChangedLanes(["src/shared/string-normalization.ts"]);
+    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
+
+    expect(plan.commands.find((command) => command.args[0] === "lint:core")?.env).toMatchObject({
+      OPENCLAW_OXLINT_SKIP_LOCK: "1",
+      PATH: "/usr/bin",
+    });
+  });
+
+  it("passes the parent heavy-check lock marker to the full lint command", () => {
+    const result = detectChangedLanes(["pnpm-workspace.yaml"]);
+    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
+
+    expect(plan.commands.find((command) => command.args[0] === "lint")?.env).toMatchObject({
+      OPENCLAW_OXLINT_SKIP_LOCK: "1",
+      PATH: "/usr/bin",
+    });
+  });
+
   it("routes core test-only changes to core test lanes only", () => {
     const result = detectChangedLanes(["src/shared/string-normalization.test.ts"]);
 


### PR DESCRIPTION
## Summary

- Problem: `pnpm check:changed` could wait on the local heavy-check lock that it already held when it reached a lint lane.
- Why it matters: local changed-scope validation could appear hung even though no independent heavy check was running.
- What changed: lint commands generated by `scripts/check-changed.mjs` now receive the same child env as other heavy child commands, including `OPENCLAW_OXLINT_SKIP_LOCK=1`.
- What did NOT change: lane detection, oxlint's standalone lock behavior, typecheck lock behavior, and test scheduling logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `check:changed` acquired the parent heavy-check lock, but lint plan entries were added without the child env produced by `createChangedCheckChildEnv()`. When `pnpm lint:*` launched `scripts/run-oxlint.mjs`, oxlint did not see `OPENCLAW_OXLINT_SKIP_LOCK=1` and tried to acquire the same shared heavy-check lock.
- Missing detection / guardrail: existing tests asserted the child env itself and typecheck env propagation, but did not assert env propagation for lint commands.
- Contributing context (if known): `tsgo` and test lanes already had explicit parent-lock markers, which made the failure specific to lint lanes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/changed-lanes.test.ts`
- Scenario the test should lock in: `createChangedCheckPlan()` must attach `OPENCLAW_OXLINT_SKIP_LOCK=1` to both scoped lint commands such as `lint:core` and the full `lint` command used by all-lane plans.
- Why this is the smallest reliable guardrail: the bug is in plan construction before child processes run, so checking the generated command env catches the regression without spawning nested lint jobs.
- Existing test that already covers this (if any): none for lint command env propagation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`pnpm check:changed` should no longer self-wait on the local heavy-check lock when it reaches lint lanes.

## Diagram (if applicable)

```text
Before:
check:changed holds heavy-check lock
  -> pnpm lint:core without OPENCLAW_OXLINT_SKIP_LOCK
  -> run-oxlint tries to acquire heavy-check lock
  -> waits behind parent check:changed

After:
check:changed holds heavy-check lock
  -> pnpm lint:core with OPENCLAW_OXLINT_SKIP_LOCK=1
  -> run-oxlint skips reacquiring the parent lock
  -> lint proceeds
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/WSL local checkout
- Runtime/container: Node 22 via pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local heavy-check behavior

### Steps

1. Run `pnpm check:changed` or a changed-scope plan that includes a lint lane.
2. Observe that the parent `check:changed` process owns `.git/openclaw-local-checks/heavy-check.lock`.
3. Before this patch, the child `run-oxlint.mjs` process could queue behind that same parent-owned lock.
4. After this patch, run the targeted changed-scope validation for the touched files.

### Expected

- Lint child commands launched by `check:changed` skip reacquiring the parent heavy-check lock and proceed normally.

### Actual

- Before the patch: a lint child could wait behind `check:changed` itself.
- After the patch: targeted changed-scope validation completed successfully.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed before the fix:

```text
[check:changed] queued behind the local heavy-check lock held by check:changed, pid 336236, cwd <repo>...
```

Passing verification after the fix:

```text
pnpm test test/scripts/changed-lanes.test.ts
pnpm check:changed scripts/check-changed.mjs test/scripts/changed-lanes.test.ts
git diff --check
```

## Human Verification (required)

- Verified scenarios:
  - `pnpm test test/scripts/changed-lanes.test.ts` passed.
  - `pnpm check:changed scripts/check-changed.mjs test/scripts/changed-lanes.test.ts` passed.
  - `git diff --check` passed.
- Edge cases checked:
  - Scoped lint command env propagation for `lint:core`.
  - Full lint command env propagation for all-lane plans.
- What you did **not** verify:
  - Full `pnpm check:changed` for unrelated local `src/auto-reply/reply/*` worktree changes.
  - Full `pnpm test`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: lint lanes now inherit the parent-lock skip marker from `check:changed`.
  - Mitigation: this only applies to lint commands launched under the already locked parent changed-check run; standalone lint commands still use `run-oxlint.mjs` lock behavior unchanged.
