### PR TITLE
fix(control-ui): allow blob: avatar URLs through CSP and UI regex

### DIFF
--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -44,7 +44,7 @@ export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }
     "frame-ancestors 'none'",
     scriptSrc,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' data:",
+    "img-src 'self' data: blob:",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -198,7 +198,7 @@ export function normalizeAgentLabel(agent: {
   );
 }
 
-const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/(?!\/))/i;
+const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/(?!\/)|blob:)/i;
 
 export function isRenderableControlUiAvatarUrl(value: string): boolean {
   return CONTROL_UI_AVATAR_URL_RE.test(value);


### PR DESCRIPTION
Fixes the agent avatar flash-then-revert / broken-image bug in Control UI chat.

**Root cause:** 
-  creates a  URL for local auth-protected avatars
- The UI regex rejected  URLs, falling back to the logo
- Even after the regex fix, the gateway CSP  directive did not include , causing the browser to block the image

**Changes:**
- : add  to 
- : add  to  CSP directive

**Testing:**
Verified locally that the custom avatar now renders correctly and persists across refreshes.