### PR TITLE
Add TUI context mode selector

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -3,8 +3,15 @@ import { createCommandHandlers } from "./tui-command-handlers.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
+type SelectableOverlay = {
+  onSelect?: (item: { value: string; label?: string; description?: string }) => void;
+};
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
+
+async function flushAsyncSelect() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 function createHarness(params?: {
   sendChat?: ReturnType<typeof vi.fn>;
@@ -37,6 +44,8 @@ function createHarness(params?: {
   const refreshSessionInfo = params?.refreshSessionInfo ?? vi.fn().mockResolvedValue(undefined);
   const applySessionInfoFromPatch = params?.applySessionInfoFromPatch ?? vi.fn();
   const setActivityStatus = params?.setActivityStatus ?? (vi.fn() as SetActivityStatusMock);
+  const openOverlay = vi.fn();
+  const closeOverlay = vi.fn();
   const requestExit = vi.fn();
   const runAuthFlow: RunAuthFlow | undefined =
     params?.runAuthFlow ??
@@ -59,8 +68,8 @@ function createHarness(params?: {
     opts: params?.opts ?? {},
     state: state as never,
     deliverDefault: false,
-    openOverlay: vi.fn(),
-    closeOverlay: vi.fn(),
+    openOverlay,
+    closeOverlay,
     refreshSessionInfo: refreshSessionInfo as never,
     loadHistory,
     setSession,
@@ -81,6 +90,8 @@ function createHarness(params?: {
     handleCommand,
     getGatewayStatus,
     sendChat,
+    openOverlay,
+    closeOverlay,
     patchSession,
     resetSession,
     setSession,
@@ -115,7 +126,7 @@ describe("tui command handlers", () => {
       setActivityStatus,
     });
 
-    const pending = handleCommand("/context");
+    const pending = handleCommand("/context detail");
     await Promise.resolve();
 
     expect(setActivityStatus).toHaveBeenCalledWith("sending");
@@ -131,17 +142,71 @@ describe("tui command handlers", () => {
   it("forwards unknown slash commands to the gateway", async () => {
     const { handleCommand, sendChat, addUser, addSystem, requestRender } = createHarness();
 
-    await handleCommand("/context");
+    await handleCommand("/unregistered-command");
 
     expect(addSystem).not.toHaveBeenCalled();
-    expect(addUser).toHaveBeenCalledWith("/context");
+    expect(addUser).toHaveBeenCalledWith("/unregistered-command");
     expect(sendChat).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: "agent:main:main",
-        message: "/context",
+        message: "/unregistered-command",
       }),
     );
     expect(requestRender).toHaveBeenCalled();
+  });
+
+  it("opens a context mode selector for /context without sending immediately", async () => {
+    const { handleCommand, sendChat, openOverlay } = createHarness();
+
+    await handleCommand("/context");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(openOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends the selected context mode through the gateway command path", async () => {
+    const { handleCommand, sendChat, openOverlay, closeOverlay } = createHarness();
+
+    await handleCommand("/context");
+    const selector = openOverlay.mock.calls[0]?.[0] as SelectableOverlay | undefined;
+    selector?.onSelect?.({ value: "detail", label: "detail" });
+    await flushAsyncSelect();
+
+    expect(sendChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        message: "/context detail",
+      }),
+    );
+    expect(closeOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards /context list directly", async () => {
+    const { handleCommand, sendChat, openOverlay } = createHarness();
+
+    await handleCommand("/context list");
+
+    expect(openOverlay).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        message: "/context list",
+      }),
+    );
+  });
+
+  it("forwards /context help directly", async () => {
+    const { handleCommand, sendChat, openOverlay } = createHarness();
+
+    await handleCommand("/context help");
+
+    expect(openOverlay).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        message: "/context help",
+      }),
+    );
   });
 
   it("forwards /status to the shared gateway command path", async () => {
@@ -202,7 +267,7 @@ describe("tui command handlers", () => {
   it("defers local run binding until gateway events provide a real run id", async () => {
     const { handleCommand, noteLocalRunId, state } = createHarness();
 
-    await handleCommand("/context");
+    await handleCommand("/context detail");
 
     expect(noteLocalRunId).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBeNull();
@@ -261,7 +326,7 @@ describe("tui command handlers", () => {
       setActivityStatus,
     });
 
-    await handleCommand("/context");
+    await handleCommand("/context detail");
 
     expect(addSystem).toHaveBeenCalledWith("send failed: Error: gateway down");
     expect(setActivityStatus).toHaveBeenLastCalledWith("error");
@@ -288,7 +353,7 @@ describe("tui command handlers", () => {
       isConnected: false,
     });
 
-    await handleCommand("/context");
+    await handleCommand("/context detail");
 
     expect(sendChat).not.toHaveBeenCalled();
     expect(addUser).not.toHaveBeenCalled();

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -163,6 +163,30 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     });
   };
 
+  const openContextModeSelector = () => {
+    const items = [
+      {
+        value: "list",
+        label: "list",
+        description: "Short context breakdown",
+      },
+      {
+        value: "detail",
+        label: "detail",
+        description: "Per-file, per-tool, per-skill, and system prompt size",
+      },
+      {
+        value: "json",
+        label: "json",
+        description: "Machine-readable context report",
+      },
+    ];
+    const selector = createSearchableSelectList(items, 9);
+    openSelector(selector, async (value) => {
+      await sendMessage(`/context ${value}`);
+    });
+  };
+
   const openSessionSelector = async () => {
     try {
       const result = await client.listSessions({
@@ -330,6 +354,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "agents":
         await openAgentSelector();
+        break;
+      case "context":
+        if (!args) {
+          openContextModeSelector();
+        } else {
+          await sendMessage(raw);
+        }
         break;
       case "crestodian":
         chatLog.addSystem(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Submitting bare `/context` in the TUI forwarded directly to Gateway help instead of offering the available context report modes.
- Why it matters: The TUI already has searchable selectors for similar choice flows, and `/context list|detail|json` works once the user knows the modes.
- What changed: Bare `/context` now opens a searchable TUI selector for `list`, `detail`, and `json`; selecting a mode sends `/context <mode>` through the existing Gateway command path.
- What did NOT change (scope boundary): Gateway `/context` semantics, report generation, direct `/context <args>` forwarding, and other TUI selectors were not changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tui/tui-command-handlers.test.ts`
- Scenario the test should lock in: Bare `/context` opens the selector without sending immediately; selecting `detail` sends `/context detail`; `/context list` and `/context help` continue to forward directly.
- Why this is the smallest reliable guardrail: The behavior is isolated to TUI command dispatch and overlay selection wiring.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Submitting bare `/context` in the TUI opens a searchable selector for context report modes. Direct commands such as `/context list`, `/context detail`, `/context json`, and `/context help` continue to go to Gateway unchanged.

## Diagram (if applicable)

```text
Before:
[user submits /context] -> [TUI forwards raw command] -> [Gateway help output]

After:
[user submits /context] -> [TUI mode selector] -> [user selects mode] -> [Gateway receives /context <mode>]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v25.9.0 via `/home/dev-user/.nvm/versions/node/v25.9.0/bin`
- Model/provider: N/A
- Integration/channel (if any): TUI
- Relevant config (redacted): N/A

### Steps

1. In the TUI, submit `/context`.
2. Select `detail` from the searchable selector.
3. Submit `/context list` directly.
4. Submit `/context help` directly.

### Expected

- Bare `/context` opens the selector and does not immediately call `sendChat`.
- Selecting `detail` sends `/context detail`.
- `/context list` and `/context help` forward directly to Gateway.

### Actual

- Covered by local unit tests in `src/tui/tui-command-handlers.test.ts`; behavior matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```text
corepack pnpm exec vitest run src/tui/tui-command-handlers.test.ts
Test Files  1 passed (1)
Tests  21 passed (21)

corepack pnpm exec oxfmt --check src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts
All matched files use the correct format.

corepack pnpm tsgo:core:test
completed successfully

git diff --check
completed successfully
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Bare `/context` selector open, `detail` selection dispatch, direct `/context list`, direct `/context help`, send failure/offline forwarding paths using argumented `/context`.
- Edge cases checked: Bare `/context` does not send immediately; `/context help` remains reachable via Gateway.
- What you did **not** verify: Manual interactive TUI rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Users who expected bare `/context` to show Gateway help now see a mode selector instead.
  - Mitigation: `/context help` continues to forward directly to Gateway so textual help remains available.