### PR TITLE
docs(browser): document local startup timeout bounds

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -280,7 +280,9 @@ See [Plugins](/tools/plugin).
 - Local managed profiles use `browser.localLaunchTimeoutMs` for Chrome CDP HTTP
   discovery after process start and `browser.localCdpReadyTimeoutMs` for
   post-launch CDP websocket readiness. Raise them on slower hosts where Chrome
-  starts successfully but readiness checks race startup.
+  starts successfully but readiness checks race startup. Both values are
+  clamped to a maximum of 120000 ms (120 s); larger values are silently capped.
+  Zero, negative, or non-finite values fall back to the built-in defaults.
 - Auto-detect order: default browser if Chromium-based → Chrome → Brave → Edge → Chromium → Chrome Canary.
 - `browser.executablePath` accepts `~` for your OS home directory.
 - Control service: loopback only (port derived from `gateway.port`, default `18791`).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -280,9 +280,8 @@ See [Plugins](/tools/plugin).
 - Local managed profiles use `browser.localLaunchTimeoutMs` for Chrome CDP HTTP
   discovery after process start and `browser.localCdpReadyTimeoutMs` for
   post-launch CDP websocket readiness. Raise them on slower hosts where Chrome
-  starts successfully but readiness checks race startup. Both values are
-  clamped to a maximum of 120000 ms (120 s); larger values are silently capped.
-  Zero, negative, or non-finite values fall back to the built-in defaults.
+  starts successfully but readiness checks race startup. Both values must be
+  positive integers up to `120000` ms; invalid config values are rejected.
 - Auto-detect order: default browser if Chromium-based → Chrome → Brave → Edge → Chromium → Chrome Canary.
 - `browser.executablePath` accepts `~` for your OS home directory.
 - Control service: loopback only (port derived from `gateway.port`, default `18791`).

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -140,8 +140,8 @@ curl -s http://127.0.0.1:18791/tabs
 On Raspberry Pi, older VPS hosts, or slow storage, raise
 `browser.localLaunchTimeoutMs` when Chrome needs more time to expose its CDP HTTP
 endpoint. Raise `browser.localCdpReadyTimeoutMs` when launch succeeds but
-`openclaw browser start` still reports `not reachable after start`. Values are
-capped at 120000 ms.
+`openclaw browser start` still reports `not reachable after start`. Values must
+be positive integers up to `120000` ms; invalid config values are rejected.
 
 ### Problem: "No Chrome tabs found for profile=\"user\""
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -200,7 +200,8 @@ Browser settings live in `~/.openclaw/openclaw.json`.
   process to expose its CDP HTTP endpoint. `localCdpReadyTimeoutMs` is the
   follow-up budget for CDP websocket readiness after the process is discovered.
   Raise these on Raspberry Pi, low-end VPS, or older hardware where Chromium
-  starts slowly. Values are capped at 120000 ms.
+  starts slowly. Values must be positive integers up to `120000` ms; invalid
+  config values are rejected.
 - `actionTimeoutMs` is the default budget for browser `act` requests when the caller does not pass `timeoutMs`. The client transport adds a small slack window so long waits can finish instead of timing out at the HTTP boundary.
 - `tabCleanup` is best-effort cleanup for tabs opened by primary-agent browser sessions. Subagent, cron, and ACP lifecycle cleanup still closes their explicit tracked tabs at session end; primary sessions keep active tabs reusable, then close idle or excess tracked tabs in the background.
 


### PR DESCRIPTION
## Summary                                                                                               
                                                                                                           
  The new `browser.localLaunchTimeoutMs` and `browser.localCdpReadyTimeoutMs` options (added in b2b898c2)  
  are silently clamped by `normalizeStartupTimeoutMs` in `extensions/browser/src/browser/config.ts`:

  - Maximum: 120000 ms (`MAX_BROWSER_STARTUP_TIMEOUT_MS`) — larger values are capped without warning
  - Zero, negative, or non-finite values fall back to the built-in defaults

  Today the configuration reference only says "raise them on slower hosts" with no upper bound mentioned.
  Users on very slow CI runners who try `localLaunchTimeoutMs: 300000` get a silent 120 s ceiling and the
  same race they were trying to fix.

  This adds one sentence to `docs/gateway/configuration-reference.md` documenting both the cap and the
  fallback behavior.

  ## Test plan

  - [x] Docs-only change; no code touched
  - [x] Verified bounds against `normalizeStartupTimeoutMs` in `extensions/browser/src/browser/config.ts`
