### PR TITLE
docs: add agchk community audit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ by Peter Steinberger and the community.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.
 AI/vibe-coded PRs welcome! 🤖
 
+### Community ecosystem
+
+- [agchk](https://github.com/huangrichao2020/agchk) — optional community architecture audit tooling for AI agent systems. See [#71947](https://github.com/openclaw/openclaw/issues/71947) for an example OpenClaw scan result.
+
 Special thanks to [Mario Zechner](https://mariozechner.at/) for his support and for
 [pi-mono](https://github.com/badlogic/pi-mono).
 Special thanks to Adam Doppelt for the lobster.bot domain.


### PR DESCRIPTION
## Summary

- Problem: README has a Community section, but no small place to point users at external agent-architecture audit tooling.
- Why it matters: `agchk` now has a reproducible OpenClaw scan in #71947, so the README link is tied to concrete audit output instead of a generic external-resource listing.
- What changed: Added a tiny `Community ecosystem` subsection linking to `agchk` and the OpenClaw scan result.
- What did NOT change (scope boundary): No runtime code, docs site navigation, ClawHub behavior, security model, or official endorsement language changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #71947
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

README now mentions `agchk` as optional community architecture audit tooling and links to #71947 for an example OpenClaw scan.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Read the root README Community section.
2. Confirm the new `agchk` entry links to the reproducible audit issue.
3. Run docs-only changed checks.

### Expected

- README includes a concise community ecosystem link.
- The link points at `agchk` and #71947.
- Docs-only changed checks pass.

### Actual

- README includes the new community ecosystem link.
- #71947 contains an `agchk` scan using `huangrichao2020/agchk@8c3a97f` against `openclaw/openclaw@42f87c07`.
- #71947 now frames the score as an `agchk` maturity signal rather than a claim that the repo has no issues. It includes manually triaged leads around a tracked root-level repair script, browser evaluate trust boundaries, slash-command dispatch policy, and test-fixture secret false positives.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- [x] Docs check: `pnpm check:changed`

## Human Verification (required)

- Verified scenarios: `pnpm check:changed` passed and selected the docs-only lane.
- Edge cases checked: Confirmed this PR touches only `README.md`.
- What you did **not** verify: Full `pnpm check` / `pnpm test`, because this is a README-only docs change.

AI-assisted: yes. I understand this PR only adds a README community link and does not change OpenClaw behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Maintainers may prefer not to list external tooling in the root README.
  - Mitigation: The wording says optional community tooling and links to a concrete OpenClaw audit issue for context.

