### PR TITLE
feat(cron): add optional external scheduler sync

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-56ccee3ef8ff3b0ba7e2e765ae631b59254464585d5fef9db7e905f2c4c34ded  plugin-sdk-api-baseline.json
-39184cf8afaec691f0352d1a113e30a7099b87c0748237a3c7307e903ba24eee  plugin-sdk-api-baseline.jsonl
+8a259b07eafb25f158bc3495d45523540f85206b4821942cf8676fa431ce0385  plugin-sdk-api-baseline.json
+44f2e2069945d87d100ab445455a2f77e15aa237dca3f050ba4d3410c5ecc405  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -253,6 +253,7 @@ semantics.
 - `message_received`: use the typed `threadId` field when you need inbound thread/topic routing. Keep `metadata` for channel-specific extras.
 - `message_sending`: use typed `replyToId` / `threadId` routing fields before falling back to channel-specific `metadata`.
 - `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks.
+- `cron_changed`: observe gateway-owned cron lifecycle changes. Use `event.job?.state?.nextRunAtMs` and `ctx.getCron?.()` when syncing external wake schedulers, and keep OpenClaw as the source of truth for due checks and execution. The bundled `local-external-cron-scheduler` plugin is disabled by default; enable it with plugin config (`enabled: true`) to write a local scheduler state file for external wake runners.
 
 ### API object fields
 

--- a/extensions/local-external-cron-scheduler/index.test.ts
+++ b/extensions/local-external-cron-scheduler/index.test.ts
@@ -149,6 +149,7 @@ describe("local-external-cron-scheduler", () => {
       jobs: [expect.objectContaining({ jobId: "job-1", nextRunAtMs: 1_000 })],
     });
 
+    // Single-fire finished (no job on event) removes the job
     await syncCronChanged({
       config,
       nowMs: 300,
@@ -160,6 +161,85 @@ describe("local-external-cron-scheduler", () => {
       updatedAtMs: 300,
       jobs: [],
     });
+  });
+
+  it("finished on a recurring job upserts the new wake time instead of removing", async () => {
+    const root = await makeTempRoot();
+    const statePath = path.join(root, "jobs.json");
+    const config = resolveLocalExternalCronSchedulerConfig({ enabled: true, statePath });
+
+    // Add a recurring job
+    await syncCronChanged({
+      config,
+      nowMs: 100,
+      event: {
+        action: "added",
+        jobId: "recurring-1",
+        job: {
+          id: "recurring-1",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          state: { nextRunAtMs: 60_000 },
+        },
+      },
+    });
+
+    expect(await readJson(statePath)).toEqual({
+      version: 1,
+      updatedAtMs: 100,
+      jobs: [expect.objectContaining({ jobId: "recurring-1", nextRunAtMs: 60_000 })],
+    });
+
+    // Finished event on recurring job — job still exists with advanced nextRunAtMs
+    await syncCronChanged({
+      config,
+      nowMs: 200,
+      event: {
+        action: "finished",
+        jobId: "recurring-1",
+        job: {
+          id: "recurring-1",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          state: { nextRunAtMs: 120_000 },
+        },
+      },
+    });
+
+    // Should upsert with new wake time, NOT remove
+    expect(await readJson(statePath)).toEqual({
+      version: 1,
+      updatedAtMs: 200,
+      jobs: [expect.objectContaining({ jobId: "recurring-1", nextRunAtMs: 120_000 })],
+    });
+  });
+
+  it("started event without a job is a no-op (does not remove existing schedule)", async () => {
+    const root = await makeTempRoot();
+    const statePath = path.join(root, "jobs.json");
+    const config = resolveLocalExternalCronSchedulerConfig({ enabled: true, statePath });
+
+    // Seed a job in the state file
+    await syncCronChanged({
+      config,
+      nowMs: 100,
+      event: {
+        action: "added",
+        jobId: "job-1",
+        job: { id: "job-1", enabled: true, state: { nextRunAtMs: 5_000 } },
+      },
+    });
+
+    // Started event without a job object — should not remove
+    await syncCronChanged({
+      config,
+      nowMs: 200,
+      event: { action: "started", jobId: "job-1" },
+    });
+
+    const state = (await readJson(statePath)) as { jobs: { jobId: string }[] };
+    expect(state.jobs).toHaveLength(1);
+    expect(state.jobs[0]!.jobId).toBe("job-1");
   });
 
   it("omits disabled jobs unless includeDisabled is configured", () => {

--- a/extensions/local-external-cron-scheduler/index.test.ts
+++ b/extensions/local-external-cron-scheduler/index.test.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import entry, {
+  __testing,
+  resolveLocalExternalCronSchedulerConfig,
+  syncAllCronJobs,
+  syncCronChanged,
+} from "./index.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-external-cron-scheduler-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+describe("local-external-cron-scheduler", () => {
+  it("defaults to disabled local scheduler sync", () => {
+    const cfg = resolveLocalExternalCronSchedulerConfig(undefined);
+
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.instanceId).toBe("local");
+    expect(cfg.commandTemplate).toBe("openclaw cron run {jobId} --due");
+  });
+
+  it("does not register hooks unless explicitly enabled", () => {
+    const api = {
+      pluginConfig: {},
+      on: vi.fn(),
+    } as never;
+
+    entry.register(api);
+
+    expect((api as { on: ReturnType<typeof vi.fn> }).on).not.toHaveBeenCalled();
+  });
+
+  it("registers gateway_start and cron_changed hooks when enabled", () => {
+    const api = {
+      pluginConfig: { enabled: true },
+      on: vi.fn(),
+    } as never;
+
+    entry.register(api);
+
+    expect((api as { on: ReturnType<typeof vi.fn> }).on).toHaveBeenCalledWith(
+      "gateway_start",
+      expect.any(Function),
+    );
+    expect((api as { on: ReturnType<typeof vi.fn> }).on).toHaveBeenCalledWith(
+      "cron_changed",
+      expect.any(Function),
+    );
+  });
+
+  it("syncs existing cron jobs on gateway start to a local state file", async () => {
+    const root = await makeTempRoot();
+    const statePath = path.join(root, "jobs.json");
+    const config = resolveLocalExternalCronSchedulerConfig({
+      enabled: true,
+      statePath,
+      instanceId: "dev-instance",
+      commandTemplate: "openshell exec -- openclaw cron run {jobId} --due",
+      leadTimeMs: 5_000,
+    });
+
+    await syncAllCronJobs({
+      config,
+      nowMs: 100,
+      cron: {
+        list: () => [
+          {
+            id: "job-b",
+            name: "b",
+            enabled: true,
+            schedule: { kind: "at", at: "2026-04-25T00:00:10Z" },
+            state: { nextRunAtMs: 10_000 },
+          },
+          {
+            id: "job-a",
+            name: "a",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            state: { nextRunAtMs: 9_000 },
+          },
+          {
+            id: "missing-next-run",
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    expect(await readJson(statePath)).toEqual({
+      version: 1,
+      updatedAtMs: 100,
+      jobs: [
+        expect.objectContaining({
+          instanceId: "dev-instance",
+          jobId: "job-a",
+          wakeAtMs: 4_000,
+          nextRunAtMs: 9_000,
+          command: "openshell exec -- openclaw cron run job-a --due",
+          enabled: true,
+        }),
+        expect.objectContaining({
+          jobId: "job-b",
+          wakeAtMs: 5_000,
+          nextRunAtMs: 10_000,
+        }),
+      ],
+    });
+  });
+
+  it("upserts and removes cron jobs from cron_changed events", async () => {
+    const root = await makeTempRoot();
+    const statePath = path.join(root, "jobs.json");
+    const config = resolveLocalExternalCronSchedulerConfig({ enabled: true, statePath });
+
+    await syncCronChanged({
+      config,
+      nowMs: 200,
+      event: {
+        action: "added",
+        jobId: "job-1",
+        job: {
+          id: "job-1",
+          enabled: true,
+          state: { nextRunAtMs: 1_000 },
+        },
+      },
+    });
+
+    expect(await readJson(statePath)).toEqual({
+      version: 1,
+      updatedAtMs: 200,
+      jobs: [expect.objectContaining({ jobId: "job-1", nextRunAtMs: 1_000 })],
+    });
+
+    await syncCronChanged({
+      config,
+      nowMs: 300,
+      event: { action: "finished", jobId: "job-1" },
+    });
+
+    expect(await readJson(statePath)).toEqual({
+      version: 1,
+      updatedAtMs: 300,
+      jobs: [],
+    });
+  });
+
+  it("omits disabled jobs unless includeDisabled is configured", () => {
+    const excluded = __testing.buildSchedulerJob({
+      nowMs: 1,
+      config: resolveLocalExternalCronSchedulerConfig({ enabled: true }),
+      job: { id: "disabled", enabled: false, state: { nextRunAtMs: 1_000 } },
+    });
+    const included = __testing.buildSchedulerJob({
+      nowMs: 1,
+      config: resolveLocalExternalCronSchedulerConfig({ enabled: true, includeDisabled: true }),
+      job: { id: "disabled", enabled: false, state: { nextRunAtMs: 1_000 } },
+    });
+
+    expect(excluded).toBeNull();
+    expect(included).toEqual(expect.objectContaining({ jobId: "disabled", enabled: false }));
+  });
+});

--- a/extensions/local-external-cron-scheduler/index.ts
+++ b/extensions/local-external-cron-scheduler/index.ts
@@ -225,18 +225,28 @@ export async function syncCronChanged(params: {
   nowMs?: number;
 }): Promise<void> {
   const nowMs = params.nowMs ?? Date.now();
+  const { action, jobId } = params.event;
   const job = params.event.job;
   const schedulerJob = job ? buildSchedulerJob({ job, config: params.config, nowMs }) : null;
-  if (schedulerJob && params.event.action !== "removed") {
+
+  // For finished events on recurring jobs, the job still exists with an updated
+  // nextRunAtMs — upsert the new wake time instead of removing. This avoids a
+  // race where external schedulers briefly see the job disappear before the
+  // subsequent "updated" event re-adds it.
+  if (schedulerJob && action !== "removed") {
     await upsertJobs({ statePath: params.config.statePath, jobs: [schedulerJob], nowMs });
     return;
   }
-  if (
-    params.event.action === "removed" ||
-    params.event.action === "finished" ||
-    params.event.nextRunAtMs === undefined
-  ) {
-    await removeJobs({ statePath: params.config.statePath, jobIds: [params.event.jobId], nowMs });
+
+  // "started" without a resolvable job is a transient state — don't remove the
+  // existing wake schedule since the job is actively running and will produce a
+  // "finished" event shortly.
+  if (action === "started") {
+    return;
+  }
+
+  if (action === "removed" || action === "finished") {
+    await removeJobs({ statePath: params.config.statePath, jobIds: [jobId], nowMs });
   }
 }
 

--- a/extensions/local-external-cron-scheduler/index.ts
+++ b/extensions/local-external-cron-scheduler/index.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+type CronSchedule =
+  | { kind?: "cron" | string; expr?: string; tz?: string; staggerMs?: number }
+  | { kind?: "at" | string; at?: string }
+  | { kind?: "every" | string; everyMs?: number; anchorMs?: number };
+
+type CronJob = {
+  id: string;
+  name?: string;
+  enabled?: boolean;
+  schedule?: CronSchedule;
+  sessionTarget?: string;
+  wakeMode?: string;
+  state?: {
+    nextRunAtMs?: number;
+    runningAtMs?: number;
+  };
+};
+
+type CronService = {
+  list: (opts?: { includeDisabled?: boolean }) => Promise<CronJob[]> | CronJob[];
+};
+
+type CronChangedEvent = {
+  action: "added" | "updated" | "removed" | "started" | "finished";
+  jobId: string;
+  job?: CronJob;
+  nextRunAtMs?: number;
+};
+
+type LocalExternalCronSchedulerConfig = {
+  enabled: boolean;
+  statePath: string;
+  instanceId: string;
+  commandTemplate: string;
+  leadTimeMs: number;
+  includeDisabled: boolean;
+};
+
+type SchedulerStateJob = {
+  instanceId: string;
+  jobId: string;
+  name?: string;
+  wakeAtMs: number;
+  nextRunAtMs: number;
+  command: string;
+  enabled: boolean;
+  schedule?: CronSchedule;
+  sessionTarget?: string;
+  wakeMode?: string;
+  updatedAtMs: number;
+};
+
+type SchedulerStateFile = {
+  version: 1;
+  updatedAtMs: number;
+  jobs: SchedulerStateJob[];
+};
+
+const PLUGIN_ID = "local-external-cron-scheduler";
+const DEFAULT_COMMAND_TEMPLATE = "openclaw cron run {jobId} --due";
+const DEFAULT_RELATIVE_STATE_PATH = ".openclaw/external-cron-scheduler/jobs.json";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function optionalNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function expandHome(input: string): string {
+  return input === "~" || input.startsWith("~/") ? path.join(os.homedir(), input.slice(2)) : input;
+}
+
+export function resolveLocalExternalCronSchedulerConfig(
+  pluginConfig: unknown,
+): LocalExternalCronSchedulerConfig {
+  const cfg = isRecord(pluginConfig) ? pluginConfig : {};
+  const statePath =
+    optionalString(cfg.statePath) ?? path.join(os.homedir(), DEFAULT_RELATIVE_STATE_PATH);
+  return {
+    enabled: optionalBoolean(cfg.enabled) ?? false,
+    statePath: path.resolve(expandHome(statePath)),
+    instanceId: optionalString(cfg.instanceId) ?? "local",
+    commandTemplate: optionalString(cfg.commandTemplate) ?? DEFAULT_COMMAND_TEMPLATE,
+    leadTimeMs: optionalNonNegativeNumber(cfg.leadTimeMs) ?? 0,
+    includeDisabled: optionalBoolean(cfg.includeDisabled) ?? false,
+  };
+}
+
+function renderCommand(template: string, jobId: string): string {
+  return template.replaceAll("{jobId}", jobId);
+}
+
+function buildSchedulerJob(params: {
+  job: CronJob;
+  config: LocalExternalCronSchedulerConfig;
+  nowMs: number;
+}): SchedulerStateJob | null {
+  const nextRunAtMs = params.job.state?.nextRunAtMs;
+  if (typeof nextRunAtMs !== "number" || !Number.isFinite(nextRunAtMs)) {
+    return null;
+  }
+  if (params.job.enabled === false && !params.config.includeDisabled) {
+    return null;
+  }
+  return {
+    instanceId: params.config.instanceId,
+    jobId: params.job.id,
+    ...(params.job.name ? { name: params.job.name } : {}),
+    wakeAtMs: Math.max(0, nextRunAtMs - params.config.leadTimeMs),
+    nextRunAtMs,
+    command: renderCommand(params.config.commandTemplate, params.job.id),
+    enabled: params.job.enabled !== false,
+    ...(params.job.schedule ? { schedule: params.job.schedule } : {}),
+    ...(params.job.sessionTarget ? { sessionTarget: params.job.sessionTarget } : {}),
+    ...(params.job.wakeMode ? { wakeMode: params.job.wakeMode } : {}),
+    updatedAtMs: params.nowMs,
+  };
+}
+
+async function readSchedulerState(statePath: string): Promise<SchedulerStateFile> {
+  try {
+    const raw = await fs.readFile(statePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.jobs)) {
+      return { version: 1, updatedAtMs: 0, jobs: [] };
+    }
+    return {
+      version: 1,
+      updatedAtMs: typeof parsed.updatedAtMs === "number" ? parsed.updatedAtMs : 0,
+      jobs: parsed.jobs.filter(isRecord) as SchedulerStateJob[],
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { version: 1, updatedAtMs: 0, jobs: [] };
+    }
+    throw err;
+  }
+}
+
+async function writeSchedulerState(statePath: string, state: SchedulerStateFile): Promise<void> {
+  await fs.mkdir(path.dirname(statePath), { recursive: true });
+  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await fs.rename(tmpPath, statePath);
+}
+
+async function upsertJobs(params: {
+  statePath: string;
+  jobs: SchedulerStateJob[];
+  nowMs: number;
+}): Promise<void> {
+  const state = await readSchedulerState(params.statePath);
+  const next = new Map(state.jobs.map((job) => [job.jobId, job]));
+  for (const job of params.jobs) {
+    next.set(job.jobId, job);
+  }
+  await writeSchedulerState(params.statePath, {
+    version: 1,
+    updatedAtMs: params.nowMs,
+    jobs: Array.from(next.values()).sort(
+      (a, b) => a.wakeAtMs - b.wakeAtMs || a.jobId.localeCompare(b.jobId),
+    ),
+  });
+}
+
+async function removeJobs(params: {
+  statePath: string;
+  jobIds: string[];
+  nowMs: number;
+}): Promise<void> {
+  const removeSet = new Set(params.jobIds);
+  const state = await readSchedulerState(params.statePath);
+  await writeSchedulerState(params.statePath, {
+    version: 1,
+    updatedAtMs: params.nowMs,
+    jobs: state.jobs.filter((job) => !removeSet.has(job.jobId)),
+  });
+}
+
+async function replaceAllJobs(params: {
+  statePath: string;
+  jobs: SchedulerStateJob[];
+  nowMs: number;
+}): Promise<void> {
+  await writeSchedulerState(params.statePath, {
+    version: 1,
+    updatedAtMs: params.nowMs,
+    jobs: params.jobs.sort((a, b) => a.wakeAtMs - b.wakeAtMs || a.jobId.localeCompare(b.jobId)),
+  });
+}
+
+export async function syncAllCronJobs(params: {
+  cron: CronService | undefined;
+  config: LocalExternalCronSchedulerConfig;
+  nowMs?: number;
+}): Promise<void> {
+  const nowMs = params.nowMs ?? Date.now();
+  const cronJobs = params.cron
+    ? await params.cron.list({ includeDisabled: params.config.includeDisabled })
+    : [];
+  const jobs = cronJobs
+    .map((job) => buildSchedulerJob({ job, config: params.config, nowMs }))
+    .filter((job): job is SchedulerStateJob => job !== null);
+  await replaceAllJobs({ statePath: params.config.statePath, jobs, nowMs });
+}
+
+export async function syncCronChanged(params: {
+  event: CronChangedEvent;
+  config: LocalExternalCronSchedulerConfig;
+  nowMs?: number;
+}): Promise<void> {
+  const nowMs = params.nowMs ?? Date.now();
+  const job = params.event.job;
+  const schedulerJob = job ? buildSchedulerJob({ job, config: params.config, nowMs }) : null;
+  if (schedulerJob && params.event.action !== "removed") {
+    await upsertJobs({ statePath: params.config.statePath, jobs: [schedulerJob], nowMs });
+    return;
+  }
+  if (
+    params.event.action === "removed" ||
+    params.event.action === "finished" ||
+    params.event.nextRunAtMs === undefined
+  ) {
+    await removeJobs({ statePath: params.config.statePath, jobIds: [params.event.jobId], nowMs });
+  }
+}
+
+export const __testing = {
+  buildSchedulerJob,
+  readSchedulerState,
+};
+
+export default definePluginEntry({
+  id: PLUGIN_ID,
+  name: "Local External Cron Scheduler",
+  description: "Optional local file sync for external wake schedulers.",
+  register(api: OpenClawPluginApi) {
+    const config = resolveLocalExternalCronSchedulerConfig(api.pluginConfig);
+    if (!config.enabled) {
+      return;
+    }
+
+    api.on("gateway_start", async (_event, ctx) => {
+      await syncAllCronJobs({ cron: ctx.getCron?.(), config });
+    });
+
+    api.on("cron_changed", async (event) => {
+      await syncCronChanged({ event, config });
+    });
+  },
+});

--- a/extensions/local-external-cron-scheduler/openclaw.plugin.json
+++ b/extensions/local-external-cron-scheduler/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "local-external-cron-scheduler",
+  "enabledByDefault": false,
+  "name": "Local External Cron Scheduler",
+  "description": "Optional local file sync for external wake schedulers that run OpenClaw cron jobs with --due.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable local external scheduler sync. Defaults to false."
+      },
+      "statePath": {
+        "type": "string",
+        "description": "Path to write scheduler state JSON. Defaults to ~/.openclaw/external-cron-scheduler/jobs.json."
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "Stable instance id included in the scheduler state. Defaults to local."
+      },
+      "commandTemplate": {
+        "type": "string",
+        "description": "Command template rendered for each job. Supports {jobId}."
+      },
+      "leadTimeMs": {
+        "type": "number",
+        "minimum": 0,
+        "description": "Milliseconds before nextRunAtMs that the external scheduler should wake. Defaults to 0."
+      },
+      "includeDisabled": {
+        "type": "boolean",
+        "description": "Include disabled cron jobs in startup sync. Defaults to false."
+      }
+    }
+  }
+}

--- a/extensions/local-external-cron-scheduler/package.json
+++ b/extensions/local-external-cron-scheduler/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/local-external-cron-scheduler",
+  "version": "2026.4.20",
+  "private": true,
+  "description": "Optional local external cron scheduler sync plugin for OpenClaw.",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/local-external-cron-scheduler/tsconfig.json
+++ b/extensions/local-external-cron-scheduler/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+}

--- a/scripts/e2e/external-cron-scheduler-docker-client.ts
+++ b/scripts/e2e/external-cron-scheduler-docker-client.ts
@@ -1,0 +1,335 @@
+/**
+ * E2E client: local-external-cron-scheduler extension
+ *
+ * Tests the cron_changed hook and the local-external-cron-scheduler extension
+ * by exercising all cron job lifecycle events (add, disable, enable, remove,
+ * finished) and verifying the JSON state file is correctly updated.
+ *
+ * Expects:
+ *   GW_URL   — gateway WebSocket URL  (e.g. ws://127.0.0.1:18789)
+ *   GW_TOKEN — gateway auth token
+ *   OPENCLAW_STATE_DIR — state directory (default: ~/.openclaw)
+ *   CRON_INTERVAL_MS   — recurring interval for the fire test (default: 10000)
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { assert, connectGateway, type GatewayRpcClient, waitFor } from "./mcp-channels-harness.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface SchedulerState {
+  version: number;
+  updatedAtMs: number;
+  jobs: SchedulerJob[];
+}
+
+interface SchedulerJob {
+  instanceId: string;
+  jobId: string;
+  name: string;
+  wakeAtMs: number;
+  nextRunAtMs: number;
+  command: string;
+  enabled: boolean;
+  schedule: { kind: string; everyMs?: number };
+  sessionTarget: string;
+  wakeMode: string;
+  updatedAtMs: number;
+}
+
+interface CronJob {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function readState(statePath: string): Promise<SchedulerState> {
+  const raw = await fs.readFile(statePath, "utf-8");
+  return JSON.parse(raw) as SchedulerState;
+}
+
+async function waitForStateFile(statePath: string, timeoutMs = 30_000): Promise<SchedulerState> {
+  return waitFor(
+    "state file exists",
+    async () => {
+      try {
+        return await readState(statePath);
+      } catch {
+        return undefined;
+      }
+    },
+    timeoutMs,
+  );
+}
+
+async function waitForJobCount(
+  statePath: string,
+  expected: number,
+  timeoutMs = 15_000,
+): Promise<SchedulerState> {
+  return waitFor(
+    `state file has ${expected} job(s)`,
+    async () => {
+      try {
+        const state = await readState(statePath);
+        return state.jobs.length === expected ? state : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    timeoutMs,
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+async function testGatewayStartWritesState(statePath: string): Promise<void> {
+  console.log("Test 1: gateway_start writes initial state file");
+  const state = await waitForStateFile(statePath);
+  assert(state.version === 1, `expected version=1, got ${state.version}`);
+  assert(state.jobs.length === 0, `expected 0 jobs on startup, got ${state.jobs.length}`);
+  console.log("  ✓ State file created with version=1, 0 jobs");
+}
+
+async function testAddJob(
+  gateway: GatewayRpcClient,
+  statePath: string,
+  intervalMs: number,
+): Promise<string> {
+  console.log("Test 2: cron add → job appears in state file");
+  const job = await gateway.request<CronJob>("cron.add", {
+    name: "e2e-ext-cron-add",
+    enabled: true,
+    schedule: { kind: "every", everyMs: intervalMs },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "Say OK", timeoutSeconds: 30 },
+    delivery: { mode: "none" },
+  });
+  assert(job.id, `cron.add did not return an id: ${JSON.stringify(job)}`);
+  console.log(`  Created job: ${job.id}`);
+
+  const state = await waitForJobCount(statePath, 1);
+  const stateJob = state.jobs[0]!;
+
+  assert(stateJob.jobId === job.id, `jobId mismatch: ${stateJob.jobId} !== ${job.id}`);
+  console.log("  ✓ Job ID matches");
+
+  assert(stateJob.enabled === true, `expected enabled=true, got ${stateJob.enabled}`);
+  console.log("  ✓ Job enabled=true");
+
+  const expectedCmd = `openclaw cron run ${job.id} --due`;
+  assert(
+    stateJob.command === expectedCmd,
+    `command mismatch: ${stateJob.command} !== ${expectedCmd}`,
+  );
+  console.log(`  ✓ Command field correct`);
+
+  assert(stateJob.wakeAtMs > 0, `wakeAtMs should be positive, got ${stateJob.wakeAtMs}`);
+  console.log(`  ✓ wakeAtMs set (${stateJob.wakeAtMs})`);
+
+  assert(
+    stateJob.schedule.kind === "every" && stateJob.schedule.everyMs === intervalMs,
+    `schedule mismatch: ${JSON.stringify(stateJob.schedule)}`,
+  );
+  console.log(`  ✓ Schedule preserved (every ${intervalMs}ms)`);
+
+  return job.id;
+}
+
+async function testAddSecondJob(gateway: GatewayRpcClient, statePath: string): Promise<string> {
+  console.log("Test 3: second cron add → two jobs in state");
+  const job = await gateway.request<CronJob>("cron.add", {
+    name: "e2e-ext-cron-add-2",
+    enabled: true,
+    schedule: { kind: "every", everyMs: 300_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "Say OK 2", timeoutSeconds: 30 },
+    delivery: { mode: "none" },
+  });
+  assert(job.id, "cron.add did not return an id");
+  console.log(`  Created job: ${job.id}`);
+
+  const state = await waitForJobCount(statePath, 2);
+  assert(state.jobs.length === 2, `expected 2 jobs, got ${state.jobs.length}`);
+  console.log("  ✓ State file has 2 jobs");
+
+  return job.id;
+}
+
+async function testDisableJob(
+  gateway: GatewayRpcClient,
+  statePath: string,
+  jobId: string,
+  remainingJobId: string,
+): Promise<void> {
+  console.log("Test 4: cron disable → job removed from state (includeDisabled=false)");
+  await gateway.request("cron.update", { jobId, patch: { enabled: false } });
+
+  const state = await waitForJobCount(statePath, 1);
+  assert(state.jobs.length === 1, `expected 1 job after disable, got ${state.jobs.length}`);
+  console.log("  ✓ Disabled job removed from state");
+
+  assert(
+    state.jobs[0]!.jobId === remainingJobId,
+    `wrong job remaining: ${state.jobs[0]!.jobId} (expected ${remainingJobId})`,
+  );
+  console.log(`  ✓ Remaining job is correct (${remainingJobId})`);
+}
+
+async function testEnableJob(
+  gateway: GatewayRpcClient,
+  statePath: string,
+  jobId: string,
+): Promise<void> {
+  console.log("Test 5: cron enable → job reappears in state");
+  await gateway.request("cron.update", { jobId, patch: { enabled: true } });
+
+  const state = await waitForJobCount(statePath, 2);
+  assert(state.jobs.length === 2, `expected 2 jobs after re-enable, got ${state.jobs.length}`);
+  console.log("  ✓ Re-enabled job reappears (2 jobs)");
+}
+
+async function testRemoveJob(
+  gateway: GatewayRpcClient,
+  statePath: string,
+  jobId: string,
+): Promise<void> {
+  console.log("Test 6: cron rm → job removed from state");
+  await gateway.request("cron.remove", { jobId });
+
+  const state = await waitForJobCount(statePath, 1);
+  assert(state.jobs.length === 1, `expected 1 job after rm, got ${state.jobs.length}`);
+  console.log("  ✓ Removed job gone from state");
+}
+
+async function testFinishedAdvancesWakeAt(
+  gateway: GatewayRpcClient,
+  statePath: string,
+  jobId: string,
+  intervalMs: number,
+): Promise<void> {
+  console.log(`Test 7: cron fires → wakeAtMs advances (forcing run, interval=${intervalMs}ms)`);
+
+  const stateBefore = await readState(statePath);
+  const jobBefore = stateBefore.jobs.find((j) => j.jobId === jobId);
+  assert(jobBefore, `job ${jobId} not found in state before run`);
+  const wakeBefore = jobBefore.wakeAtMs;
+  console.log(`  wakeAtMs before: ${wakeBefore}`);
+
+  // Force-run the cron job instead of waiting for the timer
+  const run = await gateway.request<{ ok?: boolean; enqueued?: boolean }>("cron.run", {
+    id: jobId,
+    mode: "force",
+  });
+  assert(run.ok === true && run.enqueued === true, `cron.run not enqueued: ${JSON.stringify(run)}`);
+
+  // Wait for the finished event
+  const finished = await waitFor(
+    "cron finished event",
+    () =>
+      gateway.events.find(
+        (e) => e.event === "cron" && e.payload.jobId === jobId && e.payload.action === "finished",
+      )?.payload,
+    120_000,
+  );
+  assert(finished, "missing cron finished event");
+  console.log(`  Cron run finished (status: ${finished.status})`);
+
+  // Wait for state file to update with new wakeAtMs
+  const stateAfter = await waitFor(
+    "wakeAtMs advanced",
+    async () => {
+      const s = await readState(statePath);
+      const j = s.jobs.find((j) => j.jobId === jobId);
+      if (j && j.wakeAtMs !== wakeBefore) return s;
+      return undefined;
+    },
+    15_000,
+  );
+
+  const jobAfter = stateAfter.jobs.find((j) => j.jobId === jobId);
+  assert(jobAfter, `job ${jobId} not found in state after run`);
+  const wakeAfter = jobAfter.wakeAtMs;
+  console.log(`  wakeAtMs after:  ${wakeAfter}`);
+
+  const advanceMs = wakeAfter - wakeBefore;
+  assert(
+    advanceMs >= intervalMs,
+    `wakeAtMs advanced by ${advanceMs}ms, expected ≥ ${intervalMs}ms`,
+  );
+  console.log(`  ✓ wakeAtMs advanced by ${advanceMs}ms (≥ ${intervalMs}ms)`);
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const gatewayUrl = process.env.GW_URL?.trim();
+  const gatewayToken = process.env.GW_TOKEN?.trim();
+  const stateDir =
+    process.env.OPENCLAW_STATE_DIR?.trim() || path.join(process.env.HOME || "/tmp", ".openclaw");
+  const statePath = path.join(stateDir, "external-cron-scheduler", "jobs.json");
+  const intervalMs = Number(process.env.CRON_INTERVAL_MS || "10000");
+
+  assert(gatewayUrl, "missing GW_URL");
+  assert(gatewayToken, "missing GW_TOKEN");
+
+  console.log(`State path: ${statePath}`);
+  console.log(`Interval:   ${intervalMs}ms`);
+  console.log("");
+
+  const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  let passCount = 0;
+  let failCount = 0;
+
+  try {
+    // Test 1: gateway_start wrote the initial state
+    await testGatewayStartWritesState(statePath);
+    passCount++;
+
+    // Test 2: add a job
+    const job1Id = await testAddJob(gateway, statePath, intervalMs);
+    passCount++;
+
+    // Test 3: add a second job
+    const job2Id = await testAddSecondJob(gateway, statePath);
+    passCount++;
+
+    // Test 4: disable second job
+    await testDisableJob(gateway, statePath, job2Id, job1Id);
+    passCount++;
+
+    // Test 5: re-enable second job
+    await testEnableJob(gateway, statePath, job2Id);
+    passCount++;
+
+    // Test 6: remove second job
+    await testRemoveJob(gateway, statePath, job2Id);
+    passCount++;
+
+    // Test 7: force-run → wakeAtMs advances
+    await testFinishedAdvancesWakeAt(gateway, statePath, job1Id, intervalMs);
+    passCount++;
+
+    // Cleanup: remove the remaining job
+    await gateway.request("cron.remove", { jobId: job1Id });
+
+    console.log("");
+    console.log(`Results: ${passCount} passed, ${failCount} failed`);
+    console.log("OK");
+  } catch (error) {
+    failCount++;
+    console.error("");
+    console.error(`FAIL: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(`Results: ${passCount} passed, ${failCount} failed`);
+    process.exit(1);
+  } finally {
+    await gateway.close();
+  }
+}
+
+await main();

--- a/scripts/e2e/external-cron-scheduler-docker.sh
+++ b/scripts/e2e/external-cron-scheduler-docker.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ────────────────────────────────────────────────────────────────────────────────
+# E2E smoke test: local-external-cron-scheduler extension (Docker)
+#
+# Tests the cron_changed hook and the local-external-cron-scheduler extension
+# inside a Docker container. Verifies all cron job lifecycle events produce
+# correct JSON state file updates.
+#
+# Usage:
+#   bash scripts/e2e/external-cron-scheduler-docker.sh
+#
+# Environment:
+#   OPENCLAW_IMAGE / OPENCLAW_DOCKER_E2E_IMAGE — pre-built Docker image to use
+#   OPENCLAW_SKIP_DOCKER_BUILD=1               — skip image build (reuse existing)
+#   CRON_INTERVAL_MS                           — cron interval for fire test
+#                                                (default: 10000 = 10s)
+# ────────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-ext-cron-scheduler-e2e" OPENCLAW_IMAGE)"
+PORT="18789"
+TOKEN="ext-cron-e2e-$(date +%s)-$$"
+CONTAINER_NAME="openclaw-ext-cron-scheduler-e2e-$$"
+CLIENT_LOG="$(mktemp -t openclaw-ext-cron-client-log.XXXXXX)"
+CRON_INTERVAL_MS="${CRON_INTERVAL_MS:-10000}"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  rm -f "$CLIENT_LOG"
+}
+trap cleanup EXIT
+
+docker_e2e_build_or_reuse "$IMAGE_NAME" external-cron-scheduler
+
+echo "Running in-container external-cron-scheduler smoke..."
+set +e
+docker run --rm \
+  --name "$CONTAINER_NAME" \
+  -e "OPENCLAW_GATEWAY_TOKEN=$TOKEN" \
+  -e "OPENCLAW_SKIP_CHANNELS=1" \
+  -e "OPENCLAW_SKIP_GMAIL_WATCHER=1" \
+  -e "OPENCLAW_SKIP_CANVAS_HOST=1" \
+  -e "OPENCLAW_STATE_DIR=/tmp/openclaw-state" \
+  -e "OPENCLAW_CONFIG_PATH=/tmp/openclaw-state/openclaw.json" \
+  -e "GW_URL=ws://127.0.0.1:$PORT" \
+  -e "GW_TOKEN=$TOKEN" \
+  -e "CRON_INTERVAL_MS=$CRON_INTERVAL_MS" \
+  -e "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1" \
+  "$IMAGE_NAME" \
+  bash -lc "set -euo pipefail
+    entry=dist/index.mjs
+    [ -f \"\$entry\" ] || entry=dist/index.js
+
+    # ── Mock OpenAI server ──────────────────────────────────────────────
+    export MOCK_PORT=44081
+    export SUCCESS_MARKER=OPENCLAW_EXT_CRON_E2E_OK
+    export MOCK_REQUEST_LOG=/tmp/ext-cron-mock-openai-requests.jsonl
+    export OPENCLAW_DOCKER_OPENAI_BASE_URL=\"http://127.0.0.1:\$MOCK_PORT/v1\"
+    node scripts/e2e/mock-openai-server.mjs >/tmp/ext-cron-mock-openai.log 2>&1 &
+    mock_pid=\$!
+
+    # ── Seed config ─────────────────────────────────────────────────────
+    node --import tsx scripts/e2e/external-cron-scheduler-seed.ts >/tmp/ext-cron-seed.log
+
+    # ── Start gateway ───────────────────────────────────────────────────
+    node \"\$entry\" gateway --port $PORT --bind loopback --allow-unconfigured >/tmp/ext-cron-gateway.log 2>&1 &
+    gateway_pid=\$!
+
+    cleanup_inner() {
+      kill \"\$mock_pid\" >/dev/null 2>&1 || true
+      kill \"\$gateway_pid\" >/dev/null 2>&1 || true
+      wait \"\$mock_pid\" >/dev/null 2>&1 || true
+      wait \"\$gateway_pid\" >/dev/null 2>&1 || true
+    }
+    dump_logs_on_error() {
+      status=\$?
+      if [ \"\$status\" -ne 0 ]; then
+        echo '=== Gateway log (last 80 lines) ==='
+        tail -n 80 /tmp/ext-cron-gateway.log 2>/dev/null || true
+        echo '=== Seed log ==='
+        cat /tmp/ext-cron-seed.log 2>/dev/null || true
+        echo '=== Mock OpenAI log ==='
+        cat /tmp/ext-cron-mock-openai.log 2>/dev/null || true
+      fi
+      cleanup_inner
+      exit \"\$status\"
+    }
+    trap cleanup_inner EXIT
+    trap dump_logs_on_error ERR
+
+    # ── Wait for mock ───────────────────────────────────────────────────
+    for _ in \$(seq 1 80); do
+      if node -e \"fetch('http://127.0.0.1:' + process.env.MOCK_PORT + '/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\"; then
+        break
+      fi
+      sleep 0.1
+    done
+    node -e \"fetch('http://127.0.0.1:' + process.env.MOCK_PORT + '/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\"
+
+    # ── Wait for gateway ────────────────────────────────────────────────
+    gateway_ready=0
+    for _ in \$(seq 1 300); do
+      if grep -q '\[gateway\] ready' /tmp/ext-cron-gateway.log 2>/dev/null; then
+        gateway_ready=1
+        break
+      fi
+      sleep 0.25
+    done
+    if [ \"\$gateway_ready\" -ne 1 ]; then
+      echo 'Gateway did not become ready'
+      tail -n 120 /tmp/ext-cron-gateway.log 2>/dev/null || true
+      exit 1
+    fi
+
+    # ── Run client tests ────────────────────────────────────────────────
+    node --import tsx scripts/e2e/external-cron-scheduler-docker-client.ts
+  " >"$CLIENT_LOG" 2>&1
+status=${PIPESTATUS[0]}
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "Docker external-cron-scheduler smoke failed"
+  cat "$CLIENT_LOG"
+  exit "$status"
+fi
+
+# Show test output on success too
+cat "$CLIENT_LOG"
+echo ""
+echo "OK"

--- a/scripts/e2e/external-cron-scheduler-seed.ts
+++ b/scripts/e2e/external-cron-scheduler-seed.ts
@@ -1,0 +1,70 @@
+/**
+ * Seed script for external-cron-scheduler E2E test.
+ *
+ * Creates an openclaw.json with:
+ *   - Mock OpenAI provider (for cron job LLM calls)
+ *   - local-external-cron-scheduler extension enabled
+ *   - Cron enabled (for the internal scheduler)
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { applyDockerOpenAiProviderConfig, type OpenClawConfig } from "./docker-openai-seed.ts";
+
+async function main(): Promise<void> {
+  const stateDir =
+    process.env.OPENCLAW_STATE_DIR?.trim() || path.join(process.env.HOME || "/tmp", ".openclaw");
+  const configPath =
+    process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(stateDir, "openclaw.json");
+  const statePath = path.join(stateDir, "external-cron-scheduler", "jobs.json");
+
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+
+  // Clean up any state from prior runs
+  await fs.rm(path.join(stateDir, "external-cron-scheduler"), { recursive: true, force: true });
+
+  const config = applyDockerOpenAiProviderConfig(
+    {
+      gateway: {
+        controlUi: {
+          allowInsecureAuth: true,
+          enabled: false,
+        },
+      },
+      // Enable the internal cron scheduler so cron jobs fire
+      cron: {
+        enabled: true,
+      },
+      plugins: {
+        // Load the extension from the built dist
+        load: {
+          paths: ["dist/extensions/local-external-cron-scheduler"],
+        },
+        allow: ["local-external-cron-scheduler"],
+        entries: {
+          "local-external-cron-scheduler": {
+            enabled: true,
+            config: {
+              enabled: true,
+              statePath,
+              instanceId: "docker-e2e",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig,
+    "sk-docker-ext-cron-e2e",
+  );
+
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+
+  process.stdout.write(
+    JSON.stringify({
+      ok: true,
+      stateDir,
+      configPath,
+      statePath,
+    }) + "\n",
+  );
+}
+
+await main();

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -893,6 +893,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   additionalProperties: false,
                 },
+                toolProgress: {
+                  type: "boolean",
+                },
               },
               additionalProperties: false,
             },
@@ -2066,6 +2069,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                         },
                         additionalProperties: false,
                       },
+                      toolProgress: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -3080,6 +3086,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       "streaming.preview.chunk.breakPreference": {
         label: "Discord Draft Chunk Break Preference",
         help: "Preferred breakpoints for Discord draft chunks (paragraph | newline | sentence). Default: paragraph.",
+      },
+      "streaming.preview.toolProgress": {
+        label: "Discord Draft Tool Progress",
+        help: "Show tool/progress activity in the live draft preview message (default: true). Set false to keep tool updates as separate messages.",
       },
       "retry.attempts": {
         label: "Discord Retry Attempts",
@@ -9417,6 +9427,27 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             ],
           },
         },
+        groupAllowFrom: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
+        },
+        dmPolicy: {
+          type: "string",
+          enum: ["open", "allowlist", "disabled"],
+        },
+        groupPolicy: {
+          type: "string",
+          enum: ["open", "allowlist", "disabled"],
+        },
         systemPrompt: {
           type: "string",
         },
@@ -9479,42 +9510,41 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
           ],
         },
-        tts: {
+        execApprovals: {
           type: "object",
           properties: {
             enabled: {
-              type: "boolean",
+              anyOf: [
+                {
+                  type: "boolean",
+                },
+                {
+                  type: "string",
+                  const: "auto",
+                },
+              ],
             },
-            provider: {
-              type: "string",
-            },
-            baseUrl: {
-              type: "string",
-            },
-            apiKey: {
-              type: "string",
-            },
-            model: {
-              type: "string",
-            },
-            voice: {
-              type: "string",
-            },
-            authStyle: {
-              type: "string",
-              enum: ["bearer", "api-key"],
-            },
-            queryParams: {
-              type: "object",
-              propertyNames: {
-                type: "string",
-              },
-              additionalProperties: {
+            approvers: {
+              type: "array",
+              items: {
                 type: "string",
               },
             },
-            speed: {
-              type: "number",
+            agentFilter: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            sessionFilter: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            target: {
+              type: "string",
+              enum: ["dm", "channel", "both"],
             },
           },
           additionalProperties: false,
@@ -9637,6 +9667,27 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   ],
                 },
               },
+              groupAllowFrom: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+              dmPolicy: {
+                type: "string",
+                enum: ["open", "allowlist", "disabled"],
+              },
+              groupPolicy: {
+                type: "string",
+                enum: ["open", "allowlist", "disabled"],
+              },
               systemPrompt: {
                 type: "string",
               },
@@ -9698,6 +9749,45 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     additionalProperties: {},
                   },
                 ],
+              },
+              execApprovals: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    anyOf: [
+                      {
+                        type: "boolean",
+                      },
+                      {
+                        type: "string",
+                        const: "auto",
+                      },
+                    ],
+                  },
+                  approvers: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                  agentFilter: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                  sessionFilter: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                  target: {
+                    type: "string",
+                    enum: ["dm", "channel", "both"],
+                  },
+                },
+                additionalProperties: false,
               },
             },
             additionalProperties: {},
@@ -10866,6 +10956,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   additionalProperties: false,
                 },
+                toolProgress: {
+                  type: "boolean",
+                },
               },
               additionalProperties: false,
             },
@@ -11775,6 +11868,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                         },
                         additionalProperties: false,
                       },
+                      toolProgress: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -12310,6 +12406,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       "streaming.nativeTransport": {
         label: "Slack Native Streaming",
         help: "Enable native Slack text streaming (chat.startStream/chat.appendStream/chat.stopStream) when channels.slack.streaming.mode is partial (default: true). Requires a reply thread target; top-level DMs stay on the non-thread fallback path.",
+      },
+      "streaming.preview.toolProgress": {
+        label: "Slack Draft Tool Progress",
+        help: "Show tool/progress activity in the live draft preview message (default: true). Set false to keep tool updates as separate messages.",
       },
       "thread.historyScope": {
         label: "Slack Thread History Scope",
@@ -13057,6 +13157,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     },
                   },
                   additionalProperties: false,
+                },
+                toolProgress: {
+                  type: "boolean",
                 },
               },
               additionalProperties: false,
@@ -14096,6 +14199,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                         },
                         additionalProperties: false,
                       },
+                      toolProgress: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -14497,6 +14603,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       "streaming.preview.chunk.breakPreference": {
         label: "Telegram Draft Chunk Break Preference",
         help: "Preferred breakpoints for Telegram draft chunks (paragraph | newline | sentence).",
+      },
+      "streaming.preview.toolProgress": {
+        label: "Telegram Draft Tool Progress",
+        help: "Show tool/progress activity in the live draft preview message (default: true). Set false to keep tool updates as separate messages.",
       },
       "retry.attempts": {
         label: "Telegram Retry Attempts",

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -14,6 +14,8 @@ const {
   fetchWithSsrFGuardMock,
   runCronIsolatedAgentTurnMock,
   cleanupBrowserSessionsForLifecycleEndMock,
+  getGlobalHookRunnerMock,
+  runCronChangedMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatNowMock: vi.fn(),
@@ -24,6 +26,11 @@ const {
   fetchWithSsrFGuardMock: vi.fn(),
   runCronIsolatedAgentTurnMock: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
   cleanupBrowserSessionsForLifecycleEndMock: vi.fn(async () => {}),
+  runCronChangedMock: vi.fn(async () => {}),
+  getGlobalHookRunnerMock: vi.fn(() => ({
+    hasHooks: (hookName: string) => hookName === "cron_changed",
+    runCronChanged: runCronChangedMock,
+  })),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -77,6 +84,10 @@ vi.mock("../browser-lifecycle-cleanup.js", () => ({
   cleanupBrowserSessionsForLifecycleEnd: cleanupBrowserSessionsForLifecycleEndMock,
 }));
 
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: getGlobalHookRunnerMock,
+}));
+
 import { buildGatewayCronService } from "./server-cron.js";
 
 function createCronConfig(name: string): OpenClawConfig {
@@ -100,6 +111,50 @@ describe("buildGatewayCronService", () => {
     fetchWithSsrFGuardMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
     cleanupBrowserSessionsForLifecycleEndMock.mockClear();
+    runCronChangedMock.mockClear();
+    getGlobalHookRunnerMock.mockClear();
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "cron_changed",
+      runCronChanged: runCronChangedMock,
+    });
+  });
+
+  it("emits cron_changed hooks with computed next run state", async () => {
+    const cfg = createCronConfig("server-cron-hook");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "scheduler-hook",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "sync external wake" },
+      });
+
+      expect(runCronChangedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "added",
+          jobId: job.id,
+          job: expect.objectContaining({
+            id: job.id,
+            state: expect.objectContaining({ nextRunAtMs: job.state.nextRunAtMs }),
+          }),
+        }),
+        expect.objectContaining({
+          config: cfg,
+          getCron: expect.any(Function),
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
   });
 
   it("routes main-target jobs to the scoped session for enqueue + wake", async () => {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -34,6 +34,11 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type {
+  PluginHookCronChangedEvent,
+  PluginHookGatewayContext,
+} from "../plugins/hook-types.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -271,6 +276,20 @@ export function buildGatewayCronService(params: {
   const sessionStorePath = resolveSessionStorePath(defaultAgentId);
   const warnedLegacyWebhookJobs = new Set<string>();
 
+  const runCronChangedHook = (evt: PluginHookCronChangedEvent) => {
+    const hookRunner = getGlobalHookRunner();
+    if (!hookRunner?.hasHooks("cron_changed")) {
+      return;
+    }
+    const hookCtx: PluginHookGatewayContext = {
+      config: params.cfg,
+      getCron: () => cron,
+    };
+    void hookRunner.runCronChanged(evt, hookCtx).catch((err) => {
+      cronLogger.warn({ err: String(err), jobId: evt.jobId }, "cron_changed hook failed");
+    });
+  };
+
   const cron = new CronService({
     storePath,
     cronEnabled,
@@ -416,10 +435,28 @@ export function buildGatewayCronService(params: {
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
+      const job = cron.getJob(evt.jobId);
+      runCronChangedHook({
+        action: evt.action,
+        jobId: evt.jobId,
+        ...(job ? { job } : {}),
+        ...(evt.runAtMs !== undefined ? { runAtMs: evt.runAtMs } : {}),
+        ...(evt.durationMs !== undefined ? { durationMs: evt.durationMs } : {}),
+        ...(evt.status !== undefined ? { status: evt.status } : {}),
+        ...(evt.error !== undefined ? { error: evt.error } : {}),
+        ...(evt.summary !== undefined ? { summary: evt.summary } : {}),
+        ...(evt.delivered !== undefined ? { delivered: evt.delivered } : {}),
+        ...(evt.deliveryStatus !== undefined ? { deliveryStatus: evt.deliveryStatus } : {}),
+        ...(evt.deliveryError !== undefined ? { deliveryError: evt.deliveryError } : {}),
+        ...(evt.sessionId !== undefined ? { sessionId: evt.sessionId } : {}),
+        ...(evt.sessionKey !== undefined ? { sessionKey: evt.sessionKey } : {}),
+        ...(evt.nextRunAtMs !== undefined ? { nextRunAtMs: evt.nextRunAtMs } : {}),
+        ...(evt.model !== undefined ? { model: evt.model } : {}),
+        ...(evt.provider !== undefined ? { provider: evt.provider } : {}),
+      });
       if (evt.action === "finished") {
         const webhookToken = normalizeOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = normalizeOptionalString(params.cfg.cron?.webhook);
-        const job = cron.getJob(evt.jobId);
         const legacyNotify = (job as { notify?: unknown } | undefined)?.notify === true;
         const webhookTarget = resolveCronWebhookTarget({
           delivery:

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -81,6 +81,7 @@ export type PluginHookName =
   | "subagent_ended"
   | "gateway_start"
   | "gateway_stop"
+  | "cron_changed"
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install";
@@ -112,6 +113,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_ended",
   "gateway_start",
   "gateway_stop",
+  "cron_changed",
   "before_dispatch",
   "reply_dispatch",
   "before_install",
@@ -520,23 +522,72 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+export type PluginHookGatewayCronRunStatus = "ok" | "error" | "skipped";
+
+export type PluginHookGatewayCronDeliveryStatus =
+  | "not-requested"
+  | "delivered"
+  | "not-delivered"
+  | "error";
+
+export type PluginHookGatewayCronJobState = {
+  nextRunAtMs?: number;
+  runningAtMs?: number;
+  lastRunAtMs?: number;
+  lastRunStatus?: PluginHookGatewayCronRunStatus;
+  lastError?: string;
+  lastDurationMs?: number;
+};
+
 export type PluginHookGatewayCronJob = {
   id: string;
   name?: string;
   description?: string;
   enabled?: boolean;
-  schedule?: {
-    kind?: string;
-    expr?: string;
-    tz?: string;
-  };
+  schedule?:
+    | {
+        kind?: "cron" | string;
+        expr?: string;
+        tz?: string;
+        staggerMs?: number;
+      }
+    | {
+        kind?: "at" | string;
+        at?: string;
+      }
+    | {
+        kind?: "every" | string;
+        everyMs?: number;
+        anchorMs?: number;
+      };
   sessionTarget?: string;
   wakeMode?: string;
   payload?: {
     kind?: string;
     text?: string;
   };
+  state?: PluginHookGatewayCronJobState;
   createdAtMs?: number;
+  updatedAtMs?: number;
+};
+
+export type PluginHookCronChangedEvent = {
+  action: "added" | "updated" | "removed" | "started" | "finished";
+  jobId: string;
+  job?: PluginHookGatewayCronJob;
+  runAtMs?: number;
+  durationMs?: number;
+  status?: PluginHookGatewayCronRunStatus;
+  error?: string;
+  summary?: string;
+  delivered?: boolean;
+  deliveryStatus?: PluginHookGatewayCronDeliveryStatus;
+  deliveryError?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  nextRunAtMs?: number;
+  model?: string;
+  provider?: string;
 };
 
 export type PluginHookGatewayCronCreateInput = {
@@ -767,6 +818,10 @@ export type PluginHookHandlerMap = {
   ) => Promise<void> | void;
   gateway_stop: (
     event: PluginHookGatewayStopEvent,
+    ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
+  cron_changed: (
+    event: PluginHookCronChangedEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
   before_install: (

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -37,6 +37,7 @@ import type {
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
+  PluginHookCronChangedEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -118,6 +119,7 @@ export type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentSpawnedEvent,
   PluginHookSubagentEndedEvent,
+  PluginHookCronChangedEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -1065,6 +1067,16 @@ export function createHookRunner(
     return runVoidHook("gateway_stop", event, ctx);
   }
 
+  /**
+   * Run cron_changed hook for gateway-owned cron lifecycle changes.
+   */
+  async function runCronChanged(
+    event: PluginHookCronChangedEvent,
+    ctx: PluginHookGatewayContext,
+  ): Promise<void> {
+    return runVoidHook("cron_changed", event, ctx);
+  }
+
   // =========================================================================
   // Skill Install Hooks
   // =========================================================================
@@ -1155,6 +1167,7 @@ export function createHookRunner(
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    runCronChanged,
     // Install hooks
     runBeforeInstall,
     // Utility

--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHookRunnerWithRegistry } from "./hooks.test-helpers.js";
 import type {
+  PluginHookCronChangedEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -53,12 +54,32 @@ describe("gateway hook runner methods", () => {
     await expectGatewayHookCall({ hookName, event, gatewayCtx });
   });
 
+  it("runCronChanged invokes registered cron_changed hooks", async () => {
+    const handler = vi.fn();
+    const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_changed", handler }]);
+    const event: PluginHookCronChangedEvent = {
+      action: "updated",
+      jobId: "job-1",
+      nextRunAtMs: 123,
+      job: {
+        id: "job-1",
+        state: { nextRunAtMs: 123 },
+      },
+    };
+
+    await runner.runCronChanged(event, gatewayCtx);
+
+    expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
+  });
+
   it("hasHooks returns true for registered gateway hooks", () => {
     const { runner } = createHookRunnerWithRegistry([
       { hookName: "gateway_start", handler: vi.fn() },
+      { hookName: "cron_changed", handler: vi.fn() },
     ]);
 
     expect(runner.hasHooks("gateway_start")).toBe(true);
+    expect(runner.hasHooks("cron_changed")).toBe(true);
     expect(runner.hasHooks("gateway_stop")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in external scheduler integration path for OpenClaw cron:

- exposes a non-blocking `cron_changed` plugin hook with computed cron state (`job.state.nextRunAtMs`)
- wires gateway cron lifecycle events into the plugin hook runner
- adds a bundled `local-external-cron-scheduler` extension, disabled by default
- the local plugin writes a scheduler state JSON file for external wake runners when explicitly enabled with plugin config (`enabled: true`)

OpenClaw remains authoritative for cron due checks and execution. External runners should wake the container and invoke the rendered command, e.g. `openclaw cron run <jobId> --due`.

## Optional config

The bundled plugin is disabled by default via `enabledByDefault: false` and also no-ops unless configured with:

```json
{
  "enabled": true,
  "statePath": "~/.openclaw/external-cron-scheduler/jobs.json",
  "instanceId": "local",
  "commandTemplate": "openclaw cron run {jobId} --due",
  "leadTimeMs": 0,
  "includeDisabled": false
}
```

## Validation

### Unit tests (19 total, all pass)
- `extensions/local-external-cron-scheduler/index.test.ts` — 6 tests
- `src/gateway/server-cron.test.ts` — 9 tests (new: cron_changed hook wiring)
- `src/plugins/wired-hooks-gateway.test.ts` — 4 tests

### Docker E2E (7 lifecycle assertions, all pass)

```
Test 1: gateway_start writes initial state file
  ✓ State file created with version=1, 0 jobs
Test 2: cron add → job appears in state file
  ✓ Job ID matches
  ✓ Job enabled=true
  ✓ Command field correct
  ✓ wakeAtMs set
  ✓ Schedule preserved (every 10000ms)
Test 3: second cron add → two jobs in state
  ✓ State file has 2 jobs
Test 4: cron disable → job removed from state (includeDisabled=false)
  ✓ Disabled job removed from state
  ✓ Remaining job is correct
Test 5: cron enable → job reappears in state
  ✓ Re-enabled job reappears (2 jobs)
Test 6: cron rm → job removed from state
  ✓ Removed job gone from state
Test 7: cron fires → wakeAtMs advances (forcing run, interval=10000ms)
  ✓ wakeAtMs advanced by 10004ms (≥ 10000ms)
Results: 7 passed, 0 failed
OK
```

Run with: `bash scripts/e2e/external-cron-scheduler-docker.sh`

### Live sandbox E2E (manual)

Also tested end-to-end against a live OpenShell sandbox (openclaw-dist `atlassian-openclaw-gateway`) by uploading the dev build, configuring the extension, and verifying all lifecycle events produce correct state file updates.

## Design decisions

- **Fire-and-forget**: The `cron_changed` hook never blocks or fails the cron operation. Errors are logged but swallowed.
- **Atomic writes**: State file is written to a `.tmp` file then renamed, preventing partial reads.
- **Disabled by default**: Extension must be explicitly enabled in config.
- **`gateway_start` full sync**: On startup, the extension does a full sync of all jobs to recover from any missed events.