### PR TITLE
fix(update): avoid findstr in Windows restart helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Bedrock: defer the AWS SDK import until Bedrock discovery actually runs so plugin registration and setup stay lightweight on cold start. Fixes #71690. Thanks @jarvis-ai-gregmoser.
 - Installer/macOS: stop immediately when Homebrew `node@24` installation fails and avoid printing PATH advice for missing Homebrew Node installs. Fixes #70411. Thanks @1fanwang.
 - WhatsApp: remove ack reactions after a visible reply when `messages.removeAckAfterReply` is enabled, matching other reaction-capable channels. Fixes #26183. Thanks @MrUnforsaken.
+- CLI/update: keep Windows update restarts hidden without `findstr`, preserving the scheduled-task end/wait/run order and stale-listener cleanup. Fixes #59394 and #57682; addresses the stale-listener portion of #69970. Thanks @sherlock-huang.
 - Providers/Z.AI: map OpenClaw thinking controls to Z.AI's `thinking` payload and add opt-in preserved thinking replay via `params.preserveThinking`, so GLM 5.x can keep prior `reasoning_content` when requested. Fixes #58680. Thanks @xuanmingguo.
 - Channels/status: keep read-only channel lists on manifest and package metadata by default, loading setup runtime only for explicit fallback callers. Thanks @shakkernerd.
 - Plugins: scope setup and web-provider metadata manifest reads to explicit plugin ids when callers already know the owning plugin set. Thanks @vincentkoc.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/diagnostics-prometheus:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/diagnostics-otel:
     dependencies:
       '@opentelemetry/api':

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -316,6 +316,9 @@ exit 0
       expect(content).not.toContain("-File");
       expect(content).toContain('$ErrorActionPreference = "Continue"');
       expect(content).toContain("gateway-restart.log");
+      expect(content).toContain(
+        'Write-RestartLog "openclaw restart attempt source=update target=$taskName"',
+      );
       expect(content).toContain("$taskName = 'OpenClaw Gateway'");
       expect(content).toContain("function Invoke-OpenClawSchtasksWithTimeout");
       expect(content).toContain("function Get-OpenClawScheduledTaskState");
@@ -488,9 +491,9 @@ exit 0
       expect(mockChild.unref).toHaveBeenCalled();
     });
 
-    it("uses cmd.exe on Windows", async () => {
+    it("uses hidden cmd wrapper on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
-      const scriptPath = "C:\\Temp\\fake-script.bat";
+      const scriptPath = "C:\\Temp\\fake-script.cmd";
       const mockChild = { unref: vi.fn() };
       vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
@@ -506,7 +509,7 @@ exit 0
 
     it("quotes cmd.exe /c paths with metacharacters on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
-      const scriptPath = "C:\\Temp\\me&(ow)\\fake-script.bat";
+      const scriptPath = "C:\\Temp\\me&(ow)\\fake-script.cmd";
       const mockChild = { unref: vi.fn() };
       vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -19,7 +19,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
  * Replaces every `'` with `'\''` (end quote, escaped quote, resume quote).
- * For batch scripts, validates against special characters instead.
+ * For Windows task names, validates against shell metacharacters instead.
  */
 function shellEscape(value: string): string {
   return value.replace(/'/g, "'\\''");
@@ -27,6 +27,7 @@ function shellEscape(value: string): string {
 
 /** Validates a task name is safe for embedding in Windows restart scripts. */
 function isWindowsTaskNameSafe(value: string): boolean {
+  // Keep the old batch-safe subset: schtasks.exe still receives this value.
   return /^[A-Za-z0-9 _\-().]+$/.test(value);
 }
 
@@ -82,7 +83,7 @@ export async function prepareRestartScript(
       const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });
       filename = `openclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
-# Standalone restart script — survives parent process termination.
+# Standalone restart script - survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
 ${logSetup}
@@ -111,7 +112,7 @@ exit "$status"
       const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });
       filename = `openclaw-restart-${timestamp}.sh`;
       scriptContent = `#!/bin/sh
-# Standalone restart script — survives parent process termination.
+# Standalone restart script - survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
 # Capture launchctl output so bootstrap/kickstart failures leave a durable
@@ -342,8 +343,8 @@ exit $status
  * Executes the prepared restart script as a **detached** process.
  *
  * The script must outlive the CLI process because the CLI itself is part
- * of the service being restarted — `systemctl restart` / `launchctl
- * kickstart -k` will terminate the current process tree.  Using
+ * of the service being restarted - `systemctl restart` / `launchctl
+ * kickstart -k` will terminate the current process tree. Using
  * `spawn({ detached: true })` + `unref()` ensures the script survives
  * the parent's exit.
  *


### PR DESCRIPTION
## Summary

This updates the Windows update restart helper to avoid generating a detached batch script that polls the gateway port with `netstat | findstr`.

The Windows restart handoff now writes a hidden `.cmd` wrapper for policy compatibility and executes the embedded PowerShell restart logic through `powershell -NoProfile -ExecutionPolicy Bypass -Command`. It:

- launches the detached restart handoff with `windowsHide: true`
- avoids `-File` so Group Policy script execution settings cannot block a generated `.ps1` file before `schtasks.exe` runs
- polls the gateway port with `Get-NetTCPConnection` first
- falls back to parsing `netstat.exe -ano -p tcp` directly in PowerShell, without `findstr` or a cmd pipeline
- preserves the existing `schtasks /End` -> wait/kill listener -> `schtasks /Run` flow, restart log, and self-cleanup behavior

This targets the update-restart path specifically. The normal gateway start/restart stale-port code already has a Windows helper; this closes the remaining generated `findstr` path that can leave a visible console window after Windows updates.

Fixes #59394 and #57682. Addresses the stale-listener portion of #69970.

## Tests

- `pnpm exec oxfmt --check src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts`
- `pnpm exec oxlint src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts`
- `pnpm exec vitest run src/cli/update-cli/restart-helper.test.ts -t Windows`
- `pnpm exec vitest run src/infra/changelog-unreleased.test.ts`
- `pnpm exec oxfmt --check CHANGELOG.md`