### PR TITLE
fix(gateway): add scope containment check to device.token.revoke

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -181,7 +181,13 @@ describe("deviceHandlers", () => {
   });
 
   it("disconnects active clients after revoking a device token", async () => {
-    getPairedDeviceMock.mockResolvedValue(null);
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: [],
+      tokens: {},
+    });
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions("device.token.revoke", {
       deviceId: " device-1 ",
@@ -206,7 +212,13 @@ describe("deviceHandlers", () => {
   });
 
   it("allows admin-scoped callers to revoke another device's token", async () => {
-    getPairedDeviceMock.mockResolvedValue(null);
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-2",
+      role: "operator",
+      roles: ["operator"],
+      scopes: [],
+      tokens: {},
+    });
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions(
       "device.token.revoke",
@@ -228,7 +240,13 @@ describe("deviceHandlers", () => {
   });
 
   it("treats normalized device ids as self-owned for token revocation", async () => {
-    getPairedDeviceMock.mockResolvedValue(null);
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: [],
+      tokens: {},
+    });
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions(
       "device.token.revoke",
@@ -367,7 +385,29 @@ describe("deviceHandlers", () => {
     expect(opts.respond).toHaveBeenCalledWith(
       false,
       undefined,
-      expect.objectContaining({ message: "unknown deviceId/role" }),
+      expect.objectContaining({ message: "device token revocation denied" }),
+    );
+  });
+
+  it("hard-denies when device is not found in pairing store", async () => {
+    getPairedDeviceMock.mockResolvedValue(null);
+    revokeDeviceTokenMock.mockResolvedValue(null);
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: "device-1", role: "operator" },
+      { client: createClient(["operator.pairing"]) },
+    );
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).not.toHaveBeenCalled();
+    expect(opts.context.logGateway.warn).toHaveBeenCalledWith(
+      expect.stringContaining("reason=unknown-device"),
+    );
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "device token revocation denied" }),
     );
   });
 

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -181,6 +181,7 @@ describe("deviceHandlers", () => {
   });
 
   it("disconnects active clients after revoking a device token", async () => {
+    getPairedDeviceMock.mockResolvedValue(null);
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions("device.token.revoke", {
       deviceId: " device-1 ",
@@ -205,6 +206,7 @@ describe("deviceHandlers", () => {
   });
 
   it("allows admin-scoped callers to revoke another device's token", async () => {
+    getPairedDeviceMock.mockResolvedValue(null);
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions(
       "device.token.revoke",
@@ -226,6 +228,7 @@ describe("deviceHandlers", () => {
   });
 
   it("treats normalized device ids as self-owned for token revocation", async () => {
+    getPairedDeviceMock.mockResolvedValue(null);
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions(
       "device.token.revoke",
@@ -351,6 +354,7 @@ describe("deviceHandlers", () => {
   });
 
   it("does not disconnect clients when token revocation fails", async () => {
+    getPairedDeviceMock.mockResolvedValue(null);
     revokeDeviceTokenMock.mockResolvedValue(null);
     const opts = createOptions("device.token.revoke", {
       deviceId: "device-1",
@@ -684,6 +688,131 @@ describe("deviceHandlers", () => {
       true,
       { requestId: "req-2", deviceId: "device-2", rejectedAtMs: 456 },
       undefined,
+    );
+  });
+
+  it("rejects revoking a token whose role scopes exceed the caller's scopes", async () => {
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: ["operator.admin"],
+      tokens: {
+        operator: {
+          token: "admin-token",
+          role: "operator",
+          scopes: ["operator.admin"],
+          createdAtMs: 123,
+        },
+      },
+    });
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: "device-1", role: "operator" },
+      { client: createClient(["operator.pairing"]) },
+    );
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).not.toHaveBeenCalled();
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "device token revocation denied" }),
+    );
+  });
+
+  it("allows revoking a token when the caller holds all target role scopes", async () => {
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: ["operator.pairing"],
+      tokens: {
+        operator: {
+          token: "pairing-token",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          createdAtMs: 123,
+        },
+      },
+    });
+    revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: "device-1", role: "operator" },
+      { client: createClient(["operator.pairing"]) },
+    );
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).toHaveBeenCalledWith({
+      deviceId: "device-1",
+      role: "operator",
+    });
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      { deviceId: "device-1", role: "operator", revokedAtMs: 456 },
+      undefined,
+    );
+  });
+
+  it("allows revoking a higher-scope token when the caller has operator.admin", async () => {
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-2",
+      role: "operator",
+      roles: ["operator"],
+      scopes: ["operator.admin"],
+      tokens: {
+        operator: {
+          token: "admin-token",
+          role: "operator",
+          scopes: ["operator.admin"],
+          createdAtMs: 123,
+        },
+      },
+    });
+    revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 789 });
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: "device-2", role: "operator" },
+      { client: createClient(["operator.admin", "operator.pairing"]) },
+    );
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).toHaveBeenCalledWith({
+      deviceId: "device-2",
+      role: "operator",
+    });
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      { deviceId: "device-2", role: "operator", revokedAtMs: 789 },
+      undefined,
+    );
+  });
+
+  it("falls back to device scopes when the role token has no explicit scopes", async () => {
+    getPairedDeviceMock.mockResolvedValue({
+      deviceId: "device-1",
+      role: "operator",
+      roles: ["operator"],
+      scopes: ["operator.write"],
+      tokens: {},
+    });
+    const opts = createOptions(
+      "device.token.revoke",
+      { deviceId: "device-1", role: "operator" },
+      { client: createClient(["operator.pairing"]) },
+    );
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).not.toHaveBeenCalled();
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "device token revocation denied" }),
     );
   });
 });

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -453,30 +453,43 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     const pairedDevice = await getPairedDevice(deviceId);
-    if (pairedDevice) {
-      const targetScopes = normalizeDeviceAuthScopes(
-        pairedDevice.tokens?.[role.trim()]?.scopes ?? pairedDevice.scopes,
+    if (!pairedDevice) {
+      context.logGateway.warn(
+        `device token revocation denied device=${deviceId} role=${role} reason=unknown-device`,
       );
-      const missingScope = resolveMissingRequestedScope({
-        role,
-        requestedScopes: targetScopes,
-        allowedScopes: authz.callerScopes,
-      });
-      if (missingScope) {
-        context.logGateway.warn(
-          `device token revocation denied device=${deviceId} role=${role} reason=caller-missing-scope scope=${missingScope}`,
-        );
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "device token revocation denied"),
-        );
-        return;
-      }
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "device token revocation denied"),
+      );
+      return;
+    }
+    const targetScopes = normalizeDeviceAuthScopes(
+      pairedDevice.tokens?.[role.trim()]?.scopes ?? pairedDevice.scopes,
+    );
+    const missingScope = resolveMissingRequestedScope({
+      role,
+      requestedScopes: targetScopes,
+      allowedScopes: authz.callerScopes,
+    });
+    if (missingScope) {
+      context.logGateway.warn(
+        `device token revocation denied device=${deviceId} role=${role} reason=caller-missing-scope scope=${missingScope}`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "device token revocation denied"),
+      );
+      return;
     }
     const entry = await revokeDeviceToken({ deviceId, role });
     if (!entry) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "device token revocation denied"),
+      );
       return;
     }
     const normalizedDeviceId = deviceId.trim();

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -452,6 +452,28 @@ export const deviceHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const pairedDevice = await getPairedDevice(deviceId);
+    if (pairedDevice) {
+      const targetScopes = normalizeDeviceAuthScopes(
+        pairedDevice.tokens?.[role.trim()]?.scopes ?? pairedDevice.scopes,
+      );
+      const missingScope = resolveMissingRequestedScope({
+        role,
+        requestedScopes: targetScopes,
+        allowedScopes: authz.callerScopes,
+      });
+      if (missingScope) {
+        context.logGateway.warn(
+          `device token revocation denied device=${deviceId} role=${role} reason=caller-missing-scope scope=${missingScope}`,
+        );
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "device token revocation denied"),
+        );
+        return;
+      }
+    }
     const entry = await revokeDeviceToken({ deviceId, role });
     if (!entry) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -331,6 +331,47 @@ describe("gateway device.token.rotate caller scope guard", () => {
     }
   });
 
+  test("rejects revoking a token whose role scopes exceed the caller session scopes", async () => {
+    const started = await startServer("secret");
+    const target = await issueOperatorToken({
+      name: "revoke-scope-target",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.admin"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    const attacker = await issueOperatorToken({
+      name: "revoke-scope-attacker",
+      approvedScopes: ["operator.pairing"],
+      tokenScopes: ["operator.pairing"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let pairingWs: WebSocket | undefined;
+    try {
+      pairingWs = await connectPairingScopedOperator({
+        port: started.port,
+        identityPath: attacker.identityPath,
+        deviceToken: attacker.token,
+      });
+
+      const revoke = await rpcReq(pairingWs, "device.token.revoke", {
+        deviceId: target.deviceId,
+        role: "operator",
+      });
+      expect(revoke.ok).toBe(false);
+      expect(revoke.error?.message).toBe("device token revocation denied");
+
+      const paired = await getPairedDevice(target.deviceId);
+      expect(paired?.tokens?.operator?.revokedAtMs).toBeUndefined();
+    } finally {
+      pairingWs?.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
   test("rejects rotating a token for an unapproved role on an existing paired device", async () => {
     const started = await startServer("secret");
     const attacker = await issueOperatorToken({


### PR DESCRIPTION
## Summary

- **Problem:** `device.token.revoke` skips the `resolveMissingRequestedScope` caller-scope containment check that `device.token.rotate` enforces. A caller with only `operator.pairing` scope can revoke tokens for devices carrying higher-scope roles like `operator.admin` or `operator.write`.
- **Why it matters:** Enables targeted denial of service against higher-privileged paired devices by invalidating their access credentials.
- **What changed:** Added `resolveMissingRequestedScope` scope containment check to the `device.token.revoke` handler, mirroring the existing pattern in `device.token.rotate`. The unknown-device path now hard-denies rather than falling through to the mutation (TOCTOU close).
- **What did NOT change:** The device-ownership check (`deniesCrossDeviceManagement`) added in #50626 remains unchanged. No changes to `device.token.rotate`, `revokeDeviceToken`, or any other handler.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71990
- Related #50626
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The #50626 fix added device-ownership checks (`resolveDeviceManagementAuthz` + `deniesCrossDeviceManagement`) to both `device.token.rotate` and `device.token.revoke`, but only added the scope containment check (`resolveMissingRequestedScope`) to `rotate`. The `revoke` handler was left with ownership-only authorization. Additionally, the scope check was conditionally gated on `if (pairedDevice)`, leaving a TOCTOU window where a device absent at `getPairedDevice` time but present when `revokeDeviceToken` acquires its lock would bypass the scope guard entirely.
- **Missing detection / guardrail:** No test verified that `device.token.revoke` enforced scope containment comparable to `device.token.rotate`.
- **Contributing context:** The two handlers share similar structure but were secured incrementally across separate fixes, and the scope check was not applied consistently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/gateway/server-methods/devices.test.ts` (5 new tests), `src/gateway/server.device-token-rotate-authz.test.ts` (1 new test)
- **Scenario the test should lock in:** A caller with only `operator.pairing` scope cannot revoke a device token whose role carries `operator.admin` scope. An admin-scoped caller can still revoke. A caller with matching scopes can revoke. A missing device is hard-denied rather than falling through.
- **Why this is the smallest reliable guardrail:** The unit tests mock `getPairedDevice` and `resolveMissingRequestedScope` to isolate the authorization logic. The integration test exercises the full gateway WebSocket RPC path with real device pairing state.
- **Existing test that already covers this:** The rotate handler has analogous tests in `server.device-token-rotate-authz.test.ts` but no parallel existed for revoke.

## User-visible / Behavior Changes

None. The change only adds deny paths for previously-allowed operations. Callers revoking within their scope set see no difference.

## Diagram (if applicable)

```text
Before:
[caller with pairing scope] -> device.token.revoke(deviceId, admin-role) -> ok: true (token revoked)

After:
[caller with pairing scope] -> device.token.revoke(deviceId, admin-role) -> denied (scope containment)
[caller with admin scope]   -> device.token.revoke(deviceId, admin-role) -> ok: true (token revoked)
[unknown device]             -> device.token.revoke(deviceId, role)         -> denied (unknown-device)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — revoke now enforces scope containment before invalidating tokens
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — narrows who can revoke device tokens to callers holding the target role's scopes
- If any Yes, explain risk + mitigation: The change restricts a previously-permissive path. The only risk is that callers relying on the unintended ability to revoke higher-scope tokens will be denied. This is the intended fix.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ (pnpm)
- Model/provider: N/A (code-level fix)
- Integration/channel: WebSocket JSON-RPC gateway

### Steps

1. Authenticate to gateway as primary-auth caller with only `operator.pairing` scope
2. Call `device.pair.list` to enumerate paired devices
3. Call `device.token.revoke` targeting a device with `operator.admin`-scoped token
4. Observe: revoke denied with opaque error (before fix: succeeds)

### Expected

Revoke denied — caller does not hold `operator.admin` scope.

### Actual

Before fix: revoke succeeds (`ok: true`), target device token revoked.
After fix: revoke denied (`ok: false`), target device token unchanged.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Unit tests (25/25 passed), integration tests (7/7 passed), build + typecheck + lint clean
- **Edge cases checked:** Caller with matching scopes (allowed), admin caller (allowed), unknown device (hard-deny), device-level scope fallback
- **What I did NOT verify:** Full E2E gateway deployment with live devices; Android/iOS native client behavior

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — for callers already within their scope set. No for callers relying on the ability to revoke higher-scope tokens (which was unintended behavior).
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Existing automation or tooling that calls `device.token.revoke` with a low-scope caller for a high-scope target will start receiving deny responses.
  - Mitigation: This is the intended security fix. Such callers should use an admin-scoped token instead.