### PR TITLE
[codex] Recover chat updates after missed final event

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -487,6 +487,7 @@ describe("handleSendChat", () => {
         deliver: false,
         idempotencyKey: expect.any(String),
       }),
+      { timeoutMs: 15_000 },
     );
     expect(host.chatQueue).toEqual([]);
     expect(host.chatRunId).toBe("run-main");
@@ -515,6 +516,7 @@ describe("handleSendChat", () => {
         message: "/btw summarize this",
         deliver: false,
       }),
+      { timeoutMs: 15_000 },
     );
     expect(host.chatRunId).toBeNull();
     expect(host.chatMessages).toEqual([]);
@@ -626,13 +628,17 @@ describe("handleSendChat", () => {
 
     await steerQueuedChatMessage(host, "queued-1");
 
-    expect(request).toHaveBeenCalledWith("chat.send", {
-      sessionKey: "agent:main:main",
-      message: "tighten the plan",
-      deliver: false,
-      idempotencyKey: expect.any(String),
-      attachments: undefined,
-    });
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      {
+        sessionKey: "agent:main:main",
+        message: "tighten the plan",
+        deliver: false,
+        idempotencyKey: expect.any(String),
+        attachments: undefined,
+      },
+      { timeoutMs: 15_000 },
+    );
     expect(host.chatRunId).toBe("run-1");
     expect(host.chatStream).toBe("Working...");
     expect(host.chatQueue).toEqual([

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -753,6 +753,33 @@ describe("connectGateway", () => {
     },
   );
 
+  it("uses assistant session.message as a fallback when the chat final event is missed", async () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-session-message";
+    host.chatStream = "waiting for final";
+    emitToolResultEvent(client);
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done from transcript" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    await Promise.resolve();
+
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+    expect(host.toolStreamOrder).toHaveLength(0);
+  });
+
   it("clears tracked BTW terminal runs after reconnect hello", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -488,9 +488,18 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
 }
 
+function isAssistantSessionMessage(payload: { message?: unknown } | undefined): boolean {
+  const message = payload?.message;
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const role = (message as { role?: unknown }).role;
+  return typeof role === "string" && role.trim().toLowerCase() === "assistant";
+}
+
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string } | undefined,
+  payload: { sessionKey?: string; message?: unknown } | undefined,
 ) {
   applySessionsChangedEvent(host as unknown as SessionsState, payload);
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
@@ -505,6 +514,22 @@ function handleSessionMessageGatewayEvent(
   // first LLM delta arrives.
   if (host.chatRunId) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
+    if (isAssistantSessionMessage(payload)) {
+      const completedRunId = host.chatRunId;
+      void loadChatHistory(host as unknown as ChatState).finally(() => {
+        if (host.chatRunId !== completedRunId) {
+          return;
+        }
+        host.chatRunId = null;
+        (host as unknown as { chatStream: string | null }).chatStream = null;
+        (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
+        deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
+        resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
+        void flushChatQueueForEvent(
+          host as unknown as Parameters<typeof flushChatQueueForEvent>[0],
+        );
+      });
+    }
     return;
   }
   deferredReloadHost.pendingSessionMessageReloadSessionKey = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -624,6 +624,29 @@ describe("loadChatHistory", () => {
 });
 
 describe("sendChatMessage", () => {
+  it("uses a bounded timeout for chat.send", async () => {
+    const request = vi.fn().mockResolvedValue({ status: "started", runId: "run-1" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "hello");
+
+    expect(result).toMatch(/.+/);
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      {
+        sessionKey: "main",
+        message: "hello",
+        deliver: false,
+        idempotencyKey: expect.any(String),
+        attachments: undefined,
+      },
+      { timeoutMs: 15_000 },
+    );
+  });
+
   it("formats structured non-auth connect failures for chat send", async () => {
     const request = vi.fn().mockRejectedValue(
       new GatewayRequestError({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -18,6 +18,7 @@ const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
+const CHAT_SEND_TIMEOUT_MS = 15_000;
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
 function beginChatHistoryRequest(state: ChatState): number {
@@ -461,13 +462,17 @@ async function requestChatSend(
   state: ChatState,
   params: { message: string; attachments?: ChatAttachment[]; runId: string },
 ) {
-  await state.client!.request("chat.send", {
-    sessionKey: state.sessionKey,
-    message: params.message,
-    deliver: false,
-    idempotencyKey: params.runId,
-    attachments: buildApiAttachments(params.attachments),
-  });
+  await state.client!.request(
+    "chat.send",
+    {
+      sessionKey: state.sessionKey,
+      message: params.message,
+      deliver: false,
+      idempotencyKey: params.runId,
+      attachments: buildApiAttachments(params.attachments),
+    },
+    { timeoutMs: CHAT_SEND_TIMEOUT_MS },
+  );
 }
 
 type AssistantMessageNormalizationOptions = {

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -306,6 +306,47 @@ describe("GatewayBrowserClient", () => {
     expect(signedPayload).toContain("|stored-device-token|nonce-1");
   });
 
+  it("rejects timed-out requests, closes the stale socket, and clears the pending entry", async () => {
+    vi.useFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    const { ws } = await startConnect(client);
+    const requestPromise = client.request("chat.send", { message: "hello" }, { timeoutMs: 25 });
+    const requestId = (JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string }).id;
+    const rejected = expect(requestPromise).rejects.toThrow("chat.send timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(ws.readyState).toBe(3);
+
+    ws.emitMessage({
+      type: "res",
+      id: requestId,
+      ok: true,
+      payload: { status: "started" },
+    });
+  });
+
+  it("reconnects after a timed-out request closes the socket", async () => {
+    vi.useFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    const { ws } = await startConnect(client);
+    const requestPromise = client.request("chat.send", { message: "hello" }, { timeoutMs: 25 });
+    const rejected = expect(requestPromise).rejects.toThrow("chat.send timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    ws.emitClose(4000, "chat.send timeout");
+
+    await vi.advanceTimersByTimeAsync(800);
+    expect(wsInstances).toHaveLength(2);
+  });
+
   it("ignores cached operator device tokens that do not include read access", async () => {
     localStorage.clear();
     storeDeviceAuthToken({

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -131,6 +131,7 @@ export type GatewayHelloOk = {
 type Pending = {
   resolve: (value: unknown) => void;
   reject: (err: unknown) => void;
+  timeoutId?: number;
 };
 
 type SelectedConnectAuth = {
@@ -370,6 +371,9 @@ export class GatewayBrowserClient {
 
   private flushPending(err: Error) {
     for (const [, p] of this.pending) {
+      if (typeof p.timeoutId === "number") {
+        window.clearTimeout(p.timeoutId);
+      }
       p.reject(err);
     }
     this.pending.clear();
@@ -618,14 +622,41 @@ export class GatewayBrowserClient {
     };
   }
 
-  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+  request<T = unknown>(
+    method: string,
+    params?: unknown,
+    options?: { timeoutMs?: number },
+  ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error("gateway not connected"));
     }
     const id = generateUUID();
     const frame = { type: "req", id, method, params };
     const p = new Promise<T>((resolve, reject) => {
-      this.pending.set(id, { resolve: (v) => resolve(v as T), reject });
+      const pending: Pending = {
+        resolve: (v) => {
+          if (typeof pending.timeoutId === "number") {
+            window.clearTimeout(pending.timeoutId);
+          }
+          resolve(v as T);
+        },
+        reject: (err) => {
+          if (typeof pending.timeoutId === "number") {
+            window.clearTimeout(pending.timeoutId);
+          }
+          reject(err);
+        },
+      };
+      if (typeof options?.timeoutMs === "number" && options.timeoutMs > 0) {
+        pending.timeoutId = window.setTimeout(() => {
+          this.pending.delete(id);
+          pending.reject(new Error(`${method} timed out after ${options.timeoutMs}ms`));
+          if (this.ws?.readyState === WebSocket.OPEN) {
+            this.ws.close(4000, `${method} timeout`);
+          }
+        }, options.timeoutMs);
+      }
+      this.pending.set(id, pending);
     });
     this.ws.send(JSON.stringify(frame));
     return p;


### PR DESCRIPTION
## Summary

- Add a bounded browser gateway request timeout and apply it to `chat.send` so a stale socket does not leave the chat UI waiting forever.
- Recover the chat view when an assistant `session.message` arrives while the UI still believes a run is active, covering the case where the final chat event is missed.
- Add regression coverage for request timeout behavior, chat send timeout wiring, and the assistant transcript-event fallback.

## Validation

- `corepack pnpm check:no-conflict-markers`
- `corepack pnpm tsgo:core`
- `corepack pnpm tsgo:core:test`
- `OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm test ui/src/ui/gateway.node.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-gateway.node.test.ts` - 4 files, 106 tests passed
- `corepack pnpm --dir ui run build` - passed; emitted existing dynamic import warnings

## Notes

- `corepack pnpm lint:core` currently fails on current `origin/main` at `src/logging/diagnostic-stability.ts:178` for an unrelated exhaustive-switch issue. This branch diff only touches the seven UI files in this PR.
