### PR TITLE
fix(models): honor --agent for auth login

### DIFF
--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -134,6 +134,25 @@ describe("models cli", () => {
     );
   });
 
+  it.each([
+    {
+      label: "login",
+      args: ["models", "auth", "--agent", "coder", "login", "--provider", "openai-codex"],
+      expected: { provider: "openai-codex", agent: "coder" },
+    },
+    {
+      label: "login-github-copilot",
+      args: ["models", "auth", "--agent", "coder", "login-github-copilot", "--yes"],
+      expected: { provider: "github-copilot", method: "device", yes: true, agent: "coder" },
+    },
+  ])("passes auth parent --agent to models auth $label", async ({ args, expected }) => {
+    await runModelsCommand(args);
+    expect(modelsAuthLoginCommand).toHaveBeenCalledWith(
+      expect.objectContaining(expected),
+      expect.any(Object),
+    );
+  });
+
   it("shows help for models auth without error exit", async () => {
     const program = new Command();
     program.exitOverride();

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -304,8 +304,7 @@ export function registerModelsCli(program: Command) {
     .option("--method <id>", "Provider auth method id")
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts, command) => {
-      const agent =
-        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      const agent = resolveOptionFromCommand<string>(command, "agent");
       await runModelsCommand(async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
         await modelsAuthLoginCommand(
@@ -366,8 +365,7 @@ export function registerModelsCli(program: Command) {
     .description("Login to GitHub Copilot via GitHub device flow (TTY required)")
     .option("--yes", "Overwrite existing profile without prompting", false)
     .action(async (opts, command) => {
-      const agent =
-        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      const agent = resolveOptionFromCommand<string>(command, "agent");
       await runModelsCommand(async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
         await modelsAuthLoginCommand(

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -303,7 +303,9 @@ export function registerModelsCli(program: Command) {
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
     .option("--set-default", "Apply the provider's default model recommendation", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
         await modelsAuthLoginCommand(
@@ -311,6 +313,7 @@ export function registerModelsCli(program: Command) {
             provider: opts.provider as string | undefined,
             method: opts.method as string | undefined,
             setDefault: Boolean(opts.setDefault),
+            agent,
           },
           defaultRuntime,
         );
@@ -362,7 +365,9 @@ export function registerModelsCli(program: Command) {
     .command("login-github-copilot")
     .description("Login to GitHub Copilot via GitHub device flow (TTY required)")
     .option("--yes", "Overwrite existing profile without prompting", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
         await modelsAuthLoginCommand(
@@ -370,6 +375,7 @@ export function registerModelsCli(program: Command) {
             provider: "github-copilot",
             method: "device",
             yes: Boolean(opts.yes),
+            agent,
           },
           defaultRuntime,
         );

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -9,10 +9,12 @@ const mocks = vi.hoisted(() => ({
   clackIsCancel: vi.fn((value: unknown) => value === Symbol.for("clack:cancel")),
   clackSelect: vi.fn(),
   clackText: vi.fn(),
+  listAgentIds: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   resolveAgentDir: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentWorkspaceDir: vi.fn(),
+  resolveKnownAgentId: vi.fn(),
   upsertAuthProfile: vi.fn(),
   resolvePluginProviders: vi.fn(),
   createClackPrompter: vi.fn(),
@@ -75,6 +77,7 @@ vi.mock("@clack/prompts", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds: mocks.listAgentIds,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
@@ -94,6 +97,7 @@ vi.mock("../../wizard/clack-prompter.js", () => ({
 
 vi.mock("./shared.js", () => ({
   loadValidConfigOrThrow: mocks.loadValidConfigOrThrow,
+  resolveKnownAgentId: mocks.resolveKnownAgentId,
   updateConfig: mocks.updateConfig,
 }));
 
@@ -267,6 +271,10 @@ describe("modelsAuthLoginCommand", () => {
     mocks.clackText.mockReset();
     mocks.upsertAuthProfile.mockReset();
 
+    mocks.listAgentIds.mockReturnValue(["main", "coder"]);
+    mocks.resolveKnownAgentId.mockImplementation(
+      ({ rawAgentId }: { rawAgentId?: string | null }) => rawAgentId?.trim() || undefined,
+    );
     mocks.resolveDefaultAgentId.mockReturnValue("main");
     mocks.resolveAgentDir.mockReturnValue("/tmp/openclaw/agents/main");
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
@@ -369,6 +377,42 @@ describe("modelsAuthLoginCommand", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Tip: Codex-capable models can use native Codex web search. Enable it with openclaw configure --section web (recommended mode: cached). Docs: https://docs.openclaw.ai/tools/web",
+    );
+  });
+
+  it("uses the requested agent directory for plugin login", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      agents: {
+        list: [{ id: "main" }, { id: "coder" }],
+      },
+    };
+    const initialConfig = currentConfig;
+    mocks.resolveAgentDir.mockImplementation((_cfg, agentId: string) =>
+      agentId === "coder" ? "/tmp/openclaw/agents/coder" : "/tmp/openclaw/agents/main",
+    );
+    mocks.resolveAgentWorkspaceDir.mockImplementation((_cfg, agentId: string) =>
+      agentId === "coder" ? "/tmp/openclaw/workspace-coder" : "/tmp/openclaw/workspace",
+    );
+
+    await modelsAuthLoginCommand({ provider: "openai-codex", agent: "coder" }, runtime);
+
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentDir).toHaveBeenCalledWith(initialConfig, "coder");
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(initialConfig, "coder");
+    expect(mocks.loadAuthProfileStoreForRuntime).toHaveBeenCalledWith(
+      "/tmp/openclaw/agents/coder",
+    );
+    expect(runProviderAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw/agents/coder",
+        workspaceDir: "/tmp/openclaw/workspace-coder",
+      }),
+    );
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw/agents/coder",
+      }),
     );
   });
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -43,7 +43,7 @@ import {
   pickAuthMethod,
   resolveProviderMatch,
 } from "../provider-auth-helpers.js";
-import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+import { loadValidConfigOrThrow, resolveKnownAgentId, updateConfig } from "./shared.js";
 
 function guardCancel<T>(value: T | symbol): T {
   if (typeof value === "symbol" || isCancel(value)) {
@@ -103,12 +103,15 @@ function listProvidersWithTokenMethods(providers: ProviderPlugin[]): ProviderPlu
 
 async function resolveModelsAuthContext(params?: {
   requestedProvider?: string;
+  requestedAgent?: string;
 }): Promise<ResolvedModelsAuthContext> {
   const config = await loadValidConfigOrThrow();
-  const defaultAgentId = resolveDefaultAgentId(config);
-  const agentDir = resolveAgentDir(config, defaultAgentId);
+  const agentId =
+    resolveKnownAgentId({ cfg: config, rawAgentId: params?.requestedAgent }) ??
+    resolveDefaultAgentId(config);
+  const agentDir = resolveAgentDir(config, agentId);
   const workspaceDir =
-    resolveAgentWorkspaceDir(config, defaultAgentId) ?? resolveDefaultAgentWorkspaceDir();
+    resolveAgentWorkspaceDir(config, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const providers = resolvePluginProviders({
     config,
     workspaceDir,
@@ -536,6 +539,7 @@ type LoginOptions = {
   method?: string;
   setDefault?: boolean;
   yes?: boolean;
+  agent?: string;
 };
 
 /**
@@ -588,6 +592,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
 
   const { config, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
     requestedProvider: opts.provider,
+    requestedAgent: opts.agent,
   });
   const prompter = createClackPrompter();
   const authProviders = listProvidersWithAuthMethods(providers);


### PR DESCRIPTION
## Summary

- Problem: `openclaw models auth --agent <id> login` accepted a parent `--agent` flag, but the login flow still resolved and wrote auth profiles through the configured default agent.
- Why it matters: users with separate agent stores could not refresh a stale token for a specific agent without manually copying `auth-profiles.json` entries.
- What changed: auth login now carries the resolved parent `--agent` into the provider auth context, so provider auth methods and persisted profiles use the selected agent's `agentDir` and workspace.
- What did NOT change (scope boundary): `paste-token`, `setup-token`, auth order commands, provider auth methods, and default-agent behavior when no `--agent` is supplied are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71864
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the `models auth` parent command had an `--agent` option, but `login` and `login-github-copilot` did not read parent command options before calling `modelsAuthLoginCommand`.
- Missing detection / guardrail: CLI tests covered `models status --agent`, but not auth login's parent `--agent` propagation or the downstream auth persistence context.
- Contributing context (if known): `models auth order` already used `resolveOptionFromCommand()` for parent `--agent`; login missed that same pattern.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/models-cli.test.ts`, `src/commands/models/auth.test.ts`
- Scenario the test should lock in: `models auth --agent coder login --provider openai-codex` passes `agent: "coder"`, resolves the coder `agentDir/workspaceDir`, and persists the profile to the coder store.
- Why this is the smallest reliable guardrail: it covers both the Commander parent-option seam and the auth context used by provider login without requiring a live OAuth browser flow.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A, regression tests added.

## User-visible / Behavior Changes

`openclaw models auth --agent <id> login ...` and `openclaw models auth --agent <id> login-github-copilot ...` now target the selected agent's auth store instead of always using the configured default agent.

## Diagram (if applicable)

```text
Before:
models auth --agent coder login -> default agentDir -> main auth-profiles.json

After:
models auth --agent coder login -> coder agentDir/workspaceDir -> coder auth-profiles.json
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: OAuth/token material is written to the user-selected existing agent store rather than the default store. The agent id is validated with the existing `resolveKnownAgentId()` path before resolving `agentDir`.

## Repro + Verification

### Environment

- OS: Windows local dev for tests
- Runtime/container: local pnpm/vitest
- Model/provider: mocked OpenAI Codex provider auth flow
- Integration/channel (if any): models auth CLI
- Relevant config (redacted): test config with `main` and `coder` agents

### Steps

1. Configure two agents, `main` and `coder`.
2. Run `openclaw models auth --agent coder login --provider openai-codex`.
3. Complete the provider auth flow.

### Expected

- Login context uses the `coder` agent directory and writes the auth profile to the `coder` auth store.

### Actual

- Before this fix, login ignored the parent `--agent` flag and used the default agent auth store.

## Evidence

- [x] Passing regression coverage: `pnpm exec vitest run src\cli\models-cli.test.ts` -> 1 file passed, 6 tests passed
- [x] Passing regression coverage: `pnpm exec vitest run src\commands\models\auth.test.ts` -> 1 file passed, 11 tests passed
- [x] Changed-file gate: `pnpm check:changed` passed
- [x] Whitespace check: `git diff --check` passed

## Human Verification (required)

- Verified scenarios: parent `--agent` propagation for `models auth login` and `login-github-copilot`; auth login context resolves and writes through the selected agent directory.
- Edge cases checked: default-agent behavior remains covered when no `--agent` is supplied; unknown-agent validation stays on the existing shared resolver path.
- What you did **not** verify: live OAuth browser/device flow against a real provider, because the regression is in local CLI option routing and auth context selection.

## Review Conversations

N/A, no review conversations on this PR yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users may now write credentials to a non-default agent store when they intentionally pass `--agent`.
  - Mitigation: this is the documented/expected behavior for the flag, and the agent id is validated before any auth context is built.
