### PR TITLE
fix(slack): suppress already_reacted from agent react tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/reactions: treat Slack `already_reacted` responses as idempotent success in the shared reaction helper so duplicate reaction adds do not fail agent actions or status updates. Fixes #69005; carries forward #71843 and historical #9520; refs #50733 and #58048. Thanks @martingarramon and @bolismauro.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -197,6 +197,41 @@ describe("handleSlackAction", () => {
     ).rejects.toThrow(/Slack reactions are disabled/);
   });
 
+  it("treats already_reacted as a no-op success", async () => {
+    reactSlackMessage.mockImplementationOnce(async () => {
+      throw new Error("An API error occurred: already_reacted");
+    });
+    const result = await handleSlackAction(
+      {
+        action: "react",
+        channelId: "C1",
+        messageId: "123.456",
+        emoji: "✅",
+      },
+      slackConfig(),
+    );
+    expect(reactSlackMessage).toHaveBeenCalled();
+    const payload = JSON.parse((result.content?.[0] as { type: "text"; text: string }).text);
+    expect(payload).toEqual({ ok: true, added: "✅" });
+  });
+
+  it("rethrows non-already_reacted Slack errors from the react tool", async () => {
+    reactSlackMessage.mockImplementationOnce(async () => {
+      throw new Error("An API error occurred: invalid_emoji");
+    });
+    await expect(
+      handleSlackAction(
+        {
+          action: "react",
+          channelId: "C1",
+          messageId: "123.456",
+          emoji: "✅",
+        },
+        slackConfig(),
+      ),
+    ).rejects.toThrow(/invalid_emoji/);
+  });
+
   it("passes threadTs to sendSlackMessage for thread replies", async () => {
     await handleSlackAction(
       {

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -115,7 +115,7 @@ describe("handleSlackAction", () => {
     { name: "raw channel id", channelId: "C1" },
     { name: "channel: prefixed id", channelId: "channel:C1" },
   ])("adds reactions for $name", async ({ channelId }) => {
-    await handleSlackAction(
+    const result = await handleSlackAction(
       {
         action: "react",
         channelId,
@@ -130,6 +130,8 @@ describe("handleSlackAction", () => {
       "✅",
       expect.objectContaining({ cfg: expect.any(Object) }),
     );
+    const payload = JSON.parse((result.content?.[0] as { type: "text"; text: string }).text);
+    expect(payload).toEqual({ ok: true, added: "✅" });
   });
 
   it("removes reactions on empty emoji", async () => {
@@ -195,24 +197,6 @@ describe("handleSlackAction", () => {
         slackConfig({ actions: { reactions: false } }),
       ),
     ).rejects.toThrow(/Slack reactions are disabled/);
-  });
-
-  it("treats already_reacted as a no-op success", async () => {
-    reactSlackMessage.mockImplementationOnce(async () => {
-      throw new Error("An API error occurred: already_reacted");
-    });
-    const result = await handleSlackAction(
-      {
-        action: "react",
-        channelId: "C1",
-        messageId: "123.456",
-        emoji: "✅",
-      },
-      slackConfig(),
-    );
-    expect(reactSlackMessage).toHaveBeenCalled();
-    const payload = JSON.parse((result.content?.[0] as { type: "text"; text: string }).text);
-    expect(payload).toEqual({ ok: true, added: "✅" });
   });
 
   it("rethrows non-already_reacted Slack errors from the react tool", async () => {

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -1,5 +1,4 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
@@ -211,18 +210,10 @@ export async function handleSlackAction(
           : await slackActionRuntime.removeOwnSlackReactions(channelId, messageId);
         return jsonResult({ ok: true, removed });
       }
-      const addPromise = writeOpts
-        ? slackActionRuntime.reactSlackMessage(channelId, messageId, emoji, writeOpts)
-        : slackActionRuntime.reactSlackMessage(channelId, messageId, emoji);
-      try {
-        await addPromise;
-      } catch (err) {
-        // already_reacted is a no-op: the reaction is already in the desired
-        // state. Mirrors the suppression at
-        // monitor/message-handler/dispatch.ts in the status-reaction adapter.
-        if (!formatErrorMessage(err).includes("already_reacted")) {
-          throw err;
-        }
+      if (writeOpts) {
+        await slackActionRuntime.reactSlackMessage(channelId, messageId, emoji, writeOpts);
+      } else {
+        await slackActionRuntime.reactSlackMessage(channelId, messageId, emoji);
       }
       return jsonResult({ ok: true, added: emoji });
     }

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
@@ -210,10 +211,18 @@ export async function handleSlackAction(
           : await slackActionRuntime.removeOwnSlackReactions(channelId, messageId);
         return jsonResult({ ok: true, removed });
       }
-      if (writeOpts) {
-        await slackActionRuntime.reactSlackMessage(channelId, messageId, emoji, writeOpts);
-      } else {
-        await slackActionRuntime.reactSlackMessage(channelId, messageId, emoji);
+      const addPromise = writeOpts
+        ? slackActionRuntime.reactSlackMessage(channelId, messageId, emoji, writeOpts)
+        : slackActionRuntime.reactSlackMessage(channelId, messageId, emoji);
+      try {
+        await addPromise;
+      } catch (err) {
+        // already_reacted is a no-op: the reaction is already in the desired
+        // state. Mirrors the suppression at
+        // monitor/message-handler/dispatch.ts in the status-reaction adapter.
+        if (!formatErrorMessage(err).includes("already_reacted")) {
+          throw err;
+        }
       }
       return jsonResult({ ok: true, added: emoji });
     }

--- a/extensions/slack/src/actions.reactions.test.ts
+++ b/extensions/slack/src/actions.reactions.test.ts
@@ -1,0 +1,60 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+import { reactSlackMessage } from "./actions.js";
+
+function createClient() {
+  return {
+    reactions: {
+      add: vi.fn(async () => ({})),
+    },
+  } as unknown as WebClient & {
+    reactions: {
+      add: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function slackPlatformError(error: string) {
+  return Object.assign(new Error(`An API error occurred: ${error}`), {
+    data: {
+      ok: false,
+      error,
+    },
+  });
+}
+
+describe("reactSlackMessage", () => {
+  it("treats Slack already_reacted responses as idempotent success", async () => {
+    const client = createClient();
+    client.reactions.add.mockRejectedValueOnce(slackPlatformError("already_reacted"));
+
+    await expect(
+      reactSlackMessage("C1", "123.456", ":white_check_mark:", {
+        client,
+        token: "xoxb-test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "white_check_mark",
+    });
+  });
+
+  it("propagates unrelated Slack reaction add errors", async () => {
+    const client = createClient();
+    client.reactions.add.mockRejectedValueOnce(slackPlatformError("invalid_name"));
+
+    await expect(
+      reactSlackMessage("C1", "123.456", "not-an-emoji", {
+        client,
+        token: "xoxb-test",
+      }),
+    ).rejects.toMatchObject({
+      data: {
+        error: "invalid_name",
+      },
+    });
+  });
+});

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -77,6 +77,17 @@ function normalizeEmoji(raw: string) {
   return trimmed.replace(/^:+|:+$/g, "");
 }
 
+function isSlackAlreadyReactedError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const data = (err as { data?: unknown }).data;
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  return (data as { error?: unknown }).error === "already_reacted";
+}
+
 async function getClient(opts: SlackActionClientOpts = {}, mode: "read" | "write" = "read") {
   if (opts.client) {
     return opts.client;
@@ -100,11 +111,18 @@ export async function reactSlackMessage(
   opts: SlackActionClientOpts = {},
 ) {
   const client = await getClient(opts, "write");
-  await client.reactions.add({
-    channel: channelId,
-    timestamp: messageId,
-    name: normalizeEmoji(emoji),
-  });
+  try {
+    await client.reactions.add({
+      channel: channelId,
+      timestamp: messageId,
+      name: normalizeEmoji(emoji),
+    });
+  } catch (err) {
+    if (isSlackAlreadyReactedError(err)) {
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function removeSlackReaction(

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -296,11 +296,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       await reactSlackMessage(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {
         token: ctx.botToken,
         client: ctx.app.client,
-      }).catch((err) => {
-        if (formatErrorMessage(err).includes("already_reacted")) {
-          return;
-        }
-        throw err;
       });
     },
     removeReaction: async (emoji) => {


### PR DESCRIPTION
Fixes #69005.

When the agent uses the Slack `react` tool to add an emoji that is already on a message, Slack returns `already_reacted` and the existing tool path propagates it as a tool failure (visible to the user as an error message). The reaction is already in the desired state — this should be a no-op success, not an error.

## Asymmetry on main

The status-reaction adapter at `extensions/slack/src/monitor/message-handler/dispatch.ts:296-304` already suppresses `already_reacted` on its own `reactSlackMessage` call site (and `removeSlackReaction` symmetrically suppresses `no_reaction` at the next block). The agent-tool call site at `extensions/slack/src/action-runtime.ts:213-216` had no such handler, so the two paths disagreed about whether `already_reacted` is a failure.

## Change

Added the same `formatErrorMessage(err).includes("already_reacted")` suppression at the agent-tool call site, so both paths now agree: `already_reacted` = the reaction is in the desired state = `{ ok: true, added: emoji }`. Imports `formatErrorMessage` from `openclaw/plugin-sdk/error-runtime` (same source `dispatch.ts` already uses).

Two new tests in `extensions/slack/src/action-runtime.test.ts`:

1. `already_reacted` is treated as a no-op success — the tool returns `{ ok: true, added: emoji }` and `reactSlackMessage` was still called.
2. Non-`already_reacted` Slack errors (e.g. `invalid_emoji`) still propagate.

## Testing

Local: `pnpm test extensions/slack/src/action-runtime.test.ts` — 41 passed (39 existing + 2 new).