### PR TITLE
Add startup progress indicators

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,11 +179,13 @@ bootstrap_gum_temp() {
     gum_tmpdir="$(mktemp -d)"
     TMPFILES+=("$gum_tmpdir")
 
+    ui_info "Preparing spinner support"
     if ! download_file "${base}/${asset}" "$gum_tmpdir/$asset"; then
         GUM_REASON="download failed"
         return 1
     fi
 
+    ui_info "Verifying spinner support download"
     if ! download_file "${base}/checksums.txt" "$gum_tmpdir/checksums.txt"; then
         GUM_REASON="checksum unavailable or failed"
         return 1
@@ -1441,7 +1443,7 @@ install_node() {
         if command -v apt-get &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_quiet_step "Downloading NodeSource setup script" download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_quiet_step "Configuring NodeSource repository" bash "$tmp"
                 run_quiet_step "Installing Node.js" apt-get install -y -qq nodejs
@@ -1452,7 +1454,7 @@ install_node() {
         elif command -v dnf &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_quiet_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_quiet_step "Configuring NodeSource repository" bash "$tmp"
                 run_quiet_step "Installing Node.js" dnf install -y -q nodejs
@@ -1463,7 +1465,7 @@ install_node() {
         elif command -v yum &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_quiet_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_quiet_step "Configuring NodeSource repository" bash "$tmp"
                 run_quiet_step "Installing Node.js" yum install -y -q nodejs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -444,6 +444,7 @@ run_quiet_step() {
 
     local log
     log="$(mktempfile)"
+    local showed_progress=false
 
     if [[ -n "$GUM" ]] && gum_is_tty && ! is_shell_function "${1:-}"; then
         local cmd_quoted=""
@@ -453,10 +454,18 @@ run_quiet_step() {
         if run_with_spinner "$title" bash -c "${cmd_quoted}>${log_quoted} 2>&1"; then
             return 0
         fi
+        showed_progress=true
     else
+        # Keep users informed even when gum spinner cannot run (for example shell functions).
+        ui_info "${title}"
+        showed_progress=true
         if "$@" >"$log" 2>&1; then
             return 0
         fi
+    fi
+
+    if [[ "$showed_progress" == "false" ]]; then
+        ui_info "${title}"
     fi
 
     ui_error "${title} failed — re-run with --verbose for details"
@@ -2265,6 +2274,8 @@ main() {
         return 0
     fi
 
+    # bootstrap_gum_temp may perform network downloads before any spinner is available.
+    echo -e "${INFO}Preparing installer interface...${NC}"
     bootstrap_gum_temp || true
     print_installer_banner
     print_gum_status

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -15,7 +15,7 @@ import { enableConsoleCapture } from "../logging.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveManifestCommandAliasOwner } from "../plugins/manifest-command-aliases.runtime.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
-import { withProgress } from "./progress.js";
+import { createCliProgress } from "./progress.js";
 import { maybeWarnAboutDebugProxyCoverage } from "../proxy-capture/coverage.js";
 import {
   finalizeDebugProxyCapture,
@@ -249,7 +249,25 @@ export async function runCli(argv: string[] = process.argv) {
         return;
       }
       const { runCrestodian } = await import("../crestodian/crestodian.js");
-      await runCrestodian();
+      const progress = createCliProgress({
+        label: "Starting Crestodian…",
+        indeterminate: true,
+        delayMs: 120,
+        fallback: "none",
+      });
+      let progressStopped = false;
+      const stopProgress = () => {
+        if (progressStopped) {
+          return;
+        }
+        progressStopped = true;
+        progress.done();
+      };
+      try {
+        await runCrestodian({ onReady: stopProgress });
+      } finally {
+        stopProgress();
+      }
       return;
     }
 
@@ -265,113 +283,121 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
-    await withProgress(
-      {
-        label: "Loading OpenClaw CLI…",
-        indeterminate: true,
-        delayMs: 120,
-        fallback: "none",
-      },
-      async () => {
-        if (await tryRouteCli(normalizedArgv)) {
-          return;
+    if (await tryRouteCli(normalizedArgv)) {
+      return;
+    }
+
+    const startupProgress = createCliProgress({
+      label: "Loading OpenClaw CLI…",
+      indeterminate: true,
+      delayMs: 120,
+      fallback: "none",
+    });
+    let startupProgressStopped = false;
+    const stopStartupProgress = () => {
+      if (startupProgressStopped) {
+        return;
+      }
+      startupProgressStopped = true;
+      startupProgress.done();
+    };
+
+    try {
+      // Capture all console output into structured logs while keeping stdout/stderr behavior.
+      enableConsoleCapture();
+
+      const [
+        { buildProgram },
+        { runFatalErrorHooks },
+        { installUnhandledRejectionHandler },
+        { restoreTerminalState },
+      ] = await Promise.all([
+        import("./program.js"),
+        import("../infra/fatal-error-hooks.js"),
+        import("../infra/unhandled-rejections.js"),
+        import("../terminal/restore.js"),
+      ]);
+      const program = buildProgram();
+
+      // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+      // These log the error and exit gracefully instead of crashing without trace.
+      installUnhandledRejectionHandler();
+
+      process.on("uncaughtException", (error) => {
+        console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+        for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
+          console.error("[openclaw]", message);
         }
+        restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
+        process.exit(1);
+      });
 
-        // Capture all console output into structured logs while keeping stdout/stderr behavior.
-        enableConsoleCapture();
-
-        const [
-          { buildProgram },
-          { runFatalErrorHooks },
-          { installUnhandledRejectionHandler },
-          { restoreTerminalState },
-        ] = await Promise.all([
-          import("./program.js"),
-          import("../infra/fatal-error-hooks.js"),
-          import("../infra/unhandled-rejections.js"),
-          import("../terminal/restore.js"),
-        ]);
-        const program = buildProgram();
-
-        // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-        // These log the error and exit gracefully instead of crashing without trace.
-        installUnhandledRejectionHandler();
-
-        process.on("uncaughtException", (error) => {
-          console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-          for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
-            console.error("[openclaw]", message);
-          }
-          restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
-          process.exit(1);
-        });
-
-        const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-        const invocation = resolveCliArgvInvocation(parseArgv);
-        // Register the primary command (builtin or subcli) so help and command parsing
-        // are correct even with lazy command registration.
-        const { primary } = invocation;
-        if (primary && shouldRegisterPrimaryCommandOnly(parseArgv)) {
-          const { getProgramContext } = await import("./program/program-context.js");
-          const ctx = getProgramContext(program);
-          if (ctx) {
-            const { registerCoreCliByName } = await import("./program/command-registry.js");
-            await registerCoreCliByName(program, ctx, primary, parseArgv);
-          }
-          const { registerSubCliByName } = await import("./program/register.subclis.js");
-          await registerSubCliByName(program, primary);
+      const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+      const invocation = resolveCliArgvInvocation(parseArgv);
+      // Register the primary command (builtin or subcli) so help and command parsing
+      // are correct even with lazy command registration.
+      const { primary } = invocation;
+      if (primary && shouldRegisterPrimaryCommandOnly(parseArgv)) {
+        const { getProgramContext } = await import("./program/program-context.js");
+        const ctx = getProgramContext(program);
+        if (ctx) {
+          const { registerCoreCliByName } = await import("./program/command-registry.js");
+          await registerCoreCliByName(program, ctx, primary, parseArgv);
         }
+        const { registerSubCliByName } = await import("./program/register.subclis.js");
+        await registerSubCliByName(program, primary);
+      }
 
-        const hasBuiltinPrimary =
-          primary !== null &&
-          program.commands.some(
-            (command) => command.name() === primary || command.aliases().includes(primary),
-          );
-        const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
-          argv: parseArgv,
-          primary,
-          hasBuiltinPrimary,
-        });
-        if (!shouldSkipPluginRegistration) {
-          // Register plugin CLI commands before parsing
-          const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
-          const config = await registerPluginCliCommandsFromValidatedConfig(
-            program,
-            undefined,
-            undefined,
-            {
-              mode: "lazy",
-              primary,
-            },
-          );
-          if (config) {
-            if (
-              primary &&
-              !program.commands.some(
-                (command) => command.name() === primary || command.aliases().includes(primary),
-              )
-            ) {
-              const missingPluginCommandMessage = resolveMissingPluginCommandMessage(
-                primary,
-                config,
-              );
-              if (missingPluginCommandMessage) {
-                throw new Error(missingPluginCommandMessage);
-              }
+      const hasBuiltinPrimary =
+        primary !== null &&
+        program.commands.some(
+          (command) => command.name() === primary || command.aliases().includes(primary),
+        );
+      const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
+        argv: parseArgv,
+        primary,
+        hasBuiltinPrimary,
+      });
+      if (!shouldSkipPluginRegistration) {
+        // Register plugin CLI commands before parsing
+        const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
+        const config = await registerPluginCliCommandsFromValidatedConfig(
+          program,
+          undefined,
+          undefined,
+          {
+            mode: "lazy",
+            primary,
+          },
+        );
+        if (config) {
+          if (
+            primary &&
+            !program.commands.some(
+              (command) => command.name() === primary || command.aliases().includes(primary),
+            )
+          ) {
+            const missingPluginCommandMessage = resolveMissingPluginCommandMessage(primary, config);
+            if (missingPluginCommandMessage) {
+              throw new Error(missingPluginCommandMessage);
             }
           }
         }
+      }
 
-        try {
-          await program.parseAsync(parseArgv);
-        } catch (error) {
-          if (!(error instanceof CommanderError)) {
-            throw error;
-          }
-          process.exitCode = error.exitCode;
+      stopStartupProgress();
+
+      try {
+        await program.parseAsync(parseArgv);
+      } catch (error) {
+        if (!(error instanceof CommanderError)) {
+          throw error;
         }
-      },
-    );
+        process.exitCode = error.exitCode;
+      }
+    } finally {
+      stopStartupProgress();
+    }
   } finally {
     await closeCliMemoryManagers();
   }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -252,7 +252,7 @@ export async function runCli(argv: string[] = process.argv) {
       const progress = createCliProgress({
         label: "Starting Crestodian…",
         indeterminate: true,
-        delayMs: 120,
+        delayMs: 0,
         fallback: "none",
       });
       let progressStopped = false;
@@ -290,7 +290,7 @@ export async function runCli(argv: string[] = process.argv) {
     const startupProgress = createCliProgress({
       label: "Loading OpenClaw CLI…",
       indeterminate: true,
-      delayMs: 120,
+      delayMs: 0,
       fallback: "none",
     });
     let startupProgressStopped = false;

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -15,6 +15,7 @@ import { enableConsoleCapture } from "../logging.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveManifestCommandAliasOwner } from "../plugins/manifest-command-aliases.runtime.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
+import { withProgress } from "./progress.js";
 import { maybeWarnAboutDebugProxyCoverage } from "../proxy-capture/coverage.js";
 import {
   finalizeDebugProxyCapture,
@@ -264,100 +265,113 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
-    if (await tryRouteCli(normalizedArgv)) {
-      return;
-    }
+    await withProgress(
+      {
+        label: "Loading OpenClaw CLI…",
+        indeterminate: true,
+        delayMs: 120,
+        fallback: "none",
+      },
+      async () => {
+        if (await tryRouteCli(normalizedArgv)) {
+          return;
+        }
 
-    // Capture all console output into structured logs while keeping stdout/stderr behavior.
-    enableConsoleCapture();
+        // Capture all console output into structured logs while keeping stdout/stderr behavior.
+        enableConsoleCapture();
 
-    const [
-      { buildProgram },
-      { runFatalErrorHooks },
-      { installUnhandledRejectionHandler },
-      { restoreTerminalState },
-    ] = await Promise.all([
-      import("./program.js"),
-      import("../infra/fatal-error-hooks.js"),
-      import("../infra/unhandled-rejections.js"),
-      import("../terminal/restore.js"),
-    ]);
-    const program = buildProgram();
+        const [
+          { buildProgram },
+          { runFatalErrorHooks },
+          { installUnhandledRejectionHandler },
+          { restoreTerminalState },
+        ] = await Promise.all([
+          import("./program.js"),
+          import("../infra/fatal-error-hooks.js"),
+          import("../infra/unhandled-rejections.js"),
+          import("../terminal/restore.js"),
+        ]);
+        const program = buildProgram();
 
-    // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-    // These log the error and exit gracefully instead of crashing without trace.
-    installUnhandledRejectionHandler();
+        // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+        // These log the error and exit gracefully instead of crashing without trace.
+        installUnhandledRejectionHandler();
 
-    process.on("uncaughtException", (error) => {
-      console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-      for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
-        console.error("[openclaw]", message);
-      }
-      restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
-      process.exit(1);
-    });
+        process.on("uncaughtException", (error) => {
+          console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+          for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
+            console.error("[openclaw]", message);
+          }
+          restoreTerminalState("uncaught exception", { resumeStdinIfPaused: false });
+          process.exit(1);
+        });
 
-    const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-    const invocation = resolveCliArgvInvocation(parseArgv);
-    // Register the primary command (builtin or subcli) so help and command parsing
-    // are correct even with lazy command registration.
-    const { primary } = invocation;
-    if (primary && shouldRegisterPrimaryCommandOnly(parseArgv)) {
-      const { getProgramContext } = await import("./program/program-context.js");
-      const ctx = getProgramContext(program);
-      if (ctx) {
-        const { registerCoreCliByName } = await import("./program/command-registry.js");
-        await registerCoreCliByName(program, ctx, primary, parseArgv);
-      }
-      const { registerSubCliByName } = await import("./program/register.subclis.js");
-      await registerSubCliByName(program, primary);
-    }
+        const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+        const invocation = resolveCliArgvInvocation(parseArgv);
+        // Register the primary command (builtin or subcli) so help and command parsing
+        // are correct even with lazy command registration.
+        const { primary } = invocation;
+        if (primary && shouldRegisterPrimaryCommandOnly(parseArgv)) {
+          const { getProgramContext } = await import("./program/program-context.js");
+          const ctx = getProgramContext(program);
+          if (ctx) {
+            const { registerCoreCliByName } = await import("./program/command-registry.js");
+            await registerCoreCliByName(program, ctx, primary, parseArgv);
+          }
+          const { registerSubCliByName } = await import("./program/register.subclis.js");
+          await registerSubCliByName(program, primary);
+        }
 
-    const hasBuiltinPrimary =
-      primary !== null &&
-      program.commands.some(
-        (command) => command.name() === primary || command.aliases().includes(primary),
-      );
-    const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
-      argv: parseArgv,
-      primary,
-      hasBuiltinPrimary,
-    });
-    if (!shouldSkipPluginRegistration) {
-      // Register plugin CLI commands before parsing
-      const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
-      const config = await registerPluginCliCommandsFromValidatedConfig(
-        program,
-        undefined,
-        undefined,
-        {
-          mode: "lazy",
-          primary,
-        },
-      );
-      if (config) {
-        if (
-          primary &&
-          !program.commands.some(
+        const hasBuiltinPrimary =
+          primary !== null &&
+          program.commands.some(
             (command) => command.name() === primary || command.aliases().includes(primary),
-          )
-        ) {
-          const missingPluginCommandMessage = resolveMissingPluginCommandMessage(primary, config);
-          if (missingPluginCommandMessage) {
-            throw new Error(missingPluginCommandMessage);
+          );
+        const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
+          argv: parseArgv,
+          primary,
+          hasBuiltinPrimary,
+        });
+        if (!shouldSkipPluginRegistration) {
+          // Register plugin CLI commands before parsing
+          const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
+          const config = await registerPluginCliCommandsFromValidatedConfig(
+            program,
+            undefined,
+            undefined,
+            {
+              mode: "lazy",
+              primary,
+            },
+          );
+          if (config) {
+            if (
+              primary &&
+              !program.commands.some(
+                (command) => command.name() === primary || command.aliases().includes(primary),
+              )
+            ) {
+              const missingPluginCommandMessage = resolveMissingPluginCommandMessage(
+                primary,
+                config,
+              );
+              if (missingPluginCommandMessage) {
+                throw new Error(missingPluginCommandMessage);
+              }
+            }
           }
         }
-      }
-    }
 
-    try {
-      await program.parseAsync(parseArgv);
-    } catch (error) {
-      if (!(error instanceof CommanderError)) {
-        throw error;
-      }
-      process.exitCode = error.exitCode;
-    }
+        try {
+          await program.parseAsync(parseArgv);
+        } catch (error) {
+          if (!(error instanceof CommanderError)) {
+            throw error;
+          }
+          process.exitCode = error.exitCode;
+        }
+      },
+    );
   } finally {
     await closeCliMemoryManagers();
   }

--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCrestodian } from "./crestodian.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
 
+const withProgressMock = vi.hoisted(() =>
+  vi.fn(async (_opts: unknown, work: (progress: { setLabel: (label: string) => void }) => Promise<unknown>) => {
+    return await work({ setLabel: vi.fn() });
+  }),
+);
+
 vi.mock("./probes.js", () => ({
   probeLocalCommand: vi.fn(async (command: string) => ({
     command,
@@ -39,6 +45,10 @@ vi.mock("./overview.js", () => ({
   })),
 }));
 
+vi.mock("../cli/progress.js", () => ({
+  withProgress: withProgressMock,
+}));
+
 describe("runCrestodian", () => {
   beforeEach(() => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
@@ -69,6 +79,10 @@ describe("runCrestodian", () => {
     );
 
     expect(runGatewayRestart).not.toHaveBeenCalled();
+    expect(withProgressMock).toHaveBeenCalledWith(
+      expect.objectContaining({ label: "Loading Crestodian overview…" }),
+      expect.any(Function),
+    );
     expect(lines.join("\n")).toContain("[crestodian] planner: openai/gpt-5.5");
     expect(lines.join("\n")).toContain("[crestodian] interpreted: restart gateway");
     expect(lines.join("\n")).toContain("Plan: restart the Gateway. Say yes to apply.");
@@ -90,6 +104,10 @@ describe("runCrestodian", () => {
     );
 
     expect(planner).not.toHaveBeenCalled();
+    expect(withProgressMock).toHaveBeenCalledWith(
+      expect.objectContaining({ label: "Loading Crestodian overview…" }),
+      expect.any(Function),
+    );
     expect(lines.join("\n")).toContain("Default model:");
   });
 
@@ -112,6 +130,10 @@ describe("runCrestodian", () => {
     expect(runInteractiveTui).toHaveBeenCalledWith(
       expect.objectContaining({ runInteractiveTui }),
       runtime,
+    );
+    expect(withProgressMock).toHaveBeenCalledWith(
+      expect.objectContaining({ label: "Starting Crestodian…" }),
+      expect.any(Function),
     );
     expect(lines.join("\n")).not.toContain("Say: status");
   });

--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -5,12 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCrestodian } from "./crestodian.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
 
-const withProgressMock = vi.hoisted(() =>
-  vi.fn(async (_opts: unknown, work: (progress: { setLabel: (label: string) => void }) => Promise<unknown>) => {
-    return await work({ setLabel: vi.fn() });
-  }),
-);
-
 vi.mock("./probes.js", () => ({
   probeLocalCommand: vi.fn(async (command: string) => ({
     command,
@@ -45,10 +39,6 @@ vi.mock("./overview.js", () => ({
   })),
 }));
 
-vi.mock("../cli/progress.js", () => ({
-  withProgress: withProgressMock,
-}));
-
 describe("runCrestodian", () => {
   beforeEach(() => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
@@ -64,11 +54,13 @@ describe("runCrestodian", () => {
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(tempDir, "openclaw.json"));
     const { runtime, lines } = createCrestodianTestRuntime();
     const runGatewayRestart = vi.fn(async () => {});
+    const onReady = vi.fn();
 
     await runCrestodian(
       {
         message: "the local bridge looks sleepy, poke it",
         deps: { runGatewayRestart },
+        onReady,
         planWithAssistant: async () => ({
           reply: "I can queue a Gateway restart.",
           command: "restart gateway",
@@ -79,10 +71,7 @@ describe("runCrestodian", () => {
     );
 
     expect(runGatewayRestart).not.toHaveBeenCalled();
-    expect(withProgressMock).toHaveBeenCalledWith(
-      expect.objectContaining({ label: "Loading Crestodian overview…" }),
-      expect.any(Function),
-    );
+    expect(onReady).not.toHaveBeenCalled();
     expect(lines.join("\n")).toContain("[crestodian] planner: openai/gpt-5.5");
     expect(lines.join("\n")).toContain("[crestodian] interpreted: restart gateway");
     expect(lines.join("\n")).toContain("Plan: restart the Gateway. Say yes to apply.");
@@ -94,20 +83,19 @@ describe("runCrestodian", () => {
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(tempDir, "openclaw.json"));
     const { runtime, lines } = createCrestodianTestRuntime();
     const planner = vi.fn(async () => ({ command: "restart gateway" }));
+    const onReady = vi.fn();
 
     await runCrestodian(
       {
         message: "models",
         planWithAssistant: planner,
+        onReady,
       },
       runtime,
     );
 
     expect(planner).not.toHaveBeenCalled();
-    expect(withProgressMock).toHaveBeenCalledWith(
-      expect.objectContaining({ label: "Loading Crestodian overview…" }),
-      expect.any(Function),
-    );
+    expect(onReady).not.toHaveBeenCalled();
     expect(lines.join("\n")).toContain("Default model:");
   });
 
@@ -117,12 +105,14 @@ describe("runCrestodian", () => {
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(tempDir, "openclaw.json"));
     const { runtime, lines } = createCrestodianTestRuntime();
     const runInteractiveTui = vi.fn(async () => {});
+    const onReady = vi.fn();
 
     await runCrestodian(
       {
         input: { isTTY: true } as unknown as NodeJS.ReadableStream,
         output: { isTTY: true } as unknown as NodeJS.WritableStream,
         runInteractiveTui,
+        onReady,
       },
       runtime,
     );
@@ -131,10 +121,7 @@ describe("runCrestodian", () => {
       expect.objectContaining({ runInteractiveTui }),
       runtime,
     );
-    expect(withProgressMock).toHaveBeenCalledWith(
-      expect.objectContaining({ label: "Starting Crestodian…" }),
-      expect.any(Function),
-    );
+    expect(onReady).toHaveBeenCalledTimes(1);
     expect(lines.join("\n")).not.toContain("Say: status");
   });
 });

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -1,5 +1,6 @@
 import { stdin as defaultStdin, stdout as defaultStdout } from "node:process";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
+import { withProgress } from "../cli/progress.js";
 import type { CrestodianAssistantPlanner } from "./assistant.js";
 import { resolveCrestodianOperation } from "./dialogue.js";
 import {
@@ -49,7 +50,15 @@ export async function runCrestodian(
   }
 
   if (opts.message?.trim()) {
-    const overview = await loadCrestodianOverview();
+    const overview = await withProgress(
+      {
+        label: "Loading Crestodian overview…",
+        indeterminate: true,
+        delayMs: 120,
+        fallback: "none",
+      },
+      async () => await loadCrestodianOverview(),
+    );
     runtime.log(formatCrestodianOverview(overview));
     runtime.log("");
     await runOneShot(opts.message, runtime, opts);
@@ -68,5 +77,13 @@ export async function runCrestodian(
 
   const runInteractiveTui =
     opts.runInteractiveTui ?? (await import("./tui-backend.js")).runCrestodianTui;
-  await runInteractiveTui(opts, runtime);
+  await withProgress(
+    {
+      label: "Starting Crestodian…",
+      indeterminate: true,
+      delayMs: 120,
+      fallback: "none",
+    },
+    async () => await runInteractiveTui(opts, runtime),
+  );
 }

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -20,6 +20,7 @@ export type RunCrestodianOptions = {
   yes?: boolean;
   json?: boolean;
   interactive?: boolean;
+  onReady?: () => void;
   deps?: CrestodianCommandDeps;
   planWithAssistant?: CrestodianAssistantPlanner;
   input?: NodeJS.ReadableStream;
@@ -77,13 +78,6 @@ export async function runCrestodian(
 
   const runInteractiveTui =
     opts.runInteractiveTui ?? (await import("./tui-backend.js")).runCrestodianTui;
-  await withProgress(
-    {
-      label: "Starting Crestodian…",
-      indeterminate: true,
-      delayMs: 120,
-      fallback: "none",
-    },
-    async () => await runInteractiveTui(opts, runtime),
-  );
+  opts.onReady?.();
+  await runInteractiveTui(opts, runtime);
 }

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -55,7 +55,7 @@ export async function runCrestodian(
       {
         label: "Loading Crestodian overview…",
         indeterminate: true,
-        delayMs: 120,
+        delayMs: 0,
         fallback: "none",
       },
       async () => await loadCrestodianOverview(),


### PR DESCRIPTION
Show an indeterminate spinner during slow CLI bootstrap and while Crestodian loads its overview, with immediate feedback (no hardcoded 2s delay threshold).

The startup progress now stops before command execution and before the interactive TUI session begins, so nested progress is not suppressed.

Validation:
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm exec vitest run src/cli/run-main.exit.test.ts src/crestodian/crestodian.test.ts