### PR TITLE
fix(plugins): force non-native jiti on Windows to avoid ERR_UNSUPPORTED_ESM_URL_SCHEME

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -870,7 +870,11 @@ describe("plugin sdk alias helpers", () => {
     }
   });
 
-  it("prefers native Jiti loads on Windows for built JavaScript entries", () => {
+  it("disables native Jiti loads on Windows to avoid ERR_UNSUPPORTED_ESM_URL_SCHEME", () => {
+    // Regression test for https://github.com/openclaw/openclaw/issues/71749:
+    // jiti's native import() path passes raw absolute paths like `C:\\…`
+    // straight to Node's ESM loader, which rejects them as `Received
+    // protocol 'c:'`. We therefore force the non-native path on win32.
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       configurable: true,
@@ -878,9 +882,9 @@ describe("plugin sdk alias helpers", () => {
     });
 
     try {
-      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(true);
+      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(false);
       expect(shouldPreferNativeJiti(`/repo/${bundledDistPluginFile("browser", "index.js")}`)).toBe(
-        true,
+        false,
       );
     } finally {
       Object.defineProperty(process, "platform", {
@@ -890,7 +894,11 @@ describe("plugin sdk alias helpers", () => {
     }
   });
 
-  it("keeps plugin loader dist shortcuts native on Windows", () => {
+  it("forces transpile path for plugin loader dist shortcuts on Windows", () => {
+    // Companion to the test above: even when a caller sets
+    // `preferBuiltDist`, the win32 short-circuit must still apply, because
+    // the underlying problem is in jiti's native import path — not in our
+    // resolver heuristics.
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       configurable: true,
@@ -902,7 +910,7 @@ describe("plugin sdk alias helpers", () => {
         resolvePluginLoaderJitiTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`, {
           preferBuiltDist: true,
         }),
-      ).toBe(true);
+      ).toBe(false);
       expect(
         resolvePluginLoaderJitiTryNative(`/repo/${bundledDistPluginFile("browser", "helper.ts")}`, {
           preferBuiltDist: true,

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -695,7 +695,21 @@ export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
 
 function supportsNativeJitiRuntime(): boolean {
   const versions = process.versions as { bun?: string };
-  return typeof versions.bun !== "string";
+  if (typeof versions.bun === "string") {
+    return false;
+  }
+  // On native Windows, jiti's native import() path passes the resolved
+  // module path directly to Node's ESM loader, which rejects raw absolute
+  // paths like `C:\…` with `ERR_UNSUPPORTED_ESM_URL_SCHEME — Received
+  // protocol 'c:'`. Until jiti normalizes those paths via pathToFileURL
+  // upstream, force the non-native (vfs/transpile) path on win32 so plugin
+  // loading does not crash channel providers like Telegram on startup.
+  // See https://github.com/openclaw/openclaw/issues/71749 (and the prior
+  // related issue #61911).
+  if (process.platform === "win32") {
+    return false;
+  }
+  return true;
 }
 
 function isBundledPluginDistModulePath(modulePath: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #71749. On native Windows, OpenClaw 2026.4.24's gateway starts but the Telegram channel provider crash-loops on startup with:

```
ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data,
and node are supported by the default ESM loader. On Windows, absolute
paths must be valid file:// URLs. Received protocol 'c:'
```

This regresses an earlier fix tracked in #61911 and reproduces in a clean reinstall, with external plugins disabled, even with only the four bundled plugins (`active-memory`, `browser`, `device-pair`, `telegram`) loaded.

## Root cause

`jiti`'s native `import()` fast-path forwards the resolved module path directly to Node's ESM loader. On Windows, Node's loader requires `file://` URLs and rejects raw absolute paths like `C:\Users\…\node_modules\openclaw\dist\…`, hence `Received protocol 'c:'`. Until `jiti` normalizes those paths via `pathToFileURL` upstream, the right answer in OpenClaw is to force the non-native (vfs/transpile) jiti path on `win32`.

The reporter independently arrived at this conclusion and confirmed end-to-end: patching `resolvePluginLoaderJitiTryNative` in the installed `dist` to return `false` when `process.platform === "win32"` makes the Telegram provider start and Telegram messages flow normally.

## Fix

Single chokepoint: `supportsNativeJitiRuntime()` in `src/plugins/sdk-alias.ts` already gates both `shouldPreferNativeJiti` and `resolvePluginLoaderJitiTryNative`. Add `process.platform === "win32"` alongside the existing Bun exclusion so both APIs short-circuit consistently:

```ts
function supportsNativeJitiRuntime(): boolean {
  const versions = process.versions as { bun?: string };
  if (typeof versions.bun === "string") return false;
  if (process.platform === "win32") return false;   // new
  return true;
}
```

## Tests

Two existing tests in `sdk-alias.test.ts` previously locked in the broken native-on-win32 behavior:

- `prefers native Jiti loads on Windows for built JavaScript entries`
- `keeps plugin loader dist shortcuts native on Windows`

Both are rewritten to assert the fixed behavior, with a comment pointing back to this issue. macOS / Linux / Bun expectations are unchanged.

## Behavior matrix

| Platform | Built `.js` plugin entries | TS plugin entries | Bundled `dist/extensions/*` |
|---|---|---|---|
| Linux/macOS | native (unchanged) | transpile (unchanged) | native (unchanged) |
| Bun | transpile (unchanged) | transpile (unchanged) | transpile (unchanged) |
| **Windows** | **transpile (fix)** | transpile (unchanged) | **transpile (fix)** |

## Risk

Low. The transpile path is what every Windows install was effectively forced into via the reporter's local hotfix anyway. Slight cold-start cost on Windows for built-JS plugins, in exchange for not crashing.

## Out of scope

Reporter notes the prior targeted patch in `runtime-web-channel-plugin-DJqeP2uH.js` did not fix it on its own; the decisive fix is the shared resolver. This PR fixes the shared resolver, which is the upstream of both call sites.

A follow-up could push the fix down into `jiti` itself (normalize paths via `pathToFileURL` before passing to native `import()`). That belongs in unjs/jiti, not here.

Closes #71749. Related: #61911, #49716.