### PR TITLE
fix(agents): strip leaked tool-call JSON from visible text

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -515,12 +515,27 @@ describe("stripDowngradedToolCallText", () => {
     expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
   });
 
-  it("strips incomplete bare tool_calls JSON fragments to the end of the chunk", () => {
-    expect(
-      stripDowngradedToolCallText(
-        'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}',
-      ),
-    ).toBe("Before");
+  it("preserves incomplete bare tool_calls JSON fragments", () => {
+    const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("preserves no-op bare JSON scans without trimming history whitespace", () => {
+    const input = '  {"type":"function","description":"example"}  ';
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+  });
+
+  it("requires strict OpenAI-style tool call entries before stripping", () => {
+    const input = [
+      "Before",
+      '{"tool_calls":[{"id":"123","function":{"name":"report","arguments":"{}"}}]}',
+      "After",
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
   });
 
   it("preserves bare tool_calls JSON inside fenced and inline code examples", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
+  stripDowngradedToolCallText,
 } from "./assistant-visible-text.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
 
@@ -501,6 +502,39 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+});
+
+describe("stripDowngradedToolCallText", () => {
+  it("strips bare OpenAI-style tool_calls JSON while preserving the visible lead-in", () => {
+    const input = [
+      "Aku submit issue-nya sekarang.",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}',
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
+  });
+
+  it("strips incomplete bare tool_calls JSON fragments to the end of the chunk", () => {
+    expect(
+      stripDowngradedToolCallText(
+        'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}',
+      ),
+    ).toBe("Before");
+  });
+
+  it("preserves bare tool_calls JSON inside fenced and inline code examples", () => {
+    const input = [
+      "Example:",
+      "",
+      "```json",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}',
+      "```",
+      "",
+      'Inline `{"tool_calls":[{"function":{"name":"process"}}]}` stays visible.',
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
   });
 });
 

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -427,29 +427,18 @@ export function stripDowngradedToolCallText(text: string): string {
       return false;
     }
     const functionValue = value.function;
-    if (
-      isRecord(functionValue) &&
-      (value.type === "function" || typeof value.id === "string") &&
-      (typeof functionValue.name === "string" ||
-        typeof functionValue.arguments === "string" ||
-        isRecord(functionValue.arguments))
-    ) {
-      return true;
-    }
     return (
-      value.type === "function_call" &&
-      typeof value.name === "string" &&
-      (typeof value.arguments === "string" || isRecord(value.arguments) || "call_id" in value)
+      value.type === "function" &&
+      isRecord(functionValue) &&
+      typeof functionValue.name === "string" &&
+      (typeof functionValue.arguments === "string" || isRecord(functionValue.arguments))
     );
   };
 
   const hasToolCallsArray = (value: unknown): boolean =>
-    Array.isArray(value) && value.some((item) => isToolCallObject(item));
+    Array.isArray(value) && value.length > 0 && value.every((item) => isToolCallObject(item));
 
   const isBareToolCallJsonPayload = (value: unknown): boolean => {
-    if (hasToolCallsArray(value) || isToolCallObject(value)) {
-      return true;
-    }
     if (!isRecord(value)) {
       return false;
     }
@@ -473,9 +462,6 @@ export function stripDowngradedToolCallText(text: string): string {
     return false;
   };
 
-  const looksLikeBareToolCallJsonFragment = (value: string): boolean =>
-    /^\s*\{[\s\S]*"tool_calls"\s*:\s*\[/i.test(value);
-
   const skipOneRedundantNewline = (input: string, start: number, result: string): number => {
     let index = start;
     while (index < input.length && (input[index] === " " || input[index] === "\t")) {
@@ -495,14 +481,27 @@ export function stripDowngradedToolCallText(text: string): string {
     return index;
   };
 
-  const stripBareToolCallJsonPayloads = (input: string): string => {
+  const findNextLineBreak = (input: string, start: number): number => {
+    const nextNewline = input.indexOf("\n", start);
+    const nextCarriage = input.indexOf("\r", start);
+    if (nextNewline === -1) {
+      return nextCarriage;
+    }
+    if (nextCarriage === -1) {
+      return nextNewline;
+    }
+    return Math.min(nextNewline, nextCarriage);
+  };
+
+  const stripBareToolCallJsonPayloads = (input: string): { text: string; changed: boolean } => {
     if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input)) {
-      return input;
+      return { text: input, changed: false };
     }
 
     const codeRegions = findCodeRegions(input);
     let result = "";
     let cursor = 0;
+    let changed = false;
     for (let index = 0; index < input.length; index += 1) {
       const ch = input[index];
       if ((ch !== "{" && ch !== "[") || index < cursor || isInsideCode(index, codeRegions)) {
@@ -511,7 +510,6 @@ export function stripDowngradedToolCallText(text: string): string {
 
       const end = consumeJsonish(input, index);
       let shouldStrip = false;
-      let stripEnd = end ?? input.length;
       if (end !== null) {
         const raw = input.slice(index, end);
         if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
@@ -528,7 +526,12 @@ export function stripDowngradedToolCallText(text: string): string {
           continue;
         }
       } else {
-        shouldStrip = looksLikeBareToolCallJsonFragment(input.slice(index));
+        const nextLineBreak = findNextLineBreak(input, index + 1);
+        if (nextLineBreak === -1) {
+          break;
+        }
+        index = nextLineBreak;
+        continue;
       }
 
       if (!shouldStrip) {
@@ -536,12 +539,16 @@ export function stripDowngradedToolCallText(text: string): string {
       }
 
       result += input.slice(cursor, index);
-      stripEnd = skipOneRedundantNewline(input, stripEnd, result);
+      const stripEnd = skipOneRedundantNewline(input, end, result);
       cursor = stripEnd;
+      changed = true;
       index = Math.max(index, cursor - 1);
     }
+    if (!changed) {
+      return { text: input, changed: false };
+    }
     result += input.slice(cursor);
-    return result;
+    return { text: result, changed: true };
   };
 
   const stripToolCalls = (input: string): string => {
@@ -599,7 +606,8 @@ export function stripDowngradedToolCallText(text: string): string {
     return result;
   };
 
-  let cleaned = stripBareToolCallJsonPayloads(text);
+  const bareToolCallJsonResult = stripBareToolCallJsonPayloads(text);
+  let cleaned = bareToolCallJsonResult.text;
 
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
   cleaned = stripToolCalls(cleaned);
@@ -610,7 +618,7 @@ export function stripDowngradedToolCallText(text: string): string {
   // Remove [Historical context: ...] markers (self-contained within brackets).
   cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
 
-  return cleaned.trim();
+  return cleaned === text && !bareToolCallJsonResult.changed ? text : cleaned.trim();
 }
 
 function stripRelevantMemoriesTags(text: string): string {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -29,6 +29,7 @@ const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
 const TOOL_CALL_XML_PAYLOAD_START_RE =
   /^\s*(?:\r?\n\s*)?<(?:function|invoke|parameters?|arguments?)\b/i;
+const BARE_TOOL_CALL_JSON_QUICK_RE = /"tool_calls"\s*:|"type"\s*:\s*"function(?:_call)?"/i;
 
 type ToolCallPayloadKind = "json" | "xml" | null;
 
@@ -329,7 +330,10 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+  const hasDowngradedMarkers =
+    /\[Tool (?:Call|Result)/i.test(text) || /\[Historical context/i.test(text);
+  const mayHaveBareToolCallJson = BARE_TOOL_CALL_JSON_QUICK_RE.test(text);
+  if (!hasDowngradedMarkers && !mayHaveBareToolCallJson) {
     return text;
   }
 
@@ -415,6 +419,131 @@ export function stripDowngradedToolCallText(text: string): string {
     return end;
   };
 
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+  const isToolCallObject = (value: unknown): boolean => {
+    if (!isRecord(value)) {
+      return false;
+    }
+    const functionValue = value.function;
+    if (
+      isRecord(functionValue) &&
+      (value.type === "function" || typeof value.id === "string") &&
+      (typeof functionValue.name === "string" ||
+        typeof functionValue.arguments === "string" ||
+        isRecord(functionValue.arguments))
+    ) {
+      return true;
+    }
+    return (
+      value.type === "function_call" &&
+      typeof value.name === "string" &&
+      (typeof value.arguments === "string" || isRecord(value.arguments) || "call_id" in value)
+    );
+  };
+
+  const hasToolCallsArray = (value: unknown): boolean =>
+    Array.isArray(value) && value.some((item) => isToolCallObject(item));
+
+  const isBareToolCallJsonPayload = (value: unknown): boolean => {
+    if (hasToolCallsArray(value) || isToolCallObject(value)) {
+      return true;
+    }
+    if (!isRecord(value)) {
+      return false;
+    }
+    if (hasToolCallsArray(value.tool_calls)) {
+      return true;
+    }
+    if (isRecord(value.message) && hasToolCallsArray(value.message.tool_calls)) {
+      return true;
+    }
+    if (Array.isArray(value.choices)) {
+      return value.choices.some((choice) => {
+        if (!isRecord(choice)) {
+          return false;
+        }
+        return (
+          (isRecord(choice.message) && hasToolCallsArray(choice.message.tool_calls)) ||
+          (isRecord(choice.delta) && hasToolCallsArray(choice.delta.tool_calls))
+        );
+      });
+    }
+    return false;
+  };
+
+  const looksLikeBareToolCallJsonFragment = (value: string): boolean =>
+    /^\s*\{[\s\S]*"tool_calls"\s*:\s*\[/i.test(value);
+
+  const skipOneRedundantNewline = (input: string, start: number, result: string): number => {
+    let index = start;
+    while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+      index += 1;
+    }
+    if (
+      (input[index] === "\n" || input[index] === "\r") &&
+      (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
+    ) {
+      if (input[index] === "\r") {
+        index += 1;
+      }
+      if (input[index] === "\n") {
+        index += 1;
+      }
+    }
+    return index;
+  };
+
+  const stripBareToolCallJsonPayloads = (input: string): string => {
+    if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input)) {
+      return input;
+    }
+
+    const codeRegions = findCodeRegions(input);
+    let result = "";
+    let cursor = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      const ch = input[index];
+      if ((ch !== "{" && ch !== "[") || index < cursor || isInsideCode(index, codeRegions)) {
+        continue;
+      }
+
+      const end = consumeJsonish(input, index);
+      let shouldStrip = false;
+      let stripEnd = end ?? input.length;
+      if (end !== null) {
+        const raw = input.slice(index, end);
+        if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
+          index = Math.max(index, end - 1);
+          continue;
+        }
+        try {
+          shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
+        } catch {
+          shouldStrip = false;
+        }
+        if (!shouldStrip) {
+          index = Math.max(index, end - 1);
+          continue;
+        }
+      } else {
+        shouldStrip = looksLikeBareToolCallJsonFragment(input.slice(index));
+      }
+
+      if (!shouldStrip) {
+        continue;
+      }
+
+      result += input.slice(cursor, index);
+      stripEnd = skipOneRedundantNewline(input, stripEnd, result);
+      cursor = stripEnd;
+      index = Math.max(index, cursor - 1);
+    }
+    result += input.slice(cursor);
+    return result;
+  };
+
   const stripToolCalls = (input: string): string => {
     const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
     let result = "";
@@ -470,8 +599,10 @@ export function stripDowngradedToolCallText(text: string): string {
     return result;
   };
 
+  let cleaned = stripBareToolCallJsonPayloads(text);
+
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
-  let cleaned = stripToolCalls(text);
+  cleaned = stripToolCalls(cleaned);
 
   // Remove [Tool Result for ID ...] blocks and their content.
   cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");


### PR DESCRIPTION
## Summary
- strip bare OpenAI-style `{"tool_calls":[...]}` JSON payloads from assistant-visible text
- preserve surrounding visible prose and code examples while removing complete or truncated leaked tool-call payloads
- add regressions for the #70797 leak shape, incomplete fragments, and fenced/inline code preservation

Fixes #70797.

## Tests
- `pnpm test src/shared/text/assistant-visible-text.test.ts`
- `pnpm test src/agents/pi-embedded-utils.test.ts -- -t stripDowngradedToolCallText`
- `pnpm check:changed`
