### PR TITLE
fix(cron): finalize task ledger before clearing active-jobs flag (#71963)

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -583,8 +583,13 @@ export function applyJobResult(
 }
 
 function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOutcome): void {
-  clearCronJobActive(result.jobId);
+  // Finalize the task ledger BEFORE clearing the active-jobs flag. The task
+  // registry maintenance sweep treats cron tasks as "lost" when they are still
+  // running AND `isCronJobActive(jobId)` returns false — clearing the flag
+  // first opens a tiny but real window where an in-flight sweep can
+  // mis-attribute a successful run as lost. See #71963.
   tryFinishCronTaskRun(state, result);
+  clearCronJobActive(result.jobId);
   const store = state.store;
   if (!store) {
     return;


### PR DESCRIPTION
Fixes part of #71963.

## What
`applyOutcomeToStoredJob` currently clears the in-memory `active-jobs` flag *before* finalizing the cron run's task-ledger record. The registry maintenance sweep (60s timer) treats cron tasks as `lost / backing session missing` when they are still `running` AND `isCronJobActive(jobId)` returns `false`. The clear-then-finalize order opens a sub-millisecond window where an in-flight sweep can observe exactly that state and mark a successful cron run lost.

Swap the order: finalize the task ledger first, then clear the active-jobs flag. The active flag now vouches for the task right up until it has reached a terminal status, so the sweep can never observe the false-lost state in-process.

## Why this matches the report
The reporter (#71963) sees `Task error lost ... backing session missing` errors accumulating against `sessionTarget: "isolated"` cron jobs whose `lastRunStatus` is `ok`. Their proposal #2 — *"write the terminal task state before the isolated session is reaped"* — is exactly this change at the cron-side bookkeeping layer.

## Scope
- 7 lines, comment included.
- Existing cron timer/ops tests still pass (`timer.test.ts`, `timer.regression.test.ts`, `ops.test.ts`, `task-registry.maintenance.issue-60299.test.ts`).
- No public API change.

## What this does NOT fix
A second cause in the same report — cron tasks left in `running` state across **gateway restarts** — is not addressed here. After a restart the in-memory `active-jobs` set is empty, so any pre-existing `running` cron task records hit the same condition on the first sweep and get marked lost. Reconciling those needs a startup-time pass (e.g. cancel-with-reason or promote-to-succeeded based on `cronJob.lastRunAtMs`) and intentionally lives in a follow-up PR to keep this change reviewable.

The 883 `inconsistent_timestamps` warnings the reporter mentions are also a separate issue.

## Test
```
pnpm test src/cron/service/timer.test.ts src/cron/service/ops.test.ts \
  src/cron/service/timer.regression.test.ts \
  src/tasks/task-registry.maintenance.issue-60299.test.ts -- --run
# Test Files  4 passed (4)
# Tests       40 passed (40)
```
