### PR TITLE
fix(auto-reply): poison inbound dedupe after externally-visible dispatch

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -3236,6 +3236,63 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("poisons inbound dedupe when error fires after a reply was emitted (#69303)", async () => {
+    setNoAbort();
+    const cfg = { diagnostics: { enabled: true } } as OpenClawConfig;
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "whatsapp:+15555550125",
+      To: "whatsapp:+15555550125",
+      AccountId: "default",
+      MessageSid: "msg-poison-after-emit",
+      SessionKey: "agent:main:whatsapp:direct:+15555550125",
+      CommandBody: "hello",
+      RawBody: "hello",
+      Body: "hello",
+    });
+    // First call emits a block reply (externally visible) and then throws —
+    // the catch path should poison rather than release. Second call is set
+    // up only to prove the retry never reaches the resolver.
+    const replyResolver = vi
+      .fn<
+        (_ctx: MsgContext, _opts?: GetReplyOptions, _cfg?: OpenClawConfig) => Promise<ReplyPayload>
+      >()
+      .mockImplementationOnce(async (_ctx, opts) => {
+        await opts?.onBlockReply?.({ text: "partial" });
+        throw new Error("post-dispatch failure");
+      })
+      .mockResolvedValueOnce({ text: "retry should be skipped" });
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg,
+        dispatcher: createDispatcher(),
+        replyResolver,
+      }),
+    ).rejects.toThrow("post-dispatch failure");
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    // Retry must be skipped at the inbound entrypoint — replay would surface
+    // a duplicate visible message and re-run any associated turn-state side
+    // effects.
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        outcome: "skipped",
+        reason: "duplicate",
+      }),
+    );
+  });
+
   it("passes configOverride to replyResolver when provided", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -72,7 +72,12 @@ import type {
   DispatchFromConfigResult,
 } from "./dispatch-from-config.types.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
-import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
+import {
+  claimInboundDedupe,
+  commitInboundDedupe,
+  poisonInboundDedupe,
+  releaseInboundDedupe,
+} from "./inbound-dedupe.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 
@@ -671,6 +676,12 @@ export async function dispatchReplyFromConfig(
 
   markProcessing();
 
+  // Tracks whether an outbound reply has been dispatched in this turn. Used by
+  // the catch path below to choose between releaseInboundDedupe (safe-retry on
+  // transient pre-dispatch failure) and poisonInboundDedupe (block replay once
+  // any externally-visible reply has gone out). See #69303.
+  let outboundReplyDispatched = false;
+
   try {
     const abortRuntime = params.fastAbortResolver ? null : await loadAbortRuntime();
     const fastAbortResolver = params.fastAbortResolver ?? abortRuntime?.tryFastAbortFromMessage;
@@ -738,13 +749,20 @@ export async function dispatchReplyFromConfig(
             `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
           );
         }
+        if (result.ok) {
+          outboundReplyDispatched = true;
+        }
         return {
           queuedFinal: result.ok,
           routedFinalCount: result.ok ? 1 : 0,
         };
       }
+      const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
+      if (queuedFinal) {
+        outboundReplyDispatched = true;
+      }
       return {
-        queuedFinal: dispatcher.sendFinalReply(normalizedPayload),
+        queuedFinal,
         routedFinalCount: 0,
       };
     };
@@ -1200,6 +1218,7 @@ export async function dispatchReplyFromConfig(
               queuedFinal = result.ok || queuedFinal;
               if (result.ok) {
                 routedFinalCount += 1;
+                outboundReplyDispatched = true;
               }
               if (!result.ok) {
                 logVerbose(
@@ -1209,6 +1228,9 @@ export async function dispatchReplyFromConfig(
             } else {
               const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
               queuedFinal = didQueue || queuedFinal;
+              if (didQueue) {
+                outboundReplyDispatched = true;
+              }
             }
           }
         } catch (err) {
@@ -1232,7 +1254,16 @@ export async function dispatchReplyFromConfig(
     return { queuedFinal, counts };
   } catch (err) {
     if (inboundDedupeClaim.status === "claimed") {
-      releaseInboundDedupe(inboundDedupeClaim.key);
+      if (outboundReplyDispatched) {
+        // A reply has gone out — replaying the same message_id would surface a
+        // duplicate visible message and re-run any associated turn-state side
+        // effects. Stamp the cache so the inbound entrypoint short-circuits.
+        poisonInboundDedupe(inboundDedupeClaim.key);
+      } else {
+        // Nothing emitted yet; the original release-after-error contract from
+        // 7c91d0dbc9 still applies — let the same message_id retry cleanly.
+        releaseInboundDedupe(inboundDedupeClaim.key);
+      }
     }
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -908,6 +908,9 @@ export async function dispatchReplyFromConfig(
         await sendPayloadAsync(payload, undefined, false);
         return;
       }
+      // TODO(#69303-followup): tool-result-only path; not flagged on
+      // outboundReplyDispatched. Catch path will release, not poison, if this
+      // is the only visible output before an error. See PR #71819.
       dispatcher.sendToolResult(payload);
     };
     const sendPlanUpdate = async (payload: {
@@ -924,6 +927,9 @@ export async function dispatchReplyFromConfig(
         await sendPayloadAsync(replyPayload, undefined, false);
         return;
       }
+      // TODO(#69303-followup): tool-result-only path; not flagged on
+      // outboundReplyDispatched. Catch path will release, not poison, if this
+      // is the only visible output before an error. See PR #71819.
       dispatcher.sendToolResult(replyPayload);
     };
     const summarizeApprovalLabel = (payload: {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -480,6 +480,15 @@ export async function dispatchReplyFromConfig(
     });
   };
 
+  // Tracks whether ANY externally-visible dispatch has fired in this turn —
+  // final reply, TTS-only reply, plugin binding notice, fast-abort reply,
+  // tool result delivery, or block reply. Read by the catch path below to
+  // choose between releaseInboundDedupe (safe-retry on transient pre-dispatch
+  // failure) and poisonInboundDedupe (block replay once anything has gone
+  // out). Set by the dispatch closures defined below and the inline reply /
+  // TTS-only sites in the main try-block. See #69303.
+  let outboundReplyDispatched = false;
+
   /**
    * Helper to send a payload via route-reply (async).
    * Only used when actually routing to a different provider.
@@ -506,6 +515,9 @@ export async function dispatchReplyFromConfig(
     if (result && !result.ok) {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
     }
+    if (result?.ok) {
+      outboundReplyDispatched = true;
+    }
   };
 
   const sendBindingNotice = async (
@@ -519,11 +531,17 @@ export async function dispatchReplyFromConfig(
           `dispatch-from-config: route-reply (plugin binding notice) failed: ${result.error ?? "unknown error"}`,
         );
       }
+      if (result.ok) {
+        outboundReplyDispatched = true;
+      }
       return result.ok;
     }
-    return mode === "additive"
-      ? dispatcher.sendToolResult(payload)
-      : dispatcher.sendFinalReply(payload);
+    const queued =
+      mode === "additive" ? dispatcher.sendToolResult(payload) : dispatcher.sendFinalReply(payload);
+    if (queued) {
+      outboundReplyDispatched = true;
+    }
+    return queued;
   };
 
   const pluginOwnedBindingRecord =
@@ -676,12 +694,6 @@ export async function dispatchReplyFromConfig(
 
   markProcessing();
 
-  // Tracks whether an outbound reply has been dispatched in this turn. Used by
-  // the catch path below to choose between releaseInboundDedupe (safe-retry on
-  // transient pre-dispatch failure) and poisonInboundDedupe (block replay once
-  // any externally-visible reply has gone out). See #69303.
-  let outboundReplyDispatched = false;
-
   try {
     const abortRuntime = params.fastAbortResolver ? null : await loadAbortRuntime();
     const fastAbortResolver = params.fastAbortResolver ?? abortRuntime?.tryFastAbortFromMessage;
@@ -703,6 +715,7 @@ export async function dispatchReplyFromConfig(
           queuedFinal = result.ok;
           if (result.ok) {
             routedFinalCount += 1;
+            outboundReplyDispatched = true;
           }
           if (!result.ok) {
             logVerbose(
@@ -711,6 +724,9 @@ export async function dispatchReplyFromConfig(
           }
         } else {
           queuedFinal = dispatcher.sendFinalReply(payload);
+          if (queuedFinal) {
+            outboundReplyDispatched = true;
+          }
         }
       } else {
         logVerbose(
@@ -1038,6 +1054,7 @@ export async function dispatchReplyFromConfig(
               await sendPayloadAsync(deliveryPayload, undefined, false);
             } else {
               dispatcher.sendToolResult(deliveryPayload);
+              outboundReplyDispatched = true;
             }
           };
           return run();
@@ -1121,6 +1138,7 @@ export async function dispatchReplyFromConfig(
               await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
             } else {
               dispatcher.sendBlockReply(normalizedPayload);
+              outboundReplyDispatched = true;
             }
           };
           return run();

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { importFreshModule } from "../../../test/helpers/import-fresh.js";
 import type { MsgContext } from "../templating.js";
-import { resetInboundDedupe } from "./inbound-dedupe.js";
+import {
+  claimInboundDedupe,
+  poisonInboundDedupe,
+  releaseInboundDedupe,
+  resetInboundDedupe,
+} from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -71,5 +76,31 @@ describe("inbound dedupe", () => {
       inboundA.resetInboundDedupe();
       inboundB.resetInboundDedupe();
     }
+  });
+
+  it("poisonInboundDedupe stamps the cache so subsequent identical inbound is skipped", () => {
+    const claim = claimInboundDedupe(sharedInboundContext);
+    expect(claim).toMatchObject({ status: "claimed" });
+    if (claim.status !== "claimed") {
+      throw new Error("expected claimed inbound dedupe result");
+    }
+
+    poisonInboundDedupe(claim.key);
+
+    // cache.peek (used by claim) hits the stamped cache → duplicate.
+    expect(claimInboundDedupe(sharedInboundContext)).toMatchObject({ status: "duplicate" });
+  });
+
+  it("releaseInboundDedupe leaves the cache unstamped so transient retries can re-claim", () => {
+    const claim = claimInboundDedupe(sharedInboundContext);
+    expect(claim).toMatchObject({ status: "claimed" });
+    if (claim.status !== "claimed") {
+      throw new Error("expected claimed inbound dedupe result");
+    }
+
+    releaseInboundDedupe(claim.key);
+
+    // Cache is unstamped; the same message_id can re-enter and re-claim.
+    expect(claimInboundDedupe(sharedInboundContext)).toMatchObject({ status: "claimed" });
   });
 });

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -135,6 +135,9 @@ export function releaseInboundDedupe(key: string, opts?: { inFlight?: Set<string
 // Contrasts with releaseInboundDedupe (drop in-flight, leave cache unstamped),
 // which preserves the "nothing emitted yet, safe to retry" semantics added in
 // 7c91d0dbc9 for transient pre-dispatch failures.
+//
+// Functionally equivalent to commitInboundDedupe; named separately so call
+// sites are self-documenting about which terminal state they're entering.
 export function poisonInboundDedupe(
   key: string,
   opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -126,6 +126,25 @@ export function releaseInboundDedupe(key: string, opts?: { inFlight?: Set<string
   inFlight.delete(key);
 }
 
+// Mark an in-flight dedupe claim as poisoned: stamp the cache so subsequent
+// identical inbound message_ids short-circuit at the inbound entrypoint, and
+// drop in-flight tracking. Use when an error fires after externally-visible
+// progress (an outbound reply was dispatched), so the same message_id cannot
+// replay a partially-completed turn.
+//
+// Contrasts with releaseInboundDedupe (drop in-flight, leave cache unstamped),
+// which preserves the "nothing emitted yet, safe to retry" semantics added in
+// 7c91d0dbc9 for transient pre-dispatch failures.
+export function poisonInboundDedupe(
+  key: string,
+  opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },
+): void {
+  const cache = opts?.cache ?? inboundDedupeCache;
+  cache.check(key, opts?.now);
+  const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
+  inFlight.delete(key);
+}
+
 export function resetInboundDedupe(): void {
   inboundDedupeCache.clear();
   inboundDedupeInFlight.clear();


### PR DESCRIPTION
Fixes #69303.

When the catch path in `dispatch-from-config.ts` runs after a reply has already been emitted, releasing the inbound dedupe lets the same provider `message_id` replay turns that already produced externally-visible progress — duplicate visible messages, re-run side effects. The original "release on transient pre-dispatch failure" semantics from `7c91d0dbc9` were correct; the gap was treating "any error after dispatch" the same way.

## Approach

Per @NikolaFC's preferred shape from the issue thread: a third terminal state alongside the existing release semantics, decided by whether anything externally-visible already went out.

- New `poisonInboundDedupe()` in `inbound-dedupe.ts` — same effect as `commit` (stamps cache, drops in-flight tracking), but a distinct name keeps the call site self-documenting.
- Function-scope `outboundReplyDispatched` flag in `dispatch-from-config.ts`, set at every visible dispatch site. Catch path branches: poison if any reply went out, otherwise release (preserves current behavior for the "nothing emitted yet" path).

The first commit shipped the flag at `sendFinalPayload` + TTS only. Adversarial review caught the asymmetry — only the final-reply path was protected. The second commit broadens the flag to the four other sites that can reach the outer catch:

- `sendPayloadAsync` route-reply success — tool-result and block-reply callbacks when `shouldRouteToOriginating` is true
- `sendBindingNotice` route-reply success or `dispatcher.send*` truthy
- fast-abort branch — the abort reply itself is externally visible
- `onToolResult` (`dispatcher.sendToolResult`) and `onBlockReply` (`dispatcher.sendBlockReply`) callbacks

Flag's comment updated to "ANY externally-visible dispatch" to match.

## Testing

- 2 unit tests in `inbound-dedupe.test.ts` covering poison vs release semantics from the dedupe module's own seam.
- 1 integration test in `dispatch-from-config.test.ts` mirroring the existing "releases inbound dedupe when dispatch fails before completion" test (which covers the pre-dispatch-throw case): `replyResolver` emits a block reply via `opts.onBlockReply`, then throws. Retry with the same `MessageSid` must be skipped (`outcome=skipped reason=duplicate`) — proves the catch path poisoned rather than released.

Local on the rebased branch: targeted run of both test files via `vitest.auto-reply-reply.config.ts` — 86 passed.

## Out of scope

The flag tracks outbound *replies*. Tool-result-only side effects (`dispatcher.sendToolResult` with no visible reply going out) are not currently included — that would need the flag threaded deeper through the reply pipeline. Kept narrow per the issue's "minimal first fix" framing — happy to layer the broader boundary in a follow-up if you want it covered here.