### PR TITLE
test(auto-reply): cover transcriptCommandBody asymmetry in buildReplyPromptBodies

### DIFF
--- a/src/auto-reply/reply.media-note.test.ts
+++ b/src/auto-reply/reply.media-note.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
-import { buildReplyPromptBodies } from "./reply/prompt-prelude.js";
+import { REPLY_MEDIA_HINT, buildReplyPromptBodies } from "./reply/prompt-prelude.js";
 
 describe("getReplyFromConfig media note plumbing", () => {
   it("includes all MediaPaths in the agent prompt", () => {
@@ -64,5 +64,85 @@ describe("getReplyFromConfig media note plumbing", () => {
       "[media attached: /tmp/media-store/real-image.png (image/png) | https://example.com/real-image.png]",
     );
     expect(prompt).toContain(describedBody);
+  });
+});
+
+describe("buildReplyPromptBodies transcriptCommandBody asymmetry", () => {
+  it("excludes REPLY_MEDIA_HINT from transcriptCommandBody but includes it in prefixedCommandBody and queuedBody", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "send me a picture",
+      BodyForAgent: "send me a picture",
+      From: "+1001",
+      To: "+2000",
+      MediaPaths: ["/tmp/photo.png"],
+      MediaUrls: ["https://example.com/photo.png"],
+      MediaTypes: ["image/png"],
+    });
+    const result = buildReplyPromptBodies({
+      ctx: sessionCtx,
+      sessionCtx,
+      effectiveBaseBody: sessionCtx.BodyForAgent,
+      prefixedBody: sessionCtx.BodyForAgent,
+    });
+
+    expect(result.mediaNote).toBeTruthy();
+    expect(result.mediaReplyHint).toBe(REPLY_MEDIA_HINT);
+
+    // The model-only routing hint must not leak into the user-visible
+    // transcript. The prefix and queue paths (which feed the model) do
+    // include it; the transcript path (which feeds visible history) does not.
+    expect(result.transcriptCommandBody).not.toContain(REPLY_MEDIA_HINT);
+    expect(result.prefixedCommandBody).toContain(REPLY_MEDIA_HINT);
+    expect(result.queuedBody).toContain(REPLY_MEDIA_HINT);
+
+    // The mediaNote itself is user-visible context (not a routing hint), so
+    // it appears in all three paths.
+    const mediaNote = result.mediaNote;
+    expect(mediaNote).toBeDefined();
+    if (mediaNote) {
+      expect(result.transcriptCommandBody).toContain(mediaNote);
+      expect(result.prefixedCommandBody).toContain(mediaNote);
+      expect(result.queuedBody).toContain(mediaNote);
+    }
+  });
+
+  it("defaults transcriptCommandBody to effectiveBaseBody when transcriptBody is omitted", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "hello",
+      BodyForAgent: "hello rewritten for agent",
+      From: "+1001",
+      To: "+2000",
+    });
+    const result = buildReplyPromptBodies({
+      ctx: sessionCtx,
+      sessionCtx,
+      effectiveBaseBody: sessionCtx.BodyForAgent,
+      prefixedBody: sessionCtx.BodyForAgent,
+    });
+
+    expect(result.mediaNote).toBeUndefined();
+    expect(result.transcriptCommandBody).toBe("hello rewritten for agent");
+  });
+
+  it("uses transcriptBody override without affecting prefixedCommandBody or queuedBody", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "raw user text",
+      BodyForAgent: "agent-rewritten body",
+      From: "+1001",
+      To: "+2000",
+    });
+    const result = buildReplyPromptBodies({
+      ctx: sessionCtx,
+      sessionCtx,
+      effectiveBaseBody: sessionCtx.BodyForAgent,
+      prefixedBody: sessionCtx.BodyForAgent,
+      transcriptBody: "raw user text",
+    });
+
+    expect(result.transcriptCommandBody).toBe("raw user text");
+    expect(result.prefixedCommandBody).toContain("agent-rewritten body");
+    expect(result.queuedBody).toContain("agent-rewritten body");
+    expect(result.prefixedCommandBody).not.toContain("raw user text");
+    expect(result.queuedBody).not.toContain("raw user text");
   });
 });


### PR DESCRIPTION
Follow-up coverage for #71229 (kept runtime context out of visible transcripts). The `transcriptCommandBody` return field of `buildReplyPromptBodies` is asymmetric on purpose: it excludes `REPLY_MEDIA_HINT` while `prefixedCommandBody` and `queuedBody` both include it. The hint is a model-only routing instruction; leaking it into the user-visible transcript would expose how the agent decides to inline media. That asymmetry was uncovered.

## Changes

Three new cases in `src/auto-reply/reply.media-note.test.ts` under a new `describe("buildReplyPromptBodies transcriptCommandBody asymmetry")`:

1. With a media note present, `REPLY_MEDIA_HINT` appears in `prefixedCommandBody` and `queuedBody` but not in `transcriptCommandBody`. The `mediaNote` itself is in all three (it's user-visible context, not routing).
2. `transcriptBody` omitted → `transcriptCommandBody` defaults to `effectiveBaseBody`.
3. `transcriptBody` override changes only the transcript path; `prefixedCommandBody` and `queuedBody` still see `effectiveBaseBody`.

## Why this is worth locking

If a future refactor accidentally pipes `mediaReplyHint` into `transcriptCommandBody`, the model-only routing instruction silently leaks into the user-facing visible log. Coverage today is one incidental `not.toContain` assertion in `get-reply-run.media-only.test.ts:922` for a different concern (system-event suppression) — the asymmetry itself is not asserted anywhere.

## Testing

Local: `pnpm test src/auto-reply/reply.media-note.test.ts` — 5 passed (2 existing + 3 new).

No production changes.