### PR TITLE
fix(cli-runtime): translate OpenClaw `transport` field on user mcp.servers to Claude `type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ Docs: https://docs.openclaw.ai
   equivalent transcripts.
 - Agents/replies: forward sanitized underlying agent failure details on external
   channels instead of replacing unknown failures with a generic retry message.
+- CLI/MCP: translate OpenClaw `mcp.servers.*.transport` entries into
+  Claude/Gemini CLI `type` fields so streamable HTTP MCP servers load in CLI
+  backend sessions. (#71724) Thanks @Blockchain-Oracle.
 - Browser/CDP: honor configured remote and `attachOnly` CDP HTTP/WebSocket
   timeouts when opening tabs through raw CDP or `/json/new` fallback. (#54238)
   Thanks @FuncWei.

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -227,6 +227,93 @@ describe("prepareCliBundleMcpConfig", () => {
     await prepared.cleanup?.();
   });
 
+  it("translates OpenClaw transport field on user mcp.servers into Claude type", async () => {
+    const workspaceDir = await tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-user-servers-transport-",
+    );
+
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: {
+        command: "node",
+        args: ["./fake-claude.mjs"],
+      },
+      workspaceDir,
+      config: {
+        plugins: { enabled: false },
+        mcp: {
+          servers: {
+            context7: {
+              transport: "streamable-http",
+              url: "https://mcp.context7.com/mcp",
+              headers: { CONTEXT7_API_KEY: "ctx7sk-test" },
+            },
+            "omi-sse": {
+              transport: "sse",
+              url: "https://api.omi.me/v1/mcp/sse",
+            },
+          },
+        },
+      },
+    });
+
+    const configFlagIndex = prepared.backend.args?.indexOf("--mcp-config") ?? -1;
+    expect(configFlagIndex).toBeGreaterThanOrEqual(0);
+    const generatedConfigPath = prepared.backend.args?.[configFlagIndex + 1];
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath as string, "utf-8")) as {
+      mcpServers?: Record<string, { type?: string; transport?: string; url?: string }>;
+    };
+
+    expect(raw.mcpServers?.context7?.type).toBe("http");
+    expect(raw.mcpServers?.context7?.url).toBe("https://mcp.context7.com/mcp");
+    expect(raw.mcpServers?.context7?.transport).toBeUndefined();
+
+    expect(raw.mcpServers?.["omi-sse"]?.type).toBe("sse");
+    expect(raw.mcpServers?.["omi-sse"]?.transport).toBeUndefined();
+
+    await prepared.cleanup?.();
+  });
+
+  it("preserves explicit type and still strips transport on user mcp.servers", async () => {
+    const workspaceDir = await tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-user-servers-transport-explicit-",
+    );
+
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: {
+        command: "node",
+        args: ["./fake-claude.mjs"],
+      },
+      workspaceDir,
+      config: {
+        plugins: { enabled: false },
+        mcp: {
+          servers: {
+            mixed: {
+              type: "http",
+              transport: "sse",
+              url: "https://mcp.example.com/mcp",
+            },
+          },
+        },
+      },
+    });
+
+    const configFlagIndex = prepared.backend.args?.indexOf("--mcp-config") ?? -1;
+    const generatedConfigPath = prepared.backend.args?.[configFlagIndex + 1];
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath as string, "utf-8")) as {
+      mcpServers?: Record<string, { type?: string; transport?: string }>;
+    };
+
+    expect(raw.mcpServers?.mixed?.type).toBe("http");
+    expect(raw.mcpServers?.mixed?.transport).toBeUndefined();
+
+    await prepared.cleanup?.();
+  });
+
   it("user mcp.servers do not override the loopback additionalConfig", async () => {
     const workspaceDir = await tempHarness.createTempDir(
       "openclaw-cli-bundle-mcp-user-servers-loopback-",

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -635,4 +635,52 @@ describe("prepareCliBundleMcpConfig", () => {
 
     await prepared.cleanup?.();
   });
+
+  it("translates user mcp.servers transport fields in Gemini system settings", async () => {
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: {
+        command: "gemini",
+        args: ["--prompt", "{prompt}"],
+      },
+      workspaceDir: "/tmp/openclaw-bundle-mcp-gemini",
+      config: {
+        plugins: { enabled: false },
+        mcp: {
+          servers: {
+            context7: {
+              transport: "streamable-http",
+              url: "https://mcp.context7.com/mcp",
+              headers: {
+                Authorization: "Bearer ${CONTEXT7_API_KEY}",
+              },
+            },
+          },
+        },
+      },
+      env: {
+        CONTEXT7_API_KEY: "ctx7-test",
+      },
+    });
+
+    expect(prepared.env?.CONTEXT7_API_KEY).toBe("ctx7-test");
+    expect(typeof prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH).toBe("string");
+    const raw = JSON.parse(
+      await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+    ) as {
+      mcp?: { allowed?: string[] };
+      mcpServers?: Record<
+        string,
+        { type?: string; transport?: string; url?: string; headers?: Record<string, string> }
+      >;
+    };
+    expect(raw.mcp?.allowed).toEqual(["context7"]);
+    expect(raw.mcpServers?.context7?.type).toBe("http");
+    expect(raw.mcpServers?.context7?.transport).toBeUndefined();
+    expect(raw.mcpServers?.context7?.url).toBe("https://mcp.context7.com/mcp");
+    expect(raw.mcpServers?.context7?.headers?.Authorization).toBe("Bearer ctx7-test");
+
+    await prepared.cleanup?.();
+  });
 });

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -91,6 +91,45 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const OPENCLAW_TRANSPORT_TO_BUNDLE_TYPE: Record<string, string> = {
+  "streamable-http": "http",
+  http: "http",
+  sse: "sse",
+  stdio: "stdio",
+};
+
+/**
+ * Translate the OpenClaw `transport` field on an MCP server entry into the
+ * `type` field expected by downstream CLI runners (Claude, Gemini). The
+ * OpenClaw config schema (`McpServerConfig.transport`) accepts
+ * `"sse" | "streamable-http"`, while Claude Code and Gemini expect
+ * `type: "http" | "sse" | "stdio"`. Without this translation, user-defined
+ * HTTP MCP servers from `mcp.servers` are written into the bundled CLI config
+ * with an unrecognized `transport` key and rejected (or silently treated as
+ * stdio) by the downstream CLI.
+ *
+ * If both `transport` and `type` are set, `type` wins (explicit downstream
+ * override). The `transport` key is removed from the result either way so it
+ * does not leak into the downstream CLI config.
+ */
+function translateOpenClawTransportToBundleType(
+  server: BundleMcpServerConfig,
+): BundleMcpServerConfig {
+  const next = { ...server } as Record<string, unknown>;
+  const rawTransport = next.transport;
+  delete next.transport;
+  if (typeof next.type === "string") {
+    return next as BundleMcpServerConfig;
+  }
+  if (typeof rawTransport === "string") {
+    const mapped = OPENCLAW_TRANSPORT_TO_BUNDLE_TYPE[rawTransport];
+    if (mapped) {
+      next.type = mapped;
+    }
+  }
+  return next as BundleMcpServerConfig;
+}
+
 function normalizeStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string")
     ? [...value]
@@ -418,10 +457,18 @@ export async function prepareCliBundleMcpConfig(params: {
   mergedConfig = applyMergePatch(mergedConfig, bundleConfig.config) as BundleMcpConfig;
   const configuredMcp = normalizeConfiguredMcpServers(params.config?.mcp?.servers);
   if (Object.keys(configuredMcp).length > 0) {
+    const translatedConfiguredMcp = Object.fromEntries(
+      Object.entries(configuredMcp).map(([name, server]) => [
+        name,
+        translateOpenClawTransportToBundleType(server as BundleMcpServerConfig),
+      ]),
+    ) as BundleMcpConfig["mcpServers"];
     const existingMcpServers = mergedConfig.mcpServers;
     mergedConfig = {
       ...mergedConfig,
-      mcpServers: existingMcpServers ? { ...existingMcpServers, ...configuredMcp } : configuredMcp,
+      mcpServers: existingMcpServers
+        ? { ...existingMcpServers, ...translatedConfiguredMcp }
+        : translatedConfiguredMcp,
     } satisfies BundleMcpConfig;
   }
   if (params.additionalConfig) {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -170,14 +170,15 @@ async function expectBuiltArtifactNodeRequireFastPath(
     fs.mkdirSync(pluginRoot, { recursive: true });
 
     const importerPath = path.join(pluginRoot, "index.js");
-    const sidecarPath = path.join(pluginRoot, "fast-path-sidecar.js");
+    const sidecarPath = path.join(pluginRoot, "fast-path-sidecar.cjs");
     fs.writeFileSync(importerPath, "export default {};\n", "utf8");
-    // CommonJS so `nodeRequire` succeeds without falling back to jiti.
+    // CommonJS so `nodeRequire` succeeds without falling back to jiti, even
+    // after runtime-deps mirroring writes a `type: "module"` package boundary.
     fs.writeFileSync(sidecarPath, "module.exports = { sentinel: 7 };\n", "utf8");
 
     expect(
       channelEntryContract.loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {
-        specifier: "./fast-path-sidecar.js",
+        specifier: "./fast-path-sidecar.cjs",
         exportName: "sentinel",
       }),
     ).toBe(7);


### PR DESCRIPTION
## Summary

Upstream commit `61250e2bea` ("fix(cli-runtime): merge user mcp.servers into claude-cli bundle config") merges `params.config.mcp.servers` into the bundled Claude CLI config, but it passes each server entry through unchanged.

The OpenClaw config schema (`McpServerConfig` in `src/config/types.mcp.ts`) declares HTTP transport via:

```ts
transport?: "sse" | "streamable-http";
```

while Claude Code (and Gemini) expect:

```json
{ "type": "sse" | "http" | "stdio" }
```

After the merge fix, a config like:

```json
{
  "mcp": {
    "servers": {
      "context7": {
        "transport": "streamable-http",
        "url": "https://mcp.context7.com/mcp",
        "headers": { "CONTEXT7_API_KEY": "..." }
      }
    }
  }
}
```

still fails to register inside Claude CLI sessions because Claude doesn't recognize the `transport` key. The server is silently ignored or rejected by `--strict-mcp-config`, even though the value follows the OpenClaw-blessed schema.

## What this changes

In `src/agents/cli-runner/bundle-mcp.ts`, before merging `configuredMcp` into `mergedConfig.mcpServers`:

- Translate `transport: "streamable-http" | "http" | "sse" | "stdio"` → `type: "http" | "sse" | "stdio"`.
- If the user already set `type` explicitly, that wins (no overwrite).
- The `transport` key is always dropped from the downstream config so it doesn't leak into the CLI session.

This matches the schema Claude Code documents at https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/mcp-integration/references/server-types.md.

## Why this matters

I run an OpenClaw VPS where `mcp.servers.context7` is configured the OpenClaw way (`transport: "streamable-http"`). After updating to `2026.4.24`, the merge fix landed but `mcp__context7__*` tools were still not callable from inside Claude CLI sessions — because `transport` is the wrong key for Claude. Adding the translation step makes user-configured HTTP MCP servers actually reach Claude.

## Out of scope (follow-ups)

- Gemini path (`normalizeGeminiServerConfig`) only copies `server.type` — same translation would help there. Left out of this PR for scope; happy to follow up.
- Codex (`normalizeCodexServerConfig`) handles its own schema and isn't affected.

## Test plan

- [x] `pnpm vitest run src/agents/cli-runner/bundle-mcp.test.ts` — 15 tests pass (13 existing + 2 new).
- [x] `pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/agents/cli-runner/bundle-mcp.ts src/agents/cli-runner/bundle-mcp.test.ts` — 0 warnings, 0 errors.
- [x] Verified end-to-end on my VPS by hot-patching `dist/prepare.runtime-CZHxT6tF.js` with the equivalent JS — Context7 MCP tools became callable from inside Claude CLI sessions immediately after gateway restart.

## New tests

1. `translates OpenClaw transport field on user mcp.servers into Claude type` — covers both `streamable-http` → `http` and `sse` → `sse`, asserts `transport` key is stripped.
2. `preserves explicit type and still strips transport on user mcp.servers` — covers the case where the user set both `type` and `transport`; `type` wins, `transport` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)