### PR TITLE
Show generated image links in ACP

### DIFF
--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -1189,4 +1189,56 @@ describe("acp final chat snapshots", () => {
     });
     sessionStore.clearAllSessionsForTest();
   });
+
+  it("resets emitted text offsets when gateway messageId changes", async () => {
+    const { agent, sessionUpdate, promptPromise, runId, sessionStore } =
+      await createSnapshotHarness();
+    const imageLink = "/api/chat/media/outgoing/session/att/full";
+
+    await agent.handleGatewayEvent({
+      event: "chat",
+      payload: {
+        sessionKey: "snapshot-session",
+        runId,
+        state: "delta",
+        message: {
+          id: "stable-container-id",
+          messageId: "assistant-text",
+          content: [{ type: "text", text: "NO_REPLY" }],
+        },
+      },
+    } as unknown as EventFrame);
+
+    await agent.handleGatewayEvent({
+      event: "chat",
+      payload: {
+        sessionKey: "snapshot-session",
+        runId,
+        state: "final",
+        stopReason: "end_turn",
+        message: {
+          id: "stable-container-id",
+          messageId: "assistant-media",
+          content: [{ type: "image", openUrl: imageLink }],
+        },
+      },
+    } as unknown as EventFrame);
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "snapshot-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "NO_REPLY" },
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "snapshot-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: `Generated image: ${imageLink}` },
+      },
+    });
+    sessionStore.clearAllSessionsForTest();
+  });
 });

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -291,7 +291,10 @@ describe("acp session UX bridge behavior", () => {
               ],
             },
             { role: "system", content: [{ type: "text", text: "ignore me" }] },
-            { role: "assistant", content: [{ type: "image", image: "skip" }] },
+            {
+              role: "assistant",
+              content: [{ type: "image", openUrl: "/api/chat/media/outgoing/session/att/full" }],
+            },
           ],
         };
       }
@@ -350,6 +353,16 @@ describe("acp session UX bridge behavior", () => {
       update: {
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: "Answer" },
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "agent:main:work",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Generated image: /api/chat/media/outgoing/session/att/full",
+        },
       },
     });
     expect(sessionUpdate).toHaveBeenCalledWith({

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -76,6 +76,7 @@ type PendingPrompt = {
   disconnectContext?: DisconnectContext;
   resolve: (response: PromptResponse) => void;
   reject: (err: Error) => void;
+  sentMessageId?: string;
   sentTextLength?: number;
   sentText?: string;
   sentThoughtLength?: number;
@@ -167,12 +168,17 @@ type GatewayChatContentBlock = {
   type?: string;
   text?: string;
   thinking?: string;
+  url?: unknown;
+  openUrl?: unknown;
+  uri?: unknown;
 };
 
 type ReplayChunk = {
   sessionUpdate: "user_message_chunk" | "agent_message_chunk" | "agent_thought_chunk";
   text: string;
 };
+
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f-\x9f]/g;
 
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
@@ -340,6 +346,15 @@ function extractReplayChunks(message: GatewayTranscriptMessage): ReplayChunk[] {
       });
       continue;
     }
+    const mediaLinkText =
+      role === "assistant" ? formatGeneratedMediaLinkText(typedBlock) : undefined;
+    if (mediaLinkText) {
+      replayChunks.push({
+        sessionUpdate: "agent_message_chunk",
+        text: mediaLinkText,
+      });
+      continue;
+    }
     if (
       role === "assistant" &&
       typedBlock.type === "thinking" &&
@@ -353,6 +368,62 @@ function extractReplayChunks(message: GatewayTranscriptMessage): ReplayChunk[] {
     }
   }
   return replayChunks;
+}
+
+function normalizeDisplayUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.replace(CONTROL_CHAR_RE, "").trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function formatGeneratedMediaLinkText(block: GatewayChatContentBlock): string | undefined {
+  if (block.type !== "image") {
+    return undefined;
+  }
+  const url =
+    normalizeDisplayUrl(block.openUrl) ??
+    normalizeDisplayUrl(block.url) ??
+    normalizeDisplayUrl(block.uri);
+  return url ? `Generated image: ${url}` : undefined;
+}
+
+function formatAssistantMessageText(content: GatewayChatContentBlock[] | undefined) {
+  const parts: string[] = [];
+  for (const block of content ?? []) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      continue;
+    }
+    const typedBlock = block as GatewayChatContentBlock;
+    if (typedBlock.type === "text" && typeof typedBlock.text === "string" && typedBlock.text) {
+      parts.push(typedBlock.text);
+      continue;
+    }
+    const mediaLinkText = formatGeneratedMediaLinkText(typedBlock);
+    if (mediaLinkText) {
+      parts.push(mediaLinkText);
+    }
+  }
+  const text = parts.join("\n").trimEnd();
+  return text || undefined;
+}
+
+function readGatewayMessageId(messageData: Record<string, unknown>): string | undefined {
+  const openclaw = messageData.__openclaw;
+  if (openclaw && typeof openclaw === "object" && !Array.isArray(openclaw)) {
+    const id = (openclaw as { id?: unknown }).id;
+    if (typeof id === "string" && id.trim()) {
+      return id;
+    }
+  }
+  for (const key of ["messageId", "id", "idempotencyKey"]) {
+    const value = messageData[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function buildSessionMetadata(params: {
@@ -980,6 +1051,14 @@ export class AcpGatewayAgent implements Agent {
     if (!pending) {
       return;
     }
+    const messageId = readGatewayMessageId(messageData);
+    if (messageId && pending.sentMessageId !== messageId) {
+      pending.sentMessageId = messageId;
+      pending.sentTextLength = 0;
+      pending.sentText = undefined;
+      pending.sentThoughtLength = 0;
+      pending.sentThought = undefined;
+    }
 
     const fullThought = content
       ?.filter((block) => block?.type === "thinking")
@@ -1000,11 +1079,7 @@ export class AcpGatewayAgent implements Agent {
       });
     }
 
-    const fullText = content
-      ?.filter((block) => block?.type === "text")
-      .map((block) => block.text ?? "")
-      .join("\n")
-      .trimEnd();
+    const fullText = formatAssistantMessageText(content);
     const sentSoFar = pending.sentTextLength ?? 0;
     if (!fullText || fullText.length <= sentSoFar) {
       return;

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -178,8 +178,6 @@ type ReplayChunk = {
   text: string;
 };
 
-const CONTROL_CHAR_RE = /[\x00-\x1f\x7f-\x9f]/g;
-
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
 
@@ -370,11 +368,23 @@ function extractReplayChunks(message: GatewayTranscriptMessage): ReplayChunk[] {
   return replayChunks;
 }
 
+function stripDisplayControlChars(value: string): string {
+  let result = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if ((code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f)) {
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
 function normalizeDisplayUrl(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
-  const normalized = value.replace(CONTROL_CHAR_RE, "").trim();
+  const normalized = stripDisplayControlChars(value).trim();
   return normalized.length > 0 ? normalized : undefined;
 }
 
@@ -395,12 +405,11 @@ function formatAssistantMessageText(content: GatewayChatContentBlock[] | undefin
     if (!block || typeof block !== "object" || Array.isArray(block)) {
       continue;
     }
-    const typedBlock = block as GatewayChatContentBlock;
-    if (typedBlock.type === "text" && typeof typedBlock.text === "string" && typedBlock.text) {
-      parts.push(typedBlock.text);
+    if (block.type === "text" && typeof block.text === "string" && block.text) {
+      parts.push(block.text);
       continue;
     }
-    const mediaLinkText = formatGeneratedMediaLinkText(typedBlock);
+    const mediaLinkText = formatGeneratedMediaLinkText(block);
     if (mediaLinkText) {
       parts.push(mediaLinkText);
     }
@@ -417,7 +426,7 @@ function readGatewayMessageId(messageData: Record<string, unknown>): string | un
       return id;
     }
   }
-  for (const key of ["messageId", "id", "idempotencyKey"]) {
+  for (const key of ["messageId", "idempotencyKey"]) {
     const value = messageData[key];
     if (typeof value === "string" && value.trim()) {
       return value;

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -375,6 +375,18 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("prints a generated image link for ACP image results after a silent marker", async () => {
+    await withAcpSessionEnv(async () => {
+      const imageLink =
+        "Generated image: /api/chat/media/outgoing/agent%3Amain%3Atui/test-attachment/full";
+      const result = await runAcpTurnWithAssistantEvents(["NO_REPLY", imageLink]);
+
+      expect(result.assistantEvents).toEqual([{ text: imageLink, delta: imageLink }]);
+      expect(result.logLines).toContain(imageLink);
+      expect(result.logLines.some((line) => line.includes("NO_REPLY"))).toBe(false);
+    });
+  });
+
   it("fails closed for ACP-shaped session keys missing ACP metadata", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");


### PR DESCRIPTION
## Summary
- convert assistant image transcript blocks into ACP-visible generated image links
- reset ACP text/thought offsets when a new gateway message id arrives
- cover replay and CLI silent-marker image-link behavior in tests

## Tests
- pnpm vitest run src/acp/translator.session-rate-limit.test.ts src/commands/agent.acp.test.ts