### PR TITLE
fix(heartbeat): keep successful exec completions internal

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -4,6 +4,8 @@ import {
   buildExecEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
+  isSuccessfulExecCompletionEvent,
+  shouldRelayExecCompletionEvents,
 } from "./heartbeat-events-filter.js";
 
 describe("heartbeat event prompts", () => {
@@ -46,12 +48,19 @@ describe("heartbeat event prompts", () => {
 
   it.each([
     {
+      name: "keeps structured successful exec completions internal by default",
+      events: ["Exec completed (abc12345, code 0) :: tests passed"],
+      opts: undefined,
+      expected: ["completed successfully", "reply HEARTBEAT_OK only"],
+      unexpected: ["tests passed", "Please relay the command output to the user"],
+    },
+    {
       name: "builds user-relay exec prompt by default",
-      events: ["Exec finished (node=abc id=123, code 0)\nUploaded file"],
+      events: ["Exec failed (abc12345, code 1) :: Upload failed"],
       opts: undefined,
       expected: [
-        "Exec finished",
-        "Uploaded file",
+        "Exec failed",
+        "Upload failed",
         "Please relay the command output to the user",
         "If it failed",
       ],
@@ -86,10 +95,34 @@ describe("heartbeat event prompts", () => {
   });
 
   it("truncates oversized user-relay exec prompt output", () => {
-    const prompt = buildExecEventPrompt([`Exec finished: ${"x".repeat(8_100)}`]);
+    const prompt = buildExecEventPrompt([`Exec failed (abc12345, code 1) :: ${"x".repeat(8_100)}`]);
 
     expect(prompt).toContain("[truncated]");
     expect(prompt.length).toBeLessThan(8_500);
+  });
+
+  it("strips successful exec completion output from mixed user-relay batches", () => {
+    const prompt = buildExecEventPrompt([
+      "Exec completed (success1, code 0) :: secret success output",
+      "Exec failed (failed1, code 1) :: actionable failure",
+    ]);
+
+    expect(prompt).toContain("Exec failed");
+    expect(prompt).toContain("actionable failure");
+    expect(prompt).not.toContain("secret success output");
+  });
+
+  it("only relays exec completions with failures or ambiguous legacy status", () => {
+    expect(shouldRelayExecCompletionEvents(["Exec completed (abc12345, code 0) :: ok"])).toBe(
+      false,
+    );
+    expect(shouldRelayExecCompletionEvents(["Exec failed (abc12345, code 1) :: failed"])).toBe(
+      true,
+    );
+    expect(shouldRelayExecCompletionEvents(["Exec completed (abc12345, signal SIGTERM)"])).toBe(
+      true,
+    );
+    expect(shouldRelayExecCompletionEvents(["Exec finished: legacy completion"])).toBe(true);
   });
 });
 
@@ -106,6 +139,16 @@ describe("heartbeat event classification", () => {
     { value: "cron finished", expected: false },
   ])("classifies exec completion events for %j", ({ value, expected }) => {
     expect(isExecCompletionEvent(value)).toBe(expected);
+  });
+
+  it.each([
+    { value: "Exec completed (abc12345, code 0)", expected: true },
+    { value: "Exec completed (abc12345, code 0) :: output", expected: true },
+    { value: "Exec completed (abc12345, code 1)", expected: false },
+    { value: "Exec failed (abc12345, code 0)", expected: false },
+    { value: "Exec finished: legacy completion", expected: false },
+  ])("classifies successful exec completion events for %j", ({ value, expected }) => {
+    expect(isSuccessfulExecCompletionEvent(value)).toBe(expected);
   });
 
   it.each([

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -2,6 +2,10 @@ import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
+const STRUCTURED_EXEC_COMPLETION_RE =
+  /^exec (completed|failed) \([a-z0-9_-]{1,64}, (code -?\d+|signal [^)]+)\)( :: .*)?$/;
+const SUCCESSFUL_STRUCTURED_EXEC_COMPLETION_RE =
+  /^exec completed \([a-z0-9_-]{1,64}, code 0\)( :: .*)?$/;
 
 // Build a dynamic prompt for cron events by embedding the actual event content.
 // This ensures the model sees the reminder text directly instead of relying on
@@ -44,8 +48,12 @@ export function buildExecEventPrompt(
   pendingEvents: string[],
   opts?: { deliverToUser?: boolean },
 ): string {
-  const deliverToUser = opts?.deliverToUser ?? true;
-  const rawEventText = pendingEvents.join("\n").trim();
+  const deliverToUser =
+    (opts?.deliverToUser ?? true) && shouldRelayExecCompletionEvents(pendingEvents);
+  const relayedEvents = deliverToUser
+    ? pendingEvents.filter((event) => !isSuccessfulExecCompletionEvent(event))
+    : pendingEvents;
+  const rawEventText = relayedEvents.join("\n").trim();
   const eventText =
     rawEventText.length > MAX_EXEC_EVENT_PROMPT_CHARS
       ? `${rawEventText.slice(0, MAX_EXEC_EVENT_PROMPT_CHARS)}\n\n[truncated]`
@@ -54,6 +62,13 @@ export function buildExecEventPrompt(
     return (
       "An async command completion event was triggered, but no command output was found. " +
       "Reply HEARTBEAT_OK only. Do not mention, summarize, or reuse output from any earlier run."
+    );
+  }
+  if (shouldKeepExecCompletionInternal(pendingEvents)) {
+    return (
+      "An async command completed successfully. " +
+      "Handle the result internally and reply HEARTBEAT_OK only unless you need to continue the task with tools. " +
+      "Do not relay, summarize, or reuse the command output in a user-facing reply."
     );
   }
   if (!deliverToUser) {
@@ -105,11 +120,26 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 export function isExecCompletionEvent(evt: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(evt).trimStart();
   return (
-    /^exec finished(?::|\s*\()/.test(normalized) ||
-    /^exec (completed|failed) \([a-z0-9_-]{1,64}, (code -?\d+|signal [^)]+)\)( :: .*)?$/.test(
-      normalized,
-    )
+    /^exec finished(?::|\s*\()/.test(normalized) || STRUCTURED_EXEC_COMPLETION_RE.test(normalized)
   );
+}
+
+export function isSuccessfulExecCompletionEvent(evt: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(evt).trimStart();
+  return SUCCESSFUL_STRUCTURED_EXEC_COMPLETION_RE.test(normalized);
+}
+
+export function shouldRelayExecCompletionEvents(events: string[]): boolean {
+  const execEvents = events.filter(isExecCompletionEvent);
+  if (execEvents.length === 0) {
+    return true;
+  }
+  return execEvents.some((event) => !isSuccessfulExecCompletionEvent(event));
+}
+
+function shouldKeepExecCompletionInternal(events: string[]): boolean {
+  const execEvents = events.filter(isExecCompletionEvent);
+  return execEvents.length > 0 && execEvents.every(isSuccessfulExecCompletionEvent);
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -550,7 +550,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
       expect(options?.messageThreadId).toBeUndefined();
     });
   });
-  it("keeps exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
+  it("keeps failed exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {
         agents: {
@@ -586,7 +586,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
       const getReplySpy = vi.fn().mockResolvedValue({
         text: "The review-worker spawn finished successfully.",
       });
-      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+      enqueueSystemEvent("Exec failed (review-run, code 1) :: review worker failed", {
         sessionKey,
         trusted: false,
         deliveryContext: {
@@ -614,6 +614,75 @@ describe("Ghost reminder bug (issue #13317)", () => {
         "The review-worker spawn finished successfully.",
         expect.objectContaining({ messageThreadId: 47 }),
       );
+    });
+  });
+
+  it("keeps successful exec completions internal even when a chat target is available", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:direct:123";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:123",
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "123",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The async command completed successfully.",
+      });
+      enqueueSystemEvent("Exec completed (abc12345, code 0) :: tests passed", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:123",
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Provider: "exec-event",
+          Body: expect.stringContaining("reply HEARTBEAT_OK only"),
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(getReplySpy.mock.calls[0]?.[0]?.Body).not.toContain("tests passed");
+      expect(sendTelegram).not.toHaveBeenCalled();
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -73,6 +73,7 @@ import {
   buildCronEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
+  shouldRelayExecCompletionEvents,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
 import { resolveHeartbeatReasonKind } from "./heartbeat-reason.js";
@@ -644,6 +645,7 @@ type HeartbeatPromptResolution = {
   prompt: string | null;
   hasExecCompletion: boolean;
   hasCronEvents: boolean;
+  suppressUserDelivery: boolean;
 };
 
 function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
@@ -709,19 +711,34 @@ After completing all due tasks, reply HEARTBEAT_OK.`;
           prompt += `\n\nAdditional context from HEARTBEAT.md:\n${directives}`;
         }
       }
-      return { prompt, hasExecCompletion: false, hasCronEvents: false };
+      return {
+        prompt,
+        hasExecCompletion: false,
+        hasCronEvents: false,
+        suppressUserDelivery: false,
+      };
     }
-    return { prompt: null, hasExecCompletion: false, hasCronEvents: false };
+    return {
+      prompt: null,
+      hasExecCompletion: false,
+      hasCronEvents: false,
+      suppressUserDelivery: false,
+    };
   }
 
+  const shouldRelayExecEvents = hasExecCompletion && shouldRelayExecCompletionEvents(execEvents);
+  const suppressUserDelivery = hasExecCompletion && !shouldRelayExecEvents;
+
   const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt(execEvents, { deliverToUser: params.canRelayToUser })
+    ? buildExecEventPrompt(execEvents, {
+        deliverToUser: params.canRelayToUser && shouldRelayExecEvents,
+      })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const prompt = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
 
-  return { prompt, hasExecCompletion, hasCronEvents };
+  return { prompt, hasExecCompletion, hasCronEvents, suppressUserDelivery };
 }
 
 export async function runHeartbeatOnce(opts: {
@@ -841,15 +858,16 @@ export async function runHeartbeatOnce(opts: {
     delivery.channel !== "none" && delivery.to && visibility.showAlerts,
   );
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const { prompt, hasExecCompletion, hasCronEvents } = resolveHeartbeatRunPrompt({
-    cfg,
-    heartbeat,
-    preflight,
-    canRelayToUser,
-    workspaceDir,
-    startedAt,
-    heartbeatFileContent: preflight.heartbeatFileContent,
-  });
+  const { prompt, hasExecCompletion, hasCronEvents, suppressUserDelivery } =
+    resolveHeartbeatRunPrompt({
+      cfg,
+      heartbeat,
+      preflight,
+      canRelayToUser,
+      workspaceDir,
+      startedAt,
+      heartbeatFileContent: preflight.heartbeatFileContent,
+    });
 
   // If no tasks are due, skip heartbeat entirely
   if (prompt === null) {
@@ -1194,6 +1212,21 @@ export async function runHeartbeatOnce(opts: {
         preview: previewText?.slice(0, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
+        accountId: delivery.accountId,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
+
+    if (suppressUserDelivery) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: "internal-exec-completion",
+        preview: previewText?.slice(0, 200),
+        durationMs: Date.now() - startedAt,
+        hasMedia: mediaUrls.length > 0,
+        channel: delivery.channel,
         accountId: delivery.accountId,
       });
       await updateTaskTimestamps();


### PR DESCRIPTION
## Summary
- stop treating successful background `exec` completions (`code 0`) as user-relay events by default
- keep successful exec completion wakes internal, consume the event, and suppress user delivery even when a chat target is available
- continue relaying failed, signaled, and ambiguous legacy exec completions so users still see actionable failures

## Tests
- `pnpm vitest run src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `pnpm test:unit:fast`
- `pnpm tsgo:core`
- `pnpm format:check -- src/infra/heartbeat-events-filter.ts src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `pnpm lint:core`
- `env -u OPENCLAW_NO_RESPAWN pnpm check:changed`
- `pnpm build`

Note: local gateway service exports `OPENCLAW_NO_RESPAWN=1`, so `check:changed` is run with that variable unset to avoid contaminating unrelated process-respawn tests.
