### PR TITLE
test(slack): cover formatSlackFileReference + formatSlackFileReferenceList

### DIFF
--- a/extensions/slack/src/file-reference.test.ts
+++ b/extensions/slack/src/file-reference.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { formatSlackFileReference, formatSlackFileReferenceList } from "./file-reference.js";
+import type { SlackFile } from "./types.js";
+
+describe("formatSlackFileReference", () => {
+  it("falls back to 'file' when the SlackFile is undefined", () => {
+    expect(formatSlackFileReference(undefined)).toBe("file");
+  });
+
+  it("falls back to 'file' when name and id are both missing", () => {
+    expect(formatSlackFileReference({})).toBe("file");
+  });
+
+  it("returns the name alone when fileId is missing", () => {
+    const file: SlackFile = { name: "report.pdf" };
+    expect(formatSlackFileReference(file)).toBe("report.pdf");
+  });
+
+  it("returns 'file (fileId: ...)' when only id is present", () => {
+    const file: SlackFile = { id: "F09ABC123" };
+    expect(formatSlackFileReference(file)).toBe("file (fileId: F09ABC123)");
+  });
+
+  it("returns 'name (fileId: ...)' when both name and id are present", () => {
+    const file: SlackFile = { name: "design.sketch", id: "F09ABC123" };
+    expect(formatSlackFileReference(file)).toBe("design.sketch (fileId: F09ABC123)");
+  });
+
+  it("treats whitespace-only name as missing and falls back to 'file'", () => {
+    const file: SlackFile = { name: "   ", id: "F09XYZ" };
+    expect(formatSlackFileReference(file)).toBe("file (fileId: F09XYZ)");
+  });
+});
+
+describe("formatSlackFileReferenceList", () => {
+  it("falls back to 'file' for an undefined files list", () => {
+    expect(formatSlackFileReferenceList(undefined)).toBe("file");
+  });
+
+  it("falls back to 'file' for an empty files list", () => {
+    expect(formatSlackFileReferenceList([])).toBe("file");
+  });
+
+  it("formats a single file via formatSlackFileReference", () => {
+    const files: SlackFile[] = [{ name: "only.png", id: "F1" }];
+    expect(formatSlackFileReferenceList(files)).toBe("only.png (fileId: F1)");
+  });
+
+  it("joins multiple files with ', ' and preserves per-file fallbacks", () => {
+    const files: SlackFile[] = [
+      { name: "first.txt", id: "F1" },
+      { id: "F2" },
+      { name: "third.png" },
+    ];
+    expect(formatSlackFileReferenceList(files)).toBe(
+      "first.txt (fileId: F1), file (fileId: F2), third.png",
+    );
+  });
+});


### PR DESCRIPTION
Both helpers in `extensions/slack/src/file-reference.ts` are exported and used by four production call sites but had no companion test file. Adding direct coverage so the fallback chains are locked.

## Coverage gap

- `formatSlackFileReference` — used by `monitor/media.ts:285`, `monitor/message-handler/prepare.ts:460`, `monitor/message-handler/prepare-content.ts:129`. Branches:
  - undefined file → `"file"`
  - file with neither name nor id → `"file"`
  - file with name only → `name`
  - file with id only → `"file (fileId: ...)"`
  - file with both → `"name (fileId: ...)"`
  - whitespace-only name → falls through `normalizeOptionalString` to `"file"`
- `formatSlackFileReferenceList` — used by `monitor/thread.ts`. Branches:
  - undefined list → `"file"`
  - empty list → `"file"`
  - single file (delegates to `formatSlackFileReference`)
  - mixed-shape multi-file (joined with `", "`)

## Changes

New file `extensions/slack/src/file-reference.test.ts` — 10 cases, no mocks, pure-function assertions.

## Testing

Local: `pnpm test extensions/slack/src/file-reference.test.ts` — 10 passed (10).

No production changes.