### PR TITLE
fix(whatsapp): preserve e164 for group history allowlists

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -28,6 +28,7 @@ export type GroupHistoryEntry = {
   timestamp?: number;
   id?: string;
   senderJid?: string;
+  senderE164?: string;
 };
 
 type ApplyGroupGatingParams = {
@@ -80,6 +81,7 @@ function recordPendingGroupHistoryEntry(params: {
       timestamp: params.msg.timestamp,
       id: params.msg.id,
       senderJid: senderIdentity.jid ?? params.msg.senderJid,
+      senderE164: senderIdentity.e164 ?? params.msg.senderE164,
     },
   });
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts
@@ -56,6 +56,35 @@ describe("whatsapp inbound context visibility", () => {
     ]);
   });
 
+  it("matches allowlisted group history by cached E.164 when sender JID is a LID", () => {
+    const history = resolveVisibleWhatsAppGroupHistory({
+      history: [
+        {
+          sender: "Alice (+111)",
+          body: "Allowed LID context",
+          senderJid: "alice@lid",
+          senderE164: "+111",
+        },
+        {
+          sender: "Mallory (+999)",
+          body: "Blocked LID context",
+          senderJid: "mallory@lid",
+          senderE164: "+999",
+        },
+      ],
+      mode: "allowlist",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["+111"],
+    });
+
+    expect(history).toEqual([
+      expect.objectContaining({
+        sender: "Alice (+111)",
+        body: "Allowed LID context",
+      }),
+    ]);
+  });
+
   it("redacts blocked quoted replies in allowlist mode", () => {
     const reply = resolveVisibleWhatsAppReplyContext({
       msg: makeBlockedQuotedReplyMessage("msg-reply-1"),

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
@@ -17,6 +17,7 @@ export type GroupHistoryEntry = {
   timestamp?: number;
   id?: string;
   senderJid?: string;
+  senderE164?: string;
 };
 
 type ContextVisibilityMode = "all" | "allowlist" | "allowlist_quote";
@@ -61,7 +62,10 @@ export function resolveVisibleWhatsAppGroupHistory(params: {
     isSenderAllowed: (entry) =>
       isWhatsAppSupplementalSenderAllowed({
         allowFrom: params.groupAllowFrom,
-        sender: entry.senderJid ? { jid: entry.senderJid } : null,
+        sender:
+          entry.senderJid || entry.senderE164
+            ? { jid: entry.senderJid, e164: entry.senderE164 }
+            : null,
       }),
   }).items;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: WhatsApp group history entries only retained `senderJid` for supplemental-context allowlist filtering.
- Why it matters: modern WhatsApp group senders can be represented by LID JIDs while the inbound message already has the resolved E.164 number; dropping that E.164 can hide legitimate allowlisted history context.
- What changed: pending group history now stores `senderE164`, and the allowlist visibility check compares both cached JID/LID and cached E.164 identity values.
- What did NOT change (scope boundary): group authorization, message processing, reply context filtering, and visible history formatting are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: group history stored a display sender and `senderJid`, but did not preserve the resolved E.164 identity already available on the inbound message.
- Missing detection / guardrail: there was no regression test for allowlist-filtered supplemental group history where the cached sender JID is a LID and the allowlist is E.164-based.
- Contributing context (if known): WhatsApp/Baileys can surface group participants as LID identities while OpenClaw policies commonly use E.164 allowlists.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts`
- Scenario the test should lock in: allowlist mode keeps group history from a LID sender when the history entry has the sender's cached E.164 and the allowlist contains that E.164.
- Why this is the smallest reliable guardrail: the bug is in the local supplemental context visibility check, independent of live Baileys transport.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

In WhatsApp groups using allowlist-filtered supplemental context, legitimate history from LID-backed allowlisted senders is retained more reliably. No config changes.

## Diagram (if applicable)

```text
Before:
[LID group sender + resolved E.164] -> history keeps senderJid only -> E.164 allowlist may filter it out

After:
[LID group sender + resolved E.164] -> history keeps senderJid + senderE164 -> allowlist can match
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp / Baileys identity handling
- Relevant config (redacted): WhatsApp group policy `allowlist`, supplemental context visibility `allowlist`

### Steps

1. Create group history entries where `senderJid` is a LID and `senderE164` is known.
2. Resolve visible WhatsApp group history with `groupPolicy: "allowlist"` and `groupAllowFrom: ["+111"]`.
3. Compare retained history entries.

### Expected

- The entry with `senderE164: "+111"` remains visible.
- Other LID entries with non-allowlisted E.164 values are filtered.

### Actual

- Before this patch, the E.164 value was not retained for the visibility check; after this patch, it is used.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unit test for LID-backed group history matching an E.164 allowlist.
- Edge cases checked: existing non-allowlisted group history filtering and quoted reply visibility tests still pass.
- What you did **not** verify: live WhatsApp group traffic in a real Baileys session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Slightly more identity metadata is carried in in-memory group history entries.
  - Mitigation: this is the same sender identity already present on the inbound message and is only used for local visibility filtering; rendered history output is unchanged.

Validation run locally:

- `corepack pnpm -s vitest extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts --run`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/auto-reply/monitor/group-gating.ts extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts`
- `corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/whatsapp/src/auto-reply/monitor/group-gating.ts extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts`
- `corepack pnpm -s tsgo:extensions:test`
