### PR TITLE
fix: stabilize isolated heartbeat routing

### DIFF
--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -126,7 +126,7 @@ describe("handshake auth helpers", () => {
       }),
     ).toBe(false);
   });
-  it("rejects silent role-upgrade for remote clients", () => {
+  it("rejects silent role-upgrade and metadata-upgrade for remote clients", () => {
     expect(
       shouldAllowSilentLocalPairing({
         locality: "remote",
@@ -134,6 +134,15 @@ describe("handshake auth helpers", () => {
         isControlUi: false,
         isWebchat: false,
         reason: "role-upgrade",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAllowSilentLocalPairing({
+        locality: "remote",
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        reason: "metadata-upgrade",
       }),
     ).toBe(false);
   });

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -201,6 +201,73 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
     });
   });
 
+  it("uses the configured isolated heartbeat base when a forced live session has no pending work", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "main");
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const liveSessionKey = "agent:main:cloud-codex";
+      await seedSessionStore(storePath, liveSessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "telegram:170703438",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: liveSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(store["agent:main:cloud-codex:heartbeat"]).toBeUndefined();
+    });
+  });
+
+  it("consumes forced-session cron events from the forced base session while running on its isolated sibling", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "main");
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "Relay the forced-session cron update now" });
+
+      const liveSessionKey = "agent:main:cloud-codex";
+      await seedSessionStore(storePath, liveSessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "telegram:170703438",
+      });
+      enqueueSystemEvent("Cron: forced live-session update", {
+        sessionKey: liveSessionKey,
+        contextKey: "cron:forced-live-session-update",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: liveSessionKey,
+        reason: "cron:forced-live-session-update",
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      expect(peekSystemEventEntries(liveSessionKey)).toEqual([]);
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        SessionKey: "agent:main:cloud-codex:heartbeat",
+        Provider: "cron-event",
+      });
+    });
+  });
+
   it("consumes base-session cron events when isolated heartbeat runs on a :heartbeat session", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
@@ -334,6 +401,7 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       expect(calledCtx.SessionKey).toBe(isolatedSessionKey);
       expect(calledCtx.Provider).toBe("exec-event");
       expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
+      expect(peekSystemEventEntries(isolatedSessionKey)).toEqual([]);
     });
   });
 

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -35,11 +35,11 @@ beforeEach(() => {
   resetSystemEventsForTest();
 });
 
-function createHeartbeatTelegramConfig(): OpenClawConfig {
+function createHeartbeatTelegramConfig(isolatedSession = false): OpenClawConfig {
   return {
     agents: {
       defaults: {
-        heartbeat: { every: "30m" },
+        heartbeat: { every: "30m", ...(isolatedSession ? { isolatedSession: true } : {}) },
         model: { primary: "test/model" },
       },
     },
@@ -122,6 +122,42 @@ describe("heartbeat runner skips when target session lane is busy", () => {
 
       expect(replySpy).toHaveBeenCalled();
       expect(result.status).toBe("ran");
+    });
+  });
+
+  it("checks the isolated heartbeat lane when wake re-enters on an active :heartbeat session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+
+      enqueueSystemEvent("exec finished: deploy succeeded", {
+        sessionKey: isolatedSessionKey,
+      });
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${isolatedSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedSessionKey,
+        reason: "hook:wake",
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(replySpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -125,6 +125,71 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
+  it("skips isolated heartbeat when the configured base lane is busy", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${baseSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${baseSessionKey}`);
+      expect(getQueueSize).not.toHaveBeenCalledWith(`session:${baseSessionKey}:heartbeat`);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("skips isolated heartbeat when a forced live session lane is busy", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const forcedLiveSessionKey = "agent:main:cloud-codex";
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${forcedLiveSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        sessionKey: forcedLiveSessionKey,
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${baseSessionKey}`);
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${forcedLiveSessionKey}`);
+      expect(getQueueSize).not.toHaveBeenCalledWith(`session:${forcedLiveSessionKey}:heartbeat`);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("checks the isolated heartbeat lane when wake re-enters on an active :heartbeat session", async () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig(true);

--- a/src/infra/heartbeat-runner.subagent-session-guard.test.ts
+++ b/src/infra/heartbeat-runner.subagent-session-guard.test.ts
@@ -9,74 +9,91 @@ import { withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
 installHeartbeatRunnerTestRuntime();
 
 describe("runHeartbeatOnce", () => {
-  it("falls back to the main session when a subagent session key is forced", async () => {
-    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
-      const cfg: OpenClawConfig = {
-        agents: {
-          defaults: {
-            workspace: tmpDir,
-            heartbeat: {
-              every: "5m",
-              target: "whatsapp",
+  it.each([
+    {
+      name: "when a subagent session key is forced",
+      heartbeat: undefined,
+      sessionKey: "agent:main:subagent:demo",
+      expectedRunSessionKey: "agent:main:main",
+    },
+    {
+      name: "when isolatedSession is enabled and a subagent session key is forced",
+      heartbeat: { isolatedSession: true },
+      sessionKey: "agent:main:subagent:demo",
+      expectedRunSessionKey: "agent:main:main:heartbeat",
+    },
+  ])(
+    "falls back to the main session %s",
+    async ({ heartbeat, sessionKey, expectedRunSessionKey }) => {
+      await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "whatsapp",
+                ...heartbeat,
+              },
             },
           },
-        },
-        channels: {
-          whatsapp: {
-            allowFrom: ["*"],
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+            },
           },
-        },
-        session: { store: storePath },
-      };
+          session: { store: storePath },
+        };
 
-      const mainSessionKey = resolveMainSessionKey(cfg);
-      await fs.writeFile(
-        storePath,
-        JSON.stringify({
-          [mainSessionKey]: {
-            sessionId: "sid-main",
-            updatedAt: Date.now(),
-            lastChannel: "whatsapp",
-            lastProvider: "whatsapp",
-            lastTo: "120363401234567890@g.us",
-          },
-          "agent:main:subagent:demo": {
-            sessionId: "sid-subagent",
-            updatedAt: Date.now(),
-            lastChannel: "whatsapp",
-            lastProvider: "whatsapp",
-            lastTo: "120363409999999999@g.us",
-          },
-        }),
-      );
+        const mainSessionKey = resolveMainSessionKey(cfg);
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [mainSessionKey]: {
+              sessionId: "sid-main",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "120363401234567890@g.us",
+            },
+            "agent:main:subagent:demo": {
+              sessionId: "sid-subagent",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "120363409999999999@g.us",
+            },
+          }),
+        );
 
-      replySpy.mockResolvedValue({ text: "Final alert" });
-      const sendWhatsApp = vi.fn().mockResolvedValue({
-        messageId: "m1",
-        toJid: "jid",
+        replySpy.mockResolvedValue({ text: "Final alert" });
+        const sendWhatsApp = vi.fn().mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+        await runHeartbeatOnce({
+          cfg,
+          sessionKey,
+          deps: {
+            getReplyFromConfig: replySpy,
+            whatsapp: sendWhatsApp,
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        expect(replySpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            SessionKey: expectedRunSessionKey,
+            OriginatingChannel: undefined,
+            OriginatingTo: undefined,
+          }),
+          expect.anything(),
+          cfg,
+        );
       });
-
-      await runHeartbeatOnce({
-        cfg,
-        sessionKey: "agent:main:subagent:demo",
-        deps: {
-          getReplyFromConfig: replySpy,
-          whatsapp: sendWhatsApp,
-          getQueueSize: () => 0,
-          nowMs: () => 0,
-        },
-      });
-
-      expect(replySpy).toHaveBeenCalledTimes(1);
-      expect(replySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          SessionKey: mainSessionKey,
-          OriginatingChannel: undefined,
-          OriginatingTo: undefined,
-        }),
-        expect.anything(),
-        cfg,
-      );
-    });
-  });
+    },
+  );
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -530,6 +530,9 @@ type HeartbeatSkipReason = "empty-heartbeat-file";
 
 type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
+  inspectionSessionKey: string;
+  inspectionSessionEntry?: ReturnType<typeof resolveHeartbeatSession>["entry"];
+  isolationSourceSessionKey: string;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   turnSourceDeliveryContext: ReturnType<typeof resolveSystemEventDeliveryContext>;
   hasTaggedCronEvents: boolean;
@@ -556,13 +559,55 @@ async function resolveHeartbeatPreflight(params: {
   reason?: string;
 }): Promise<HeartbeatPreflight> {
   const reasonFlags = resolveHeartbeatReasonFlags(params.reason);
-  const session = resolveHeartbeatSession(
-    params.cfg,
-    params.agentId,
-    params.heartbeat,
-    params.forcedSessionKey,
-  );
-  const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const configuredSession = resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat);
+  const forcedSession = params.forcedSessionKey
+    ? resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat, params.forcedSessionKey)
+    : undefined;
+  const forcedIsConfiguredIsolatedLane =
+    params.heartbeat?.isolatedSession === true &&
+    forcedSession !== undefined &&
+    forcedSession.sessionKey.startsWith(configuredSession.sessionKey) &&
+    /^(:heartbeat)+$/.test(forcedSession.sessionKey.slice(configuredSession.sessionKey.length));
+  const forcedIsRealHeartbeatSession =
+    params.heartbeat?.isolatedSession === true &&
+    forcedSession !== undefined &&
+    /:heartbeat(?:[:][Hh]eartbeat)*$/i.test(forcedSession.sessionKey) &&
+    !forcedIsConfiguredIsolatedLane;
+  const forcedTargetsDistinctSession =
+    forcedSession !== undefined && forcedSession.sessionKey !== configuredSession.sessionKey;
+  const forcedPendingEventEntries = forcedSession
+    ? peekSystemEventEntries(forcedSession.sessionKey)
+    : [];
+  const forcedHasPendingEvents = forcedPendingEventEntries.length > 0;
+  const shouldUseForcedDistinctSession =
+    forcedTargetsDistinctSession &&
+    (forcedIsConfiguredIsolatedLane || forcedIsRealHeartbeatSession || forcedHasPendingEvents);
+  const session =
+    params.heartbeat?.isolatedSession === true
+      ? shouldUseForcedDistinctSession
+        ? {
+            ...forcedSession,
+            suppressOriginatingContext:
+              forcedSession.suppressOriginatingContext ||
+              configuredSession.suppressOriginatingContext,
+          }
+        : {
+            ...configuredSession,
+            suppressOriginatingContext:
+              configuredSession.suppressOriginatingContext ||
+              forcedSession?.suppressOriginatingContext === true,
+          }
+      : (forcedSession ?? configuredSession);
+  const inspectionSession =
+    params.heartbeat?.isolatedSession === true && shouldUseForcedDistinctSession
+      ? forcedSession
+      : (forcedIsConfiguredIsolatedLane || forcedIsRealHeartbeatSession) && forcedSession
+        ? forcedSession
+        : session;
+  const inspectionSessionKey = inspectionSession.sessionKey;
+  const inspectionSessionEntry = inspectionSession.entry;
+  const isolationSourceSessionKey = inspectionSessionKey;
+  const pendingEventEntries = peekSystemEventEntries(inspectionSessionKey);
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
@@ -576,13 +621,12 @@ async function resolveHeartbeatPreflight(params: {
     if (params.heartbeat?.isolatedSession !== true) {
       return true;
     }
-    const configuredSession = resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat);
     const { isolatedSessionKey } = resolveIsolatedHeartbeatSessionKey({
-      sessionKey: session.sessionKey,
+      sessionKey: inspectionSessionKey,
       configuredSessionKey: configuredSession.sessionKey,
-      sessionEntry: session.entry,
+      sessionEntry: inspectionSessionEntry,
     });
-    return isolatedSessionKey === session.sessionKey;
+    return isolatedSessionKey === inspectionSessionKey;
   })();
   const shouldInspectPendingEvents =
     reasonFlags.isExecEventReason ||
@@ -597,6 +641,9 @@ async function resolveHeartbeatPreflight(params: {
   const basePreflight = {
     ...reasonFlags,
     session,
+    inspectionSessionKey,
+    inspectionSessionEntry,
+    isolationSourceSessionKey,
     pendingEventEntries,
     turnSourceDeliveryContext,
     hasTaggedCronEvents,
@@ -777,11 +824,27 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: preflight.skipReason };
   }
   const { entry, sessionKey, storePath, suppressOriginatingContext } = preflight.session;
+  const useIsolatedSession = heartbeat?.isolatedSession === true;
+  const isolatedSessionResolution = useIsolatedSession
+    ? (() => {
+        const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
+        return {
+          configuredSession,
+          ...resolveIsolatedHeartbeatSessionKey({
+            sessionKey: preflight.isolationSourceSessionKey,
+            configuredSessionKey: configuredSession.sessionKey,
+            sessionEntry: preflight.inspectionSessionEntry,
+          }),
+        };
+      })()
+    : undefined;
 
   // Check the resolved session lane — if it is busy, skip to avoid interrupting
   // an active streaming turn.  The wake-layer retry (heartbeat-wake.ts) will
   // re-schedule this wake automatically.  See #14396 (closed without merge).
-  const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey);
+  const sessionLaneKey = resolveEmbeddedSessionLane(
+    isolatedSessionResolution?.isolatedSessionKey ?? sessionKey,
+  );
   const sessionLaneSize = (opts.deps?.getQueueSize ?? getQueueSize)(sessionLaneKey);
   if (sessionLaneSize > 0) {
     emitHeartbeatEvent({
@@ -799,7 +862,6 @@ export async function runHeartbeatOnce(opts: {
   // a new session ID (empty transcript) each run, avoiding the cost of
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
-  const useIsolatedSession = heartbeat?.isolatedSession === true;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
@@ -858,22 +920,14 @@ export async function runHeartbeatOnce(opts: {
     const shouldConsumeInspectedEvents =
       !preflight.isWakeReason && preflight.shouldInspectPendingEvents;
     if (shouldConsumeInspectedEvents && preflight.pendingEventEntries.length > 0) {
-      consumeSystemEventEntries(sessionKey, preflight.pendingEventEntries);
+      consumeSystemEventEntries(preflight.inspectionSessionKey, preflight.pendingEventEntries);
     }
     return { status: "skipped", reason: "no-tasks-due" };
   }
 
   let runSessionKey = sessionKey;
-  if (useIsolatedSession) {
-    const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
-    // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
-    // re-entry for heartbeat-created isolated sessions. Real session keys that
-    // happen to end with `:heartbeat` still get a distinct isolated sibling.
-    const { isolatedSessionKey, isolatedBaseSessionKey } = resolveIsolatedHeartbeatSessionKey({
-      sessionKey,
-      configuredSessionKey: configuredSession.sessionKey,
-      sessionEntry: entry,
-    });
+  if (useIsolatedSession && isolatedSessionResolution) {
+    const { isolatedSessionKey, isolatedBaseSessionKey } = isolatedSessionResolution;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedSessionKey,
@@ -882,7 +936,7 @@ export async function runHeartbeatOnce(opts: {
       forceNew: true,
     });
     const staleIsolatedSessionKey = resolveStaleHeartbeatIsolatedSessionKey({
-      sessionKey,
+      sessionKey: preflight.isolationSourceSessionKey,
       isolatedSessionKey,
       isolatedBaseSessionKey,
     });
@@ -966,7 +1020,7 @@ export async function runHeartbeatOnce(opts: {
     if (!preflight.shouldInspectPendingEvents || preflight.pendingEventEntries.length === 0) {
       return;
     }
-    consumeSystemEventEntries(sessionKey, preflight.pendingEventEntries);
+    consumeSystemEventEntries(preflight.inspectionSessionKey, preflight.pendingEventEntries);
   };
 
   const ctx = {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -373,6 +373,14 @@ function resolveHeartbeatSession(
   };
 }
 
+function isHeartbeatSuffixChain(value: string) {
+  return /^(:heartbeat)+$/i.test(value);
+}
+
+function hasHeartbeatSuffixChain(value: string) {
+  return /:heartbeat(?::heartbeat)*$/i.test(value);
+}
+
 function resolveIsolatedHeartbeatSessionKey(params: {
   sessionKey: string;
   configuredSessionKey: string;
@@ -384,7 +392,7 @@ function resolveIsolatedHeartbeatSessionKey(params: {
     if (
       params.sessionKey.startsWith(storedBaseSessionKey) &&
       suffix.length > 0 &&
-      /^(:heartbeat)+$/.test(suffix)
+      isHeartbeatSuffixChain(suffix)
     ) {
       return {
         isolatedSessionKey: `${storedBaseSessionKey}:heartbeat`,
@@ -402,8 +410,8 @@ function resolveIsolatedHeartbeatSessionKey(params: {
   const configuredSuffix = params.sessionKey.slice(params.configuredSessionKey.length);
   if (
     params.sessionKey.startsWith(params.configuredSessionKey) &&
-    /^(:heartbeat)+$/.test(configuredSuffix) &&
-    !params.configuredSessionKey.endsWith(":heartbeat")
+    isHeartbeatSuffixChain(configuredSuffix) &&
+    !params.configuredSessionKey.toLowerCase().endsWith(":heartbeat")
   ) {
     return {
       isolatedSessionKey: `${params.configuredSessionKey}:heartbeat`,
@@ -532,7 +540,7 @@ type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
   inspectionSessionKey: string;
   inspectionSessionEntry?: ReturnType<typeof resolveHeartbeatSession>["entry"];
-  isolationSourceSessionKey: string;
+  busySessionKeys: string[];
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   turnSourceDeliveryContext: ReturnType<typeof resolveSystemEventDeliveryContext>;
   hasTaggedCronEvents: boolean;
@@ -567,11 +575,11 @@ async function resolveHeartbeatPreflight(params: {
     params.heartbeat?.isolatedSession === true &&
     forcedSession !== undefined &&
     forcedSession.sessionKey.startsWith(configuredSession.sessionKey) &&
-    /^(:heartbeat)+$/.test(forcedSession.sessionKey.slice(configuredSession.sessionKey.length));
+    isHeartbeatSuffixChain(forcedSession.sessionKey.slice(configuredSession.sessionKey.length));
   const forcedIsRealHeartbeatSession =
     params.heartbeat?.isolatedSession === true &&
     forcedSession !== undefined &&
-    /:heartbeat(?:[:][Hh]eartbeat)*$/i.test(forcedSession.sessionKey) &&
+    hasHeartbeatSuffixChain(forcedSession.sessionKey) &&
     !forcedIsConfiguredIsolatedLane;
   const forcedTargetsDistinctSession =
     forcedSession !== undefined && forcedSession.sessionKey !== configuredSession.sessionKey;
@@ -600,13 +608,20 @@ async function resolveHeartbeatPreflight(params: {
       : (forcedSession ?? configuredSession);
   const inspectionSession =
     params.heartbeat?.isolatedSession === true && shouldUseForcedDistinctSession
-      ? forcedSession
-      : (forcedIsConfiguredIsolatedLane || forcedIsRealHeartbeatSession) && forcedSession
-        ? forcedSession
-        : session;
+      ? (forcedSession ?? session)
+      : session;
   const inspectionSessionKey = inspectionSession.sessionKey;
   const inspectionSessionEntry = inspectionSession.entry;
-  const isolationSourceSessionKey = inspectionSessionKey;
+  const busySessionKeys = Array.from(
+    new Set([
+      session.sessionKey,
+      ...(params.heartbeat?.isolatedSession === true &&
+      forcedSession !== undefined &&
+      forcedSession.sessionKey !== session.sessionKey
+        ? [forcedSession.sessionKey]
+        : []),
+    ]),
+  );
   const pendingEventEntries = peekSystemEventEntries(inspectionSessionKey);
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
@@ -643,7 +658,7 @@ async function resolveHeartbeatPreflight(params: {
     session,
     inspectionSessionKey,
     inspectionSessionEntry,
-    isolationSourceSessionKey,
+    busySessionKeys,
     pendingEventEntries,
     turnSourceDeliveryContext,
     hasTaggedCronEvents,
@@ -831,7 +846,7 @@ export async function runHeartbeatOnce(opts: {
         return {
           configuredSession,
           ...resolveIsolatedHeartbeatSessionKey({
-            sessionKey: preflight.isolationSourceSessionKey,
+            sessionKey: preflight.inspectionSessionKey,
             configuredSessionKey: configuredSession.sessionKey,
             sessionEntry: preflight.inspectionSessionEntry,
           }),
@@ -839,14 +854,15 @@ export async function runHeartbeatOnce(opts: {
       })()
     : undefined;
 
-  // Check the resolved session lane — if it is busy, skip to avoid interrupting
-  // an active streaming turn.  The wake-layer retry (heartbeat-wake.ts) will
-  // re-schedule this wake automatically.  See #14396 (closed without merge).
-  const sessionLaneKey = resolveEmbeddedSessionLane(
-    isolatedSessionResolution?.isolatedSessionKey ?? sessionKey,
-  );
-  const sessionLaneSize = (opts.deps?.getQueueSize ?? getQueueSize)(sessionLaneKey);
-  if (sessionLaneSize > 0) {
+  // Check the pre-isolation session lanes — if any are busy, skip to avoid
+  // interrupting an active streaming turn that shares the same delivery context.
+  // The wake-layer retry (heartbeat-wake.ts) will re-schedule this wake automatically.
+  // See #14396 (closed without merge).
+  const resolveQueueSize = opts.deps?.getQueueSize ?? getQueueSize;
+  const busySessionLaneKey = preflight.busySessionKeys
+    .map((busySessionKey) => resolveEmbeddedSessionLane(busySessionKey))
+    .find((laneKey) => resolveQueueSize(laneKey) > 0);
+  if (busySessionLaneKey) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: "requests-in-flight",
@@ -936,7 +952,7 @@ export async function runHeartbeatOnce(opts: {
       forceNew: true,
     });
     const staleIsolatedSessionKey = resolveStaleHeartbeatIsolatedSessionKey({
-      sessionKey: preflight.isolationSourceSessionKey,
+      sessionKey: preflight.inspectionSessionKey,
       isolatedSessionKey,
       isolatedBaseSessionKey,
     });

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -105,6 +105,54 @@ describe("bundled plugin public surface loader", () => {
     expect(createJiti).not.toHaveBeenCalled();
   });
 
+  it("falls back to jiti when source require hits emitted-style js imports", async () => {
+    const jitiLoader = vi.fn(() => ({ marker: "source-jiti-ok" }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({
+      createJiti,
+    }));
+    const requireLoader = Object.assign(
+      vi.fn(() => {
+        const error = new Error(
+          "Cannot find module './config-defaults.js'",
+        ) as NodeJS.ErrnoException;
+        error.code = "ERR_MODULE_NOT_FOUND";
+        throw error;
+      }),
+      {
+        extensions: {
+          ".ts": vi.fn(),
+        },
+      },
+    );
+    vi.doMock("node:module", async () => {
+      const actual = await vi.importActual<typeof import("node:module")>("node:module");
+      return Object.assign({}, actual, {
+        createRequire: vi.fn(() => requireLoader),
+      });
+    });
+
+    const publicSurfaceLoader = await importFreshModule<
+      typeof import("./public-surface-loader.js")
+    >(import.meta.url, "./public-surface-loader.js?scope=source-require-fallback-jiti");
+    const tempRoot = createTempDir();
+    const bundledPluginsDir = path.join(tempRoot, "extensions");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+
+    const modulePath = path.join(bundledPluginsDir, "demo", "secret-contract-api.ts");
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'export const marker = "source-jiti-ok";\n', "utf8");
+
+    expect(
+      publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync<{ marker: string }>({
+        dirName: "demo",
+        artifactBasename: "secret-contract-api.js",
+      }).marker,
+    ).toBe("source-jiti-ok");
+    expect(requireLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
+    expect(jitiLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
+  });
+
   it("reuses one bundled dist jiti loader across public artifacts with the same native mode", async () => {
     const createJiti = vi.fn(() => vi.fn((modulePath: string) => ({ modulePath })));
     vi.doMock("jiti", () => ({

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -30,28 +30,6 @@ const publicSurfaceLocations = new Map<
 const jitiLoaders: PluginJitiLoaderCache = new Map();
 const sharedBundledPublicSurfaceJitiLoaders: PluginJitiLoaderCache = new Map();
 
-function isSourceArtifactPath(modulePath: string): boolean {
-  switch (path.extname(modulePath).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-    case ".mtsx":
-    case ".ctsx":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
-  return (
-    !params.tryNative &&
-    isSourceArtifactPath(params.modulePath) &&
-    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
-  );
-}
-
 function createResolutionKey(params: { dirName: string; artifactBasename: string }): string {
   const bundledPluginsDir = resolveBundledPluginsDir();
   return `${params.dirName}::${params.artifactBasename}::${bundledPluginsDir ? path.resolve(bundledPluginsDir) : "<default>"}`;
@@ -109,10 +87,52 @@ function getJiti(modulePath: string) {
   return loader;
 }
 
+function isSourceArtifactPath(modulePath: string): boolean {
+  switch (path.extname(modulePath).toLowerCase()) {
+    case ".ts":
+    case ".tsx":
+    case ".mts":
+    case ".cts":
+    case ".mtsx":
+    case ".ctsx":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
+  return (
+    !params.tryNative &&
+    isSourceArtifactPath(params.modulePath) &&
+    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
+  );
+}
+
+function shouldFallbackSourceArtifactRequireToJiti(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    error.name === "SyntaxError" || code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND"
+  );
+}
+
 function loadPublicSurfaceModule(modulePath: string): unknown {
   const tryNative = resolvePluginLoaderJitiTryNative(modulePath, { preferBuiltDist: true });
   if (canUseSourceArtifactRequire({ modulePath, tryNative })) {
-    return sourceArtifactRequire(modulePath);
+    try {
+      return sourceArtifactRequire(modulePath);
+    } catch (error) {
+      // Some source public artifacts keep emitted-style `.js` relative import
+      // specifiers. Plain require() then looks for compiled sibling `.js` files
+      // that do not exist in source-tree runs, while jiti resolves the `.ts`
+      // sources correctly.
+      if (!shouldFallbackSourceArtifactRequireToJiti(error)) {
+        throw error;
+      }
+    }
   }
   return getJiti(modulePath)(modulePath);
 }


### PR DESCRIPTION
## Summary

This replaces #70735 with a clean branch based on current `origin/main`.

- keep idle forced chat-session heartbeat runs on the configured isolated heartbeat lane instead of materializing duplicate lanes such as `agent:main:cloud-codex:heartbeat`
- keep busy checks on pre-isolation base lanes, including forced live lanes, so isolated heartbeat turns do not interrupt active streaming turns that share the same delivery context
- still honor distinct forced heartbeat/event lanes when they are real heartbeat lanes or have pending queued work, so cron/exec/system events continue to drain from the correct source session
- preserve the bundled source public artifact loader behavior by resolving source artifacts through the validated real path before the source-require/Jiti fallback path
- expand regression coverage for isolated heartbeat key stability, busy-lane/subagent fallbacks, and public artifact loading

## Root cause

`runHeartbeatOnce()` accepted `opts.sessionKey` as a forced session before isolated heartbeat routing picked the execution lane. With `isolatedSession: true`, a normal live chat lane with no pending work could become the isolation source and create a new `<chat-session>:heartbeat` registry entry, even when `heartbeat.session` explicitly configured the canonical heartbeat base.

## Behavior after this change

- idle forced live sessions fall back to the configured isolated heartbeat base
- forced live session lanes are still checked for in-flight work before the isolated heartbeat starts
- forced lanes with queued events remain distinct and drain their own pending events
- already-suffixed heartbeat lanes stay stable instead of accumulating more `:heartbeat` suffixes
- subagent session keys still fall back to the main heartbeat lane

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.isolated-key-stability.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts src/infra/heartbeat-runner.subagent-session-guard.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/public-surface-loader.test.ts`
- `pnpm check:test-types`
- `pnpm check`
