### PR TITLE
fix(plugins): fallback npm_config_cache to os.tmpdir()

### DIFF
--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -779,9 +779,11 @@ export function createBundledRuntimeDepsInstallEnv(
   env: NodeJS.ProcessEnv,
   options: { cacheDir?: string } = {},
 ): NodeJS.ProcessEnv {
+  const cacheDir = options.cacheDir ?? os.tmpdir();
   return {
     ...createNpmProjectInstallEnv(env, options),
     npm_config_legacy_peer_deps: "true",
+    npm_config_cache: cacheDir,
   };
 }
 


### PR DESCRIPTION
Continuation of #71614 (closed without merge).

The channel-disable fix was already landed on `origin/main`. This PR carries the remaining fix: using `os.tmpdir()` as fallback for `npm_config_cache` in `createBundledRuntimeDepsInstallEnv` to prevent npm from writing under $HOME/node_modules during bundled runtime dependency installs.

Fixes #71070