### PR TITLE
fix(codex): require authorized inbound claims for bound turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: pass the OpenClaw system prompt through Claude's prompt-file flag so Windows runs avoid argv length failures without changing system prompt semantics. Fixes #69158. (#69211) Thanks @skylee-01, @cassioanorte, @Syu0, and @Stache73.
 - Agents/CLI sessions: bind `google-gemini-cli` session auth-epoch to the Google account identity in `~/.gemini/oauth_creds.json`, so Gemini-backed agents resume their conversation after gateway restart instead of minting a fresh session, and stale bindings are invalidated when the authenticated Google account changes. Fixes #70973. (#71076) Thanks @openperf.
 - Slack: stop treating user mentions in assistant-authored message edit blocks as sender attribution, preventing edited bot messages from spoofing a mentioned DM user. (#71700) Thanks @vincentkoc.
+- Codex: consume unauthorized bound conversation inbound claims before they can fall through to other claim handlers or enqueue Codex turns. (#71702) Thanks @vincentkoc.
 
 ## 2026.4.24
 

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { handleCodexConversationBindingResolved } from "./conversation-binding.js";
+import {
+  handleCodexConversationBindingResolved,
+  handleCodexConversationInboundClaim,
+} from "./conversation-binding.js";
 
 let tempDir: string;
 
@@ -39,5 +42,30 @@ describe("codex conversation binding", () => {
     });
 
     await expect(fs.stat(sidecar)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("ignores inbound bound messages when command authorization is absent", async () => {
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "run this",
+        channel: "discord",
+        isGroup: true,
+      },
+      {
+        channelId: "discord",
+        pluginBinding: {
+          pluginId: "codex",
+          source: "conversation-bind",
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile: path.join(tempDir, "session.jsonl"),
+            workspaceDir: tempDir,
+          },
+        },
+      },
+    );
+
+    expect(result).toBeUndefined();
   });
 });

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -44,7 +44,7 @@ describe("codex conversation binding", () => {
     await expect(fs.stat(sidecar)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("ignores inbound bound messages when command authorization is absent", async () => {
+  it("consumes inbound bound messages when command authorization is absent", async () => {
     const result = await handleCodexConversationInboundClaim(
       {
         content: "run this",
@@ -54,8 +54,13 @@ describe("codex conversation binding", () => {
       {
         channelId: "discord",
         pluginBinding: {
+          bindingId: "binding-1",
           pluginId: "codex",
-          source: "conversation-bind",
+          pluginRoot: tempDir,
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel-1",
+          boundAt: Date.now(),
           data: {
             kind: "codex-app-server-session",
             version: 1,
@@ -66,6 +71,6 @@ describe("codex conversation binding", () => {
       },
     );
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ handled: true });
   });
 });

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -113,6 +113,9 @@ export async function handleCodexConversationInboundClaim(
   if (!data) {
     return undefined;
   }
+  if (event.commandAuthorized !== true) {
+    return undefined;
+  }
   const prompt = (event.bodyForAgent ?? event.content ?? "").trim();
   if (!prompt) {
     return { handled: true };

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -114,7 +114,7 @@ export async function handleCodexConversationInboundClaim(
     return undefined;
   }
   if (event.commandAuthorized !== true) {
-    return undefined;
+    return { handled: true };
   }
   const prompt = (event.bodyForAgent ?? event.content ?? "").trim();
   if (!prompt) {


### PR DESCRIPTION
### Motivation
- The Codex conversation inbound-claim path accepted bound conversation messages and enqueued bound turns without verifying `commandAuthorized`, allowing untrusted participants to trigger Codex turns that inherit permissive runtime defaults.

### Description
- Add an explicit authorization gate so `handleCodexConversationInboundClaim` returns `undefined` unless `event.commandAuthorized === true` before enqueuing `runBoundTurn`.
- Preserve existing behavior for empty prompts and for normal bound-turn execution once authorized.
- Add a regression test `handleCodexConversationInboundClaim` that verifies inbound bound messages without `commandAuthorized` are ignored.

### Testing
- Ran `pnpm test extensions/codex/src/conversation-binding.test.ts` and the test file passed (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaeaf5039c83209a4e81820dbc98be)