### PR TITLE
fix(mattermost): respect streaming config for draft preview

### DIFF
--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -109,6 +109,39 @@ describe("resolveMattermostReplyToMode", () => {
     expect(resolveMattermostReplyToMode(account, "channel")).toBe("off");
   });
 
+  it("defaults previewStreamMode to partial when streaming is unset", () => {
+    const account = resolveMattermostAccount({ cfg: {}, accountId: "default" });
+    expect(account.previewStreamMode).toBe("partial");
+  });
+
+  it("resolves previewStreamMode off when streaming is off", () => {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: {
+            streaming: "off",
+          },
+        },
+      },
+      accountId: "default",
+    });
+    expect(account.previewStreamMode).toBe("off");
+  });
+
+  it("resolves previewStreamMode partial when streaming is partial", () => {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: {
+            streaming: "partial",
+          },
+        },
+      },
+      accountId: "default",
+    });
+    expect(account.previewStreamMode).toBe("partial");
+  });
+
   it("preserves shared commands config when an account overrides one commands field", () => {
     const account = resolveMattermostAccount({
       cfg: {

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -2,6 +2,7 @@ import { createAccountListHelpers } from "openclaw/plugin-sdk/account-helpers";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveMergedAccountConfig } from "openclaw/plugin-sdk/account-resolution";
 import {
+  resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockCoalesce,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingChunkMode,
@@ -36,6 +37,7 @@ export type ResolvedMattermostAccount = {
   chunkMode?: MattermostAccountConfig["chunkMode"];
   blockStreaming?: boolean;
   blockStreamingCoalesce?: MattermostAccountConfig["blockStreamingCoalesce"];
+  previewStreamMode: "off" | "partial" | "block";
 };
 
 const mattermostAccountHelpers = createAccountListHelpers("mattermost");
@@ -123,6 +125,7 @@ export function resolveMattermostAccount(params: {
     blockStreaming: resolveChannelStreamingBlockEnabled(merged) ?? merged.blockStreaming,
     blockStreamingCoalesce:
       resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
+    previewStreamMode: resolveChannelPreviewStreamMode(merged, "partial"),
   };
 }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1619,14 +1619,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             },
           },
         });
-        const draftStream = createMattermostDraftStream({
-          client,
-          channelId,
-          rootId: effectiveReplyToId,
-          throttleMs: 1200,
-          log: logVerboseMessage,
-          warn: logVerboseMessage,
-        });
+        const previewEnabled = account.previewStreamMode !== "off";
+        const draftStream = previewEnabled
+          ? createMattermostDraftStream({
+              client,
+              channelId,
+              rootId: effectiveReplyToId,
+              throttleMs: 1200,
+              log: logVerboseMessage,
+              warn: logVerboseMessage,
+            })
+          : undefined;
         let lastPartialText = "";
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
@@ -1668,6 +1671,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         };
 
         const updateDraftFromPartial = (text?: string) => {
+          if (!draftStream) {
+            return;
+          }
           const cleaned = text?.trim();
           if (!cleaned) {
             return;
@@ -1692,34 +1698,56 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
             typingCallbacks,
             deliver: async (payload: ReplyPayload, info) => {
-              await deliverMattermostReplyWithDraftPreview({
-                payload,
-                info,
-                client,
-                draftStream,
-                effectiveReplyToId,
-                resolvePreviewFinalText,
-                previewState,
-                logVerboseMessage,
-                deliverFinal: async () => {
-                  await deliverMattermostReplyPayload({
-                    core,
-                    cfg,
-                    payload,
-                    to,
-                    accountId: account.accountId,
-                    agentId: route.agentId,
-                    replyToId: resolveMattermostReplyRootId({
-                      threadRootId: effectiveReplyToId,
-                      replyToId: payload.replyToId,
-                    }),
-                    textLimit,
-                    tableMode,
-                    sendMessage: sendMessageMattermost,
-                  });
-                  runtime.log?.(`delivered reply to ${to}`);
-                },
-              });
+              if (draftStream) {
+                await deliverMattermostReplyWithDraftPreview({
+                  payload,
+                  info,
+                  client,
+                  draftStream,
+                  effectiveReplyToId,
+                  resolvePreviewFinalText,
+                  previewState,
+                  logVerboseMessage,
+                  deliverFinal: async () => {
+                    await deliverMattermostReplyPayload({
+                      core,
+                      cfg,
+                      payload,
+                      to,
+                      accountId: account.accountId,
+                      agentId: route.agentId,
+                      replyToId: resolveMattermostReplyRootId({
+                        threadRootId: effectiveReplyToId,
+                        replyToId: payload.replyToId,
+                      }),
+                      textLimit,
+                      tableMode,
+                      sendMessage: sendMessageMattermost,
+                    });
+                    runtime.log?.(`delivered reply to ${to}`);
+                  },
+                });
+              } else {
+                if (payload.isReasoning) {
+                  return;
+                }
+                await deliverMattermostReplyPayload({
+                  core,
+                  cfg,
+                  payload,
+                  to,
+                  accountId: account.accountId,
+                  agentId: route.agentId,
+                  replyToId: resolveMattermostReplyRootId({
+                    threadRootId: effectiveReplyToId,
+                    replyToId: payload.replyToId,
+                  }),
+                  textLimit,
+                  tableMode,
+                  sendMessage: sendMessageMattermost,
+                });
+                runtime.log?.(`delivered reply to ${to}`);
+              }
             },
             onError: (err, info) => {
               runtime.error?.(`mattermost ${info.kind} reply failed: ${String(err)}`);
@@ -1750,22 +1778,28 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onReasoningEnd: () => {
                     lastPartialText = "";
                   },
-                  onReasoningStream: async () => {
-                    if (!lastPartialText) {
-                      draftStream.update("Thinking…");
-                    }
-                  },
-                  onToolStart: async (payload) => {
-                    draftStream.update(buildMattermostToolStatusText(payload));
-                  },
+                  onReasoningStream: draftStream
+                    ? async () => {
+                        if (!lastPartialText) {
+                          draftStream.update("Thinking…");
+                        }
+                      }
+                    : undefined,
+                  onToolStart: draftStream
+                    ? async (payload) => {
+                        draftStream.update(buildMattermostToolStatusText(payload));
+                      }
+                    : undefined,
                 },
               }),
           });
         } finally {
-          try {
-            await draftStream.stop();
-          } catch (err) {
-            logVerboseMessage(`mattermost draft preview cleanup failed: ${String(err)}`);
+          if (draftStream) {
+            try {
+              await draftStream.stop();
+            } catch (err) {
+              logVerboseMessage(`mattermost draft preview cleanup failed: ${String(err)}`);
+            }
           }
           markRunComplete();
         }


### PR DESCRIPTION
## Problem

The draft preview system introduced in #47838 creates a Mattermost post and repeatedly edits it during streaming. This causes every message to show "(Edited)" in Mattermost and, more critically, overwrites previous content - if a user isn't watching in real-time, intermediate messages (tool status, thinking indicators) are lost as they're replaced.

The draft stream was created unconditionally with no check for the channel streaming config. The `resolveChannelPreviewStreamMode` SDK function exists and is used by Telegram, but the Mattermost monitor never called it. Setting `streaming: "off"` in config had no effect.

## Fix

- Added `previewStreamMode` field to `ResolvedMattermostAccount` using `resolveChannelPreviewStreamMode` from the plugin SDK
- When `streaming` is `"off"`, the draft stream is not created and replies are delivered directly without the create-then-edit pattern
- When streaming is enabled (`"partial"` default), behavior is unchanged

## Config

```json5
{
  channels: {
    mattermost: {
      streaming: "off", // disables draft preview editing
    },
  },
}
```

## Tests

- 3 new tests for `previewStreamMode` resolution (default partial, off, partial)
- All 50 existing Mattermost tests continue to pass
- No changes to the draft preview finalization logic when streaming is enabled