### PR TITLE
fix(update): omit install-stage dist inventory paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: omit temporary bundled-extension `.openclaw-install-stage` trees from the packaged dist inventory, avoiding false unsafe-path failures on package-manager `.bin` symlinks during `openclaw update`.
 - Windows/native: keep CLI startup and bundled provider plugin loading off
   Windows ESM raw-path failure paths, fixing native onboarding/install smoke on
   Node 24. Thanks @steipete.

--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -97,6 +97,16 @@ describe("package dist inventory", () => {
         ".bin",
         "fxparser",
       );
+      const omittedInstallStageSymlink = path.join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "amazon-bedrock-mantle",
+        ".openclaw-install-stage",
+        "node_modules",
+        ".bin",
+        "anthropic-ai-sdk",
+      );
       const omittedExtensionNodeModuleSymlink = path.join(
         packageRoot,
         "dist",
@@ -122,6 +132,7 @@ describe("package dist inventory", () => {
       await fs.mkdir(path.dirname(omittedRuntimeDepsStamp), { recursive: true });
       await fs.mkdir(path.dirname(omittedRuntimeDepsTempFile), { recursive: true });
       await fs.mkdir(path.dirname(omittedRuntimeDepsTempSymlink), { recursive: true });
+      await fs.mkdir(path.dirname(omittedInstallStageSymlink), { recursive: true });
       await fs.mkdir(path.dirname(omittedExtensionNodeModuleSymlink), { recursive: true });
       await fs.mkdir(path.dirname(omittedExtensionRootAliasSymlink), { recursive: true });
       await fs.mkdir(path.join(packageRoot, "dist", "plugin-sdk"), { recursive: true });
@@ -137,6 +148,7 @@ describe("package dist inventory", () => {
       await fs.writeFile(omittedRuntimeDepsStamp, "{}\n", "utf8");
       await fs.writeFile(omittedRuntimeDepsTempFile, "module.exports = 1;\n", "utf8");
       await fs.symlink(path.join(packageRoot, "color-support.js"), omittedRuntimeDepsTempSymlink);
+      await fs.symlink(path.join(packageRoot, "color-support.js"), omittedInstallStageSymlink);
       await fs.symlink(
         path.join(packageRoot, "color-support.js"),
         omittedExtensionNodeModuleSymlink,

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -26,6 +26,7 @@ const OMITTED_PRIVATE_QA_DIST_PREFIXES = ["dist/qa-runtime-"];
 const OMITTED_DIST_SUBTREE_PATTERNS = [
   /^dist\/extensions\/node_modules(?:\/|$)/u,
   /^dist\/extensions\/[^/]+\/node_modules(?:\/|$)/u,
+  /^dist\/extensions\/[^/]+\/\.openclaw-install-stage(?:\/|$)/u,
   /^dist\/extensions\/[^/]+\/\.openclaw-runtime-deps-[^/]+(?:\/|$)/u,
   /^dist\/extensions\/qa-matrix(?:\/|$)/u,
   new RegExp(`^dist/plugin-sdk/extensions/${LEGACY_QA_LAB_DIR}(?:/|$)`, "u"),


### PR DESCRIPTION
## Summary

`openclaw update` can fail when the package dist inventory walks a bundled extension install staging tree that contains package-manager `.bin` symlinks, e.g.:

`dist/extensions/amazon-bedrock-mantle/.openclaw-install-stage/node_modules/.bin/anthropic-ai-sdk`

This PR:

- Omits `dist/extensions/*/.openclaw-install-stage/...` from package dist inventory collection, matching other temporary bundled-extension runtime-dependency subtrees.
- Adds a regression test covering the staged `.bin` symlink while preserving fail-closed symlink rejection for normal packaged dist entries.
- Adds a changelog note for the updater fix.

## Test plan

- [x] `pnpm vitest run src/infra/package-dist-inventory.test.ts`
- [x] `pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/infra/package-dist-inventory.ts src/infra/package-dist-inventory.test.ts`
