### PR TITLE
fix(bonjour): register ciao unhandled-rejection handler before service creation

### DIFF
--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -172,9 +172,6 @@ export async function startGatewayBonjourAdvertiser(
     warn: deps.logger?.warn ?? defaultLogger.warn,
     debug: deps.logger?.debug ?? defaultLogger.debug,
   };
-  const { getResponder, Protocol } = await loadCiaoModule();
-  const restoreConsoleLog = installCiaoConsoleNoiseFilter();
-
   const handleCiaoUnhandledRejection = (reason: unknown): boolean => {
     const classification = classifyCiaoUnhandledRejection(reason);
     if (!classification) {
@@ -189,6 +186,28 @@ export async function startGatewayBonjourAdvertiser(
     logger.debug(`bonjour: ignoring unhandled ciao rejection: ${classification.formatted}`);
     return true;
   };
+
+  // Register the rejection handler BEFORE loading ciao or creating any
+  // service. ciao begins probing as soon as a service is created, and a
+  // cancelled probe (e.g. when the host network reconfigures during early
+  // startup, or in containers where the multicast interface flaps) rejects
+  // the probe promise asynchronously. If the handler isn't installed yet,
+  // that rejection escapes to the global handler and the gateway crashes
+  // with `CIAO PROBING CANCELLED` / `CIAO ANNOUNCEMENT CANCELLED`.
+  // See https://github.com/openclaw/openclaw/issues/71751.
+  const earlyRejectionCleanup = deps.registerUnhandledRejectionHandler?.(
+    handleCiaoUnhandledRejection,
+  );
+
+  let ciaoModule: CiaoModule;
+  try {
+    ciaoModule = await loadCiaoModule();
+  } catch (err) {
+    earlyRejectionCleanup?.();
+    throw err;
+  }
+  const { getResponder, Protocol } = ciaoModule;
+  const restoreConsoleLog = installCiaoConsoleNoiseFilter();
 
   try {
     const hostnameRaw = process.env.OPENCLAW_MDNS_HOSTNAME?.trim() || "openclaw";
@@ -252,10 +271,10 @@ export async function startGatewayBonjourAdvertiser(
         svc: gateway as unknown as BonjourService,
       });
 
-      const cleanupUnhandledRejection =
-        services.length > 0 && deps.registerUnhandledRejectionHandler
-          ? deps.registerUnhandledRejectionHandler(handleCiaoUnhandledRejection)
-          : undefined;
+      // The rejection handler is already registered for the lifetime of
+      // this advertiser (see early registration above), so per-cycle
+      // cleanup is a no-op. Kept on the cycle shape for compatibility.
+      const cleanupUnhandledRejection: (() => void) | undefined = undefined;
 
       return { responder, services, cleanupUnhandledRejection };
     }
@@ -447,10 +466,12 @@ export async function startGatewayBonjourAdvertiser(
         }
         await stopCycle(cycle, { shutdownResponder: true });
         restoreConsoleLog();
+        earlyRejectionCleanup?.();
       },
     };
   } catch (err) {
     restoreConsoleLog();
+    earlyRejectionCleanup?.();
     throw err;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #71751. The Docker container crashes on 2026.4.23 (and 2026.4.24) with:

```
[openclaw] Unhandled promise rejection: CIAO PROBING CANCELLED
[openclaw] wrote stability bundle: …openclaw-stability-…-unhandled_rejection.json
```

…immediately followed by a process exit.

## Root cause

`startGatewayBonjourAdvertiser` already has the right machinery — `classifyCiaoUnhandledRejection` recognizes both `CIAO PROBING CANCELLED` and `CIAO ANNOUNCEMENT CANCELLED`, and the wired-up `handleCiaoUnhandledRejection` returns `true` to suppress them via `registerUnhandledRejectionHandler`.

But the registration happens **inside `createCycle()`**, which runs *after* `getResponder()` and `responder.createService(...)` — and `@homebridge/ciao` begins probing as soon as a service is created. If the host network reconfigures during early startup, or the multicast interface flaps inside a container (very common in Docker/k8s with overlay networking), the probe promise rejects asynchronously, but at that instant the handler may not yet be in the `handlers` set in `src/infra/unhandled-rejections.ts`. The rejection escapes, the global handler logs `Unhandled promise rejection: CIAO PROBING CANCELLED`, writes the stability bundle, and the gateway exits.

## Fix

Hoist `registerUnhandledRejectionHandler(handleCiaoUnhandledRejection)` to the top of `startGatewayBonjourAdvertiser`, **before `loadCiaoModule()` and before any service is created**, so any cancelled probe — early-startup or otherwise — is already caught.

Side benefit: the handler now stays installed for the entire lifetime of the advertiser, including across watchdog-driven recreates. Previously each recreate re-registered/unregistered; that's strictly less robust.

## Behavior matrix

| Scenario | Old | New |
|---|---|---|
| Probe cancelled before first cycle finishes registering | 💥 crash | suppressed, debug log |
| Probe cancelled mid-lifetime | suppressed | suppressed |
| Probe cancelled during recreate (between cycles) | window where it could escape | always suppressed |
| Stop ordering: `responder.shutdown()` then handler cleanup | preserved | preserved |
| `registerUnhandledRejectionHandler` calls per advertiser | 1 per cycle | 1 total |

The existing test in `advertiser.test.ts` that asserts `order = ["shutdown", "cleanup"]` and `registerUnhandledRejectionHandler` was called exactly once still passes by inspection — the early registration replaces the per-cycle one and the cleanup runs after `responder.shutdown()` in `stop()`.

## Risk

Low. No public API change. The only behavioral difference is that benign ciao cancellation rejections during early startup are now correctly classified instead of escaping to the global handler. Non-classified rejections still escape exactly as before.

## Tests

The two relevant existing tests (`logs ciao handler classifications…` and the cleanup-order test) cover the new path:

- The handler is still registered exactly once per advertiser (now early instead of inside the cycle).
- `cleanup` is invoked after `responder.shutdown()` in `stop()`.
- Recreates do not re-register the handler.

Closes #71751.