### PR TITLE
fix(openai): extend Azure image timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Docs: https://docs.openclaw.ai
   internal calls no longer hit `scope-upgrade` pairing prompts while remote,
   browser, node, device-token, and explicit-device paths still require normal
   pairing approval. Fixes #63548.
+- Providers/Azure OpenAI: give deployment-scoped image generation requests a
+  longer 600s default timeout so slow `gpt-image-2` generations can complete
+  without a per-call `timeoutMs`. Fixes #71705. Thanks @voytas75.
 - CLI/gateway: keep diagnostic probes from creating first-time read-only device
   pairings, while still reusing cached device tokens for detailed read probes.
   Fixes #71766. Thanks @SunboZ.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -543,6 +543,8 @@ For image-generation requests on a recognized Azure host, OpenClaw:
 - Sends the `api-key` header instead of `Authorization: Bearer`
 - Uses deployment-scoped paths (`/openai/deployments/{deployment}/...`)
 - Appends `?api-version=...` to each request
+- Uses a 600s default request timeout for Azure image-generation calls.
+  Per-call `timeoutMs` values still override this default.
 
 Other base URLs (public OpenAI, OpenAI-compatible proxies) keep the standard
 OpenAI image request shape.

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1316,6 +1316,35 @@ describe("openai image generation provider", () => {
             n: 1,
             size: "1024x1024",
           },
+          timeoutMs: 600_000,
+        }),
+      );
+    });
+
+    it("lets explicit timeoutMs override the Azure image default", async () => {
+      mockGeneratedPngResponse();
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2-1",
+        prompt: "Azure cat",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://myresource.openai.azure.com/openai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        timeoutMs: 123_456,
+      });
+
+      expect(postJsonRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 123_456,
         }),
       );
     });

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -32,6 +32,7 @@ const DEFAULT_OPENAI_CODEX_IMAGE_RESPONSES_MODEL = "gpt-5.5";
 const OPENAI_CODEX_IMAGE_INSTRUCTIONS = "You are an image generation assistant.";
 const OPENAI_TRANSPARENT_BACKGROUND_IMAGE_MODEL = "gpt-image-1.5";
 const DEFAULT_OPENAI_IMAGE_TIMEOUT_MS = 180_000;
+const DEFAULT_AZURE_OPENAI_IMAGE_TIMEOUT_MS = 600_000;
 const DEFAULT_OUTPUT_MIME = "image/png";
 const DEFAULT_OUTPUT_EXTENSION = "png";
 const DEFAULT_SIZE = "1024x1024";
@@ -91,8 +92,14 @@ function sanitizeLogValue(value: unknown): string {
     : cleaned;
 }
 
-function resolveOpenAIImageTimeoutMs(timeoutMs: number | undefined): number {
-  return timeoutMs ?? DEFAULT_OPENAI_IMAGE_TIMEOUT_MS;
+function resolveOpenAIImageTimeoutMs(
+  timeoutMs: number | undefined,
+  options?: { isAzure?: boolean },
+): number {
+  return (
+    timeoutMs ??
+    (options?.isAzure ? DEFAULT_AZURE_OPENAI_IMAGE_TIMEOUT_MS : DEFAULT_OPENAI_IMAGE_TIMEOUT_MS)
+  );
 }
 
 function resolveOpenAIImageCount(count: number | undefined): number {
@@ -746,7 +753,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
       });
       const count = resolveOpenAIImageCount(req.count);
       const size = req.size ?? DEFAULT_SIZE;
-      const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
+      const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs, { isAzure });
       const url = isAzure
         ? buildAzureImageUrl(rawBaseUrl, model, isEdit ? "edits" : "generations")
         : `${baseUrl}/images/${isEdit ? "edits" : "generations"}`;


### PR DESCRIPTION
## Summary

- Problem: Azure `gpt-image-2` image generations can take longer than OpenClaw's shared 180s OpenAI image timeout.
- Why it matters: deployment-scoped Azure image requests can now have the right request shape but still fail unless users manually pass a large `timeoutMs`.
- What changed: Azure image-generation calls on recognized Azure OpenAI hosts now default to 600s while explicit `timeoutMs` still wins.
- What did NOT change (scope boundary): public OpenAI, OpenAI-compatible proxy, and Codex image timeout defaults stay unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71705
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/openai/image-generation-provider.ts` resolved every direct OpenAI image request through the same `DEFAULT_OPENAI_IMAGE_TIMEOUT_MS = 180_000`, including Azure deployment-scoped image generation.
- Missing detection / guardrail: Azure image request-shape coverage asserted endpoint/auth/body behavior but did not assert the Azure timeout default or explicit override.
- Contributing context: #71705 reports Azure `gpt-image-2` succeeding with `timeoutMs=600000` and via the official SDK after roughly 394s.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openai/image-generation-provider.test.ts`
- Scenario the test should lock in: recognized Azure image-generation hosts get a 600s default timeout and explicit `timeoutMs` overrides it.
- Why this is the smallest reliable guardrail: the timeout is resolved inside the provider request adapter before transport.
- Existing test that already covers this (if any): Azure request-shape test now also covers the default timeout.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Azure OpenAI image-generation requests on recognized Azure hosts now wait up to 600s by default. Users can still override with per-call `timeoutMs`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: OpenAI provider, Azure OpenAI image-generation path
- Integration/channel (if any): image generation tool/provider
- Relevant config (redacted): Azure `models.providers.openai.baseUrl`

### Steps

1. Configure `models.providers.openai.baseUrl` to a recognized Azure OpenAI host.
2. Generate an image using an Azure deployment name such as `gpt-image-2-1`.
3. Observe provider transport timeout handling.

### Expected

- Azure image generation gets enough default timeout budget for slow `gpt-image-2` generations.
- Explicit `timeoutMs` still overrides the default.

### Actual

- Before: default path used 180s for Azure and could abort before Azure finished.
- After: Azure image-generation path uses 600s unless overridden.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/openai/image-generation-provider.test.ts`
  - `pnpm check:changed`
- Edge cases checked: explicit Azure `timeoutMs` override remains honored; non-Azure default path unchanged by code path.
- What you did **not** verify: live Azure generation, because this environment does not have the reporter's Azure deployment/API key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: longer default waits can keep a slow Azure image request open for longer.
  - Mitigation: scoped only to recognized Azure image-generation hosts, and users can still pass a smaller `timeoutMs`.
