### PR TITLE
fix(image-gen): raise default Azure OpenAI image timeout to 600s

### DIFF
--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -32,6 +32,10 @@ const DEFAULT_OPENAI_CODEX_IMAGE_RESPONSES_MODEL = "gpt-5.5";
 const OPENAI_CODEX_IMAGE_INSTRUCTIONS = "You are an image generation assistant.";
 const OPENAI_TRANSPARENT_BACKGROUND_IMAGE_MODEL = "gpt-image-1.5";
 const DEFAULT_OPENAI_IMAGE_TIMEOUT_MS = 180_000;
+// Azure OpenAI image generation (e.g. gpt-image-2) routinely takes several
+// minutes per request; the upstream OpenAI default of 180s is too aggressive.
+// See https://github.com/openclaw/openclaw/issues/71705.
+const DEFAULT_AZURE_OPENAI_IMAGE_TIMEOUT_MS = 600_000;
 const DEFAULT_OUTPUT_MIME = "image/png";
 const DEFAULT_OUTPUT_EXTENSION = "png";
 const DEFAULT_SIZE = "1024x1024";
@@ -90,8 +94,14 @@ function sanitizeLogValue(value: unknown): string {
     : cleaned;
 }
 
-function resolveOpenAIImageTimeoutMs(timeoutMs: number | undefined): number {
-  return timeoutMs ?? DEFAULT_OPENAI_IMAGE_TIMEOUT_MS;
+function resolveOpenAIImageTimeoutMs(
+  timeoutMs: number | undefined,
+  options?: { isAzure?: boolean },
+): number {
+  if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    return timeoutMs;
+  }
+  return options?.isAzure ? DEFAULT_AZURE_OPENAI_IMAGE_TIMEOUT_MS : DEFAULT_OPENAI_IMAGE_TIMEOUT_MS;
 }
 
 function resolveOpenAIImageCount(count: number | undefined): number {
@@ -742,7 +752,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
       });
       const count = resolveOpenAIImageCount(req.count);
       const size = req.size ?? DEFAULT_SIZE;
-      const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
+      const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs, { isAzure });
       const url = isAzure
         ? buildAzureImageUrl(rawBaseUrl, model, isEdit ? "edits" : "generations")
         : `${baseUrl}/images/${isEdit ? "edits" : "generations"}`;


### PR DESCRIPTION
## Summary

Fixes #71705. Azure OpenAI image generation (e.g. `gpt-image-2`) routinely takes 5+ minutes per request, but `image-generation-provider.ts` applies the same 180s default timeout that public OpenAI uses. As a result, otherwise-valid Azure image generations are aborted by OpenClaw even though the same request succeeds via the official Python SDK after ~394s, and via OpenClaw itself when `timeoutMs=600000` is explicitly passed.

## Change

- Adds `DEFAULT_AZURE_OPENAI_IMAGE_TIMEOUT_MS = 600_000`.
- `resolveOpenAIImageTimeoutMs(timeoutMs, { isAzure })` now picks the Azure-aware default when no caller-provided timeout is set.
- The Azure detection (`isAzureOpenAIBaseUrl`) is already computed at the call site, so the change is one parameter.

## Behavior

| Path | Caller timeoutMs | Old default | New default |
|------|------------------|-------------|-------------|
| Public OpenAI | unset | 180s | 180s (unchanged) |
| Azure OpenAI | unset | 180s | 600s |
| Either | set | wins | wins (unchanged) |

Also tightens the resolver to ignore non-finite / non-positive `timeoutMs` values instead of accepting them.

## Risk

Low. No public API change; explicit caller timeouts still win; the public OpenAI path is byte-identical. Only the unset-timeout Azure case behaves differently, which is the bug being fixed.

## Tests

Touched a single internal helper used by the existing image-gen path; no test changes needed for the helper itself, and existing image-generation tests still pass against the updated signature (the `options` arg is optional).

Closes #71705.