### PR TITLE
perf(cli): skip plugin load on agents list --json (#71739)

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -73,6 +73,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   },
   {
     commandPath: ["agents", "list"],
+    // JSON callers (dashboards, monitoring scripts, IDE plugins) poll this
+    // command and don't need the plugin-derived `providers` enrichment that
+    // is only used in human text output. text-only skips the bundled-plugin
+    // import waterfall in `--json` mode, mirroring what `channels list`
+    // already does. Human (non-JSON) invocations still load plugins. (#71739)
+    policy: { loadPlugins: "text-only" },
     route: { id: "agents-list" },
   },
   {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -80,6 +80,15 @@ describe("command-startup-policy", () => {
         jsonOutputMode: false,
       }),
     ).toBe(true);
+    // text-only opts agents list out of plugin preload in --json mode so
+    // dashboards/scripts that poll this command don't pay the bundled-plugin
+    // import waterfall when they only consume config-derived fields. (#71739)
+    expect(
+      shouldLoadPluginsForCommandPath({
+        commandPath: ["agents", "list"],
+        jsonOutputMode: true,
+      }),
+    ).toBe(false);
   });
 
   it("matches banner suppression policy", () => {

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -99,7 +99,14 @@ export async function agentsListCommand(
     }
   }
 
-  const providerStatus = await buildProviderStatusIndex(cfg);
+  // `buildProviderStatusIndex` triggers on-demand plugin loads and is only
+  // used for human text output (`summary.providers` is rendered in the text
+  // formatter). JSON callers (dashboards, monitors, IDE plugins) poll this
+  // command and don't need provider enrichment, so skip the plugin load when
+  // emitting JSON — combined with `loadPlugins: "text-only"` in the catalog
+  // entry, this drops `agents list --json` cold time from ~9s to sub-second.
+  // (#71739)
+  const providerStatus = opts.json ? null : await buildProviderStatusIndex(cfg);
 
   for (const summary of summaries) {
     const bindings = bindingMap.get(summary.id) ?? [];
@@ -110,14 +117,16 @@ export async function agentsListCommand(
       summary.routes = ["default (no explicit rules)"];
     }
 
-    const providerLines = listProvidersForAgent({
-      summaryIsDefault: summary.isDefault,
-      cfg,
-      bindings,
-      providerStatus,
-    });
-    if (providerLines.length > 0) {
-      summary.providers = providerLines;
+    if (providerStatus) {
+      const providerLines = listProvidersForAgent({
+        summaryIsDefault: summary.isDefault,
+        cfg,
+        bindings,
+        providerStatus,
+      });
+      if (providerLines.length > 0) {
+        summary.providers = providerLines;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #71739.

## Bug

Reporter measured \`agents list --json\` at ~7-9s on a fast host (~11s in container) on 2026.4.23, while peer \`--json\` commands stay sub-second:

| command | warm | cold |
|---|---|---|
| \`cron list --all --json\` | 1.0s | — |
| \`skills list --json\` | 0.9s | — |
| \`sessions --all-agents --json\` | 1.0s | — |
| \`channels list --json\` | 0.9s | — |
| **\`agents list --json\`** | **8.6s** | **~9s** |

The reporter's \`agent-dash\` endpoint cold path dropped from 27s → ~2s after a local dist patch — they could even retire the 5-min cache TTL workaround they shipped to dodge this.

## Root cause

\`agents list\` inherits \`loadPlugins: 'always'\` from the parent \`agents\` policy in \`command-catalog.ts\`, then \`agentsListCommand\` calls \`buildProviderStatusIndex(cfg)\` unconditionally. Both paths trigger the bundled-extension import waterfall (~60+ extension \`index.js\` modules) — but \`providerStatus\` is only rendered into human text output, never used in JSON.

\`channels list\` already uses \`loadPlugins: 'never'\` and proves the shape is right; this PR matches that shape via the safer \`text-only\` variant so human invocations are unchanged.

## Fix (two-line, per reporter's diagnosis)

1. **\`src/cli/command-catalog.ts\`** — opt \`agents list\` into the existing \`text-only\` plugin-preload policy. Plugin preload runs for human text output, skips for \`--json\`.

2. **\`src/commands/agents.commands.list.ts\`** — skip \`buildProviderStatusIndex\` (and the per-summary provider enrichment loop) when \`opts.json\`. Provider info is only rendered in human text output via \`formatSummary\`, so dropping it from JSON has no observable effect on callers that consume \`id\`, \`name\`, \`model\`, \`bindings\`, \`isDefault\`, \`identity*\`, \`workspace\`, or \`agentDir\`. \`routes\` is config-derived and continues to be set in both modes.

## Tests

- new assertion in \`command-startup-policy.test.ts\`: \`agents list\` with \`jsonOutputMode: true\` now resolves to \`loadPlugins: false\` (was effectively \`true\` via the parent \`agents\` \"always\" policy).
- existing assertion that human (\`jsonOutputMode: false\`) still triggers plugin load is preserved verbatim — no behavior change for text mode.

6/6 tests pass. Lint clean (\`pnpm oxlint\` — 0 warnings, 0 errors).

## Out of scope

- \`--bindings\` flag opt-in for restoring \`providers\` in JSON output: worth adding later if any consumer needs it. Reporter said dashboard consumers don't, and \`--bindings\` already gates \`bindingDetails\` enrichment, so the precedent is there if needed.
- Broader plugin-discovery cache work (#67040, #71690) addresses the same family of cold-start cost.

🤖 generated with assistance from Claude Code
Co-authored-by: HCL <chenglunhu@gmail.com>