### PR TITLE
fix(memory): preserve session corpus labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu and @funmerlin.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu and @funmerlin.
+- Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMemorySearchManagerMockConfigs,
   getMemorySearchManagerMockParams,
@@ -12,6 +12,26 @@ import {
   createMemorySearchToolOrThrow,
   expectUnavailableMemorySearchDetails,
 } from "./tools.test-helpers.js";
+
+const sessionStore = vi.hoisted(() => ({
+  "agent:main:main": {
+    sessionId: "thread-1",
+    updatedAt: 1,
+    sessionFile: "/tmp/sessions/thread-1.jsonl",
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/session-transcript-hit")>();
+  return {
+    ...actual,
+    loadCombinedSessionStoreForGateway: vi.fn(() => ({
+      storePath: "(test)",
+      store: sessionStore,
+    })),
+  };
+});
 
 describe("memory_search unavailable payloads", () => {
   beforeEach(() => {
@@ -169,5 +189,41 @@ describe("memory_search unavailable payloads", () => {
     await tool.execute("patched-config", { query: "provider switch" });
 
     expect(getMemorySearchManagerMockConfigs()).toEqual([patchedConfig]);
+  });
+
+  it("preserves sessions corpus labels for session transcript hits", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "sessions/thread-1.jsonl",
+        startLine: 1,
+        endLine: 2,
+        score: 0.9,
+        snippet: "Thread transcript note",
+        source: "sessions" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+        tools: { sessions: { visibility: "all" } },
+      },
+      agentSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("sessions", { query: "thread note", corpus: "sessions" });
+    const details = result.details as { results: Array<{ corpus: string; path: string }> };
+
+    expect(details.results).toEqual([
+      {
+        corpus: "sessions",
+        path: "sessions/thread-1.jsonl",
+        startLine: 1,
+        endLine: 2,
+        score: 0.9,
+        snippet: "Thread transcript note",
+        source: "sessions",
+      },
+    ]);
   });
 });

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -127,6 +127,12 @@ describe("memory_search unavailable payloads", () => {
       (result.details as { debug?: { searchMs?: number } }).debug?.searchMs,
     ).toBeGreaterThanOrEqual(0);
   });
+});
+
+describe("memory_search corpus labels", () => {
+  beforeEach(() => {
+    resetMemoryToolMockState({ searchImpl: async () => [] });
+  });
 
   it("uses explicit plugin context agent over synthetic active-memory session keys", async () => {
     const tool = createMemorySearchToolOrThrow({

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -197,8 +197,16 @@ describe("memory_search corpus labels", () => {
     expect(getMemorySearchManagerMockConfigs()).toEqual([patchedConfig]);
   });
 
-  it("preserves sessions corpus labels for session transcript hits", async () => {
+  it("preserves source corpus labels for memory and session transcript hits", async () => {
     setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 3,
+        endLine: 4,
+        score: 0.95,
+        snippet: "Durable memory note",
+        source: "memory" as const,
+      },
       {
         path: "sessions/thread-1.jsonl",
         startLine: 1,
@@ -217,10 +225,19 @@ describe("memory_search corpus labels", () => {
       },
       agentSessionKey: "agent:main:main",
     });
-    const result = await tool.execute("sessions", { query: "thread note", corpus: "sessions" });
+    const result = await tool.execute("mixed", { query: "thread note" });
     const details = result.details as { results: Array<{ corpus: string; path: string }> };
 
     expect(details.results).toEqual([
+      {
+        corpus: "memory",
+        path: "MEMORY.md",
+        startLine: 3,
+        endLine: 4,
+        score: 0.95,
+        snippet: "Durable memory note",
+        source: "memory",
+      },
       {
         corpus: "sessions",
         path: "sessions/thread-1.jsonl",

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -268,7 +268,7 @@ export function createMemorySearchTool(options: {
           const searchStartedAt = Date.now();
           let rawResults: MemorySearchResult[] = [];
           let surfacedMemoryResults: Array<
-            Record<string, unknown> & { corpus: "memory"; score: number; path: string }
+            Record<string, unknown> & { corpus: MemorySource; score: number; path: string }
           > = [];
           let provider: string | undefined;
           let model: string | undefined;
@@ -326,7 +326,7 @@ export function createMemorySearchTool(options: {
                 : decorated;
             surfacedMemoryResults = memoryResults.map((result) => ({
               ...result,
-              corpus: "memory" as const,
+              corpus: result.source,
             }));
             const sleepTimezone = resolveMemoryDeepDreamingConfig({
               pluginConfig: resolveMemoryCorePluginConfig(cfg),

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -37,7 +37,7 @@ import {
 } from "./tools.shared.js";
 
 type MemorySearchToolResult =
-  | (Record<string, unknown> & { corpus: "memory"; score: number; path: string })
+  | (MemorySearchResult & { corpus: MemorySource })
   | MemoryCorpusSearchResult;
 
 function sortMemorySearchToolResults<T extends { score: number; path: string }>(results: T[]): T[] {
@@ -267,9 +267,7 @@ export function createMemorySearchTool(options: {
           });
           const searchStartedAt = Date.now();
           let rawResults: MemorySearchResult[] = [];
-          let surfacedMemoryResults: Array<
-            Record<string, unknown> & { corpus: MemorySource; score: number; path: string }
-          > = [];
+          let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
           let provider: string | undefined;
           let model: string | undefined;
           let fallback: unknown;

--- a/src/media/image-ops.tempdir.test.ts
+++ b/src/media/image-ops.tempdir.test.ts
@@ -34,7 +34,7 @@ describe("image-ops temp dir", () => {
     expect(prefix?.endsWith("-")).toBe(true);
     const uuid = prefix?.slice(uuidPrefix.length, -1) ?? "";
     expect(uuid).toHaveLength(36);
-    expect(Array.from(uuid).every((char) => /[0-9a-f-]/u.test(char))).toBe(true);
+    expect(/^[0-9a-f-]+$/u.test(uuid)).toBe(true);
     expect([8, 13, 18, 23].map((index) => uuid[index])).toEqual(["-", "-", "-", "-"]);
     expect(path.dirname(prefix ?? "")).toBe(secureRoot);
     expect(createdTempDir.startsWith(prefix ?? "")).toBe(true);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `memory_search` surfaced session transcript hits with `corpus: "memory"`, including when callers explicitly requested `corpus=sessions`.
- Why it matters: callers could not reliably distinguish durable memory-file hits from session transcript hits, so recall provenance was misleading.
- What changed: preserve the memory-manager hit `source` when shaping tool results, so session hits surface as `corpus: "sessions"` and memory-file hits continue to surface as `corpus: "memory"`.
- What did NOT change (scope boundary): search ranking, source filtering, session visibility filtering, citation decoration, wiki supplement behavior, recall tracking, config, and permissions are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #72885
- Related #72886
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: `memory_search corpus=sessions` returned a session transcript hit whose `source` was `sessions` but whose surfaced `corpus` was incorrectly `memory`.
- Real environment tested: macOS local OpenClaw Gateway, isolated temp `OPENCLAW_STATE_DIR`, token auth on loopback, `memory-core` enabled, FTS-only memory indexing with `provider=auto`, no external LLM/provider call required.
- Exact steps or command run after this patch: seeded an isolated session transcript containing `The current Project Nebula codename is ORBIT-10.`, launched the Gateway, then called `POST /tools/invoke` with `tool=memory_search`, `sessionKey=agent:main:main`, and args `{ "query": "current Project Nebula codename ORBIT-10", "corpus": "sessions", "maxResults": 3, "minScore": 0 }`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the local Gateway run:

  ```text
  rebased-branch-after head=d9ab27acb1 status=200 ok=true resultCount=1 source=sessions corpus=sessions path=sessions/main/session-bootstrap.jsonl snippet="Assistant: The current Project Nebula codename is ORBIT-10."
  ```
- Observed result after fix: the Gateway returned the real session transcript hit with `corpus: "sessions"`.
- What was not tested: full remote/Testbox suite and cross-OS package acceptance; the changed lanes are limited to `memory-core` extension production/test code.
- Before evidence (optional but encouraged): Copied live output from fetched `origin/main` `378da8b9d3` with the same isolated Gateway setup:

  ```text
  origin-main-before head=378da8b9d3 status=200 ok=true resultCount=1 source=sessions corpus=memory path=sessions/main/session-bootstrap.jsonl snippet="Assistant: The current Project Nebula codename is ORBIT-10."
  ```

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: memory-manager results already carry a required `source`, but `memory_search` result shaping hard-coded every surfaced memory-manager hit to `corpus: "memory"`.
- Missing detection / guardrail: existing tests covered unavailable/debug payloads and adjacent visibility behavior, but not the output corpus label for authorized session transcript hits.
- Contributing context (if known): session transcript hits share the same memory-manager result path as memory-file hits after search, source filtering, visibility filtering, and citation decoration.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/tools.test.ts`
- Scenario the test should lock in: an authorized `source: "sessions"` memory-manager hit returned through `memory_search corpus=sessions` surfaces `corpus: "sessions"`.
- Why this is the smallest reliable guardrail: the bug was in the tool result mapper, so a focused tool test covers the changed branch without requiring an embedding provider or full agent turn.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`memory_search` results now report session transcript hits as `corpus: "sessions"` instead of incorrectly reporting them as `corpus: "memory"`.

## Diagram (if applicable)

```text
Before:
[memory manager hit source=sessions] -> [memory_search result corpus=memory]

After:
[memory manager hit source=sessions] -> [memory_search result corpus=sessions]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw workspace; local isolated Gateway process
- Model/provider: no model call; memory search used `provider=auto` with FTS-only indexing
- Integration/channel (if any): Gateway HTTP `/tools/invoke`, `memory-core`
- Relevant config (redacted): `plugins.entries.memory-core.enabled=true`, `agents.defaults.memorySearch.sources=["memory","sessions"]`, `agents.defaults.memorySearch.experimental.sessionMemory=true`, `agents.defaults.memorySearch.store.vector.enabled=false`, `tools.sessions.visibility="all"`, `gateway.auth.mode="token"` with token redacted

### Steps

1. Rebased the PR branch onto fetched `origin/main` `378da8b9d3` and removed the previous changelog/doc-only commits.
2. Ran the isolated Gateway proof once on `origin/main` and once on this branch with the same seeded session transcript and the same `/tools/invoke` request.
3. Ran focused memory-core tests, formatting, changed-lane validation, and Codex review against `origin/main`.

### Expected

- A session transcript search hit should surface both `source: "sessions"` and `corpus: "sessions"`.

### Actual

- Before: current main surfaced `source: "sessions"` with `corpus: "memory"`.
- After: this branch surfaces `source: "sessions"` with `corpus: "sessions"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

- `pnpm docs:list`
- `pnpm install` (local dependency refresh; lockfile unchanged)
- Live Gateway before/after proof through `POST /tools/invoke` on `origin/main` `378da8b9d3` and branch `d9ab27acb1`
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts`
- `pnpm changed:lanes --json` -> `extensions`, `extensionTests`
- `pnpm test extensions/memory-core/src/tools.test.ts extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/tools.citations.test.ts` -> 3 files, 28 tests passed
- `pnpm check:changed`
- `codex review --base origin/main` -> no actionable correctness issues

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real Gateway `/tools/invoke` before/after proof for `memory_search corpus=sessions`; unit regression for the mapper; adjacent session visibility and citation tests; changed-file typecheck/lint/import-cycle gate; Codex review.
- Edge cases checked: authorized session transcript hit survives visibility filtering, session-only corpus request, result typing for `MemorySource`, and adjacent wiki/citation result shaping tests.
- What you did **not** verify: broad full-suite/Testbox/cross-OS package acceptance, because the diff is limited to memory-core result shaping and the changed gate remained narrow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: consumers that accidentally relied on the wrong `corpus: "memory"` label for session transcript hits may see the corrected label.
  - Mitigation: this only aligns the surfaced contract with the existing required `source` field and documented `corpus=sessions` behavior.

