### PR TITLE
fix(status): support lancedb memory runtime probes

### DIFF
--- a/src/commands/status.scan-memory.test.ts
+++ b/src/commands/status.scan-memory.test.ts
@@ -4,10 +4,15 @@ const mocks = vi.hoisted(() => ({
   resolveMemorySearchConfig: vi.fn(),
   getMemorySearchManager: vi.fn(),
   resolveSharedMemoryStatusSnapshot: vi.fn(),
+  setConsoleSubsystemFilter: vi.fn(),
 }));
 
 vi.mock("../agents/memory-search.js", () => ({
   resolveMemorySearchConfig: mocks.resolveMemorySearchConfig,
+}));
+
+vi.mock("../logging/console.js", () => ({
+  setConsoleSubsystemFilter: mocks.setConsoleSubsystemFilter,
 }));
 
 vi.mock("./status.scan.deps.runtime.js", () => ({
@@ -55,6 +60,10 @@ describe("status.scan-memory", () => {
       requireDefaultStore,
     });
 
+    expect(mocks.setConsoleSubsystemFilter).toHaveBeenNthCalledWith(1, [
+      "__openclaw_status_json_memory_probe_quiet__",
+    ]);
+    expect(mocks.setConsoleSubsystemFilter).toHaveBeenLastCalledWith(null);
     expect(mocks.resolveSharedMemoryStatusSnapshot).toHaveBeenCalledWith({
       cfg: { agents: {} },
       agentStatus,

--- a/src/commands/status.scan-memory.ts
+++ b/src/commands/status.scan-memory.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { setConsoleSubsystemFilter } from "../logging/console.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
 import {
   resolveSharedMemoryStatusSnapshot,
@@ -30,12 +31,17 @@ export async function resolveStatusMemoryStatusSnapshot(params: {
   requireDefaultStore?: (agentId: string) => string;
 }): Promise<MemoryStatusSnapshot | null> {
   const { getMemorySearchManager } = await loadStatusScanDepsRuntimeModule();
-  return await resolveSharedMemoryStatusSnapshot({
-    cfg: params.cfg,
-    agentStatus: params.agentStatus,
-    memoryPlugin: params.memoryPlugin,
-    resolveMemoryConfig: resolveMemorySearchConfig,
-    getMemorySearchManager,
-    requireDefaultStore: params.requireDefaultStore,
-  });
+  setConsoleSubsystemFilter(["__openclaw_status_json_memory_probe_quiet__"]);
+  try {
+    return await resolveSharedMemoryStatusSnapshot({
+      cfg: params.cfg,
+      agentStatus: params.agentStatus,
+      memoryPlugin: params.memoryPlugin,
+      resolveMemoryConfig: resolveMemorySearchConfig,
+      getMemorySearchManager,
+      requireDefaultStore: params.requireDefaultStore,
+    });
+  } finally {
+    setConsoleSubsystemFilter(null);
+  }
 }

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveGatewayProbeSnapshot } from "./status.scan.shared.js";
+import {
+  resolveGatewayProbeSnapshot,
+  resolveSharedMemoryStatusSnapshot,
+} from "./status.scan.shared.js";
 
 const mocks = vi.hoisted(() => ({
   buildGatewayConnectionDetailsWithResolvers: vi.fn(),
@@ -138,5 +141,59 @@ describe("resolveGatewayProbeSnapshot", () => {
 
     expect(result.gatewayProbe?.error).toBe("timeout; warn");
     expect(result.gatewayProbeAuthWarning).toBeUndefined();
+  });
+});
+
+describe("resolveSharedMemoryStatusSnapshot", () => {
+  it("allows memory-slot plugins to provide status without built-in store paths", async () => {
+    const manager = {
+      probeVectorAvailability: vi.fn(async () => true),
+      status: vi.fn(() => ({
+        backend: "lancedb-pro",
+        provider: "openai-compatible",
+        requestedProvider: "openai-compatible",
+        model: "nomic-embed-text",
+        dbPath: "/tmp/lancedb-pro",
+        workspaceDir: "/tmp/workspace",
+        vector: { enabled: true, available: true },
+      })),
+      close: vi.fn(async () => undefined),
+    };
+
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: { agents: {} },
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-lancedb-pro" },
+      resolveMemoryConfig: vi.fn(() => null),
+      getMemorySearchManager: vi.fn(async () => ({ manager })),
+      requireDefaultStore: vi.fn(() => "/tmp/main.sqlite"),
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        agentId: "main",
+        backend: "lancedb-pro",
+        vector: { enabled: true, available: true },
+      }),
+    );
+    expect(manager.probeVectorAvailability).toHaveBeenCalled();
+    expect(manager.status).toHaveBeenCalled();
+    expect(manager.close).toHaveBeenCalled();
+  });
+
+  it("keeps returning null for built-in memory without explicit config or store", async () => {
+    const getMemorySearchManager = vi.fn(async () => ({ manager: null }));
+
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: { agents: {} },
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig: vi.fn(() => null),
+      getMemorySearchManager,
+      requireDefaultStore: vi.fn(() => "/tmp/main.sqlite"),
+    });
+
+    expect(result).toBeNull();
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -187,19 +187,23 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
   }
   const agentId = agentStatus.defaultId ?? "main";
   const defaultStorePath = params.requireDefaultStore?.(agentId);
+  const pluginProvidesMemoryStatus = memoryPlugin.slot === "memory-lancedb-pro";
   if (
     defaultStorePath &&
+    !pluginProvidesMemoryStatus &&
     !hasExplicitMemorySearchConfig(cfg, agentId) &&
     !existsSync(defaultStorePath)
   ) {
     return null;
   }
   const resolvedMemory = params.resolveMemoryConfig(cfg, agentId);
-  if (!resolvedMemory) {
+  if (!resolvedMemory && !pluginProvidesMemoryStatus) {
     return null;
   }
   const shouldInspectStore =
-    hasExplicitMemorySearchConfig(cfg, agentId) || existsSync(resolvedMemory.store.path);
+    pluginProvidesMemoryStatus ||
+    hasExplicitMemorySearchConfig(cfg, agentId) ||
+    (resolvedMemory ? existsSync(resolvedMemory.store.path) : false);
   if (!shouldInspectStore) {
     return null;
   }


### PR DESCRIPTION
## Summary
- allow selected memory-slot plugins such as `memory-lancedb-pro` to provide memory status through a registered runtime even when the built-in sqlite/qmd store path is absent
- silence plugin console output during memory status probing so `openclaw status --json --all` remains valid JSON
- add coverage for LanceDB-style memory runtime status and the status-probe console filter

## Why
`memory-lancedb-pro` can be operational through its plugin runtime while not using the built-in sqlite/qmd memory store path. The previous status scan gate returned `null` before asking the registered memory runtime for status, so healthy third-party memory backends could appear unavailable.

Also, status-time plugin loading can emit informational plugin logs to stdout. That breaks strict JSON consumers of `openclaw status --json --all` even when the actual status payload is valid.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --write src/commands/status.scan-memory.ts src/commands/status.scan.shared.ts src/commands/status.scan-memory.test.ts src/commands/status.scan.shared.test.ts`
- `pnpm test -- --run src/commands/status.scan-memory.test.ts src/commands/status.scan.shared.test.ts`

## Related
- Runtime plugin-side PR: https://github.com/win4r/memory-lancedb-pro-codex/pull/7
