### PR TITLE
[plugin sdk] docs: plugin host hook RFC

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1189,7 +1189,8 @@
                       "plugins/sdk-testing",
                       "plugins/manifest",
                       "plugins/architecture",
-                      "plugins/architecture-internals"
+                      "plugins/architecture-internals",
+                      "plugins/plan-mode-plugin-host-hooks"
                     ]
                   }
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1178,6 +1178,10 @@
                     ]
                   },
                   {
+                    "group": "Plugin design RFCs",
+                    "pages": ["plugins/plan-mode-plugin-host-hooks"]
+                  },
+                  {
                     "group": "SDK reference",
                     "pages": [
                       "plugins/sdk-overview",
@@ -1189,8 +1193,7 @@
                       "plugins/sdk-testing",
                       "plugins/manifest",
                       "plugins/architecture",
-                      "plugins/architecture-internals",
-                      "plugins/plan-mode-plugin-host-hooks"
+                      "plugins/architecture-internals"
                     ]
                   }
                 ]

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -651,7 +651,7 @@ be registered, but catalog and UI display metadata are still partly host-owned.
 
 ```ts
 type ToolPolicyDecision =
-  | { allow?: true }
+  | { allow: true }
   | { block: true; reason: string; code?: string }
   | { requireApproval: true; reason: string; approvalKind?: string };
 

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -86,31 +86,99 @@ Concrete existing-code anchors for the audit:
   `src/infra/heartbeat-runner.ts`, but the current plugin SDK does not expose
   the requested typed lifecycle-owned helper surfaces.
 
+## Reusable SDK Capability Matrix
+
+Plan Mode is the pressure test because it currently costs roughly a large
+feature PR worth of host edits. It should not be the only beneficiary. The hook
+families below are SDK primitives that let other plugins become first-class
+without copying the same host patches.
+
+| RFC | SDK primitive                                                             | Public, bundled, or protocol surface                                                                                                    | Plan Mode proof case                                                                                      | Other plugin families enabled                                                                                                                                     |
+| --- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A   | Plugin session extensions and patch actions                               | Public SDK registration plus gateway protocol patch method/envelope. Patch actions may declare gateway scopes.                          | Store plan mode, approval status, question state, pending injection ids, and nudge job ids.               | Memory/context managers, deployment workflows, incident/ticket bots, budget governors, channel preference plugins, long-running job monitors.                     |
+| B   | Durable next-turn injection queue and agent turn preparation              | Public enqueue API plus host-owned runner dequeue boundary. Turn hooks may be public; queue storage is host-owned.                      | Continue after approval, revise a plan, answer a question, inject scheduled nudges exactly once.          | CI triage follow-ups, code review bots, release handoff prompts, memory recall injectors, incident escalation prompts, customer-support workflow plugins.         |
+| C   | Trusted tool policy and plugin tool metadata                              | Normal metadata is public; pre-plugin policy is bundled/trusted-only; tool display is a gateway/UI descriptor contract.                 | Block mutating tools while approval is pending and publish Plan Mode tool display/safety metadata.        | Cost/budget limiters, workspace policy plugins, dangerous action approval wrappers, deployment freeze gates, data egress guards, sandbox/tool visibility plugins. |
+| D   | Scoped commands, trusted command ownership, and continuation              | Public command SDK for scopes/continuation; reserved roots require bundled/trusted manifest ownership.                                  | `/plan accept` patches state, enqueues continuation, and resumes the agent.                               | `/deploy approve`, `/review ship`, `/incident ack`, `/budget override`, `/memory pin`, `/ticket close`, and channel-specific command adapters.                    |
+| E   | Control UI contribution descriptors                                       | Gateway projection plus data-only UI descriptor contract. Arbitrary plugin browser JavaScript is out of scope for the first version.    | Plan/Plan Auto modes, approval/question cards, composer guards, and status indicators without UI patches. | Release dashboards, budget warnings, incident banners, review gates, memory/context panels, channel-auth cards, human approval cards.                             |
+| F   | Agent events, run context, session scheduler, and heartbeat contributions | Public typed event/scheduler helpers plus host-owned lifecycle cleanup. Some event categories may be bundled/trusted-only if sensitive. | Persist plan snapshots, track subagents, schedule nudges, and add heartbeat reminders.                    | Telemetry exporters, audit logs, SLA escalators, background sync plugins, recurring check-ins, CI/deploy monitors, memory indexers.                               |
+
+## Plugin Archetype Matrix
+
+These examples are intentionally not Plan Mode-specific. They show why the
+proposed hooks belong in the OpenClaw SDK rather than in one bundled plugin.
+
+| Plugin archetype           | Session extension                                           | Next-turn injection                                        | Tool policy and metadata                                                 | Scoped commands                                                         | UI contribution                                     | Events, scheduler, heartbeat                                        |
+| -------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------- |
+| Human approval workflow    | Approval state, approver, deadline, decision history.       | Continue after approval or inject revision instructions.   | Block risky tools until approved; mark approval tools as state-mutating. | `/approve`, `/reject`, `/revise` with approval scopes and continuation. | Approval cards, pending banners, composer guards.   | Expire stale approvals and nudge approvers.                         |
+| Deployment/release plugin  | Release candidate, environment, rollout phase, rollback id. | Inject release checklist or post-approval deploy command.  | Gate deploy/rollback tools during freeze windows.                        | `/deploy approve`, `/rollback`, `/release status`.                      | Release status panel and deploy approval card.      | Watch CI/deploy events, schedule smoke-test follow-ups.             |
+| Cost/budget governor       | Per-session budget, model/tool spend, override state.       | Inject budget warning or downgrade guidance on next turn.  | Block expensive tools/models or require override approval.               | `/budget status`, `/budget override`.                                   | Budget meter, warning card, blocked-input hint.     | Heartbeat reminders when budget is near limit; export spend events. |
+| Memory/context manager     | Pins, recall cursors, source visibility, compaction policy. | Inject selected memories/context once at turn start.       | Decorate memory tools with display/safety metadata.                      | `/memory pin`, `/memory forget`, `/context refresh`.                    | Context panel and memory-selection cards.           | Index agent events and schedule background refresh.                 |
+| Code review/PR gate        | Review checklist, unresolved findings, approval state.      | Inject review summary or required fix list.                | Block merge/push/deploy tools until findings are resolved.               | `/review approve`, `/review request-changes`, `/review rerun`.          | Review gate card, status chips, finding summary.    | Watch test/review events and schedule bot rechecks.                 |
+| Incident/ticket workflow   | Incident id, severity, owner, SLA, ticket sync cursor.      | Inject handoff, escalation, or ticket-update instructions. | Gate risky remediation tools behind incident role/scope.                 | `/incident ack`, `/incident escalate`, `/ticket close`.                 | Incident banner, SLA countdown, ticket action card. | Schedule escalations and export timeline events.                    |
+| Channel integration plugin | Channel thread state, auth handoff, delivery preferences.   | Inject deferred replies or cross-channel follow-ups.       | Mark channel tools with delivery/safety metadata.                        | `/telegram approve`, `/slack handoff`, `/email summarize`.              | Auth cards, channel delivery status, input guards.  | Track delivery events and retry scheduled sends.                    |
+| Workspace policy plugin    | Workspace rules, allowed paths, exception grants.           | Inject policy explanation or remediation steps.            | Block or require approval for policy-violating tools.                    | `/policy explain`, `/policy grant`, `/policy revoke`.                   | Policy warning card and blocked-action explanation. | Audit tool events and clear grants on session reset.                |
+| Telemetry/export plugin    | Export cursor, sink status, redaction mode.                 | Rare; may inject diagnostic summary after failure.         | Add metadata to telemetry/export tools.                                  | `/telemetry status`, `/telemetry retry`.                                | Export status panel and failure card.               | Subscribe to agent/tool events and schedule retries.                |
+| Long-running job monitor   | Job ids, progress, owner, cancellation state.               | Inject completion/failure summary into next active turn.   | Decorate job tools and gate cancellation.                                | `/job status`, `/job cancel`, `/job follow`.                            | Progress card and completion notification.          | Poll jobs, emit heartbeats, clean up on session close.              |
+
+## How The Hooks Enter The SDK
+
+The implementation should land as SDK infrastructure, not as Plan Mode code.
+Each hook family should have an explicit layer so plugin authors know which
+parts are stable public API, which parts are trusted-only, and which parts are
+gateway/UI protocol contracts.
+
+| SDK layer                  | What changes                                                                                                                                                                                                                                                                          | Hook families involved                     | Review requirement                                                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Public plugin API          | Add typed registration functions such as `registerSessionExtension`, `enqueueNextTurnInjection`, command `requiredScopes`, command `continueAgent`, UI contribution registration, typed event subscription, run-context helpers, scheduler helpers, and heartbeat contribution hooks. | A, B, D, E, F plus public metadata from C. | Additive TypeScript types, plugin SDK docs, generated API reference if applicable, and compile-time fixture plugin usage. |
+| Trusted/bundled plugin API | Add privileged registration for pre-plugin tool policy and reserved command ownership.                                                                                                                                                                                                | C and D.                                   | Manifest trust declaration, bundled-only enforcement, negative tests for external plugins, and clear security docs.       |
+| Manifest/schema            | Declare trusted capabilities, command roots, UI contribution ids, optional required scopes, and any cold-discovery metadata that should be visible before runtime activation.                                                                                                         | C, D, E, possibly F.                       | Manifest validation tests and disabled-plugin behavior tests.                                                             |
+| Gateway protocol           | Add plugin session patch route/envelope, public session projection, UI contribution projection, tool metadata/catalog projection, and stable error codes.                                                                                                                             | A, C, E.                                   | Backward-compatible schema changes, scope enforcement tests, and client compatibility notes.                              |
+| Agent runner boundary      | Add durable injection dequeue and `agent_turn_prepare` ordering before retry/fallback/provider transforms.                                                                                                                                                                            | B and F.                                   | Retry/fallback exactly-once tests and deterministic prompt ordering tests.                                                |
+| Control UI contract        | Consume descriptor-only plugin contributions for chat modes, generic cards, status surfaces, event classifiers, and input guards.                                                                                                                                                     | E plus metadata from C.                    | No arbitrary plugin browser code in the first version; descriptor sanitization and enable/disable tests.                  |
+| Lifecycle cleanup          | Clean plugin-owned state, injections, run context, scheduler jobs, UI descriptors, policies, tools, and commands on plugin disablement, session reset, session delete, compaction, and gateway restart.                                                                               | A through F.                               | Fixture tests for disablement, reset, delete, restart, and projection cleanup.                                            |
+| Fixture plugin tests       | Add a tiny plugin that exercises every new seam without product behavior.                                                                                                                                                                                                             | A through F.                               | The fixture is the contract guardrail for Plan Mode and future third-party plugins.                                       |
+
+Plugin authors should be able to answer six questions from the SDK docs after
+these hooks land:
+
+1. Where do I store per-session plugin state without adding fields to core
+   `SessionEntry`?
+2. How do I schedule exactly-once instructions for the next agent turn?
+3. How do I enforce trusted tool policy before ordinary plugin hooks and explain
+   tool risk in UI/catalogs?
+4. How do my slash commands declare required scopes, patch state, and
+   optionally resume the agent?
+5. How do I project mode, status, cards, and input guards into Control UI
+   without shipping arbitrary browser code?
+6. How do I subscribe to run events, keep run-scoped data, schedule
+   session-owned work, and clean it up on reset, delete, and plugin
+   disablement?
+
 ## Maintainer Decision To Make
 
 The decision is not "merge PR #71676 or reject Plan Mode." The useful decision
-is:
+is broader:
 
 > Which host seams must OpenClaw expose so Plan Mode can be implemented as a
 > first-class bundled plugin without reversible installer patches or scattered
-> core edits?
+> core edits, and so future plugins can reuse the same SDK primitives?
 
 The proposed answer is six hook families:
 
-| RFC | Hook family                                                  | Required before Plan Mode plugin parity? | Why                                                                                            |
-| --- | ------------------------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| A   | Plugin session extensions and patch actions                  | Yes                                      | Plan Mode is fundamentally durable per-session state.                                          |
-| B   | Durable next-turn injections and agent turn preparation      | Yes                                      | Approvals, revisions, question answers, and nudges must feed the next run exactly once.        |
-| C   | Trusted tool policy and plugin tool metadata                 | Yes                                      | Mutation blocking must run before ordinary tool hooks; plugin tools need first-class metadata. |
-| D   | Scoped plugin commands and command continuation              | Yes                                      | `/plan accept` and related commands must mutate state and resume execution.                    |
-| E   | Control UI contribution slots                                | Yes for first-class UX                   | Plan/Plan Auto mode, approval cards, and input guards must not patch UI files.                 |
-| F   | Agent event, run context, scheduler, and heartbeat lifecycle | Yes for full parity                      | Snapshot persistence, subagent gates, nudges, and lifecycle cleanup depend on runtime events.  |
+| RFC | Hook family                                                  | Required before Plan Mode plugin parity? | Reusable SDK reason                                                                                                                           |
+| --- | ------------------------------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| A   | Plugin session extensions and patch actions                  | Yes                                      | Any plugin with durable per-session workflow state needs host storage, projection, patch authorization, and lifecycle cleanup.                |
+| B   | Durable next-turn injections and agent turn preparation      | Yes                                      | Any plugin that converts a later approval, event, timer, or channel callback into the next agent turn needs exactly-once turn preparation.    |
+| C   | Trusted tool policy and plugin tool metadata                 | Yes                                      | Any plugin enforcing workspace, budget, approval, release, or safety policy needs a non-bypassable policy tier and explainable tool metadata. |
+| D   | Scoped plugin commands and command continuation              | Yes                                      | Any plugin with mutating slash commands needs host-enforced scopes and the option to resume the agent after command-side state changes.       |
+| E   | Control UI contribution slots                                | Yes for first-class UX                   | Any plugin with modes, approvals, warnings, status, or input guards needs a data-driven UI slot instead of checked-in UI patches.             |
+| F   | Agent event, run context, scheduler, and heartbeat lifecycle | Yes for full parity                      | Any plugin that reacts to runs, tools, subagents, timers, or recurring reminders needs typed event subscriptions and host-owned cleanup.      |
 
 The hook PR should implement those seams with a tiny fixture plugin. The Plan
 Mode plugin should come after the hook PR and use PR #71676 as its parity
 oracle.
 
-## Why A Plugin-Only Port Is Not Enough
+## Why Current SDK Surfaces Are Not Enough
 
 OpenClaw already has a useful plugin system:
 
@@ -361,6 +429,23 @@ type PlanModeSessionState = {
 
 This state should live under a plugin namespace, not on the root session entry.
 
+### RFC A Reusable SDK Scenarios
+
+Session extensions are useful for any plugin that owns durable per-session
+workflow state:
+
+- review gates can store PR id, unresolved findings, reviewer decisions, and
+  merge gate state
+- release plugins can store environment, rollout phase, freeze window, and
+  rollback id
+- memory managers can store pins, recall cursors, compaction policy, and source
+  visibility
+- budget governors can store spend counters, thresholds, override decisions,
+  and expiry
+- channel plugins can store thread bindings, delivery preferences, and auth
+  handoff state
+- incident bots can store severity, owner, ticket sync cursor, and SLA deadline
+
 ### RFC A Fixture Tests
 
 Required fixture coverage:
@@ -468,6 +553,20 @@ Plan Mode uses next-turn injections for:
 - scheduled plan nudges
 - subagent finished-follow-up instructions
 - "continue after approval" command flow
+
+### RFC B Reusable SDK Scenarios
+
+Durable next-turn injections are useful for any plugin that receives a decision,
+event, timer, or channel callback outside the current model call and needs to
+feed the next agent turn exactly once:
+
+- review plugins can inject required fixes after an asynchronous review pass
+- deployment plugins can inject a release checklist after human approval
+- memory managers can hydrate selected context before the next model call
+- incident plugins can inject escalation or handoff instructions after an SLA
+  timer fires
+- CI plugins can inject the next diagnostic step after log fetching completes
+- channel plugins can inject deferred replies or cross-channel follow-ups
 
 ### RFC B Failure Behavior
 
@@ -590,6 +689,21 @@ Plan Mode uses tool metadata for:
 - `plan_mode_status`
 - any future plan artifact export tool
 
+### RFC C Reusable SDK Scenarios
+
+Trusted tool policy and tool metadata are useful for any plugin that needs both
+policy enforcement and explainable tool presentation:
+
+- budget plugins can block or require approval for expensive tools or models
+- workspace policy plugins can block filesystem, browser, or network tools that
+  violate path or data-egress rules
+- deployment plugins can gate deploy and rollback tools during freeze windows
+- dangerous-action wrappers can require scoped approval for high-risk mutation
+  tools
+- compliance plugins can add audit and safety labels to plugin-owned tools
+- tool catalog extensions can publish display, risk, category, and ownership
+  metadata without hardcoding host display maps
+
 ### RFC C Fixture Tests
 
 Required fixture coverage:
@@ -676,6 +790,19 @@ Plan Mode commands would:
 - enqueue next-turn injections when needed
 - return `continueAgent: true` when execution should resume
 - return read-only status without continuation for `/plan status`
+
+### RFC D Reusable SDK Scenarios
+
+Scoped command continuation is useful for any plugin whose slash commands mutate
+state and then optionally resume the agent:
+
+- `/review approve`, `/review request-changes`, and `/review rerun`
+- `/deploy approve`, `/deploy pause`, `/rollback`, and `/release status`
+- `/budget override`, `/budget reset`, and `/budget status`
+- `/incident ack`, `/incident escalate`, and `/ticket close`
+- `/memory pin`, `/memory forget`, and `/context refresh`
+- `/policy grant`, `/policy revoke`, and `/policy explain`
+- `/telegram approve`, `/slack handoff`, and `/email summarize`
 
 ### RFC D Fixture Tests
 
@@ -779,6 +906,23 @@ Plan Mode UI contribution should replace host patches for:
 - approval event parsing
 - session status badge or sidebar section
 - composer guard when approval is pending
+
+### RFC E Reusable SDK Scenarios
+
+Control UI contribution slots are useful for any plugin that needs visible state
+or safe user interaction without patching the web app:
+
+- human approval plugins can render approval cards and pending banners
+- release plugins can show rollout progress, deploy approval cards, and freeze
+  banners
+- budget governors can show spend meters, override cards, and blocked-input
+  hints
+- memory/context plugins can show context panels, source visibility cards, and
+  memory pickers
+- incident plugins can show severity banners, SLA countdowns, and ticket action
+  cards
+- channel plugins can show auth cards, delivery status, and channel-specific
+  input guards
 
 ### RFC E Fixture Tests
 
@@ -895,6 +1039,22 @@ Plan Mode uses this hook family for:
 - creating and cancelling auto-nudge jobs
 - adding heartbeat prompt nudges
 - cleaning up jobs when session state resets
+
+### RFC F Reusable SDK Scenarios
+
+Agent events, run context, scheduler lifecycle, and heartbeat contributions are
+useful for any plugin that reacts to runtime facts or owns background work:
+
+- telemetry exporters can subscribe to sanitized events and batch scheduled
+  exports
+- memory indexers can observe run/tool events and refresh derived context
+- CI watchers can poll workflows and inject completion or failure summaries
+- incident bots can schedule SLA escalations and heartbeat unresolved incidents
+- channel plugins can track delivery events and retry failed sends
+- long-running job monitors can poll job state, emit progress, and clean up on
+  session close
+- subagent coordinators can store per-run state and inject follow-up once
+  subagents settle
 
 ### RFC F Fixture Tests
 

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -36,6 +36,56 @@ and preventing a plugin port from silently dropping parity.
 | E   | [#71736](https://github.com/openclaw/openclaw/issues/71736) | Control UI plugin contribution slots                                        |
 | F   | [#71737](https://github.com/openclaw/openclaw/issues/71737) | Agent events, run context, scheduler lifecycle, and heartbeat contributions |
 
+## Current SDK Research Baseline
+
+This RFC packet is intentionally using
+[#71427](https://github.com/openclaw/openclaw/issues/71427) as the review bar.
+That issue was closed because current `main` already exposed hooks that owned
+the requested tool-call and tool-result persistence lifecycle. For the six Plan
+Mode RFCs, the test is therefore not "is there any nearby hook?" The test is:
+
+- Does the existing SDK surface own the same lifecycle boundary?
+- Does it expose the payload shape a plugin needs without patching host files?
+- Does it provide host-owned ordering, authorization, disablement, and cleanup?
+- Can a fixture plugin prove the behavior without Plan Mode-specific core code?
+
+The current answer is mixed. OpenClaw has useful adjacent hooks, but none of
+the six RFCs is fully resolved by the current plugin SDK.
+
+| RFC                                                              | Existing current surface                                                                                                                                                                             | What it already covers                                                                                             | Why it does not resolve the RFC                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A. Plugin session extensions and patch actions                   | Fixed `SessionEntry`, fixed `sessions.patch`, hardcoded `GatewaySessionRow`, internal post-write `session:patch`, scoped plugin gateway RPCs.                                                        | Core can persist and patch known session fields; plugins can expose separate gateway methods with declared scopes. | There is no `api.registerSessionExtension(...)`, no namespaced persisted plugin session state, no gateway-routed plugin patch action, no public extension projection in session rows, and no host-owned reset/delete/compaction cleanup for plugin state.                  |
+| B. Durable next-turn injections and turn preparation             | `before_prompt_build`, legacy `before_agent_start`, and in-memory system events can prepend context to a prompt.                                                                                     | Plugins can add current-turn prompt context.                                                                       | There is no durable `enqueueNextTurnInjection(...)`, no `agent_turn_prepare` boundary before retry/provider transforms, no exactly-once dequeue semantics, no persisted expiry/dedupe, and no disabled-plugin suppression for queued injections.                           |
+| C. Trusted tool policy and tool metadata                         | `before_tool_call` can block, rewrite params, or require approval; core config filters tools before wrapping; plugin tools have basic catalog fields.                                                | Normal plugins can observe or block ordinary tool calls; plugin tools can appear in the catalog.                   | There is no trusted pre-plugin policy stage, no bundled-only policy registration, no guarantee a normal plugin cannot reorder around the gate, no plugin tool metadata/display registry, and no safe decoration path for core-owned tools such as `update_plan`.           |
+| D. Scoped commands, ownership, and continuation                  | `api.registerCommand(...)` exists; command context includes `gatewayClientScopes`; plugin gateway methods can declare `opts.scope`; duplicate plugin command registrations are blocked.              | Plugins can register slash commands and self-inspect available scopes.                                             | Commands cannot declare `requiredScopes` for host enforcement, untrusted plugins cannot have a reviewed reserved-root ownership model, and plugin command handling always stops instead of returning `continueAgent` to resume an agent turn.                              |
+| E. Control UI contribution slots                                 | Remote slash command discovery exists; generic plugin approval request/broadcast/card rendering exists; chat rendering and tool-card classification are host-coded.                                  | The UI can list plugin slash commands and can render a generic plugin approval card.                               | There is no `api.registerControlUiContribution(...)`, no chat mode descriptor projection, no input guard descriptor, no plugin event/status classifier registry, and no first-class data-driven UI slot for plugin-owned cards beyond the generic approval surface.        |
+| F. Agent events, run context, scheduler, and heartbeat lifecycle | `runtime.events.onAgentEvent` exposes raw agent events; internal `AgentRunContext` exists; `gateway_start` can expose `getCron`; prompt hooks can affect normal prompts; heartbeat can be requested. | Plugins can observe broad runtime events, manually use low-level cron access, and add generic prompt context.      | There is no typed `api.onAgentEvent(...)` with filters and cleanup, no namespaced plugin run-context bag, no session-owned scheduler helper with plugin cleanup on reset/delete/disable, and no heartbeat-specific contribution hook or heartbeat-scoped turn preparation. |
+
+Concrete existing-code anchors for the audit:
+
+- Current hook names live in `src/plugins/hook-types.ts`; they include
+  `before_prompt_build`, `before_tool_call`, `tool_result_persist`,
+  `before_message_write`, `gateway_start`, and agent/subagent lifecycle hooks,
+  but not `agent_turn_prepare` or `heartbeat_prompt_contribution`.
+- Session patch validation is fixed in
+  `src/gateway/protocol/schema/sessions.ts` and
+  `src/gateway/server-methods/sessions.ts`; plugin-specific session patch
+  fields are not accepted.
+- Plugin command definitions in `src/plugins/types.ts` and execution in
+  `src/plugins/commands.ts` support auth and handler context, but not
+  declarative command scopes, reserved-root ownership, or agent continuation.
+- Tool hooks in `src/plugins/hooks.ts` and
+  `src/agents/pi-tools.before-tool-call.ts` provide normal plugin ordering, not
+  a host-trusted pre-plugin policy tier.
+- Control UI rendering in `ui/src/ui/views/chat.ts`,
+  `ui/src/ui/app-tool-stream.ts`, and `ui/src/ui/chat/tool-cards.ts` is still
+  hardcoded around known chat/tool/event shapes rather than projected plugin UI
+  contribution descriptors.
+- Agent events, run context, cron, and heartbeat behavior exist in
+  `src/infra/agent-events.ts`, `src/cron/*`, and
+  `src/infra/heartbeat-runner.ts`, but the current plugin SDK does not expose
+  the requested typed lifecycle-owned helper surfaces.
+
 ## Maintainer Decision To Make
 
 The decision is not "merge PR #71676 or reject Plan Mode." The useful decision

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -25,6 +25,17 @@ This document is intentionally more detailed than a public user guide. It is a
 maintainer handoff artifact for filing RFC issues, reviewing the host-hook PR,
 and preventing a plugin port from silently dropping parity.
 
+## Filed RFC Issues
+
+| RFC | Issue                                                       | Decision thread                                                             |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| A   | [#71732](https://github.com/openclaw/openclaw/issues/71732) | Plugin session extensions and patch actions                                 |
+| B   | [#71733](https://github.com/openclaw/openclaw/issues/71733) | Durable next-turn injections and agent turn preparation hooks               |
+| C   | [#71734](https://github.com/openclaw/openclaw/issues/71734) | Trusted tool policy stage and plugin tool metadata                          |
+| D   | [#71735](https://github.com/openclaw/openclaw/issues/71735) | Scoped plugin commands, trusted command ownership, and continuation         |
+| E   | [#71736](https://github.com/openclaw/openclaw/issues/71736) | Control UI plugin contribution slots                                        |
+| F   | [#71737](https://github.com/openclaw/openclaw/issues/71737) | Agent events, run context, scheduler lifecycle, and heartbeat contributions |
+
 ## Maintainer Decision To Make
 
 The decision is not "merge PR #71676 or reject Plan Mode." The useful decision

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -11,6 +11,12 @@ read_when:
 
 Draft maintainer RFC packet.
 
+<Warning>
+  This document is a proposal and maintainer handoff, not implemented SDK
+  reference. The named APIs are contract targets for a future host-hook PR and
+  should not be documented as available until that implementation lands.
+</Warning>
+
 Primary behavior source:
 
 - PR #71676, "Plan Mode rebased onto upstream/main + executing-state subsystem"
@@ -234,6 +240,30 @@ host code. That breadth is the evidence for the missing seams.
 
 The host-hook PR should not copy those implementations. It should replace the
 host-specific edits with generic extension points.
+
+## PR 71676 Entry-Point Coverage Map
+
+The goal is not to preserve every file touched by PR #71676. The goal is to
+preserve every behavior class while moving Plan Mode-specific code into a
+plugin package. This map is the parity checklist for the future implementation
+PR.
+
+| PR #71676 entry point                                                         | Current patch shape                                                                           | Required SDK hook family                        | Parity requirement for plugin port                                                                                                                                  |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session model, gateway schema, and generated app client models                | Adds root session fields and updates gateway/client model shapes.                             | RFC A plus RFC E projection.                    | Plugin state lives under a namespaced session extension, projects safe public fields to gateway rows/details, and keeps client model generation additive.           |
+| `sessions.patch` and approval mutation routing                                | Adds Plan Mode-specific patch actions and validation.                                         | RFC A plus RFC D for command-triggered actions. | Plugin patch actions use host validation, authorization, error codes, persistence, and session-change broadcasts.                                                   |
+| Agent prompt preparation and pending interaction queue                        | Adds pending injections and runner wiring.                                                    | RFC B.                                          | Approval accept, revise, question answer, nudge, and subagent follow-up instructions reach the next turn exactly once across retry/fallback/provider transforms.    |
+| Plan prompt rules and runtime state hydration                                 | Adds Plan Mode runtime context to prompt assembly.                                            | RFC B plus RFC F run context.                   | Plugin contributes deterministic turn-preparation context without editing runner internals or global prompt files.                                                  |
+| Tool mutation gate while approval is pending                                  | Adds Plan Mode logic around tool execution.                                                   | RFC C.                                          | Trusted bundled policy blocks or requires approval before ordinary plugin `before_tool_call` hooks can mutate or reorder the call.                                  |
+| Plan Mode tools and `update_plan` integration                                 | Adds or modifies tool registrations, catalog data, display data, and plan telemetry behavior. | RFC C.                                          | Plugin-owned tools publish metadata; core-owned tools such as `update_plan` are either safely decorated or explicitly left as telemetry with parallel plugin tools. |
+| Slash commands in web, text channels, and Telegram flows                      | Adds `/plan` handling and text-channel behaviors.                                             | RFC D plus RFC B.                               | Plugin commands declare scopes, mutate plugin state, enqueue continuations, and optionally resume the agent without channel-specific core patches.                  |
+| Control UI mode switcher, approval/question cards, composer behavior, and CSS | Adds host-known Plan Mode UI components.                                                      | RFC E.                                          | UI consumes descriptor-only plugin contributions for modes, generic cards, status surfaces, event classifiers, and input guards.                                    |
+| Agent events, plan snapshots, approval lifecycle, and subagent gates          | Adds Plan Mode-specific event subscribers and derived state persistence.                      | RFC F plus RFC A.                               | Plugin receives typed/sanitized events, stores derived state in its extension, and tracks per-run/subagent data with host-owned cleanup.                            |
+| Cron jobs, nudges, and heartbeat prompt content                               | Adds Plan Mode-specific scheduling and heartbeat prompt behavior.                             | RFC F plus RFC B.                               | Plugin creates session-owned jobs, cleans them on reset/delete/disable, and contributes heartbeat or next-turn context through a documented hook.                   |
+| Docs, skills, QA scenarios, rollout patch, and operator runbooks              | Adds product documentation and testing around Plan Mode behavior.                             | Plugin package docs plus fixture tests.         | Hook PR keeps only generic SDK docs/tests; Plan Mode plugin owns product docs, skills, prompts, QA, rollout, and channel-specific behavior.                         |
+
+If a future hook implementation PR cannot satisfy a row above with a fixture
+plugin, the Plan Mode plugin port should not claim 100% parity with PR #71676.
 
 ## Current Plugin Surface Gap Analysis
 
@@ -1217,200 +1247,31 @@ All changes should be additive:
 6. Run parity audit against PR #71676.
 7. Close or replace PR #71676 once the plugin port matches behavior.
 
-## Copy-Ready RFC Issue Packet
-
-### Issue A Title
-
-`[RFC] Plugin session extensions and patch actions`
-
-### Issue A Body
-
-Summary:
-
-Add a namespaced plugin session extension API so bundled plugins can persist
-typed per-session state, expose an explicit public projection to gateway/UI
-clients, and mutate that state through gateway-authorized patch actions.
-
-Problem:
-
-Plan Mode currently requires root `SessionEntry` fields and hardcoded
-`sessions.patch` behavior. A first-class plugin needs the same durability,
-validation, projection, broadcast, and lifecycle behavior without Plan
-Mode-specific core fields.
-
-Required decisions:
-
-- `sessions.pluginPatch` method vs `sessions.patch.plugin` envelope
-- public projection shape
-- lifecycle hooks for reset/delete/compaction/migration
-- stable error codes
-
-Acceptance:
-
-- fixture plugin can persist extension state
-- invalid payload fails closed
-- projection appears in session rows
-- private fields do not leak
-- reset/delete cleans extension state
-
-### Issue B Title
-
-`[RFC] Durable next-turn injections and agent turn preparation hooks`
-
-### Issue B Body
-
-Summary:
-
-Add a host-owned queue for plugin next-turn injections plus an
-`agent_turn_prepare` hook so plugins can schedule future prompt additions with
-exactly-once semantics.
-
-Problem:
-
-Plan Mode approval acceptance, revision, question answering, nudges, and
-subagent follow-ups must affect a future run exactly once. `before_prompt_build`
-is not durable enough and should not be used as a pending interaction queue.
-
-Required decisions:
-
-- storage location for pending injections
-- dequeue timing relative to retries and provider transforms
-- prompt ordering relative to `before_prompt_build`
-- expiry and dedupe behavior
-
-Acceptance:
-
-- fixture injection reaches next run once
-- retry/fallback does not duplicate it
-- expired injection is discarded
-- plugin disablement suppresses injections
-
-### Issue C Title
-
-`[RFC] Trusted tool policy stage and plugin tool metadata`
-
-### Issue C Body
-
-Summary:
-
-Add a trusted pre-plugin tool policy stage and plugin-owned tool metadata so
-bundled plugins can enforce host-level policy and display first-class tool UI.
-
-Problem:
-
-Plan Mode must block mutating tools before normal plugin `before_tool_call`
-hooks. Plan Mode tools also need catalog/display/safety metadata without core
-tool catalog patches.
-
-Required decisions:
-
-- trust tier for pre-plugin policy hooks
-- policy decision shape
-- plugin tool display metadata schema
-- whether core-owned tools such as `update_plan` can be decorated
-
-Acceptance:
-
-- fixture policy blocks before normal hooks
-- normal plugin cannot override trusted block
-- external plugin cannot register trusted policy
-- fixture tool metadata appears in UI/tool display lookup
-
-### Issue D Title
-
-`[RFC] Scoped plugin commands, trusted command ownership, and continuation`
-
-### Issue D Body
-
-Summary:
-
-Extend plugin commands with declarative gateway scopes, trusted command-root
-ownership, and a `continueAgent` result for commands that should resume an
-agent run after handling.
-
-Problem:
-
-Plan Mode `/plan accept`, `/plan revise`, and `/plan answer` must patch state,
-enqueue a continuation, and resume the agent. Current plugin commands do not
-declare required scopes and default to stopping.
-
-Required decisions:
-
-- command scope declaration shape
-- reserved command ownership model
-- `continueAgent` result semantics
-- command discovery before plugin runtime activation
-
-Acceptance:
-
-- fixture command enforces `operator.approvals`
-- read-only command works with read scope
-- `continueAgent: true` resumes execution
-- existing commands preserve current behavior
-
-### Issue E Title
-
-`[RFC] Control UI plugin contribution slots`
-
-### Issue E Body
-
-Summary:
-
-Add data-driven Control UI contribution slots for plugin chat modes, approval
-cards, event classifiers, input guards, and status surfaces.
-
-Problem:
-
-Plan Mode should not patch `mode-switcher`, `app-tool-stream`, `app-render`, or
-custom CSS to become visible in the web UI. A first-class plugin needs UI
-contribution descriptors exposed by the gateway.
-
-Required decisions:
-
-- manifest vs runtime contribution projection
-- initial component catalog
-- event classifier descriptor shape
-- input guard behavior
-- disablement semantics
-
-Acceptance:
-
-- fixture chat mode appears only when plugin is enabled
-- fixture approval payload renders through generic card slot
-- fixture action sends plugin patch action
-- input guard reflects projected plugin session state
-
-### Issue F Title
-
-`[RFC] Agent event subscriptions, run context, scheduler lifecycle, and heartbeat contributions`
-
-### Issue F Body
-
-Summary:
-
-Expose safe plugin subscriptions to agent events, run-scoped plugin context,
-session-scoped scheduler helpers, and heartbeat prompt contributions.
-
-Problem:
-
-Plan Mode parity requires plan snapshot persistence, subagent tracking, run
-completion cleanup, scheduled nudges, and heartbeat prompt nudges. Plugins need
-stable helpers for those behaviors without raw event-bus access.
-
-Required decisions:
-
-- event types exposed to plugins
-- run-context storage lifecycle
-- session-scoped scheduler ownership model
-- dedicated heartbeat hook vs `agent_turn_prepare`
-
-Acceptance:
-
-- fixture plugin observes one agent event
-- fixture plugin writes derived extension state
-- run context is cleaned after completion
-- session reset deletes fixture jobs
-- heartbeat contribution appears only when state requests it
+## Filed RFC Issue Body Standard
+
+The six GitHub issues are the authoritative decision threads. Each issue body
+should stay self-contained and should not rely on PR comments for key context.
+Each filed RFC issue should include:
+
+- a clear warning that the APIs are proposed SDK surface, not implemented API
+- the Plan Mode parity pressure from PR #71676
+- the current SDK surface and why it is adjacent but insufficient
+- the proposed host seam and at least one TypeScript-shaped API sketch
+- reusable non-Plan plugin examples
+- maintainer decisions needed before implementation
+- fixture-plugin acceptance criteria
+- links back to this RFC PR and PR #71676
+
+Current filed issues:
+
+| RFC | Issue                                                       | SDK primitive                                                             | Non-Plan examples emphasized                                                                                       |
+| --- | ----------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| A   | [#71732](https://github.com/openclaw/openclaw/issues/71732) | Plugin session extensions and patch actions                               | review gates, releases, memory managers, budgets, channel bindings, incidents                                      |
+| B   | [#71733](https://github.com/openclaw/openclaw/issues/71733) | Durable next-turn injection queue and agent turn preparation              | review follow-ups, deployment checklists, memory hydration, incident handoffs, CI diagnostics, channel replies     |
+| C   | [#71734](https://github.com/openclaw/openclaw/issues/71734) | Trusted tool policy and plugin tool metadata                              | budget guards, workspace policy, deployment freezes, dangerous-action wrappers, compliance labels, catalog plugins |
+| D   | [#71735](https://github.com/openclaw/openclaw/issues/71735) | Scoped commands, trusted command ownership, and continuation              | deploy, review, budget, incident, memory, policy, and channel slash commands                                       |
+| E   | [#71736](https://github.com/openclaw/openclaw/issues/71736) | Control UI contribution descriptors                                       | approval cards, release dashboards, budget warnings, memory panels, incident banners, channel auth cards           |
+| F   | [#71737](https://github.com/openclaw/openclaw/issues/71737) | Agent events, run context, session scheduler, and heartbeat contributions | telemetry exporters, memory indexers, CI watchers, incident escalations, channel retries, long-running jobs        |
 
 ## Open Questions
 

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -238,7 +238,10 @@ things:
 ## Evidence From PR 71676
 
 PR #71676 touches a broad surface because it implements Plan Mode directly in
-host code. That breadth is the evidence for the missing seams.
+host code. That breadth is the evidence for the missing seams. Paths in this
+table are repo-root relative as they appear in the #71676 branch/diff; some are
+intentionally absent from current `main` because #71676 is the parity oracle,
+not code to cherry-pick.
 
 | Behavior in PR #71676                                        | Representative host files                                                                                                                                                        | What this proves                                                                                            |
 | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -1,0 +1,1207 @@
+---
+title: "Plan Mode Plugin Host Hooks RFC"
+summary: "Maintainer RFC packet for the generic host hooks required to port Plan Mode into a first-class bundled plugin"
+read_when:
+  - Reviewing PR #71676 or a Plan Mode plugin port
+  - Deciding which generic host hooks are needed before Plan Mode can leave core patches
+  - Implementing plugin-owned session state, turn injections, tool policy, command continuation, Control UI slots, or scheduler lifecycle
+---
+
+## RFC Packet Status
+
+Draft maintainer RFC packet.
+
+Primary behavior source:
+
+- PR #71676, "Plan Mode rebased onto upstream/main + executing-state subsystem"
+
+Primary implementation goal:
+
+- Make PR #71676 shrinkable by moving Plan Mode behavior into a bundled plugin.
+- Land one host-hook PR that adds generic, reusable OpenClaw plugin seams.
+- Keep Plan Mode-specific behavior out of core.
+
+This document is intentionally more detailed than a public user guide. It is a
+maintainer handoff artifact for filing RFC issues, reviewing the host-hook PR,
+and preventing a plugin port from silently dropping parity.
+
+## Maintainer Decision To Make
+
+The decision is not "merge PR #71676 or reject Plan Mode." The useful decision
+is:
+
+> Which host seams must OpenClaw expose so Plan Mode can be implemented as a
+> first-class bundled plugin without reversible installer patches or scattered
+> core edits?
+
+The proposed answer is six hook families:
+
+| RFC | Hook family                                                  | Required before Plan Mode plugin parity? | Why                                                                                            |
+| --- | ------------------------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| A   | Plugin session extensions and patch actions                  | Yes                                      | Plan Mode is fundamentally durable per-session state.                                          |
+| B   | Durable next-turn injections and agent turn preparation      | Yes                                      | Approvals, revisions, question answers, and nudges must feed the next run exactly once.        |
+| C   | Trusted tool policy and plugin tool metadata                 | Yes                                      | Mutation blocking must run before ordinary tool hooks; plugin tools need first-class metadata. |
+| D   | Scoped plugin commands and command continuation              | Yes                                      | `/plan accept` and related commands must mutate state and resume execution.                    |
+| E   | Control UI contribution slots                                | Yes for first-class UX                   | Plan/Plan Auto mode, approval cards, and input guards must not patch UI files.                 |
+| F   | Agent event, run context, scheduler, and heartbeat lifecycle | Yes for full parity                      | Snapshot persistence, subagent gates, nudges, and lifecycle cleanup depend on runtime events.  |
+
+The hook PR should implement those seams with a tiny fixture plugin. The Plan
+Mode plugin should come after the hook PR and use PR #71676 as its parity
+oracle.
+
+## Why A Plugin-Only Port Is Not Enough
+
+OpenClaw already has a useful plugin system:
+
+- `api.registerTool(...)`
+- `api.registerCommand(...)`
+- `api.registerHook(...)` and `api.on(...)`
+- `api.registerGatewayMethod(...)`
+- `api.registerInteractiveHandler(...)`
+- lifecycle hooks such as `before_prompt_build`, `before_tool_call`, and
+  `gateway_start`
+
+Those seams are not enough for Plan Mode parity because Plan Mode crosses
+boundaries that current plugins cannot own safely:
+
+- It needs typed, durable session state visible to gateway clients.
+- It needs state mutation through `sessions.patch`-class authorization and
+  broadcast behavior.
+- It needs pending instructions to be consumed exactly once at the next agent
+  turn boundary.
+- It needs a mutation gate that runs before normal plugin `before_tool_call`
+  hooks.
+- It needs command handlers to require approval scope and continue the agent.
+- It needs first-class Control UI contributions without checked-in UI patches.
+- It needs agent event subscriptions and run-scoped state without exposing raw
+  mutable internals.
+- It needs scheduled jobs and heartbeat prompt contributions tied to session
+  lifecycle.
+
+If these seams are not added, the "plugin" version becomes one of two bad
+things:
+
+- a partial plugin with real feature regressions, or
+- a plugin installer that patches host files, which is not first-class plugin
+  behavior.
+
+## Evidence From PR 71676
+
+PR #71676 touches a broad surface because it implements Plan Mode directly in
+host code. That breadth is the evidence for the missing seams.
+
+| Behavior in PR #71676                                        | Representative host files                                                                                                                                                        | What this proves                                                                                            |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Plan state and approval state are persisted on sessions      | `src/config/sessions/types.ts`, `src/gateway/protocol/schema/sessions.ts`, `src/gateway/sessions-patch.ts`, `src/gateway/session-utils.ts`, `src/gateway/session-utils.types.ts` | Plugin state needs a typed persistence and gateway projection contract.                                     |
+| Plan approval actions mutate sessions                        | `src/gateway/sessions-patch.ts`, `src/gateway/server-methods/sessions.ts`, `src/gateway/protocol/schema/error-codes.ts`                                                          | Plugin patch actions need the same authorization, validation, and broadcast path as native session patches. |
+| Pending agent injections are queued and drained              | `src/auto-reply/reply/agent-runner-execution.ts`, `src/agents/pi-embedded-runner/pending-injection.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`                           | Prompt hooks are too weak; a durable next-turn queue is needed.                                             |
+| Plan prompt rules are injected at run time                   | `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/system-prompt.ts`, `src/agents/system-prompt.ts`                                                  | The plugin needs deterministic turn-preparation contributions.                                              |
+| Mutating tools are blocked during unapproved plan mode       | `src/agents/pi-tools.before-tool-call.ts`, `src/agents/pi-tools.ts`                                                                                                              | A trusted tool policy stage must precede ordinary plugin hooks.                                             |
+| Plan Mode adds agent tools                                   | `src/agents/openclaw-tools.ts`, `src/agents/openclaw-tools.registration.ts`, `src/agents/tool-catalog.ts`, `src/agents/tool-display-config.ts`                                   | Plugin-owned tools need catalog, display, and safety metadata.                                              |
+| `/plan` is hardwired as a command                            | `src/auto-reply/reply/commands-plan.ts`, `src/auto-reply/reply/commands-handlers.runtime.ts`, `src/plugins/command-registration.ts`                                              | Plugin commands need scoped auth, trusted command ownership, and continuation.                              |
+| Plan approval cards are hardwired in the web UI              | `ui/src/ui/chat/mode-switcher.ts`, `ui/src/ui/app-tool-stream.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/views/plan-approval-inline.ts`, `ui/src/styles/chat/plan-cards.css`     | Control UI needs plugin contribution slots for mode chips and approval renderers.                           |
+| Plan snapshots and approvals are persisted from agent events | `src/infra/agent-events.ts`, `src/gateway/plan-snapshot-persister.ts`, `src/gateway/server-runtime-subscriptions.ts`                                                             | Plugin code needs safe agent event subscriptions and run-context storage.                                   |
+| Nudges are scheduled and injected into heartbeat prompts     | `src/infra/heartbeat-runner.ts`, `src/cron/*`, `src/cron/isolated-agent/run.ts`                                                                                                  | Plugins need session-scoped scheduler lifecycle and heartbeat prompt contribution.                          |
+
+The host-hook PR should not copy those implementations. It should replace the
+host-specific edits with generic extension points.
+
+## Current Plugin Surface Gap Analysis
+
+| Existing plugin surface          | Useful for Plan Mode              | Missing piece                                                                                                               |
+| -------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `api.registerTool(...)`          | Registers Plan Mode tools.        | No shared tool catalog/display metadata; no safe way to decorate a core-owned tool such as `update_plan`.                   |
+| `before_tool_call`               | Can observe and block tools.      | Runs at normal plugin priority; Plan Mode policy must be host-trusted and pre-plugin to prevent bypass or ordering bugs.    |
+| `before_prompt_build`            | Can add prompt context.           | Not durable, not exactly-once, not tied to persisted pending interactions, and not a future-turn queue.                     |
+| `api.registerCommand(...)`       | Registers `/plan`-style commands. | No declarative scopes, no trusted root ownership, and command execution defaults to stopping instead of resuming the agent. |
+| `api.registerGatewayMethod(...)` | Could expose plugin RPCs.         | Does not integrate with session patch semantics, session row projection, or `sessions.changed` broadcasts.                  |
+| `gateway_start` with `getCron`   | Can schedule background jobs.     | No session-extension lifecycle cleanup and no heartbeat prompt contribution path.                                           |
+| Existing UI code                 | Can render host-known cards.      | No data-driven plugin UI contribution registry for chat modes, approval cards, input guards, or plugin events.              |
+| Existing agent event internals   | Host can persist derived state.   | Plugins do not get a safe, stable subscription API or run-scoped extension bag.                                             |
+
+## Compatibility Principles
+
+The hook PR must follow these principles:
+
+- Additive gateway protocol changes only.
+- Additive plugin SDK changes only.
+- No Plan Mode-specific ids, states, fields, or prompt text in core.
+- No external plugin escalation into trusted policy hooks by default.
+- No eager loading of broad plugin runtime surfaces for cold UI discovery.
+- Deterministic prompt, hook, and metadata ordering.
+- Stable failure behavior: invalid plugin state patches fail closed.
+- Plugin disablement removes tools, commands, UI contributions, policy gates,
+  scheduled jobs, and heartbeat contributions.
+
+## RFC A: Plugin Session Extensions And Patch Actions
+
+### RFC A Problem
+
+Plan Mode is durable session state. It needs to store whether a session is in
+normal mode, planning mode, approval-pending mode, approved execution mode, or
+auto-approve mode. It also needs to store metadata such as current cycle id,
+last plan steps, pending question, pending injection ids, blocking subagent ids,
+and nudge job ids.
+
+Adding those fields directly to `SessionEntry` makes the feature core-owned.
+Keeping them in plugin-private files breaks gateway projection, UI state,
+authorization, and session lifecycle.
+
+### RFC A Proposed API Shape
+
+```ts
+type PluginSessionExtensionRegistration<TState, TPublic, TAction> = {
+  key: string;
+  schema: {
+    state: unknown;
+    action: unknown;
+  };
+  initialState?: () => TState | undefined;
+  publicProjection?: (state: TState, ctx: PluginSessionProjectionContext) => TPublic | undefined;
+  patchActions: {
+    [actionType: string]: PluginSessionPatchAction<TState, TAction>;
+  };
+  lifecycle?: {
+    onReset?: PluginSessionLifecycleHandler<TState>;
+    onDelete?: PluginSessionLifecycleHandler<TState>;
+    onCompaction?: PluginSessionLifecycleHandler<TState>;
+    onMigration?: PluginSessionMigrationHandler<TState>;
+  };
+};
+
+api.registerSessionExtension(registration);
+```
+
+A gateway patch action can be represented as either:
+
+```ts
+{
+  sessionKey: string;
+  plugin: {
+    key: "plan-mode";
+    action: "submitApproval";
+    payload: {
+      decision: "accept";
+    }
+  }
+}
+```
+
+or a dedicated method:
+
+```ts
+sessions.pluginPatch({
+  sessionKey,
+  pluginKey: "plan-mode",
+  action: "submitApproval",
+  payload,
+});
+```
+
+The dedicated method is cleaner for review because it avoids growing
+`sessions.patch` into an unbounded plugin envelope. The additive envelope is
+more ergonomic for existing session clients. Maintainers should choose one
+shape before implementation.
+
+### RFC A Host Files
+
+Likely host files for the hook PR:
+
+- `src/plugins/types.ts`
+- `src/plugins/registry.ts`
+- `src/plugins/captured-registration.ts`
+- `src/plugins/api-builder.ts`
+- `src/config/sessions/types.ts`
+- `src/gateway/protocol/schema/sessions.ts`
+- `src/gateway/session-utils.ts`
+- `src/gateway/session-utils.types.ts`
+- `src/gateway/sessions-patch.ts`
+- `src/gateway/server-methods/sessions.ts`
+- `src/gateway/protocol/schema/error-codes.ts`
+- `src/plugins/contracts/plugin-sdk-subpaths.test.ts`
+- `src/plugins/contracts/registry.contract.test.ts`
+
+### RFC A Authorization Model
+
+Session extension patch actions must declare required gateway scopes:
+
+```ts
+patchActions: {
+  submitApproval: {
+    requiredScopes: ["operator.approvals"],
+    handler,
+  },
+  readStatus: {
+    requiredScopes: ["sessions.read"],
+    handler,
+  },
+}
+```
+
+The gateway must enforce scopes before invoking the plugin action. Plugins
+should not reimplement scope checking manually.
+
+### RFC A Projection Model
+
+Plugin state must not be dumped wholesale into every client response. Each
+extension should return an explicit public projection:
+
+```ts
+publicProjection(state) {
+  return {
+    mode: state.mode,
+    approvalStatus: state.approval?.status,
+    title: state.approval?.title,
+    updatedAt: state.updatedAt,
+  };
+}
+```
+
+Private fields such as raw prompts, internal queue ids, or plugin-specific
+scheduler ids can remain hidden.
+
+### RFC A Failure Behavior
+
+- Unknown plugin key: stable `PLUGIN_SESSION_EXTENSION_NOT_FOUND` error.
+- Unknown action: stable `PLUGIN_SESSION_EXTENSION_ACTION_NOT_FOUND` error.
+- Invalid payload: stable `PLUGIN_SESSION_EXTENSION_INVALID_PAYLOAD` error.
+- Disabled plugin: stable `PLUGIN_DISABLED` or equivalent existing disabled
+  plugin error.
+- Handler throws: fail closed and do not partially persist state.
+- Projection throws: omit projection and log a plugin error; do not break
+  session listing.
+
+### RFC A Plan Mode Mapping
+
+Plan Mode plugin state can be modeled as:
+
+```ts
+type PlanModeSessionState = {
+  mode: "normal" | "plan" | "plan_auto";
+  cycleId?: string;
+  approval?: {
+    status: "drafting" | "pending" | "approved" | "rejected" | "cancelled";
+    title?: string;
+    summary?: string;
+    submittedAt?: string;
+    decidedAt?: string;
+  };
+  lastPlanSteps?: Array<{ step: string; status: string }>;
+  pendingQuestion?: {
+    id: string;
+    prompt: string;
+    choices?: Array<{ label: string; description?: string }>;
+  };
+  pendingInjectionIds?: string[];
+  blockingSubagentRunIds?: string[];
+  nudgeJobIds?: string[];
+};
+```
+
+This state should live under a plugin namespace, not on the root session entry.
+
+### RFC A Fixture Tests
+
+Required fixture coverage:
+
+- A fixture plugin registers an extension and receives a patch action.
+- Invalid patch payload fails without writing state.
+- Disabled plugin extension cannot be patched.
+- Public projection appears in session row output.
+- Private extension fields are not projected.
+- Session reset invokes extension lifecycle cleanup.
+- Session delete removes extension state.
+
+## RFC B: Durable Next-Turn Injections And Agent Turn Preparation
+
+### RFC B Problem
+
+Plan Mode cannot rely only on `before_prompt_build`. Approval acceptance,
+revision requests, user question answers, scheduled nudges, and subagent
+follow-ups must affect a future agent turn exactly once.
+
+A prompt hook is ephemeral. It can add context to the current prompt, but it
+does not provide a durable pending queue that survives command handling,
+retries, gateway restarts, or delayed scheduled jobs.
+
+### RFC B Proposed API Shape
+
+```ts
+type NextTurnInjection = {
+  id: string;
+  pluginKey: string;
+  sessionKey: string;
+  targetRunId?: string;
+  role: "user" | "system";
+  content: string;
+  reason: string;
+  createdAt: string;
+  expiresAt?: string;
+  dedupeKey?: string;
+};
+
+api.enqueueNextTurnInjection(injection);
+
+api.on("agent_turn_prepare", async (event, ctx) => {
+  return {
+    prependSystemContext: "string",
+    prependUserMessages: [{ content: "string" }],
+  };
+});
+```
+
+The host should own storage and dequeue. A plugin should not patch runner
+arguments directly.
+
+### RFC B Dequeue Semantics
+
+The runner should consume injections:
+
+1. after the inbound command or chat message has resolved the target session,
+2. before the agent retry/fallback loop starts,
+3. before provider-specific transforms,
+4. exactly once per injection id,
+5. transactionally with session state update.
+
+If a run is retried inside the same user action, the same consumed injection
+should remain part of that run's prepared prompt but should not be consumed
+again as a new pending item.
+
+### RFC B Host Files
+
+Likely host files for the hook PR:
+
+- `src/plugins/hook-types.ts`
+- `src/plugins/hooks.ts`
+- `src/plugins/types.ts`
+- `src/plugins/registry.ts`
+- `src/config/sessions/types.ts`
+- `src/auto-reply/reply/agent-runner-execution.ts`
+- `src/agents/pi-embedded-runner/run.ts`
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+- `src/agents/pi-embedded-runner/run/params.ts`
+- `src/agents/cli-runner/prepare.ts`
+- `src/agents/harness/prompt-compaction-hook-helpers.ts`
+
+### RFC B Ordering Contract
+
+Recommended prompt assembly order:
+
+1. host base system prompt
+2. stable provider or harness prompt overlays
+3. plugin `agent_turn_prepare.prependSystemContext`
+4. existing `before_prompt_build` system contributions
+5. durable system-role next-turn injections
+6. durable user-role next-turn injections
+7. current user prompt
+
+Maintainers may choose a different order, but it must be documented and tested.
+
+### RFC B Plan Mode Mapping
+
+Plan Mode uses next-turn injections for:
+
+- approved plan execution instructions
+- revise-plan instructions
+- answer-to-pending-question payloads
+- scheduled plan nudges
+- subagent finished-follow-up instructions
+- "continue after approval" command flow
+
+### RFC B Failure Behavior
+
+- Invalid injection payload fails before persisting.
+- Expired injection is discarded with a diagnostic event.
+- Disabled plugin's pending injections are ignored or removed.
+- Missing session key fails closed.
+- Duplicate `dedupeKey` updates or drops according to a documented policy.
+
+### RFC B Fixture Tests
+
+Required fixture coverage:
+
+- A fixture plugin enqueues an injection and the next run receives it.
+- Injection is consumed exactly once.
+- Retry/fallback does not duplicate the injection.
+- Expired injection does not reach the model.
+- Plugin disablement suppresses pending injections.
+- Existing `before_prompt_build` tests still pass.
+
+## RFC C: Trusted Tool Policy And Plugin Tool Metadata
+
+### RFC C Problem
+
+Plan Mode blocks mutating tools while approval is pending. That gate must be
+stronger than ordinary plugin `before_tool_call` hooks because normal plugins
+may also mutate params, require approvals, or block/allow calls. A Plan Mode
+mutation gate should not depend on arbitrary hook priority.
+
+Plan Mode tools also need first-class display metadata. Today plugin tools can
+be registered, but catalog and UI display metadata are still partly host-owned.
+
+### RFC C Proposed Policy API Shape
+
+```ts
+type ToolPolicyDecision =
+  | { allow?: true }
+  | { block: true; reason: string; code?: string }
+  | { requireApproval: true; reason: string; approvalKind?: string };
+
+api.registerToolPolicy({
+  id: "plan-mode.mutation-gate",
+  stage: "pre_plugin_hooks",
+  trust: "bundled",
+  handler: async (event, ctx) => ToolPolicyDecision,
+});
+```
+
+The first implementation should only allow trusted bundled plugins to register
+`pre_plugin_hooks` policy. External plugins can continue to use
+`before_tool_call`.
+
+### RFC C Proposed Metadata API Shape
+
+```ts
+api.registerToolMetadata({
+  name: "plan_mode_status",
+  title: "Plan mode status",
+  category: "planning",
+  display: {
+    icon: "clipboard-check",
+    compactLabel: "Plan status",
+  },
+  safety: {
+    mutatesState: false,
+    requiresApproval: false,
+  },
+});
+```
+
+Metadata should be deterministic and should disappear when the plugin is
+disabled.
+
+### RFC C Core-Owned Tool Decoration
+
+Plan Mode may need to extend the meaning of the existing `update_plan` tool.
+That should not require replacing the tool. Add an explicit decoration seam:
+
+```ts
+api.decorateTool({
+  name: "update_plan",
+  metadata,
+  eventMapper,
+});
+```
+
+If maintainers do not want a generic decoration API yet, the Plan Mode plugin
+should own parallel tools and consume `update_plan` only as ordinary telemetry.
+This is an explicit RFC decision.
+
+### RFC C Host Files
+
+Likely host files for the hook PR:
+
+- `src/plugins/types.ts`
+- `src/plugins/registry.ts`
+- `src/plugins/hook-types.ts`
+- `src/plugins/hooks.ts`
+- `src/agents/pi-tools.before-tool-call.ts`
+- `src/agents/openclaw-tools.ts`
+- `src/agents/tool-catalog.ts`
+- `src/agents/tool-display-config.ts`
+- `ui/src/ui/tool-display.ts`
+- `ui/src/ui/chat/tool-cards.ts`
+
+### RFC C Plan Mode Mapping
+
+Plan Mode uses tool policy for:
+
+- blocking write/edit/shell/browser mutation tools during pending approval
+- allowing read-only/status tools during planning
+- allowing Plan Mode tools that manage approval state
+- optionally requiring a separate approval for high-risk post-approval actions
+
+Plan Mode uses tool metadata for:
+
+- `enter_plan_mode`
+- `exit_plan_mode`
+- `ask_user_question`
+- `plan_mode_status`
+- any future plan artifact export tool
+
+### RFC C Fixture Tests
+
+Required fixture coverage:
+
+- A trusted fixture policy blocks before ordinary `before_tool_call`.
+- A normal plugin cannot override a trusted block.
+- External plugin cannot register `pre_plugin_hooks` policy.
+- Fixture tool metadata appears in tool display lookup.
+- Disabling the fixture plugin removes its metadata and policy.
+
+## RFC D: Scoped Plugin Commands And Command Continuation
+
+### RFC D Problem
+
+Plan Mode needs slash commands that do more than return a text response.
+Examples include:
+
+- `/plan status`
+- `/plan accept`
+- `/plan revise <instructions>`
+- `/plan answer <question-id> <answer>`
+- `/plan auto on`
+- `/plan auto off`
+
+Mutating commands need approval scope. Some commands need to resume the agent
+after the command has patched session state or enqueued a next-turn injection.
+Current plugin commands do not declare scopes and default to stopping command
+processing.
+
+### RFC D Proposed API Shape
+
+```ts
+api.registerCommand({
+  name: "plan",
+  requiredScopes: ["operator.approvals"],
+  ownership: "trusted-core-command",
+  handler: async (ctx) => {
+    return {
+      message: "Plan accepted. Continuing.",
+      continueAgent: true,
+      delivery: "ephemeral",
+    };
+  },
+});
+```
+
+The existing behavior should remain the default:
+
+- no `requiredScopes` means current auth behavior
+- no `continueAgent` means do not resume the agent
+- untrusted plugins cannot claim core-reserved roots
+
+### RFC D Host Files
+
+Likely host files for the hook PR:
+
+- `src/plugins/types.ts`
+- `src/plugins/commands.ts`
+- `src/plugins/command-registration.ts`
+- `src/auto-reply/reply/commands-plugin.ts`
+- `src/auto-reply/reply/commands-handlers.runtime.ts`
+- `src/auto-reply/commands-registry.shared.ts`
+- `src/gateway/protocol/schema/scopes.ts` if scopes are centralized there
+
+### RFC D Command Ownership
+
+Maintainers should choose one trusted ownership model:
+
+| Option              | Description                                               | Pros                                       | Cons                                 |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------ | ------------------------------------ |
+| Manifest ownership  | Plugin manifest declares trusted command roots.           | Cold discovery and docs can see ownership. | Requires manifest schema change.     |
+| Runtime ownership   | `registerCommand` declares trusted ownership.             | Simple and direct.                         | Requires runtime load to know claim. |
+| Two-phase ownership | Manifest declares claim; runtime confirms implementation. | Best for UI/help/discovery.                | More implementation work.            |
+
+For Plan Mode, two-phase ownership is probably best if the command should
+appear in slash command help before the full plugin runtime is activated.
+
+### RFC D Plan Mode Mapping
+
+Plan Mode commands would:
+
+- inspect plugin session extension state
+- call plugin session patch actions
+- enqueue next-turn injections when needed
+- return `continueAgent: true` when execution should resume
+- return read-only status without continuation for `/plan status`
+
+### RFC D Fixture Tests
+
+Required fixture coverage:
+
+- Command requiring `operator.approvals` rejects insufficient scope.
+- Read-only fixture command works with read scope only.
+- Command returning `continueAgent: true` resumes agent execution.
+- Command returning no continuation preserves current behavior.
+- Untrusted plugin cannot claim a reserved command root.
+
+## RFC E: Control UI Plugin Contribution Slots
+
+### RFC E Problem
+
+Plan Mode is not first-class if its UI requires patching the web app. A plugin
+needs to contribute:
+
+- mode switcher entries
+- approval cards
+- question cards
+- event stream classifiers
+- chat input guards
+- optional side-panel or inline status sections
+
+Arbitrary plugin JavaScript in the browser is too much for the first version.
+The initial Control UI surface should be declarative and data-driven.
+
+### RFC E Proposed API Shape
+
+```ts
+api.registerControlUiContribution({
+  id: "plan-mode.ui",
+  chatModes: [
+    {
+      id: "plan",
+      label: "Plan",
+      description: "Draft a plan before executing changes.",
+      sessionPatchAction: {
+        pluginKey: "plan-mode",
+        action: "setMode",
+        payload: { mode: "plan" },
+      },
+    },
+  ],
+  approvalRenderers: [
+    {
+      kind: "plan-mode.approval",
+      component: "approval-card",
+      actions: ["accept", "revise", "cancel"],
+    },
+  ],
+  inputGuards: [
+    {
+      when: { extension: "plan-mode", field: "approval.status", equals: "pending" },
+      message: "Plan approval is pending.",
+    },
+  ],
+});
+```
+
+This shape is illustrative. The important requirement is that the UI can render
+plugin-owned state and actions without importing plugin browser code.
+
+### RFC E Gateway Projection
+
+The gateway should expose enabled UI contributions through a plugin registry or
+session bootstrap method. The UI should receive:
+
+- contribution id
+- owning plugin id
+- chat mode entries
+- approval renderer descriptors
+- event classifier descriptors
+- input guard descriptors
+- version or schema id
+
+Disabled plugins must not contribute UI descriptors.
+
+### RFC E Host Files
+
+Likely host files for the hook PR:
+
+- `src/plugins/types.ts`
+- `src/plugins/registry.ts`
+- `src/gateway/server-methods/plugins.ts` or equivalent plugin registry method
+- `ui/src/ui/types.ts`
+- `ui/src/ui/chat/mode-switcher.ts`
+- `ui/src/ui/app-tool-stream.ts`
+- `ui/src/ui/app-render.ts`
+- `ui/src/ui/views/chat.ts`
+- `ui/src/styles/chat/layout.css`
+
+### RFC E Plan Mode Mapping
+
+Plan Mode UI contribution should replace host patches for:
+
+- Plan and Plan Auto mode entries
+- inline approval card
+- inline question card
+- approval event parsing
+- session status badge or sidebar section
+- composer guard when approval is pending
+
+### RFC E Fixture Tests
+
+Required fixture coverage:
+
+- Fixture chat mode appears when plugin is enabled.
+- Fixture chat mode disappears when plugin is disabled.
+- Fixture approval payload renders through a generic card renderer.
+- Fixture action sends the expected plugin patch action.
+- Input guard disables or annotates composer based on projected state.
+
+## RFC F: Agent Events, Run Context, Scheduler, And Heartbeat Lifecycle
+
+### RFC F Problem
+
+Plan Mode needs to observe and react to agent lifecycle facts:
+
+- plan snapshots
+- approval submissions
+- tool calls
+- subagent starts and finishes
+- run completion
+- run cancellation
+- scheduled nudges
+- heartbeat prompt assembly
+
+The host should not expose raw mutable event bus internals to plugins. It
+should expose stable event subscriptions, run-scoped plugin data, and
+session-scoped scheduler lifecycle helpers.
+
+### RFC F Proposed Event API Shape
+
+```ts
+api.onAgentEvent("run_completed", async (event, ctx) => {
+  const state = await ctx.sessions.getExtensionState(event.sessionKey, "plan-mode");
+  await ctx.sessions.patchExtension(event.sessionKey, "plan-mode", {
+    action: "closeCycle",
+    payload: { runId: event.runId },
+  });
+});
+```
+
+Event subscription should be stable and typed. The plugin should receive
+read-only event data plus safe gateway/session helpers.
+
+### RFC F Proposed Run Context API Shape
+
+```ts
+ctx.runContext.set("plan-mode", {
+  cycleId,
+  enteredPlanModeAt,
+});
+
+const value = ctx.runContext.get("plan-mode");
+```
+
+Run context data should be automatically cleaned up when the run completes.
+
+### RFC F Proposed Scheduler API Shape
+
+```ts
+ctx.scheduler.createSessionJob({
+  pluginKey: "plan-mode",
+  sessionKey,
+  kind: "heartbeat",
+  schedule,
+  payload,
+});
+
+ctx.scheduler.deleteSessionJobs({
+  pluginKey: "plan-mode",
+  sessionKey,
+});
+```
+
+Existing `gateway_start.getCron` can remain for low-level cron access, but Plan
+Mode needs session lifecycle cleanup and consistent ownership.
+
+### RFC F Proposed Heartbeat Hook Shape
+
+```ts
+api.on("heartbeat_prompt_contribution", async (event, ctx) => {
+  return {
+    prependUserContext: "The approved plan is still pending execution...",
+  };
+});
+```
+
+This could also be modeled as a specialized `agent_turn_prepare` event. The RFC
+decision is whether heartbeat turns should use a dedicated hook for clarity.
+
+### RFC F Host Files
+
+Likely host files for the hook PR:
+
+- `src/infra/agent-events.ts`
+- `src/gateway/server-runtime-subscriptions.ts`
+- `src/infra/heartbeat-runner.ts`
+- `src/cron/types.ts`
+- `src/cron/normalize.ts`
+- `src/cron/isolated-agent/run.ts`
+- `src/plugins/hook-types.ts`
+- `src/plugins/hooks.ts`
+- `src/plugins/types.ts`
+
+### RFC F Plan Mode Mapping
+
+Plan Mode uses this hook family for:
+
+- persisting latest plan snapshot
+- marking approval cycle completion
+- tracking blocking subagent ids
+- following up when subagents settle
+- creating and cancelling auto-nudge jobs
+- adding heartbeat prompt nudges
+- cleaning up jobs when session state resets
+
+### RFC F Fixture Tests
+
+Required fixture coverage:
+
+- Fixture plugin receives a safe agent event.
+- Fixture plugin writes derived session extension state from an event.
+- Run context data is available during a run and cleaned after completion.
+- Session reset deletes fixture-owned scheduled jobs.
+- Heartbeat contribution appears only when extension state requests it.
+
+## One Host-Hook PR Implementation Plan
+
+The implementation PR should be small relative to PR #71676 and should avoid
+Plan Mode feature logic. Recommended commit stack:
+
+1. Add plugin session extension registry and patch action plumbing.
+2. Add durable next-turn injection queue and agent turn preparation hook.
+3. Add trusted tool policy stage and plugin tool metadata registry.
+4. Add command scopes, trusted ownership, and `continueAgent`.
+5. Add Control UI contribution projection and minimal renderer slots.
+6. Add agent event subscription, run context, scheduler lifecycle, and
+   heartbeat contribution helpers.
+7. Add a tiny fixture plugin and contract tests.
+8. Add docs and migration notes.
+
+## Host-Hook PR Non-Negotiables
+
+The hook PR should not include:
+
+- Plan Mode prompts
+- Plan Mode tools
+- Plan Mode command text
+- Plan Mode CSS
+- Plan Mode hardcoded session fields
+- Telegram-specific Plan Mode delivery behavior
+- local installer patch logic
+- Smarter-Claw-specific compatibility code
+
+The hook PR should include:
+
+- generic contracts
+- tests that prove plugin ownership
+- trust gates for privileged hooks
+- disablement behavior
+- docs for plugin authors and maintainers
+
+## Fixture Plugin Contract
+
+Create a fixture plugin with no product behavior. Suggested id:
+`host-hook-fixture`.
+
+The fixture should:
+
+- register a session extension
+- expose one public projection field
+- handle one read-only patch action
+- handle one mutating patch action
+- enqueue one next-turn injection
+- register one tool policy
+- register one tool metadata record
+- register one scoped command
+- return `continueAgent: true` from one command path
+- contribute one chat mode descriptor
+- contribute one approval card descriptor
+- observe one agent event
+- store one run-context value
+- create and clean up one session-scoped scheduled job
+- contribute one heartbeat prompt string
+
+The fixture plugin is the guardrail that future Plan Mode work depends on.
+
+## Plan Mode Plugin Migration Sequence
+
+After the hook PR lands:
+
+1. Create a bundled Plan Mode plugin.
+2. Move root session state into a plugin session extension.
+3. Move approval and question actions into plugin patch actions.
+4. Move Plan Mode tools into plugin registration.
+5. Move mutation gate into trusted tool policy.
+6. Move `/plan` commands into plugin command registration.
+7. Move approval/revision/question continuations into next-turn injections.
+8. Move web UI mode entries and approval cards into UI contributions.
+9. Move snapshot persistence into agent event subscriptions.
+10. Move nudge scheduling into scheduler lifecycle helpers.
+11. Move heartbeat prompt text into heartbeat contribution hook.
+12. Remove all Plan Mode hardcoded core patches.
+13. Run feature-by-feature parity against PR #71676.
+
+## Plan Mode Parity Checklist
+
+The plugin port should not be considered complete until all of these are true:
+
+- Agent can enter Plan Mode.
+- Agent can exit Plan Mode.
+- Agent can ask a pending user question.
+- User can answer the pending question.
+- Agent can submit a plan approval request.
+- User can accept the plan.
+- User can request revision.
+- User can cancel or reject the plan.
+- Accepted plan resumes execution.
+- Revision resumes planning.
+- Mutating tools are blocked while approval is pending.
+- Read-only tools remain available while approval is pending.
+- `update_plan` or equivalent plan telemetry remains visible.
+- Plan and Plan Auto mode are visible in Control UI.
+- Approval cards render in Control UI.
+- Question cards render in Control UI.
+- Slash commands work from text channels.
+- Telegram command flow works without Telegram-specific core patches.
+- Subagent follow-up gates work.
+- Scheduled nudges work.
+- Heartbeat nudges work.
+- Session reset cleans Plan Mode state.
+- Plugin disablement removes Plan Mode tools, commands, UI, policies, and jobs.
+
+## Security Review Notes
+
+This hook set expands plugin power. The implementation must define a trust
+model.
+
+Recommended trust tiers:
+
+| Tier            | Can register normal hooks | Can register trusted tool policy | Can contribute UI    | Can patch session extension | Can own reserved commands     |
+| --------------- | ------------------------- | -------------------------------- | -------------------- | --------------------------- | ----------------------------- |
+| External plugin | Yes                       | No                               | Data-only if enabled | Own namespace only          | No                            |
+| Bundled plugin  | Yes                       | Yes with manifest declaration    | Yes                  | Own namespace only          | Yes with manifest declaration |
+| Core            | Yes                       | Yes                              | Yes                  | Any core state              | Yes                           |
+
+Security requirements:
+
+- Policy hooks that run before normal plugins must be bundled/trusted only.
+- Plugin session patch actions must enforce gateway scopes.
+- UI contributions must be declarative and sanitized.
+- Plugin state projection must be explicit.
+- Scheduler helpers must clean up by plugin id and session key.
+- Disablement must remove privileged behavior immediately after restart.
+
+## Backward Compatibility Notes
+
+All changes should be additive:
+
+- Existing plugins keep using `before_prompt_build`.
+- Existing plugins keep using `before_tool_call`.
+- Existing plugin commands keep current stop-after-command behavior.
+- Existing session rows remain compatible.
+- Existing Control UI behavior remains unchanged when no plugin contributes UI.
+- Existing cron and heartbeat behavior remains unchanged when no plugin
+  contributes scheduler state.
+
+## Rollout Plan
+
+1. Land the RFC PR.
+2. File RFC issues for the six hook families.
+3. Confirm maintainer decisions on open questions.
+4. Land one hook implementation PR with fixture tests.
+5. Build bundled Plan Mode plugin against the hooks.
+6. Run parity audit against PR #71676.
+7. Close or replace PR #71676 once the plugin port matches behavior.
+
+## Copy-Ready RFC Issue Packet
+
+### Issue A Title
+
+`[RFC] Plugin session extensions and patch actions`
+
+### Issue A Body
+
+Summary:
+
+Add a namespaced plugin session extension API so bundled plugins can persist
+typed per-session state, expose an explicit public projection to gateway/UI
+clients, and mutate that state through gateway-authorized patch actions.
+
+Problem:
+
+Plan Mode currently requires root `SessionEntry` fields and hardcoded
+`sessions.patch` behavior. A first-class plugin needs the same durability,
+validation, projection, broadcast, and lifecycle behavior without Plan
+Mode-specific core fields.
+
+Required decisions:
+
+- `sessions.pluginPatch` method vs `sessions.patch.plugin` envelope
+- public projection shape
+- lifecycle hooks for reset/delete/compaction/migration
+- stable error codes
+
+Acceptance:
+
+- fixture plugin can persist extension state
+- invalid payload fails closed
+- projection appears in session rows
+- private fields do not leak
+- reset/delete cleans extension state
+
+### Issue B Title
+
+`[RFC] Durable next-turn injections and agent turn preparation hooks`
+
+### Issue B Body
+
+Summary:
+
+Add a host-owned queue for plugin next-turn injections plus an
+`agent_turn_prepare` hook so plugins can schedule future prompt additions with
+exactly-once semantics.
+
+Problem:
+
+Plan Mode approval acceptance, revision, question answering, nudges, and
+subagent follow-ups must affect a future run exactly once. `before_prompt_build`
+is not durable enough and should not be used as a pending interaction queue.
+
+Required decisions:
+
+- storage location for pending injections
+- dequeue timing relative to retries and provider transforms
+- prompt ordering relative to `before_prompt_build`
+- expiry and dedupe behavior
+
+Acceptance:
+
+- fixture injection reaches next run once
+- retry/fallback does not duplicate it
+- expired injection is discarded
+- plugin disablement suppresses injections
+
+### Issue C Title
+
+`[RFC] Trusted tool policy stage and plugin tool metadata`
+
+### Issue C Body
+
+Summary:
+
+Add a trusted pre-plugin tool policy stage and plugin-owned tool metadata so
+bundled plugins can enforce host-level policy and display first-class tool UI.
+
+Problem:
+
+Plan Mode must block mutating tools before normal plugin `before_tool_call`
+hooks. Plan Mode tools also need catalog/display/safety metadata without core
+tool catalog patches.
+
+Required decisions:
+
+- trust tier for pre-plugin policy hooks
+- policy decision shape
+- plugin tool display metadata schema
+- whether core-owned tools such as `update_plan` can be decorated
+
+Acceptance:
+
+- fixture policy blocks before normal hooks
+- normal plugin cannot override trusted block
+- external plugin cannot register trusted policy
+- fixture tool metadata appears in UI/tool display lookup
+
+### Issue D Title
+
+`[RFC] Scoped plugin commands, trusted command ownership, and continuation`
+
+### Issue D Body
+
+Summary:
+
+Extend plugin commands with declarative gateway scopes, trusted command-root
+ownership, and a `continueAgent` result for commands that should resume an
+agent run after handling.
+
+Problem:
+
+Plan Mode `/plan accept`, `/plan revise`, and `/plan answer` must patch state,
+enqueue a continuation, and resume the agent. Current plugin commands do not
+declare required scopes and default to stopping.
+
+Required decisions:
+
+- command scope declaration shape
+- reserved command ownership model
+- `continueAgent` result semantics
+- command discovery before plugin runtime activation
+
+Acceptance:
+
+- fixture command enforces `operator.approvals`
+- read-only command works with read scope
+- `continueAgent: true` resumes execution
+- existing commands preserve current behavior
+
+### Issue E Title
+
+`[RFC] Control UI plugin contribution slots`
+
+### Issue E Body
+
+Summary:
+
+Add data-driven Control UI contribution slots for plugin chat modes, approval
+cards, event classifiers, input guards, and status surfaces.
+
+Problem:
+
+Plan Mode should not patch `mode-switcher`, `app-tool-stream`, `app-render`, or
+custom CSS to become visible in the web UI. A first-class plugin needs UI
+contribution descriptors exposed by the gateway.
+
+Required decisions:
+
+- manifest vs runtime contribution projection
+- initial component catalog
+- event classifier descriptor shape
+- input guard behavior
+- disablement semantics
+
+Acceptance:
+
+- fixture chat mode appears only when plugin is enabled
+- fixture approval payload renders through generic card slot
+- fixture action sends plugin patch action
+- input guard reflects projected plugin session state
+
+### Issue F Title
+
+`[RFC] Agent event subscriptions, run context, scheduler lifecycle, and heartbeat contributions`
+
+### Issue F Body
+
+Summary:
+
+Expose safe plugin subscriptions to agent events, run-scoped plugin context,
+session-scoped scheduler helpers, and heartbeat prompt contributions.
+
+Problem:
+
+Plan Mode parity requires plan snapshot persistence, subagent tracking, run
+completion cleanup, scheduled nudges, and heartbeat prompt nudges. Plugins need
+stable helpers for those behaviors without raw event-bus access.
+
+Required decisions:
+
+- event types exposed to plugins
+- run-context storage lifecycle
+- session-scoped scheduler ownership model
+- dedicated heartbeat hook vs `agent_turn_prepare`
+
+Acceptance:
+
+- fixture plugin observes one agent event
+- fixture plugin writes derived extension state
+- run context is cleaned after completion
+- session reset deletes fixture jobs
+- heartbeat contribution appears only when state requests it
+
+## Open Questions
+
+1. Should Plan Mode be an always-bundled plugin or an opt-in bundled plugin?
+2. Should Plan Mode command ownership be declared in the plugin manifest, at
+   runtime, or both?
+3. Should `update_plan` be decorated by plugins, or should Plan Mode own a
+   parallel tool?
+4. Should heartbeat prompt contributions be separate from generic turn
+   preparation?
+5. Should UI contribution descriptors be available from cold manifest metadata,
+   runtime registry state, or both?
+6. What is the minimum trust signal required for pre-plugin tool policy?
+7. Should session extension state participate in transcript export or remain
+   session-store only?

--- a/docs/plan/plan-mode-plugin-host-hooks-rfc.md
+++ b/docs/plan/plan-mode-plugin-host-hooks-rfc.md
@@ -184,6 +184,21 @@ The hook PR should implement those seams with a tiny fixture plugin. The Plan
 Mode plugin should come after the hook PR and use PR #71676 as its parity
 oracle.
 
+## Already Implemented Comparison
+
+This RFC packet should not ask maintainers to guess whether an existing hook is
+"close enough." The table below is the #71427-style comparison for the six
+requested SDK seams.
+
+| RFC | Existing SDK surface that may look similar                                                           | Why it is not enough                                                                                                                                         | Non-Plan plugin consumers                                                                 |
+| --- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| A   | Fixed `sessions.patch`, hardcoded session rows, internal `session:patch`, plugin gateway RPC scopes. | There is no namespaced plugin session extension with host-owned patch validation, projection, broadcast, lifecycle cleanup, and disabled-plugin behavior.    | review gates, release workflows, memory managers, budget governors, channel bindings      |
+| B   | `before_prompt_build`, legacy `before_agent_start`, and in-memory system events.                     | These are current-turn prompt hooks, not a durable exactly-once next-turn queue with retry-safe dequeue, expiry, dedupe, and disabled-plugin suppression.    | CI triage, incident handoff, memory hydration, channel retries, approval continuations    |
+| C   | Normal `before_tool_call`, core config filtering, basic plugin tool catalog fields.                  | Normal hooks share plugin ordering; there is no bundled/trusted pre-plugin policy tier, metadata/display registry, or core-tool decoration rule.             | budget guards, workspace policy, deploy freezes, dangerous-action approvals               |
+| D   | `api.registerCommand(...)`, `gatewayClientScopes` in context, scoped plugin gateway methods.         | Plugins can inspect scopes manually, but commands cannot declare host-enforced scopes, trusted reserved-root ownership, or `continueAgent`.                  | deploy approvals, review commands, budget overrides, incident commands, channel commands  |
+| E   | Remote slash commands and generic plugin approval cards.                                             | Existing UI support covers discovery and one generic card class, not chat modes, input guards, status surfaces, event classifiers, or descriptor projection. | approval workflows, release dashboards, budget warnings, incident banners, memory panels  |
+| F   | Raw `runtime.events.onAgentEvent`, internal run context, `gateway_start.getCron`, prompt hooks.      | Plugins lack typed filtered event subscriptions, namespaced run context, session-owned scheduler cleanup, and heartbeat contribution ordering.               | telemetry exporters, memory indexers, CI watchers, incident escalators, long-running jobs |
+
 ## Why Current SDK Surfaces Are Not Enough
 
 OpenClaw already has a useful plugin system:
@@ -1098,8 +1113,10 @@ Required fixture coverage:
 
 ## One Host-Hook PR Implementation Plan
 
-The implementation PR should be small relative to PR #71676 and should avoid
-Plan Mode feature logic. Recommended commit stack:
+This RFC defines the complete host-hook contract. The follow-up implementation
+PR must implement all generic hooks needed before Plan Mode can be packaged as
+a plugin with PR #71676 parity. That PR should be small relative to PR #71676
+and should avoid Plan Mode feature logic. Recommended commit stack:
 
 1. Add plugin session extension registry and patch action plumbing.
 2. Add durable next-turn injection queue and agent turn preparation hook.
@@ -1132,10 +1149,11 @@ The hook PR should include:
 - disablement behavior
 - docs for plugin authors and maintainers
 
-## Fixture Plugin Contract
+## SDK Contract Fixture
 
 Create a fixture plugin with no product behavior. Suggested id:
-`host-hook-fixture`.
+`host-hook-fixture`. This is not a Plan Mode fixture; it is a generic SDK
+contract fixture that proves a reusable plugin can exercise every new seam.
 
 The fixture should:
 
@@ -1155,7 +1173,15 @@ The fixture should:
 - create and clean up one session-scoped scheduled job
 - contribute one heartbeat prompt string
 
-The fixture plugin is the guardrail that future Plan Mode work depends on.
+The fixture plugin is the guardrail that future Plan Mode work depends on, but
+it should model generic plugin classes such as:
+
+- approval workflow: persistent approval state, scoped command, UI card, and
+  continuation
+- budget or workspace policy gate: trusted tool policy, metadata, override
+  command, and warning UI
+- background lifecycle plugin: event subscription, run context, scheduled job,
+  heartbeat contribution, and cleanup
 
 ## Plan Mode Plugin Migration Sequence
 

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -143,7 +143,7 @@ oracle, not code to cherry-pick.
 | Plan snapshots and subagent state                 | `src/infra/agent-events.ts`, `src/gateway/plan-snapshot-persister.ts`, `src/gateway/server-runtime-subscriptions.ts`                                   | Agent event subscriptions plus run context extensions                 |
 | Auto nudges and heartbeats                        | `src/infra/heartbeat-runner.ts`, `src/cron/*`                                                                                                          | Session-scoped scheduler lifecycle plus heartbeat prompt contribution |
 
-## RFC 1: Plugin Session Extensions
+## RFC A: Plugin Session Extensions
 
 ### Session Contract
 
@@ -187,7 +187,7 @@ subagent ids, and nudge job ids under its own extension key.
 - Public projection appears in session rows without leaking private fields.
 - Reset/delete lifecycle clears extension state and related scheduled work.
 
-## RFC 2: Agent Turn Preparation And Injection
+## RFC B: Agent Turn Preparation And Injection
 
 ### Turn Contract
 
@@ -234,7 +234,7 @@ prompts without patching `agent-runner-execution.ts` or runner internals.
 - Retry/fallback does not duplicate the injection.
 - Existing `before_prompt_build` output still applies in deterministic order.
 
-## RFC 3: Tool Policy And Tool Metadata
+## RFC C: Tool Policy And Tool Metadata
 
 ### Tool Contract
 
@@ -243,6 +243,7 @@ Add a trusted tool policy surface separate from normal `before_tool_call`:
 ```ts
 api.registerToolPolicy({
   id: "example.policy",
+  trust: "bundled",
   stage: "pre_plugin_hooks",
   handler,
 });
@@ -253,10 +254,10 @@ Also let plugin-owned tools publish catalog and display metadata:
 ```ts
 api.registerToolMetadata({
   name,
-  displayName,
+  title,
   category,
   safety,
-  ui,
+  display,
 });
 ```
 
@@ -284,7 +285,7 @@ Mode in the core tool catalog.
 - A fixture plugin tool appears with registered display metadata.
 - Existing `before_tool_call` tests keep passing.
 
-## RFC 4: Commands, Scopes, And Agent Continuation
+## RFC D: Commands, Scopes, And Agent Continuation
 
 ### Command Contract
 
@@ -330,7 +331,7 @@ scope and then continue the agent when appropriate.
 - A fixture command returning `continueAgent: true` resumes the agent.
 - Existing plugin commands still default to no continuation.
 
-## RFC 5: Control UI Plugin Contribution Slots
+## RFC E: Control UI Plugin Contribution Slots
 
 ### UI Contract
 
@@ -377,7 +378,7 @@ input when waiting on an approval response if the product wants that behavior.
 - A fixture plugin approval payload renders through the registered card slot.
 - Removing or disabling the plugin removes its UI contributions.
 
-## RFC 6: Agent Events, Run Context, And Scheduler Lifecycle
+## RFC F: Agent Events, Run Context, And Scheduler Lifecycle
 
 ### Event And Scheduler Contract
 
@@ -385,8 +386,8 @@ Expose safe agent event subscriptions and run-context storage:
 
 ```ts
 api.onAgentEvent("tool_result", handler);
-api.setRunContextData(runId, "example", value);
-api.getRunContextData(runId, "example");
+ctx.runContext.set(runId, "example", value);
+ctx.runContext.get(runId, "example");
 ```
 
 Add scheduler lifecycle helpers tied to session extension state:

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -386,8 +386,8 @@ Expose safe agent event subscriptions and run-context storage:
 
 ```ts
 api.onAgentEvent("tool_result", handler);
-ctx.runContext.set(runId, "example", value);
-ctx.runContext.get(runId, "example");
+ctx.runContext.set("example", value);
+ctx.runContext.get("example");
 ```
 
 Add scheduler lifecycle helpers tied to session extension state:

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -32,6 +32,17 @@ Read [the full RFC packet](/plan/plan-mode-plugin-host-hooks-rfc) for:
 - migration plan from PR #71676 to a bundled plugin
 - copy-ready GitHub RFC issue bodies
 
+Filed RFC issues:
+
+| RFC | Issue                                                       | Topic                                                                       |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| A   | [#71732](https://github.com/openclaw/openclaw/issues/71732) | Plugin session extensions and patch actions                                 |
+| B   | [#71733](https://github.com/openclaw/openclaw/issues/71733) | Durable next-turn injections and agent turn preparation hooks               |
+| C   | [#71734](https://github.com/openclaw/openclaw/issues/71734) | Trusted tool policy stage and plugin tool metadata                          |
+| D   | [#71735](https://github.com/openclaw/openclaw/issues/71735) | Scoped plugin commands, trusted command ownership, and continuation         |
+| E   | [#71736](https://github.com/openclaw/openclaw/issues/71736) | Control UI plugin contribution slots                                        |
+| F   | [#71737](https://github.com/openclaw/openclaw/issues/71737) | Agent events, run context, scheduler lifecycle, and heartbeat contributions |
+
 ## Summary
 
 Make Plan Mode plugin-owned by adding a small set of generic host seams to

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -8,13 +8,29 @@ title: "Plan Mode plugin host hooks"
 sidebarTitle: "Plan Mode Hooks"
 ---
 
-This is an RFC bundle for making Plan Mode a first-class bundled plugin. It is
-based on PR #71676, "Plan Mode rebased onto upstream/main + executing-state
-subsystem".
+This page is the public index for the Plan Mode host-hook RFC work. The full
+maintainer packet lives in
+[Plan Mode Plugin Host Hooks RFC](/plan/plan-mode-plugin-host-hooks-rfc).
+
+The RFC is based on PR #71676, "Plan Mode rebased onto upstream/main +
+executing-state subsystem".
 
 The design goal is to use PR #71676 as the behavior contract and parity oracle,
 not as the merge target. The hook PR should be small, additive,
 backwards-compatible, and covered by fixture-plugin tests.
+
+## Maintainer Packet
+
+Read [the full RFC packet](/plan/plan-mode-plugin-host-hooks-rfc) for:
+
+- current plugin surface gap analysis
+- PR #71676 evidence by host entry point
+- per-hook TypeScript-shaped contract proposals
+- expected host files for each hook family
+- security and trust-tier decisions
+- fixture-plugin acceptance tests
+- migration plan from PR #71676 to a bundled plugin
+- copy-ready GitHub RFC issue bodies
 
 ## Summary
 

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -24,6 +24,9 @@ backwards-compatible, and covered by fixture-plugin tests.
 Read [the full RFC packet](/plan/plan-mode-plugin-host-hooks-rfc) for:
 
 - current plugin surface gap analysis
+- current SDK research against existing hooks, using
+  [#71427](https://github.com/openclaw/openclaw/issues/71427) as the comparison
+  bar
 - PR #71676 evidence by host entry point
 - per-hook TypeScript-shaped contract proposals
 - expected host files for each hook family

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -1,0 +1,437 @@
+---
+summary: "RFC bundle for the generic host hooks needed to make Plan Mode a first-class bundled plugin"
+read_when:
+  - Designing or reviewing Plan Mode as a bundled plugin
+  - Adding plugin-owned session state, turn injections, tool policy, command continuation, or Control UI slots
+  - Shrinking a large feature PR into generic host hooks plus plugin-owned behavior
+title: "Plan Mode plugin host hooks"
+sidebarTitle: "Plan Mode Hooks"
+---
+
+This is an RFC bundle for making Plan Mode a first-class bundled plugin. It is
+based on PR #71676, "Plan Mode rebased onto upstream/main + executing-state
+subsystem".
+
+The design goal is to use PR #71676 as the behavior contract and parity oracle,
+not as the merge target. The hook PR should be small, additive,
+backwards-compatible, and covered by fixture-plugin tests.
+
+## Summary
+
+Make Plan Mode plugin-owned by adding a small set of generic host seams to
+OpenClaw. The host PR should not merge Plan Mode behavior into core. It should
+expose the runtime, session, command, UI, event, and scheduler hooks that let a
+bundled plugin own the behavior without patching unrelated core files.
+
+## Problem
+
+PR #71676 proves the behavior, but it does so by embedding Plan Mode across
+core entry points:
+
+- session persistence and `sessions.patch`
+- agent turn prompt preparation
+- pending injection queues
+- pre-tool mutation gates
+- tool catalog and display metadata
+- slash command continuation
+- Control UI mode switcher and approval cards
+- agent event persistence
+- cron and heartbeat nudges
+
+That makes Plan Mode hard to review, hard to shrink, and hard to maintain as a
+plugin. A separate plugin port cannot reach full feature parity unless the host
+first exposes the small number of missing seams.
+
+## Goals
+
+- Keep Plan Mode behavior plugin-owned.
+- Keep core generic and plugin-id agnostic.
+- Add only host seams that are required by PR #71676 behavior.
+- Support durable session state and gateway projection without ad hoc root
+  session fields.
+- Support exactly-once next-turn injections without plugins rewriting prompt
+  assembly.
+- Support host-owned pre-tool policy ordering that cannot be bypassed by normal
+  plugin hooks.
+- Support data-driven Control UI contributions for chat modes and approval
+  surfaces.
+- Support command handlers that can patch state and resume the agent.
+- Provide fixture-plugin tests for each new seam before porting Plan Mode.
+
+## Non Goals
+
+- Do not merge Plan Mode itself in the host hook PR.
+- Do not add Plan Mode-specific ids, schemas, or vocabulary to core.
+- Do not make external plugins fully trusted by default.
+- Do not expand broad SDK barrels when a narrow contract is enough.
+- Do not rely on local installer patches as the long-term plugin contract.
+
+## Current Patch Evidence
+
+The following PR #71676 areas show where the host currently needs generic
+hooks. Paths are repo-root relative.
+
+| Behavior                                          | PR #71676 core touch points                                                                                                                            | Missing generic seam                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Durable approval and plan state                   | `src/config/sessions/types.ts`, `src/gateway/protocol/schema/sessions.ts`, `src/gateway/sessions-patch.ts`, `src/gateway/session-utils.ts`             | Plugin session extension and plugin patch actions                     |
+| Approval, revision, nudge, and question injection | `src/auto-reply/reply/agent-runner-execution.ts`, `src/agents/pi-embedded-runner/pending-injection.ts`, `src/agents/pi-embedded-runner/run/attempt.ts` | Durable next-turn injection queue                                     |
+| Mutation blocking before approval                 | `src/agents/pi-tools.before-tool-call.ts`, `src/agents/pi-tools.ts`                                                                                    | Pre-plugin tool policy gate                                           |
+| Plan tools and display                            | `src/agents/openclaw-tools.ts`, `src/agents/tool-catalog.ts`, `src/agents/tool-display-config.ts`, Control UI tool display JSON                        | Plugin tool catalog and display metadata                              |
+| `/plan` command flow                              | `src/auto-reply/reply/commands-plan.ts`, `src/auto-reply/reply/commands-plugin.ts`, `src/plugins/command-registration.ts`                              | Scoped command continuation and trusted command ownership             |
+| Approval cards and mode switcher                  | `ui/src/ui/chat/mode-switcher.ts`, `ui/src/ui/app-tool-stream.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/views/plan-approval-inline.ts`                | Control UI plugin contribution slots                                  |
+| Plan snapshots and subagent state                 | `src/infra/agent-events.ts`, `src/gateway/plan-snapshot-persister.ts`, `src/gateway/server-runtime-subscriptions.ts`                                   | Agent event subscriptions plus run context extensions                 |
+| Auto nudges and heartbeats                        | `src/infra/heartbeat-runner.ts`, `src/cron/*`                                                                                                          | Session-scoped scheduler lifecycle plus heartbeat prompt contribution |
+
+## RFC 1: Plugin Session Extensions
+
+### Session Contract
+
+Add a plugin registration surface:
+
+```ts
+api.registerSessionExtension({
+  key: "example",
+  schema,
+  publicProjection,
+  patchActions,
+  lifecycle,
+});
+```
+
+The registered extension owns a namespaced session state blob. Core persists it,
+validates patch actions, projects safe fields to gateway clients, and resets it
+through documented lifecycle hooks.
+
+### Session Host Work
+
+- Add a generic `session.extensions.<pluginKey>` store.
+- Add schema-backed validation for extension patch payloads.
+- Add gateway patch routing, for example `sessions.pluginPatch`, or an additive
+  `sessions.patch.plugin` envelope.
+- Broadcast normal session-change events after plugin patch actions.
+- Include public projection in session list/detail rows.
+- Add lifecycle points for reset, close, delete, compaction, and migration.
+
+### Session Plan Mode Uses
+
+Plan Mode would store approval mode, cycle id, title, summary, last plan steps,
+pending question, pending injection ids, auto-approve settings, blocking
+subagent ids, and nudge job ids under its own extension key.
+
+### Session Acceptance Tests
+
+- A fixture plugin registers a session extension and patches it through gateway
+  RPC.
+- Invalid patch payloads fail closed with a stable error code.
+- Public projection appears in session rows without leaking private fields.
+- Reset/delete lifecycle clears extension state and related scheduled work.
+
+## RFC 2: Agent Turn Preparation And Injection
+
+### Turn Contract
+
+Add a durable agent-turn preparation seam:
+
+```ts
+api.enqueueNextTurnInjection({
+  sessionKey,
+  id,
+  role: "user",
+  content,
+  reason,
+});
+
+api.on("agent_turn_prepare", async (event, ctx) => {
+  return {
+    prependSystemContext,
+    prependUserMessages,
+  };
+});
+```
+
+The host owns dequeue timing and exactly-once semantics. Plugins may enqueue
+future-turn injections, but the runner decides when to consume them.
+
+### Turn Host Work
+
+- Drain pending plugin injections once before agent retry/fallback loops.
+- Preserve the injected content through prompt assembly and provider transforms.
+- Mark consumed injections transactionally so retries do not duplicate them.
+- Include session extension state and current run metadata in hook context.
+- Keep existing `before_prompt_build` compatibility intact.
+
+### Turn Plan Mode Uses
+
+Plan Mode would enqueue approved-plan execution instructions, revise-plan
+instructions, question answers, scheduled nudges, and subagent follow-up
+prompts without patching `agent-runner-execution.ts` or runner internals.
+
+### Turn Acceptance Tests
+
+- A fixture plugin enqueues an injection and the next agent run receives it
+  exactly once.
+- Retry/fallback does not duplicate the injection.
+- Existing `before_prompt_build` output still applies in deterministic order.
+
+## RFC 3: Tool Policy And Tool Metadata
+
+### Tool Contract
+
+Add a trusted tool policy surface separate from normal `before_tool_call`:
+
+```ts
+api.registerToolPolicy({
+  id: "example.policy",
+  stage: "pre_plugin_hooks",
+  handler,
+});
+```
+
+Also let plugin-owned tools publish catalog and display metadata:
+
+```ts
+api.registerToolMetadata({
+  name,
+  displayName,
+  category,
+  safety,
+  ui,
+});
+```
+
+### Tool Host Work
+
+- Run trusted policy gates before normal plugin `before_tool_call` hooks.
+- Keep normal `before_tool_call` terminal block behavior unchanged.
+- Make policy registration available only to bundled/trusted plugins unless a
+  future trust model says otherwise.
+- Add tool display metadata lookup for plugin-owned tools.
+- Add a generic way for plugins to extend or decorate built-in tool contracts
+  when core owns the base tool.
+
+### Tool Plan Mode Uses
+
+Plan Mode would block mutating tools while a plan is pending approval, expose
+`enter_plan_mode`, `exit_plan_mode`, `ask_user_question`, and
+`plan_mode_status`, and decorate `update_plan` behavior without hardcoding Plan
+Mode in the core tool catalog.
+
+### Tool Acceptance Tests
+
+- A fixture policy blocks a mutating tool before a normal `before_tool_call`
+  hook can alter the call.
+- A fixture plugin tool appears with registered display metadata.
+- Existing `before_tool_call` tests keep passing.
+
+## RFC 4: Commands, Scopes, And Agent Continuation
+
+### Command Contract
+
+Extend plugin command definitions:
+
+```ts
+api.registerCommand({
+  name: "example",
+  requiredScopes: ["operator.approvals"],
+  ownership: "trusted-core-command",
+  handler,
+});
+```
+
+Extend command results:
+
+```ts
+return {
+  message: "Accepted.",
+  continueAgent: true,
+};
+```
+
+### Command Host Work
+
+- Add declarative command `requiredScopes`.
+- Add command result `continueAgent`.
+- Preserve current command behavior when `continueAgent` is absent.
+- Add a trusted ownership path for bundled plugins to claim command roots that
+  otherwise look core-reserved.
+- Keep external plugin command names isolated by default.
+
+### Command Plan Mode Uses
+
+Plan Mode would own `/plan`, `/plan status`, `/plan accept`, `/plan revise`,
+`/plan answer`, and auto mode toggles. Mutating commands would require approval
+scope and then continue the agent when appropriate.
+
+### Command Acceptance Tests
+
+- A fixture command requiring `operator.approvals` rejects callers without that
+  scope.
+- A fixture command returning `continueAgent: true` resumes the agent.
+- Existing plugin commands still default to no continuation.
+
+## RFC 5: Control UI Plugin Contribution Slots
+
+### UI Contract
+
+Expose data-driven UI contribution metadata through the gateway plugin
+registry. Initial slots:
+
+- chat mode entries
+- approval card renderers
+- tool/event stream classifiers
+- chat input guards
+- sidebar or inline status panels
+
+Example manifest or runtime projection:
+
+```ts
+api.registerControlUiContribution({
+  chatModes: [...],
+  approvalRenderers: [...],
+  eventClassifiers: [...],
+  inputGuards: [...],
+});
+```
+
+The initial renderer model should prefer declarative data and existing safe UI
+components over arbitrary plugin JavaScript in the browser.
+
+### UI Host Work
+
+- Add gateway projection for enabled plugin UI contributions.
+- Add Control UI registries for chat modes and approval cards.
+- Add a safe event classifier boundary for plugin-owned approval payloads.
+- Add an input guard result that can disable or annotate the composer.
+- Keep CSS classes and layout tokens host-owned where possible.
+
+### UI Plan Mode Uses
+
+Plan Mode would add Plan and Plan Auto mode entries, render approval/question
+cards, classify plugin approval events, show mode/status hints, and block chat
+input when waiting on an approval response if the product wants that behavior.
+
+### UI Acceptance Tests
+
+- A fixture plugin contributes a chat mode entry visible in the mode switcher.
+- A fixture plugin approval payload renders through the registered card slot.
+- Removing or disabling the plugin removes its UI contributions.
+
+## RFC 6: Agent Events, Run Context, And Scheduler Lifecycle
+
+### Event And Scheduler Contract
+
+Expose safe agent event subscriptions and run-context storage:
+
+```ts
+api.onAgentEvent("tool_result", handler);
+api.setRunContextData(runId, "example", value);
+api.getRunContextData(runId, "example");
+```
+
+Add scheduler lifecycle helpers tied to session extension state:
+
+```ts
+ctx.scheduler.createSessionJob(...);
+ctx.scheduler.deleteSessionJobs({ sessionKey, pluginKey });
+```
+
+Add a heartbeat prompt contribution hook:
+
+```ts
+api.on("heartbeat_prompt_contribution", handler);
+```
+
+### Event And Scheduler Host Work
+
+- Expose agent events without leaking mutable internal event bus references.
+- Provide run-scoped plugin data that is cleaned up when the run completes.
+- Let session extension lifecycle clean up cron or heartbeat jobs.
+- Let heartbeat prompt assembly ask enabled plugins for additive prompt text.
+- Keep existing `gateway_start.getCron` behavior for lower-level cron access.
+
+### Event And Scheduler Plan Mode Uses
+
+Plan Mode would persist plan snapshots, track blocking subagent ids, clear
+approval state after run completion, attach nudge jobs to sessions, and add
+heartbeat prompt nudges from plugin-owned state.
+
+### Event And Scheduler Acceptance Tests
+
+- A fixture plugin observes an agent event and persists derived session state.
+- Run-context data is unavailable after run cleanup.
+- Session reset deletes fixture scheduler jobs.
+- A fixture heartbeat contribution appears only when its session extension
+  state requests it.
+
+## One Hook PR Shape
+
+The hook PR should be one focused host PR with these commits:
+
+1. Session extension registry, gateway patch action plumbing, and tests.
+2. Agent turn injection queue and `agent_turn_prepare` hook, with tests.
+3. Trusted tool policy gate and tool metadata registry, with tests.
+4. Command scopes, trusted command ownership, and `continueAgent`, with tests.
+5. Control UI contribution projection and minimal renderer slots, with tests.
+6. Agent event, run-context, and scheduler lifecycle helpers, with tests.
+7. Documentation and a fixture plugin that exercises all new seams.
+
+Plan Mode plugin code should not be included. The fixture plugin should be tiny
+and intentionally non-product so reviewers can evaluate the seams without
+reviewing Plan Mode behavior.
+
+## Fixture Plugin Requirements
+
+The fixture plugin should prove the full path:
+
+- registers a session extension
+- patches extension state through gateway RPC
+- projects public state to the UI
+- enqueues a next-turn injection
+- blocks a tool through pre-plugin policy
+- registers a plugin-owned tool with display metadata
+- registers a scoped command that can continue the agent
+- contributes one chat mode and one approval card
+- observes one agent event and writes derived state
+- creates and cleans up one session-scoped scheduled job
+
+## Migration Plan For Plan Mode
+
+1. Land the host hook PR with fixture tests.
+2. Build Plan Mode as a bundled plugin against the new seams.
+3. Use PR #71676 as the feature-by-feature parity oracle.
+4. Port behavior by surface, not by file:
+   - session state and patch actions
+   - tools and tool policy
+   - agent turn injections
+   - commands and continuation
+   - UI contributions
+   - event persistence
+   - scheduler nudges
+5. Delete host patches that become unnecessary.
+6. Run parity tests against the original PR behavior before requesting merge.
+
+## Review Checklist
+
+- No Plan Mode-specific ids or fields are added to core.
+- Public SDK changes are additive and documented.
+- External plugins cannot register trusted policy gates unless explicitly
+  allowed by the trust model.
+- Session extension state validates all external payloads.
+- Gateway protocol changes are additive.
+- UI contributions are disabled when the owning plugin is disabled.
+- Prompt and injection ordering is deterministic.
+- Existing plugin hook behavior remains compatible.
+- Fixture tests cover every new seam.
+
+## Open Questions
+
+- Should plugin session patch actions live under `sessions.patch` or a separate
+  `sessions.pluginPatch` gateway method?
+- Should trusted command ownership be manifest-declared, runtime-declared, or
+  both?
+- Should Control UI plugin contributions be manifest-only for cold discovery,
+  runtime-projected after gateway startup, or a two-phase model?
+- Should `update_plan` become explicitly extensible, or should Plan Mode own a
+  parallel tool and treat `update_plan` as ordinary planning telemetry?
+- Should heartbeat prompt contributions be a separate hook or a specialized
+  case of `agent_turn_prepare`?

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -53,6 +53,25 @@ OpenClaw. The host PR should not merge Plan Mode behavior into core. It should
 expose the runtime, session, command, UI, event, and scheduler hooks that let a
 bundled plugin own the behavior without patching unrelated core files.
 
+These hooks are SDK work first and Plan Mode enablement second. Plan Mode is
+the large feature used to prove the seams, but the same contracts support other
+bundled or external plugins that need durable session state, scoped commands,
+trusted tool policy, UI descriptors, lifecycle cleanup, and safe runtime event
+handling.
+
+## Reusable Plugin Examples
+
+| Plugin type                     | Hook families it can reuse                                                                                 | What the SDK hooks enable                                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Human approval workflow         | Session extensions, patch actions, command continuation, UI approval descriptors, scheduler cleanup.       | Persist approvals, block sensitive tools, render approval cards, and resume the agent after a decision.       |
+| Deployment and release workflow | Session state, next-turn injections, trusted tool policy, scoped commands, UI status, scheduler lifecycle. | Gate deploy tools, show rollout progress, continue after approval, and schedule smoke-test follow-ups.        |
+| Cost or budget governor         | Session state, trusted policy, command scopes, UI warning descriptors, event subscriptions.                | Track spend, block expensive actions, expose scoped overrides, and warn users before continuing.              |
+| Memory or context manager       | Session extensions, turn preparation, event subscriptions, run context, UI status.                         | Store plugin-owned context, inject selected memories once, update derived context, and show visibility state. |
+| Review or CI gate               | Session state, tool policy, slash commands, UI cards, scheduler and event subscriptions.                   | Track findings or CI runs, block merge/deploy actions, rerun checks, and nudge stale reviews.                 |
+| Incident or ticket bot          | Session state, next-turn injections, scoped commands, UI banners, scheduler lifecycle.                     | Track incidents, escalate on SLA timers, sync ticket actions, and inject handoff instructions.                |
+| Channel integration             | Channel session state, command scopes, UI delivery descriptors, event subscriptions, scheduled retries.    | Bind Telegram/Slack/email threads, show delivery/auth state, and schedule retry or handoff behavior.          |
+| Workspace policy plugin         | Session policy state, trusted tool policy, scoped commands, UI warnings, lifecycle cleanup.                | Enforce path/data rules before tools run, explain policy failures, and clear temporary grants on reset.       |
+
 ## Problem
 
 PR #71676 proves the behavior, but it does so by embedding Plan Mode across

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -128,7 +128,9 @@ first exposes the small number of missing seams.
 ## Current Patch Evidence
 
 The following PR #71676 areas show where the host currently needs generic
-hooks. Paths are repo-root relative.
+hooks. Paths are repo-root relative as they appear in the #71676 branch/diff;
+some are intentionally absent from current `main` because #71676 is the parity
+oracle, not code to cherry-pick.
 
 | Behavior                                          | PR #71676 core touch points                                                                                                                            | Missing generic seam                                                  |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -19,6 +19,12 @@ The design goal is to use PR #71676 as the behavior contract and parity oracle,
 not as the merge target. The hook PR should be small, additive,
 backwards-compatible, and covered by fixture-plugin tests.
 
+<Warning>
+  This page is an RFC proposal, not implemented SDK reference. The APIs and
+  hooks named here are design targets for a future host-hook PR; they are not
+  available on current `main`.
+</Warning>
+
 ## Maintainer Packet
 
 Read [the full RFC packet](/plan/plan-mode-plugin-host-hooks-rfc) for:

--- a/docs/plugins/plan-mode-plugin-host-hooks.md
+++ b/docs/plugins/plan-mode-plugin-host-hooks.md
@@ -16,8 +16,10 @@ The RFC is based on PR #71676, "Plan Mode rebased onto upstream/main +
 executing-state subsystem".
 
 The design goal is to use PR #71676 as the behavior contract and parity oracle,
-not as the merge target. The hook PR should be small, additive,
-backwards-compatible, and covered by fixture-plugin tests.
+not as the merge target. This RFC defines the complete host-hook contract; the
+follow-up implementation PR must implement all generic hooks needed before Plan
+Mode can be packaged as a bundled plugin. The hook PR should be small,
+additive, backwards-compatible, and covered by fixture-plugin tests.
 
 <Warning>
   This page is an RFC proposal, not implemented SDK reference. The APIs and
@@ -30,6 +32,8 @@ backwards-compatible, and covered by fixture-plugin tests.
 Read [the full RFC packet](/plan/plan-mode-plugin-host-hooks-rfc) for:
 
 - current plugin surface gap analysis
+- an "already implemented?" comparison that distinguishes adjacent existing
+  hooks from the exact SDK contracts still missing
 - current SDK research against existing hooks, using
   [#71427](https://github.com/openclaw/openclaw/issues/71427) as the comparison
   bar
@@ -420,7 +424,7 @@ heartbeat prompt nudges from plugin-owned state.
 
 ## One Hook PR Shape
 
-The hook PR should be one focused host PR with these commits:
+The follow-up hook PR should be one focused host PR with these commits:
 
 1. Session extension registry, gateway patch action plumbing, and tests.
 2. Agent turn injection queue and `agent_turn_prepare` hook, with tests.
@@ -434,9 +438,11 @@ Plan Mode plugin code should not be included. The fixture plugin should be tiny
 and intentionally non-product so reviewers can evaluate the seams without
 reviewing Plan Mode behavior.
 
-## Fixture Plugin Requirements
+## SDK Contract Fixture Requirements
 
-The fixture plugin should prove the full path:
+The fixture plugin should prove the full path without Plan Mode product logic.
+It should model reusable SDK consumers such as an approval workflow, a
+budget/workspace policy gate, and a background lifecycle plugin:
 
 - registers a session extension
 - patches extension state through gateway RPC


### PR DESCRIPTION
## Summary

This PR is the maintainer RFC/decision artifact for making Plan Mode a first-class bundled plugin without merging the large host patch from #71676.

- Problem: #71676 proves Plan Mode behavior, but it embeds the feature across session state, gateway patching, agent turn preparation, pending injections, tool policy, commands, Control UI, agent events, scheduler/cron, heartbeat prompts, docs, QA, and channel flows.
- Why it matters: maintainers prefer a plugin path. Plan Mode cannot be packaged as a plugin with 100% parity until OpenClaw exposes the generic host seams defined here.
- What changed: added the complete host-hook contract, six issue-sized RFC threads, current-SDK gap research, an “already implemented?” comparison, reusable plugin matrices, a #71676 entry-point coverage map, and fixture-test expectations.
- What did NOT change: this PR intentionally does not implement hooks, Plan Mode behavior, prompts, tools, UI cards, session fields, scheduler changes, or runtime SDK APIs.

## RFC Status Warning

This is proposed SDK design, not implemented SDK reference. The docs include explicit warning callouts, and the public page has been moved out of `SDK reference` into a dedicated `Plugin design RFCs` nav group.

## Decision This PR Asks Maintainers To Make

This RFC defines the complete host-hook contract. The follow-up implementation PR must implement all generic hooks needed before Plan Mode can be packaged as a bundled plugin and audited against #71676 for parity.

The implementation PR should be one focused host-hook PR with generic SDK contracts and fixture tests. It should not include Plan Mode product prompts, Plan Mode tools, Plan Mode command text, Plan Mode CSS, Telegram-specific Plan Mode behavior, local installer patch logic, or Smarter-Claw compatibility code.

## RFC Decision Threads

- #71732 — Plugin session extensions and patch actions
- #71733 — Durable next-turn injections and agent turn preparation hooks
- #71734 — Trusted tool policy stage and plugin tool metadata
- #71735 — Scoped plugin commands, trusted command ownership, and continuation
- #71736 — Control UI plugin contribution slots
- #71737 — Agent events, run context, scheduler lifecycle, and heartbeat contributions

Each issue body now includes: proposed/not-implemented status, current SDK surface, why that surface is adjacent but insufficient, proposed seam, Plan Mode parity use, reusable non-Plan plugin examples, decisions needed, and fixture acceptance criteria.

## Already Implemented? Standard

Use the #71427 closure standard: an existing hook only resolves an RFC if it owns the same lifecycle boundary, payload shape, ordering, authorization, disablement, cleanup, and fixture-test semantics.

Current OpenClaw has useful adjacent surfaces (`before_prompt_build`, `before_tool_call`, plugin commands, plugin gateway RPCs, generic plugin approvals, raw runtime events, and `gateway_start.getCron`). These do not provide the exact SDK contracts required here.

## RFC Contents

The full RFC packet covers:

- current SDK research against existing hooks, using #71427 as the comparison bar
- reusable SDK capability matrix across public SDK, trusted/bundled SDK, gateway protocol, UI descriptors, runner boundary, lifecycle cleanup, and fixture tests
- plugin archetype matrix for approval workflows, deploy/release, budget guards, memory/context, review/CI, incidents/tickets, channel integrations, workspace policy, telemetry/exporters, and long-running jobs
- #71676 entry-point coverage map for Plan Mode parity
- per-hook TypeScript-shaped API sketches
- expected host files for each implementation slice
- authorization, trust-tier, disablement, cleanup, and failure semantics
- SDK contract fixture expectations for approval workflow, budget/policy gate, and background lifecycle plugin scenarios
- Plan Mode migration sequence and parity checklist

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #71676
- Related #71732
- Related #71733
- Related #71734
- Related #71735
- Related #71736
- Related #71737
- [ ] This PR fixes a bug or regression

## Verification

Verified locally:

- `pnpm format:docs:check`
- `pnpm lint:docs`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`

## Human Verification

- Confirmed the docs nav no longer places the proposal under stable SDK reference.
- Confirmed both docs pages warn that the named APIs are proposed, not implemented.
- Confirmed the RFC packet includes a #71676 entry-point coverage map.
- Confirmed all six live issue bodies are expanded beyond Plan Mode-only examples.
- Did not run runtime Plan Mode behavior because this PR is docs/RFC-only and implements no hooks.

## Compatibility / Migration

- Backward compatible? Yes, docs-only.
- Config/env changes? No.
- Migration needed? No.

## Risks and Mitigations

- Risk: reviewers mistake the RFC for implemented SDK reference.
  - Mitigation: warning callouts plus `Plugin design RFCs` nav placement.
- Risk: proposal appears Plan Mode-specific.
  - Mitigation: reusable SDK matrices, non-Plan plugin examples, expanded issue bodies, and generic SDK contract fixture scenarios.
- Risk: proposal overclaims parity.
  - Mitigation: #71676 entry-point coverage map and explicit note that actual parity requires the follow-up hook implementation PR plus fixture tests.

## Next Step After This PR

Implement the generic host hooks described here in one focused follow-up PR with SDK types, gateway protocol support, runner integration, lifecycle cleanup, and a tiny SDK contract fixture. After that lands, Plan Mode can move into a bundled plugin and be audited against #71676 for 100% parity.
