### PR TITLE
fix(plugins): fallback npm_config_cache to os.tmpdir() (v3)

### DIFF
--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -792,9 +792,11 @@ export function createBundledRuntimeDepsInstallEnv(
   env: NodeJS.ProcessEnv,
   options: { cacheDir?: string } = {},
 ): NodeJS.ProcessEnv {
+  const cacheDir = options.cacheDir ?? os.tmpdir();
   return {
     ...createNpmProjectInstallEnv(env, options),
     npm_config_legacy_peer_deps: "true",
+    npm_config_cache: cacheDir,
   };
 }
 


### PR DESCRIPTION
v3 of fix from #71614 and #71926 and #71935 (auto-closed by stale-PR cleanup).

Use `os.tmpdir()` as safe fallback when `npm_config_cache` is unset, preventing npm from writing under $HOME/node_modules during bundled runtime dependency installs.

Fix: `src/plugins/bundled-runtime-deps.ts` → `createBundledRuntimeDepsInstallEnv`