### PR TITLE
Fix CLI transcript compaction lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: unwrap nested Claude result envelopes in CLI JSON output so delegated agent responses surface as final text instead of raw result JSON. (#66819) Thanks @mraleko.
 - Agents/Claude CLI: apply the configured 1M context window override to eligible Claude CLI Opus and Sonnet models when `context1m` is enabled. (#70863) Thanks @bidadh.
 - Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local credentials are current. Fixes #71256. (#71332) Thanks @matthiasjanke and @neeravmakwana.
+- CLI backends: compact OpenClaw transcripts after over-budget CLI turns and reseed fresh CLI sessions from the compacted transcript instead of stale external resume state. Fixes #68329. (#71916) Thanks @obviyus.
 
 ## 2026.4.24
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -73,6 +73,7 @@ type AcpRuntimeErrorsRuntime = typeof import("../acp/runtime/errors.js");
 type AcpSessionIdentifiersRuntime = typeof import("../acp/runtime/session-identifiers.js");
 type DeliveryRuntime = typeof import("./command/delivery.runtime.js");
 type SessionStoreRuntime = typeof import("./command/session-store.runtime.js");
+type CliCompactionRuntime = typeof import("./command/cli-compaction.js");
 type TranscriptResolveRuntime = typeof import("../config/sessions/transcript-resolve.runtime.js");
 type CliDepsRuntime = typeof import("../cli/deps.js");
 type ExecDefaultsRuntime = typeof import("./exec-defaults.js");
@@ -88,6 +89,7 @@ let acpRuntimeErrorsRuntimePromise: Promise<AcpRuntimeErrorsRuntime> | undefined
 let acpSessionIdentifiersRuntimePromise: Promise<AcpSessionIdentifiersRuntime> | undefined;
 let deliveryRuntimePromise: Promise<DeliveryRuntime> | undefined;
 let sessionStoreRuntimePromise: Promise<SessionStoreRuntime> | undefined;
+let cliCompactionRuntimePromise: Promise<CliCompactionRuntime> | undefined;
 let transcriptResolveRuntimePromise: Promise<TranscriptResolveRuntime> | undefined;
 let cliDepsRuntimePromise: Promise<CliDepsRuntime> | undefined;
 let execDefaultsRuntimePromise: Promise<ExecDefaultsRuntime> | undefined;
@@ -129,6 +131,11 @@ function loadDeliveryRuntime(): Promise<DeliveryRuntime> {
 function loadSessionStoreRuntime(): Promise<SessionStoreRuntime> {
   sessionStoreRuntimePromise ??= import("./command/session-store.runtime.js");
   return sessionStoreRuntimePromise;
+}
+
+function loadCliCompactionRuntime(): Promise<CliCompactionRuntime> {
+  cliCompactionRuntimePromise ??= import("./command/cli-compaction.js");
+  return cliCompactionRuntimePromise;
 }
 
 function loadTranscriptResolveRuntime(): Promise<TranscriptResolveRuntime> {
@@ -874,6 +881,11 @@ async function agentCommandInternal(
     const startedAt = Date.now();
     let lifecycleEnded = false;
     const attemptExecutionRuntime = await loadAttemptExecutionRuntime();
+    const runContext = resolveAgentRunContext(opts);
+    const messageChannel = resolveMessageChannel(
+      runContext.messageChannel,
+      opts.replyChannel ?? opts.channel,
+    );
 
     let result: Awaited<ReturnType<AttemptExecutionRuntime["runAgentAttempt"]>>;
     let fallbackProvider = provider;
@@ -882,11 +894,6 @@ async function agentCommandInternal(
     let liveSwitchRetries = 0;
     for (;;) {
       try {
-        const runContext = resolveAgentRunContext(opts);
-        const messageChannel = resolveMessageChannel(
-          runContext.messageChannel,
-          opts.replyChannel ?? opts.channel,
-        );
         const spawnedBy = normalizedSpawned.spawnedBy ?? sessionEntry?.spawnedBy;
         const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
           cfg,
@@ -1102,6 +1109,27 @@ async function agentCommandInternal(
           sessionAgentId,
           threadId: opts.threadId,
           sessionCwd: workspaceDir,
+        });
+        sessionEntry = await (
+          await loadCliCompactionRuntime()
+        ).runCliTurnCompactionLifecycle({
+          cfg,
+          sessionId,
+          sessionKey: sessionKey ?? sessionId,
+          sessionEntry,
+          sessionStore,
+          storePath,
+          sessionAgentId,
+          workspaceDir,
+          agentDir,
+          provider: result.meta.agentMeta?.provider ?? provider,
+          model: result.meta.agentMeta?.model ?? model,
+          skillsSnapshot,
+          messageChannel,
+          agentAccountId: runContext.accountId,
+          senderIsOwner: opts.senderIsOwner,
+          thinkLevel: resolvedThinkLevel,
+          extraSystemPrompt: opts.extraSystemPrompt,
         });
       } catch (error) {
         log.warn(

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -74,6 +74,7 @@ function buildPreparedContext(params?: {
   sessionKey?: string;
   cliSessionId?: string;
   runId?: string;
+  openClawHistoryPrompt?: string;
 }): PreparedCliRunContext {
   const backend = {
     command: "codex",
@@ -115,6 +116,9 @@ function buildPreparedContext(params?: {
     systemPrompt: "You are a helpful assistant.",
     systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
     bootstrapPromptWarningLines: [],
+    ...(params?.openClawHistoryPrompt
+      ? { openClawHistoryPrompt: params.openClawHistoryPrompt }
+      : {}),
     authEpochVersion: 2,
   };
 }
@@ -322,6 +326,56 @@ describe("runCliAgent reliability", () => {
       stopReason: "completed",
       refusal: false,
     });
+  });
+
+  it("seeds fresh CLI sessions from the OpenClaw transcript", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const result = await runPreparedCliAgent(
+      buildPreparedContext({
+        openClawHistoryPrompt:
+          "Continue this conversation using the OpenClaw transcript below.\n\nUser: earlier ask\n\nAssistant: earlier answer\n\n<next_user_message>\nhi\n</next_user_message>",
+      }),
+    );
+
+    expect(result.meta.finalPromptText).toContain("User: earlier ask");
+    expect(result.meta.finalPromptText).toContain("Assistant: earlier answer");
+  });
+
+  it("keeps resumed CLI sessions on native resume history", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const result = await runPreparedCliAgent(
+      buildPreparedContext({
+        cliSessionId: "cli-session",
+        openClawHistoryPrompt: "User: earlier ask",
+      }),
+    );
+
+    expect(result.meta.finalPromptText).not.toContain("User: earlier ask");
+    expect(result.meta.finalPromptText).toContain("hi");
   });
 
   it("reports CLI reply backends as streaming until the managed run finishes", async () => {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -759,6 +759,19 @@ describe("runCliAgent reliability", () => {
     const { dir, sessionFile } = createSessionFile({
       history: [{ role: "user", content: "earlier ask" }],
     });
+    fs.appendFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "msg-0",
+        timestamp: new Date(2).toISOString(),
+        summary: "compacted earlier ask",
+        firstKeptEntryId: "msg-0",
+        tokensBefore: 10_000,
+      })}\n`,
+      "utf-8",
+    );
     const config: OpenClawConfig = {
       agents: {
         defaults: {
@@ -796,7 +809,7 @@ describe("runCliAgent reliability", () => {
       });
 
       expect(context.params.prompt).toBe("hook context\n\ncurrent ask");
-      expect(context.openClawHistoryPrompt).toContain("User: earlier ask");
+      expect(context.openClawHistoryPrompt).toContain("Compaction summary: compacted earlier ask");
       expect(context.openClawHistoryPrompt).toContain("hook context");
       expect(context.openClawHistoryPrompt).toContain("current ask");
     } finally {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -8,6 +8,7 @@ import {
   createReplyOperation,
   replyRunRegistry,
 } from "../auto-reply/reply/reply-run-registry.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { runPreparedCliAgent } from "./cli-runner.js";
 import {
@@ -18,6 +19,7 @@ import {
 } from "./cli-runner.test-support.js";
 import { executePreparedCliRun } from "./cli-runner/execute.js";
 import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
+import { prepareCliRunContext } from "./cli-runner/prepare.js";
 import * as sessionHistoryModule from "./cli-runner/session-history.js";
 import { MAX_CLI_SESSION_HISTORY_MESSAGES } from "./cli-runner/session-history.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
@@ -750,6 +752,55 @@ describe("runCliAgent reliability", () => {
       });
     } finally {
       historySpy.mockRestore();
+    }
+  });
+
+  it("builds fresh-session history reseed prompts from hook-mutated prompts", async () => {
+    const { dir, sessionFile } = createSessionFile({
+      history: [{ role: "user", content: "earlier ask" }],
+    });
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: dir,
+          cliBackends: {
+            "codex-cli": {
+              command: "codex",
+              args: ["exec"],
+              output: "text",
+              input: "arg",
+              sessionMode: "existing",
+            },
+          },
+        },
+      },
+    };
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
+      runBeforePromptBuild: vi.fn(async () => ({ prependContext: "hook context" })),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+    mockGetGlobalHookRunner.mockReturnValue(hookRunner as never);
+
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "s1",
+        sessionFile,
+        workspaceDir: dir,
+        config,
+        prompt: "current ask",
+        provider: "codex-cli",
+        model: "gpt-5.4",
+        timeoutMs: 1_000,
+        runId: "run-history-hook",
+      });
+
+      expect(context.params.prompt).toBe("hook context\n\ncurrent ask");
+      expect(context.openClawHistoryPrompt).toContain("User: earlier ask");
+      expect(context.openClawHistoryPrompt).toContain("hook context");
+      expect(context.openClawHistoryPrompt).toContain("current ask");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -205,8 +205,11 @@ export async function executePreparedCliRun(
         })
       : undefined;
 
+  const basePrompt = cliSessionIdToUse
+    ? params.prompt
+    : (context.openClawHistoryPrompt ?? params.prompt);
   let prompt = applyPluginTextReplacements(
-    prependBootstrapPromptWarning(params.prompt, context.bootstrapPromptWarningLines, {
+    prependBootstrapPromptWarning(basePrompt, context.bootstrapPromptWarningLines, {
       preserveExactPrompt: context.heartbeatPrompt,
     }),
     context.backendResolved.textTransforms?.input,
@@ -270,7 +273,7 @@ export async function executePreparedCliRun(
         : undefined;
       try {
         cliBackendLog.info(
-          `cli exec: provider=${params.provider} model=${context.normalizedModel} promptChars=${params.prompt.length}`,
+          `cli exec: provider=${params.provider} model=${context.normalizedModel} promptChars=${basePrompt.length}`,
         );
         const logOutputText =
           isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]) ||

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -42,7 +42,11 @@ import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildSystemPrompt, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
-import { buildCliSessionHistoryPrompt, loadCliSessionHistoryMessages } from "./session-history.js";
+import {
+  buildCliSessionHistoryPrompt,
+  loadCliSessionHistoryMessages,
+  loadCliSessionReseedMessages,
+} from "./session-history.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
 const prepareDeps = {
@@ -363,7 +367,13 @@ export async function prepareCliRunContext(
   const openClawHistoryPrompt = reusableCliSession.sessionId
     ? undefined
     : buildCliSessionHistoryPrompt({
-        messages: loadOpenClawHistoryMessages(),
+        messages: loadCliSessionReseedMessages({
+          sessionId: params.sessionId,
+          sessionFile: params.sessionFile,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          config: params.config,
+        }),
         prompt: preparedPrompt,
       });
   systemPrompt = applyPluginTextReplacements(systemPrompt, backendResolved.textTransforms?.input);

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -259,16 +259,17 @@ export async function prepareCliRunContext(
       `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,
     );
   }
-  const openClawHistoryPrompt = buildCliSessionHistoryPrompt({
-    messages: loadCliSessionHistoryMessages({
+  let openClawHistoryMessages: unknown[] | undefined;
+  const loadOpenClawHistoryMessages = () => {
+    openClawHistoryMessages ??= loadCliSessionHistoryMessages({
       sessionId: params.sessionId,
       sessionFile: params.sessionFile,
       sessionKey: params.sessionKey,
       agentId: params.agentId,
       config: params.config,
-    }),
-    prompt: params.prompt,
-  });
+    });
+    return openClawHistoryMessages;
+  };
   const heartbeatPrompt = resolveHeartbeatPromptForSystemPrompt({
     config: params.config,
     agentId: sessionAgentId,
@@ -323,13 +324,7 @@ export async function prepareCliRunContext(
     try {
       const hookResult = await resolvePromptBuildHookResult({
         prompt: params.prompt,
-        messages: loadCliSessionHistoryMessages({
-          sessionId: params.sessionId,
-          sessionFile: params.sessionFile,
-          sessionKey: params.sessionKey,
-          agentId: params.agentId,
-          config: params.config,
-        }),
+        messages: loadOpenClawHistoryMessages(),
         hookCtx: {
           runId: params.runId,
           agentId: sessionAgentId,
@@ -365,6 +360,12 @@ export async function prepareCliRunContext(
       cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
     }
   }
+  const openClawHistoryPrompt = reusableCliSession.sessionId
+    ? undefined
+    : buildCliSessionHistoryPrompt({
+        messages: loadOpenClawHistoryMessages(),
+        prompt: preparedPrompt,
+      });
   systemPrompt = applyPluginTextReplacements(systemPrompt, backendResolved.textTransforms?.input);
   const systemPromptReport = buildSystemPromptReport({
     source: "run",

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -42,7 +42,7 @@ import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildSystemPrompt, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
-import { loadCliSessionHistoryMessages } from "./session-history.js";
+import { buildCliSessionHistoryPrompt, loadCliSessionHistoryMessages } from "./session-history.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
 const prepareDeps = {
@@ -259,6 +259,16 @@ export async function prepareCliRunContext(
       `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,
     );
   }
+  const openClawHistoryPrompt = buildCliSessionHistoryPrompt({
+    messages: loadCliSessionHistoryMessages({
+      sessionId: params.sessionId,
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      config: params.config,
+    }),
+    prompt: params.prompt,
+  });
   const heartbeatPrompt = resolveHeartbeatPromptForSystemPrompt({
     config: params.config,
     agentId: sessionAgentId,
@@ -392,6 +402,7 @@ export async function prepareCliRunContext(
     systemPrompt,
     systemPromptReport,
     bootstrapPromptWarningLines: bootstrapPromptWarning.lines,
+    ...(openClawHistoryPrompt ? { openClawHistoryPrompt } : {}),
     heartbeatPrompt,
     authEpoch,
     authEpochVersion: CLI_AUTH_EPOCH_VERSION,

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildCliSessionHistoryPrompt,
   loadCliSessionHistoryMessages,
   MAX_CLI_SESSION_HISTORY_FILE_BYTES,
   MAX_CLI_SESSION_HISTORY_MESSAGES,
@@ -216,5 +217,30 @@ describe("loadCliSessionHistoryMessages", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
       fs.rmSync(customStoreDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("buildCliSessionHistoryPrompt", () => {
+  it("renders OpenClaw transcript history around the next user message", () => {
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [
+        { role: "user", content: "old ask" },
+        { role: "assistant", content: [{ type: "text", text: "old answer" }] },
+      ],
+      prompt: "new ask",
+    });
+
+    expect(prompt).toContain("User: old ask");
+    expect(prompt).toContain("Assistant: old answer");
+    expect(prompt).toContain("<next_user_message>\nnew ask\n</next_user_message>");
+  });
+
+  it("skips reseed text when the transcript has no renderable conversation", () => {
+    expect(
+      buildCliSessionHistoryPrompt({
+        messages: [{ role: "tool", content: "ignored" }],
+        prompt: "new ask",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCliSessionHistoryPrompt,
   loadCliSessionHistoryMessages,
+  loadCliSessionReseedMessages,
   MAX_CLI_SESSION_HISTORY_FILE_BYTES,
   MAX_CLI_SESSION_HISTORY_MESSAGES,
 } from "./session-history.js";
@@ -216,6 +217,91 @@ describe("loadCliSessionHistoryMessages", () => {
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
       fs.rmSync(customStoreDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadCliSessionReseedMessages", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not reseed fresh CLI sessions from raw transcript history before compaction", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-no-compaction",
+      messages: ["raw secret", "large context"],
+    });
+
+    try {
+      expect(
+        loadCliSessionReseedMessages({
+          sessionId: "session-no-compaction",
+          sessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+        }),
+      ).toEqual([]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reseeds fresh CLI sessions from the latest compaction summary and post-compaction tail", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-compacted",
+      messages: ["pre-compaction raw history"],
+    });
+    fs.appendFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "msg-0",
+        timestamp: new Date(2).toISOString(),
+        summary: "safe compacted summary",
+        firstKeptEntryId: "msg-0",
+        tokensBefore: 10_000,
+      })}\n`,
+      "utf-8",
+    );
+    fs.appendFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "msg-1",
+        parentId: "compaction-1",
+        timestamp: new Date(3).toISOString(),
+        message: {
+          role: "user",
+          content: "post-compaction ask",
+          timestamp: 3,
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    try {
+      const reseed = loadCliSessionReseedMessages({
+        sessionId: "session-compacted",
+        sessionFile,
+        sessionKey: "agent:main:main",
+        agentId: "main",
+      });
+      expect(reseed).toMatchObject([
+        { role: "compactionSummary", summary: "safe compacted summary" },
+        { role: "user", content: "post-compaction ask" },
+      ]);
+      expect(buildCliSessionHistoryPrompt({ messages: reseed, prompt: "next" })).toContain(
+        "Compaction summary: safe compacted summary",
+      );
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -329,4 +329,16 @@ describe("buildCliSessionHistoryPrompt", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("caps rendered reseed history before adding the next user message", () => {
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [{ role: "compactionSummary", summary: "x".repeat(100) }],
+      prompt: "current ask must survive",
+      maxHistoryChars: 20,
+    });
+
+    expect(prompt).toContain("[OpenClaw reseed history truncated]");
+    expect(prompt).toContain("<next_user_message>\ncurrent ask must survive\n</next_user_message>");
+    expect(prompt).not.toContain("x".repeat(80));
+  });
 });

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -18,6 +18,12 @@ export const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
 type HistoryMessage = {
   role?: unknown;
   content?: unknown;
+  summary?: unknown;
+};
+type HistoryEntry = {
+  type?: unknown;
+  message?: unknown;
+  summary?: unknown;
 };
 
 function coerceHistoryText(content: unknown): string {
@@ -50,11 +56,20 @@ export function buildCliSessionHistoryPrompt(params: {
       }
       const entry = message as HistoryMessage;
       const role =
-        entry.role === "assistant" ? "Assistant" : entry.role === "user" ? "User" : undefined;
+        entry.role === "assistant"
+          ? "Assistant"
+          : entry.role === "user"
+            ? "User"
+            : entry.role === "compactionSummary"
+              ? "Compaction summary"
+              : undefined;
       if (!role) {
         return [];
       }
-      const text = coerceHistoryText(entry.content);
+      const text =
+        entry.role === "compactionSummary" && typeof entry.summary === "string"
+          ? entry.summary.trim()
+          : coerceHistoryText(entry.content);
       return text ? [`${role}: ${text}`] : [];
     })
     .join("\n\n")
@@ -118,7 +133,7 @@ function resolveSafeCliSessionFile(params: {
   };
 }
 
-export function loadCliSessionHistoryMessages(params: {
+function loadCliSessionEntries(params: {
   sessionId: string;
   sessionFile: string;
   sessionKey?: string;
@@ -140,12 +155,57 @@ export function loadCliSessionHistoryMessages(params: {
     if (!stat.isFile() || stat.size > MAX_CLI_SESSION_HISTORY_FILE_BYTES) {
       return [];
     }
-    const entries = SessionManager.open(realSessionFile).getEntries();
-    const history = entries.flatMap((entry) =>
-      entry?.type === "message" ? [entry.message as unknown] : [],
-    );
-    return limitAgentHookHistoryMessages(history, MAX_CLI_SESSION_HISTORY_MESSAGES);
+    return SessionManager.open(realSessionFile).getEntries();
   } catch {
     return [];
   }
+}
+
+export function loadCliSessionHistoryMessages(params: {
+  sessionId: string;
+  sessionFile: string;
+  sessionKey?: string;
+  agentId?: string;
+  config?: OpenClawConfig;
+}): unknown[] {
+  const history = loadCliSessionEntries(params).flatMap((entry) => {
+    const candidate = entry as HistoryEntry;
+    return candidate.type === "message" ? [candidate.message] : [];
+  });
+  return limitAgentHookHistoryMessages(history, MAX_CLI_SESSION_HISTORY_MESSAGES);
+}
+
+export function loadCliSessionReseedMessages(params: {
+  sessionId: string;
+  sessionFile: string;
+  sessionKey?: string;
+  agentId?: string;
+  config?: OpenClawConfig;
+}): unknown[] {
+  const entries = loadCliSessionEntries(params);
+  const latestCompactionIndex = entries.findLastIndex((entry) => {
+    const candidate = entry as HistoryEntry;
+    return candidate.type === "compaction" && typeof candidate.summary === "string";
+  });
+  if (latestCompactionIndex < 0) {
+    return [];
+  }
+
+  const compaction = entries[latestCompactionIndex] as HistoryEntry;
+  const summary = typeof compaction.summary === "string" ? compaction.summary.trim() : "";
+  if (!summary) {
+    return [];
+  }
+
+  const tailMessages = entries.slice(latestCompactionIndex + 1).flatMap((entry) => {
+    const candidate = entry as HistoryEntry;
+    return candidate.type === "message" ? [candidate.message] : [];
+  });
+  return [
+    {
+      role: "compactionSummary",
+      summary,
+    },
+    ...limitAgentHookHistoryMessages(tailMessages, MAX_CLI_SESSION_HISTORY_MESSAGES - 1),
+  ];
 }

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -14,6 +14,7 @@ import {
 
 export const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
 export const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
+export const MAX_CLI_SESSION_RESEED_HISTORY_CHARS = 12 * 1024;
 
 type HistoryMessage = {
   role?: unknown;
@@ -48,8 +49,10 @@ function coerceHistoryText(content: unknown): string {
 export function buildCliSessionHistoryPrompt(params: {
   messages: unknown[];
   prompt: string;
+  maxHistoryChars?: number;
 }): string | undefined {
-  const renderedHistory = params.messages
+  const maxHistoryChars = params.maxHistoryChars ?? MAX_CLI_SESSION_RESEED_HISTORY_CHARS;
+  const renderedHistoryRaw = params.messages
     .flatMap((message) => {
       if (!message || typeof message !== "object") {
         return [];
@@ -74,6 +77,10 @@ export function buildCliSessionHistoryPrompt(params: {
     })
     .join("\n\n")
     .trim();
+  const renderedHistory =
+    renderedHistoryRaw.length > maxHistoryChars
+      ? `${renderedHistoryRaw.slice(0, maxHistoryChars).trimEnd()}\n[OpenClaw reseed history truncated]`
+      : renderedHistoryRaw;
 
   if (!renderedHistory) {
     return undefined;

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -15,6 +15,69 @@ import {
 export const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
 export const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
 
+type HistoryMessage = {
+  role?: unknown;
+  content?: unknown;
+};
+
+function coerceHistoryText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((block) => {
+      if (!block || typeof block !== "object") {
+        return [];
+      }
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" && text.trim().length > 0 ? [text.trim()] : [];
+    })
+    .join("\n")
+    .trim();
+}
+
+export function buildCliSessionHistoryPrompt(params: {
+  messages: unknown[];
+  prompt: string;
+}): string | undefined {
+  const renderedHistory = params.messages
+    .flatMap((message) => {
+      if (!message || typeof message !== "object") {
+        return [];
+      }
+      const entry = message as HistoryMessage;
+      const role =
+        entry.role === "assistant" ? "Assistant" : entry.role === "user" ? "User" : undefined;
+      if (!role) {
+        return [];
+      }
+      const text = coerceHistoryText(entry.content);
+      return text ? [`${role}: ${text}`] : [];
+    })
+    .join("\n\n")
+    .trim();
+
+  if (!renderedHistory) {
+    return undefined;
+  }
+
+  return [
+    "Continue this conversation using the OpenClaw transcript below as prior session history.",
+    "Treat it as authoritative context for this fresh CLI session.",
+    "",
+    "<conversation_history>",
+    renderedHistory,
+    "</conversation_history>",
+    "",
+    "<next_user_message>",
+    params.prompt,
+    "</next_user_message>",
+  ].join("\n");
+}
+
 function safeRealpathSync(filePath: string): string | undefined {
   try {
     return fs.realpathSync(filePath);

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -79,6 +79,7 @@ export type PreparedCliRunContext = {
   systemPrompt: string;
   systemPromptReport: SessionSystemPromptReport;
   bootstrapPromptWarningLines: string[];
+  openClawHistoryPrompt?: string;
   heartbeatPrompt?: string;
   authEpoch?: string;
   authEpochVersion: number;

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1,0 +1,170 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ContextEngine } from "../../context-engine/types.js";
+import {
+  resetCliCompactionTestDeps,
+  runCliTurnCompactionLifecycle,
+  setCliCompactionTestDeps,
+} from "./cli-compaction.js";
+
+function buildContextEngine(params: {
+  compactCalls: Array<Parameters<ContextEngine["compact"]>[0]>;
+}): ContextEngine {
+  return {
+    info: {
+      id: "legacy",
+      name: "Legacy Context Engine",
+    },
+    async ingest() {
+      return { ingested: false };
+    },
+    async assemble(assembleParams) {
+      return { messages: assembleParams.messages, estimatedTokens: 0 };
+    },
+    async compact(compactParams) {
+      params.compactCalls.push(compactParams);
+      return {
+        ok: true,
+        compacted: true,
+        result: {
+          summary: "compacted",
+          tokensBefore: compactParams.currentTokenCount ?? 0,
+          tokensAfter: 100,
+        },
+      };
+    },
+  };
+}
+
+async function writeSessionFile(params: { sessionFile: string; sessionId: string }) {
+  await fs.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  await fs.writeFile(
+    params.sessionFile,
+    [
+      JSON.stringify({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: params.sessionId,
+        timestamp: new Date(0).toISOString(),
+        cwd: path.dirname(params.sessionFile),
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "old ask", timestamp: 1 },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "old answer" }],
+          timestamp: 2,
+        },
+      }),
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("runCliTurnCompactionLifecycle", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-compaction-"));
+  });
+
+  afterEach(async () => {
+    resetCliCompactionTestDeps();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("compacts over-budget CLI transcripts and clears external CLI resume state", async () => {
+    const sessionKey = "agent:main:cli";
+    const sessionId = "session-cli";
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const storePath = path.join(tmpDir, "sessions.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "claude-session",
+      },
+      claudeCliSessionId: "claude-session",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0]).toMatchObject({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget: 1_000,
+      currentTokenCount: 950,
+      force: true,
+      compactionTarget: "budget",
+    });
+    expect(maintenance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "compaction",
+        sessionId,
+        sessionKey,
+        sessionFile,
+      }),
+    );
+    expect(updatedEntry?.compactionCount).toBe(1);
+    expect(updatedEntry?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(updatedEntry?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(updatedEntry?.claudeCliSessionId).toBeUndefined();
+  });
+});

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -1,0 +1,267 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveContextEngine as resolveContextEngineImpl } from "../../context-engine/registry.js";
+import type { ContextEngine } from "../../context-engine/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { buildEmbeddedCompactionRuntimeContext } from "../pi-embedded-runner/compaction-runtime-context.js";
+import { runContextEngineMaintenance as runContextEngineMaintenanceImpl } from "../pi-embedded-runner/context-engine-maintenance.js";
+import { shouldPreemptivelyCompactBeforePrompt as shouldPreemptivelyCompactBeforePromptImpl } from "../pi-embedded-runner/run/preemptive-compaction.js";
+import { resolveLiveToolResultMaxChars as resolveLiveToolResultMaxCharsImpl } from "../pi-embedded-runner/tool-result-truncation.js";
+import { createPreparedEmbeddedPiSettingsManager as createPreparedEmbeddedPiSettingsManagerImpl } from "../pi-project-settings.js";
+import { applyPiAutoCompactionGuard as applyPiAutoCompactionGuardImpl } from "../pi-settings.js";
+import type { SkillSnapshot } from "../skills.js";
+import { recordCliCompactionInStore as recordCliCompactionInStoreImpl } from "./session-store.js";
+
+type SessionManagerLike = ReturnType<typeof SessionManager.open>;
+type SettingsManagerLike = {
+  getCompactionReserveTokens: () => number;
+  getCompactionKeepRecentTokens: () => number;
+  applyOverrides: (overrides: {
+    compaction: {
+      reserveTokens?: number;
+      keepRecentTokens?: number;
+    };
+  }) => void;
+  setCompactionEnabled?: (enabled: boolean) => void;
+};
+type CliCompactionDeps = {
+  openSessionManager: (sessionFile: string) => SessionManagerLike;
+  resolveContextEngine: (cfg: OpenClawConfig) => Promise<ContextEngine>;
+  createPreparedEmbeddedPiSettingsManager: (params: {
+    cwd: string;
+    agentDir: string;
+    cfg?: OpenClawConfig;
+    contextTokenBudget?: number;
+  }) => SettingsManagerLike | Promise<SettingsManagerLike>;
+  applyPiAutoCompactionGuard: (params: {
+    settingsManager: SettingsManagerLike;
+    contextEngineInfo?: ContextEngine["info"];
+  }) => unknown;
+  shouldPreemptivelyCompactBeforePrompt: typeof shouldPreemptivelyCompactBeforePromptImpl;
+  resolveLiveToolResultMaxChars: typeof resolveLiveToolResultMaxCharsImpl;
+  runContextEngineMaintenance: typeof runContextEngineMaintenanceImpl;
+  recordCliCompactionInStore: typeof recordCliCompactionInStoreImpl;
+};
+
+const log = createSubsystemLogger("agents/cli-compaction");
+
+const cliCompactionDeps: CliCompactionDeps = {
+  openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+  resolveContextEngine: resolveContextEngineImpl,
+  createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
+  applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
+  shouldPreemptivelyCompactBeforePrompt: shouldPreemptivelyCompactBeforePromptImpl,
+  resolveLiveToolResultMaxChars: resolveLiveToolResultMaxCharsImpl,
+  runContextEngineMaintenance: runContextEngineMaintenanceImpl,
+  recordCliCompactionInStore: recordCliCompactionInStoreImpl,
+};
+
+export function setCliCompactionTestDeps(overrides: Partial<typeof cliCompactionDeps>): void {
+  Object.assign(cliCompactionDeps, overrides);
+}
+
+export function resetCliCompactionTestDeps(): void {
+  Object.assign(cliCompactionDeps, {
+    openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+    resolveContextEngine: resolveContextEngineImpl,
+    createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
+    applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
+    shouldPreemptivelyCompactBeforePrompt: shouldPreemptivelyCompactBeforePromptImpl,
+    resolveLiveToolResultMaxChars: resolveLiveToolResultMaxCharsImpl,
+    runContextEngineMaintenance: runContextEngineMaintenanceImpl,
+    recordCliCompactionInStore: recordCliCompactionInStoreImpl,
+  });
+}
+
+function resolvePositiveInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function getSessionBranchMessages(sessionManager: SessionManagerLike): AgentMessage[] {
+  return sessionManager
+    .getBranch()
+    .flatMap((entry) =>
+      entry.type === "message" && typeof entry.message === "object" && entry.message !== null
+        ? [entry.message]
+        : [],
+    );
+}
+
+function resolveSessionTokenSnapshot(sessionEntry: SessionEntry | undefined): number | undefined {
+  return resolvePositiveInteger(
+    sessionEntry?.totalTokensFresh === false ? undefined : sessionEntry?.totalTokens,
+  );
+}
+
+async function compactCliTranscript(params: {
+  contextEngine: ContextEngine;
+  sessionId: string;
+  sessionKey: string;
+  sessionFile: string;
+  sessionManager: SessionManagerLike;
+  cfg: OpenClawConfig;
+  workspaceDir: string;
+  agentDir: string;
+  provider: string;
+  model: string;
+  contextTokenBudget: number;
+  currentTokenCount: number;
+  skillsSnapshot?: SkillSnapshot;
+  messageChannel?: string;
+  agentAccountId?: string;
+  senderIsOwner?: boolean;
+  thinkLevel?: Parameters<typeof buildEmbeddedCompactionRuntimeContext>[0]["thinkLevel"];
+  extraSystemPrompt?: string;
+}) {
+  const runtimeContext = {
+    ...buildEmbeddedCompactionRuntimeContext({
+      sessionKey: params.sessionKey,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageChannel,
+      agentAccountId: params.agentAccountId,
+      authProfileId: undefined,
+      workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
+      config: params.cfg,
+      skillsSnapshot: params.skillsSnapshot,
+      senderIsOwner: params.senderIsOwner,
+      provider: params.provider,
+      modelId: params.model,
+      thinkLevel: params.thinkLevel,
+      extraSystemPrompt: params.extraSystemPrompt,
+    }),
+    currentTokenCount: params.currentTokenCount,
+    tokenBudget: params.contextTokenBudget,
+    trigger: "cli_budget",
+  };
+
+  const compactResult = await params.contextEngine.compact({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionFile: params.sessionFile,
+    tokenBudget: params.contextTokenBudget,
+    currentTokenCount: params.currentTokenCount,
+    force: true,
+    compactionTarget: "budget",
+    runtimeContext,
+  });
+
+  if (!compactResult.compacted) {
+    log.warn(
+      `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${compactResult.reason ?? "nothing to compact"}`,
+    );
+    return false;
+  }
+
+  await cliCompactionDeps.runContextEngineMaintenance({
+    contextEngine: params.contextEngine,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionFile: params.sessionFile,
+    reason: "compaction",
+    sessionManager: params.sessionManager,
+    runtimeContext,
+  });
+  return true;
+}
+
+export async function runCliTurnCompactionLifecycle(params: {
+  cfg: OpenClawConfig;
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  workspaceDir: string;
+  agentDir: string;
+  provider: string;
+  model: string;
+  skillsSnapshot?: SkillSnapshot;
+  messageChannel?: string;
+  agentAccountId?: string;
+  senderIsOwner?: boolean;
+  thinkLevel?: Parameters<typeof buildEmbeddedCompactionRuntimeContext>[0]["thinkLevel"];
+  extraSystemPrompt?: string;
+}): Promise<SessionEntry | undefined> {
+  const sessionFile = params.sessionEntry?.sessionFile;
+  const contextTokenBudget = resolvePositiveInteger(params.sessionEntry?.contextTokens);
+  if (!sessionFile || !contextTokenBudget) {
+    return params.sessionEntry;
+  }
+
+  const contextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
+  const sessionManager = cliCompactionDeps.openSessionManager(sessionFile);
+  const settingsManager = await cliCompactionDeps.createPreparedEmbeddedPiSettingsManager({
+    cwd: params.workspaceDir,
+    agentDir: params.agentDir,
+    cfg: params.cfg,
+    contextTokenBudget,
+  });
+  await cliCompactionDeps.applyPiAutoCompactionGuard({
+    settingsManager,
+    contextEngineInfo: contextEngine.info,
+  });
+
+  const preemptiveCompaction = cliCompactionDeps.shouldPreemptivelyCompactBeforePrompt({
+    messages: getSessionBranchMessages(sessionManager),
+    prompt: "",
+    contextTokenBudget,
+    reserveTokens: settingsManager.getCompactionReserveTokens(),
+    toolResultMaxChars: cliCompactionDeps.resolveLiveToolResultMaxChars({
+      contextWindowTokens: contextTokenBudget,
+      cfg: params.cfg,
+      agentId: params.sessionAgentId,
+    }),
+  });
+  const tokenSnapshot = resolveSessionTokenSnapshot(params.sessionEntry);
+  const currentTokenCount = Math.max(
+    preemptiveCompaction.estimatedPromptTokens,
+    tokenSnapshot ?? 0,
+  );
+  if (
+    !preemptiveCompaction.shouldCompact &&
+    currentTokenCount <= preemptiveCompaction.promptBudgetBeforeReserve
+  ) {
+    return params.sessionEntry;
+  }
+
+  const compacted = await compactCliTranscript({
+    contextEngine,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionFile,
+    sessionManager,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    agentDir: params.agentDir,
+    provider: params.provider,
+    model: params.model,
+    contextTokenBudget,
+    currentTokenCount,
+    skillsSnapshot: params.skillsSnapshot,
+    messageChannel: params.messageChannel,
+    agentAccountId: params.agentAccountId,
+    senderIsOwner: params.senderIsOwner,
+    thinkLevel: params.thinkLevel,
+    extraSystemPrompt: params.extraSystemPrompt,
+  });
+
+  if (!compacted || !params.sessionStore || !params.storePath) {
+    return params.sessionEntry;
+  }
+
+  return (
+    (await cliCompactionDeps.recordCliCompactionInStore({
+      provider: params.provider,
+      sessionKey: params.sessionKey,
+      sessionStore: params.sessionStore,
+      storePath: params.storePath,
+    })) ?? params.sessionEntry
+  );
+}

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -202,3 +202,29 @@ export async function clearCliSessionInStore(params: {
   sessionStore[sessionKey] = persisted;
   return persisted;
 }
+
+export async function recordCliCompactionInStore(params: {
+  provider: string;
+  sessionKey: string;
+  sessionStore: Record<string, SessionEntry>;
+  storePath: string;
+}): Promise<SessionEntry | undefined> {
+  const { provider, sessionKey, sessionStore, storePath } = params;
+  const entry = sessionStore[sessionKey];
+  if (!entry) {
+    return undefined;
+  }
+
+  const next = { ...entry };
+  clearCliSession(next, provider);
+  next.compactionCount = (entry.compactionCount ?? 0) + 1;
+  next.updatedAt = Date.now();
+
+  const persisted = await updateSessionStore(storePath, (store) => {
+    const merged = mergeSessionEntry(store[sessionKey], next);
+    store[sessionKey] = merged;
+    return merged;
+  });
+  sessionStore[sessionKey] = persisted;
+  return persisted;
+}


### PR DESCRIPTION
Fixes #68329.
Supersedes #68388.

Summary:
- compact persisted OpenClaw CLI transcripts when a CLI turn pushes the session over budget
- clear external CLI resume state after compaction so the next turn cannot reload stale provider history
- reseed fresh CLI sessions from the compacted OpenClaw transcript instead of writing provider-private history files

Tests:
- OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD=1 pnpm test src/agents/command/cli-compaction.test.ts src/agents/cli-runner/session-history.test.ts src/agents/cli-runner.reliability.test.ts
- CI=true OPENCLAW_LOCAL_CHECK=0 pnpm check:changed
