### PR TITLE
fix(gateway): bootstrap env proxy dispatcher at startup

### DIFF
--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
+const ensureGlobalUndiciEnvProxyDispatcherMock = vi.fn();
 const ensureOpenClawModelsJsonMock = vi.fn<
   (config: unknown, agentDir: unknown) => Promise<{ agentDir: string; wrote: boolean }>
 >(async () => ({ agentDir: "/tmp/agent", wrote: false }));
@@ -38,6 +39,30 @@ vi.mock("../agents/pi-embedded-runner/model.js", () => ({
     options?: unknown,
   ) => resolveModelAsyncMock(provider, modelId, agentDir, cfg, options),
 }));
+
+vi.mock("../infra/net/undici-global-dispatcher.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/net/undici-global-dispatcher.js")>(
+    "../infra/net/undici-global-dispatcher.js",
+  );
+  return {
+    ...actual,
+    ensureGlobalUndiciEnvProxyDispatcher: ensureGlobalUndiciEnvProxyDispatcherMock,
+  };
+});
+
+describe("gateway startup network bootstrap", () => {
+  beforeEach(() => {
+    ensureGlobalUndiciEnvProxyDispatcherMock.mockClear();
+  });
+
+  it("installs the env proxy dispatcher for gateway-side provider requests", async () => {
+    const { __testing } = await import("./server-startup.js");
+
+    __testing.bootstrapGatewayNetworkEnvironment();
+
+    expect(ensureGlobalUndiciEnvProxyDispatcherMock).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("gateway startup primary model warmup", () => {
   beforeEach(() => {

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -24,6 +24,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
@@ -34,6 +35,10 @@ import {
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
+
+export function bootstrapGatewayNetworkEnvironment(): void {
+  ensureGlobalUndiciEnvProxyDispatcher();
+}
 
 async function prewarmConfiguredPrimaryModel(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -226,5 +231,6 @@ export async function startGatewaySidecars(params: {
 }
 
 export const __testing = {
+  bootstrapGatewayNetworkEnvironment,
   prewarmConfiguredPrimaryModel,
 };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -115,7 +115,7 @@ import { createGatewayRuntimeState } from "./server-runtime-state.js";
 import { resolveSessionKeyForRun } from "./server-session-key.js";
 import { logGatewayStartup } from "./server-startup-log.js";
 import { runStartupMatrixMigration } from "./server-startup-matrix-migration.js";
-import { startGatewaySidecars } from "./server-startup.js";
+import { bootstrapGatewayNetworkEnvironment, startGatewaySidecars } from "./server-startup.js";
 import { startGatewayTailscaleExposure } from "./server-tailscale.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { attachGatewayWsHandlers } from "./server-ws-runtime.js";
@@ -368,6 +368,8 @@ export async function startGatewayServer(
   port = 18789,
   opts: GatewayServerOptions = {},
 ): Promise<GatewayServer> {
+  bootstrapGatewayNetworkEnvironment();
+
   const minimalTestGateway =
     process.env.VITEST === "1" && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
 


### PR DESCRIPTION
## Summary

- install the global Undici env proxy dispatcher at gateway startup
- keep the existing embedded-runner timeout/proxy wrapping behavior unchanged
- add a startup regression test for gateway-side provider requests

## Why

Gateway-side provider/plugin paths can execute before an embedded agent attempt has installed the env proxy dispatcher. In proxy-only environments this leaves OpenAI SDK traffic without the configured HTTP(S) proxy and surfaces as `LLM request failed: network connection error` / `Connection error`, even though credentials resolve correctly.

## Validation

- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server-startup.test.ts --pool=forks`
- `pnpm exec oxlint --type-aware src/gateway/server.impl.ts src/gateway/server-startup.ts src/gateway/server-startup.test.ts`
- `pnpm exec oxfmt --check src/gateway/server.impl.ts src/gateway/server-startup.ts src/gateway/server-startup.test.ts`

## Canary

Validated the same fix adapted onto an OpenClaw 2026.4.24 Atlas sandbox canary:

- `openai/gpt-5.5` agent smoke returned `atlas 4.24 proxy bootstrap ok`
- `openai/gpt-5.4-mini` gateway model smoke returned `atlas 4.24 mini smoke ok`
- no fallback was used for the `gpt-5.5` smoke
