### PR TITLE
Add session sleep wake tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/sessions: add `sessions_sleep` so agents can persist lightweight
+  self-wake timers for long-running polling loops without shell sleeps or
+  background daemons.
 - CLI/image generation: expose generic `--background` on
   `openclaw infer image generate` and `openclaw infer image edit`, keep
   `--openai-background` as an OpenAI alias, and let fal image generation honor

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -886,6 +886,15 @@
         "message"
       ]
     },
+    "sessions_sleep": {
+      "emoji": "⏱️",
+      "title": "Sleep",
+      "detailKeys": [
+        "wakeAfterSeconds",
+        "dedupeKey",
+        "message"
+      ]
+    },
     "tts": {
       "emoji": "🔊",
       "title": "TTS",

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -101,6 +101,25 @@ assistant text once instead of replaying both streamed/intermediate text payload
 and the final answer. Media and structured Discord payloads are still delivered
 as separate payloads so attachments and components are not dropped.
 
+### Agent-owned sleeps
+
+Session agents can use the `sessions_sleep` tool to schedule their own
+continuation turns without starting shell sleeps or external polling daemons.
+The tool stores a one-shot cron job bound to the current session, wakes the
+session at the requested time, runs with lightweight context by default, and
+uses `delivery: none` so the agent remains responsible for sending the final
+user-facing reply.
+
+Use a stable `dedupeKey` for polling loops. Calling `sessions_sleep` again with
+the same key refreshes the existing timer instead of creating duplicate wakeups.
+Keep the wake prompt self-contained and small, with only the run id, next check
+action, and the result-delivery instruction needed for that continuation.
+
+Recommended long-running research cadence:
+
+- Ask Pro: sleep 10 minutes after submission, then check every 5 minutes.
+- Deep Research: sleep 30 minutes after submission, then check every 10 minutes.
+
 ### Payload options for isolated jobs
 
 - `--message`: prompt text (required for isolated)

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -30,6 +30,7 @@ import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
+import { createSessionsSleepTool } from "./tools/sessions-sleep-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
@@ -291,6 +292,10 @@ export function createOpenClawTools(
             sandboxed: options?.sandboxed,
             config: resolvedConfig,
             callGateway: openClawToolsDeps.callGateway,
+          }),
+          createSessionsSleepTool({
+            agentSessionKey: options?.agentSessionKey,
+            config: resolvedConfig,
           }),
           createSessionsSpawnTool({
             agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -160,6 +160,7 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "sessions_history",
   "sessions_list",
   "sessions_send",
+  "sessions_sleep",
   "sessions_spawn",
   "subagents",
   "tts",

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -21,6 +21,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "sessions_list",
   "sessions_history",
   "sessions_send",
+  "sessions_sleep",
   "sessions_spawn",
   "sessions_yield",
   "subagents",

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -271,6 +271,22 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("reclaims incomplete lock files after the short startup-recovery grace", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      await fs.writeFile(lockPath, "", "utf8");
+      const incompleteDate = new Date(Date.now() - 5_000);
+      await fs.utimes(lockPath, incompleteDate, incompleteDate);
+
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 500,
+        staleMs: 60_000,
+      });
+      await lock.release();
+      await expect(fs.access(lockPath)).rejects.toThrow();
+    });
+  });
+
   it("watchdog releases stale in-process locks", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -46,6 +46,7 @@ const DEFAULT_STALE_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_HOLD_MS = 5 * 60 * 1000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
+const DEFAULT_INCOMPLETE_LOCK_RECLAIM_MS = 2_000;
 const MAX_LOCK_HOLD_MS = 2_147_000_000;
 
 type CleanupState = {
@@ -394,7 +395,9 @@ async function shouldReclaimContendedLockFile(
   try {
     const stat = await fs.stat(lockPath);
     const ageMs = Math.max(0, nowMs - stat.mtimeMs);
-    return ageMs > staleMs;
+    const mtimeStaleMs =
+      details.pid === null ? Math.min(staleMs, DEFAULT_INCOMPLETE_LOCK_RECLAIM_MS) : staleMs;
+    return ageMs > mtimeStaleMs;
   } catch (error) {
     const code = (error as { code?: string } | null)?.code;
     return code !== "ENOENT";

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -166,6 +166,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "sessions_sleep",
+    label: "sessions_sleep",
+    description: "Sleep current session and resume later",
+    sectionId: "sessions",
+    profiles: ["coding", "messaging"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_spawn",
     label: "sessions_spawn",
     description: SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -562,6 +562,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Yield",
       detailKeys: ["message"],
     },
+    sessions_sleep: {
+      emoji: "⏱️",
+      title: "Sleep",
+      detailKeys: ["wakeAfterSeconds", "dedupeKey", "message"],
+    },
     tts: {
       emoji: "🔊",
       title: "TTS",

--- a/src/agents/tools/sessions-sleep-tool.test.ts
+++ b/src/agents/tools/sessions-sleep-tool.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayCallOptions } from "./gateway.js";
+import { createSessionsSleepTool } from "./sessions-sleep-tool.js";
+
+describe("sessions_sleep tool", () => {
+  function createTool(params?: {
+    sessionKey?: string;
+    nowMs?: number;
+    calls?: unknown[];
+    listJobs?: unknown[];
+  }) {
+    const calls = params?.calls ?? [];
+    const callGatewayTool = async <T = Record<string, unknown>>(
+      method: string,
+      _opts: GatewayCallOptions,
+      payload?: unknown,
+    ): Promise<T> => {
+      calls.push({ method, payload });
+      if (method === "cron.list") {
+        return { jobs: params?.listJobs ?? [] } as T;
+      }
+      if (method === "cron.update") {
+        return { id: "job-existing", ...(payload as Record<string, unknown>) } as T;
+      }
+      return { id: "job-new", ...(payload as Record<string, unknown>) } as T;
+    };
+    const tool = createSessionsSleepTool(
+      {
+        agentSessionKey: params?.sessionKey ?? "agent:main:telegram:default:direct:test-user",
+        config: { session: { mainKey: "main" } },
+      },
+      {
+        callGatewayTool,
+        nowMs: () => params?.nowMs ?? 1_000,
+      },
+    );
+    return { tool, callGatewayTool, calls };
+  }
+
+  it("schedules a lightweight current-session one-shot wake", async () => {
+    const { tool, calls } = createTool({ nowMs: 10_000 });
+    const result = await tool.execute("call-1", {
+      wakeAfterSeconds: 600,
+      message: "Continue Ask Pro run askpro_1.",
+      dedupeKey: "askpro:askpro_1",
+      toolsAllow: ["browser", "message", "sessions_sleep"],
+    });
+
+    expect(result.details).toMatchObject({
+      status: "scheduled",
+      action: "created",
+      wakeAfterSeconds: 600,
+      dedupeKey: "askpro:askpro_1",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      method: "cron.list",
+      payload: { includeDisabled: true, limit: 200, query: "askpro:askpro_1" },
+    });
+    expect(calls[1]).toMatchObject({
+      method: "cron.add",
+      payload: {
+        name: "Session sleep: askpro:askpro_1",
+        description: "openclaw:sessions_sleep:askpro:askpro_1",
+        enabled: true,
+        deleteAfterRun: true,
+        schedule: { kind: "at", at: "1970-01-01T00:10:10.000Z" },
+        sessionTarget: "session:agent:main:telegram:default:direct:test-user",
+        wakeMode: "now",
+        sessionKey: "agent:main:telegram:default:direct:test-user",
+        agentId: "main",
+        payload: {
+          kind: "agentTurn",
+          message: "Continue Ask Pro run askpro_1.",
+          timeoutSeconds: 900,
+          lightContext: true,
+          toolsAllow: ["browser", "message", "sessions_sleep"],
+        },
+        delivery: { mode: "none" },
+        failureAlert: false,
+      },
+    });
+  });
+
+  it("refreshes an existing deduped sleep instead of adding a duplicate", async () => {
+    const { tool, calls } = createTool({
+      listJobs: [{ id: "job-existing", description: "openclaw:sessions_sleep:askpro:askpro_1" }],
+    });
+
+    const result = await tool.execute("call-1", {
+      wakeAfterSeconds: 300,
+      message: "Check again.",
+      dedupeKey: "askpro:askpro_1",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "scheduled",
+      action: "updated",
+      dedupeKey: "askpro:askpro_1",
+    });
+    expect(calls.map((call) => (call as { method: string }).method)).toEqual([
+      "cron.list",
+      "cron.update",
+    ]);
+    expect(calls[1]).toMatchObject({
+      payload: {
+        id: "job-existing",
+        patch: {
+          schedule: { kind: "at", at: "1970-01-01T00:05:01.000Z" },
+          payload: {
+            kind: "agentTurn",
+            message: "Check again.",
+            timeoutSeconds: 900,
+            lightContext: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("returns an error when no current session exists", async () => {
+    const callGatewayMock = vi.fn();
+    const callGatewayTool = async <T = Record<string, unknown>>(
+      method: string,
+      gatewayOpts: GatewayCallOptions,
+      payload?: unknown,
+    ): Promise<T> => {
+      callGatewayMock(method, gatewayOpts, payload);
+      return {} as T;
+    };
+    const tool = createSessionsSleepTool({}, { callGatewayTool });
+    const result = await tool.execute("call-1", {
+      wakeAfterSeconds: 60,
+      message: "Wake up.",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "No session context",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured error for invalid sleep params", async () => {
+    const { tool, calls } = createTool();
+    const result = await tool.execute("call-1", {
+      message: "Wake up.",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "wakeAfterSeconds required",
+    });
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/agents/tools/sessions-sleep-tool.ts
+++ b/src/agents/tools/sessions-sleep-tool.ts
@@ -1,0 +1,247 @@
+import { Type } from "typebox";
+import { loadConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { SESSIONS_SLEEP_DESCRIPTION_PREFIX } from "../../cron/session-sleep.js";
+import { assertSafeCronSessionTargetId } from "../../cron/session-target.js";
+import type { CronJob } from "../../cron/types.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
+import { optionalStringEnum } from "../schema/typebox.js";
+import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
+import { callGatewayTool, readGatewayCallOptions, type GatewayCallOptions } from "./gateway.js";
+
+const DEFAULT_SLEEP_TIMEOUT_SECONDS = 900;
+const MAX_SLEEP_SECONDS = 30 * 24 * 60 * 60;
+
+const SessionsSleepToolSchema = Type.Object(
+  {
+    wakeAfterSeconds: Type.Number({
+      description: "Seconds from now before this session should wake for the continuation turn.",
+      minimum: 1,
+    }),
+    message: Type.String({
+      description:
+        "Self-contained continuation prompt for the wake turn. Keep it short and include the exact state needed to continue.",
+    }),
+    dedupeKey: Type.Optional(
+      Type.String({
+        description:
+          "Stable key for the sleep being scheduled. Reusing the key refreshes the existing timer instead of creating duplicates.",
+      }),
+    ),
+    name: Type.Optional(Type.String({ description: "Optional human-readable timer name." })),
+    toolsAllow: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Optional minimal tool allow-list for the wake turn, e.g. ['browser','message','sessions_sleep'].",
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description:
+          "Optional timeout for the wake turn. Defaults to a bounded timeout suitable for polling.",
+        minimum: 0,
+      }),
+    ),
+    thinking: Type.Optional(
+      Type.String({ description: "Optional thinking level for the wake turn." }),
+    ),
+    lightContext: Type.Optional(
+      Type.Boolean({
+        description:
+          "Whether to skip full workspace bootstrap context on the wake turn. Defaults to true for efficient polling.",
+      }),
+    ),
+    gatewayUrl: Type.Optional(Type.String()),
+    gatewayToken: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Number()),
+    onDuplicate: optionalStringEnum(["update", "add"] as const, {
+      description:
+        "When dedupeKey matches an existing job, update it or add another job. Default: update.",
+    }),
+  },
+  { additionalProperties: true },
+);
+
+type GatewayToolCaller = typeof callGatewayTool;
+
+type SessionsSleepToolDeps = {
+  callGatewayTool?: GatewayToolCaller;
+  nowMs?: () => number;
+};
+
+type CronListResult = {
+  jobs?: unknown[];
+};
+
+function normalizeWakeAfterSeconds(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("wakeAfterSeconds required");
+  }
+  return Math.min(MAX_SLEEP_SECONDS, Math.max(1, Math.floor(value)));
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeToolsAllow(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const tools = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  return tools.length > 0 ? tools : undefined;
+}
+
+function normalizeTimeoutSeconds(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_SLEEP_TIMEOUT_SECONDS;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function buildSleepDescription(dedupeKey: string): string {
+  return `${SESSIONS_SLEEP_DESCRIPTION_PREFIX}${dedupeKey}`;
+}
+
+function readMatchingSleepJob(jobs: unknown[], dedupeKey: string): CronJob | null {
+  const description = buildSleepDescription(dedupeKey);
+  for (const job of jobs) {
+    if (!job || typeof job !== "object") {
+      continue;
+    }
+    const candidate = job as Partial<CronJob>;
+    if (candidate.description === description && typeof candidate.id === "string") {
+      return candidate as CronJob;
+    }
+  }
+  return null;
+}
+
+function sleepName(params: { explicitName?: string; dedupeKey?: string }): string {
+  if (params.explicitName) {
+    return params.explicitName;
+  }
+  if (params.dedupeKey) {
+    return `Session sleep: ${params.dedupeKey.slice(0, 64)}`;
+  }
+  return "Session sleep";
+}
+
+export function createSessionsSleepTool(
+  opts?: {
+    agentSessionKey?: string;
+    config?: OpenClawConfig;
+  },
+  deps?: SessionsSleepToolDeps,
+): AnyAgentTool {
+  const callGateway = deps?.callGatewayTool ?? callGatewayTool;
+  const nowMs = deps?.nowMs ?? Date.now;
+  return {
+    label: "Session Sleep",
+    name: "sessions_sleep",
+    description:
+      "Sleep this session and wake it later with a self-contained continuation prompt. Use this for efficient long-running polling instead of shell sleep or busy polling. The wake turn defaults to lightweight context and no fallback delivery; the agent must send any user-facing result itself. For Ask Pro, sleep 10 minutes after submit, then 5 minutes between checks. For Deep Research, sleep 30 minutes after submit, then 10 minutes between checks.",
+    parameters: SessionsSleepToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = opts?.agentSessionKey?.trim();
+      if (!sessionKey) {
+        return jsonResult({ status: "error", error: "No session context" });
+      }
+
+      let wakeAfterSeconds: number;
+      let message: string;
+      try {
+        wakeAfterSeconds = normalizeWakeAfterSeconds(params.wakeAfterSeconds);
+        message = readStringParam(params, "message", { required: true });
+      } catch (error) {
+        return jsonResult({
+          status: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      const dedupeKey = normalizeOptionalString(params.dedupeKey);
+      const name = sleepName({
+        explicitName: normalizeOptionalString(params.name),
+        dedupeKey,
+      });
+      const wakeAt = new Date(nowMs() + wakeAfterSeconds * 1000).toISOString();
+      const cfg = opts?.config ?? loadConfig();
+      const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const sessionTarget = `session:${assertSafeCronSessionTargetId(sessionKey)}`;
+      const gatewayOpts: GatewayCallOptions = {
+        ...readGatewayCallOptions(params),
+        timeoutMs:
+          typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+            ? params.timeoutMs
+            : 60_000,
+      };
+      const payload: Record<string, unknown> = {
+        kind: "agentTurn",
+        message,
+        timeoutSeconds: normalizeTimeoutSeconds(params.timeoutSeconds),
+        lightContext: params.lightContext === undefined ? true : params.lightContext === true,
+      };
+      const toolsAllow = normalizeToolsAllow(params.toolsAllow);
+      if (toolsAllow) {
+        payload.toolsAllow = toolsAllow;
+      }
+      const thinking = normalizeOptionalString(params.thinking);
+      if (thinking) {
+        payload.thinking = thinking;
+      }
+
+      const baseJob: Record<string, unknown> = {
+        name,
+        enabled: true,
+        deleteAfterRun: true,
+        schedule: { kind: "at", at: wakeAt },
+        sessionTarget,
+        wakeMode: "now",
+        sessionKey,
+        agentId,
+        payload,
+        delivery: { mode: "none" },
+        failureAlert: false,
+      };
+      if (dedupeKey) {
+        baseJob.description = buildSleepDescription(dedupeKey);
+      }
+
+      if (dedupeKey && params.onDuplicate !== "add") {
+        const list = (await callGateway("cron.list", gatewayOpts, {
+          includeDisabled: true,
+          limit: 200,
+          query: dedupeKey,
+        })) as CronListResult;
+        const existing = readMatchingSleepJob(Array.isArray(list.jobs) ? list.jobs : [], dedupeKey);
+        if (existing) {
+          const updated = await callGateway("cron.update", gatewayOpts, {
+            id: existing.id,
+            patch: baseJob,
+          });
+          return jsonResult({
+            status: "scheduled",
+            action: "updated",
+            wakeAt,
+            wakeAfterSeconds,
+            dedupeKey,
+            job: updated,
+          });
+        }
+      }
+
+      const created = await callGateway("cron.add", gatewayOpts, baseJob);
+      return jsonResult({
+        status: "scheduled",
+        action: "created",
+        wakeAt,
+        wakeAfterSeconds,
+        ...(dedupeKey ? { dedupeKey } : {}),
+        job: created,
+      });
+    },
+  };
+}

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -23,6 +23,7 @@ describe("CronService restart catch-up", () => {
     enqueueSystemEvent: ReturnType<typeof vi.fn>;
     requestHeartbeatNow: ReturnType<typeof vi.fn>;
     onEvent?: ReturnType<typeof vi.fn>;
+    runIsolatedAgentJob?: ReturnType<typeof vi.fn>;
   }) {
     return new CronService({
       storePath: params.storePath,
@@ -30,7 +31,9 @@ describe("CronService restart catch-up", () => {
       log: noopLogger,
       enqueueSystemEvent: params.enqueueSystemEvent as never,
       requestHeartbeatNow: params.requestHeartbeatNow as never,
-      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })) as never,
+      runIsolatedAgentJob:
+        (params.runIsolatedAgentJob as never) ??
+        (vi.fn(async () => ({ status: "ok" as const })) as never),
       onEvent: params.onEvent as ((evt: CronEvent) => void) | undefined,
     });
   }
@@ -57,12 +60,14 @@ describe("CronService restart catch-up", () => {
       enqueueSystemEvent: ReturnType<typeof vi.fn>;
       requestHeartbeatNow: ReturnType<typeof vi.fn>;
       onEvent: ReturnType<typeof vi.fn>;
+      runIsolatedAgentJob: ReturnType<typeof vi.fn>;
     }) => Promise<void>,
   ) {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeatNow = vi.fn();
     const onEvent = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
 
     await writeStoreJobs(store.storePath, jobs);
 
@@ -71,11 +76,12 @@ describe("CronService restart catch-up", () => {
       enqueueSystemEvent,
       requestHeartbeatNow,
       onEvent,
+      runIsolatedAgentJob,
     });
 
     try {
       await cron.start();
-      await run({ cron, enqueueSystemEvent, requestHeartbeatNow, onEvent });
+      await run({ cron, enqueueSystemEvent, requestHeartbeatNow, onEvent, runIsolatedAgentJob });
     } finally {
       cron.stop();
       await store.cleanup();
@@ -251,6 +257,98 @@ describe("CronService restart catch-up", () => {
             status: "error",
             error: "cron: job interrupted by gateway restart",
             runAtMs: staleRunningAt,
+          }),
+        );
+      },
+    );
+  });
+
+  it("requeues an interrupted sessions_sleep one-shot once on startup", async () => {
+    const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
+    const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");
+
+    await withRestartedCron(
+      [
+        {
+          id: "restart-stale-session-sleep",
+          name: "session sleep stale marker",
+          description: "openclaw:sessions_sleep:askpro:run-1",
+          enabled: true,
+          deleteAfterRun: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T16:30:00.000Z"),
+          schedule: { kind: "at", at: "2025-12-13T16:00:00.000Z" },
+          sessionTarget: "session:agent:main:bluebubbles:default:direct:+15551234567",
+          wakeMode: "now",
+          payload: { kind: "agentTurn", message: "Check Ask Pro run run-1." },
+          delivery: { mode: "none" },
+          state: {
+            nextRunAtMs: dueAt,
+            runningAtMs: staleRunningAt,
+          },
+        },
+      ],
+      async ({ cron, runIsolatedAgentJob, onEvent }) => {
+        expect(noopLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ jobId: "restart-stale-session-sleep" }),
+          "cron: requeuing interrupted sessions_sleep wake on startup",
+        );
+        expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+        expect(onEvent).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: "finished",
+            jobId: "restart-stale-session-sleep",
+            status: "error",
+          }),
+        );
+
+        const listedJobs = await cron.list({ includeDisabled: true });
+        expect(listedJobs.find((job) => job.id === "restart-stale-session-sleep")).toBeUndefined();
+      },
+    );
+  });
+
+  it("disables an interrupted sessions_sleep one-shot after its startup retry was already used", async () => {
+    const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
+    const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");
+
+    await withRestartedCron(
+      [
+        {
+          id: "restart-stale-session-sleep-retried",
+          name: "session sleep retried stale marker",
+          description: "openclaw:sessions_sleep:askpro:run-1",
+          enabled: true,
+          deleteAfterRun: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T16:30:00.000Z"),
+          schedule: { kind: "at", at: "2025-12-13T16:00:00.000Z" },
+          sessionTarget: "session:agent:main:bluebubbles:default:direct:+15551234567",
+          wakeMode: "now",
+          payload: { kind: "agentTurn", message: "Check Ask Pro run run-1." },
+          delivery: { mode: "none" },
+          state: {
+            nextRunAtMs: dueAt,
+            runningAtMs: staleRunningAt,
+            startupInterruptedRetryCount: 1,
+          },
+        },
+      ],
+      async ({ cron, runIsolatedAgentJob, onEvent }) => {
+        expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+
+        const listedJobs = await cron.list({ includeDisabled: true });
+        const updated = listedJobs.find((job) => job.id === "restart-stale-session-sleep-retried");
+        expect(updated?.enabled).toBe(false);
+        expect(updated?.state.runningAtMs).toBeUndefined();
+        expect(updated?.state.lastStatus).toBe("error");
+        expect(updated?.state.nextRunAtMs).toBeUndefined();
+        expect(updated?.state.lastError).toBe("cron: job interrupted by gateway restart");
+        expect(onEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: "finished",
+            jobId: "restart-stale-session-sleep-retried",
+            status: "error",
           }),
         );
       },

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -7,6 +7,7 @@ import {
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
 import { createCronExecutionId } from "../run-id.js";
+import { SESSIONS_SLEEP_DESCRIPTION_PREFIX } from "../session-sleep.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
   applyJobPatch,
@@ -43,6 +44,8 @@ import {
 } from "./timer.js";
 
 const STARTUP_INTERRUPTED_ERROR = "cron: job interrupted by gateway restart";
+const STARTUP_SESSION_SLEEP_REQUEUED =
+  "cron: sessions_sleep wake interrupted by gateway restart; requeued once";
 
 type InterruptedStartupRun = {
   jobId: string;
@@ -89,6 +92,43 @@ function markInterruptedStartupRun(params: {
     runAtMs: runningAtMs,
     durationMs: job.state.lastDurationMs,
   };
+}
+
+function requeueInterruptedSessionSleepStartupRun(params: {
+  state: CronServiceState;
+  job: CronJob;
+  runningAtMs: number;
+  nowMs: number;
+}): boolean {
+  const { job, runningAtMs, nowMs } = params;
+  if (
+    job.schedule.kind !== "at" ||
+    typeof job.description !== "string" ||
+    !job.description.startsWith(SESSIONS_SLEEP_DESCRIPTION_PREFIX)
+  ) {
+    return false;
+  }
+  const retryCount =
+    typeof job.state.startupInterruptedRetryCount === "number" &&
+    Number.isFinite(job.state.startupInterruptedRetryCount)
+      ? Math.max(0, Math.floor(job.state.startupInterruptedRetryCount))
+      : 0;
+  if (retryCount >= 1) {
+    return false;
+  }
+
+  params.state.deps.log.warn(
+    { jobId: job.id, runningAtMs },
+    "cron: requeuing interrupted sessions_sleep wake on startup",
+  );
+
+  job.enabled = true;
+  job.state.runningAtMs = undefined;
+  job.state.nextRunAtMs = nowMs;
+  job.state.lastError = STARTUP_SESSION_SLEEP_REQUEUED;
+  job.state.startupInterruptedRetryCount = retryCount + 1;
+  job.updatedAtMs = nowMs;
+  return true;
 }
 
 function mergeManualRunSnapshotAfterReload(params: {
@@ -149,6 +189,17 @@ export async function start(state: CronServiceState) {
       job.state ??= {};
       if (typeof job.state.runningAtMs === "number") {
         const nowMs = state.deps.nowMs();
+        if (
+          requeueInterruptedSessionSleepStartupRun({
+            state,
+            job,
+            runningAtMs: job.state.runningAtMs,
+            nowMs,
+          })
+        ) {
+          markedAnyInterruptedRun = true;
+          continue;
+        }
         const interrupted = markInterruptedStartupRun({
           state,
           job,

--- a/src/cron/session-sleep.ts
+++ b/src/cron/session-sleep.ts
@@ -1,0 +1,1 @@
+export const SESSIONS_SLEEP_DESCRIPTION_PREFIX = "openclaw:sessions_sleep:";

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -157,6 +157,8 @@ export type CronJobState = {
   lastFailureAlertAtMs?: number;
   /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */
   scheduleErrorCount?: number;
+  /** Internal restart-recovery guard for idempotent one-shot session sleeps. */
+  startupInterruptedRetryCount?: number;
   /** Explicit delivery outcome, separate from execution outcome. */
   lastDeliveryStatus?: CronDeliveryStatus;
   /** Delivery-specific error text when available. */


### PR DESCRIPTION
## Summary
- add `sessions_sleep` for lightweight, agent-owned session wake timers backed by cron
- wire the tool into OpenClaw tool registration, catalog, display, and sandbox allow lists
- requeue interrupted `sessions_sleep` startup wakes once while preserving fail-closed behavior for normal one-shot cron jobs

## Tests
- `pnpm test src/cron/service.restart-catchup.test.ts src/agents/tools/sessions-sleep-tool.test.ts src/agents/tools/cron-tool.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint:core`