### PR TITLE
fix(google): emit Ogg/Opus for voice-note targets so WhatsApp auto-replies play as native voice notes

### DIFF
--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -1,5 +1,12 @@
 import * as providerHttp from "openclaw/plugin-sdk/provider-http";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runFfmpegMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  runFfmpeg: runFfmpegMock,
+}));
+
 import { buildGoogleSpeechProvider, __testing } from "./speech-provider.js";
 
 function installGoogleTtsFetchMock(pcm = Buffer.from([1, 0, 2, 0])) {
@@ -27,6 +34,17 @@ function installGoogleTtsFetchMock(pcm = Buffer.from([1, 0, 2, 0])) {
 }
 
 describe("Google speech provider", () => {
+  beforeEach(() => {
+    runFfmpegMock.mockReset();
+    runFfmpegMock.mockImplementation(async (args: string[]) => {
+      const outputPath = args.at(-1);
+      if (typeof outputPath === "string") {
+        const fs = await import("node:fs/promises");
+        await fs.writeFile(outputPath, Buffer.from("opus-default"));
+      }
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -370,5 +388,53 @@ describe("Google speech provider", () => {
     expect(postJsonRequestSpy).toHaveBeenCalledWith(
       expect.objectContaining({ allowPrivateNetwork: true }),
     );
+  });
+
+  it("transcodes Google PCM to Opus for voice-note targets", async () => {
+    installGoogleTtsFetchMock();
+    runFfmpegMock.mockImplementationOnce(async (args: string[]) => {
+      const outputPath = args.at(-1);
+      if (typeof outputPath !== "string") {
+        throw new Error("missing ffmpeg output path");
+      }
+      const fs = await import("node:fs/promises");
+      await fs.writeFile(outputPath, Buffer.from("fake-opus-data"));
+    });
+
+    const provider = buildGoogleSpeechProvider();
+    const result = await provider.synthesize({
+      text: "Hello world",
+      cfg: {},
+      providerConfig: { apiKey: "google-test-key" },
+      target: "voice-note",
+      timeoutMs: 30_000,
+    });
+
+    expect(result.outputFormat).toBe("opus");
+    expect(result.fileExtension).toBe(".opus");
+    expect(result.voiceCompatible).toBe(true);
+    expect(result.audioBuffer.toString()).toBe("fake-opus-data");
+    expect(runFfmpegMock).toHaveBeenCalledWith(
+      expect.arrayContaining(["-c:a", "libopus", "-ar", "48000"]),
+      { timeoutMs: 30_000 },
+    );
+  });
+
+  it("emits WAV for non-voice-note targets and does not invoke ffmpeg", async () => {
+    installGoogleTtsFetchMock();
+
+    const provider = buildGoogleSpeechProvider();
+    const result = await provider.synthesize({
+      text: "Hello world",
+      cfg: {},
+      providerConfig: { apiKey: "google-test-key" },
+      target: "audio-file",
+      timeoutMs: 30_000,
+    });
+
+    expect(result.outputFormat).toBe("wav");
+    expect(result.fileExtension).toBe(".wav");
+    expect(result.voiceCompatible).toBe(false);
+    expect(runFfmpegMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
@@ -12,6 +15,7 @@ import type {
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech-core";
 import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech-core";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { resolveGoogleGenerativeAiHttpRequestConfig } from "./api.js";
 
@@ -264,6 +268,41 @@ function wrapPcm16MonoToWav(pcm: Buffer, sampleRate = GOOGLE_TTS_SAMPLE_RATE): B
   return Buffer.concat([header, pcm]);
 }
 
+async function transcodeWavToOpus(wavBuffer: Buffer, timeoutMs: number | undefined) {
+  const tempRoot = resolvePreferredOpenClawTmpDir();
+  await mkdir(tempRoot, { recursive: true, mode: 0o700 });
+  const tempDir = await mkdtemp(path.join(tempRoot, "tts-google-"));
+  try {
+    const inputPath = path.join(tempDir, "input.wav");
+    const outputPath = path.join(tempDir, "voice.opus");
+    await writeFile(inputPath, wavBuffer, { mode: 0o600 });
+    await runFfmpeg(
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        inputPath,
+        "-vn",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "64k",
+        "-ar",
+        "48000",
+        "-ac",
+        "1",
+        outputPath,
+      ],
+      { timeoutMs },
+    );
+    return await readFile(outputPath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 async function synthesizeGoogleTtsPcm(params: {
   text: string;
   apiKey: string;
@@ -394,8 +433,18 @@ export function buildGoogleSpeechProvider(): SpeechProviderPlugin {
         speakerName: overrides.speakerName ?? config.speakerName,
         timeoutMs: req.timeoutMs,
       });
+      const wav = wrapPcm16MonoToWav(pcm);
+      if (req.target === "voice-note") {
+        const opus = await transcodeWavToOpus(wav, req.timeoutMs);
+        return {
+          audioBuffer: opus,
+          outputFormat: "opus",
+          fileExtension: ".opus",
+          voiceCompatible: true,
+        };
+      }
       return {
-        audioBuffer: wrapPcm16MonoToWav(pcm),
+        audioBuffer: wav,
         outputFormat: "wav",
         fileExtension: ".wav",
         voiceCompatible: false,


### PR DESCRIPTION
## Summary

- Problem: Google TTS auto-replies arrive as plain WAV file attachments instead of native voice notes (PTT). WhatsApp silently drops the WAV when delivered as a voice-note target because WAV is not in the voice-compatible audio extension allowlist (`.oga`, `.ogg`, `.opus`, `.mp3`, `.m4a`).
- Why it matters: Google TTS provider returns `voiceCompatible: false` regardless of `req.target`, breaking voice-note delivery on WhatsApp (and any other channel routing through the voice-compatible audio gate).
- What changed: When `req.target === "voice-note"`, transcode the WAV-wrapped PCM to Ogg/Opus locally via the existing `runFfmpeg` plugin-sdk seam (libopus, 64k, 48kHz mono) and return `voiceCompatible: true` with `.opus` extension. Mirrors the established pattern in `extensions/minimax/speech-provider.ts` and `extensions/xiaomi/speech-provider.ts`.
- What did NOT change: Non-voice-note targets keep the existing WAV path unchanged. Telephony path is untouched (returns raw PCM with `sampleRate`, no transcoding needed).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Same conceptual fix as #69528 (`fix(microsoft-tts): emit ogg/opus for voice-note targets so WhatsApp auto-replies play as native voice notes`).
- Same transcode pattern as the existing `extensions/minimax/speech-provider.ts` (line 212 `transcodeMp3ToOpus`) and `extensions/xiaomi/speech-provider.ts` (line 245 `transcodeAudioToOpus`).
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `extensions/google/speech-provider.ts` `synthesize` returned `{ outputFormat: "wav", fileExtension: ".wav", voiceCompatible: false }` unconditionally. The `voiceCompatible: false` flag tells the dispatcher to deliver the buffer as a plain file attachment rather than a PTT voice note, and even if the dispatcher tried to send it as a voice note, the WAV format is not in the WhatsApp-acceptable allowlist (`src/media/audio.ts:VOICE_MESSAGE_AUDIO_EXTENSIONS`), so it is silently dropped.
- Missing detection / guardrail: No regression test exercised `target: "voice-note"` against the resulting `outputFormat`/`voiceCompatible` shape for the Google provider.
- Contributing context: The Gemini `:generateContent` audio output endpoint that backs this provider only returns raw 24kHz mono PCM — `audio_encoding` selection is not exposed on that surface (see [`googleapis/go-genai#322`](https://github.com/googleapis/go-genai/issues/322)). So unlike OpenAI/ElevenLabs/Microsoft (whose APIs let the caller request opus directly), Google needs the same local transcode path that minimax + xiaomi already use.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/google/speech-provider.test.ts`
- Scenarios locked in:
  1. `target: "voice-note"` → asserts `outputFormat: "opus"`, `fileExtension: ".opus"`, `voiceCompatible: true`, and that `runFfmpeg` is called with `-c:a libopus -ar 48000`.
  2. `target: "audio-file"` → asserts `outputFormat: "wav"`, `fileExtension: ".wav"`, `voiceCompatible: false`, and that `runFfmpeg` is NOT called.
- Why this is the smallest reliable guardrail: Mirrors the existing test in `extensions/minimax/speech-provider.test.ts:339` ("transcodes MiniMax MP3 to Opus for voice-note targets").

## User-visible / Behavior Changes

- Google TTS replies on voice-note-capable channels (WhatsApp, Telegram, Feishu, Matrix, Discord) now play as native voice notes (PTT) instead of being dropped or shown as file attachments.
- Non-voice-note targets (audio-file delivery, telephony) keep their existing behavior — no format or buffer changes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No (uses the existing `runFfmpeg` plugin-sdk seam and `resolvePreferredOpenClawTmpDir` already used by `extensions/minimax` and `extensions/xiaomi`)
- Secrets/tokens handling changed? No
- New/changed network calls? No (same Gemini `:generateContent` endpoint, same auth, same body)
- Command/tool execution surface changed? No new commands; reuses existing ffmpeg invocation pattern
- Data access scope changed? No (writes to `resolvePreferredOpenClawTmpDir()` tempdir with mode `0o700`, removes after read)

## Repro + Verification

### Environment

- OS: Debian 12 (gateway VM)
- Runtime: node 24.x
- Channel: WhatsApp (any voice-note-capable channel reproduces)
- Config: `messages.tts.provider: "google"`; `messages.tts.providers.google.{model: "gemini-3.1-flash-tts-preview", voiceName: "Leda"}`

### Steps

1. Configure Google TTS provider as above.
2. Trigger a TTS reply via a `[[tts:text]]...[[/tts:text]]` directive (or any path that hits `provider.synthesize` with `target: "voice-note"`).

### Expected

- Reply arrives as a native voice note (PTT) on WhatsApp.

### Actual (before this fix)

- WhatsApp silently drops the WAV; reply is text-only or falls back to a different speech provider when one is configured.

## Evidence

- [x] Failing test before / passing after: added "transcodes Google PCM to Opus for voice-note targets" in `extensions/google/speech-provider.test.ts`. Without the source change, the assertions on `outputFormat: "opus"` / `voiceCompatible: true` fail.

## Human Verification (required)

- Verified scenarios:
  - `target: "voice-note"`: provider returns opus buffer + `voiceCompatible: true`; WhatsApp delivers it as a native voice note end-to-end on a controlled production gateway.
  - `target: "audio-file"`: behavior unchanged — WAV bytes, `voiceCompatible: false`, no ffmpeg invocation (verified by both unit test and existing tests).
  - `synthesizeTelephony`: untouched code path; existing tests still pass.
- Edge cases checked: ffmpeg failure / missing binary surfaces a clear `runFfmpeg` error from the plugin-sdk seam (matches minimax/xiaomi behavior).
- What I did not verify: Telegram / Feishu / Matrix / Discord native voice-note rendering (only verified WhatsApp end-to-end). Reasoning by parity with #69528 — same dispatcher gate, same expected behavior across channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- New runtime requirement? `ffmpeg` with libopus support must be available on the host. This already applies to bundled providers `extensions/minimax` and `extensions/xiaomi` and is the established expectation for OC media-handling deployments.

## Risks and Mitigations

- Risk: Hosts without ffmpeg installed will see voice-note synthesis fail with a clear `runFfmpeg` error (same failure mode as minimax/xiaomi today).
  - Mitigation: Match existing precedent — no separate handling needed; the error message from `requireSystemBin("ffmpeg")` already includes install hints (`brew install ffmpeg` / `apt install ffmpeg`).
- Risk: Slight added latency from local transcode for voice-note targets.
  - Mitigation: libopus encoding of ~5–15s of PCM is sub-100ms in practice; well below user perception for an async voice reply.

---

AI-assisted (Claude wrote this PR after diagnosing the bug; lightly tested locally + verified end-to-end on a production gateway deploy). Human reviewed every diff hunk before push.
