### PR TITLE
refactor: reuse finalized inbound dispatch context

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -213,7 +213,39 @@ describe("withReplyDispatcher", () => {
     expect(typing.markDispatchIdle).toHaveBeenCalled();
   });
 
+  it("finalizes buffered dispatcher context once across setup and dispatch", async () => {
+    const ctx = buildTestCtx();
+    hoisted.finalizeInboundContextMock.mockClear();
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(hoisted.finalizeInboundContextMock).toHaveBeenCalledTimes(1);
+  });
+
   it("runs message_sending hooks before inbound dispatcher delivery", async () => {
+    const ctx = buildTestCtx({
+      From: "whatsapp:+15551234567",
+      To: "whatsapp:+15557654321",
+      OriginatingTo: "whatsapp:+15551234567",
+    });
+    hoisted.finalizeInboundContextMock.mockClear();
     const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
     hoisted.getGlobalHookRunnerMock.mockReturnValue({
       hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
@@ -223,11 +255,7 @@ describe("withReplyDispatcher", () => {
     hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
 
     await dispatchInboundMessageWithDispatcher({
-      ctx: buildTestCtx({
-        From: "whatsapp:+15551234567",
-        To: "whatsapp:+15557654321",
-        OriginatingTo: "whatsapp:+15551234567",
-      }),
+      ctx,
       cfg: {} as OpenClawConfig,
       dispatcherOptions: {
         deliver: async () => undefined,
@@ -252,6 +280,7 @@ describe("withReplyDispatcher", () => {
         conversationId: "conv-1",
       },
     );
+    expect(hoisted.finalizeInboundContextMock).toHaveBeenCalledTimes(1);
   });
 
   it("reconciles queuedFinal and counts after dispatcher-side cancellation", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -22,11 +22,7 @@ import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions, ReplyPayload } from "./types.js";
 
-function resolveDispatcherSilentReplyContext(
-  ctx: MsgContext | FinalizedMsgContext,
-  cfg: OpenClawConfig,
-) {
-  const finalized = finalizeInboundContext(ctx);
+function resolveDispatcherSilentReplyContext(finalized: FinalizedMsgContext, cfg: OpenClawConfig) {
   const policySessionKey =
     finalized.CommandSource === "native"
       ? (finalized.CommandTargetSessionKey ?? finalized.SessionKey)
@@ -64,14 +60,13 @@ function resolveInboundReplyHookTarget(
 }
 
 function buildMessageSendingBeforeDeliver(
-  ctx: MsgContext | FinalizedMsgContext,
+  finalized: FinalizedMsgContext,
 ): ReplyDispatchBeforeDeliver | undefined {
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("message_sending")) {
     return undefined;
   }
 
-  const finalized = finalizeInboundContext(ctx);
   const hookCtx = deriveInboundMessageHookContext(finalized);
   const replyTarget = resolveInboundReplyHookTarget(finalized, hookCtx);
 
@@ -118,19 +113,18 @@ function finalizeDispatchResult(
   };
 }
 
-export async function dispatchInboundMessage(params: {
-  ctx: MsgContext | FinalizedMsgContext;
+async function runInboundDispatch(params: {
+  ctx: FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const finalized = finalizeInboundContext(params.ctx);
   const result = await withReplyDispatcher({
     dispatcher: params.dispatcher,
     run: () =>
       dispatchReplyFromConfig({
-        ctx: finalized,
+        ctx: params.ctx,
         cfg: params.cfg,
         dispatcher: params.dispatcher,
         replyOptions: params.replyOptions,
@@ -140,6 +134,19 @@ export async function dispatchInboundMessage(params: {
   return finalizeDispatchResult(result, params.dispatcher);
 }
 
+export async function dispatchInboundMessage(params: {
+  ctx: MsgContext | FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  dispatcher: ReplyDispatcher;
+  replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
+  replyResolver?: GetReplyFromConfig;
+}): Promise<DispatchInboundResult> {
+  return runInboundDispatch({
+    ...params,
+    ctx: finalizeInboundContext(params.ctx),
+  });
+}
+
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
@@ -147,9 +154,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
+  const finalized = finalizeInboundContext(params.ctx);
+  const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const beforeDeliver =
-    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx);
+    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
       ...params.dispatcherOptions,
@@ -157,8 +165,8 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
     });
   try {
-    return await dispatchInboundMessage({
-      ctx: params.ctx,
+    return await runInboundDispatch({
+      ctx: finalized,
       cfg: params.cfg,
       dispatcher,
       replyResolver: params.replyResolver,
@@ -180,15 +188,16 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
+  const finalized = finalizeInboundContext(params.ctx);
+  const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,
     beforeDeliver:
-      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx),
+      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized),
     silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
   });
-  return await dispatchInboundMessage({
-    ctx: params.ctx,
+  return await runInboundDispatch({
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,


### PR DESCRIPTION
## Summary

- Problem: inbound reply dispatch wrappers finalized the same message context more than once while preparing silent-reply policy, message-sending hooks, and the actual dispatch call.
- Why it matters: `finalizeInboundContext()` normalizes multiple text, command, label, and media fields on the hot reply path; repeating it adds avoidable work and makes wrapper setup harder to reason about.
- What changed: the wrappers now finalize the inbound context once, reuse that `FinalizedMsgContext` for silent-reply policy and hook setup, and pass it to a private `runInboundDispatch()` helper for the shared dispatch body.
- What did NOT change: the exported `dispatchInboundMessage()` API still accepts raw `MsgContext` and performs finalization internally; reply routing, hook semantics, silent-reply policy, dispatcher lifecycle, and public contracts are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the wrapper helpers each accepted the broader `MsgContext | FinalizedMsgContext` shape and independently called `finalizeInboundContext()` before delegating to `dispatchInboundMessage()`, which finalized again.
- Missing detection / guardrail: existing tests covered behavior but did not assert the number of finalization passes on wrapper paths.
- Contributing context (if known): `dispatchInboundMessage()` is a public entry point, so wrappers need a private finalized-context execution path to avoid changing the public API.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/dispatch.test.ts`
- Scenario the test should lock in: buffered and hook-enabled inbound dispatch wrappers call `finalizeInboundContext()` once while still passing the finalized context through setup and dispatch.
- Why this is the smallest reliable guardrail: the behavior is local to the dispatch wrapper seam and can be verified with the existing mocked dispatcher and inbound-context test harness.
- Existing test that already covers this (if any): existing dispatcher lifecycle, silent-reply, and `message_sending` hook tests covered behavior but not duplicate finalization.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
wrapper -> finalize for policy/hooks -> dispatchInboundMessage -> finalize again -> dispatch

After:
wrapper -> finalize once -> policy/hooks + runInboundDispatch -> dispatch
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL/Linux local checkout
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): auto-reply dispatch path
- Relevant config (redacted): N/A

### Steps

1. Inspect `src/auto-reply/dispatch.ts` wrapper flow and confirm repeated calls to `finalizeInboundContext()`.
2. Refactor wrappers to finalize once and call the private `runInboundDispatch()` helper with a `FinalizedMsgContext`.
3. Add unit coverage asserting wrapper paths finalize once.
4. Run focused and changed-surface validation.

### Expected

- Inbound dispatch behavior remains unchanged.
- Wrapper paths avoid redundant context finalization.
- Dispatcher lifecycle, `message_sending` hooks, and silent-reply policy tests stay green.

### Actual

- `pnpm test src/auto-reply/dispatch.test.ts`: passed, 10 tests.
- `pnpm check:changed`: passed after temporarily applying `Men-cotton/check-changed-lock-marker` for the known local heavy-check lock issue; 116 files and 1558 tests passed.
- `git diff --check`: passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `dispatchInboundMessageWithBufferedDispatcher()` finalizes once across setup and dispatch.
  - `dispatchInboundMessageWithDispatcher()` preserves `message_sending` hook behavior while finalizing once.
  - Existing dispatcher lifecycle, silent-reply policy, and cancellation-count tests still pass.
- Edge cases checked:
  - Public `dispatchInboundMessage()` still accepts raw context and finalizes internally.
  - Temporary `Men-cotton/check-changed-lock-marker` verification files were restored after `check:changed`.
- What you did **not** verify:
  - No live messaging-channel delivery test was run.
  - No dedicated performance benchmark was run; this is a small hot-path cleanup guarded by call-count coverage.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: reusing a finalized context could accidentally skip normalization for callers that still enter through the public API.
  - Mitigation: `dispatchInboundMessage()` still finalizes before calling `runInboundDispatch()`, while wrapper paths explicitly finalize once before setup.
- Risk: hook or silent-reply setup could receive a different context shape than before.
  - Mitigation: both setup helpers now require `FinalizedMsgContext`, and existing hook/silent-reply tests plus new call-count assertions cover the wrapper paths.
