### PR TITLE
fix(image): resolve provider-prefixed configured models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: keep queued subagent announces session-only when the
   requester has no external channel target, avoiding ambiguous multi-channel
   delivery failures. Fixes #59201. Thanks @larrylhollan.
+- Image understanding: preserve configured provider-prefixed vision model
+  metadata when callers request the model without the provider prefix, so custom
+  image models keep their `input: ["text", "image"]` capability. Fixes #33185.
+  Thanks @Kobe9312 and @vincentkoc.
 - Gateway/subagents: keep direct-loopback backend RPCs authenticated with the
   shared gateway token/password off stale CLI paired-device scope baselines, so
   internal calls no longer hit `scope-upgrade` pairing prompts while remote,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -449,6 +449,57 @@ describe("resolveModel", () => {
     });
   });
 
+  it("matches provider-prefixed configured model ids through provider aliases", () => {
+    const cfg = {
+      models: {
+        providers: {
+          volcengine: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("volcengine/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("bytedance", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "volcengine/vision-model",
+      input: ["text", "image"],
+    });
+  });
+
+  it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("meta/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.model?.id).toBe("vision-model");
+    expect(result.model?.input).toEqual(["text"]);
+  });
+
   it("prefers provider-prefixed configured metadata over discovered text-only models", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "custom",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -421,6 +421,71 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text", "image"]);
   });
 
+  it("propagates image input when configured model ids include the provider prefix", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("custom/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "custom",
+      id: "custom/vision-model",
+      input: ["text", "image"],
+    });
+  });
+
+  it("prefers provider-prefixed configured metadata over discovered text-only models", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "custom",
+      modelId: "vision-model",
+      templateModel: {
+        ...makeModel("vision-model"),
+        provider: "custom",
+        input: ["text"],
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("custom/vision-model"),
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "custom",
+      id: "custom/vision-model",
+      input: ["text", "image"],
+    });
+  });
+
   it("keeps unknown fallback models text-only instead of borrowing image input from another configured model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -260,13 +260,38 @@ function resolveProviderTransport(params: {
   };
 }
 
+function matchesProviderScopedModelId(params: {
+  candidateId?: string;
+  provider: string;
+  modelId: string;
+}): boolean {
+  const { candidateId, provider, modelId } = params;
+  if (candidateId === modelId) {
+    return true;
+  }
+  const slashIndex = candidateId?.indexOf("/") ?? -1;
+  if (!candidateId || slashIndex <= 0) {
+    return false;
+  }
+  const candidateProvider = candidateId.slice(0, slashIndex);
+  const candidateModelId = candidateId.slice(slashIndex + 1);
+  return (
+    candidateModelId === modelId &&
+    normalizeProviderId(candidateProvider) === normalizeProviderId(provider)
+  );
+}
+
 function findInlineModelMatch(params: {
   providers: Record<string, InlineProviderConfig>;
   provider: string;
   modelId: string;
 }) {
   const matchesModelId = (entry: { provider: string; id?: string }) =>
-    entry.id === params.modelId || entry.id === `${entry.provider}/${params.modelId}`;
+    matchesProviderScopedModelId({
+      candidateId: entry.id,
+      provider: entry.provider,
+      modelId: params.modelId,
+    });
   const inlineModels = buildInlineProviderModels(params.providers);
   const exact = inlineModels.find(
     (entry) => entry.provider === params.provider && matchesModelId(entry),
@@ -312,8 +337,12 @@ function findConfiguredProviderModel(
   provider: string,
   modelId: string,
 ) {
-  return providerConfig?.models?.find(
-    (candidate) => candidate.id === modelId || candidate.id === `${provider}/${modelId}`,
+  return providerConfig?.models?.find((candidate) =>
+    matchesProviderScopedModelId({
+      candidateId: candidate.id,
+      provider,
+      modelId,
+    }),
   );
 }
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -265,17 +265,18 @@ function findInlineModelMatch(params: {
   provider: string;
   modelId: string;
 }) {
+  const matchesModelId = (entry: { provider: string; id?: string }) =>
+    entry.id === params.modelId || entry.id === `${entry.provider}/${params.modelId}`;
   const inlineModels = buildInlineProviderModels(params.providers);
   const exact = inlineModels.find(
-    (entry) => entry.provider === params.provider && entry.id === params.modelId,
+    (entry) => entry.provider === params.provider && matchesModelId(entry),
   );
   if (exact) {
     return exact;
   }
   const normalizedProvider = normalizeProviderId(params.provider);
   return inlineModels.find(
-    (entry) =>
-      normalizeProviderId(entry.provider) === normalizedProvider && entry.id === params.modelId,
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && matchesModelId(entry),
   );
 }
 
@@ -306,6 +307,16 @@ function isModelsAddMetadataModel(params: {
   );
 }
 
+function findConfiguredProviderModel(
+  providerConfig: InlineProviderConfig | undefined,
+  provider: string,
+  modelId: string,
+) {
+  return providerConfig?.models?.find(
+    (candidate) => candidate.id === modelId || candidate.id === `${provider}/${modelId}`,
+  );
+}
+
 function applyConfiguredProviderOverrides(params: {
   provider: string;
   discoveredModel: ProviderRuntimeModel;
@@ -324,9 +335,9 @@ function applyConfiguredProviderOverrides(params: {
     };
   }
   const configuredModel =
-    providerConfig.models?.find((candidate) => candidate.id === modelId) ??
+    findConfiguredProviderModel(providerConfig, params.provider, modelId) ??
     (discoveredModel.id !== modelId
-      ? providerConfig.models?.find((candidate) => candidate.id === discoveredModel.id)
+      ? findConfiguredProviderModel(providerConfig, params.provider, discoveredModel.id)
       : undefined);
   const metadataOverrideModel =
     params.preferDiscoveredModelMetadata &&
@@ -546,7 +557,7 @@ function resolveConfiguredFallbackModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, cfg, agentDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });


### PR DESCRIPTION
## Summary

- Problem: configured provider models stored as `provider/model` could lose their configured image capability when callers requested `model` under the same provider.
- Why it matters: custom vision providers could resolve to text-only fallback/discovery metadata and then fail image understanding despite a valid configured `input: ["text", "image"]` row.
- What changed: model resolution now treats `model` and `provider/model` as the same configured row for inline matches, discovered-model overrides, and fallback models.
- What did NOT change (scope boundary): provider transport/auth behavior and image runtime dispatch stay unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33185
- Supersedes #71458
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/pi-embedded-runner/model.ts` only matched configured model rows by the bare requested model id. A configured row such as `custom/vision-model` did not match a request for provider `custom`, model `vision-model`.
- Missing detection / guardrail: resolver tests covered bare configured ids carrying image metadata, but not provider-prefixed configured ids.
- Contributing context (if known): #71458 identified the same resolver gap, but its image-runtime half is already covered by #71500 on current `main`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/model.test.ts`
- Scenario the test should lock in: configured provider-prefixed image model ids preserve `input: ["text", "image"]`, including when discovery has a text-only row.
- Why this is the smallest reliable guardrail: the bug is in shared model resolution before provider/image execution.
- Existing test that already covers this (if any): image runtime coverage from #71500 covers configured image models after resolver success.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Custom configured vision models keep image capability metadata when the configured id includes the provider prefix.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: custom configured image provider
- Integration/channel (if any): image understanding model resolver
- Relevant config (redacted): `models.providers.custom.models[].id = "custom/vision-model"`

### Steps

1. Configure provider `custom` with model id `custom/vision-model` and `input: ["text", "image"]`.
2. Resolve provider `custom`, model `vision-model`.
3. Simulate either no discovery row or a discovered text-only row.

### Expected

- Resolver returns the configured `custom/vision-model` metadata with image input.

### Actual

- Before: resolver missed the configured row and could synthesize/keep text-only metadata.
- After: resolver matches the provider-prefixed configured row.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/pi-embedded-runner/model.test.ts src/media-understanding/image.test.ts`
  - `pnpm check:changed`
- Edge cases checked: discovery miss and discovered text-only row.
- What you did **not** verify: live third-party provider call.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: provider-prefixed configured ids could shadow discovered bare ids for the same provider.
  - Mitigation: matching remains scoped to the same provider or normalized provider alias only.
