### PR TITLE
fix(feishu): accept nested schema 2 card identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.
 - Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.
 - CLI/gateway: keep `gateway status --deep` plugin-aware so configured plugin manifest warnings, including missing channel config metadata, stay visible during install and update smoke checks.
+- Feishu: accept Schema 2 card callbacks whose operator identity is nested under `operator.user_id`, so card buttons dispatch instead of being dropped as malformed. Fixes #71670. (#71787) Thanks @rubencu.
 - Feishu: fall back to a top-level group send when normal group quoted replies target a withdrawn or missing message, preventing replies from disappearing silently while preserving native topic safety. Fixes #79349. Thanks @arlen8411.
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -194,6 +194,16 @@ function firstString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+function readFeishuIdentityField(
+  value: unknown,
+  field: "open_id" | "user_id" | "union_id",
+): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return firstString(value[field]);
+}
+
 function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEvent | null {
   if (!isRecord(value)) {
     return null;
@@ -204,10 +214,24 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   if (!isRecord(action)) {
     return null;
   }
+  const operatorUserId = operator.user_id;
   const token = readString(value.token);
-  const openId = firstString(operator.open_id, value.open_id, context.open_id);
-  const userId = firstString(operator.user_id, value.user_id, context.user_id);
-  const unionId = firstString(operator.union_id);
+  const openId = firstString(
+    operator.open_id,
+    readFeishuIdentityField(operatorUserId, "open_id"),
+    value.open_id,
+    context.open_id,
+  );
+  const userId = firstString(
+    operator.user_id,
+    readFeishuIdentityField(operatorUserId, "user_id"),
+    value.user_id,
+    context.user_id,
+  );
+  const unionId = firstString(
+    operator.union_id,
+    readFeishuIdentityField(operatorUserId, "union_id"),
+  );
   const tag = readString(action.tag);
   const actionValue = action.value;
   const openMessageId = firstString(value.open_message_id, context.open_message_id);

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
@@ -257,6 +257,57 @@ describe("Feishu card-action lifecycle", () => {
     expect(latestFinalizedContext().MessageSid).toBe("card-action-tok-card-v2-context");
   });
 
+  it("routes v2 callbacks with nested operator identity", async () => {
+    const onCardAction = await setupLifecycleMonitor();
+    const chatId = "p2p:ou_user1";
+
+    await onCardAction({
+      operator: {
+        user_id: {
+          open_id: "ou_user1",
+          user_id: "user_1",
+          union_id: "union_1",
+        },
+      },
+      token: "tok-card-v2-nested-operator",
+      action: {
+        tag: "button",
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: {
+            u: "ou_user1",
+            h: chatId,
+            t: "p2p",
+            e: Date.now() + 60_000,
+          },
+        }),
+      },
+      context: {
+        open_message_id: "om_card_v2_nested",
+        open_chat_id: chatId,
+      },
+    });
+
+    expect(lastRuntime?.error).not.toHaveBeenCalled();
+    expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    expect(createFeishuReplyDispatcherMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acct-card",
+        chatId,
+        replyToMessageId: "om_card_v2_nested",
+      }),
+    );
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        AccountId: "acct-card",
+        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+        MessageSid: "card-action-tok-card-v2-nested-operator",
+      }),
+    );
+  });
+
   it("routes SDK-style card callbacks without context as direct callbacks", async () => {
     const onCardAction = await setupLifecycleMonitor();
 


### PR DESCRIPTION
## Summary

- Problem: current `main` accepts Schema 2 `context.open_chat_id`, but still drops Feishu/Lark card callbacks when the only Open ID is nested under `operator.user_id.open_id`.
- Why it matters: affected card button clicks reach the gateway webhook but never enter the card-action handler, so quick actions and approval buttons appear to no-op.
- What changed: normalize `operator.user_id.{open_id,user_id,union_id}` at the Feishu card-action parser boundary, while preserving existing flat identity fallbacks.
- What did NOT change: no config/env surface, no outbound card schema, no command/routing semantics, and no `CHANGELOG.md` entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #71670
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Schema 2 card-action callbacks with nested `operator.user_id.open_id` were dropped as malformed before dispatch.
- Real environment tested: actual local OpenClaw gateway processes in two worktrees: `origin/main` at the rebase checkpoint and the PR code tree now published as current head `574f4c09cd6b8eaa2fd395c450f63b41bbb3db14`.
- Exact steps or command run after this patch: a local Node proof harness spawned `pnpm openclaw gateway run --allow-unconfigured --auth none --bind loopback --verbose` with an isolated Feishu webhook account, then POSTed a signed Schema 2 `card.action.trigger` payload to the Feishu webhook route.
- Evidence after fix (redacted runtime log):

```text
2026-05-10T09:29:42.042-04:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, device-pair, feishu, file-transfer, memory-core, phone-control, talk-voice; 2.9s)
2026-05-10T09:29:42.117-04:00 [feishu] starting feishu[proof] (mode: webhook)
2026-05-10T09:29:42.344-04:00 [feishu] feishu[proof]: Webhook server listening on 127.0.0.1:50164
2026-05-10T09:29:42.715-04:00 [feishu] feishu[proof]: handling structured card action feishu.quick_actions.help from ou_user1
```

- Observed result after fix: the signed callback reaches the structured card-action path and uses the nested Open ID `ou_user1`.
- What was not tested: a production Feishu/Lark tenant button click; this proof uses a signed local Feishu webhook payload through the live gateway, with fake app credentials and no real Feishu API side effects.
- Before evidence:

```text
2026-05-10T09:29:01.022-04:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, device-pair, feishu, file-transfer, memory-core, phone-control, talk-voice; 2.1s)
2026-05-10T09:29:01.098-04:00 [feishu] starting feishu[proof] (mode: webhook)
2026-05-10T09:29:01.315-04:00 [feishu] feishu[proof]: Webhook server listening on 127.0.0.1:50135
2026-05-10T09:29:01.396-04:00 [feishu] feishu[proof]: ignoring malformed card action payload
```

## Root Cause (if applicable)

- Root cause: the Feishu card-action parser read flat `operator.open_id`, top-level `open_id`, and `context.open_id`, but did not read the nested `operator.user_id.open_id` object shape seen in Schema 2 card callbacks.
- Missing detection / guardrail: lifecycle coverage had flat operator identity and `context.open_chat_id` coverage, but not the nested operator identity object.
- Contributing context (if known): the current Lark SDK normalizer also reads flat `event.operator.open_id`, so OpenClaw needs to normalize this raw callback shape at its own handler boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts`
- Scenario the test should lock in: a Schema 2 card-action callback with nested `operator.user_id.{open_id,user_id,union_id}` and `context.open_chat_id` routes through the monitor handler into the reply dispatcher.
- Why this is the smallest reliable guardrail: it exercises the parser and handler boundary where the malformed callback was dropped.
- Existing test that already covers this (if any): existing flat-identity card-action tests cover the non-nested fallback paths.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Feishu/Lark Schema 2 card button callbacks that identify the operator through nested `operator.user_id.*` now dispatch normally instead of being dropped as malformed.

## Diagram (if applicable)

```text
Before:
[Schema 2 card click] -> [Feishu webhook] -> [card parser misses nested operator.user_id.open_id] -> [drop as malformed]

After:
[Schema 2 card click] -> [Feishu webhook] -> [normalize nested identity] -> [card-action handler]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 25.2.1 / pnpm gateway worktrees
- Model/provider: N/A for the parser fix
- Integration/channel (if any): Feishu/Lark webhook mode
- Relevant config (redacted): isolated `channels.feishu.accounts.proof` webhook account using loopback host/port, fake app credentials, `verificationToken`, and `encryptKey`

### Steps

1. Start `pnpm openclaw gateway run --allow-unconfigured --auth none --bind loopback --verbose` with the isolated Feishu webhook account.
2. POST a signed Schema 2 `card.action.trigger` payload with `operator.user_id.open_id = "ou_user1"` and no flat `operator.open_id`.
3. Compare the gateway log on `origin/main` and on this PR code tree.

### Expected

- The callback should be parsed with `ou_user1` and enter the structured card-action handler.

### Actual

- Before: gateway logged `feishu[proof]: ignoring malformed card action payload`.
- After: gateway logged `feishu[proof]: handling structured card action feishu.quick_actions.help from ou_user1`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

- `pnpm changed:lanes --json` -> `extensions`, `extensionTests`; final PR diff has no changelog file
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/monitor.account.ts extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts`
- `git diff --check`
- `pnpm test extensions/feishu/src/monitor.lifecycle.test.ts extensions/feishu/src/bot.card-action.test.ts extensions/feishu/src/monitor.webhook-e2e.test.ts` -> 3 files, 40 tests passed
- `pnpm check:changed` -> passed on current head `574f4c09cd6b8eaa2fd395c450f63b41bbb3db14`
- `codex review --base origin/main` after the final cleanup -> no actionable findings; review also reran `pnpm test extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts` -> Feishu shard passed, 61 files and 733 tests

PR automation on current head:

- `Real behavior proof` -> passed on current head `574f4c09cd6b8eaa2fd395c450f63b41bbb3db14`

## Human Verification (required)

- Agent-run verification: before/after live gateway webhook proof, nested Schema 2 operator identity lifecycle test, existing flat card-action paths, signed Feishu webhook e2e coverage, changed gate, and local Codex review.
- Edge cases checked: flat `operator.open_id` still has priority, `operator.user_id.user_id` and `operator.user_id.union_id` are preserved when present, `context.open_chat_id` still routes the callback chat, and malformed payload filtering still requires token/open ID/action tag/record action value.
- User manual verification: owner performs final manual verification outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
- Current thread check: no unresolved non-outdated review threads remain.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting another identity shape could accidentally mask malformed callbacks.
  - Mitigation: the parser still requires a token, a resolved Open ID, an action tag, and a record-valued action payload; the new lifecycle test proves the nested branch while existing tests keep flat fallback behavior covered.

