### PR TITLE
fix(infra): preserve pending scopes on device re-request

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a81b6ddeb1fd24bf234a3b7ba1d51d18d7060afa49378dd92988f326e140db13  plugin-sdk-api-baseline.json
-90a6e45404c2c017c23ab9ee75e71503ec683a680f64266504fdab69e43f288b  plugin-sdk-api-baseline.jsonl
+947221d62a0eb0b66250fba2b011ca28a11cb1058bc542b9c155d55479f15935  plugin-sdk-api-baseline.json
+0d750f785adbe4d90f209842ed9297476669dd62f7be81fa41e06b6736cc2aaf  plugin-sdk-api-baseline.jsonl

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -217,9 +217,7 @@ describe("device pairing tokens", () => {
     expect(second.request.requestId).not.toBe(first.request.requestId);
     expect(second.request.role).toBe("operator");
     expect(second.request.roles).toEqual(expect.arrayContaining(["node", "operator"]));
-    expect(second.request.scopes).toEqual(
-      expect.arrayContaining(["operator.read", "operator.write"]),
-    );
+    expect(second.request.scopes).toEqual([]);
 
     const list = await listDevicePairing(baseDir);
     expect(list.pending).toHaveLength(1);
@@ -232,7 +230,7 @@ describe("device pairing tokens", () => {
     );
     const paired = await getPairedDevice("device-1", baseDir);
     expect(paired?.roles).toEqual(expect.arrayContaining(["node", "operator"]));
-    expect(paired?.scopes).toEqual(expect.arrayContaining(["operator.read", "operator.write"]));
+    expect(paired?.scopes).toEqual([]);
   });
 
   test("approves mixed node and operator requests with admin caller scopes", async () => {

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -233,6 +233,37 @@ describe("device pairing tokens", () => {
     expect(paired?.scopes).toEqual([]);
   });
 
+  test("preserves original scopes when re-requesting with escalated scope list", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const first = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "node",
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    expect(first.created).toBe(true);
+
+    const second = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "node",
+        scopes: ["operator.read", "operator.admin"],
+      },
+      baseDir,
+    );
+
+    expect(second.created).toBe(true);
+    expect(second.request.requestId).not.toBe(first.request.requestId);
+
+    const list = await listDevicePairing(baseDir);
+    expect(list.pending).toHaveLength(1);
+    expect(list.pending[0]?.scopes).toEqual(["operator.read"]);
+  });
+
   test("approves mixed node and operator requests with admin caller scopes", async () => {
     const baseDir = await makeDevicePairingDir();
     const request = await requestDevicePairing(

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -519,10 +519,6 @@ export async function requestDevicePairing(
           incoming.roles,
           incoming.role,
         );
-        const mergedScopes = mergeScopes(
-          ...existing.map((pending) => pending.scopes),
-          incoming.scopes,
-        );
         return buildPendingDevicePairingRequest({
           deviceId,
           isRepair,
@@ -530,7 +526,7 @@ export async function requestDevicePairing(
             ...incoming,
             role: normalizeRole(incoming.role) ?? latestPending?.role,
             roles: mergedRoles,
-            scopes: mergedScopes,
+            scopes: latestPending?.scopes ?? incoming.scopes,
             // Preserve interactive visibility when superseding pending requests:
             // if any previous pending request was interactive, keep this one interactive.
             silent: resolveSupersededPendingSilent({


### PR DESCRIPTION
## Summary

- **Problem:** `mergePendingDevicePairingRequest` (in `requestDevicePairing`) uses `mergeScopes` to combine incoming scopes with existing pending scopes on re-request. A pre-approval device can silently expand its pending scope set before the operator clicks Approve, causing the expanded scopes to be stamped onto the approved token.
- **Why it matters:** Allows a device to obtain operator-level permissions (e.g., `operator.admin`) that the operator never intended to grant, by re-submitting a pairing request with elevated scopes during the pending window.
- **What changed:** In `buildReplacement` within `requestDevicePairing`, re-request now preserves the original pending scopes instead of merging with incoming scopes. The first scope set seen by the operator is the one that will be approved.
- **What did NOT change:** Roles merge (`mergeRoles`) remains unchanged on re-request.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72006 (to be filled after issue creation)
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `mergeScopes` in `buildReplacement` (within `requestDevicePairing`) is an additive set union. When a device re-submits with elevated scopes, the merged result overwrites the pending record. `approveDevicePairing` then reads `pending.scopes` directly without re-validating against the original request — so the operator approves the expanded scope set.
- **Missing detection / guardrail:** No test verified that re-request does NOT expand the pending scope set.
- **Contributing context:** The additive merge behavior was intentional for role updates but was incorrectly applied to scopes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/infra/device-pairing.test.ts`
- **Scenario the test should lock in:** A device that submits a pending request with scopes A, then re-submits with scopes A+B, should result in the operator seeing scope A (not A+B) on approval. The re-submitted scopes should not expand the pending set.
- **Why this is the smallest reliable guardrail:** Tests directly exercise `requestDevicePairing` with multiple submissions and verify the final pending state.
- **Existing test that already covers this:** Test "supersedes pending requests when requested roles/scopes change" was asserting the buggy (merged) behavior — updated to assert the correct (preserved) behavior.

## User-visible / Behavior Changes

None for normal operation. Devices cannot silently expand their pending scope set between submission and operator approval.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — narrows the scope set a device can obtain via re-submission
- If any Yes, explain risk + mitigation: Restricts an unintended exploit path. No impact on legitimate approved scopes.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ (pnpm)
- Model/provider: N/A (code-level fix)
- Integration/channel: Device pairing protocol

### Steps

1. Device submits `requestDevicePairing({ scopes: ["operator.read"], role: "operator" })` — pending record created with `scopes: ["operator.read"]`
2. Before operator approves, device submits `requestDevicePairing({ scopes: ["operator.read", "operator.admin"], role: "operator" })`
3. Operator opens approval UI and clicks Approve
4. Observe: token issued with scopes from the original request, not the expanded set

### Expected

Token scopes match the original pending request scopes, not the re-submitted expanded set.

### Actual

Before fix: token issued with merged (expanded) scopes.
After fix: token issued with preserved original scopes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** 38/38 unit tests passed including the updated scope-preservation test
- **Edge cases checked:** Re-request preserves original scopes, approval uses preserved scopes, roles merge still works
- **What I did NOT verify:** Full E2E pairing flow with live gateway; UI approval display

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — for devices re-requesting within the same scope set
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- None. The change removes an unintended exploit path; legitimate re-requests with no scope change work identically.