### PR TITLE
fix(bonjour): suppress CIAO PROBING CANCELLED across plugin module instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/Bonjour: stop the gateway from crash-looping on `CIAO PROBING CANCELLED` when the mDNS watchdog cancels a stuck probe. Restores the rejection-handler wiring dropped during the bonjour plugin migration and shares unhandled-rejection state across module instances so plugin-staged copies of `openclaw/plugin-sdk/runtime` register into the same handler set the host consults. Especially affects Docker on macOS, where mDNS probing reliably hits the watchdog. Thanks @troyhitch.
 - Plugins/startup: remove ownerless bundled runtime-dependency install locks
   after a short grace window and include lock owner details when startup times
   out waiting for a plugin runtime-deps lock. Thanks @steipete.

--- a/extensions/bonjour/index.ts
+++ b/extensions/bonjour/index.ts
@@ -1,4 +1,5 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime";
 import { startGatewayBonjourAdvertiser } from "./src/advertiser.js";
 
 function formatBonjourInstanceName(displayName: string) {
@@ -32,7 +33,7 @@ export default definePluginEntry({
             cliPath: ctx.cliPath,
             minimal: ctx.minimal,
           },
-          { logger: api.logger },
+          { logger: api.logger, registerUnhandledRejectionHandler },
         );
         return { stop: advertiser.stop };
       },

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -11,7 +11,20 @@ import { runFatalErrorHooks } from "./fatal-error-hooks.js";
 
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 
-const handlers = new Set<UnhandledRejectionHandler>();
+// Plugins resolve `openclaw/plugin-sdk/runtime` through their own staged
+// `node_modules`, which loads a separate copy of this module. To keep registry
+// state shared across instances, anchor the handlers Set on globalThis.
+const HANDLERS_GLOBAL_KEY = Symbol.for("openclaw.unhandledRejection.handlers");
+const handlers: Set<UnhandledRejectionHandler> = (() => {
+  const g = globalThis as unknown as Record<symbol, Set<UnhandledRejectionHandler>>;
+  const existing = g[HANDLERS_GLOBAL_KEY];
+  if (existing instanceof Set) {
+    return existing;
+  }
+  const created = new Set<UnhandledRejectionHandler>();
+  g[HANDLERS_GLOBAL_KEY] = created;
+  return created;
+})();
 
 const FATAL_ERROR_CODES = new Set([
   "ERR_OUT_OF_MEMORY",


### PR DESCRIPTION
## Summary

After commit cb4fc58547 ("feat(plugins): move Bonjour discovery into bundled plugin"), the gateway crash-loops on Docker (especially macOS) with `[openclaw] Unhandled promise rejection: CIAO PROBING CANCELLED` every ~40s. This PR fixes it by:

1. **`extensions/bonjour/index.ts`** — passing `registerUnhandledRejectionHandler` through to `startGatewayBonjourAdvertiser`. The advertiser still contained `handleCiaoUnhandledRejection` (which classifies and swallows the well-known ciao cancellation quirk), but the new plugin entry only forwarded `{ logger }`, leaving the suppression as dead code.
2. **`src/infra/unhandled-rejections.ts`** — anchoring the `handlers` Set on `globalThis[Symbol.for("openclaw.unhandledRejection.handlers")]`. Wiring (1) alone wasn't enough, because plugins are staged with their own `node_modules/openclaw/`, so the plugin's `import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime"` resolves to a *different* module instance than the gateway's. Two module instances → two separate `handlers` Sets → registrations land in one Set, the host's `unhandledRejection` listener consults the other, and suppression silently no-ops. The `globalThis` singleton makes process-level state actually process-singleton.

## Why this matters

- Anyone running the gateway in Docker since 2026-04-23 likely has a crash-looping container right now. Docker on macOS is the worst-affected (virtualized network makes mDNS probing reliably hit the watchdog's 40s "stuck in probing" timer), but any environment where mDNS probing is unreliable will trip it.
- The `globalThis` change in `unhandled-rejections.ts` makes the existing public `registerUnhandledRejectionHandler` correct for *any* future plugin that uses it, not just bonjour. Plugins resolving SDK exports to staged copies of the package is a general issue; this fix lets module-level registries survive that.

## Considered alternatives

- **`OPENCLAW_DISABLE_BONJOUR=1`** — works as a workaround but loses LAN auto-discovery. Not a fix.
- **Adding `registerUnhandledRejectionHandler` to the `OpenClawPluginApi` surface** — architecturally cleaner (closure over host state), but expands a public seam, requires docs/contract updates, and third-party plugins wouldn't benefit until they update. The `globalThis` singleton fixes the existing exported API at the source, with a smaller surface.

## Verification

Reproduced the crash on Docker on macOS with the previous build:

```
[plugins] bonjour: restarting advertiser (service stuck in probing for 38309ms ...)
[openclaw] Unhandled promise rejection: CIAO PROBING CANCELLED
openclaw-gateway-1 exited with code 1 (restarting)
```

After this patch + rebuild + clearing `~/.openclaw/plugin-runtime-deps/openclaw-*` (to force re-stage with fixed code), the gateway survives consecutive watchdog probe-cancel cycles:

```
15:33:50 [plugins] bonjour: restarting advertiser (service stuck in probing for 38309ms ...)
15:33:50 [plugins] bonjour: advertised gateway ... state=unannounced
15:34:00 [plugins] bonjour: watchdog detected non-announced service; attempting re-advertise ...
15:34:01 [plugins] bonjour: advertised gateway ... state=announcing
```

Container stays healthy. No `Unhandled promise rejection` in logs.

## Test plan

- [ ] CI green
- [ ] Maintainer review (cc @vincentkoc — original author of the bonjour migration)
- [ ] Optional: new test in `extensions/bonjour/src/advertiser.test.ts` asserting that an unwired `registerUnhandledRejectionHandler` is no longer the suppression's only failure mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)