### PR TITLE
fix(plugins): fallback npm_config_cache to os.tmpdir() (v6)

### DIFF
--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -794,9 +794,11 @@ export function createBundledRuntimeDepsInstallEnv(
   env: NodeJS.ProcessEnv,
   options: { cacheDir?: string } = {},
 ): NodeJS.ProcessEnv {
+  const cacheDir = options.cacheDir ?? os.tmpdir();
   return {
     ...createNpmProjectInstallEnv(env, options),
     npm_config_legacy_peer_deps: "true",
+    npm_config_cache: cacheDir,
   };
 }
 


### PR DESCRIPTION
v6 - use `os.tmpdir()` as safe fallback for `npm_config_cache` in `createBundledRuntimeDepsInstallEnv` (+2 lines)