### PR TITLE
feat(dashboard-launcher): add openclaw dashboard {start|stop|status|logs} extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -223,6 +223,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/copilot-proxy/**"
+"extensions: dashboard-launcher":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/dashboard-launcher/**"
 "extensions: diagnostics-otel":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/dashboard-launcher/README.md
+++ b/extensions/dashboard-launcher/README.md
@@ -1,0 +1,68 @@
+# @openclaw/dashboard-launcher
+
+Supervises the Mission Control Next.js dashboard via top-level `openclaw dashboard` verbs. The extension is purely a process supervisor — Mission Control's source stays in its own repo; this extension reads its env-driven contract.
+
+## Verbs
+
+| Verb     | Description                                                             |
+| -------- | ----------------------------------------------------------------------- |
+| `start`  | Spawn `node server.js` (or `npm run dev` with `--dev`) and watch it     |
+| `stop`   | Flip the intent flag and SIGTERM the supervised pid (SIGKILL after 10s) |
+| `status` | Print PID, intent, port, public-mode flag, health probe, log tail       |
+| `logs`   | Tail the combined dashboard log                                         |
+
+## Required environment
+
+| Variable                  | Purpose                                                                  |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `OPENCLAW_DASHBOARD_PATH` | Absolute path to the Mission Control checkout (must contain `server.js`) |
+| `OPENCLAW_DASHBOARD_PORT` | Optional port override (default `3001`)                                  |
+| `MISSION_CONTROL_PUBLIC`  | `1` to launch in public mode; requires `MC_AUTH_TOKEN`                   |
+| `MC_AUTH_TOKEN`           | ≥32 hex chars when `MISSION_CONTROL_PUBLIC=1`                            |
+
+## Quick start
+
+```sh
+export OPENCLAW_DASHBOARD_PATH=/path/to/MissionControl
+openclaw dashboard start          # foreground supervisor; Ctrl-C to leave
+openclaw dashboard status         # in another shell
+openclaw dashboard logs --follow  # tail the combined log
+openclaw dashboard stop           # signal the supervisor to stop and exit
+```
+
+## Logs and state
+
+| Path                                 | Contents                         |
+| ------------------------------------ | -------------------------------- |
+| `~/.openclaw/logs/dashboard.out.log` | Mission Control stdout           |
+| `~/.openclaw/logs/dashboard.err.log` | Mission Control stderr           |
+| `~/.openclaw/dashboard.intent`       | `running` or `stopped`           |
+| `~/.openclaw/dashboard.pid`          | PID of the live supervised child |
+
+## Adoption guard
+
+`start` refuses if `:3001` is already bound by another process. Pass `--adopt` to record that PID as the supervised process (no spawn — pure status/log adoption). Useful when migrating from the standalone `com.missioncontrol.nextjs` launchd plist.
+
+## Migration from the launchd plist
+
+```sh
+launchctl bootout gui/$UID/com.missioncontrol.nextjs
+openclaw dashboard start
+```
+
+Operators who prefer launchd-only management can keep doing exactly what they did — this extension is additive.
+
+## Boot guard
+
+When `MISSION_CONTROL_PUBLIC=1`, the extension refuses to spawn unless `MC_AUTH_TOKEN` is at least 32 hex characters. The intent is to fail fast with a clear message instead of letting the child boot-loop on Mission Control's own guard.
+
+## Restart policy
+
+- Backoff ladder: 1s, 2s, 4s, 8s, 60s ceiling.
+- Reset to 1s after 5 minutes of clean uptime.
+- Stop intent (`~/.openclaw/dashboard.intent` = `stopped`) breaks the loop on the next iteration.
+
+## Limitations
+
+- Logs are not rotated automatically; clear them with `: > ~/.openclaw/logs/dashboard.out.log` if they grow.
+- The supervisor itself is foreground — when the operator's shell exits, supervision ends. For boot persistence either keep using the launchd plist or wrap `openclaw dashboard start` in your own service manager.

--- a/extensions/dashboard-launcher/RECON-NOTES.md
+++ b/extensions/dashboard-launcher/RECON-NOTES.md
@@ -1,0 +1,72 @@
+# RECON-NOTES — `dashboard-launcher` extension
+
+> Phase C planning artefact. Confirms / corrects assumptions in
+> `(MissionControl) docs/plans/2026-04-25-004-feat-openclaw-dashboard-extension-plan.md`
+> before Units 2–5 land. Delete or archive once that PR ships.
+
+## Plugin SDK landing pad — confirmed
+
+| Concern                                | Reality                                                                                                                                                                                                                                                         | Source                                                                                                                                                                                              |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Top-level CLI verb registration        | `api.registerCli((ctx) => …, { commands: ["dashboard"] })` from inside `register(api)`. The registrar receives `{ program }` (Commander.js) and adds subcommands directly.                                                                                      | `src/plugins/types.ts:2084`, examples in `extensions/browser/plugin-registration.ts:35`, `extensions/memory-core/index.ts:61`, `extensions/voice-call/index.ts:597`, `extensions/qa-lab/index.ts:9` |
+| Plugin entry shape                     | `definePluginEntry({ id, name, description, register })` from `openclaw/plugin-sdk/plugin-entry`. Entry file is `index.ts` at the package root.                                                                                                                 | `src/plugin-sdk/plugin-entry.ts`, `extensions/diagnostics-otel/index.ts`                                                                                                                            |
+| Manifest                               | `openclaw.plugin.json` (id + configSchema) **plus** `package.json` `openclaw` block (extensions, runtimeExtensions, compat.pluginApi, build.openclawVersion).                                                                                                   | `extensions/diagnostics-otel/{openclaw.plugin.json,package.json}`                                                                                                                                   |
+| `nodeHostCommands` ≠ CLI verbs         | `nodeHostCommands` are gateway-routed JSON-RPC commands (`{ command, cap, handle(paramsJSON) }`). Wrong tool for `openclaw dashboard start`. Use `registerCli` instead.                                                                                         | `src/plugins/types.ts:1931`, `extensions/browser/plugin-registration.ts`                                                                                                                            |
+| `registerService` for long-lived loops | `OpenClawPluginService` has `start(ctx)` / `stop(ctx)`. **NOT** the right model for the supervisor — the supervisor only runs while the user is shell-blocked on `openclaw dashboard start`, not as a gateway-resident service. Stay inline in the CLI handler. | `src/plugins/types.ts:1976`                                                                                                                                                                         |
+
+**Implication:** Plan 004 Unit 5's "modify `src/cli/command-catalog.ts`" assumption was overly cautious. We need to add a `commandPath: ["dashboard"]` entry to that catalog **only** for policy hints (`loadPlugins: "always"` so the extension is loaded when the verb is invoked). Command _behaviour_ lives entirely inside the extension.
+
+## CODEOWNERS — `src/cli/command-catalog.ts`
+
+`grep -E '^/src/cli' .github/CODEOWNERS` — no rule. The file falls through to the default owners (no explicit reviewer pinned). The secops block (`@openclaw/secops`) covers `*auth*`, `*secret*`, security paths — adding a non-security `commandPath: ["dashboard"]` row should not trigger it.
+
+**Caveat:** the openclaw `AGENTS.md` says "Larger behavior/product/security/ownership: owner ask/review." A new top-level CLI verb is a public surface, so even without a CODEOWNERS rule, the maintainer should be looped in via PR review before this lands. **No emergency bypass.**
+
+## `openclaw status` row contribution — research deferred
+
+`grep -rn "openclaw status\|registerStatus" src/gateway src/cli` did not turn up an obvious `api.registerStatus(...)` API. R8 ("`openclaw status` gains a `dashboard:` row") is therefore **deferred to a follow-up plan** rather than scoped into this extension. The standalone `openclaw dashboard status` verb (Unit 4) is sufficient for v1.
+
+## Existing extensions to mirror
+
+- **Closest analog**: `extensions/qa-lab/` (small extension that registers a CLI command via `api.registerCli`, no provider/channel surface). Mirror its `package.json`, `index.ts`, `openclaw.plugin.json` shape.
+- **CLI registration shape**: `extensions/browser/plugin-registration.ts:35` — `api.registerCli(({ program }) => registerBrowserCli(program), { commands: ["browser"] })`.
+
+## Process supervision precedent
+
+`grep -l "child_process" extensions/*/` shows a few extensions spawn child processes (codex, discord, feishu, google-meet, bluebubbles), but none run a long-lived restart-on-crash supervisor in the foreground of a CLI invocation. Plan 004's `supervisor.ts` is novel — no in-tree pattern to mirror.
+
+**Implication:** the supervisor needs its own focused tests (covered by the plan's test scenarios in Unit 3). Existing extensions don't tell us anything about behaviour-under-launchd-supervision; Mission Control's launchd plist is the only such precedent and that lives in the operator's `~/Library/LaunchAgents/`, not in either repo.
+
+## Documentation surface checklist
+
+Per the openclaw repo `AGENTS.md` "New channel/plugin/app/doc surface: update `.github/labeler.yml` + GH labels":
+
+- [ ] Add `dashboard-launcher: extensions/dashboard-launcher/**` to `.github/labeler.yml`
+- [ ] Create the matching GH label (`area:dashboard-launcher` or whatever convention the repo uses — verify against existing labels before opening the PR)
+- [ ] If `extensions/AGENTS.md` lists known extensions, add a one-liner there too
+- [ ] If a new `AGENTS.md` is added inside the extension, also add a sibling `CLAUDE.md` symlink (per repo convention)
+
+## Repo gates the PR will face
+
+| Gate                                                         | Why this PR triggers it                                  |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| `pnpm check:changed` (extension prod lane)                   | New extension prod code                                  |
+| `pnpm test:changed` (extension test lane)                    | New `extensions/dashboard-launcher/test/*.test.ts` files |
+| `pnpm tsgo` (typecheck via tsgo only — never `tsc --noEmit`) | TS code                                                  |
+| `pnpm build`                                                 | New extension shipped as part of the bundle              |
+| `pnpm check:architecture`                                    | New extension boundary-checks                            |
+
+## Open questions for the maintainer review
+
+1. Should the new top-level verb be `openclaw dashboard` or namespaced under an existing parent verb? (Plan picks `openclaw dashboard`; verify against repo's CLI taxonomy before merge.)
+2. Acceptable to defer R8 (status-row contribution) to a follow-up plan once the `registerStatus` SDK seam is confirmed?
+3. The plan's `--adopt` flag uses `lsof` — acceptable, or should it be implemented in pure Node? (No precedent in the repo either way.)
+
+## Verdict
+
+Plan 004 is implementable as written, with two adjustments:
+
+1. **Don't touch `src/cli/command-catalog.ts` first.** Try `api.registerCli` only and rely on the SDK's lazy-load path. Add a catalog row only if discovery / banner / load-policy regression appears.
+2. **Defer R8** (`openclaw status` row) to a follow-up. Keep this extension scoped to its own `dashboard` verb.
+
+With those, Units 2–5 can proceed without architectural surprises. Estimated landing footprint: 1 new extension (~10 files), 0 changes to `src/cli/`, 1 small change to `.github/labeler.yml`.

--- a/extensions/dashboard-launcher/index.ts
+++ b/extensions/dashboard-launcher/index.ts
@@ -1,0 +1,25 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerDashboardCli } from "./src/command.js";
+
+export default definePluginEntry({
+  id: "dashboard-launcher",
+  name: "Dashboard Launcher",
+  description:
+    "Supervise the Mission Control dashboard via `openclaw dashboard {start|stop|status|logs}`",
+  register(api) {
+    api.registerCli(
+      ({ program }) => {
+        registerDashboardCli(program);
+      },
+      {
+        descriptors: [
+          {
+            name: "dashboard",
+            description: "Supervise the Mission Control dashboard companion",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+  },
+});

--- a/extensions/dashboard-launcher/openclaw.plugin.json
+++ b/extensions/dashboard-launcher/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "dashboard-launcher",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/dashboard-launcher/package.json
+++ b/extensions/dashboard-launcher/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openclaw/dashboard-launcher",
+  "version": "2026.4.25",
+  "private": true,
+  "description": "OpenClaw dashboard launcher — supervises the Mission Control Next.js companion",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.25"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.25"
+    },
+    "build": {
+      "openclawVersion": "2026.4.25"
+    }
+  }
+}

--- a/extensions/dashboard-launcher/src/command.ts
+++ b/extensions/dashboard-launcher/src/command.ts
@@ -1,0 +1,147 @@
+import { execSync } from "node:child_process";
+import type { Command } from "commander";
+import { tailLogs } from "./logs.js";
+import { dashboardPath } from "./paths.js";
+import { formatStatus, status } from "./status.js";
+import { isProcessAlive, readPid, runSupervisor, stopSupervisor, writePid } from "./supervisor.js";
+
+const DEFAULT_PORT = 3001;
+
+interface StartOptions {
+  port?: string;
+  adopt?: boolean;
+  public?: boolean;
+  dev?: boolean;
+}
+
+interface LogsOptions {
+  follow?: boolean;
+  lines?: string;
+  err?: boolean;
+}
+
+interface StatusOptions {
+  port?: string;
+  public?: boolean;
+}
+
+function resolvePort(flag: string | undefined): number {
+  const fromFlag = flag != null ? Number(flag) : Number.NaN;
+  if (Number.isFinite(fromFlag) && fromFlag > 0) {
+    return fromFlag;
+  }
+  const fromEnv = process.env.OPENCLAW_DASHBOARD_PORT;
+  if (fromEnv != null) {
+    const parsed = Number(fromEnv);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_PORT;
+}
+
+function lsofPid(port: number): number | null {
+  try {
+    const out = execSync(`lsof -tiTCP:${port} -sTCP:LISTEN`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!out) {
+      return null;
+    }
+    const pid = Number.parseInt(out.split(/\s+/)[0], 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function registerDashboardCli(program: Command): void {
+  const dashboard = program
+    .command("dashboard")
+    .description("Supervise the Mission Control dashboard (Next.js companion)");
+
+  dashboard
+    .command("start")
+    .description("Spawn Mission Control and supervise it until stopped")
+    .option("--port <port>", "Override port (default 3001 / OPENCLAW_DASHBOARD_PORT)")
+    .option("--adopt", "Take over an already-running dashboard on the target port", false)
+    .option("--public", "Run with MISSION_CONTROL_PUBLIC=1 (requires MC_AUTH_TOKEN)", false)
+    .option("--dev", "Spawn 'npm run dev' instead of 'node server.js'", false)
+    .action(async (opts: StartOptions) => {
+      const port = resolvePort(opts.port);
+      const cwd = dashboardPath();
+      const incumbent = lsofPid(port);
+      if (incumbent != null && incumbent !== process.pid) {
+        if (opts.adopt) {
+          writePid(incumbent);
+          process.stdout.write(
+            `adopted dashboard already running on :${port} (pid ${incumbent})\n`,
+          );
+          return;
+        }
+        process.stderr.write(
+          `dashboard already running on :${port} (pid ${incumbent}). Pass --adopt to take it over, or stop it first.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const publicMode = Boolean(opts.public) || process.env.MISSION_CONTROL_PUBLIC === "1";
+      await runSupervisor({
+        env: {
+          port,
+          publicMode,
+          authToken: process.env.MC_AUTH_TOKEN,
+          dev: Boolean(opts.dev),
+        },
+        cwd,
+      });
+    });
+
+  dashboard
+    .command("stop")
+    .description("Stop the supervised dashboard process")
+    .action(async () => {
+      const result = await stopSupervisor();
+      if (result.pid == null) {
+        process.stdout.write("no dashboard running\n");
+      } else {
+        process.stdout.write(`stopped dashboard (pid ${result.pid})\n`);
+      }
+    });
+
+  dashboard
+    .command("status")
+    .description("Report the supervised dashboard's PID, intent, port, and health")
+    .option("--port <port>", "Probe a non-default port")
+    .option("--public", "Treat the dashboard as public-mode for the auth header", false)
+    .action(async (opts: StatusOptions) => {
+      const port = resolvePort(opts.port);
+      const publicMode = Boolean(opts.public) || process.env.MISSION_CONTROL_PUBLIC === "1";
+      const result = await status({
+        port,
+        publicMode,
+        authToken: process.env.MC_AUTH_TOKEN,
+      });
+      process.stdout.write(`${formatStatus(result)}\n`);
+      const pid = readPid();
+      if (pid != null && !isProcessAlive(pid)) {
+        process.exitCode = 1;
+      }
+    });
+
+  dashboard
+    .command("logs")
+    .description("Tail the supervised dashboard's combined log")
+    .option("--follow", "Stream new lines as they're written", false)
+    .option("--lines <n>", "Initial line count (default 50)")
+    .option("--err", "Tail dashboard.err.log instead of dashboard.out.log", false)
+    .action(async (opts: LogsOptions) => {
+      const lines = opts.lines != null ? Number(opts.lines) : undefined;
+      await tailLogs({
+        follow: Boolean(opts.follow),
+        lines: Number.isFinite(lines) ? lines : undefined,
+        stream: opts.err ? "err" : "out",
+      });
+    });
+}

--- a/extensions/dashboard-launcher/src/logs.ts
+++ b/extensions/dashboard-launcher/src/logs.ts
@@ -1,0 +1,91 @@
+import { createReadStream, existsSync, statSync, watch as fsWatch } from "node:fs";
+import { createInterface } from "node:readline";
+import { logPaths } from "./paths.js";
+
+export interface TailOptions {
+  follow?: boolean;
+  lines?: number;
+  /** "out" (default) reads dashboard.out.log; "err" reads dashboard.err.log. */
+  stream?: "out" | "err";
+  /** Output sink (defaults to process.stdout). */
+  out?: NodeJS.WritableStream;
+  /** Override file path resolution for tests. */
+  filePath?: string;
+}
+
+function resolveLogFile(opts: TailOptions): string {
+  if (opts.filePath) {
+    return opts.filePath;
+  }
+  const paths = logPaths();
+  return opts.stream === "err" ? paths.errLog : paths.outLog;
+}
+
+async function readLastLines(file: string, count: number): Promise<string[]> {
+  return await new Promise((resolve) => {
+    const buf: string[] = [];
+    const rl = createInterface({ input: createReadStream(file, { encoding: "utf8" }) });
+    rl.on("line", (line) => {
+      buf.push(line);
+      if (buf.length > count) {
+        buf.shift();
+      }
+    });
+    rl.on("close", () => resolve(buf));
+    rl.on("error", () => resolve(buf));
+  });
+}
+
+export async function tailLogs(opts: TailOptions = {}): Promise<{ exitCode: number }> {
+  const sink = opts.out ?? process.stdout;
+  const file = resolveLogFile(opts);
+  const lines = opts.lines ?? 50;
+
+  if (!existsSync(file)) {
+    sink.write(`no logs yet at ${file}\n`);
+    return { exitCode: 0 };
+  }
+
+  const tail = await readLastLines(file, lines);
+  for (const line of tail) {
+    sink.write(`${line}\n`);
+  }
+
+  if (!opts.follow) {
+    return { exitCode: 0 };
+  }
+
+  return await new Promise((resolve) => {
+    let position = statSync(file).size;
+    const watcher = fsWatch(file, (event) => {
+      if (event !== "change") {
+        return;
+      }
+      const size = (() => {
+        try {
+          return statSync(file).size;
+        } catch {
+          return position;
+        }
+      })();
+      if (size < position) {
+        position = 0;
+      }
+      if (size <= position) {
+        return;
+      }
+      const stream = createReadStream(file, { start: position, end: size - 1, encoding: "utf8" });
+      stream.on("data", (chunk) => sink.write(chunk));
+      stream.on("end", () => {
+        position = size;
+      });
+    });
+
+    const cleanup = () => {
+      watcher.close();
+      resolve({ exitCode: 0 });
+    };
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
+  });
+}

--- a/extensions/dashboard-launcher/src/paths.ts
+++ b/extensions/dashboard-launcher/src/paths.ts
@@ -1,0 +1,67 @@
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export class DashboardPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DashboardPathError";
+  }
+}
+
+export interface DashboardLogPaths {
+  outLog: string;
+  errLog: string;
+}
+
+const ENV_KEY = "OPENCLAW_DASHBOARD_PATH";
+
+function openclawHome(): string {
+  return resolve(homedir(), ".openclaw");
+}
+
+export function intentFile(): string {
+  return resolve(openclawHome(), "dashboard.intent");
+}
+
+export function pidFile(): string {
+  return resolve(openclawHome(), "dashboard.pid");
+}
+
+export function logPaths(): DashboardLogPaths {
+  const dir = resolve(openclawHome(), "logs");
+  return {
+    outLog: resolve(dir, "dashboard.out.log"),
+    errLog: resolve(dir, "dashboard.err.log"),
+  };
+}
+
+export function dashboardPath(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = env[ENV_KEY];
+  if (!raw || raw.trim() === "") {
+    throw new DashboardPathError(
+      `${ENV_KEY} is not set. Point it at the Mission Control checkout (the directory containing server.js).`,
+    );
+  }
+  const normalized = resolve(raw.trim());
+  let stat;
+  try {
+    stat = statSync(normalized);
+  } catch {
+    throw new DashboardPathError(`${ENV_KEY}=${raw} does not exist on disk.`);
+  }
+  if (!stat.isDirectory()) {
+    throw new DashboardPathError(`${ENV_KEY}=${raw} is not a directory.`);
+  }
+  validateMissionControlRoot(normalized);
+  return normalized;
+}
+
+export function validateMissionControlRoot(dir: string): void {
+  const serverEntry = resolve(dir, "server.js");
+  if (!existsSync(serverEntry)) {
+    throw new DashboardPathError(
+      `${dir} does not look like Mission Control: missing server.js. Set ${ENV_KEY} to the Mission Control checkout root.`,
+    );
+  }
+}

--- a/extensions/dashboard-launcher/src/status.ts
+++ b/extensions/dashboard-launcher/src/status.ts
@@ -1,0 +1,133 @@
+import { readFileSync, statSync } from "node:fs";
+import { logPaths } from "./paths.js";
+import { isProcessAlive, readIntent, readPid } from "./supervisor.js";
+
+export type Health =
+  | { state: "ok" }
+  | { state: "unauthorized" }
+  | { state: "unreachable"; reason: string }
+  | { state: "http_error"; status: number };
+
+export interface DashboardStatus {
+  intent: "running" | "stopped";
+  pid: number | null;
+  pidAlive: boolean;
+  uptimeMs: number | null;
+  port: number;
+  publicMode: boolean;
+  health: Health | null;
+  logTail: string[];
+}
+
+export interface StatusOptions {
+  port: number;
+  publicMode: boolean;
+  authToken?: string;
+  /** Override fetch for tests. */
+  fetchFn?: typeof fetch;
+  /** Probe timeout in ms (default 2_000). */
+  probeTimeoutMs?: number;
+  /** Number of trailing log lines to include. */
+  logTailLines?: number;
+}
+
+export async function probeHealth(opts: StatusOptions): Promise<Health> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const url = `http://127.0.0.1:${opts.port}/api/fleet-summary`;
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs ?? 2000);
+  const headers: Record<string, string> = {};
+  if (opts.publicMode && opts.authToken) {
+    headers.Authorization = `Bearer ${opts.authToken}`;
+  }
+  try {
+    const res = await fetchFn(url, { signal: ctrl.signal, headers });
+    if (res.status === 401 || res.status === 403) {
+      return { state: "unauthorized" };
+    }
+    if (!res.ok) {
+      return { state: "http_error", status: res.status };
+    }
+    return { state: "ok" };
+  } catch (err) {
+    return { state: "unreachable", reason: (err as Error).message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readTail(file: string, lines: number): string[] {
+  try {
+    const raw = readFileSync(file, "utf8");
+    const all = raw.split(/\r?\n/);
+    while (all.length > 0 && all[all.length - 1] === "") {
+      all.pop();
+    }
+    return all.slice(Math.max(0, all.length - lines));
+  } catch {
+    return [];
+  }
+}
+
+export async function status(opts: StatusOptions): Promise<DashboardStatus> {
+  const intent = readIntent();
+  const pid = readPid();
+  const pidAlive = pid != null && isProcessAlive(pid);
+  let uptimeMs: number | null = null;
+  if (pid != null && pidAlive) {
+    try {
+      const stat = statSync(`/proc/${pid}`);
+      uptimeMs = Date.now() - stat.mtimeMs;
+    } catch {
+      uptimeMs = null;
+    }
+  }
+  const tail = readTail(logPaths().outLog, opts.logTailLines ?? 5);
+  const health = pidAlive ? await probeHealth(opts) : null;
+  return {
+    intent,
+    pid,
+    pidAlive,
+    uptimeMs,
+    port: opts.port,
+    publicMode: opts.publicMode,
+    health,
+    logTail: tail,
+  };
+}
+
+export function formatStatus(s: DashboardStatus): string {
+  const lines: string[] = [];
+  lines.push(`dashboard intent: ${s.intent}`);
+  lines.push(
+    `pid:              ${s.pid ?? "—"} ${s.pid != null ? (s.pidAlive ? "(alive)" : "(dead)") : ""}`.trimEnd(),
+  );
+  lines.push(`port:             ${s.port}`);
+  lines.push(`public mode:      ${s.publicMode ? "yes" : "no"}`);
+  lines.push(`health:           ${describeHealth(s.health)}`);
+  if (s.logTail.length > 0) {
+    lines.push("recent log:");
+    for (const line of s.logTail) {
+      lines.push(`  ${line}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function describeHealth(health: Health | null): string {
+  if (!health) {
+    return "n/a";
+  }
+  switch (health.state) {
+    case "ok":
+      return "healthy";
+    case "unauthorized":
+      return "unauthorized (check MC_AUTH_TOKEN)";
+    case "unreachable":
+      return `unreachable (${health.reason})`;
+    case "http_error":
+      return `http_${health.status}`;
+    default:
+      return "unknown";
+  }
+}

--- a/extensions/dashboard-launcher/src/supervisor.ts
+++ b/extensions/dashboard-launcher/src/supervisor.ts
@@ -1,0 +1,290 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { dashboardPath, intentFile, logPaths, pidFile } from "./paths.js";
+
+export class BootGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BootGuardError";
+  }
+}
+
+export type Intent = "running" | "stopped";
+
+export interface SupervisorEnv {
+  port: number;
+  publicMode: boolean;
+  authToken?: string;
+  dev?: boolean;
+}
+
+export interface SpawnOnceResult {
+  child: ChildProcess;
+  exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+export interface SpawnDeps {
+  spawnFn?: typeof spawn;
+}
+
+const HEX_TOKEN_RE = /^[0-9a-fA-F]+$/;
+
+export function validateBootGuard(env: SupervisorEnv): void {
+  if (!env.publicMode) {
+    return;
+  }
+  const token = env.authToken ?? "";
+  if (token.length < 32 || !HEX_TOKEN_RE.test(token)) {
+    throw new BootGuardError(
+      "MISSION_CONTROL_PUBLIC=1 requires MC_AUTH_TOKEN to be at least 32 hex characters. Refusing to spawn.",
+    );
+  }
+}
+
+const BACKOFF_LADDER = [1, 2, 4, 8, 60] as const;
+const CLEAN_UPTIME_RESET_MS = 5 * 60 * 1000;
+
+export interface BackoffState {
+  consecutiveCrashes: number;
+  lastUptimeMs: number;
+}
+
+/** Pick the next restart delay (seconds) given the previous run's uptime. */
+export function nextBackoff(state: BackoffState): {
+  delaySeconds: number;
+  nextState: BackoffState;
+} {
+  if (state.lastUptimeMs >= CLEAN_UPTIME_RESET_MS) {
+    return {
+      delaySeconds: BACKOFF_LADDER[0],
+      nextState: { consecutiveCrashes: 1, lastUptimeMs: 0 },
+    };
+  }
+  const idx = Math.min(state.consecutiveCrashes, BACKOFF_LADDER.length - 1);
+  const delaySeconds = BACKOFF_LADDER[idx];
+  return {
+    delaySeconds,
+    nextState: { consecutiveCrashes: state.consecutiveCrashes + 1, lastUptimeMs: 0 },
+  };
+}
+
+function buildChildEnv(supervisorEnv: SupervisorEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, PORT: String(supervisorEnv.port) };
+  if (supervisorEnv.publicMode) {
+    env.MISSION_CONTROL_PUBLIC = "1";
+  }
+  if (supervisorEnv.authToken) {
+    env.MC_AUTH_TOKEN = supervisorEnv.authToken;
+  }
+  return env;
+}
+
+function ensureDir(file: string): void {
+  const dir = dirname(file);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function spawnOnce(
+  cwd: string,
+  supervisorEnv: SupervisorEnv,
+  deps: SpawnDeps = {},
+): SpawnOnceResult {
+  validateBootGuard(supervisorEnv);
+  const spawnFn = deps.spawnFn ?? spawn;
+  const command = supervisorEnv.dev ? "npm" : "node";
+  const args = supervisorEnv.dev ? ["run", "dev"] : ["server.js"];
+  const opts: SpawnOptions = {
+    cwd,
+    env: buildChildEnv(supervisorEnv),
+    stdio: ["ignore", "pipe", "pipe"],
+  };
+
+  const { outLog, errLog } = logPaths();
+  ensureDir(outLog);
+  const outStream = createWriteStream(outLog, { flags: "a" });
+  const errStream = createWriteStream(errLog, { flags: "a" });
+
+  const child = spawnFn(command, args, opts);
+  child.stdout?.pipe(outStream);
+  child.stderr?.pipe(errStream);
+
+  const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.on("error", (err) => {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          reject(new BootGuardError(`Failed to spawn '${command}': binary not found on PATH.`));
+        } else {
+          reject(err);
+        }
+      });
+      child.on("exit", (code, signal) => resolve({ code, signal }));
+    },
+  );
+
+  return { child, exitPromise };
+}
+
+export function readIntent(): Intent {
+  try {
+    const raw = readFileSync(intentFile(), "utf8").trim();
+    return raw === "stopped" ? "stopped" : "running";
+  } catch {
+    return "stopped";
+  }
+}
+
+export function writeIntent(intent: Intent): void {
+  const file = intentFile();
+  ensureDir(file);
+  writeFileSync(file, intent);
+}
+
+export function writePid(pid: number): void {
+  const file = pidFile();
+  ensureDir(file);
+  writeFileSync(file, String(pid));
+}
+
+export function readPid(): number | null {
+  try {
+    const raw = readFileSync(pidFile(), "utf8").trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPid(): void {
+  try {
+    unlinkSync(pidFile());
+  } catch {
+    /* already gone */
+  }
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export interface RunSupervisorOptions {
+  env: SupervisorEnv;
+  /** Override path resolution for tests. */
+  cwd?: string;
+  /** Inject deterministic dependencies for tests. */
+  deps?: SpawnDeps & {
+    sleep?: (ms: number) => Promise<void>;
+    intentReader?: () => Intent;
+    now?: () => number;
+  };
+}
+
+export async function runSupervisor(opts: RunSupervisorOptions): Promise<void> {
+  const env = opts.env;
+  validateBootGuard(env);
+  const cwd = opts.cwd ?? dashboardPath();
+  const deps = opts.deps ?? {};
+  const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const readIntentFn = deps.intentReader ?? readIntent;
+  const now = deps.now ?? Date.now;
+
+  writeIntent("running");
+
+  let state: BackoffState = { consecutiveCrashes: 0, lastUptimeMs: 0 };
+
+  while (readIntentFn() === "running") {
+    const startedAt = now();
+    let exit: { code: number | null; signal: NodeJS.Signals | null };
+    try {
+      const { child, exitPromise } = spawnOnce(cwd, env, deps);
+      if (child.pid) {
+        writePid(child.pid);
+      }
+      exit = await exitPromise;
+    } catch (err) {
+      clearPid();
+      throw err;
+    }
+
+    clearPid();
+    if (readIntentFn() === "stopped") {
+      return;
+    }
+
+    state.lastUptimeMs = now() - startedAt;
+    const { delaySeconds, nextState } = nextBackoff(state);
+    state = nextState;
+    void exit;
+    await sleep(delaySeconds * 1000);
+  }
+}
+
+export interface StopOptions {
+  /** Total milliseconds to wait for SIGTERM to take effect before SIGKILL. */
+  termGraceMs?: number;
+  /** Inject signalling for tests. */
+  signal?: (pid: number, sig: NodeJS.Signals | 0) => void;
+  /** Inject liveness probe for tests. */
+  alive?: (pid: number) => boolean;
+  /** Inject sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export async function stopSupervisor(
+  opts: StopOptions = {},
+): Promise<{ stopped: boolean; pid: number | null }> {
+  writeIntent("stopped");
+  const pid = readPid();
+  if (pid == null) {
+    return { stopped: true, pid: null };
+  }
+
+  const grace = opts.termGraceMs ?? 10_000;
+  const sendSignal = opts.signal ?? ((p, s) => process.kill(p, s));
+  const isAlive = opts.alive ?? isProcessAlive;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  try {
+    sendSignal(pid, "SIGTERM");
+  } catch {
+    clearPid();
+    return { stopped: true, pid };
+  }
+
+  const pollMs = Math.min(250, grace);
+  let waited = 0;
+  while (waited < grace) {
+    if (!isAlive(pid)) {
+      clearPid();
+      return { stopped: true, pid };
+    }
+    await sleep(pollMs);
+    waited += pollMs;
+  }
+
+  if (isAlive(pid)) {
+    try {
+      sendSignal(pid, "SIGKILL");
+    } catch {
+      /* already exited */
+    }
+  }
+  clearPid();
+  return { stopped: true, pid };
+}

--- a/extensions/dashboard-launcher/test/command.test.ts
+++ b/extensions/dashboard-launcher/test/command.test.ts
@@ -1,0 +1,48 @@
+import { Command } from "commander";
+import { describe, expect, test } from "vitest";
+import { registerDashboardCli } from "../src/command.js";
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerDashboardCli(program);
+  return program;
+}
+
+describe("registerDashboardCli", () => {
+  test("registers all four verbs", () => {
+    const program = buildProgram();
+    const dashboard = program.commands.find((c) => c.name() === "dashboard");
+    expect(dashboard).toBeDefined();
+    const verbs = (dashboard?.commands ?? []).map((c) => c.name()).toSorted();
+    expect(verbs).toEqual(["logs", "start", "status", "stop"]);
+  });
+
+  test("dashboard --help lists every verb", () => {
+    const program = buildProgram();
+    const dashboard = program.commands.find((c) => c.name() === "dashboard");
+    const helpText = dashboard?.helpInformation() ?? "";
+    expect(helpText).toContain("start");
+    expect(helpText).toContain("stop");
+    expect(helpText).toContain("status");
+    expect(helpText).toContain("logs");
+  });
+
+  test("start accepts --port, --adopt, --public, --dev flags", () => {
+    const program = buildProgram();
+    const start = program.commands
+      .find((c) => c.name() === "dashboard")
+      ?.commands.find((c) => c.name() === "start");
+    const flags = (start?.options ?? []).map((o) => o.long);
+    expect(flags).toEqual(expect.arrayContaining(["--port", "--adopt", "--public", "--dev"]));
+  });
+
+  test("logs accepts --follow, --lines, --err flags", () => {
+    const program = buildProgram();
+    const logs = program.commands
+      .find((c) => c.name() === "dashboard")
+      ?.commands.find((c) => c.name() === "logs");
+    const flags = (logs?.options ?? []).map((o) => o.long);
+    expect(flags).toEqual(expect.arrayContaining(["--follow", "--lines", "--err"]));
+  });
+});

--- a/extensions/dashboard-launcher/test/logs.test.ts
+++ b/extensions/dashboard-launcher/test/logs.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { tailLogs } from "../src/logs.js";
+
+let tmpHome: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "dashboard-launcher-logs-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  process.env.HOME = prevHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function captureSink(): { sink: PassThrough; read: () => string } {
+  const sink = new PassThrough();
+  const chunks: Buffer[] = [];
+  sink.on("data", (c: Buffer) => chunks.push(c));
+  return { sink, read: () => Buffer.concat(chunks).toString("utf8") };
+}
+
+describe("tailLogs", () => {
+  test("returns last N lines", async () => {
+    const file = join(tmpHome, "out.log");
+    writeFileSync(file, ["one", "two", "three", "four"].join("\n") + "\n");
+    const { sink, read } = captureSink();
+    const result = await tailLogs({ filePath: file, lines: 2, out: sink });
+    expect(result.exitCode).toBe(0);
+    expect(read()).toBe("three\nfour\n");
+  });
+
+  test("emits a friendly message when the log file is missing", async () => {
+    const missing = join(tmpHome, "no-such-log.log");
+    const { sink, read } = captureSink();
+    const result = await tailLogs({ filePath: missing, out: sink });
+    expect(result.exitCode).toBe(0);
+    expect(read()).toContain("no logs yet");
+  });
+
+  test("renders all lines when count exceeds line total", async () => {
+    const file = join(tmpHome, "small.log");
+    writeFileSync(file, "only one\n");
+    const { sink, read } = captureSink();
+    await tailLogs({ filePath: file, lines: 50, out: sink });
+    expect(read()).toBe("only one\n");
+  });
+});

--- a/extensions/dashboard-launcher/test/paths.test.ts
+++ b/extensions/dashboard-launcher/test/paths.test.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  DashboardPathError,
+  dashboardPath,
+  intentFile,
+  logPaths,
+  pidFile,
+  validateMissionControlRoot,
+} from "../src/paths.js";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "dashboard-launcher-paths-"));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeFakeMissionControl(name = "mc"): string {
+  const dir = join(tmpRoot, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "server.js"), "// stub");
+  return dir;
+}
+
+describe("dashboardPath", () => {
+  test("returns the absolute path when env points at a valid Mission Control directory", () => {
+    const dir = makeFakeMissionControl();
+    expect(dashboardPath({ OPENCLAW_DASHBOARD_PATH: dir })).toBe(resolve(dir));
+  });
+
+  test("normalizes a trailing slash", () => {
+    const dir = makeFakeMissionControl();
+    expect(dashboardPath({ OPENCLAW_DASHBOARD_PATH: `${dir}/` })).toBe(resolve(dir));
+  });
+
+  test("throws DashboardPathError when env is unset", () => {
+    expect(() => dashboardPath({})).toThrow(DashboardPathError);
+  });
+
+  test("throws DashboardPathError when env is empty string", () => {
+    expect(() => dashboardPath({ OPENCLAW_DASHBOARD_PATH: "   " })).toThrow(DashboardPathError);
+  });
+
+  test("throws when the path does not exist", () => {
+    const missing = join(tmpRoot, "nope");
+    expect(() => dashboardPath({ OPENCLAW_DASHBOARD_PATH: missing })).toThrow(/does not exist/);
+  });
+
+  test("throws when the path is a file, not a directory", () => {
+    const file = join(tmpRoot, "file.txt");
+    writeFileSync(file, "not a dir");
+    expect(() => dashboardPath({ OPENCLAW_DASHBOARD_PATH: file })).toThrow(/not a directory/);
+  });
+
+  test("throws with a Mission Control hint when server.js is missing", () => {
+    const dir = join(tmpRoot, "empty");
+    mkdirSync(dir, { recursive: true });
+    expect(() => dashboardPath({ OPENCLAW_DASHBOARD_PATH: dir })).toThrow(/missing server\.js/);
+  });
+});
+
+describe("validateMissionControlRoot", () => {
+  test("returns when server.js exists", () => {
+    const dir = makeFakeMissionControl();
+    expect(() => validateMissionControlRoot(dir)).not.toThrow();
+  });
+
+  test("throws when server.js is missing", () => {
+    const dir = join(tmpRoot, "missing-server");
+    mkdirSync(dir, { recursive: true });
+    expect(() => validateMissionControlRoot(dir)).toThrow(DashboardPathError);
+  });
+});
+
+describe("path helpers", () => {
+  test("logPaths returns absolute log paths under ~/.openclaw/logs", () => {
+    const { outLog, errLog } = logPaths();
+    expect(outLog.endsWith("/.openclaw/logs/dashboard.out.log")).toBe(true);
+    expect(errLog.endsWith("/.openclaw/logs/dashboard.err.log")).toBe(true);
+  });
+
+  test("intentFile and pidFile are under ~/.openclaw", () => {
+    expect(intentFile().endsWith("/.openclaw/dashboard.intent")).toBe(true);
+    expect(pidFile().endsWith("/.openclaw/dashboard.pid")).toBe(true);
+  });
+});

--- a/extensions/dashboard-launcher/test/status.test.ts
+++ b/extensions/dashboard-launcher/test/status.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { logPaths } from "../src/paths.js";
+import { formatStatus, probeHealth, status } from "../src/status.js";
+import { writeIntent, writePid } from "../src/supervisor.js";
+
+let tmpHome: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "dashboard-launcher-status-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  process.env.HOME = prevHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("probeHealth", () => {
+  test("ok on 200", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    const result = await probeHealth({
+      port: 3001,
+      publicMode: false,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ state: "ok" });
+  });
+
+  test("unauthorized on 401", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 401 }));
+    const result = await probeHealth({
+      port: 3001,
+      publicMode: true,
+      authToken: "token",
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result.state).toBe("unauthorized");
+  });
+
+  test("http_error on 500", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 500 }));
+    const result = await probeHealth({
+      port: 3001,
+      publicMode: false,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ state: "http_error", status: 500 });
+  });
+
+  test("unreachable when fetch throws", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const result = await probeHealth({
+      port: 3001,
+      publicMode: false,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result.state).toBe("unreachable");
+  });
+
+  test("sends bearer auth in public mode", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    await probeHealth({
+      port: 3001,
+      publicMode: true,
+      authToken: "secret",
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    const init = fetchFn.mock.calls[0]?.[1] as { headers: Record<string, string> };
+    expect(init.headers.Authorization).toBe("Bearer secret");
+  });
+});
+
+describe("status", () => {
+  test("reports stopped when intent flag is stopped", async () => {
+    writeIntent("stopped");
+    const result = await status({
+      port: 3001,
+      publicMode: false,
+      fetchFn: vi.fn() as unknown as typeof fetch,
+    });
+    expect(result.intent).toBe("stopped");
+    expect(result.health).toBeNull();
+  });
+
+  test("skips health probe when pid is dead", async () => {
+    writeIntent("running");
+    // Pid 2^31 - 1 cannot exist on any sane system; process.kill returns ESRCH.
+    writePid(2147483646);
+    const fetchFn = vi.fn();
+    const result = await status({
+      port: 3001,
+      publicMode: false,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(result.intent).toBe("running");
+    expect(result.pidAlive).toBe(false);
+    expect(result.health).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  test("includes log tail", async () => {
+    const { outLog } = logPaths();
+    mkdirSync(join(tmpHome, ".openclaw", "logs"), { recursive: true });
+    writeFileSync(outLog, "alpha\nbeta\ngamma\n");
+    writeIntent("stopped");
+
+    const result = await status({
+      port: 3001,
+      publicMode: false,
+      logTailLines: 2,
+      fetchFn: vi.fn() as unknown as typeof fetch,
+    });
+    expect(result.logTail).toEqual(["beta", "gamma"]);
+  });
+});
+
+describe("formatStatus", () => {
+  test("renders a useful summary", () => {
+    const out = formatStatus({
+      intent: "running",
+      pid: 1234,
+      pidAlive: true,
+      uptimeMs: 60_000,
+      port: 3001,
+      publicMode: true,
+      health: { state: "ok" },
+      logTail: ["last line"],
+    });
+    expect(out).toContain("dashboard intent: running");
+    expect(out).toContain("pid:");
+    expect(out).toContain("port:             3001");
+    expect(out).toContain("health:           healthy");
+    expect(out).toContain("last line");
+  });
+});

--- a/extensions/dashboard-launcher/test/supervisor.test.ts
+++ b/extensions/dashboard-launcher/test/supervisor.test.ts
@@ -1,0 +1,212 @@
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  BootGuardError,
+  nextBackoff,
+  runSupervisor,
+  stopSupervisor,
+  validateBootGuard,
+  writeIntent,
+  writePid,
+} from "../src/supervisor.js";
+
+let tmpHome: string;
+let prevHome: string | undefined;
+let prevDashboardPath: string | undefined;
+let mcRoot: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "dashboard-launcher-supervisor-"));
+  prevHome = process.env.HOME;
+  prevDashboardPath = process.env.OPENCLAW_DASHBOARD_PATH;
+  process.env.HOME = tmpHome;
+  mcRoot = join(tmpHome, "mc");
+  mkdirSync(mcRoot, { recursive: true });
+  writeFileSync(join(mcRoot, "server.js"), "// stub");
+  process.env.OPENCLAW_DASHBOARD_PATH = mcRoot;
+});
+
+afterEach(() => {
+  process.env.HOME = prevHome;
+  if (prevDashboardPath === undefined) {
+    delete process.env.OPENCLAW_DASHBOARD_PATH;
+  } else {
+    process.env.OPENCLAW_DASHBOARD_PATH = prevDashboardPath;
+  }
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("validateBootGuard", () => {
+  test("passes when public mode off", () => {
+    expect(() => validateBootGuard({ port: 3001, publicMode: false })).not.toThrow();
+  });
+
+  test("passes with a 32+ hex token in public mode", () => {
+    const token = "a".repeat(32);
+    expect(() =>
+      validateBootGuard({ port: 3001, publicMode: true, authToken: token }),
+    ).not.toThrow();
+  });
+
+  test("throws when public mode is on but token is missing", () => {
+    expect(() => validateBootGuard({ port: 3001, publicMode: true })).toThrow(BootGuardError);
+  });
+
+  test("throws when public mode is on but token is too short", () => {
+    expect(() => validateBootGuard({ port: 3001, publicMode: true, authToken: "abcd" })).toThrow(
+      BootGuardError,
+    );
+  });
+
+  test("throws when token is long enough but contains non-hex characters", () => {
+    expect(() =>
+      validateBootGuard({ port: 3001, publicMode: true, authToken: "z".repeat(40) }),
+    ).toThrow(BootGuardError);
+  });
+});
+
+describe("nextBackoff", () => {
+  test("first crash → 1s", () => {
+    const { delaySeconds } = nextBackoff({ consecutiveCrashes: 0, lastUptimeMs: 0 });
+    expect(delaySeconds).toBe(1);
+  });
+
+  test("walks 1, 2, 4, 8, 60 ladder", () => {
+    let state = { consecutiveCrashes: 0, lastUptimeMs: 0 };
+    const seen: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const result = nextBackoff(state);
+      seen.push(result.delaySeconds);
+      state = result.nextState;
+    }
+    expect(seen).toEqual([1, 2, 4, 8, 60, 60]);
+  });
+
+  test("clean uptime ≥5m resets to 1s", () => {
+    const { delaySeconds, nextState } = nextBackoff({
+      consecutiveCrashes: 4,
+      lastUptimeMs: 6 * 60 * 1000,
+    });
+    expect(delaySeconds).toBe(1);
+    expect(nextState.consecutiveCrashes).toBe(1);
+  });
+});
+
+class FakeChild extends EventEmitter {
+  pid = 4242;
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+}
+
+describe("runSupervisor loop", () => {
+  test("exits when intent flips to stopped", async () => {
+    const intents = ["running", "stopped"];
+    const intentReader = () => (intents.shift() ?? "stopped") as "running" | "stopped";
+    const child = new FakeChild();
+    const spawnFn = vi.fn(() => {
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+    });
+
+    await runSupervisor({
+      env: { port: 3001, publicMode: false },
+      cwd: mcRoot,
+      deps: {
+        spawnFn: spawnFn as unknown as typeof import("node:child_process").spawn,
+        intentReader,
+        sleep: () => Promise.resolve(),
+        now: () => 0,
+      },
+    });
+
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("respects backoff between crashes", async () => {
+    let crashes = 0;
+    const intentReader = (): "running" | "stopped" => (crashes >= 2 ? "stopped" : "running");
+    const spawnFn = vi.fn(() => {
+      const child = new FakeChild();
+      queueMicrotask(() => {
+        crashes += 1;
+        child.emit("exit", 1, null);
+      });
+      return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+    });
+    const sleep = vi.fn(() => Promise.resolve());
+
+    await runSupervisor({
+      env: { port: 3001, publicMode: false },
+      cwd: mcRoot,
+      deps: {
+        spawnFn: spawnFn as unknown as typeof import("node:child_process").spawn,
+        intentReader,
+        sleep,
+        now: () => 0,
+      },
+    });
+
+    expect(spawnFn.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+
+  test("rethrows BootGuardError when MISSION_CONTROL_PUBLIC=1 and token is missing", async () => {
+    await expect(
+      runSupervisor({
+        env: { port: 3001, publicMode: true },
+        cwd: mcRoot,
+      }),
+    ).rejects.toBeInstanceOf(BootGuardError);
+  });
+});
+
+describe("stopSupervisor", () => {
+  test("flips intent to stopped and returns when no pid file present", async () => {
+    const result = await stopSupervisor({});
+    expect(result.stopped).toBe(true);
+    expect(result.pid).toBeNull();
+  });
+
+  test("SIGTERMs the recorded pid and returns once the process is gone", async () => {
+    writeIntent("running");
+    writePid(99999);
+    let alive = true;
+    const signals: Array<[number, NodeJS.Signals | 0]> = [];
+
+    const result = await stopSupervisor({
+      termGraceMs: 1000,
+      signal: (pid, sig) => {
+        signals.push([pid, sig]);
+        if (sig === "SIGTERM") {
+          alive = false;
+        }
+      },
+      alive: () => alive,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(signals[0]).toEqual([99999, "SIGTERM"]);
+    expect(result.stopped).toBe(true);
+    expect(result.pid).toBe(99999);
+  });
+
+  test("escalates to SIGKILL when SIGTERM does not stop the process", async () => {
+    writeIntent("running");
+    writePid(88888);
+    const signals: Array<NodeJS.Signals | 0> = [];
+
+    await stopSupervisor({
+      termGraceMs: 50,
+      signal: (_pid, sig) => signals.push(sig),
+      alive: () => true,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(signals).toContain("SIGTERM");
+    expect(signals).toContain("SIGKILL");
+  });
+});

--- a/extensions/dashboard-launcher/tsconfig.json
+++ b/extensions/dashboard-launcher/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**", "./test/**"]
+}

--- a/extensions/dashboard-launcher/tsconfig.json
+++ b/extensions/dashboard-launcher/tsconfig.json
@@ -4,5 +4,13 @@
     "rootDir": "."
   },
   "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**", "./test/**"]
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/dashboard-launcher:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/deepgram:
     dependencies:
       ws:


### PR DESCRIPTION
## Summary

Adds a new bundled extension at `extensions/dashboard-launcher/` that registers a top-level `openclaw dashboard {start|stop|status|logs}` verb. The extension is purely a process supervisor for an external Mission Control Next.js dashboard (`OPENCLAW_DASHBOARD_PATH`) — no core internals are touched and no Mission Control source ships in this repo.

Why: the Mission Control companion dashboard currently runs only via a hand-installed launchd plist that is invisible to OpenClaw. Phase C of the fleet-command-center brainstorm calls for OpenClaw to manage the dashboard like any other peer process, with discoverable verbs, structured logs, restart-on-crash, and a health probe. This PR is that surface; it leaves the launchd plist alternative working untouched.

## What's in here

- 4 atomic commits, one per implementation unit:
  - **Unit 2** — path & log helpers (`src/paths.ts`)
  - **Unit 3** — supervisor (spawn/restart-on-crash with 1/2/4/8/60s backoff ladder, intent-flag stop, public-mode boot guard requiring 32-hex `MC_AUTH_TOKEN`)
  - **Unit 4** — status (PID + intent + bearer-aware `/api/fleet-summary` probe + log tail) and `tailLogs` with `--follow`
  - **Unit 5** — Commander wiring, `index.ts` SDK registration via `api.registerCli`, manifest, `package.json`, README, `.github/labeler.yml` row, `pnpm-lock.yaml` workspace link
- Recon notes from Unit 1 already on the branch (commit `b528665`) document the SDK landing pad and confirm that `nodeHostCommands` / `registerService` are the wrong seams here

## Boundaries respected

- Imports only `openclaw/plugin-sdk/*` and Commander; no `src/**`, no other extension's `src/**`, no relative escapes
- No changes to `src/cli/command-catalog.ts` — the SDK's `api.registerCli({ descriptors })` path covers verb discovery for v1 (recon notes section "Plugin SDK landing pad")
- R8 (`openclaw status` row) is **deferred** to a follow-up plan once a `registerStatus`-shaped seam is confirmed; v1 ships only the standalone `dashboard status` verb
- Mission Control source stays in its own repo — this extension reads its env-driven contract (`OPENCLAW_DASHBOARD_PATH`, `OPENCLAW_DASHBOARD_PORT`, `MISSION_CONTROL_PUBLIC`, `MC_AUTH_TOKEN`)

## Maintainer ask

A new top-level CLI verb is a public surface. Even though no `src/cli/` file is modified (so no CODEOWNERS rule fires), the recon notes flagged that maintainer review is appropriate before this lands. Specifically helpful to confirm:

1. `openclaw dashboard` as the top-level shape vs. nesting under an existing parent verb
2. That deferring R8 (status-row contribution) until the SDK seam is settled is acceptable for v1
3. Whether using `lsof -tiTCP:<port>` for the adoption guard is acceptable, or if a pure-Node port-bind probe is preferred

## Test plan

- [x] `pnpm test extensions/dashboard-launcher` — 41/41 pass (5 files: paths, supervisor, status, logs, command)
- [x] `pnpm tsgo:all` — clean
- [x] `pnpm build` — clean (extension builds with the bundle)
- [ ] Manual smoke on a Mission Control checkout: `OPENCLAW_DASHBOARD_PATH=… openclaw dashboard start` brings the dashboard up on `:3001`; `openclaw dashboard status` reports healthy; `openclaw dashboard stop` shuts it down within the 10s SIGTERM grace window
- [ ] Repo CI green (CI / Labeler / Workflow Sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)