### PR TITLE
fix(doctor): exclude trajectory sidecars from orphan transcript sweep (#71960)

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -302,6 +302,31 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
   });
 
+  // Regression for #71960: trajectory sidecars are referenced via
+  // `*.trajectory-path.json` rather than `sessions.json`, so doctor must
+  // not flag them as archivable orphan transcripts.
+  it("does not flag trajectory sidecars as orphan transcripts (#71960)", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    const sessionId = "b8fc0af0-1692-474b-b11e-636a8b8ab00f";
+    fs.writeFileSync(
+      path.join(sessionsDir, `${sessionId}.trajectory.jsonl`),
+      '{"type":"trajectory"}\n',
+    );
+    fs.writeFileSync(
+      path.join(sessionsDir, `${sessionId}.trajectory-path.json`),
+      JSON.stringify({ filePath: path.join(sessionsDir, `${sessionId}.trajectory.jsonl`) }),
+    );
+    const confirmRuntimeRepair = vi.fn(async () => true);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+    expect(stateIntegrityText()).not.toContain(
+      "These .jsonl files are no longer referenced by sessions.json",
+    );
+    expect(confirmRuntimeRepair).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(sessionsDir, `${sessionId}.trajectory.jsonl`))).toBe(true);
+  });
+
   it.skipIf(process.platform === "win32")(
     "does not archive referenced transcripts when the state dir path resolves through a symlink",
     async () => {

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -4,6 +4,7 @@ import {
   isCompactionCheckpointTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
+  isTrajectorySidecarFileName,
   isUsageCountedSessionTranscriptFileName,
   parseCompactionCheckpointTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
@@ -32,6 +33,21 @@ describe("session artifact helpers", () => {
       false,
     );
     expect(isPrimarySessionTranscriptFileName("sessions.json")).toBe(false);
+    // #71960: trajectory sidecars must not be classified as primary
+    // transcripts; doctor's orphan sweep enumerates this set.
+    expect(
+      isPrimarySessionTranscriptFileName("b8fc0af0-1692-474b-b11e-636a8b8ab00f.trajectory.jsonl"),
+    ).toBe(false);
+    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
+  });
+
+  it("classifies trajectory sidecar file names (#71960)", () => {
+    expect(isTrajectorySidecarFileName("abc.trajectory.jsonl")).toBe(true);
+    expect(
+      isTrajectorySidecarFileName("b8fc0af0-1692-474b-b11e-636a8b8ab00f.trajectory.jsonl"),
+    ).toBe(true);
+    expect(isTrajectorySidecarFileName("abc.jsonl")).toBe(false);
+    expect(isTrajectorySidecarFileName("abc.trajectory-path.json")).toBe(false);
   });
 
   it("classifies usage-counted transcript files", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -40,6 +40,18 @@ export function isCompactionCheckpointTranscriptFileName(fileName: string): bool
   return parseCompactionCheckpointTranscriptFileName(fileName) !== null;
 }
 
+/**
+ * Trajectory sidecars are written next to the primary session transcript as
+ * `<sessionFile>.trajectory.jsonl` (or `<sessionId>.trajectory.jsonl` when no
+ * primary transcript is colocated). They are referenced from a sibling
+ * `*.trajectory-path.json` pointer file rather than `sessions.json`, so they
+ * must not be treated as primary transcripts by orphan-detection or
+ * usage-accounting code paths. See #71960.
+ */
+export function isTrajectorySidecarFileName(fileName: string): boolean {
+  return fileName.endsWith(".trajectory.jsonl");
+}
+
 export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (fileName === "sessions.json") {
     return false;
@@ -48,6 +60,9 @@ export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
     return false;
   }
   if (isCompactionCheckpointTranscriptFileName(fileName)) {
+    return false;
+  }
+  if (isTrajectorySidecarFileName(fileName)) {
     return false;
   }
   return !isSessionArchiveArtifactName(fileName);


### PR DESCRIPTION
Fixes #71960.

## What
`isPrimarySessionTranscriptFileName` matches any `*.jsonl` that isn't a compaction checkpoint or archive artifact. Trajectory sidecars (`<sessionId>.trajectory.jsonl`) therefore look like primary session transcripts to doctor's orphan sweep, which only cross-references `sessions.json`. Sidecars are referenced via the sibling `*.trajectory-path.json` pointer instead, so an **active** session's sidecar gets reported as `Found 1 orphan transcript file` and offered for archival on every `openclaw doctor` run.

## Fix
Add `isTrajectorySidecarFileName` (matches `*.trajectory.jsonl`) and short-circuit it from `isPrimarySessionTranscriptFileName`. Mirrors the existing `isCompactionCheckpointTranscriptFileName` carve-out.

## Side effect (intentional)
The same classifier feeds `src/config/sessions/disk-budget.ts`'s removable-file queue. Trajectory sidecars no longer end up there either — which is correct: sidecars belong to live sessions and should be cleaned up via the regular session lifecycle, not the budget sweep.

`isUsageCountedSessionTranscriptFileName` and `parseUsageCountedSessionIdFromFileName` also exclude sidecars now, which matches the prior intent (sidecars don't have user messages and shouldn't be billed as session transcripts).

## Tests
- `src/config/sessions/artifacts.test.ts`: assert sidecar names are excluded from the primary classifier and that the new helper recognizes them; existing tests stay green.
- `src/commands/doctor-state-integrity.test.ts`: regression — drop `<id>.trajectory.jsonl` + `<id>.trajectory-path.json` into the sessions dir, run doctor, assert neither the orphan warning nor the archive prompt fires and the file survives.

```
pnpm test src/config/sessions src/commands/doctor-state-integrity.test.ts -- --run
# Test Files: 16 passed   Tests: 125 passed
```

Reporter's three suggested directions were "exclude `*.trajectory.jsonl` from primary orphan-transcript checks" / "include sidecars referenced through `*.trajectory-path.json`" / "soften the warning text". Excluding from the primary classifier is the smallest correct change and naturally covers both detection sites (doctor + disk-budget).
