### PR TITLE
docs: list Abliteration community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -23,6 +23,19 @@ OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
+### Abliteration
+
+Abliteration.ai model provider plugin for OpenClaw. Adds the `abliteration`
+provider, API-key onboarding, and the `abliteration/abliterated-model` default
+model over the OpenAI Responses API.
+
+- **npm:** `@abliterationai/openclaw-abliteration-provider`
+- **repo:** [github.com/abliterationai/openclaw-abliteration-provider](https://github.com/abliterationai/openclaw-abliteration-provider)
+
+```bash
+openclaw plugins install @abliterationai/openclaw-abliteration-provider
+```
+
 ### Apify
 
 Scrape data from any website with 20,000+ ready-made scrapers. Let your agent


### PR DESCRIPTION
## Summary

- Adds the Abliteration.ai third-party provider plugin to the community plugins page
- Links the published npm package and transferred GitHub repo under the abliterationai organization

## Verification

- /Users/socialkeyboard/Documents/openclaw/node_modules/.bin/oxfmt --check --threads=1 docs/plugins/community.md

Follow-up to closed provider PR #67948 per maintainer guidance to maintain this as a third-party plugin.