### PR TITLE
Mattermost streaming text fix [AI-assisted]

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1754,7 +1754,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     if (!lastPartialText) {
                       draftStream.update("Thinking…");
                     }
-                  },                 
+                  },
                   onToolStart: async (payload) => {
                     if (lastPartialText) {
                       // Flush any pending streamed assistant text to the current post,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1754,8 +1754,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     if (!lastPartialText) {
                       draftStream.update("Thinking…");
                     }
-                  },
+                  },                 
                   onToolStart: async (payload) => {
+                    if (lastPartialText) {
+                      // Flush any pending streamed assistant text to the current post,
+                      // then start a new post so the "Running …" status does not overwrite
+                      // what was streamed before the tool call.
+                      await draftStream.flush();
+                      draftStream.forceNewMessage();
+                      lastPartialText = "";
+                    }
                     draftStream.update(buildMattermostToolStatusText(payload));
                   },
                 },


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost plugin overwrites streaming text with tool call statuses
- Why it matters: Negative UX - streaming text is lost
- What changed: Streaming text preserved by flushing before tool call status
- What did NOT change (scope boundary): Core functionality did not change (presentation only)

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A (Unreported bug)

## Root Cause (if applicable)

- Root cause: Streaming was added to Mattermost plugin by using draft edits. Tool call status would _replace_ the entire draft.
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

User now sees streaming text. Tool call status starts a new message if there is streaming text in the current draft, otherwise replaces previous tool call status.

## Diagram (if applicable)

```text
Before:
agent: Running exec ...

After:
agent: Let me read the file.
agent: Running exec ...
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.10
- Runtime/container: openclaw standard install
- Model/provider: any
- Integration/channel (if any): Mattermost
- Relevant config (redacted): any

### Steps

1. Request a multi-step operation from the agent

### Expected
1. Streaming responses should be visible along with final output
-

### Actual
1. Streaming response is displayed but quickly overwritten by tool call status and only final output is eventually displayed.
-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [X] Screenshot/recording
- [ ] Perf numbers (if relevant)
<img width="213" height="53" alt="image" src="https://github.com/user-attachments/assets/88b5bc35-165f-4773-9fef-d90f13136a5e" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Before/after agent chats with multi-step processes
- Edge cases checked: Single-step turns still working
- What you did **not** verify: Multi-agent channel chats

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.
None
