### PR TITLE
[codex] fix Telegram verbose progress fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: apply the configured 1M context window override to eligible Claude CLI Opus and Sonnet models when `context1m` is enabled. (#70863) Thanks @bidadh.
 - Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local credentials are current. Fixes #71256. (#71332) Thanks @matthiasjanke and @neeravmakwana.
 - CLI backends: compact OpenClaw transcripts after over-budget CLI turns and reseed fresh CLI sessions from the compacted transcript instead of stale external resume state. Fixes #68329. (#71916) Thanks @obviyus.
+- Telegram: keep default tool progress messages visible when answer preview streaming is disabled. (#71825) Thanks @VACInc.
 
 ## 2026.4.24
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -765,6 +765,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("keeps default tool progress messages when answer preview streaming is off", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onItemEvent?.({ progressText: "exec ls ~/Desktop" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          suppressDefaultToolProgressMessages: false,
+        }),
+      }),
+    );
+  });
+
   it("keeps Telegram tool progress links inside code formatting", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1065,7 +1065,7 @@ export const dispatchTelegramMessage = async ({
                   previewToolProgressLines = [];
                 })
             : undefined,
-          suppressDefaultToolProgressMessages: true,
+          suppressDefaultToolProgressMessages: Boolean(answerLane.stream),
           onToolStart: async (payload) => {
             const toolName = payload.name?.trim();
             if (statusReactionController && toolName) {


### PR DESCRIPTION
## Summary

- Restore Telegram verbose tool/progress messages when no answer preview stream exists.
- Keep suppressing the default verbose bubbles when Telegram has an answer draft preview, so preview progress does not duplicate normal progress messages.
- Add regression coverage for `streamMode: "off"` proving Telegram does not create a draft stream and passes `suppressDefaultToolProgressMessages: false`.

## Root Cause

A recent Telegram change set `suppressDefaultToolProgressMessages: true` unconditionally in `extensions/telegram/src/bot-message-dispatch.ts`. The shared auto-reply dispatcher treats that flag as a blanket suppression for default tool, plan, approval, patch, and command-output progress messages. That is correct only when Telegram has an answer draft preview to replace those bubbles. When answer preview streaming is off or unavailable, Telegram had no replacement surface, so verbose chat progress disappeared.

## Affected Surface

- Telegram inbound replies and tool/progress delivery in `extensions/telegram/src/bot-message-dispatch.ts`.
- No public SDK or protocol change.
- No GitHub issue URL was provided; this PR addresses the reported Telegram verbose-message regression.

## Validation

- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts`
- `pnpm check:changed --staged` before the final changelog removal; relevant Telegram source/test lanes passed.

## Notes

This is the narrow fix because the suppression flag now matches the actual replacement UI: `Boolean(answerLane.stream)`. Discord and Slack already gate their equivalent suppression on preview progress availability.
