### PR TITLE
Respect retryable Codex app-server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ Docs: https://docs.openclaw.ai
 - Media delivery: avoid sending generated image attachments twice when the
   assistant reply already includes explicit `MEDIA:` lines for the same turn,
   and reject unsafe remote `MEDIA:` URLs before delivery. Thanks @pashpashpash.
+- Codex harness: ignore retryable app-server error notifications after Codex
+  recovers, and preserve the real nested error message for terminal app-server
+  failures instead of replacing it with a generic failure. Thanks @pashpashpash.
 - Agents/subagents: keep queued subagent announces session-only when the
   requester has no external channel target, avoiding ambiguous multi-channel
   delivery failures. Fixes #59201. Thanks @larrylhollan.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -129,6 +129,17 @@ function agentMessageDelta(delta: string, itemId = "msg-1"): ProjectorNotificati
   return forCurrentTurn("item/agentMessage/delta", { itemId, delta });
 }
 
+function appServerError(params: { message: string; willRetry: boolean }): ProjectorNotification {
+  return forCurrentTurn("error", {
+    error: {
+      message: params.message,
+      codexErrorInfo: null,
+      additionalDetails: null,
+    },
+    willRetry: params.willRetry,
+  });
+}
+
 function turnCompleted(items: unknown[] = []): ProjectorNotification {
   return {
     method: "turn/completed",
@@ -233,6 +244,40 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(result.assistantTexts).toEqual(["OK from raw"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "OK from raw" }]);
+  });
+
+  it("does not fail a completed reply after a retryable app-server error notification", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(agentMessageDelta("still working"));
+    await projector.handleNotification(
+      appServerError({ message: "stream disconnected", willRetry: true }),
+    );
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-1", text: "final answer" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.assistantTexts).toEqual(["final answer"]);
+    expect(result.promptError).toBeNull();
+    expect(result.promptErrorSource).toBeNull();
+    expect(result.lastAssistant?.stopReason).toBe("stop");
+    expect(result.lastAssistant?.errorMessage).toBeUndefined();
+  });
+
+  it("uses nested app-server error messages for terminal errors", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      appServerError({ message: "stream failed permanently", willRetry: false }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.promptError).toBe("stream failed permanently");
+    expect(result.promptErrorSource).toBe("prompt");
+    expect(result.lastAssistant).toBeUndefined();
   });
 
   it("normalizes snake_case current token usage fields", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -153,7 +153,10 @@ export class CodexAppServerEventProjector {
         this.handleRawResponseItemCompleted(params);
         break;
       case "error":
-        this.promptError = readString(params, "message") ?? "codex app-server error";
+        if (readBooleanAlias(params, ["willRetry", "will_retry"]) === true) {
+          break;
+        }
+        this.promptError = readCodexErrorNotificationMessage(params) ?? "codex app-server error";
         this.promptErrorSource = "prompt";
         break;
       default:
@@ -842,6 +845,29 @@ function readNullableString(record: JsonObject, key: string): string | null | un
 function readNumber(record: JsonObject, key: string): number | undefined {
   const value = record[key];
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readBoolean(record: JsonObject, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readBooleanAlias(record: JsonObject, keys: readonly string[]): boolean | undefined {
+  for (const key of keys) {
+    const value = readBoolean(record, key);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
+  const error = record.error;
+  if (isJsonObject(error)) {
+    return readString(error, "message") ?? readString(error, "error");
+  }
+  return readString(record, "message");
 }
 
 function readHookOutputEntries(


### PR DESCRIPTION
Codex app-server sends retryable stream error notifications while the turn is still recovering. OpenClaw was treating every app-server `error` notification as a terminal prompt failure and reading a top-level `message` field that the current protocol does not send.

That meant a turn could produce a valid assistant reply, then still be marked as failed with the generic `codex app-server error` fallback. In chat surfaces like Discord, that showed up as “Agent failed before reply” even though Codex had already produced a usable answer.

This keeps `willRetry: true` app-server errors from setting `promptError`, while still treating terminal errors as failures. Terminal errors now preserve the real nested `error.message` from Codex instead of falling back to the generic string.