### PR TITLE
fix(plugins): remove bundled load path aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Browser automation: keep stable tab ids and labels attached when Chromium replaces the raw target after form submissions or other action-triggered navigations, and return the replacement `targetId` from `/act` when the match is provable. Fixes #46137.
 - QQ Bot: make `qqbot_remind` schedule, list, and remove Gateway cron jobs directly for owner-authorized senders instead of returning `cronParams` and relying on a follow-up generic `cron` tool call. Fixes #70865. (#70937) Thanks @GaosCode.
 - Agents/ACP: hide `sessions_spawn` ACP runtime options unless an ACP backend is loaded, and make `/acp doctor` call out `plugins.allow` blocking bundled `acpx`. Thanks @vincentkoc.
+- Plugins/doctor: remove stale custom load-path aliases that point back at bundled plugins so ACPX and other bundled plugins keep using runtime-deps staging. Fixes #71906. Thanks @riosbotchen-source.
 - Media delivery: avoid sending generated image attachments twice when the assistant reply already includes explicit `MEDIA:` lines for the same turn, and reject unsafe remote `MEDIA:` URLs before delivery. Thanks @pashpashpash.
 - Codex harness: ignore retryable app-server error notifications after Codex recovers, and preserve the real nested error message for terminal app-server failures instead of replacing it with a generic failure. Thanks @pashpashpash.
 - Agents/Codex: prepare native Codex sub-agent session metadata without a

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
@@ -104,6 +104,9 @@ describe("bundled plugin load path repair", () => {
     const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([bundledPath]));
 
     expect(result.config.plugins?.load?.paths).toEqual([]);
+    expect(result.changes).toEqual([
+      `- plugins.load.paths: removed bundled feishu path ${bundledPath}`,
+    ]);
   });
 
   it("derives legacy paths from the bundled directory name instead of plugin id", () => {

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
@@ -74,7 +74,7 @@ describe("bundled plugin load path repair", () => {
     ]);
   });
 
-  it("rewrites legacy bundled paths during doctor repair", () => {
+  it("removes legacy bundled paths during doctor repair", () => {
     const packageRoot = path.resolve("app-node-modules", "openclaw");
     const legacyPath = bundledPluginRootAt(packageRoot, "feishu");
     const bundledPath = bundledDistPluginRootAt(packageRoot, "feishu");
@@ -91,9 +91,19 @@ describe("bundled plugin load path repair", () => {
     });
 
     expect(result.changes).toEqual([
-      `- plugins.load.paths: rewrote bundled feishu path from ${legacyPath} to ${bundledPath}`,
+      `- plugins.load.paths: removed bundled feishu path ${legacyPath}`,
     ]);
-    expect(result.config.plugins?.load?.paths).toEqual([bundledPath]);
+    expect(result.config.plugins?.load?.paths).toEqual([]);
+  });
+
+  it("removes current packaged bundled paths during doctor repair", () => {
+    const packageRoot = path.resolve("app-node-modules", "openclaw");
+    const bundledPath = bundledDistPluginRootAt(packageRoot, "feishu");
+    mockBundledSource("feishu", bundledPath);
+
+    const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([bundledPath]));
+
+    expect(result.config.plugins?.load?.paths).toEqual([]);
   });
 
   it("derives legacy paths from the bundled directory name instead of plugin id", () => {
@@ -130,10 +140,10 @@ describe("bundled plugin load path repair", () => {
 
     const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([legacyPath]));
 
-    expect(result.config.plugins?.load?.paths).toEqual([bundledPath]);
+    expect(result.config.plugins?.load?.paths).toEqual([]);
   });
 
-  it("rewrites dist-runtime bundled paths back to their legacy source path", () => {
+  it("removes dist-runtime bundled paths", () => {
     const packageRoot = path.resolve("app-node-modules", "openclaw");
     const legacyPath = path.join(packageRoot, "extensions", "feishu");
     const bundledPath = path.join(packageRoot, "dist-runtime", "extensions", "feishu");
@@ -141,7 +151,7 @@ describe("bundled plugin load path repair", () => {
 
     const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([legacyPath]));
 
-    expect(result.config.plugins?.load?.paths).toEqual([bundledPath]);
+    expect(result.config.plugins?.load?.paths).toEqual([]);
   });
 
   it("preserves non-string path entries when repairing legacy bundled paths", () => {
@@ -154,7 +164,7 @@ describe("bundled plugin load path repair", () => {
 
     const result = maybeRepairBundledPluginLoadPaths(cfg);
 
-    expect(result.config.plugins?.load?.paths).toEqual([bundledPath, 42, "/other/path"]);
+    expect(result.config.plugins?.load?.paths).toEqual([42, "/other/path"]);
   });
 
   it("formats a doctor hint for legacy bundled plugin paths", () => {
@@ -175,7 +185,7 @@ describe("bundled plugin load path repair", () => {
     });
 
     expect(warnings).toEqual([
-      expect.stringContaining(`plugins.load.paths: legacy bundled plugin path "${legacyPath}"`),
+      expect.stringContaining(`plugins.load.paths: bundled plugin path "${legacyPath}"`),
       expect.stringContaining('Run "openclaw doctor --fix"'),
     ]);
   });

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.ts
@@ -153,13 +153,11 @@ export function maybeRepairBundledPluginLoadPaths(
     if (hit) {
       continue;
     }
-    const replacement = entry;
-    const replacementResolved = normalizeBundledLookupPath(resolveUserPath(replacement, env));
-    if (seen.has(replacementResolved)) {
+    if (seen.has(resolved)) {
       continue;
     }
-    seen.add(replacementResolved);
-    rewritten.push(replacement);
+    seen.add(resolved);
+    rewritten.push(entry);
   }
 
   next.plugins = {

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.ts
@@ -68,11 +68,16 @@ export function scanBundledPluginLoadPathMigrations(
   }
 
   const legacyPathMap = new Map<string, { pluginId: string; toPath: string }>();
+  const bundledPathMap = new Map<string, { pluginId: string; toPath: string }>();
   for (const source of bundled.values()) {
     const legacyPath = buildLegacyBundledPath(source.localPath);
     if (!legacyPath) {
       continue;
     }
+    bundledPathMap.set(normalizeBundledLookupPath(source.localPath), {
+      pluginId: source.pluginId,
+      toPath: source.localPath,
+    });
     legacyPathMap.set(normalizeBundledLookupPath(legacyPath), {
       pluginId: source.pluginId,
       toPath: source.localPath,
@@ -85,7 +90,7 @@ export function scanBundledPluginLoadPathMigrations(
       continue;
     }
     const normalized = normalizeBundledLookupPath(resolveUserPath(rawPath, env));
-    const match = legacyPathMap.get(normalized);
+    const match = bundledPathMap.get(normalized) ?? legacyPathMap.get(normalized);
     if (!match) {
       continue;
     }
@@ -109,9 +114,9 @@ export function collectBundledPluginLoadPathWarnings(params: {
   }
   const lines = params.hits.map(
     (hit) =>
-      `- ${hit.pathLabel}: legacy bundled plugin path "${hit.fromPath}" still points at ${hit.pluginId}; current packaged path is "${hit.toPath}".`,
+      `- ${hit.pathLabel}: bundled plugin path "${hit.fromPath}" still points at ${hit.pluginId} and disables bundled runtime-deps staging.`,
   );
-  lines.push(`- Run "${params.doctorFixCommand}" to rewrite these bundled plugin paths.`);
+  lines.push(`- Run "${params.doctorFixCommand}" to remove these redundant bundled plugin paths.`);
   return lines.map((line) => sanitizeForLog(line));
 }
 
@@ -144,7 +149,11 @@ export function maybeRepairBundledPluginLoadPaths(
       continue;
     }
     const resolved = normalizeBundledLookupPath(resolveUserPath(entry, env));
-    const replacement = replacements.get(resolved)?.toPath ?? entry;
+    const hit = replacements.get(resolved);
+    if (hit) {
+      continue;
+    }
+    const replacement = entry;
     const replacementResolved = normalizeBundledLookupPath(resolveUserPath(replacement, env));
     if (seen.has(replacementResolved)) {
       continue;
@@ -164,8 +173,7 @@ export function maybeRepairBundledPluginLoadPaths(
   return {
     config: next,
     changes: hits.map(
-      (hit) =>
-        `- plugins.load.paths: rewrote bundled ${hit.pluginId} path from ${hit.fromPath} to ${hit.toPath}`,
+      (hit) => `- plugins.load.paths: removed bundled ${hit.pluginId} path ${hit.fromPath}`,
     ),
   };
 }


### PR DESCRIPTION
## Summary
- Fixes #71906 by teaching doctor repair to remove custom `plugins.load.paths` entries that alias bundled plugin roots, including the packaged `dist/extensions/<id>` path.
- Updates the existing bundled plugin load-path repair tests to cover removal of current packaged bundled paths, legacy bundled aliases, and `dist-runtime` aliases.
- Adds the user-facing changelog fix entry.

## Root Cause
Stale custom plugin load paths that pointed back at bundled plugin directories were still treated as explicit config-origin plugins. For ACPX, that bypassed the bundled runtime-deps staging flow, so `acpx/runtime` could be missing even though the staged bundled dependency was available.

## Why This Fix Is Safe
The repair only targets paths that resolve to OpenClaw's own bundled plugin roots or their known legacy bundled aliases. Removing those redundant custom paths lets normal bundled discovery own the plugin again, preserving explicit third-party or unrelated custom plugin paths. Test helper defaults remain aligned with production defaults: this change does not alter runtime defaults, only doctor repair output.

## Security And Runtime Controls
Security and runtime controls are unchanged. Plugin trust policy, bundled plugin enablement, runtime-deps installation, and module loading remain enforced by the existing loader and doctor paths; this does not rely on prompt text or advisory-only behavior.

## Tests Run
- `pnpm test src/commands/doctor/shared/bundled-plugin-load-paths.test.ts`
- `pnpm test src/commands/doctor/shared/bundled-plugin-load-paths.test.ts src/plugins/loader.test.ts -- -t "bundled plugin load path repair|loads bundled runtime deps from an external stage dir"`
- `pnpm check:changed`

Made with [Cursor](https://cursor.com)