### PR TITLE
fix(macos): SwiftFormat wrapMultilineStatementBraces on main lint

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
+++ b/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
@@ -14,7 +14,8 @@ enum ExecAllowlistMatcher {
                     if self.matches(pattern: pattern, target: target) { return entry }
                 } else if pattern != "*",
                           !ExecApprovalHelpers.patternHasPathSelector(rawExecutable),
-                          self.matchesExecutableBasename(pattern: pattern, resolution: resolution) {
+                          self.matchesExecutableBasename(pattern: pattern, resolution: resolution)
+                {
                     return entry
                 }
             case .invalid:

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -618,7 +618,8 @@ enum ExecApprovalsStore {
 
         if !ExecApprovalHelpers.patternHasPathSelector(trimmedPattern),
            !trimmedResolved.isEmpty,
-           case let .valid(migratedPattern) = ExecApprovalHelpers.validateAllowlistPattern(trimmedResolved) {
+           case let .valid(migratedPattern) = ExecApprovalHelpers.validateAllowlistPattern(trimmedResolved)
+        {
             return ExecAllowlistEntry(
                 id: entry.id,
                 pattern: migratedPattern,


### PR DESCRIPTION
## Summary

Two pre-existing SwiftFormat `wrapMultilineStatementBraces` violations on `main` that fail every macos-swift CI run, blocking any PR touching Swift code:

- `apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift:17` — opening brace of multi-line `else if`
- `apps/macos/Sources/OpenClaw/ExecApprovals.swift:621` — opening brace of multi-line `if`

Fix: move the opening `{` to its own line per the SwiftFormat rule. Pure formatting; no behavioral change.

## Why now

Discovered while rebasing PR #53553 (TTS CJK). Once the PR's own lint issues were fixed, macos-swift was still red because of these two pre-existing main violations. Unblocking #53553 plus all future macOS PRs.

## Test plan

- [x] `wrapMultilineStatementBraces` is a deterministic SwiftFormat rule; the fix is exactly what `swiftformat --lint` requested
- [ ] CI macos-swift turns green