### PR TITLE
fix(agents/failover): classify bare pi-ai stream wrapper as timeout for all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: stop session write-lock timeouts from entering model failover, so local lock contention surfaces directly instead of cascading across providers. (#68700) Thanks @MonkeyLeeT.
 - Auto-reply: run inbound reply delivery through `message_sending` hooks so plugins can transform or cancel generated replies before they are sent. (#70118) Thanks @jzakirov.
 - CI/release-checks: pass workflow inputs and matrix values through step environment variables instead of embedding them directly into `run:` shell commands, reducing template-injection surface in the cross-OS release-check workflow. (#66884) Thanks @alexlomt.
-- Agents/failover: classify the bare `An unknown error occurred` stream-wrapper message that pi-ai providers throw when streams end with `stopReason: "aborted" | "error"` as a transient timeout regardless of provider, so configured fallback chains rotate for non-Anthropic providers (Google, OpenRouter, Bedrock, etc.) instead of surfacing the literal string to users. Fixes #71620. Thanks @mattcproctor.
+- Agents/failover: classify the bare `An unknown error occurred` stream-wrapper message that pi-ai providers throw when streams end with `stopReason: "aborted" | "error"` as a transient timeout regardless of provider, so configured fallback chains rotate for non-Anthropic providers (Google, OpenRouter, Bedrock, etc.) instead of surfacing the literal string to users. Fixes #71620. Thanks @willamhou and @mattcproctor.
 
 ## 2026.4.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: stop session write-lock timeouts from entering model failover, so local lock contention surfaces directly instead of cascading across providers. (#68700) Thanks @MonkeyLeeT.
 - Auto-reply: run inbound reply delivery through `message_sending` hooks so plugins can transform or cancel generated replies before they are sent. (#70118) Thanks @jzakirov.
 - CI/release-checks: pass workflow inputs and matrix values through step environment variables instead of embedding them directly into `run:` shell commands, reducing template-injection surface in the cross-OS release-check workflow. (#66884) Thanks @alexlomt.
+- Agents/failover: classify the bare `An unknown error occurred` stream-wrapper message that pi-ai providers throw when streams end with `stopReason: "aborted" | "error"` as a transient timeout regardless of provider, so configured fallback chains rotate for non-Anthropic providers (Google, OpenRouter, Bedrock, etc.) instead of surfacing the literal string to users. Fixes #71620. Thanks @mattcproctor.
 
 ## 2026.4.23
 

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -129,15 +129,18 @@ validation failures) are treated as failover‑worthy and use the same cooldowns
 OpenAI-compatible stop-reason errors such as `Unhandled stop reason: error`,
 `stop reason: error`, and `reason: error` are classified as timeout/failover
 signals.
-Provider-scoped generic server text can also land in that timeout bucket when
-the source matches a known transient pattern. For example, Anthropic bare
-`An unknown error occurred` and JSON `api_error` payloads with transient server
-text such as `internal server error`, `unknown error, 520`, `upstream error`,
-or `backend error` are treated as failover-worthy timeouts. OpenRouter-specific
-generic upstream text such as bare `Provider returned error` is also treated as
-timeout only when the provider context is actually OpenRouter. Generic internal
-fallback text such as `LLM request failed with an unknown error.` stays
-conservative and does not trigger failover by itself.
+Generic server text can also land in that timeout bucket when the source matches
+a known transient pattern. For example, the bare pi-ai stream-wrapper message
+`An unknown error occurred` is treated as failover-worthy for every provider
+because pi-ai emits it when provider streams end with `stopReason: "aborted"` or
+`stopReason: "error"` without specific details. JSON `api_error` payloads with
+transient server text such as `internal server error`, `unknown error, 520`,
+`upstream error`, or `backend error` are also treated as failover-worthy
+timeouts.
+OpenRouter-specific generic upstream text such as bare `Provider returned error`
+is treated as timeout only when the provider context is actually OpenRouter.
+Generic internal fallback text such as `LLM request failed with an unknown
+error.` stays conservative and does not trigger failover by itself.
 
 Some provider SDKs may otherwise sleep for a long `Retry-After` window before
 returning control to OpenClaw. For Stainless-based SDKs such as Anthropic and

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -441,7 +441,12 @@ describe("failover-error", () => {
     ).toBeNull();
   });
 
-  it("classifies provider-scoped generic upstream errors for failover", () => {
+  it("classifies bare pi-ai stream wrapper as timeout regardless of provider (#71620)", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "An unknown error occurred",
+      }),
+    ).toBe("timeout");
     expect(
       resolveFailoverReasonFromError({
         provider: "anthropic",
@@ -450,24 +455,28 @@ describe("failover-error", () => {
     ).toBe("timeout");
     expect(
       resolveFailoverReasonFromError({
+        provider: "google",
+        message: "An unknown error occurred",
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openrouter",
+        message: "An unknown error occurred",
+      }),
+    ).toBe("timeout");
+  });
+
+  it("classifies openrouter-scoped upstream errors for failover", () => {
+    expect(
+      resolveFailoverReasonFromError({
         provider: "openrouter",
         message: "Provider returned error",
       }),
     ).toBe("timeout");
   });
 
-  it("does not classify provider-scoped upstream errors without the matching provider", () => {
-    expect(
-      resolveFailoverReasonFromError({
-        message: "An unknown error occurred",
-      }),
-    ).toBeNull();
-    expect(
-      resolveFailoverReasonFromError({
-        provider: "openrouter",
-        message: "An unknown error occurred",
-      }),
-    ).toBeNull();
+  it("does not classify openrouter-scoped upstream errors without the matching provider", () => {
     expect(
       resolveFailoverReasonFromError({
         message: "Provider returned error",

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -739,10 +739,39 @@ describe("classifyFailoverReason", () => {
     expect(isFailoverErrorMessage(message)).toBe(true);
   });
 
-  it("classifies provider-scoped generic upstream messages", () => {
+  it("classifies bare pi-ai stream wrapper as timeout regardless of provider (#71620)", () => {
+    // pi-ai providers throw `Error("An unknown error occurred")` provider-agnostically
+    // when streams end with stopReason "aborted" | "error" with no specific info.
+    for (const sample of [
+      "An unknown error occurred",
+      "an unknown error occurred",
+      "AN UNKNOWN ERROR OCCURRED",
+      "An unknown error occurred.",
+      "  An unknown error occurred  ",
+    ]) {
+      expect(classifyFailoverReason(sample)).toBe("timeout");
+      expect(isFailoverErrorMessage(sample)).toBe(true);
+    }
     expect(classifyFailoverReason("An unknown error occurred", { provider: "anthropic" })).toBe(
       "timeout",
     );
+    expect(classifyFailoverReason("An unknown error occurred", { provider: "google" })).toBe(
+      "timeout",
+    );
+    expect(classifyFailoverReason("An unknown error occurred", { provider: "openrouter" })).toBe(
+      "timeout",
+    );
+  });
+
+  it("does not match wrapped or unrelated unknown-error phrases as bare wrapper", () => {
+    // Wrapped messages must not slip into failover-as-timeout via the bare match.
+    expect(classifyFailoverReason("LLM request failed with an unknown error.")).toBeNull();
+    expect(
+      classifyFailoverReason("user reported that an unknown error occurred during sync"),
+    ).toBeNull();
+  });
+
+  it("classifies openrouter-scoped upstream messages", () => {
     expect(classifyFailoverReason("Provider returned error", { provider: "openrouter" })).toBe(
       "timeout",
     );
@@ -751,11 +780,7 @@ describe("classifyFailoverReason", () => {
     );
   });
 
-  it("does not classify provider-scoped generic upstream messages without provider context", () => {
-    expect(classifyFailoverReason("An unknown error occurred")).toBeNull();
-    expect(
-      classifyFailoverReason("An unknown error occurred", { provider: "openrouter" }),
-    ).toBeNull();
+  it("does not classify openrouter-scoped upstream messages without provider context", () => {
     expect(classifyFailoverReason("Provider returned error")).toBeNull();
     expect(classifyFailoverReason("Provider returned error", { provider: "anthropic" })).toBeNull();
     expect(classifyFailoverReason("Key limit exceeded")).toBeNull();

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -753,11 +753,13 @@ function isProvider(provider: string | undefined, match: string): boolean {
   return Boolean(normalized && normalized.includes(match));
 }
 
-function isAnthropicGenericUnknownError(raw: string, provider?: string): boolean {
-  return (
-    isProvider(provider, "anthropic") &&
-    (normalizeOptionalLowercaseString(raw)?.includes("an unknown error occurred") ?? false)
-  );
+// pi-ai providers throw `Error("An unknown error occurred")` provider-agnostically
+// (anthropic, google, vertex, openai-completions, mistral, bedrock, etc.) when a
+// stream ends with stopReason === "aborted" | "error" without specific info. Treat
+// it as a transient transport failure so the configured fallback chain rotates
+// instead of returning the bare string to the user (#71620).
+function isGenericUnknownStreamError(raw: string): boolean {
+  return /^\s*an unknown error occurred\.?\s*$/i.test(raw);
 }
 
 function isOpenRouterProviderReturnedError(raw: string, provider?: string): boolean {
@@ -833,7 +835,7 @@ function classifyFailoverClassificationFromMessage(
   if (isAuthErrorMessage(raw)) {
     return toReasonClassification("auth");
   }
-  if (isAnthropicGenericUnknownError(raw, provider)) {
+  if (isGenericUnknownStreamError(raw)) {
     return toReasonClassification("timeout");
   }
   if (isOpenRouterProviderReturnedError(raw, provider)) {


### PR DESCRIPTION
Fixes #71620.

## Root cause

`@mariozechner/pi-ai` providers (anthropic, google, google-vertex, openai-completions, openai-responses, mistral, amazon-bedrock, azure-openai-responses, google-gemini-cli) all throw a literal `Error("An unknown error occurred")` from a shared stream-wrapper pattern when the stream ends with `stopReason: "aborted" | "error"` and no specific error info is attached.

OpenClaw classified that bare string as transient (timeout) for failover **only** when the active provider name contained `"anthropic"`, via `isAnthropicGenericUnknownError()` in `src/agents/pi-embedded-helpers/errors.ts:756`. For non-Anthropic primaries (the issue reporter is on `google/gemini-2.5-flash`) the classifier returned `null`, so:

- `isFailoverAssistantError()` → `false`
- `failoverFailure` branch in `pi-embedded-runner/run.ts:1301` never fires
- The configured `agents.defaults.model.fallbacks` chain is silently bypassed
- The literal `An unknown error occurred` text is surfaced to end users

This is provider-agnostic upstream, but the gate was provider-scoped.

## Fix

`src/agents/pi-embedded-helpers/errors.ts:756`: rename `isAnthropicGenericUnknownError(raw, provider)` to `isGenericUnknownStreamError(raw)` and drop the `isProvider(provider, "anthropic")` gate. Replace the `includes("an unknown error occurred")` substring check with an anchored regex `/^\s*an unknown error occurred\.?\s*$/i` so we only catch the bare wrapper message and not user-text or assistant prose that happens to contain the phrase.

Tests previously locked the old behavior in two places:

- `pi-embedded-helpers.isbillingerrormessage.test.ts:742` — `classifies provider-scoped generic upstream messages` (kept the OpenRouter assertions, dropped the "An unknown error occurred" line because it no longer needs scoping)
- `pi-embedded-helpers.isbillingerrormessage.test.ts:754` and `failover-error.test.ts:459` — `does not classify provider-scoped generic upstream messages without provider context` (kept the `Provider returned error` / `Key limit exceeded` lines, dropped the "An unknown error occurred" lines that were the bug)

Added new tests covering bare/case/whitespace variants across providers `anthropic`, `google`, `openrouter`, plus negative tests for wrapped messages (`LLM request failed with an unknown error.` and a sentence containing the phrase mid-string) so they keep returning `null`.

## Verification

- `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts` — 189/189 passed.
- `pnpm test src/plugins/provider-runtime.test.ts` — 30/30 passed (uses the same classifier through `isFailoverErrorMessage`).
- `npx oxlint <changed files>` — 0 errors, 0 warnings.
- `pnpm format:check <changed files>` — clean.
- `pnpm tsgo:core` — same set of pre-existing unrelated errors as on `c070509b7f` (`ui/src/ui/views/agents-*.ts`, `src/mcp/*`, `src/media/qr-runtime.ts`, `src/plugin-sdk/*`, `src/trajectory/metadata.ts`); confirmed by stashing and re-running on clean main.

## Test plan

- [x] Existing failover regression tests pass with new behavior.
- [x] Added regression coverage for #71620 across providers and case/whitespace variants.
- [x] Negative tests prevent the substring match from accidentally classifying wrapped or descriptive prose.
- [ ] Live verification with a non-Anthropic primary that hits `stopReason: "error"` (issue reporter has confirmed the local one-line patch works on 2026.4.15).