### PR TITLE
fix(daemon): only emit existing version-manager dirs into service PATH (#71944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
-- Daemon/service: only emit hard-coded version-manager paths (`~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, fnm/pnpm fallbacks) into the gateway/node service PATH when the directories actually exist on disk, so `openclaw doctor` no longer flags `gateway.path.non-minimal` against a PATH the daemon itself wrote. Env-driven roots (`PNPM_HOME`, `VOLTA_HOME`, `BUN_INSTALL`, `FNM_DIR`, etc.) and stable user-bin dirs (`~/.local/bin`, `~/.npm-global/bin`, `~/bin`) remain unconditional. Fixes #71944.
+- Daemon/service: only emit hard-coded version-manager paths (`~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, fnm/pnpm fallbacks) into the gateway/node service PATH when the directories actually exist on disk, so `openclaw doctor` no longer flags `gateway.path.non-minimal` against a PATH the daemon itself wrote. Env-driven roots (`PNPM_HOME`, `VOLTA_HOME`, `BUN_INSTALL`, `FNM_DIR`, etc.) and stable user-bin dirs (`~/.local/bin`, `~/.npm-global/bin`, `~/bin`) remain unconditional. Fixes #71944. Thanks @Sanjays2402.
 
 ## 2026.4.25 (Unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+- Daemon/service: only emit hard-coded version-manager paths (`~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, fnm/pnpm fallbacks) into the gateway/node service PATH when the directories actually exist on disk, so `openclaw doctor` no longer flags `gateway.path.non-minimal` against a PATH the daemon itself wrote. Env-driven roots (`PNPM_HOME`, `VOLTA_HOME`, `BUN_INSTALL`, `FNM_DIR`, etc.) and stable user-bin dirs (`~/.local/bin`, `~/.npm-global/bin`, `~/bin`) remain unconditional. Fixes #71944.
+
 ## 2026.4.25 (Unreleased)
 
 ### Changes

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -270,6 +270,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
+      existsSync: () => true,
     });
 
     expect(result).toContain("/home/testuser/.nix-profile/bin");
@@ -279,6 +280,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
+      existsSync: () => true,
     });
 
     expect(result).toContain("/Users/testuser/.nix-profile/bin");
@@ -291,6 +293,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
         HOME: "/home/testuser",
         NIX_PROFILES: "/nix/var/nix/profiles/default /home/testuser/.nix-profile",
       },
+      existsSync: () => true,
     });
 
     const userIdx = result.indexOf("/home/testuser/.nix-profile/bin");
@@ -307,6 +310,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
         HOME: "/Users/testuser",
         NIX_PROFILES: "/nix/var/nix/profiles/default /Users/testuser/.nix-profile",
       },
+      existsSync: () => true,
     });
 
     const userIdx = result.indexOf("/Users/testuser/.nix-profile/bin");
@@ -323,6 +327,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
         HOME: "/home/testuser",
         NIX_PROFILES: "/nix/var/nix/profiles/per-user/testuser/profile",
       },
+      existsSync: () => true,
     });
 
     expect(result).toContain("/nix/var/nix/profiles/per-user/testuser/profile/bin");
@@ -335,6 +340,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
         HOME: "/Users/testuser",
         NIX_PROFILES: "/nix/var/nix/profiles/per-user/testuser/profile",
       },
+      existsSync: () => true,
     });
 
     expect(result).toContain("/nix/var/nix/profiles/per-user/testuser/profile/bin");
@@ -348,6 +354,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
         NIX_PROFILES:
           "/nix/var/nix/profiles/default /nix/var/nix/profiles/per-user/testuser/custom /home/testuser/.nix-profile",
       },
+      existsSync: () => true,
     });
 
     const userIdx = result.indexOf("/home/testuser/.nix-profile/bin");
@@ -421,6 +428,7 @@ describe("buildMinimalServicePath", () => {
     const result = buildMinimalServicePath({
       platform: "linux",
       env: { HOME: "/home/bob" },
+      existsSync: () => true,
     });
     const parts = splitPath(result, "linux");
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -13,10 +13,17 @@ import {
 } from "./service-env.js";
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
+  // Default existsSync stub for tests that pre-date the on-disk filter:
+  // pretend every hard-coded version-manager dir exists so we can keep the
+  // original assertions about which paths get emitted.
+  const allExist = (): boolean => true;
+  const noneExist = (): boolean => false;
+
   it("includes user bin directories when HOME is set on Linux", () => {
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
+      existsSync: allExist,
     });
 
     // Should include all common user bin directories
@@ -50,6 +57,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
+      existsSync: allExist,
     });
 
     const userDirIndex = result.indexOf("/home/testuser/.local/bin");
@@ -65,6 +73,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
       platform: "linux",
       home: "/home/testuser",
       extraDirs: ["/custom/bin"],
+      existsSync: allExist,
     });
 
     const extraDirIndex = result.indexOf("/custom/bin");
@@ -88,6 +97,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
         NVM_DIR: "/opt/nvm",
         FNM_DIR: "/opt/fnm",
       },
+      existsSync: allExist,
     });
 
     expect(result).toContain("/opt/pnpm");
@@ -103,6 +113,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
+      existsSync: allExist,
     });
 
     // Should include common user bin directories
@@ -134,6 +145,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
         NVM_DIR: "/Users/testuser/.nvm",
         PNPM_HOME: "/Users/testuser/Library/pnpm",
       },
+      existsSync: allExist,
     });
 
     // fnm uses aliases/default/bin (not current)
@@ -148,6 +160,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
+      existsSync: allExist,
     });
 
     // fnm on macOS defaults to ~/Library/Application Support/fnm
@@ -165,10 +178,90 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     const result = getMinimalServicePathParts({
       platform: "win32",
       home: "C:\\Users\\testuser",
+      existsSync: allExist,
     });
 
     // Windows returns empty array (uses existing PATH)
     expect(result).toEqual([]);
+  });
+
+  it("omits hard-coded VM fallbacks on Linux when their directories do not exist", () => {
+    // Issue #71944: doctor warns gateway.path.non-minimal about exactly these dirs.
+    // When they don't exist on disk we must not write them into the launchd plist.
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+      existsSync: noneExist,
+    });
+
+    // Stable user-bin conventions are still emitted (audit excludes these).
+    expect(result).toContain("/home/testuser/.local/bin");
+    expect(result).toContain("/home/testuser/.npm-global/bin");
+    expect(result).toContain("/home/testuser/bin");
+    // Version-manager fallbacks must be filtered out.
+    expect(result).not.toContain("/home/testuser/.volta/bin");
+    expect(result).not.toContain("/home/testuser/.asdf/shims");
+    expect(result).not.toContain("/home/testuser/.bun/bin");
+    expect(result).not.toContain("/home/testuser/.nvm/current/bin");
+    expect(result).not.toContain("/home/testuser/.fnm/current/bin");
+    expect(result).not.toContain("/home/testuser/.local/share/pnpm");
+  });
+
+  it("omits hard-coded VM fallbacks on macOS when their directories do not exist", () => {
+    // Issue #71944: matches the audit's gateway.path.non-minimal pattern set.
+    const result = getMinimalServicePathParts({
+      platform: "darwin",
+      home: "/Users/testuser",
+      existsSync: noneExist,
+    });
+
+    // Stable user-bin conventions remain.
+    expect(result).toContain("/Users/testuser/.local/bin");
+    expect(result).toContain("/Users/testuser/.npm-global/bin");
+    expect(result).toContain("/Users/testuser/bin");
+    // Hard-coded version-manager fallbacks are filtered out.
+    expect(result).not.toContain("/Users/testuser/.volta/bin");
+    expect(result).not.toContain("/Users/testuser/.asdf/shims");
+    expect(result).not.toContain("/Users/testuser/.bun/bin");
+    expect(result).not.toContain(
+      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
+    );
+    expect(result).not.toContain("/Users/testuser/.fnm/aliases/default/bin");
+    expect(result).not.toContain("/Users/testuser/Library/pnpm");
+    expect(result).not.toContain("/Users/testuser/.local/share/pnpm");
+  });
+
+  it("keeps env-configured roots even when their directories do not exist on disk", () => {
+    // Env vars are explicit user signal; users may set them before the VM is installed.
+    // The audit accepts these because they're typed by the user, not by us guessing.
+    const result = getMinimalServicePathPartsFromEnv({
+      platform: "linux",
+      env: {
+        HOME: "/home/testuser",
+        PNPM_HOME: "/opt/pnpm",
+        VOLTA_HOME: "/opt/volta",
+        BUN_INSTALL: "/opt/bun",
+      },
+      existsSync: noneExist,
+    });
+
+    expect(result).toContain("/opt/pnpm");
+    expect(result).toContain("/opt/volta/bin");
+    expect(result).toContain("/opt/bun/bin");
+  });
+
+  it("emits only the existing hard-coded VM fallbacks on macOS", () => {
+    // Realistic: a user has volta installed but not bun.
+    const exists = (candidate: string) => candidate === "/Users/testuser/.volta/bin";
+    const result = getMinimalServicePathParts({
+      platform: "darwin",
+      home: "/Users/testuser",
+      existsSync: exists,
+    });
+
+    expect(result).toContain("/Users/testuser/.volta/bin");
+    expect(result).not.toContain("/Users/testuser/.bun/bin");
+    expect(result).not.toContain("/Users/testuser/.asdf/shims");
   });
 });
 
@@ -295,6 +388,7 @@ describe("buildMinimalServicePath", () => {
     const result = buildMinimalServicePath({
       platform: "linux",
       env: { HOME: "/home/alice" },
+      existsSync: () => true,
     });
     const parts = splitPath(result, "linux");
 
@@ -361,6 +455,7 @@ describe("buildMinimalServicePath", () => {
       platform: "linux",
       extraDirs: ["/home/alice/.nvm/versions/node/v22.22.0/bin"],
       env: { HOME: "/home/alice" },
+      existsSync: () => true,
     });
     const parts = splitPath(result, "linux");
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -28,6 +29,14 @@ export type MinimalServicePathOptions = {
   extraDirs?: string[];
   home?: string;
   env?: Record<string, string | undefined>;
+  /**
+   * Predicate used to check whether an optional version-manager directory exists
+   * on disk. Injected for tests; defaults to {@link fs.existsSync}. Only consulted
+   * for hard-coded version-manager fallbacks (volta, asdf, bun, fnm, pnpm); env-driven
+   * roots (PNPM_HOME, VOLTA_HOME, …) and stable user dirs (~/.local/bin, ~/.npm-global/bin,
+   * ~/bin) remain unconditional.
+   */
+  existsSync?: (candidate: string) => boolean;
 };
 
 type BuildServicePathOptions = MinimalServicePathOptions & {
@@ -86,13 +95,31 @@ function appendSubdir(base: string | undefined, subdir: string): string | undefi
   return base.endsWith(`/${subdir}`) ? base : path.posix.join(base, subdir);
 }
 
-function addCommonUserBinDirs(dirs: string[], home: string): void {
+function addCommonUserBinDirs(
+  dirs: string[],
+  home: string,
+  existsSync: (candidate: string) => boolean,
+): void {
+  // Stable user-bin conventions — emit unconditionally. The audit excludes these.
   dirs.push(`${home}/.local/bin`);
   dirs.push(`${home}/.npm-global/bin`);
   dirs.push(`${home}/bin`);
-  dirs.push(`${home}/.volta/bin`);
-  dirs.push(`${home}/.asdf/shims`);
-  dirs.push(`${home}/.bun/bin`);
+  // Version-manager fallbacks — only emit when the directory actually exists.
+  // Otherwise the gateway plist contains paths that never resolve and the
+  // service-audit (gateway.path.non-minimal) flags its own writes.
+  addExistingDir(dirs, `${home}/.volta/bin`, existsSync);
+  addExistingDir(dirs, `${home}/.asdf/shims`, existsSync);
+  addExistingDir(dirs, `${home}/.bun/bin`, existsSync);
+}
+
+function addExistingDir(
+  dirs: string[],
+  candidate: string,
+  existsSync: (candidate: string) => boolean,
+): void {
+  if (existsSync(candidate)) {
+    dirs.push(candidate);
+  }
 }
 
 function addCommonEnvConfiguredBinDirs(
@@ -144,6 +171,7 @@ function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
 export function resolveDarwinUserBinDirs(
   home: string | undefined,
   env?: Record<string, string | undefined>,
+  existsSync: (candidate: string) => boolean = fs.existsSync,
 ): string[] {
   if (!home) {
     return [];
@@ -163,19 +191,19 @@ export function resolveDarwinUserBinDirs(
   // pnpm: binary is directly in PNPM_HOME (not in bin subdirectory)
 
   // Common user bin directories
-  addCommonUserBinDirs(dirs, home);
+  addCommonUserBinDirs(dirs, home, existsSync);
 
   // Nix Home Manager (cross-platform)
   addNixProfileBinDirs(dirs, home, env);
 
-  // Node version managers - macOS specific paths
-  // nvm: no stable default path, depends on user's shell configuration
-  // fnm: macOS default is ~/Library/Application Support/fnm, not ~/.fnm
-  dirs.push(`${home}/Library/Application Support/fnm/aliases/default/bin`); // fnm default
-  dirs.push(`${home}/.fnm/aliases/default/bin`); // fnm if customized to ~/.fnm
-  // pnpm: macOS default is ~/Library/pnpm, not ~/.local/share/pnpm
-  dirs.push(`${home}/Library/pnpm`); // pnpm default
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm XDG fallback
+  // Node version managers - macOS specific paths.
+  // Only emit hard-coded fallbacks that actually exist on disk so the gateway
+  // plist matches what the doctor's gateway.path.non-minimal audit will accept.
+  // Env-driven equivalents (FNM_DIR, PNPM_HOME) above stay unconditional.
+  addExistingDir(dirs, `${home}/Library/Application Support/fnm/aliases/default/bin`, existsSync); // fnm default
+  addExistingDir(dirs, `${home}/.fnm/aliases/default/bin`, existsSync); // fnm if customized to ~/.fnm
+  addExistingDir(dirs, `${home}/Library/pnpm`, existsSync); // pnpm default on macOS
+  addExistingDir(dirs, `${home}/.local/share/pnpm`, existsSync); // pnpm XDG fallback
 
   return dirs;
 }
@@ -187,6 +215,7 @@ export function resolveDarwinUserBinDirs(
 export function resolveLinuxUserBinDirs(
   home: string | undefined,
   env?: Record<string, string | undefined>,
+  existsSync: (candidate: string) => boolean = fs.existsSync,
 ): string[] {
   if (!home) {
     return [];
@@ -200,15 +229,16 @@ export function resolveLinuxUserBinDirs(
   addNonEmptyDir(dirs, appendSubdir(env?.FNM_DIR, "current/bin"));
 
   // Common user bin directories
-  addCommonUserBinDirs(dirs, home);
+  addCommonUserBinDirs(dirs, home, existsSync);
 
   // Nix Home Manager (cross-platform)
   addNixProfileBinDirs(dirs, home, env);
 
-  // Node version managers
-  dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink
-  dirs.push(`${home}/.fnm/current/bin`); // fnm
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm global bin
+  // Node version managers - only emit when the directory actually exists.
+  // Mirrors the macOS branch so the gateway plist agrees with the audit.
+  addExistingDir(dirs, `${home}/.nvm/current/bin`, existsSync); // nvm with current symlink
+  addExistingDir(dirs, `${home}/.fnm/current/bin`, existsSync); // fnm
+  addExistingDir(dirs, `${home}/.local/share/pnpm`, existsSync); // pnpm global bin
 
   return dirs;
 }
@@ -223,12 +253,15 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   const extraDirs = options.extraDirs ?? [];
   const systemDirs = resolveSystemPathDirs(platform);
 
-  // Add user bin directories for version managers (npm global, nvm, fnm, volta, etc.)
+  // Add user bin directories for version managers (npm global, nvm, fnm, volta, etc.).
+  // Hard-coded VM fallbacks are filtered through `existsSync` so the plist matches
+  // what `service-audit.ts:gateway.path.non-minimal` will accept.
+  const existsSync = options.existsSync ?? fs.existsSync;
   const userDirs =
     platform === "linux"
-      ? resolveLinuxUserBinDirs(options.home, options.env)
+      ? resolveLinuxUserBinDirs(options.home, options.env, existsSync)
       : platform === "darwin"
-        ? resolveDarwinUserBinDirs(options.home, options.env)
+        ? resolveDarwinUserBinDirs(options.home, options.env, existsSync)
         : [];
 
   const add = (dir: string) => {


### PR DESCRIPTION
Fixes #71944.

## Problem

`service-env.ts:resolveDarwinUserBinDirs` and `resolveLinuxUserBinDirs` unconditionally pushed every version-manager fallback (`~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, both fnm path variants, both pnpm path variants) into the gateway and node service PATH — regardless of whether those tools were actually installed.

`service-audit.ts:301-329` then matched those exact substrings (`/.volta/`, `/.asdf/`, `/.fnm/`, `/.local/share/pnpm/`, etc.) and emitted `gateway.path.non-minimal`:

> *"Gateway service PATH includes version managers or package managers; recommend a minimal PATH."*

So the daemon wrote a kitchen-sink PATH and then the doctor scolded it for the contents it had just written. Pure self-contradiction.

## Fix

Filter the **hard-coded** version-manager fallbacks through `fs.existsSync` so the plist only contains paths that actually resolve on the host. The predicate is injectable via `MinimalServicePathOptions.existsSync` so tests stay hermetic.

Three classes of dir, three rules:

| Class | Examples | Rule |
| --- | --- | --- |
| **Env-configured roots** (explicit user signal) | `PNPM_HOME`, `BUN_INSTALL`, `VOLTA_HOME`, `ASDF_DATA_DIR`, `NVM_DIR`, `FNM_DIR`, `NPM_CONFIG_PREFIX/bin` | Unconditional — user typed these, we trust them. |
| **Stable user-bin conventions** | `~/.local/bin`, `~/.npm-global/bin`, `~/bin` | Unconditional — audit excludes them. |
| **Hard-coded VM fallbacks** | `~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, `~/Library/Application Support/fnm/aliases/default/bin`, `~/.fnm/aliases/default/bin`, `~/Library/pnpm`, `~/.local/share/pnpm`, `~/.nvm/current/bin`, `~/.fnm/current/bin` | **Only emit when the directory exists on disk.** Otherwise the audit (correctly) flags them. |

Combined effect: the gateway plist and the doctor now agree about what counts as a minimal PATH.

## Tests

- 71/71 in `service-env.test.ts` (16 in `service-audit.test.ts`, 15 in `daemon-install-helpers.test.ts`).
- Existing assertions preserved by injecting `existsSync: () => true` so they still describe "what gets emitted when every dir exists".
- Three new tests covering the new behavior:
  - Linux: hard-coded VM fallbacks omitted when none exist; user-bin conventions remain.
  - macOS: same, with the macOS-specific paths.
  - Env-configured roots stay unconditional even when the directory does not exist (explicit user signal).
  - Realistic mixed case: only the existing fallbacks emitted (e.g., volta installed, bun not).

## Out of scope (worth a follow-up)

- The audit could surface a `gateway.path.stale` recommendation when on-disk version managers don't match the plist (e.g., user installed Volta after the plist was written). The current fix addresses the contradiction at write time but doesn't auto-detect drift; happy to send a follow-up if @steipete wants it.