### PR TITLE
refactor: trim reply prompt hot path plumbing

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -170,7 +170,6 @@ function baseParams(
       rawBodyNormalized: "",
       commandBodyNormalized: "",
     } as never,
-    commandSource: "",
     allowTextCommands: true,
     directives: {
       hasThinkDirective: false,
@@ -194,7 +193,6 @@ function baseParams(
       onReplyStart: vi.fn().mockResolvedValue(undefined),
       cleanup: vi.fn(),
     } as never,
-    defaultProvider: "anthropic",
     defaultModel: "claude-opus-4-1",
     timeoutMs: 30_000,
     isNewSession: true,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -182,7 +182,6 @@ type RunPreparedReplyParams = {
   sessionCfg: OpenClawConfig["session"];
   commandAuthorized: boolean;
   command: ReturnType<typeof buildCommandContext>;
-  commandSource?: string;
   allowTextCommands: boolean;
   directives: InlineDirectives;
   defaultActivation: Parameters<typeof buildGroupIntro>[0]["defaultActivation"];
@@ -212,7 +211,6 @@ type RunPreparedReplyParams = {
   };
   typing: TypingController;
   opts?: GetReplyOptions;
-  defaultProvider: string;
   defaultModel: string;
   timeoutMs: number;
   isNewSession: boolean;
@@ -347,6 +345,12 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = normalizeOptionalString(sessionCtx.GroupSystemPrompt) ?? "";
+  const execOverridePromptHint = buildExecOverridePromptHint({
+    execOverrides,
+    elevatedLevel: resolvedElevatedLevel,
+    fullAccessAvailable: fullAccessState.available,
+    fullAccessBlockedReason: fullAccessState.blockedReason,
+  });
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
     { includeFormattingHints: !useFastReplyRuntime },
@@ -357,12 +361,7 @@ export async function runPreparedReply(
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
-    buildExecOverridePromptHint({
-      execOverrides,
-      elevatedLevel: resolvedElevatedLevel,
-      fullAccessAvailable: fullAccessState.available,
-      fullAccessBlockedReason: fullAccessState.blockedReason,
-    }),
+    execOverridePromptHint,
   ].filter(Boolean);
   // Static parts only (no per-message inbound metadata) for CLI session reuse hashing.
   const extraSystemPromptStaticParts = [
@@ -370,12 +369,7 @@ export async function runPreparedReply(
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
-    buildExecOverridePromptHint({
-      execOverrides,
-      elevatedLevel: resolvedElevatedLevel,
-      fullAccessAvailable: fullAccessState.available,
-      fullAccessBlockedReason: fullAccessState.blockedReason,
-    }),
+    execOverridePromptHint,
   ].filter(Boolean);
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   // Use CommandBody/RawBody for bare reset detection (clean message without structural context).

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -386,7 +386,6 @@ export async function getReplyFromConfig(
       sessionCfg,
       commandAuthorized,
       command: fastCommand,
-      commandSource: finalized.BodyForCommands ?? finalized.CommandBody ?? finalized.RawBody ?? "",
       allowTextCommands: shouldHandleFastReplyTextCommands({
         cfg,
         commandSource: finalized.CommandSource,
@@ -416,7 +415,6 @@ export async function getReplyFromConfig(
       perMessageQueueOptions: undefined,
       typing,
       opts: resolvedOpts,
-      defaultProvider,
       defaultModel,
       timeoutMs,
       isNewSession,
@@ -464,7 +462,6 @@ export async function getReplyFromConfig(
   }
 
   let {
-    commandSource,
     command,
     allowTextCommands,
     skillCommands,
@@ -613,7 +610,6 @@ export async function getReplyFromConfig(
     sessionCfg,
     commandAuthorized,
     command,
-    commandSource,
     allowTextCommands,
     directives,
     defaultActivation,
@@ -634,7 +630,6 @@ export async function getReplyFromConfig(
     perMessageQueueOptions,
     typing,
     opts: resolvedOpts,
-    defaultProvider,
     defaultModel,
     timeoutMs,
     isNewSession,

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -14,8 +14,6 @@ export function buildReplyPromptBodies(params: {
   threadContextNote?: string;
   systemEventBlocks?: string[];
 }): {
-  mediaNote?: string;
-  mediaReplyHint?: string;
   prefixedCommandBody: string;
   queuedBody: string;
   transcriptCommandBody: string;
@@ -45,8 +43,6 @@ export function buildReplyPromptBodies(params: {
     ? [mediaNote, transcriptBody].filter(Boolean).join("\n").trim()
     : transcriptBody;
   return {
-    mediaNote,
-    mediaReplyHint,
     prefixedCommandBody,
     queuedBody,
     transcriptCommandBody,


### PR DESCRIPTION
## Summary

- Problem: the inbound reply hot path passed fields that `runPreparedReply` never consumed, and `buildReplyPromptBodies` returned media helper fields that every caller discarded.
- Why it matters: normal message handling builds these prompt bodies on every inbound reply, so carrying unused fields makes the hot path and type contract noisier than needed.
- What changed: remove unused `commandSource` / `defaultProvider` plumbing into `runPreparedReply`, stop returning discarded media helper fields from `buildReplyPromptBodies`, and compute the exec override prompt hint once before adding it to dynamic and static system prompt parts.
- What did NOT change (scope boundary): no prompt text, queue behavior, media-note text, routing behavior, or provider execution behavior is intentionally changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
inbound reply -> build prompt bodies -> pass unused fields / return discarded fields

After:
inbound reply -> build prompt bodies -> pass only consumed fields / return only consumed bodies
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/WSL workspace
- Runtime/container: Node 22 via repo `pnpm` scripts
- Model/provider: N/A
- Integration/channel (if any): inbound reply prompt construction path
- Relevant config (redacted): default local test config

### Steps

1. Inspect the staged diff with `git diff --cached`.
2. Verify the targeted reply prompt tests:
   `pnpm test src/auto-reply/reply.media-note.test.ts src/auto-reply/reply.raw-body.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply.block-streaming.test.ts`
3. Verify the normal changed gate:
   `pnpm check:changed`

### Expected

- The staged diff should only remove unused hot-path plumbing and duplicate computation.
- Reply prompt behavior should remain covered by existing media/raw-body/get-reply/block-streaming tests.
- The changed gate should complete without the heavy-check lock deadlock.

### Actual

- Staged diff is limited to:
  - `src/auto-reply/reply/get-reply.ts`
  - `src/auto-reply/reply/get-reply-run.ts`
  - `src/auto-reply/reply/prompt-prelude.ts`
  - `src/auto-reply/reply/get-reply-run.media-only.test.ts`
- Targeted tests passed.
- Normal `pnpm check:changed` passed, including typecheck, lint, import-cycle checks, guards, and changed tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The relevant before-state was static evidence from `git diff --cached`: unused `commandSource` / `defaultProvider` fields were passed into `runPreparedReply`, and `mediaNote` / `mediaReplyHint` were returned from `buildReplyPromptBodies` without being consumed by callers.

Passing verification:

- `pnpm test src/auto-reply/reply.media-note.test.ts src/auto-reply/reply.raw-body.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply.block-streaming.test.ts`
- `pnpm check:changed`

## Human Verification (required)

- Verified scenarios:
  - media note prompt plumbing still passes targeted tests
  - raw-body directive prompt handling still passes targeted tests
  - media-only `runPreparedReply` coverage still passes
  - block-streaming reply path coverage still passes
  - normal changed gate no longer reproduces the heavy-check lock wait
- Edge cases checked:
  - fast reply and normal reply callers no longer pass removed fields
  - `buildReplyPromptBodies` still returns all consumed prompt bodies
  - exec override hint is still included in both dynamic and static prompt parts
- What you did **not** verify:
  - no live messaging channel run
  - no end-to-end provider call

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a caller could have depended on the removed return fields from `buildReplyPromptBodies`.
  - Mitigation: repository search showed no consumers of `mediaNote` or `mediaReplyHint`; targeted prompt tests still pass.
- Risk: removing `commandSource` / `defaultProvider` from `runPreparedReply` could hide a future use case.
  - Mitigation: the staged diff removes only fields unused by the current implementation; directive handling and model selection still receive their own `commandSource` / `defaultProvider` inputs before `runPreparedReply`.
