### PR TITLE
fix(codex): sanitize request_user_input chat prompts

### DIFF
--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -2,12 +2,16 @@ import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness
 import { describe, expect, it, vi } from "vitest";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 
-function createParams(): EmbeddedRunAttemptParams {
+type TestParams = EmbeddedRunAttemptParams & {
+  onBlockReply: NonNullable<EmbeddedRunAttemptParams["onBlockReply"]>;
+};
+
+function createParams(): TestParams {
   return {
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     onBlockReply: vi.fn(),
-  } as unknown as EmbeddedRunAttemptParams;
+  } as unknown as TestParams;
 }
 
 describe("Codex app-server user input bridge", () => {
@@ -133,5 +137,85 @@ describe("Codex app-server user input bridge", () => {
 
     await expect(response).resolves.toEqual({ answers: {} });
     expect(bridge.handleQueuedMessage("too late")).toBe(false);
+  });
+
+  it("sanitizes untrusted request_user_input prompt text before forwarding to chat", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    void bridge.handleRequest({
+      id: "input-4",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-1",
+        questions: [
+          {
+            id: "answer",
+            header: "Mode\u202Eevil",
+            question: "Open \u001b]8;;https://example.invalid\u0007visible\u001b]8;;\u0007?",
+            isOther: true,
+            isSecret: false,
+            options: [
+              {
+                label: "Fast\u009b31m",
+                description: "Use\u0000 less\u200b reasoning",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    const text = vi.mocked(params.onBlockReply).mock.calls[0]?.[0].text ?? "";
+    expect(text).toContain("Mode evil");
+    expect(text).toContain("Open visible?");
+    expect(text).toContain("Fast");
+    expect(text).toContain("Use less reasoning");
+    expect(text).not.toContain("https://example.invalid");
+    const unsafeDisplayControls = new RegExp(
+      String.raw`[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u200b-\u200f]`,
+    );
+    expect(text.replace(/\n/g, "")).not.toMatch(unsafeDisplayControls);
+  });
+
+  it("caps oversized request_user_input prompt fields before forwarding to chat", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const huge = "A".repeat(100_000);
+
+    void bridge.handleRequest({
+      id: "input-5",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-1",
+        questions: [
+          {
+            id: "answer",
+            header: huge,
+            question: huge,
+            isOther: false,
+            isSecret: false,
+            options: [{ label: huge, description: huge }],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    const text = vi.mocked(params.onBlockReply).mock.calls[0]?.[0].text ?? "";
+    expect(text.length).toBeLessThan(1200);
+    expect(text).toContain("...");
+    expect(text).not.toContain("A".repeat(1000));
   });
 });

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -1,24 +1,23 @@
-import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 
-type TestParams = EmbeddedRunAttemptParams & {
-  onBlockReply: NonNullable<EmbeddedRunAttemptParams["onBlockReply"]>;
-};
-
-function createParams(): TestParams {
+function createParams() {
+  const onBlockReply = vi.fn();
   return {
-    sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
-    onBlockReply: vi.fn(),
-  } as unknown as TestParams;
+    paramsForRun: {
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      onBlockReply,
+    } as unknown as Parameters<typeof createCodexUserInputBridge>[0]["paramsForRun"],
+    onBlockReply,
+  };
 }
 
 describe("Codex app-server user input bridge", () => {
   it("prompts the originating chat and resolves request_user_input from the next queued message", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({
-      paramsForRun: params,
+      paramsForRun: params.paramsForRun,
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -59,7 +58,7 @@ describe("Codex app-server user input bridge", () => {
   it("maps keyed multi-question replies to Codex answer ids", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({
-      paramsForRun: params,
+      paramsForRun: params.paramsForRun,
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -105,7 +104,7 @@ describe("Codex app-server user input bridge", () => {
   it("clears pending prompts when Codex resolves the server request itself", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({
-      paramsForRun: params,
+      paramsForRun: params.paramsForRun,
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -142,7 +141,7 @@ describe("Codex app-server user input bridge", () => {
   it("sanitizes untrusted request_user_input prompt text before forwarding to chat", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({
-      paramsForRun: params,
+      paramsForRun: params.paramsForRun,
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -157,7 +156,8 @@ describe("Codex app-server user input bridge", () => {
           {
             id: "answer",
             header: "Mode\u202Eevil",
-            question: "Open \u001b]8;;https://example.invalid\u0007visible\u001b]8;;\u0007?",
+            question:
+              "Open \u001b]8;;https://example.invalid\u0007visible\u001b]8;;\u0007? dangling \u001b]8;;https://evil.example",
             isOther: true,
             isSecret: false,
             options: [
@@ -174,10 +174,11 @@ describe("Codex app-server user input bridge", () => {
     await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
     const text = vi.mocked(params.onBlockReply).mock.calls[0]?.[0].text ?? "";
     expect(text).toContain("Mode evil");
-    expect(text).toContain("Open visible?");
+    expect(text).toContain("Open visible? dangling");
     expect(text).toContain("Fast");
     expect(text).toContain("Use less reasoning");
     expect(text).not.toContain("https://example.invalid");
+    expect(text).not.toContain("https://evil.example");
     const unsafeDisplayControls = new RegExp(
       String.raw`[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u200b-\u200f]`,
     );
@@ -187,7 +188,7 @@ describe("Codex app-server user input bridge", () => {
   it("caps oversized request_user_input prompt fields before forwarding to chat", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({
-      paramsForRun: params,
+      paramsForRun: params.paramsForRun,
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -217,5 +218,50 @@ describe("Codex app-server user input bridge", () => {
     expect(text.length).toBeLessThan(1200);
     expect(text).toContain("...");
     expect(text).not.toContain("A".repeat(1000));
+  });
+
+  it("bounds request_user_input question and option counts before prompt formatting", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params.paramsForRun,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const options = Array.from({ length: 60 }, (_, index) => ({
+      label: `Option ${index + 1}`,
+      description: "",
+    }));
+    const questions = Array.from({ length: 25 }, (_, index) => ({
+      id: `q${index + 1}`,
+      header: `Header ${index + 1}`,
+      question: `Question ${index + 1}`,
+      isOther: false,
+      isSecret: false,
+      options: index === 0 ? options : null,
+    }));
+
+    const response = bridge.handleRequest({
+      id: "input-6",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-1",
+        questions,
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledTimes(1));
+    const text = vi.mocked(params.onBlockReply).mock.calls[0]?.[0].text ?? "";
+    expect(text.length).toBeLessThanOrEqual(4096);
+    expect(text).toContain("Header 20");
+    expect(text).not.toContain("Header 21");
+    expect(text).toContain("Option 50");
+    expect(text).not.toContain("Option 51");
+    expect(bridge.handleQueuedMessage("q20: final\nq21: ignored")).toBe(true);
+    await expect(response).resolves.toMatchObject({
+      answers: {
+        q20: { answers: ["final"] },
+      },
+    });
   });
 });

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -33,6 +33,30 @@ type UserInputOption = {
   description: string;
 };
 
+const USER_INPUT_PROMPT_MAX_LENGTH = 4096;
+const USER_INPUT_TEXT_SCAN_MAX_LENGTH = 4096;
+const USER_INPUT_HEADER_MAX_LENGTH = 80;
+const USER_INPUT_QUESTION_MAX_LENGTH = 500;
+const USER_INPUT_OPTION_LABEL_MAX_LENGTH = 120;
+const USER_INPUT_OPTION_DESCRIPTION_MAX_LENGTH = 200;
+const USER_INPUT_PROMPT_OMITTED = "[additional prompt text omitted]";
+const ANSI_OSC_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
+  "g",
+);
+const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
+  "g",
+);
+const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
+const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
+  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
+  "gu",
+);
+const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
+  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
+);
+
 export type CodexUserInputBridge = {
   handleRequest: (request: {
     id: number | string;
@@ -204,24 +228,65 @@ async function deliverUserInputPrompt(
 function formatUserInputPrompt(questions: UserInputQuestion[]): string {
   const lines = ["Codex needs input:"];
   questions.forEach((question, index) => {
+    const header =
+      sanitizePromptDisplayText(question.header, USER_INPUT_HEADER_MAX_LENGTH) ??
+      `Question ${index + 1}`;
+    const prompt =
+      sanitizePromptDisplayText(question.question, USER_INPUT_QUESTION_MAX_LENGTH) ??
+      "Input requested.";
     if (questions.length > 1) {
-      lines.push("", `${index + 1}. ${question.header}`, question.question);
+      lines.push("", `${index + 1}. ${header}`, prompt);
     } else {
-      lines.push("", question.header, question.question);
+      lines.push("", header, prompt);
     }
     if (question.isSecret) {
       lines.push("This channel may show your reply to other participants.");
     }
     question.options?.forEach((option, optionIndex) => {
-      lines.push(
-        `${optionIndex + 1}. ${option.label}${option.description ? ` - ${option.description}` : ""}`,
+      const label =
+        sanitizePromptDisplayText(option.label, USER_INPUT_OPTION_LABEL_MAX_LENGTH) ??
+        `Option ${optionIndex + 1}`;
+      const description = sanitizePromptDisplayText(
+        option.description,
+        USER_INPUT_OPTION_DESCRIPTION_MAX_LENGTH,
       );
+      lines.push(`${optionIndex + 1}. ${label}${description ? ` - ${description}` : ""}`);
     });
     if (question.isOther) {
       lines.push("Other: reply with your own answer.");
     }
   });
-  return lines.join("\n");
+  return truncatePrompt(lines.join("\n"), USER_INPUT_PROMPT_MAX_LENGTH);
+}
+
+function sanitizePromptDisplayText(value: string, maxLength: number): string | undefined {
+  const scanned = value.slice(0, USER_INPUT_TEXT_SCAN_MAX_LENGTH);
+  const clipped = value.length > USER_INPUT_TEXT_SCAN_MAX_LENGTH;
+  const sanitized = scanned
+    .replace(ANSI_OSC_SEQUENCE_RE, "")
+    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
+    .replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "")
+    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
+    .replace(CONTROL_CHARACTER_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!sanitized) {
+    return undefined;
+  }
+  const truncated = truncateText(sanitized, maxLength);
+  return clipped && truncated.length === sanitized.length ? `${truncated}...` : truncated;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function truncatePrompt(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  const suffix = `\n${USER_INPUT_PROMPT_OMITTED}`;
+  return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
 }
 
 function buildUserInputResponse(questions: UserInputQuestion[], inputText: string): JsonObject {

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -35,6 +35,8 @@ type UserInputOption = {
 
 const USER_INPUT_PROMPT_MAX_LENGTH = 4096;
 const USER_INPUT_TEXT_SCAN_MAX_LENGTH = 4096;
+const USER_INPUT_MAX_QUESTIONS = 20;
+const USER_INPUT_MAX_OPTIONS_PER_QUESTION = 50;
 const USER_INPUT_HEADER_MAX_LENGTH = 80;
 const USER_INPUT_QUESTION_MAX_LENGTH = 500;
 const USER_INPUT_OPTION_LABEL_MAX_LENGTH = 120;
@@ -169,6 +171,7 @@ function readUserInputParams(value: JsonValue | undefined):
     return undefined;
   }
   const questions = questionsRaw
+    .slice(0, USER_INPUT_MAX_QUESTIONS)
     .map(readQuestion)
     .filter((question): question is UserInputQuestion => Boolean(question));
   return { threadId, turnId, itemId, questions };
@@ -199,6 +202,7 @@ function readOptions(value: JsonValue | undefined): UserInputOption[] | null {
     return null;
   }
   const options = value
+    .slice(0, USER_INPUT_MAX_OPTIONS_PER_QUESTION)
     .map(readOption)
     .filter((option): option is UserInputOption => Boolean(option));
   return options.length > 0 ? options : null;
@@ -226,8 +230,21 @@ async function deliverUserInputPrompt(
 }
 
 function formatUserInputPrompt(questions: UserInputQuestion[]): string {
-  const lines = ["Codex needs input:"];
-  questions.forEach((question, index) => {
+  const lines: string[] = [];
+  let promptLength = 0;
+  let omitted = false;
+  const pushLine = (line: string): boolean => {
+    const cost = line.length + (lines.length > 0 ? 1 : 0);
+    if (promptLength + cost > USER_INPUT_PROMPT_MAX_LENGTH) {
+      omitted = true;
+      return false;
+    }
+    lines.push(line);
+    promptLength += cost;
+    return true;
+  };
+  pushLine("Codex needs input:");
+  for (const [index, question] of questions.entries()) {
     const header =
       sanitizePromptDisplayText(question.header, USER_INPUT_HEADER_MAX_LENGTH) ??
       `Question ${index + 1}`;
@@ -235,14 +252,21 @@ function formatUserInputPrompt(questions: UserInputQuestion[]): string {
       sanitizePromptDisplayText(question.question, USER_INPUT_QUESTION_MAX_LENGTH) ??
       "Input requested.";
     if (questions.length > 1) {
-      lines.push("", `${index + 1}. ${header}`, prompt);
+      if (!pushLine("") || !pushLine(`${index + 1}. ${header}`) || !pushLine(prompt)) {
+        break;
+      }
     } else {
-      lines.push("", header, prompt);
+      if (!pushLine("") || !pushLine(header) || !pushLine(prompt)) {
+        break;
+      }
     }
     if (question.isSecret) {
-      lines.push("This channel may show your reply to other participants.");
+      if (!pushLine("This channel may show your reply to other participants.")) {
+        break;
+      }
     }
-    question.options?.forEach((option, optionIndex) => {
+    let exhausted = false;
+    for (const [optionIndex, option] of (question.options ?? []).entries()) {
       const label =
         sanitizePromptDisplayText(option.label, USER_INPUT_OPTION_LABEL_MAX_LENGTH) ??
         `Option ${optionIndex + 1}`;
@@ -250,13 +274,21 @@ function formatUserInputPrompt(questions: UserInputQuestion[]): string {
         option.description,
         USER_INPUT_OPTION_DESCRIPTION_MAX_LENGTH,
       );
-      lines.push(`${optionIndex + 1}. ${label}${description ? ` - ${description}` : ""}`);
-    });
-    if (question.isOther) {
-      lines.push("Other: reply with your own answer.");
+      if (!pushLine(`${optionIndex + 1}. ${label}${description ? ` - ${description}` : ""}`)) {
+        exhausted = true;
+        break;
+      }
     }
-  });
-  return truncatePrompt(lines.join("\n"), USER_INPUT_PROMPT_MAX_LENGTH);
+    if (exhausted) {
+      break;
+    }
+    if (question.isOther) {
+      if (!pushLine("Other: reply with your own answer.")) {
+        break;
+      }
+    }
+  }
+  return finishPrompt(lines.join("\n"), omitted);
 }
 
 function sanitizePromptDisplayText(value: string, maxLength: number): string | undefined {
@@ -264,8 +296,8 @@ function sanitizePromptDisplayText(value: string, maxLength: number): string | u
   const clipped = value.length > USER_INPUT_TEXT_SCAN_MAX_LENGTH;
   const sanitized = scanned
     .replace(ANSI_OSC_SEQUENCE_RE, "")
-    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
     .replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "")
+    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
     .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
     .replace(CONTROL_CHARACTER_RE, " ")
     .replace(/\s+/g, " ")
@@ -281,12 +313,18 @@ function truncateText(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${value.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
-function truncatePrompt(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
+function finishPrompt(value: string, omitted: boolean): string {
+  if (!omitted && value.length <= USER_INPUT_PROMPT_MAX_LENGTH) {
     return value;
   }
   const suffix = `\n${USER_INPUT_PROMPT_OMITTED}`;
-  return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
+  if (value.endsWith(suffix)) {
+    return value;
+  }
+  if (value.length + suffix.length <= USER_INPUT_PROMPT_MAX_LENGTH) {
+    return `${value}${suffix}`;
+  }
+  return `${value.slice(0, Math.max(0, USER_INPUT_PROMPT_MAX_LENGTH - suffix.length))}${suffix}`;
 }
 
 function buildUserInputResponse(questions: UserInputQuestion[], inputText: string): JsonObject {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Codex app-server `request_user_input` prompts forwarded header/question/option text to chat without display sanitization or bounded preview lengths.
- Why it matters: The app-server payload can contain terminal controls, bidi/invisible formatting, OSC links, or oversized strings that make chat-forwarded prompt text misleading or noisy.
- What changed: Sanitized only the chat prompt display fields, capped per-field and full-prompt length, and kept visible OSC-8 labels while dropping control sequences and hidden formatting.
- What did NOT change (scope boundary): Request ids, answer mapping, option matching, and responses sent back to Codex are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The `request_user_input` bridge formatted app-server supplied display strings directly for chat, while approval and elicitation bridge text had already grown sanitizer/capping guardrails.
- Missing detection / guardrail: No regression test covered OSC/control/bidi prompt text or oversized prompt fields in `user-input-bridge`.
- Contributing context (if known): `request_user_input` is an experimental app-server request path and was added with minimal formatting logic.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/user-input-bridge.test.ts`
- Scenario the test should lock in: Chat-forwarded `request_user_input` prompts strip OSC/control/bidi text, preserve visible OSC labels, and cap huge prompt fields.
- Why this is the smallest reliable guardrail: The vulnerable behavior is local to prompt formatting in the bridge.
- Existing test that already covers this (if any): Existing bridge tests covered routing and answer mapping, but not display sanitization.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex `request_user_input` prompts shown in chat may now display sanitized/truncated versions of malicious or oversized labels. Normal prompts are unchanged.

## Diagram (if applicable)

```text
Before:
[app-server request_user_input] -> [raw header/question/options] -> [chat prompt]

After:
[app-server request_user_input] -> [sanitized bounded display text] -> [chat prompt]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Codex app-server bridge
- Relevant config (redacted): N/A

### Steps

1. Send a Codex app-server `item/tool/requestUserInput` request containing OSC-8, bidi/invisible formatting, C1/control characters, and oversized display fields.
2. Observe the chat prompt delivered by `createCodexUserInputBridge`.
3. Reply through the queued message path and verify the answer payload still maps to the same question ids/options.

### Expected

- Chat prompt text is readable, bounded, and does not contain hidden terminal/control formatting.

### Actual

- Before this change, the bridge forwarded the raw display strings.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Sanitized control/bidi/OSC request_user_input prompt text; capped oversized fields; existing single/multi-question routing still passes.
- Edge cases checked: OSC-8 visible label preservation, C1 controls, invisible formatting, null/empty sanitized fallback labels, large 100k-character fields.
- What you did **not** verify: A live Codex app-server process connected to a real chat channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Very long or intentionally formatted prompt text may be truncated or normalized in chat display.
  - Mitigation: Sanitization applies only to displayed prompt text; underlying request ids and answer handling are unchanged.
