### PR TITLE
refactor: trim route binding scope checks

### DIFF
--- a/src/routing/binding-scope.test.ts
+++ b/src/routing/binding-scope.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { routeBindingScopeMatches, type RouteBindingScope } from "./binding-scope.js";
+
+describe("routeBindingScopeMatches", () => {
+  it("does not read groupSpace when no guild or team constraint exists", () => {
+    let groupSpaceReads = 0;
+    const scope: RouteBindingScope = {
+      get groupSpace() {
+        groupSpaceReads += 1;
+        return "guild-1";
+      },
+      memberRoleIds: new Set(["admin"]),
+    };
+
+    expect(routeBindingScopeMatches({ roles: ["admin"] }, scope)).toBe(true);
+    expect(groupSpaceReads).toBe(0);
+  });
+
+  it("reads groupSpace once when guild and team constraints both need it", () => {
+    let groupSpaceReads = 0;
+    const scope: RouteBindingScope = {
+      get groupSpace() {
+        groupSpaceReads += 1;
+        return "shared-space";
+      },
+    };
+
+    expect(
+      routeBindingScopeMatches(
+        {
+          guildId: "shared-space",
+          teamId: "shared-space",
+        },
+        scope,
+      ),
+    ).toBe(true);
+    expect(groupSpaceReads).toBe(1);
+  });
+});

--- a/src/routing/binding-scope.ts
+++ b/src/routing/binding-scope.ts
@@ -70,17 +70,6 @@ export function resolveNormalizedRouteBindingMatch(
   };
 }
 
-function scopeIdMatches(params: {
-  constraint: string | null | undefined;
-  exact: string;
-  groupSpace: string;
-}): boolean {
-  if (!params.constraint) {
-    return true;
-  }
-  return params.constraint === params.exact || params.constraint === params.groupSpace;
-}
-
 function hasRoleLookup(
   memberRoleIds: Iterable<string>,
 ): memberRoleIds is Iterable<string> & { has(roleId: string): boolean } {
@@ -101,17 +90,37 @@ function hasAnyRouteBindingRole(
   return roles.some((role) => memberRoleIdSet.has(role));
 }
 
+function routeBindingScopeIdsMatch(
+  constraint: RouteBindingScopeConstraint,
+  scope: RouteBindingScope,
+): boolean {
+  const hasGuildConstraint = Boolean(constraint.guildId);
+  const hasTeamConstraint = Boolean(constraint.teamId);
+  if (!hasGuildConstraint && !hasTeamConstraint) {
+    return true;
+  }
+
+  const groupSpace = normalizeRouteBindingId(scope.groupSpace);
+  if (constraint.guildId) {
+    const guildId = normalizeRouteBindingId(scope.guildId);
+    if (constraint.guildId !== guildId && constraint.guildId !== groupSpace) {
+      return false;
+    }
+  }
+  if (constraint.teamId) {
+    const teamId = normalizeRouteBindingId(scope.teamId);
+    if (constraint.teamId !== teamId && constraint.teamId !== groupSpace) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function routeBindingScopeMatches(
   constraint: RouteBindingScopeConstraint,
   scope: RouteBindingScope,
 ): boolean {
-  const guildId = normalizeRouteBindingId(scope.guildId);
-  const teamId = normalizeRouteBindingId(scope.teamId);
-  const groupSpace = normalizeRouteBindingId(scope.groupSpace);
-  if (!scopeIdMatches({ constraint: constraint.guildId, exact: guildId, groupSpace })) {
-    return false;
-  }
-  if (!scopeIdMatches({ constraint: constraint.teamId, exact: teamId, groupSpace })) {
+  if (!routeBindingScopeIdsMatch(constraint, scope)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Problem: route binding scope checks normalized guild/team/group-space IDs even
  when the binding had no guild or team constraint, so hot routing scans did
  work that was immediately discarded.
- Why it matters: routing checks run across candidate bindings on inbound
  channel traffic and bound-account lookup paths.
- What changed: `routeBindingScopeMatches()` now delegates ID matching to a
  module-level helper that returns before normalization when no guild/team
  constraint exists, and normalizes `groupSpace` only once when either
  constraint is present. A focused unit test now locks in those hot-path
  read-count expectations.
- What did NOT change (scope boundary): route matching semantics, role matching,
  binding order, cache behavior, and public routing APIs are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

N/A. This is a refactor, but `src/routing/binding-scope.test.ts` now directly
guards the recomputation behavior while existing route resolver and
bound-account routing tests cover the unchanged routing behavior.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

None.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node/pnpm from the local OpenClaw checkout
- Model/provider: N/A
- Integration/channel (if any): core routing
- Relevant config (redacted): N/A

### Steps

1. Inspect `src/routing/binding-scope.ts` and
   `src/routing/binding-scope.test.ts`.
2. Run focused scope-matching coverage.
3. Run routing coverage for route resolution and bound-account lookup.
4. Run the changed-file gate.

### Expected

- Routing behavior remains unchanged.
- Scope ID normalization is skipped when a binding has no guild/team
  constraint.
- `groupSpace` normalization is not duplicated when both constraints are
  present.
- Unit coverage fails if scope matching reads `groupSpace` without a guild/team
  constraint or reads it more than once when both constraints are present.

### Actual

- `pnpm test src/routing/binding-scope.test.ts` passed.
- `pnpm test src/routing/binding-scope.test.ts src/routing/resolve-route.test.ts src/routing/bound-account-read.test.ts`
  passed.
- `pnpm test src/routing/resolve-route.test.ts src/routing/bound-account-read.test.ts`
  passed.
- `git diff --check` passed.
- `pnpm check:changed` passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct scope-matching read-count tests, route resolver
  tests, and bound-account lookup tests.
- Edge cases checked: no guild/team constraint with role matching, both
  guild/team constraints sharing `groupSpace`, guild/team scope matching,
  `groupSpace` fallback matching, and role-scoped routing through existing
  coverage.
- What you did **not** verify: live channel traffic or standalone performance
  numbers.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: subtle routing behavior regression in guild/team/group-space matching.
  - Mitigation: focused `routeBindingScopeMatches()` read-count tests were
    added, existing route resolver and bound-account tests were run, and
    `pnpm check:changed` re-ran the changed routing test target.
