### PR TITLE
fix(google): honor models.providers.google.request.allowPrivateNetwork in TTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ Docs: https://docs.openclaw.ai
 - Diagnostics/trace: report live context usage from the current prompt snapshot
   instead of provider turn totals, avoiding false near-full context spikes on
   cached or tool-heavy runs.
+- Providers/Google: honor `models.providers.google.request.allowPrivateNetwork`
+  for Gemini TTS and telephony TTS, matching Google image generation and media
+  understanding. (#71723) Thanks @ro-hansolo.
 - Plugins/Bonjour: stop the gateway from crash-looping on `CIAO PROBING CANCELLED` when the mDNS watchdog cancels a stuck probe. Restores the rejection-handler wiring dropped during the bonjour plugin migration and shares unhandled-rejection state across module instances so plugin-staged copies of `openclaw/plugin-sdk/runtime` register into the same handler set the host consults. Especially affects Docker on macOS, where mDNS probing reliably hits the watchdog. Thanks @troyhitch.
 - Google Meet: report pinned Chrome nodes as offline or missing capabilities in
   setup/join diagnostics, keep inaccessible nodes out of auto-selection, and

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -344,4 +344,31 @@ describe("Google speech provider", () => {
       expect.objectContaining({ allowPrivateNetwork: true }),
     );
   });
+
+  it("honors configured private-network opt-in for Google telephony TTS", async () => {
+    installGoogleTtsFetchMock();
+    const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest");
+
+    const provider = buildGoogleSpeechProvider();
+    await provider.synthesizeTelephony?.({
+      text: "hello",
+      cfg: {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+      providerConfig: { apiKey: "google-test-key" },
+      timeoutMs: 12_345,
+    });
+
+    expect(postJsonRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ allowPrivateNetwork: true }),
+    );
+  });
 });

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -1,3 +1,4 @@
+import * as providerHttp from "openclaw/plugin-sdk/provider-http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleSpeechProvider, __testing } from "./speech-provider.js";
 
@@ -313,6 +314,34 @@ describe("Google speech provider", () => {
       }),
     ).rejects.toThrow(
       "Google TTS failed (429): Quota exceeded [code=RESOURCE_EXHAUSTED] [request_id=google_req_123]",
+    );
+  });
+
+  it("honors configured private-network opt-in for Google TTS", async () => {
+    installGoogleTtsFetchMock();
+    const postJsonRequestSpy = vi.spyOn(providerHttp, "postJsonRequest");
+
+    const provider = buildGoogleSpeechProvider();
+    await provider.synthesize({
+      text: "hello",
+      cfg: {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+      providerConfig: { apiKey: "google-test-key" },
+      target: "audio-file",
+      timeoutMs: 12_345,
+    });
+
+    expect(postJsonRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ allowPrivateNetwork: true }),
     );
   });
 });

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,4 +1,8 @@
-import { assertOkOrThrowProviderError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  postJsonRequest,
+  sanitizeConfiguredModelProviderRequest,
+} from "openclaw/plugin-sdk/provider-http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
@@ -264,6 +268,7 @@ async function synthesizeGoogleTtsPcm(params: {
   text: string;
   apiKey: string;
   baseUrl?: string;
+  request?: ReturnType<typeof sanitizeConfiguredModelProviderRequest>;
   model: string;
   voiceName: string;
   audioProfile?: string;
@@ -274,6 +279,7 @@ async function synthesizeGoogleTtsPcm(params: {
     resolveGoogleGenerativeAiHttpRequestConfig({
       apiKey: params.apiKey,
       baseUrl: params.baseUrl,
+      request: params.request,
       capability: "audio",
       transport: "http",
     });
@@ -379,6 +385,9 @@ export function buildGoogleSpeechProvider(): SpeechProviderPlugin {
         text: req.text,
         apiKey,
         baseUrl: resolveGoogleTtsBaseUrl({ cfg: req.cfg, providerConfig: config }),
+        request: sanitizeConfiguredModelProviderRequest(
+          req.cfg?.models?.providers?.google?.request,
+        ),
         model: normalizeGoogleTtsModel(overrides.model ?? config.model),
         voiceName: normalizeGoogleTtsVoiceName(overrides.voiceName ?? config.voiceName),
         audioProfile: overrides.audioProfile ?? config.audioProfile,
@@ -405,6 +414,9 @@ export function buildGoogleSpeechProvider(): SpeechProviderPlugin {
         text: req.text,
         apiKey,
         baseUrl: resolveGoogleTtsBaseUrl({ cfg: req.cfg, providerConfig: config }),
+        request: sanitizeConfiguredModelProviderRequest(
+          req.cfg?.models?.providers?.google?.request,
+        ),
         model: config.model,
         voiceName: config.voiceName,
         audioProfile: config.audioProfile,


### PR DESCRIPTION
## Summary

- Problem: Google TTS provider ignores `models.providers.google.request.allowPrivateNetwork` config that image-gen + media-understanding honor. Always-blocked when the configured Google API endpoint resolves to a private IP. Silent fallback to a different speech provider.
- Why it matters: Documented config knob is non-functional for one capability. Users with proxies / internal backends / test mocks lose Google TTS.
- What changed: `extensions/google/speech-provider.ts` now threads `sanitizeConfiguredModelProviderRequest(req.cfg?.models?.providers?.google?.request)` into `resolveGoogleGenerativeAiHttpRequestConfig`, mirroring `image-generation-provider.ts`.
- What did NOT change: Default behavior identical when `models.providers.google.request` unset (which is the case for vast majority of users).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #67216 (the same bug for image generation; that fix updated `extensions/google/api.ts` and image-gen + media-understanding callers but missed `extensions/google/speech-provider.ts`)
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `synthesizeGoogleTtsPcm` in `extensions/google/speech-provider.ts` calls `resolveGoogleGenerativeAiHttpRequestConfig` without passing the `request` arg. The central function then defaults `allowPrivateNetwork` to `false` regardless of `models.providers.google.request.allowPrivateNetwork: true` in user config.
- Missing detection / guardrail: Sibling provider files (`extensions/google/image-generation-provider.ts`, `extensions/google/media-understanding-provider.ts`) thread `request` through; speech-provider was missed during the #67216 fix.
- Contributing context: #67216 added the central `params.request?.allowPrivateNetwork` honoring in `extensions/google/api.ts` and updated image-gen + media-understanding call sites but did not visit the speech-provider call site.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/google/speech-provider.test.ts`
- Scenario the test should lock in: When `models.providers.google.request.allowPrivateNetwork: true` is configured, calling `provider.synthesize(...)` should result in `postJsonRequest` being called with `allowPrivateNetwork: true`.
- Why this is the smallest reliable guardrail: Mirrors the existing test in `extensions/google/image-generation-provider.test.ts` ("honors configured private-network opt-in for Google image generation"). Catches the asymmetry that allowed this regression.
- Existing test that already covers this: None for TTS — only image gen had coverage; that's why the regression was not caught for the TTS path.

## User-visible / Behavior Changes

- TTS now honors `models.providers.google.request.allowPrivateNetwork` config like other Google capabilities.
- Default behavior unchanged when that config is unset (still defaults to `false`).

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No (extends an existing, documented config knob to one missed call site)
- Secrets/tokens handling changed? No
- New/changed network calls? No (same endpoint, same auth)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian 12 (gateway VM)
- Runtime: node 24.x
- Model/provider: Google TTS via `messages.tts.providers.google` + custom `models.providers.google.baseUrl`
- Integration/channel: WhatsApp (any messaging channel reproduces)
- Relevant config: `models.providers.google.request.allowPrivateNetwork: true`; `messages.tts.provider: "google"`; `messages.tts.providers.google.{model, voiceName}` configured

### Steps

1. Configure `models.providers.google.{baseUrl, models, request.allowPrivateNetwork: true}` where the resolved baseUrl points at a private IP (e.g. via `/etc/hosts` redirecting `generativelanguage.googleapis.com` to `127.0.0.1` for a local proxy).
2. Configure `messages.tts.provider: "google"` and `messages.tts.providers.google.{model, voiceName}`.
3. Trigger a TTS reply (any messaging channel).

### Expected

- TTS request reaches the configured baseUrl; receives audio response.

### Actual (before this fix)

- `[security] blocked URL fetch (url-fetch) targetOrigin=<configured baseUrl> reason=Blocked: resolves to private/internal/special-use IP address`. OC silently falls back to a different speech provider (e.g. Microsoft Edge), losing Google-specific config (`voiceName`, `audioProfile`, etc.).

## Evidence

- [x] Failing test before / passing after: added `extensions/google/speech-provider.test.ts` test ("honors configured private-network opt-in for Google TTS") fails on `main` without the source change.
- Same SSRF block error message structure as #67216 reported for image-gen, but for the audio capability.

## Human Verification (required)

- Verified scenarios:
  - Default (no `models.providers.google.request` configured): TTS request behavior unchanged — existing tests pass.
  - `request.allowPrivateNetwork: true` set: TTS reaches configured private-IP backend successfully — new test passes; verified on a deploy with the patched build.
- Edge cases checked: `synthesizeTelephony` path uses the same threading via the second call site.
- What I did not verify: live audio playback from a hostile-private-IP backend; testing was via local fetch mocks (the regression test) plus a controlled production deploy.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `sanitizeConfiguredModelProviderRequest` returns `undefined` for unset config; passing `undefined` to `resolveGoogleGenerativeAiHttpRequestConfig.request` is the same as omitting it (default-false path).
  - Mitigation: Verified against image-gen sibling which does the exact same.

---

AI-assisted (Claude wrote this PR after diagnosing the bug; lightly tested locally + verified end-to-end on a production gateway deploy). Human reviewed every diff hunk before push.
