### PR TITLE
fix(cron): invalidate stale nextRun after schedule reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: recompute pending runtime slots after live `jobs.json` schedule edits
+  without clearing due slots for formatting-only rewrites. Fixes #71607. Thanks
+  @xialonglee.
 - Gateway/subagents: keep direct-loopback backend RPCs authenticated with the
   shared gateway token/password off stale CLI paired-device scope baselines, so
   internal calls no longer hit `scope-upgrade` pairing prompts while remote,

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -35,6 +35,9 @@ openclaw cron runs --id <job-id>
 - Job definitions persist at `~/.openclaw/cron/jobs.json` so restarts do not lose schedules.
 - Runtime execution state persists next to it in `~/.openclaw/cron/jobs-state.json`. If you track cron definitions in git, track `jobs.json` and gitignore `jobs-state.json`.
 - After the split, older OpenClaw versions can read `jobs.json` but may treat jobs as fresh because runtime fields now live in `jobs-state.json`.
+- When `jobs.json` is edited while the Gateway is running, the scheduler reloads
+  changed scheduling inputs and recomputes stale `nextRunAtMs` values. Pure
+  formatting or key-order-only rewrites preserve the pending runtime state.
 - All cron executions create [background task](/automation/tasks) records.
 - One-shot jobs (`--at`) auto-delete after success by default.
 - Isolated cron runs best-effort close tracked browser tabs/processes for their `cron:<jobId>` session when the run completes, so detached browser automation does not leave orphaned processes behind.
@@ -382,6 +385,11 @@ Model override note:
 The runtime state sidecar is derived from `cron.store`: a `.json` store such as
 `~/clawd/cron/jobs.json` uses `~/clawd/cron/jobs-state.json`, while a store path
 without a `.json` suffix appends `-state.json`.
+
+If you hand-edit `jobs.json`, leave `jobs-state.json` out of source control.
+OpenClaw uses that sidecar for pending slots, active markers, and last-run
+metadata, and invalidates pending slots only when schedule fields or enabled
+state actually change.
 
 Disable cron: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -85,6 +85,11 @@ Note: retention/pruning is controlled in config:
 - `cron.sessionRetention` (default `24h`) prunes completed isolated run sessions.
 - `cron.runLog.maxBytes` + `cron.runLog.keepLines` prune `~/.openclaw/cron/runs/<jobId>.jsonl`.
 
+Note: cron job definitions live in `jobs.json`, while pending runtime state
+lives in `jobs-state.json`. If `jobs.json` is edited externally, the Gateway
+reloads changed schedules without requiring a restart; formatting-only rewrites
+do not clear the pending slot.
+
 Upgrade note: if you have older cron jobs from before the current delivery/store format, run
 `openclaw doctor --fix`. Doctor now normalizes legacy cron fields (`jobId`, `schedule.cron`,
 top-level delivery fields including legacy `threadId`, payload `provider` delivery aliases) and migrates simple

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -327,4 +327,62 @@ describe("cron service store seam coverage", () => {
 
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBeUndefined();
   });
+
+  it("clears stale nextRunAtMs after force reload when every schedule anchor changes", async () => {
+    const { storePath } = await makeStorePath();
+    const jobId = "reload-every-anchor-job";
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: STORE_TEST_NOW - 60_000 },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        updatedAtMs: STORE_TEST_NOW,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: STORE_TEST_NOW },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("clears stale nextRunAtMs after force reload when at schedule target changes", async () => {
+    const { storePath } = await makeStorePath();
+    const jobId = "reload-at-target-job";
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        schedule: { kind: "at", at: "2026-03-23T13:00:00.000Z" },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        updatedAtMs: STORE_TEST_NOW,
+        schedule: { kind: "at", at: "2026-03-23T14:00:00.000Z" },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBeUndefined();
+  });
 });

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "../service.test-harness.js";
+import { saveCronStore } from "../store.js";
+import type { CronJob } from "../types.js";
 import { findJobOrThrow } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
@@ -38,6 +40,22 @@ function createStoreTestState(storePath: string) {
     requestHeartbeatNow: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
   });
+}
+
+function createReloadCronJob(params?: Partial<CronJob>): CronJob {
+  return {
+    id: "reload-cron-expr-job",
+    name: "reload cron expr job",
+    enabled: true,
+    createdAtMs: STORE_TEST_NOW - 60_000,
+    updatedAtMs: STORE_TEST_NOW - 60_000,
+    schedule: { kind: "cron", expr: "0 6 * * *", tz: "UTC" },
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "tick" },
+    state: {},
+    ...params,
+  };
 }
 
 describe("cron service store seam coverage", () => {
@@ -192,42 +210,121 @@ describe("cron service store seam coverage", () => {
 
   it("clears stale nextRunAtMs after force reload when cron schedule expression changes", async () => {
     const { storePath } = await makeStorePath();
-    const jobId = "reload-cron-expr-job";
-    const jobName = "reload cron expr job";
-    const createdAtMs = STORE_TEST_NOW - 60_000;
-    const baseJob = {
-      id: jobId,
-      name: jobName,
-      enabled: true,
-      createdAtMs,
-      sessionTarget: "main",
-      wakeMode: "now",
-      payload: { kind: "systemEvent", text: "tick" as const },
-    };
     const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
 
-    await writeSingleJobStore(storePath, {
-      ...baseJob,
-      updatedAtMs: STORE_TEST_NOW - 60_000,
-      schedule: { kind: "cron", expr: "0 6 * * *", tz: "UTC" },
-      state: { nextRunAtMs: staleNextRunAtMs },
+    await saveCronStore(storePath, {
+      version: 1,
+      jobs: [
+        createReloadCronJob({
+          state: { nextRunAtMs: staleNextRunAtMs },
+        }),
+      ],
     });
 
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
-    expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBe(staleNextRunAtMs);
+    expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(staleNextRunAtMs);
 
     await writeSingleJobStore(storePath, {
-      ...baseJob,
+      id: "reload-cron-expr-job",
+      name: "reload cron expr job",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      state: { nextRunAtMs: staleNextRunAtMs },
       updatedAtMs: STORE_TEST_NOW - 30_000,
       schedule: { kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" },
-      state: { nextRunAtMs: staleNextRunAtMs },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" as const },
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
 
-    const reloadedJob = findJobOrThrow(state, jobId);
+    const reloadedJob = findJobOrThrow(state, "reload-cron-expr-job");
     expect(reloadedJob.schedule).toEqual({ kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" });
     expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("preserves nextRunAtMs after force reload when cron schedule key order changes only", async () => {
+    const { storePath } = await makeStorePath();
+    const dueNextRunAtMs = STORE_TEST_NOW - 1_000;
+
+    await saveCronStore(storePath, {
+      version: 1,
+      jobs: [
+        createReloadCronJob({
+          state: { nextRunAtMs: dueNextRunAtMs },
+        }),
+      ],
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeSingleJobStore(storePath, {
+      id: "reload-cron-expr-job",
+      name: "reload cron expr job",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      updatedAtMs: STORE_TEST_NOW - 30_000,
+      schedule: { expr: "0 6 * * *", kind: "cron", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" as const },
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("preserves nextRunAtMs after force reload when scheduling inputs are unchanged", async () => {
+    const { storePath } = await makeStorePath();
+    const originalNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({ state: { nextRunAtMs: originalNextRunAtMs } }),
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        updatedAtMs: STORE_TEST_NOW,
+        state: { nextRunAtMs: originalNextRunAtMs + 60_000 },
+      }),
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(
+      originalNextRunAtMs + 60_000,
+    );
+  });
+
+  it("clears stale nextRunAtMs after force reload when enabled state changes", async () => {
+    const { storePath } = await makeStorePath();
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        enabled: true,
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        enabled: false,
+        updatedAtMs: STORE_TEST_NOW,
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBeUndefined();
   });
 });

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -189,4 +189,45 @@ describe("cron service store seam coverage", () => {
       expect.stringContaining("invalid persisted sessionTarget"),
     );
   });
+
+  it("clears stale nextRunAtMs after force reload when cron schedule expression changes", async () => {
+    const { storePath } = await makeStorePath();
+    const jobId = "reload-cron-expr-job";
+    const jobName = "reload cron expr job";
+    const createdAtMs = STORE_TEST_NOW - 60_000;
+    const baseJob = {
+      id: jobId,
+      name: jobName,
+      enabled: true,
+      createdAtMs,
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" as const },
+    };
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...baseJob,
+      updatedAtMs: STORE_TEST_NOW - 60_000,
+      schedule: { kind: "cron", expr: "0 6 * * *", tz: "UTC" },
+      state: { nextRunAtMs: staleNextRunAtMs },
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBe(staleNextRunAtMs);
+
+    await writeSingleJobStore(storePath, {
+      ...baseJob,
+      updatedAtMs: STORE_TEST_NOW - 30_000,
+      schedule: { kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" },
+      state: { nextRunAtMs: staleNextRunAtMs },
+    });
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    const reloadedJob = findJobOrThrow(state, jobId);
+    expect(reloadedJob.schedule).toEqual({ kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" });
+    expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
+  });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -7,6 +7,25 @@ import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
+function didSchedulingInputsChange(previous: CronJob, next: CronJob): boolean {
+  if (previous.enabled !== next.enabled) {
+    return true;
+  }
+  return JSON.stringify(previous.schedule) !== JSON.stringify(next.schedule);
+}
+
+function invalidateStaleNextRunOnScheduleChange(params: {
+  previousJobsById: ReadonlyMap<string, CronJob>;
+  hydrated: CronJob;
+}) {
+  const previousJob = params.previousJobsById.get(params.hydrated.id);
+  if (!previousJob || !didSchedulingInputsChange(previousJob, params.hydrated)) {
+    return;
+  }
+  params.hydrated.state ??= {};
+  params.hydrated.state.nextRunAtMs = undefined;
+}
+
 async function getFileMtimeMs(path: string): Promise<number | null> {
   try {
     const stats = await fs.promises.stat(path);
@@ -29,6 +48,11 @@ export async function ensureLoaded(
   // trust the in-memory copy to avoid a stat syscall on every operation.
   if (state.store && !opts?.forceReload) {
     return;
+  }
+
+  const previousJobsById = new Map<string, CronJob>();
+  for (const job of state.store?.jobs ?? []) {
+    previousJobsById.set(job.id, job);
   }
   // Force reload always re-reads the file to avoid missing cross-service
   // edits on filesystems with coarse mtime resolution.
@@ -54,6 +78,7 @@ export async function ensureLoaded(
     }
     const hydrated =
       normalized && typeof normalized === "object" ? (normalized as unknown as CronJob) : job;
+    invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
     jobs[index] = hydrated;
     if (legacyJobIdIssue) {
       const resolvedId = typeof hydrated.id === "string" ? hydrated.id : undefined;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -7,11 +7,32 @@ import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
-function didSchedulingInputsChange(previous: CronJob, next: CronJob): boolean {
-  if (previous.enabled !== next.enabled) {
-    return true;
+function schedulesEqual(previous: CronJob["schedule"], next: CronJob["schedule"]): boolean {
+  if (previous.kind !== next.kind) {
+    return false;
   }
-  return JSON.stringify(previous.schedule) !== JSON.stringify(next.schedule);
+  switch (previous.kind) {
+    case "at":
+      return next.kind === "at" && previous.at === next.at;
+    case "every":
+      return (
+        next.kind === "every" &&
+        previous.everyMs === next.everyMs &&
+        previous.anchorMs === next.anchorMs
+      );
+    case "cron":
+      return (
+        next.kind === "cron" &&
+        previous.expr === next.expr &&
+        previous.tz === next.tz &&
+        previous.staggerMs === next.staggerMs
+      );
+  }
+  return false;
+}
+
+function didSchedulingInputsChange(previous: CronJob, next: CronJob): boolean {
+  return previous.enabled !== next.enabled || !schedulesEqual(previous.schedule, next.schedule);
 }
 
 function invalidateStaleNextRunOnScheduleChange(params: {


### PR DESCRIPTION
# fix(cron): invalidate stale nextRun after schedule reload

## Summary

This fixes a cron reload drift bug where a job could still fire using a stale in-memory `state.nextRunAtMs` after its cron expression was changed on disk.

Fixes #71607.

## Root Cause

- Timer ticks reload `jobs.json` with `forceReload: true` and `skipRecompute: true`.
- When a job's schedule expression changed, persisted `state.nextRunAtMs` could still carry a future timestamp computed for the old expression.
- Maintenance recompute intentionally preserves existing future `nextRunAtMs`, so the stale timestamp could survive and trigger an unexpected run.

## What Changed

- Updated `src/cron/service/store.ts`:
  - compare reloaded jobs against the previous in-memory copy by `id`;
  - when scheduling inputs change (`schedule` or `enabled`), clear `state.nextRunAtMs`.
- Added regression coverage in `src/cron/service/store.test.ts`:
  - verifies a forced reload with changed cron expr invalidates stale `nextRunAtMs`.

## Validation

- `pnpm test src/cron/service/store.test.ts` (pass)
- `pnpm check:changed` (fails due to unrelated pre-existing repo-wide typecheck errors in other surfaces; touched cron test surface passes)

## Risk / Follow-up

- Risk is low and scoped to reload paths where scheduling inputs change.
- Unchanged jobs keep existing behavior.

## AI-assisted

- [x] AI-assisted and manually reviewed.
