### PR TITLE
Fix configured thinking default in session rows

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -122,6 +122,13 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.4")).toContain("xhigh");
   });
 
+  it("includes xhigh for known GPT-5 models without provider hooks", () => {
+    expect(listThinkingLevels("openai-codex", "gpt-5.5")).toContain("xhigh");
+    expect(listThinkingLevels("openai", "gpt-5.5")).toContain("xhigh");
+    expect(listThinkingLevels("codex", "gpt-5.5")).toContain("xhigh");
+    expect(listThinkingLevels("github-copilot", "gpt-5.4")).toContain("xhigh");
+  });
+
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -42,6 +42,22 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 
+const KNOWN_XHIGH_PROVIDER_IDS = new Set(["openai", "openai-codex", "codex", "github-copilot"]);
+const KNOWN_XHIGH_MODEL_IDS = [
+  "gpt-5.5",
+  "gpt-5.5-pro",
+  "gpt-5.4",
+  "gpt-5.4-pro",
+  "gpt-5.4-mini",
+  "gpt-5.4-nano",
+  "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
+  "gpt-5.2",
+  "gpt-5.2-pro",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex",
+] as const;
+
 export type ThinkingLevelOption = {
   id: ThinkLevel;
   label: string;
@@ -130,6 +146,19 @@ function appendProfileLevel(profile: ResolvedThinkingProfile, id: ThinkLevel) {
   profile.levels = profile.levels.toSorted((a, b) => a.rank - b.rank);
 }
 
+function matchesKnownXHighThinkingModel(provider?: string, modelId?: string): boolean {
+  if (!provider || !KNOWN_XHIGH_PROVIDER_IDS.has(provider)) {
+    return false;
+  }
+  const normalizedModelId = normalizeOptionalLowercaseString(modelId);
+  if (!normalizedModelId) {
+    return false;
+  }
+  return KNOWN_XHIGH_MODEL_IDS.some(
+    (candidate) => normalizedModelId === candidate || normalizedModelId.startsWith(`${candidate}-`),
+  );
+}
+
 export function resolveThinkingProfile(params: {
   provider?: string | null;
   model?: string | null;
@@ -178,7 +207,8 @@ export function resolveThinkingProfile(params: {
     resolveProviderXHighThinking({
       provider: context.normalizedProvider,
       context: policyContext,
-    }) === true
+    }) === true ||
+    matchesKnownXHighThinkingModel(context.normalizedProvider, policyContext.modelId)
   ) {
     appendProfileLevel(profile, "xhigh");
   }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -139,6 +139,38 @@ describe("gateway session utils", () => {
     );
   });
 
+  test("session defaults prefer configured agent thinking default", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push({
+      pluginId: "test",
+      source: "test",
+      provider: {
+        id: "openai-codex",
+        label: "OpenAI Codex",
+        auth: [],
+        resolveThinkingProfile: () => ({
+          levels: [{ id: "off" }, { id: "medium" }, { id: "high" }],
+          defaultLevel: "off",
+        }),
+      },
+    });
+    setActivePluginRegistry(registry);
+
+    const defaults = getSessionDefaults({
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+          thinkingDefault: "high",
+        },
+        list: [{ id: "main", default: true, thinkingDefault: "xhigh" }],
+      },
+    } as OpenClawConfig);
+
+    expect(defaults.thinkingDefault).toBe("xhigh");
+    expect(defaults.thinkingLevels).toContainEqual({ id: "xhigh", label: "xhigh" });
+    expect(defaults.thinkingOptions).toContain("xhigh");
+  });
+
   test("classifySessionKey respects chat type + prefixes", () => {
     expect(classifySessionKey("global")).toBe("global");
     expect(classifySessionKey("unknown")).toBe("unknown");
@@ -905,6 +937,37 @@ describe("listSessionsFromStore selected model display", () => {
 
     expect(result.sessions[0]?.modelProvider).toBe("anthropic");
     expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
+  });
+
+  test("shows configured thinking default for inherited session rows", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+          thinkingDefault: "medium",
+        },
+        list: [{ id: "main", default: true, thinkingDefault: "xhigh" }],
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          modelProvider: "openai-codex",
+          model: "gpt-5.5",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.thinkingLevel).toBeUndefined();
+    expect(result.sessions[0]?.thinkingDefault).toBe("xhigh");
+    expect(result.sessions[0]?.thinkingLevels).toContainEqual({ id: "xhigh", label: "xhigh" });
+    expect(result.sessions[0]?.thinkingOptions).toContain("xhigh");
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -33,6 +33,7 @@ import {
 } from "../agents/subagent-run-liveness.js";
 import {
   listThinkingLevelOptions,
+  normalizeThinkLevel,
   resolveThinkingDefaultForModel,
 } from "../auto-reply/thinking.js";
 import { loadConfig } from "../config/config.js";
@@ -1048,18 +1049,58 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     cfg.agents?.defaults?.contextTokens ??
     lookupContextTokens(resolved.model, { allowAsyncLoad: false }) ??
     DEFAULT_CONTEXT_TOKENS;
-  const thinkingLevels = listThinkingLevelOptions(resolved.provider, resolved.model);
+  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+  const configuredThinkingDefault = resolveConfiguredThinkingDefault(cfg, defaultAgentId);
+  const thinkingLevels = includeThinkingLevelOptions(
+    listThinkingLevelOptions(resolved.provider, resolved.model),
+    configuredThinkingDefault,
+  );
   return {
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,
     contextTokens: contextTokens ?? null,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
-      provider: resolved.provider,
-      model: resolved.model,
-    }),
+    thinkingDefault:
+      configuredThinkingDefault ??
+      resolveThinkingDefaultForModel({
+        provider: resolved.provider,
+        model: resolved.model,
+      }),
   };
+}
+
+function resolveConfiguredThinkingDefault(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): string | undefined {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const agentDefault = cfg.agents?.list?.find(
+    (entry) => normalizeAgentId(entry?.id) === normalizedAgentId,
+  )?.thinkingDefault;
+  return agentDefault ?? cfg.agents?.defaults?.thinkingDefault;
+}
+
+function includeThinkingLevelOptions(
+  levels: ReturnType<typeof listThinkingLevelOptions>,
+  ...rawLevels: Array<string | undefined>
+): ReturnType<typeof listThinkingLevelOptions> {
+  const options = [...levels];
+  for (const raw of rawLevels) {
+    const level = normalizeThinkLevel(raw);
+    if (!level) {
+      continue;
+    }
+    const exists = options.some((option) => {
+      const id = normalizeThinkLevel(option.id);
+      const label = normalizeThinkLevel(option.label);
+      return id === level || label === level;
+    });
+    if (!exists) {
+      options.push({ id: level, label: level });
+    }
+  }
+  return options;
 }
 
 export function resolveSessionModelRef(
@@ -1401,7 +1442,17 @@ export function buildGatewaySessionRow(params: {
   const rowModel = selectedModel?.model ?? model;
   const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
   const thinkingModel = rowModel ?? DEFAULT_MODEL;
-  const thinkingLevels = listThinkingLevelOptions(thinkingProvider, thinkingModel);
+  const thinkingDefault =
+    resolveConfiguredThinkingDefault(cfg, sessionAgentId) ??
+    resolveThinkingDefaultForModel({
+      provider: thinkingProvider,
+      model: thinkingModel,
+    });
+  const thinkingLevels = includeThinkingLevelOptions(
+    listThinkingLevelOptions(thinkingProvider, thinkingModel),
+    thinkingDefault,
+    entry?.thinkingLevel,
+  );
 
   return {
     key,
@@ -1429,10 +1480,7 @@ export function buildGatewaySessionRow(params: {
     thinkingLevel: entry?.thinkingLevel,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
-      provider: thinkingProvider,
-      model: thinkingModel,
-    }),
+    thinkingDefault,
     fastMode: entry?.fastMode,
     verboseLevel: entry?.verboseLevel,
     traceLevel: entry?.traceLevel,

--- a/src/plugins/provider-thinking.test.ts
+++ b/src/plugins/provider-thinking.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  resolveProviderThinkingProfile,
+  resolveProviderXHighThinking,
+} from "./provider-thinking.js";
+
+const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
+
+type TestGlobal = typeof globalThis & {
+  [PLUGIN_REGISTRY_STATE]?: {
+    activeRegistry?: {
+      providers?: Array<{
+        provider: {
+          id: string;
+          supportsXHighThinking?: () => boolean | undefined;
+          resolveThinkingProfile?: () =>
+            | { levels: Array<{ id: "off" | "high" | "xhigh" }> }
+            | null
+            | undefined;
+        };
+      }>;
+    };
+  };
+};
+
+describe("provider thinking hooks", () => {
+  afterEach(() => {
+    delete (globalThis as TestGlobal)[PLUGIN_REGISTRY_STATE];
+  });
+
+  test("continues past matching providers without thinking hooks", () => {
+    (globalThis as TestGlobal)[PLUGIN_REGISTRY_STATE] = {
+      activeRegistry: {
+        providers: [
+          { provider: { id: "openai-codex" } },
+          {
+            provider: {
+              id: "openai-codex",
+              supportsXHighThinking: () => true,
+              resolveThinkingProfile: () => ({
+                levels: [{ id: "off" }, { id: "high" }, { id: "xhigh" }],
+              }),
+            },
+          },
+        ],
+      },
+    };
+
+    expect(
+      resolveProviderXHighThinking({
+        provider: "openai-codex",
+        context: { provider: "openai-codex", modelId: "gpt-5.5" },
+      }),
+    ).toBe(true);
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "openai-codex",
+        context: { provider: "openai-codex", modelId: "gpt-5.5" },
+      }),
+    ).toEqual({ levels: [{ id: "off" }, { id: "high" }, { id: "xhigh" }] });
+  });
+});

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -39,17 +39,15 @@ function matchesProviderId(provider: ThinkingProviderPlugin, providerId: string)
   return (provider.aliases ?? []).some((alias) => normalizeProviderId(alias) === normalized);
 }
 
-function resolveActiveThinkingProvider(providerId: string): ThinkingProviderPlugin | undefined {
+function listActiveThinkingProviders(providerId: string): ThinkingProviderPlugin[] {
   const state = (
     globalThis as typeof globalThis & { [PLUGIN_REGISTRY_STATE]?: ThinkingRegistryState }
   )[PLUGIN_REGISTRY_STATE];
-  const activeProvider = state?.activeRegistry?.providers?.find((entry) => {
-    return matchesProviderId(entry.provider, providerId);
-  })?.provider;
-  if (activeProvider) {
-    return activeProvider;
-  }
-  return undefined;
+  return (
+    state?.activeRegistry?.providers
+      ?.filter((entry) => matchesProviderId(entry.provider, providerId))
+      .map((entry) => entry.provider) ?? []
+  );
 }
 
 type ThinkingHookParams<TContext> = {
@@ -60,25 +58,47 @@ type ThinkingHookParams<TContext> = {
 export function resolveProviderBinaryThinking(
   params: ThinkingHookParams<ProviderThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.isBinaryThinking?.(params.context);
+  for (const provider of listActiveThinkingProviders(params.provider)) {
+    const result = provider.isBinaryThinking?.(params.context);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
 }
 
 export function resolveProviderXHighThinking(
   params: ThinkingHookParams<ProviderThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.supportsXHighThinking?.(params.context);
+  for (const provider of listActiveThinkingProviders(params.provider)) {
+    const result = provider.supportsXHighThinking?.(params.context);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
 }
 
 export function resolveProviderThinkingProfile(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.resolveThinkingProfile?.(params.context);
+  for (const provider of listActiveThinkingProviders(params.provider)) {
+    const result = provider.resolveThinkingProfile?.(params.context);
+    if (result !== undefined && result !== null) {
+      return result;
+    }
+  }
+  return undefined;
 }
 
 export function resolveProviderDefaultThinkingLevel(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.resolveDefaultThinkingLevel?.(
-    params.context,
-  );
+  for (const provider of listActiveThinkingProviders(params.provider)) {
+    const result = provider.resolveDefaultThinkingLevel?.(params.context);
+    if (result !== undefined && result !== null) {
+      return result;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- make gateway session defaults prefer configured `agents.list[].thinkingDefault` / `agents.defaults.thinkingDefault` before provider/model defaults
- make session rows expose the effective inherited thinking default and include configured/current levels in `thinkingLevels`/`thinkingOptions`, so `Default (xhigh)` stays selectable instead of disappearing after a user changes the dropdown
- make provider thinking hook resolution continue past matching provider entries that do not implement thinking hooks
- keep known GPT-5.x/OpenAI Codex models reporting `xhigh` even when provider runtime hooks are unavailable on the session/defaults path
- keep explicit per-session `thinkingLevel` behavior unchanged

## Why
Users can already configure default thinking with `agents.defaults.thinkingDefault` or per-agent `agents.list[].thinkingDefault`. Runtime/status paths honor those values, but some session/default surfaces still exposed only provider/model defaults or a truncated base option list. That can make the web chat dropdown show misleading labels like `Default (off)`, drop `xhigh` from the menu after changing values, or reject `xhigh` for `openai-codex/gpt-5.5` even though it is the configured inherited default.

This also closes the gap left after the 2026.4.24 dynamic thinking-options change: provider-owned dynamic modes are still used when hooks/catalog rows are available, but configured/current levels remain visible and known Codex GPT-5.x xhigh support is preserved when those hooks are not present on this path.

## Tests
- `./node_modules/.bin/vitest run src/auto-reply/thinking.test.ts src/gateway/session-utils.test.ts src/plugins/provider-thinking.test.ts`