### PR TITLE
Exec: restore approval-first host defaults

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -596,14 +596,16 @@ export function createExecTool(
 
       const approvalDefaults = loadExecApprovals().defaults;
       const configuredSecurity =
-        defaults?.security ?? approvalDefaults?.security ?? (host === "sandbox" ? "deny" : "full");
+        defaults?.security ??
+        approvalDefaults?.security ??
+        (host === "sandbox" ? "deny" : "allowlist");
       const requestedSecurity = normalizeExecSecurity(params.security);
       let security = minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity);
       if (elevatedRequested && elevatedMode === "full") {
         security = "full";
       }
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
-      const configuredAsk = defaults?.ask ?? approvalDefaults?.ask ?? "off";
+      const configuredAsk = defaults?.ask ?? approvalDefaults?.ask ?? "on-miss";
       const requestedAsk = normalizeExecAsk(params.ask);
       let ask = maxAsk(configuredAsk, requestedAsk ?? configuredAsk);
       const bypassApprovals = elevatedRequested && elevatedMode === "full";

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -432,12 +432,12 @@ describe("normalizeExecApprovals strips invalid security/ask enum values (#59006
       },
     } as unknown as ExecApprovalsFile;
     const resolved = resolveExecApprovalsFromFile({ file });
-    // Invalid "none" in defaults is stripped, so fallback to DEFAULT_SECURITY ("full")
-    expect(resolved.defaults.security).toBe("full");
-    // Invalid "never" in defaults is stripped, so fallback to DEFAULT_ASK ("off")
-    expect(resolved.defaults.ask).toBe("off");
+    // Invalid "none" in defaults is stripped, so fallback to DEFAULT_SECURITY ("allowlist")
+    expect(resolved.defaults.security).toBe("allowlist");
+    // Invalid "never" in defaults is stripped, so fallback to DEFAULT_ASK ("on-miss")
+    expect(resolved.defaults.ask).toBe("on-miss");
     // Wildcard agent "none" is stripped, so agent inherits resolved defaults
-    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.security).toBe("allowlist");
     // Wildcard agent ask="off" is valid and preserved
     expect(resolved.agent.ask).toBe("off");
   });

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -463,8 +463,8 @@ describe("exec approvals policy helpers", () => {
     });
 
     expect(summary.askFallback).toEqual({
-      effective: "full",
-      source: "OpenClaw default (full)",
+      effective: "deny",
+      source: "OpenClaw default (deny)",
     });
   });
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -168,9 +168,9 @@ export type ExecApprovalsResolved = {
 // Keep CLI + gateway defaults in sync.
 export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 1_800_000;
 
-const DEFAULT_SECURITY: ExecSecurity = "full";
-const DEFAULT_ASK: ExecAsk = "off";
-export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
+const DEFAULT_SECURITY: ExecSecurity = "allowlist";
+const DEFAULT_ASK: ExecAsk = "on-miss";
+export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "deny";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";


### PR DESCRIPTION
### Motivation
- Recent default changes made host `exec` permissive (security=`full`, ask=`off`, askFallback=`full`) which allowed host command execution without approvals when approvals/config are missing.
- This created a high-severity security regression by auto-approving on timeouts and disabling allowlist gating.
- Restore a safer, approval-first posture so missing/invalid approvals continue to require allowlist checks and deny on timeout.

### Description
- Reverted the built-in exec-approvals defaults to secure values: `DEFAULT_SECURITY` -> `allowlist`, `DEFAULT_ASK` -> `on-miss`, and `DEFAULT_EXEC_APPROVAL_ASK_FALLBACK` -> `deny` in `src/infra/exec-approvals.ts`.
- Aligned the exec tool fallbacks when `tools.exec.*` and approvals are unset so non-sandbox hosts use `allowlist` and `on-miss` instead of permissive fallbacks in `src/agents/bash-tools.exec.ts`.
- Updated focused unit expectations to reflect the restored defaults and summary wording in `src/infra/exec-approvals-config.test.ts` and `src/infra/exec-approvals-policy.test.ts`.

### Testing
- Ran the targeted unit tests with `pnpm test -- src/infra/exec-approvals-config.test.ts src/infra/exec-approvals-policy.test.ts src/agents/bash-tools.exec.approval-id.test.ts` and the suites passed (all targeted tests green).
- Ran repository checks via the pre-commit verification invoked by the committer helper, which runs `pnpm check` (type/lint/format gates) and returned no errors.
- Verified the change only touches approval defaults and exec fallback logic and that the updated tests validate the secure default behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ce7e3473f48320899f6e5b1da8ce6a)