### PR TITLE
fix(active-memory): enforce timeoutMs as hard deadline via Promise.race [AI-assisted]

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1245,6 +1245,44 @@ describe("active-memory plugin", () => {
     ).toBe(true);
   });
 
+  it("returns timeout within a hard deadline even when the subagent never checks the abort signal", async () => {
+    const CONFIGURED_TIMEOUT_MS = 200;
+    const MARGIN_MS = 500;
+    __testing.setMinimumTimeoutMsForTests(1);
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: CONFIGURED_TIMEOUT_MS,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    // Simulate a subagent that never cooperatively checks the abort signal --
+    // it just blocks for a long time.
+    runEmbeddedPiAgent.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve({ payloads: [] }), 30_000)),
+    );
+
+    const startedAt = Date.now();
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order? hard deadline test", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:hard-deadline",
+        messageProvider: "webchat",
+      },
+    );
+    const wallClockMs = Date.now() - startedAt;
+
+    // The hook returns undefined for timeout results (summary is null).
+    expect(result).toBeUndefined();
+    const infoLines = vi
+      .mocked(api.logger.info)
+      .mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(infoLines.some((line: string) => line.includes("status=timeout"))).toBe(true);
+    // Hard deadline: wall-clock time must be near timeoutMs, not 30s.
+    expect(wallClockMs).toBeLessThan(CONFIGURED_TIMEOUT_MS + MARGIN_MS);
+  });
+
   it("returns undefined instead of throwing when an unexpected error escapes prompt building", async () => {
     const result = await hooks.before_prompt_build(
       { prompt: "what should i eat? escape test", messages: undefined as never },

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1779,17 +1779,56 @@ async function maybeResolveActiveRecall(params: {
   }
 
   const controller = new AbortController();
+  const TIMEOUT_SENTINEL = Symbol("timeout");
   const timeoutId = setTimeout(() => {
     controller.abort(new Error(`active-memory timeout after ${params.config.timeoutMs}ms`));
   }, params.config.timeoutMs);
   timeoutId.unref?.();
 
+  const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => {
+        resolve(TIMEOUT_SENTINEL);
+      },
+      { once: true },
+    );
+  });
+
   try {
-    const { rawReply, transcriptPath, searchDebug } = await runRecallSubagent({
+    const subagentPromise = runRecallSubagent({
       ...params,
       modelRef: resolvedModelRef,
       abortSignal: controller.signal,
     });
+    // Silently catch late rejections after timeout so they don't become
+    // unhandled promise rejections.
+    subagentPromise.catch(() => undefined);
+
+    const raceResult = await Promise.race([subagentPromise, timeoutPromise]);
+
+    if (raceResult === TIMEOUT_SENTINEL) {
+      const result: ActiveRecallResult = {
+        status: "timeout",
+        elapsedMs: Date.now() - startedAt,
+        summary: null,
+      };
+      if (params.config.logging) {
+        params.api.logger.info?.(
+          `${logPrefix} done status=${result.status} elapsedMs=${String(result.elapsedMs)} summaryChars=0`,
+        );
+      }
+      await persistPluginStatusLines({
+        api: params.api,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        statusLine: buildPluginStatusLine({ result, config: params.config }),
+        searchDebug: result.searchDebug,
+      });
+      return result;
+    }
+
+    const { rawReply, transcriptPath, searchDebug } = raceResult;
     const summary = truncateSummary(
       normalizeActiveSummary(rawReply) ?? "",
       params.config.maxSummaryChars,


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration, reviewed by Codex). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `maybeResolveActiveRecall` in the active-memory extension awaits `runRecallSubagent()` cooperatively — the `AbortController` fires at `timeoutMs` but the function blocks until the embedded agent run checks the signal at internal checkpoints. With `timeoutMs=5000`, real-world wall-clock time reaches 11–13s.
- Why it matters: Interactive conversations become noticeably slower; the configured timeout does not guarantee quick fail-open behavior.
- What changed: Wrapped `runRecallSubagent()` with `Promise.race` against a timeout promise tied to the existing `AbortController`. When the timeout fires first, the function returns `{ status: "timeout" }` immediately. Late subagent rejections are caught silently to prevent unhandled promise errors.
- What did NOT change (scope boundary): The cooperative `AbortController` still fires to request graceful cleanup of the embedded run. No changes to `runRecallSubagent`, `runEmbeddedPiAgent`, or any core agent runtime code.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Integrations

## Linked Issue/PR
- Closes #71629
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `maybeResolveActiveRecall` used a cooperative abort pattern — `AbortController.abort()` sets `signal.aborted = true`, but the `await runRecallSubagent(...)` call blocks until the embedded run's internal retry/failover loop reaches a checkpoint that checks the signal. Between checkpoints (during LLM API calls, tool execution), the abort is ignored.
- Missing detection / guardrail: No `Promise.race` wrapper to enforce the configured timeout as a hard wall-clock deadline independent of internal abort-signal propagation.
- Contributing context: The embedded agent runner (`runEmbeddedPiAgent`) has a complex retry loop with multiple cooperative abort checkpoints, but the active-memory caller had no mechanism to return early when those checkpoints are slow to reach.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/active-memory/index.test.ts`
- Scenario the test should lock in: A subagent that blocks for 30s without checking the abort signal must still cause `maybeResolveActiveRecall` to return within `timeoutMs + 500ms` margin with `status=timeout`.
- Why this is the smallest reliable guardrail: Tests the exact boundary between cooperative and preemptive timeout enforcement at the caller level.
- Existing test that already covers this (if any): The existing "ignores late subagent payloads once the active-memory timeout signal has fired" test covers the cooperative path but does not assert wall-clock return time.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes
- `active-memory` now returns `status=timeout` within the configured `timeoutMs` (plus small scheduling jitter), instead of potentially blocking for 2–3× longer.

## Diagram (if applicable)

```text
Before:
[setTimeout fires at timeoutMs] -> [signal.aborted = true] -> [await blocks until embedded run checks signal] -> [return timeout after 11-13s]

After:
[setTimeout fires at timeoutMs] -> [Promise.race resolves TIMEOUT_SENTINEL] -> [return timeout immediately] -> [embedded run continues cleanup in background]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS (Darwin, Apple Silicon)
- Runtime: Node 22+, pnpm
- Model/provider: N/A (unit test uses mocked embedded agent)

### Steps
1. Configure `active-memory` with `timeoutMs: 200`
2. Mock `runEmbeddedPiAgent` to block for 30s without checking abort signal
3. Call `before_prompt_build` and measure wall-clock return time

### Expected
- Function returns within ~700ms (200ms timeout + 500ms margin)

### Actual
- Before fix: blocks for 30s (or until embedded run cooperatively checks signal)
- After fix: returns within ~205ms with `status=timeout`

## Evidence
- [x] Failing test/log before + passing after
- 64/64 extension tests pass
- `oxfmt --check` clean
