### PR TITLE
fix(macos): add system.run.prepare command support

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
+++ b/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
@@ -117,14 +117,16 @@ struct ExecCommandResolution {
         let resolvedPath: String? = {
             if hasPathSeparator {
                 if expanded.hasPrefix("/") {
-                    return expanded
+                    return self.canonicalizePath(expanded)
                 }
                 let base = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let root = (base?.isEmpty == false) ? base! : FileManager().currentDirectoryPath
-                return URL(fileURLWithPath: root).appendingPathComponent(expanded).path
+                return self.canonicalizePath(URL(fileURLWithPath: root).appendingPathComponent(expanded).path)
             }
             let searchPaths = self.searchPaths(from: env)
-            return CommandResolver.findExecutable(named: expanded, searchPaths: searchPaths)
+            return CommandResolver.findExecutable(named: expanded, searchPaths: searchPaths).flatMap {
+                self.canonicalizePath($0)
+            }
         }()
         let name = resolvedPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? expanded
         return ExecCommandResolution(
@@ -132,6 +134,11 @@ struct ExecCommandResolution {
             resolvedPath: resolvedPath,
             executableName: name,
             cwd: cwd)
+    }
+
+    private static func canonicalizePath(_ path: String) -> String {
+        let url = URL(fileURLWithPath: path)
+        return url.resolvingSymlinksInPath().path
     }
 
     private static func resolveShellSegmentExecutable(

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -148,6 +148,7 @@ final class MacNodeModeCoordinator {
             OpenClawCanvasA2UICommand.reset.rawValue,
             MacNodeScreenCommand.snapshot.rawValue,
             MacNodeScreenCommand.record.rawValue,
+            OpenClawSystemCommand.prepare.rawValue,
             OpenClawSystemCommand.notify.rawValue,
             OpenClawSystemCommand.which.rawValue,
             OpenClawSystemCommand.run.rawValue,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -67,6 +67,8 @@ actor MacNodeRuntime {
                 return try await self.handleScreenSnapshotInvoke(req)
             case MacNodeScreenCommand.record.rawValue:
                 return try await self.handleScreenRecordInvoke(req)
+            case OpenClawSystemCommand.prepare.rawValue:
+                return try await self.handleSystemRunPrepare(req)
             case OpenClawSystemCommand.run.rawValue:
                 return try await self.handleSystemRun(req)
             case OpenClawSystemCommand.which.rawValue:
@@ -351,6 +353,72 @@ actor MacNodeRuntime {
             fps: params.fps,
             screenIndex: params.screenIndex,
             hasAudio: res.hasAudio))
+        return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
+    }
+
+    private func handleSystemRunPrepare(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
+        let params = try Self.decodeParams(OpenClawSystemRunPrepareParams.self, from: req.paramsJSON)
+
+        let command: [String]
+        if let cmd = params.command, !cmd.isEmpty {
+            command = cmd
+        } else if let raw = params.rawCommand, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            command = ["/bin/sh", "-c", raw]
+        } else {
+            return Self.errorResponse(req, code: .invalidRequest, message: "INVALID_REQUEST: command required")
+        }
+
+        let cwd = params.cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedCwd = (cwd?.isEmpty == false) ? cwd : nil
+
+        let agentId = params.agentId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedAgentId = (agentId?.isEmpty == false) ? agentId : nil
+        let sessionKey = params.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedSessionKey = (sessionKey?.isEmpty == false) ? sessionKey : nil
+
+        let resolution = ExecCommandResolution.resolveForAllowlist(
+            command: command,
+            rawCommand: params.rawCommand,
+            cwd: resolvedCwd,
+            env: [:]).first
+
+        let argv: [String]
+        let argvChanged: Bool
+        if let resolvedPath = resolution?.resolvedPath,
+           let firstResolved = ExecCommandResolution.resolve(
+               command: [command.first!],
+               cwd: resolvedCwd,
+               env: [:])?.resolvedPath,
+           resolvedPath == firstResolved
+        {
+            argv = [resolvedPath] + command.dropFirst()
+            argvChanged = true
+        } else {
+            argv = command
+            argvChanged = false
+        }
+
+        let rawCommandString: String
+        if argvChanged {
+            rawCommandString = ExecCommandFormatter.displayString(for: argv)
+        } else {
+            rawCommandString = ExecCommandFormatter.displayString(for: argv, rawCommand: params.rawCommand)
+        }
+
+        let plan = OpenClawSystemRunApprovalPlan(
+            argv: argv,
+            cwd: resolvedCwd,
+            rawCommand: rawCommandString,
+            agentId: resolvedAgentId,
+            sessionKey: resolvedSessionKey)
+
+        struct PreparePayload: Encodable {
+            var cmdText: String
+            var plan: OpenClawSystemRunApprovalPlan
+        }
+
+        let cmdText = ExecCommandFormatter.displayString(for: command)
+        let payload = try Self.encodePayload(PreparePayload(cmdText: cmdText, plan: plan))
         return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
@@ -1,11 +1,56 @@
 import Foundation
 
 public enum OpenClawSystemCommand: String, Codable, Sendable {
+    case prepare = "system.run.prepare"
     case run = "system.run"
     case which = "system.which"
     case notify = "system.notify"
     case execApprovalsGet = "system.execApprovals.get"
     case execApprovalsSet = "system.execApprovals.set"
+}
+
+public struct OpenClawSystemRunPrepareParams: Codable, Sendable, Equatable {
+    public var command: [String]?
+    public var rawCommand: String?
+    public var cwd: String?
+    public var agentId: String?
+    public var sessionKey: String?
+
+    public init(
+        command: [String]? = nil,
+        rawCommand: String? = nil,
+        cwd: String? = nil,
+        agentId: String? = nil,
+        sessionKey: String? = nil)
+    {
+        self.command = command
+        self.rawCommand = rawCommand
+        self.cwd = cwd
+        self.agentId = agentId
+        self.sessionKey = sessionKey
+    }
+}
+
+public struct OpenClawSystemRunApprovalPlan: Codable, Sendable, Equatable {
+    public var argv: [String]
+    public var cwd: String?
+    public var rawCommand: String?
+    public var agentId: String?
+    public var sessionKey: String?
+
+    public init(
+        argv: [String],
+        cwd: String? = nil,
+        rawCommand: String? = nil,
+        agentId: String? = nil,
+        sessionKey: String? = nil)
+    {
+        self.argv = argv
+        self.cwd = cwd
+        self.rawCommand = rawCommand
+        self.agentId = agentId
+        self.sessionKey = sessionKey
+    }
 }
 
 public enum OpenClawNotificationPriority: String, Codable, Sendable {


### PR DESCRIPTION
## Summary

- **Problem:** macOS Node running in remote mode can't invoke any `system.run` command because `system.run.prepare` is not declared in the node commands
- **Why it matters:** macOS Node will be useless if system.run is disabled
- **What changed:** Added `system.run.prepare` to node declaration + implemented handler
- **Scope:** macOS node only

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## Linked Issue
- Closes #31959

## Files Changed
- `apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift` - Added `prepare` enum case + `OpenClawSystemRunPrepareParams` + `OpenClawSystemRunApprovalPlan`
- `apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift` - Registered `system.run.prepare` command
- `apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift` - Added handler + `handleSystemRunPrepare` method
- `apps/macos/Sources/OpenClaw/ExecCommandResolution.swift` - Added `canonicalizePath` for symlink resolution

## Verification
- Verified on local macOS build
- Based on upstream main commit `862b39976`
- 4 files changed, +124/-3 lines

## Compatibility
- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

---
*Rebased version of #38781 to resolve merge conflicts with current main.*