### PR TITLE
fix(ui): sync chatAvatarUrl after refreshChatAvatar to prevent avatar flicker

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -519,7 +519,14 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
       includeGlobal: true,
       includeUnknown: true,
     }),
-    refreshChatAvatar(host),
+    refreshChatAvatar(host).then((avatarUrl) => {
+      // Sync the resolved avatar URL to ChatHost.chatAvatarUrl so the
+      // Lit @state() AppViewState.chatAvatarUrl picks up the change.
+      if (avatarUrl !== null) {
+        (host as unknown as { chatAvatarUrl: string | null }).chatAvatarUrl =
+          avatarUrl;
+      }
+    }),
     refreshChatModels(host),
     refreshChatCommands(host),
   ]);
@@ -653,10 +660,10 @@ function isLocalControlUiAvatarUrl(avatarUrl: string): boolean {
   return avatarUrl.startsWith("/");
 }
 
-export async function refreshChatAvatar(host: ChatHost) {
+export async function refreshChatAvatar(host: ChatHost): Promise<string | null> {
   if (!host.connected) {
     clearChatAvatarState(host);
-    return;
+    return null;
   }
   const sessionKey = host.sessionKey;
   const requestVersion = beginChatAvatarRequest(host);
@@ -665,7 +672,7 @@ export async function refreshChatAvatar(host: ChatHost) {
     if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
       clearChatAvatarState(host);
     }
-    return;
+    return null;
   }
   clearChatAvatarState(host);
   const authHeader = resolveControlUiAuthHeader(host);
@@ -674,11 +681,11 @@ export async function refreshChatAvatar(host: ChatHost) {
   try {
     const res = await fetch(url, { method: "GET", ...(headers ? { headers } : {}) });
     if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
-      return;
+      return null;
     }
     if (!res.ok) {
       clearChatAvatarState(host);
-      return;
+      return null;
     }
     const data = (await res.json()) as {
       avatarUrl?: unknown;
@@ -687,17 +694,17 @@ export async function refreshChatAvatar(host: ChatHost) {
       avatarReason?: unknown;
     };
     if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
-      return;
+      return null;
     }
     setChatAvatarMeta(host, data);
     const avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
     if (!avatarUrl || !isRenderableControlUiAvatarUrl(avatarUrl)) {
       clearChatAvatarUrl(host);
-      return;
+      return null;
     }
     if (!isLocalControlUiAvatarUrl(avatarUrl)) {
       setChatAvatarUrl(host, avatarUrl);
-      return;
+      return avatarUrl;
     }
     const avatarRes = await fetch(avatarUrl, {
       method: "GET",
@@ -707,17 +714,19 @@ export async function refreshChatAvatar(host: ChatHost) {
       if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
         clearChatAvatarUrl(host);
       }
-      return;
+      return null;
     }
     const blobUrl = URL.createObjectURL(await avatarRes.blob());
     if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
       URL.revokeObjectURL(blobUrl);
-      return;
+      return null;
     }
     setChatAvatarUrl(host, blobUrl);
+    return blobUrl;
   } catch {
     if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
       clearChatAvatarState(host);
     }
+    return null;
   }
 }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -336,7 +336,13 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       }
       void subscribeSessions(host as unknown as SessionsState);
       void loadAssistantIdentity(host as unknown as AssistantIdentityState);
-      void refreshChatAvatar(host as unknown as Parameters<typeof refreshChatAvatar>[0]);
+      const chatHost = host as unknown as Parameters<typeof refreshChatAvatar>[0];
+      void refreshChatAvatar(chatHost).then((avatarUrl) => {
+        if (avatarUrl !== null) {
+          (chatHost as unknown as { chatAvatarUrl: string | null }).chatAvatarUrl =
+            avatarUrl;
+        }
+      });
       void loadAgents(host as unknown as AgentsState);
       void loadHealthState(host as unknown as HealthState);
       void loadNodes(host as unknown as NodesState, { quiet: true });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -531,7 +531,12 @@ export function renderChatMobileToggle(state: AppViewState) {
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   resetChatStateForSessionSwitch(state, nextSessionKey);
   void state.loadAssistantIdentity();
-  void refreshChatAvatar(state);
+  void refreshChatAvatar(state).then((avatarUrl) => {
+    if (avatarUrl !== null) {
+      (state as unknown as { chatAvatarUrl: string | null }).chatAvatarUrl =
+        avatarUrl;
+    }
+  });
   void refreshSlashCommands({
     client: state.client,
     agentId: parseAgentSessionKey(nextSessionKey)?.agentId,


### PR DESCRIPTION
## Summary

After navigating away and back in the WebUI, the custom avatar would briefly appear then be replaced by the default placeholder within 1-2s.

## Root Cause

`refreshChatAvatar()` correctly fetches the avatar blob and stores it in `ChatHost.chatAvatarUrl`, but the Lit `@state()` field `AppViewState.chatAvatarUrl` was never updated. The chat view reads `state.chatAvatarUrl`, so it always fell back to the default avatar config.

## Fix

`refreshChatAvatar()` now returns `string | null` (the resolved blob URL or null). Callers use `void refreshChatAvatar().then(avatarUrl => {...})` to sync the result to the host/state `chatAvatarUrl` field, triggering Lit's reactive re-render.

Three call sites updated:

- `onHello` (connectGateway) — gateway hello after connect
- `refreshChat()` — session init and refresh
- `switchChatSession()` — session switching

## Files Changed

- `ui/src/ui/app-chat.ts` — `refreshChatAvatar` returns `string | null`, `refreshChat` syncs the result
- `ui/src/ui/app-gateway.ts` — `onHello` uses `.then()` to sync avatar
- `ui/src/ui/app-render.helpers.ts` — `switchChatSession` uses `.then()` to sync avatar

Fixes openclaw/openclaw#71595
