### PR TITLE
fix: allow tweakcn theme imports in Control UI CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: allow tweakcn theme imports through the CSP `connect-src` directive while preserving the OpenAI Realtime origin. Thanks @anitguru.
 - Exec approvals/node: let trusted backend node invokes complete no-device Control UI approvals after the original request connection changes, while keeping node, command, cwd, env, and allow-once replay bindings enforced. Fixes #78569. Thanks @naturedogdog.
 - CLI/completion: guard the shell-profile source line written by `openclaw completion --install` with a file existence check (`[ -f ... ] && source ...` for bash/zsh, `test -f ...; and source ...` for fish) so uninstalling OpenClaw no longer makes new login shells error on a missing completion cache. (#78659) Thanks @sjf.
 - Cron/doctor: repair persisted cron jobs whose `payload.model` was stored as `"default"`, `"null"`, blank, or JSON `null` by removing the bad override during `openclaw doctor --fix` while keeping cron runtime model validation strict. Fixes #78549. Thanks @bizzle12368239.

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -17,7 +17,7 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 
-  it("allows OpenAI realtime WebRTC offer requests without allowing all HTTPS", () => {
+  it("allows exact Control UI connection origins without allowing all HTTPS", () => {
     const csp = buildControlUiCspHeader();
     const connectSrc = csp.split("; ").find((directive) => directive.startsWith("connect-src "));
     expect(connectSrc?.split(" ")).toEqual([
@@ -26,6 +26,7 @@ describe("buildControlUiCspHeader", () => {
       "ws:",
       "wss:",
       "https://api.openai.com",
+      "https://tweakcn.com",
     ]);
   });
 

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -47,6 +47,6 @@ export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }
     "img-src 'self' data: blob:",
     "font-src 'self' https://fonts.gstatic.com",
     "worker-src 'self'",
-    "connect-src 'self' ws: wss: https://api.openai.com",
+    "connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com",
   ].join("; ");
 }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -311,6 +311,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(typeof csp).toBe("string");
         expect(String(csp)).toContain("frame-ancestors 'none'");
         expect(String(csp)).toContain("script-src 'self'");
+        expect(String(csp)).toContain("connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com");
         expect(String(csp)).not.toContain("script-src 'self' 'unsafe-inline'");
       },
     });


### PR DESCRIPTION
## Summary
- allow the Control UI to fetch tweakcn theme registry payloads from `https://tweakcn.com`
- add a regression assertion for the Control UI CSP header

## Why
The new tweakcn custom theme importer fetches `https://tweakcn.com/r/themes/{id}` directly from the browser. tweakcn returns permissive CORS headers, but the Control UI CSP currently blocks that outbound fetch because `connect-src` only allows `self`, `ws:`, and `wss:`. In the browser this surfaces as `Failed to fetch` when importing a valid tweakcn theme link.

## Test plan
- [x] `docker run --rm --user root -v /opt/openclaw:/work -w /work openclaw:local sh -lc "[ -e node_modules ] || ln -s /app/node_modules node_modules; /app/node_modules/.bin/vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui.http.test.ts; rm -f test/vitest/*.timestamp-*.mjs"`
- [x] Verified local Control UI CSP includes `https://tweakcn.com`
- [x] Verified importing `https://tweakcn.com/themes/cmm3ngaig000004jl71bt739e` succeeds in the UI
