### PR TITLE
fix(memory-wiki): skip bridge pruning when public artifacts list is empty

### DIFF
--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+  getMemoryCapabilityRegistration,
   listActiveMemoryPublicArtifacts,
   type MemoryPluginPublicArtifact,
 } from "openclaw/plugin-sdk/memory-host-core";
@@ -248,12 +249,17 @@ export async function syncMemoryWikiBridgeSources(params: {
   }
   const workspaceCount = new Set(publicArtifacts.map((artifact) => artifact.workspaceDir)).size;
 
-  const removedCount = await pruneImportedSourceEntries({
-    vaultRoot: params.config.vault.path,
-    group: "bridge",
-    activeKeys,
-    state,
-  });
+  // Skip pruning when memory-core is not loaded (e.g. CLI context) to avoid
+  // removing all bridge-imported entries. See #68373.
+  const memoryCapability = getMemoryCapabilityRegistration();
+  const removedCount = memoryCapability
+    ? await pruneImportedSourceEntries({
+        vaultRoot: params.config.vault.path,
+        group: "bridge",
+        activeKeys,
+        state,
+      })
+    : 0;
   await writeMemoryWikiSourceSyncState(params.config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;
   const updatedCount = results.filter((result) => result.changed && !result.created).length;

--- a/src/memory-host-sdk/runtime-core.ts
+++ b/src/memory-host-sdk/runtime-core.ts
@@ -20,6 +20,7 @@ export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export {
   buildMemoryPromptSection as buildActiveMemoryPromptSection,
   listActiveMemoryPublicArtifacts,
+  getMemoryCapabilityRegistration,
 } from "../plugins/memory-state.js";
 export { parseAgentSessionKey } from "../routing/session-key.js";
 export type { OpenClawConfig } from "../config/config.js";


### PR DESCRIPTION
## Problem

When memory-core plugin is not loaded (e.g. CLI context), listActiveMemoryPublicArtifacts returns an empty array. The syncMemoryWikiBridgeSources function then calls pruneImportedSourceEntries with an empty activeKeys Set, which removes ALL bridge-imported entries.

This causes a race condition: any CLI wiki command after a gateway bridge import destroys all imported artifacts.

## Fix

Skip pruning when publicArtifacts is empty, since that means memory-core is not loaded and we cannot know the actual artifact list.

Fixes #68373