### PR TITLE
fix(model-ref): re-add nvidia/ prefix in normalizeStaticProviderModelId (#71552)

### DIFF
--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
+
+describe("normalizeStaticProviderModelId", () => {
+  it("re-adds the nvidia prefix for bare model ids", () => {
+    expect(normalizeStaticProviderModelId("nvidia", "nemotron-3-super-120b-a12b")).toBe(
+      "nvidia/nemotron-3-super-120b-a12b",
+    );
+  });
+
+  it("does not double-prefix already prefixed models", () => {
+    expect(normalizeStaticProviderModelId("nvidia", "moonshotai/kimi-k2.5")).toBe(
+      "moonshotai/kimi-k2.5",
+    );
+  });
+});

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -9,8 +9,8 @@ describe("normalizeStaticProviderModelId", () => {
   });
 
   it("does not double-prefix already prefixed models", () => {
-    expect(normalizeStaticProviderModelId("nvidia", "moonshotai/kimi-k2.5")).toBe(
-      "moonshotai/kimi-k2.5",
+    expect(normalizeStaticProviderModelId("nvidia", "nvidia/nemotron-3-super-120b-a12b")).toBe(
+      "nvidia/nemotron-3-super-120b-a12b",
     );
   });
 });

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -69,6 +69,9 @@ export function normalizeStaticProviderModelId(provider: string, model: string):
   if (provider === "openrouter" && !model.includes("/")) {
     return `openrouter/${model}`;
   }
+  if (provider === "nvidia" && !model.includes("/")) {
+    return `nvidia/${model}`;
+  }
   if (provider === "xai") {
     return normalizeNativeXaiModelId(model);
   }


### PR DESCRIPTION
## Fix: Nvidia provider drops vendor model prefix (#71552)

**Root cause:** `parseStaticModelRef` splits `nvidia/nemotron-3-super-120b-a12b` on the first `/` → provider=`nvidia`, modelRaw=`nemotron-3-super-120b-a12b`. `normalizeStaticProviderModelId` has a re-prefixing case for `openrouter` but not `nvidia`, so the bare model id reaches `integrate.api.nvidia.com` → HTTP 404.

**Fix:** Added the missing nvidia re-prefixing case in `normalizeStaticProviderModelId`:

```typescript
if (provider === "nvidia" && !model.includes("/")) {
  return `nvidia/${model}`;
}
```

**Test:** Added `src/agents/model-ref-shared.test.ts` covering:
- Bare `nvidia` model ids get the prefix restored (`nemotron-3-super-120b-a12b` → `nvidia/nemotron-3-super-120b-a12b`)
- Already-prefixed models pass through unchanged (no double-prefix)

Closes #71552