### PR TITLE
fix(plugins): fallback npm_config_cache to os.tmpdir()

### DIFF
--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -792,9 +792,11 @@ export function createBundledRuntimeDepsInstallEnv(
   env: NodeJS.ProcessEnv,
   options: { cacheDir?: string } = {},
 ): NodeJS.ProcessEnv {
+  const cacheDir = options.cacheDir ?? os.tmpdir();
   return {
     ...createNpmProjectInstallEnv(env, options),
     npm_config_legacy_peer_deps: "true",
+    npm_config_cache: cacheDir,
   };
 }
 


### PR DESCRIPTION
Continuation of #71614 and #71926 (both closed without merge).

Use `os.tmpdir()` as safe fallback when `npm_config_cache` is unset, preventing npm from writing under $HOME/node_modules during bundled runtime dependency installs.

This is the only remaining fix from the original #71614 that hasn't been absorbed by main (the channel-disable fix is already in main).