### PR TITLE
fix(tasks): normalize task timestamps and retained lost audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude: treat zero-token empty `stop` turns as failed provider output,
   retry once, repair replay, and allow configured model fallback instead of
   preserving them as successful silent replies. Fixes #71880. Thanks @MagnaAI.
+- Tasks: normalize task lifecycle timestamps at create, update, and restore time, and report retained lost tasks as audit warnings until their cleanup window expires. (#71871) Thanks @likewen-tech.
 - Diagnostics/OTEL: treat normal early model stream cleanup as a completed model call instead of exporting a misleading `StreamAbandoned` error span. Thanks @vincentkoc.
 - Gateway/pairing: stop corrupt or unreadable device/node pairing stores from being treated as empty state, preserving `paired.json` for repair instead of overwriting approved pairings. Fixes #71873. Thanks @iret77.
 - ACP: keep `/acp` management commands, plus local `/status` and `/unfocus`, on the Gateway path inside ACP-bound threads so they are not consumed as ACP prompt text. Fixes #66298. Thanks @kindomLee.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -194,14 +194,14 @@ openclaw tasks audit [--json]
 
 Surfaces operational issues. Findings also appear in `openclaw status` when issues are detected.
 
-| Finding                   | Severity | Trigger                                               |
-| ------------------------- | -------- | ----------------------------------------------------- |
-| `stale_queued`            | warn     | Queued for more than 10 minutes                       |
-| `stale_running`           | error    | Running for more than 30 minutes                      |
-| `lost`                    | error    | Runtime-backed task ownership disappeared             |
-| `delivery_failed`         | warn     | Delivery failed and notify policy is not `silent`     |
-| `missing_cleanup`         | warn     | Terminal task with no cleanup timestamp               |
-| `inconsistent_timestamps` | warn     | Timeline violation (for example ended before started) |
+| Finding                   | Severity   | Trigger                                                                                                      |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| `stale_queued`            | warn       | Queued for more than 10 minutes                                                                              |
+| `stale_running`           | error      | Running for more than 30 minutes                                                                             |
+| `lost`                    | warn/error | Runtime-backed task ownership disappeared; retained lost tasks warn until `cleanupAfter`, then become errors |
+| `delivery_failed`         | warn       | Delivery failed and notify policy is not `silent`                                                            |
+| `missing_cleanup`         | warn       | Terminal task with no cleanup timestamp                                                                      |
+| `inconsistent_timestamps` | warn       | Timeline violation (for example ended before started)                                                        |
 
 ### `tasks maintenance`
 
@@ -284,7 +284,7 @@ The registry loads into memory at gateway start and syncs writes to SQLite for d
 A sweeper runs every **60 seconds** and handles three things:
 
 1. **Reconciliation** — checks whether active tasks still have authoritative runtime backing. ACP/subagent tasks use child-session state, cron tasks use active-job ownership, and chat-backed CLI tasks use the owning run context. If that backing state is gone for more than 5 minutes, the task is marked `lost`.
-2. **Cleanup stamping** — sets a `cleanupAfter` timestamp on terminal tasks (endedAt + 7 days).
+2. **Cleanup stamping** — sets a `cleanupAfter` timestamp on terminal tasks (endedAt + 7 days). During retention, lost tasks still appear in audit as warnings; after `cleanupAfter` expires or when cleanup metadata is missing, they are errors.
 3. **Pruning** — deletes records past their `cleanupAfter` date.
 
 **Retention**: terminal task records are kept for **7 days**, then automatically pruned. No configuration needed.

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -75,7 +75,7 @@ Cancels a running background task.
 openclaw tasks audit [--severity <warn|error>] [--code <name>] [--limit <n>] [--json]
 ```
 
-Surfaces stale, lost, delivery-failed, or otherwise inconsistent task and Task Flow records.
+Surfaces stale, lost, delivery-failed, or otherwise inconsistent task and Task Flow records. Lost tasks retained until `cleanupAfter` are warnings; expired or unstamped lost tasks are errors.
 
 ### `maintenance`
 

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -159,20 +159,41 @@ function makeSkipInstallPrompter() {
   return { prompter, select };
 }
 
+function makeManifestRecord(plugin: {
+  id: string;
+  channels?: string[];
+  origin?: "bundled" | "global" | "workspace";
+  activation?: { onChannels?: string[] };
+}) {
+  const rootDir = `/tmp/openclaw-plugins/${plugin.id}`;
+  return {
+    id: plugin.id,
+    origin: plugin.origin ?? "bundled",
+    channels: plugin.channels ?? [],
+    providers: [],
+    cliBackends: [],
+    hooks: [],
+    skills: [],
+    rootDir,
+    source: path.join(rootDir, "index.js"),
+    manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+    ...(plugin.activation ? { activation: plugin.activation } : {}),
+  };
+}
+
 function mockActivationOnlyPlugin(plugin: {
   id: string;
   origin?: "bundled" | "global" | "workspace";
 }) {
   loadPluginManifestRegistry.mockReturnValue({
     plugins: [
-      {
+      makeManifestRecord({
         id: plugin.id,
-        channels: [],
-        ...(plugin.origin === undefined ? {} : { origin: plugin.origin }),
+        origin: plugin.origin,
         activation: {
           onChannels: ["external-chat"],
         },
-      },
+      }),
     ],
     diagnostics: [],
   });
@@ -746,7 +767,12 @@ describe("ensureChannelSetupPluginInstalled", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};
     loadPluginManifestRegistry.mockReturnValue({
-      plugins: [{ id: "custom-external-chat-plugin", channels: ["external-chat"] }],
+      plugins: [
+        makeManifestRecord({
+          id: "custom-external-chat-plugin",
+          channels: ["external-chat"],
+        }),
+      ],
       diagnostics: [],
     });
 

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -7,6 +7,20 @@ import {
   normalizeTokenProviderInput,
 } from "./provider-auth-input.js";
 
+const resolveEnvApiKey = vi.hoisted(() =>
+  vi.fn((provider: string, env?: NodeJS.ProcessEnv) => {
+    if (provider !== "minimax") {
+      return null;
+    }
+    const apiKey = env?.MINIMAX_API_KEY?.trim();
+    return apiKey ? { apiKey, source: "env: MINIMAX_API_KEY" } : null;
+  }),
+);
+
+vi.mock("../agents/model-auth-env.js", () => ({
+  resolveEnvApiKey,
+}));
+
 const ORIGINAL_MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
 const ORIGINAL_MINIMAX_OAUTH_TOKEN = process.env.MINIMAX_OAUTH_TOKEN;
 

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -83,6 +83,38 @@ describe("task-registry audit", () => {
     });
   });
 
+  it("downgrades retained lost tasks with future cleanupAfter to warnings", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "lost-retained",
+          status: "lost",
+          error: "backing session missing",
+          endedAt: now - 60_000,
+          lastEventAt: now - 60_000,
+          cleanupAfter: now + 60_000,
+        }),
+        createTask({
+          taskId: "lost-expired",
+          status: "lost",
+          error: "backing session missing",
+          endedAt: now - 120_000,
+          lastEventAt: now - 120_000,
+          cleanupAfter: now - 1,
+        }),
+      ],
+    });
+
+    expect(
+      findings.map((finding) => [finding.task.taskId, finding.code, finding.severity]),
+    ).toEqual([
+      ["lost-expired", "lost", "error"],
+      ["lost-retained", "lost", "warn"],
+    ]);
+  });
+
   it("does not double-report lost tasks as missing cleanup", () => {
     const now = Date.parse("2026-03-30T01:00:00.000Z");
     const findings = listTaskAuditFindings({

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -125,13 +125,17 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
     }
 
     if (task.status === "lost") {
+      const retainedUntilCleanup = typeof task.cleanupAfter === "number" && task.cleanupAfter > now;
       findings.push(
         createFinding({
-          severity: "error",
+          severity: retainedUntilCleanup ? "warn" : "error",
           code: "lost",
           task,
           ageMs,
-          detail: task.error?.trim() || "task lost its backing session",
+          detail: retainedUntilCleanup
+            ? task.error?.trim() ||
+              "task lost its backing session and is retained until cleanupAfter"
+            : task.error?.trim() || "task lost its backing session",
         }),
       );
     }

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1590,6 +1590,108 @@ describe("task-registry", () => {
     });
   });
 
+  it("backdates createdAt when a task is created with an earlier startedAt", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-backdated-create",
+        task: "Backdated create",
+        status: "running",
+        deliveryStatus: "pending",
+        startedAt: 1_699_999_999_000,
+      });
+
+      nowSpy.mockRestore();
+
+      expect(task).toMatchObject({
+        createdAt: 1_699_999_999_000,
+        startedAt: 1_699_999_999_000,
+        lastEventAt: 1_699_999_999_000,
+      });
+      expect(getInspectableTaskAuditSummary().byCode.inconsistent_timestamps).toBe(0);
+    });
+  });
+
+  it("keeps timestamps monotonic when an update supplies an earlier startedAt", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-backdated-update",
+        task: "Backdated update",
+        status: "queued",
+        deliveryStatus: "pending",
+      });
+
+      nowSpy.mockReturnValue(1_700_000_001_000);
+      setTaskTimingById({
+        taskId: task.taskId,
+        startedAt: 1_699_999_998_000,
+        lastEventAt: 1_699_999_998_500,
+      });
+      nowSpy.mockRestore();
+
+      expect(getTaskById(task.taskId)).toMatchObject({
+        createdAt: 1_699_999_998_000,
+        startedAt: 1_699_999_998_000,
+        lastEventAt: 1_699_999_998_500,
+      });
+      expect(getInspectableTaskAuditSummary().byCode.inconsistent_timestamps).toBe(0);
+    });
+  });
+
+  it("normalizes restored task timestamps before exposing them", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () => ({
+            tasks: new Map([
+              [
+                "task-restored-bad-timestamps",
+                {
+                  taskId: "task-restored-bad-timestamps",
+                  runtime: "acp",
+                  requesterSessionKey: "agent:main:main",
+                  ownerKey: "agent:main:main",
+                  scopeKind: "session",
+                  runId: "run-restored-bad-timestamps",
+                  task: "Restored task with old start time",
+                  status: "running",
+                  deliveryStatus: "pending",
+                  notifyPolicy: "done_only",
+                  createdAt: 200,
+                  startedAt: 100,
+                  lastEventAt: 150,
+                },
+              ],
+            ]),
+            deliveryStates: new Map(),
+          }),
+          saveSnapshot: () => {},
+        },
+      });
+
+      expect(findTaskByRunId("run-restored-bad-timestamps")).toMatchObject({
+        createdAt: 100,
+        startedAt: 100,
+        lastEventAt: 150,
+      });
+    });
+  });
+
   it("summarizes inspectable task audit findings", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1342,6 +1342,13 @@ describe("task-registry", () => {
         error: "backing session missing",
       });
       expect(getTaskById(task.taskId)?.cleanupAfter).toBeGreaterThan(now);
+      expect(getInspectableTaskAuditSummary()).toMatchObject({
+        errors: 0,
+        warnings: 1,
+        byCode: expect.objectContaining({
+          lost: 1,
+        }),
+      });
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -180,6 +180,50 @@ function cloneTaskRecord(record: TaskRecord): TaskRecord {
   return { ...record };
 }
 
+function normalizeTaskTimestamps(task: TaskRecord): TaskRecord {
+  let createdAt = task.createdAt;
+  for (const candidate of [task.startedAt, task.lastEventAt, task.endedAt]) {
+    if (typeof candidate === "number" && candidate < createdAt) {
+      createdAt = candidate;
+    }
+  }
+
+  const startedAt =
+    typeof task.startedAt === "number" ? Math.max(task.startedAt, createdAt) : task.startedAt;
+  const lastEventAt =
+    typeof task.lastEventAt === "number"
+      ? Math.max(task.lastEventAt, startedAt ?? createdAt)
+      : task.lastEventAt;
+  const endedAt =
+    typeof task.endedAt === "number"
+      ? Math.max(task.endedAt, startedAt ?? createdAt)
+      : task.endedAt;
+
+  if (
+    createdAt === task.createdAt &&
+    startedAt === task.startedAt &&
+    lastEventAt === task.lastEventAt &&
+    endedAt === task.endedAt
+  ) {
+    return task;
+  }
+
+  const normalized: TaskRecord = {
+    ...task,
+    createdAt,
+  };
+  if (typeof startedAt === "number") {
+    normalized.startedAt = startedAt;
+  }
+  if (typeof lastEventAt === "number") {
+    normalized.lastEventAt = lastEventAt;
+  }
+  if (typeof endedAt === "number") {
+    normalized.endedAt = endedAt;
+  }
+  return normalized;
+}
+
 function cloneTaskDeliveryState(state: TaskDeliveryState): TaskDeliveryState {
   return {
     ...state,
@@ -861,7 +905,7 @@ function restoreTaskRegistryOnce() {
       return;
     }
     for (const [taskId, task] of restored.tasks.entries()) {
-      tasks.set(taskId, task);
+      tasks.set(taskId, normalizeTaskTimestamps(task));
     }
     for (const [taskId, state] of restored.deliveryStates.entries()) {
       taskDeliveryStates.set(taskId, state);
@@ -889,7 +933,7 @@ function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskRecord | nu
   if (!current) {
     return null;
   }
-  const next = { ...current, ...patch };
+  const next = normalizeTaskTimestamps({ ...current, ...patch });
   if (isTerminalTaskStatus(next.status) && typeof next.cleanupAfter !== "number") {
     const terminalAt = next.endedAt ?? next.lastEventAt ?? Date.now();
     next.cleanupAfter = terminalAt + DEFAULT_TASK_RETENTION_MS;
@@ -1453,7 +1497,7 @@ export function createTaskRecord(params: {
     scopeKind,
   });
   const lastEventAt = params.lastEventAt ?? params.startedAt ?? now;
-  const record: TaskRecord = {
+  const record: TaskRecord = normalizeTaskTimestamps({
     taskId,
     runtime: params.runtime,
     taskKind: normalizeOptionalString(params.taskKind),
@@ -1481,7 +1525,7 @@ export function createTaskRecord(params: {
       status,
       terminalOutcome: params.terminalOutcome,
     }),
-  };
+  });
   if (isTerminalTaskStatus(record.status) && typeof record.cleanupAfter !== "number") {
     record.cleanupAfter =
       (record.endedAt ?? record.lastEventAt ?? record.createdAt) + DEFAULT_TASK_RETENTION_MS;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -181,6 +181,8 @@ function cloneTaskRecord(record: TaskRecord): TaskRecord {
 }
 
 function normalizeTaskTimestamps(task: TaskRecord): TaskRecord {
+  // Detached runtimes can report lifecycle times captured before the registry
+  // inserted or restored the row; keep createdAt as the visible lifecycle floor.
   let createdAt = task.createdAt;
   for (const candidate of [task.startedAt, task.lastEventAt, task.endedAt]) {
     if (typeof candidate === "number" && candidate < createdAt) {


### PR DESCRIPTION
## Summary

- normalize task lifecycle timestamps on create, update, and restore so audit-visible task records do not surface `startedAt < createdAt` skew
- downgrade retained `lost` tasks with future `cleanupAfter` from audit errors to warnings while preserving errors for expired/unstamped lost tasks
- add regression coverage for create/update/restore timestamp normalization and retained-lost audit severity

## Root cause

Task creation/update paths can receive lifecycle timestamps captured before the registry writes `createdAt = Date.now()`. A small clock/order delta can persist `startedAt < createdAt`, which the task audit correctly reports as `inconsistent_timestamps`. Persisted historical rows can also restore with the same skew. Separately, retained lost tasks with future cleanup were being reported as errors even though they are already scheduled for normal cleanup.

## Risk / caveat

`createdAt` is now normalized backward to the earliest lifecycle timestamp when required. This keeps audit ordering consistent, but means `createdAt` should be read as the lifecycle floor rather than an exact registry insertion timestamp in these repaired cases.

## Verification

- `node scripts/test-projects.mjs src/tasks/task-registry.test.ts src/tasks/task-registry.audit.test.ts`
  - `src/tasks/task-registry.audit.test.ts`: 4 passed
  - `src/tasks/task-registry.test.ts`: 45 passed
- `git diff --check origin/main...HEAD`
- `pnpm tsgo`
- `pnpm lint` — 0 errors / 0 warnings
