### PR TITLE
fix(agents): restore compaction gateway logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - fix(matrix): gate name-based allowlist resolution [AI]. (#79007) Thanks @pgondhi987.
 - Slack: include the bot's own root/parent message in new thread sessions so in-thread replies reach the agent with the parent text the user is responding to, instead of only `reply_to_id` metadata. Fixes #79338. Thanks @sxxtony.
 - Docker: keep image builds on the source pnpm workspace policy so pnpm 11 can prune production dependencies without a Docker-only workspace rewrite.
+- Agents/compaction: restore info-level gateway logs for embedded compaction start, completion, and incomplete outcomes. (#71961) Thanks @rubencu.
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Cron: treat Codex app-server turn acceptance, CLI process spawn, and tool starts as execution milestones, preventing isolated runs from tripping the early startup watchdog after work has begun.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -24,6 +24,7 @@ Auto-compaction is on by default. It runs when the session nears the context lim
 
 You will see:
 
+- `embedded run auto-compaction start` / `complete` in normal Gateway logs.
 - `🧹 Auto-compaction complete` in verbose mode.
 - `/status` showing `🧹 Compactions: <count>`.
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -376,6 +376,7 @@ You can observe compaction and session state via:
 - `/status` (in any chat session)
 - `openclaw status` (CLI)
 - `openclaw sessions` / `sessions --json`
+- Gateway logs (`pnpm gateway:watch` or `openclaw logs --follow`): `embedded run auto-compaction start` + `complete`
 - Verbose mode: `🧹 Auto-compaction complete` + compaction count
 
 ---

--- a/src/agents/openclaw-owned-tool-runtime-contract.test.ts
+++ b/src/agents/openclaw-owned-tool-runtime-contract.test.ts
@@ -47,7 +47,7 @@ function createToolHandlerCtx(): ToolHandlerContext {
       messagingToolSentTargets: [] as MessagingToolSend[],
       successfulCronAdds: 0,
     },
-    log: { debug: vi.fn(), warn: vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     flushBlockReplyBuffer: vi.fn(),
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./pi-embedded-subscribe.compaction-test-helpers.js";
 import {
   handleCompactionEnd,
+  handleCompactionStart,
   reconcileSessionStoreCompactionCountAfterSuccess,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -19,6 +20,7 @@ function createCompactionContext(params: {
   sessionKey: string;
   agentId?: string;
   initialCount: number;
+  info?: (message: string, meta?: Record<string, unknown>) => void;
 }): EmbeddedPiSubscribeContext {
   let compactionCount = params.initialCount;
   return {
@@ -37,6 +39,7 @@ function createCompactionContext(params: {
     } as never,
     log: {
       debug: vi.fn(),
+      info: params.info ?? vi.fn(),
       warn: vi.fn(),
     },
     ensureCompactionPromise: vi.fn(),
@@ -103,6 +106,168 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
   });
 });
 
+describe("compaction lifecycle logging", () => {
+  it("logs lifecycle events at info level for gateway watch visibility", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-log-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      compactionCount: 0,
+    });
+    const info = vi.fn();
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey,
+      initialCount: 0,
+      info,
+    });
+
+    handleCompactionStart(ctx, {
+      type: "compaction_start",
+      reason: "threshold",
+    });
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      reason: "threshold",
+      result: { kept: 12 },
+      willRetry: false,
+      aborted: false,
+    });
+
+    expect(info).toHaveBeenNthCalledWith(
+      1,
+      "embedded run auto-compaction start",
+      expect.objectContaining({
+        event: "embedded_run_compaction_start",
+        reason: "threshold",
+        runId: "run-test",
+        consoleMessage: "embedded run auto-compaction start: runId=run-test reason=threshold",
+      }),
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      "embedded run auto-compaction complete",
+      expect.objectContaining({
+        event: "embedded_run_compaction_end",
+        reason: "threshold",
+        runId: "run-test",
+        completed: true,
+        compactionCount: 1,
+        consoleMessage:
+          "embedded run auto-compaction complete: runId=run-test reason=threshold compactionCount=1 willRetry=false",
+      }),
+    );
+  });
+
+  it("logs manual compaction as incomplete when no result is produced", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-incomplete-log-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      compactionCount: 0,
+    });
+    const info = vi.fn();
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey,
+      initialCount: 0,
+      info,
+    });
+
+    handleCompactionStart(ctx, {
+      type: "compaction_start",
+      reason: "manual",
+    });
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      reason: "manual",
+      result: undefined,
+      willRetry: false,
+      aborted: false,
+    });
+
+    expect(info).toHaveBeenNthCalledWith(
+      1,
+      "embedded run manual compaction start",
+      expect.objectContaining({
+        event: "embedded_run_compaction_start",
+        reason: "manual",
+        runId: "run-test",
+        consoleMessage: "embedded run manual compaction start: runId=run-test reason=manual",
+      }),
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      "embedded run manual compaction incomplete",
+      expect.objectContaining({
+        event: "embedded_run_compaction_end",
+        reason: "manual",
+        runId: "run-test",
+        completed: false,
+        aborted: false,
+        consoleMessage:
+          "embedded run manual compaction incomplete: runId=run-test reason=manual aborted=false willRetry=false",
+      }),
+    );
+  });
+
+  it("defaults legacy synthetic compaction events to threshold logs", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-legacy-log-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      compactionCount: 0,
+    });
+    const info = vi.fn();
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey,
+      initialCount: 0,
+      info,
+    });
+
+    handleCompactionStart(ctx, {
+      type: "compaction_start",
+    });
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      result: { kept: 12 },
+      willRetry: false,
+      aborted: false,
+    });
+
+    expect(info).toHaveBeenNthCalledWith(
+      1,
+      "embedded run auto-compaction start",
+      expect.objectContaining({
+        event: "embedded_run_compaction_start",
+        reason: "threshold",
+        runId: "run-test",
+        consoleMessage: "embedded run auto-compaction start: runId=run-test reason=threshold",
+      }),
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      "embedded run auto-compaction complete",
+      expect.objectContaining({
+        event: "embedded_run_compaction_end",
+        reason: "threshold",
+        runId: "run-test",
+        completed: true,
+        compactionCount: 1,
+        consoleMessage:
+          "embedded run auto-compaction complete: runId=run-test reason=threshold compactionCount=1 willRetry=false",
+      }),
+    );
+  });
+});
+
 describe("handleCompactionEnd", () => {
   it("reconciles the session store after a successful compaction end event", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-handler-"));
@@ -122,10 +287,11 @@ describe("handleCompactionEnd", () => {
 
     handleCompactionEnd(ctx, {
       type: "compaction_end",
+      reason: "threshold",
       result: { kept: 12 },
       willRetry: false,
       aborted: false,
-    } as never);
+    });
 
     await waitForCompactionCount({
       storePath,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -8,18 +8,22 @@ type SessionCompactionStartEvent = Extract<AgentSessionEvent, { type: "compactio
 type SessionCompactionEndEvent = Extract<AgentSessionEvent, { type: "compaction_end" }>;
 type CompactionReason = SessionCompactionStartEvent["reason"];
 
-type CompactionStartEvent = SessionCompactionStartEvent | {
-  type: "compaction_start";
-  reason?: unknown;
-};
+type CompactionStartEvent =
+  | SessionCompactionStartEvent
+  | {
+      type: "compaction_start";
+      reason?: unknown;
+    };
 
-type CompactionEndEvent = SessionCompactionEndEvent | {
-  type: "compaction_end";
-  reason?: unknown;
-  willRetry?: unknown;
-  result?: unknown;
-  aborted?: unknown;
-};
+type CompactionEndEvent =
+  | SessionCompactionEndEvent
+  | {
+      type: "compaction_end";
+      reason?: unknown;
+      willRetry?: unknown;
+      result?: unknown;
+      aborted?: unknown;
+    };
 
 function normalizeCompactionReason(reason: unknown): CompactionReason {
   return reason === "manual" || reason === "threshold" || reason === "overflow"

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,14 +1,48 @@
-import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+type SessionCompactionStartEvent = Extract<AgentSessionEvent, { type: "compaction_start" }>;
+type SessionCompactionEndEvent = Extract<AgentSessionEvent, { type: "compaction_end" }>;
+type CompactionReason = SessionCompactionStartEvent["reason"];
+
+type CompactionStartEvent = SessionCompactionStartEvent | {
+  type: "compaction_start";
+  reason?: unknown;
+};
+
+type CompactionEndEvent = SessionCompactionEndEvent | {
+  type: "compaction_end";
+  reason?: unknown;
+  willRetry?: unknown;
+  result?: unknown;
+  aborted?: unknown;
+};
+
+function normalizeCompactionReason(reason: unknown): CompactionReason {
+  return reason === "manual" || reason === "threshold" || reason === "overflow"
+    ? reason
+    : "threshold";
+}
+
+function compactionLogKind(reason: CompactionReason): string {
+  return reason === "manual" ? "manual compaction" : "auto-compaction";
+}
+
+export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext, evt: CompactionStartEvent) {
+  const reason = normalizeCompactionReason(evt.reason);
+  const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
   ctx.ensureCompactionPromise();
-  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
+  ctx.log.info(`embedded run ${kind} start`, {
+    event: "embedded_run_compaction_start",
+    runId: ctx.params.runId,
+    reason,
+    consoleMessage: `embedded run ${kind} start: runId=${ctx.params.runId} reason=${reason}`,
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
@@ -39,10 +73,9 @@ export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   }
 }
 
-export function handleCompactionEnd(
-  ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
-) {
+export function handleCompactionEnd(ctx: EmbeddedPiSubscribeContext, evt: CompactionEndEvent) {
+  const reason = normalizeCompactionReason(evt.reason);
+  const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
   // Increment counter whenever compaction actually produced a result,
@@ -59,6 +92,15 @@ export function handleCompactionEnd(
         : undefined;
     ctx.noteCompactionTokensAfter(tokensAfter);
     const observedCompactionCount = ctx.getCompactionCount();
+    ctx.log.info(`embedded run ${kind} complete`, {
+      event: "embedded_run_compaction_end",
+      runId: ctx.params.runId,
+      reason,
+      completed: true,
+      willRetry,
+      compactionCount: observedCompactionCount,
+      consoleMessage: `embedded run ${kind} complete: runId=${ctx.params.runId} reason=${reason} compactionCount=${observedCompactionCount} willRetry=${willRetry}`,
+    });
     void reconcileSessionStoreCompactionCountAfterSuccess({
       sessionKey: ctx.params.sessionKey,
       agentId: ctx.params.agentId,
@@ -78,6 +120,17 @@ export function handleCompactionEnd(
     }
     ctx.maybeResolveCompactionWait();
     clearStaleAssistantUsageOnSessionMessages(ctx);
+  }
+  if (!hasResult || wasAborted) {
+    ctx.log.info(`embedded run ${kind} incomplete`, {
+      event: "embedded_run_compaction_end",
+      runId: ctx.params.runId,
+      reason,
+      completed: false,
+      willRetry,
+      aborted: wasAborted,
+      consoleMessage: `embedded run ${kind} incomplete: runId=${ctx.params.runId} reason=${reason} aborted=${wasAborted} willRetry=${willRetry}`,
+    });
   }
   emitAgentEvent({
     runId: ctx.params.runId,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -125,7 +125,7 @@ function createMessageEndContext(
     noteLastAssistant: vi.fn(),
     recordAssistantUsage: vi.fn(),
     commitAssistantUsage: vi.fn(),
-    log: { debug: vi.fn(), warn: params.warn ?? vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: params.warn ?? vi.fn() },
     builtinToolNames: params.builtinToolNames,
     stripBlockTags: (text: string) => text,
     finalizeAssistantTexts: params.finalizeAssistantTexts ?? vi.fn(),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -40,7 +40,7 @@ function createMockContext(overrides?: {
       deterministicApprovalPromptPending: false,
       deterministicApprovalPromptSent: false,
     },
-    log: { debug: vi.fn(), warn: vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     builtinToolNames: overrides?.builtinToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -41,6 +41,7 @@ function createTestContext(): {
     hookRunner: undefined,
     log: {
       debug: vi.fn(),
+      info: vi.fn(),
       warn,
     },
     state: {

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -115,12 +115,12 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         return;
       case "compaction_start":
         scheduleEvent(evt, () => {
-          handleCompactionStart(ctx);
+          handleCompactionStart(ctx, evt);
         });
         return;
       case "compaction_end":
         scheduleEvent(evt, () => {
-          handleCompactionEnd(ctx, evt as never);
+          handleCompactionEnd(ctx, evt);
         });
         return;
       case "agent_end":

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -115,12 +115,21 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         return;
       case "compaction_start":
         scheduleEvent(evt, () => {
-          handleCompactionStart(ctx, evt);
+          handleCompactionStart(ctx, {
+            type: "compaction_start",
+            reason: evt.reason,
+          });
         });
         return;
       case "compaction_end":
         scheduleEvent(evt, () => {
-          handleCompactionEnd(ctx, evt);
+          handleCompactionEnd(ctx, {
+            type: "compaction_end",
+            reason: evt.reason,
+            willRetry: evt.willRetry,
+            result: evt.result,
+            aborted: evt.aborted,
+          });
         });
         return;
       case "agent_end":

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -1,4 +1,5 @@
-import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-response.js";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
@@ -18,6 +19,7 @@ import type { NormalizedUsage } from "./usage.js";
 
 type EmbeddedSubscribeLogger = {
   debug: (message: string, meta?: Record<string, unknown>) => void;
+  info: (message: string, meta?: Record<string, unknown>) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
 };
 
@@ -237,6 +239,6 @@ export type ToolHandlerContext = {
 };
 
 export type EmbeddedPiSubscribeEvent =
-  | AgentEvent
+  | AgentSessionEvent
   | { type: string; [k: string]: unknown }
   | { type: "message_start"; message: AgentMessage };

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -73,7 +73,7 @@ function createToolHandlerCtx() {
       ...createBaseToolHandlerState(),
       successfulCronAdds: 0,
     },
-    log: { debug: vi.fn(), warn: vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     flushBlockReplyBuffer: vi.fn(),
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/plugins/bundle-manifest.test.ts
+++ b/src/plugins/bundle-manifest.test.ts
@@ -15,6 +15,16 @@ import {
   mkdirSafeDir,
 } from "./test-helpers/fs-fixtures.js";
 
+type ExpectedBundlePluginManifest = Omit<
+  BundlePluginManifest,
+  "capabilities" | "hooks" | "settingsFiles" | "skills"
+> & {
+  capabilities: readonly string[];
+  hooks: readonly string[];
+  settingsFiles?: readonly string[];
+  skills: readonly string[];
+};
+
 const tempDirs: string[] = [];
 
 function makeTempDir() {
@@ -235,7 +245,7 @@ describe("bundle manifest parsing", () => {
         name: "Claude Sample",
         description: "Claude fixture",
         version: undefined,
-        bundleFormat: "claude",
+        bundleFormat: "claude" as const,
         skills: ["skill-packs/starter", "commands-pack", "agents-pack", "styles"],
         settingsFiles: ["settings.json"],
         hooks: ["hooks/hooks.json", "hooks-pack"],
@@ -299,7 +309,7 @@ describe("bundle manifest parsing", () => {
         name: undefined,
         description: undefined,
         version: undefined,
-        bundleFormat: "claude",
+        bundleFormat: "claude" as const,
         skills: ["skills", "commands"],
         settingsFiles: ["settings.json"],
         hooks: [],

--- a/src/plugins/bundle-manifest.test.ts
+++ b/src/plugins/bundle-manifest.test.ts
@@ -15,7 +15,7 @@ import {
   mkdirSafeDir,
 } from "./test-helpers/fs-fixtures.js";
 
-type ExpectedBundlePluginManifest = Omit<
+type ReadonlyBundleManifestExpectation = Omit<
   BundlePluginManifest,
   "capabilities" | "hooks" | "settingsFiles" | "skills"
 > & {
@@ -134,7 +134,7 @@ type ExpectedBundlePluginManifest = Omit<
 function expectBundleManifest(params: {
   rootDir: string;
   bundleFormat: "codex" | "claude" | "cursor";
-  expected: ExpectedBundlePluginManifest;
+  expected: ReadonlyBundleManifestExpectation;
 }) {
   expect(detectBundleManifestFormat(params.rootDir)).toBe(params.bundleFormat);
   expect(expectLoadedManifest(params.rootDir, params.bundleFormat)).toEqual(params.expected);

--- a/src/plugins/provider-validation.test.ts
+++ b/src/plugins/provider-validation.test.ts
@@ -50,7 +50,7 @@ function normalizeProviderFixture(provider: ProviderPlugin) {
 
 function expectNormalizedProviderFixture(params: {
   provider: ProviderPlugin;
-  expectedProvider?: ProviderPlugin | null;
+  expectedProvider?: unknown;
   expectedDiagnostics?: ReadonlyArray<{ level: PluginDiagnostic["level"]; message: string }>;
   expectedDiagnosticText?: readonly string[];
 }) {
@@ -69,7 +69,7 @@ function expectNormalizedProviderFixture(params: {
 
 function expectProviderNormalizationResult(params: {
   provider: ProviderPlugin;
-  expectedProvider?: ProviderPlugin | null;
+  expectedProvider?: unknown;
   expectedDiagnostics?: ReadonlyArray<{ level: PluginDiagnostic["level"]; message: string }>;
   expectedDiagnosticText?: readonly string[];
   assert?: (

--- a/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
@@ -43,7 +43,7 @@ function createToolHandlerCtx(params: {
     state: {
       ...createBaseToolHandlerState(),
     },
-    log: { debug: vi.fn(), warn: vi.fn() },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     flushBlockReplyBuffer: vi.fn(),
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -55,7 +55,7 @@ describe("compaction hook wiring", () => {
         },
       },
       state: { compactionInFlight: true },
-      log: { debug: vi.fn(), warn: vi.fn() },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
       maybeResolveCompactionWait: vi.fn(),
       incrementCompactionCount: vi.fn(),
       getCompactionCount: () => params.compactionCount ?? 0,
@@ -136,12 +136,12 @@ describe("compaction hook wiring", () => {
         onAgentEvent: vi.fn(),
       },
       state: { compactionInFlight: false },
-      log: { debug: vi.fn(), warn: vi.fn() },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
       incrementCompactionCount: vi.fn(),
       ensureCompactionPromise: vi.fn(),
     };
 
-    handleCompactionStart(ctx as never);
+    handleCompactionStart(ctx as never, { type: "compaction_start", reason: "threshold" });
 
     expect(hookMocks.runner.runBeforeCompaction).toHaveBeenCalledTimes(1);
     expectCompactionEvent({
@@ -253,7 +253,7 @@ describe("compaction hook wiring", () => {
     const ctx = {
       params: { runId: "r4", session: { messages } },
       state: { compactionInFlight: true },
-      log: { debug: vi.fn(), warn: vi.fn() },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
       maybeResolveCompactionWait: vi.fn(),
       getCompactionCount: () => 1,
       incrementCompactionCount: vi.fn(),
@@ -281,7 +281,7 @@ describe("compaction hook wiring", () => {
     const ctx = {
       params: { runId: "r5", session: { messages } },
       state: { compactionInFlight: true },
-      log: { debug: vi.fn(), warn: vi.fn() },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
       noteCompactionRetry: vi.fn(),
       resetForCompactionRetry: vi.fn(),
       getCompactionCount: () => 0,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: live Gateway compaction could happen without any normal Gateway log line showing that compaction started or completed.
- Why it matters: when the embedded agent pauses for compaction, operators watching `pnpm gateway:watch` or `openclaw logs --follow` need to distinguish healthy compaction from a stuck run.
- What changed: compaction start/end now emit info-level embedded-run lifecycle logs with the upstream compaction reason, completion state, retry state, and observed compaction count.
- What did NOT change (scope boundary): no compaction policy, retry behavior, token accounting, config, provider, or hook contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: compaction completed in a live Gateway run, but normal Gateway logs did not expose compaction start/complete lifecycle lines before this patch.
- Real environment tested: local macOS repo checkout, real OpenClaw Gateway process, QA mock provider over HTTP, OpenClaw JSON-RPC `agent` request.
- Exact steps or command run after this patch: `pnpm exec tsx /tmp/openclaw-pr71961-live-compaction.ts <pr-worktree> pr-branch`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "label": "pr-branch",
  "compactionEntries": [
    {
      "agentId": "qa",
      "sessionKey": "agent:qa:main",
      "compactionCount": 1
    }
  ],
  "logContainsStart": true,
  "logContainsComplete": true,
  "compactionLogLines": [
    "2026-05-10T11:31:16.082-04:00 [agent/embedded] embedded run auto-compaction start: runId=pr71961-pr-branch-1778427074071-0 reason=threshold",
    "2026-05-10T11:31:16.094-04:00 [agent/embedded] embedded run auto-compaction complete: runId=pr71961-pr-branch-1778427074071-0 reason=threshold compactionCount=1 willRetry=false"
  ],
  "runCount": 1
}
```

- Observed result after fix: the same live Gateway compaction now emits info-level start and complete log lines.
- What was not tested: full repo `pnpm check` / full `pnpm test`; this PR was validated with targeted touched-surface tests, typechecks, live Gateway proof, and Codex review.
- Before evidence (optional but encouraged): same live script against an `origin/main` worktree at the rebase base (`4167d90bc9`) produced `compactionCount: 1` with `logContainsStart: false`, `logContainsComplete: false`, and no compaction log lines.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the embedded compaction handlers updated session state and fired hooks, but did not write normal info-level lifecycle logs for Gateway operators.
- Missing detection / guardrail: tests covered compaction count and hook behavior, but not the operator-visible log contract.
- Contributing context (if known): existing debug output was not enough for normal Gateway watch/log-follow workflows.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.compaction.test.ts`, `src/plugins/wired-hooks-compaction.test.ts`
- Scenario the test should lock in: threshold compaction logs start and complete; manual compaction logs start and incomplete; hook wiring passes the upstream compaction reason into the handler.
- Why this is the smallest reliable guardrail: the behavior lives in the embedded compaction handler and hook seam, so these tests cover the new branches without needing provider or UI mocks.
- Existing test that already covers this (if any): existing compaction count/hook tests covered state behavior, not log visibility.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Operators now see `embedded run auto-compaction start` and `embedded run auto-compaction complete` in normal Gateway logs when threshold/overflow compaction runs; manual compaction logs as manual compaction.

## Diagram (if applicable)

```text
Before:
[Gateway run crosses compaction threshold] -> [compaction happens] -> [no normal lifecycle log]

After:
[Gateway run crosses compaction threshold] -> [start log] -> [compaction happens] -> [complete/incomplete log]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25.2.1 for local commands; repo runtime remains Node 22+ compatible
- Model/provider: QA mock provider
- Integration/channel (if any): Gateway JSON-RPC `agent`
- Relevant config (redacted): QA agent with small test compaction budget (`contextWindow: 4000`, `reserveTokens: 3950`, `keepRecentTokens: 1`), Gateway logging at `info`, memory flush disabled for the live proof

### Steps

1. Start a real Gateway process from the repo under test.
2. Start the QA mock provider and send a JSON-RPC `agent` request with a prompt large enough to trigger threshold compaction.
3. Inspect the live Gateway log output and session store compaction count.

### Expected

- The session records `compactionCount: 1`.
- Gateway logs include compaction start and complete lifecycle lines.

### Actual

- Before this patch on `4167d90bc9`: `compactionCount: 1`, but no compaction start or complete log lines.
- After this patch on `6ee42aaa4e`: `compactionCount: 1`, plus start and complete log lines.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm exec oxfmt --check --threads=1 docs/concepts/compaction.md docs/reference/session-management-compaction.md src/agents/pi-embedded-subscribe.handlers.compaction.ts src/agents/pi-embedded-subscribe.handlers.compaction.test.ts src/agents/pi-embedded-subscribe.handlers.ts src/agents/pi-embedded-subscribe.handlers.types.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/plugins/wired-hooks-after-tool-call.e2e.test.ts src/plugins/wired-hooks-compaction.test.ts
git diff --check
pnpm test src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
pnpm test src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
pnpm test src/agents/pi-embedded-subscribe.handlers.compaction.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts -- -t compaction
pnpm test src/agents/pi-embedded-subscribe.handlers.compaction.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/plugins/wired-hooks-compaction.test.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/plugins/wired-hooks-after-tool-call.e2e.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
pnpm tsgo:core
pnpm tsgo:test:src
codex review --base origin/main
```

Codex review result: no actionable correctness issues found.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live Gateway before/after proof, threshold compaction start/complete logs, manual compaction incomplete branch, hook wiring, compaction count persistence, touched type surfaces.
- Edge cases checked: missing compaction result logs as incomplete; retry/debug path remains covered by existing compaction tests; no `CHANGELOG.md` diff remains in this PR.
- What you did **not** verify: full repo test/check sweep, maintainer-owned manual verification. User manual verification: owner performs final manual verification outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: log output becomes noisier for sessions that compact repeatedly.
  - Mitigation: the patch emits one start line and one end line per compaction lifecycle at info level, with no extra per-token or streaming logs.
