### PR TITLE
fix(gateway): reduce pricing fetch timeout from 60s to 10s

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -583,10 +583,10 @@ describe("model-pricing-cache", () => {
     expect(warnings).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "OpenRouter pricing fetch failed (timeout 60s): TimeoutError: The operation was aborted due to timeout",
+          "OpenRouter pricing fetch failed (timeout 10s): TimeoutError: The operation was aborted due to timeout",
         ),
         expect.stringContaining(
-          "LiteLLM pricing fetch failed (timeout 60s): TimeoutError: The operation was aborted due to timeout",
+          "LiteLLM pricing fetch failed (timeout 10s): TimeoutError: The operation was aborted due to timeout",
         ),
       ]),
     );

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -40,7 +40,7 @@ const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const LITELLM_PRICING_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const CACHE_TTL_MS = 24 * 60 * 60_000;
-const FETCH_TIMEOUT_MS = 60_000;
+const FETCH_TIMEOUT_MS = 10_000;
 const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const PROVIDER_ALIAS_TO_OPENROUTER: Record<string, string> = {
   "google-gemini-cli": "google",


### PR DESCRIPTION
## Summary

- Reduces `FETCH_TIMEOUT_MS` for OpenRouter and LiteLLM pricing fetches from 60s to 10s
- Updates test assertions to match the new timeout value

On unreachable networks, the two 60s fetch timeouts saturate the Node event loop during gateway startup, stalling channel init and heartbeat by ~2 minutes. Pricing is optional enrichment — 10s is sufficient for any reasonable connection and fails fast when endpoints are unreachable.

Observed in startup logs:
```
01:13:32 [gateway] starting channels and sidecars...
01:15:20 [model-pricing] OpenRouter pricing fetch failed (timeout 60s): TimeoutError
01:15:20 [model-pricing] LiteLLM pricing fetch failed (timeout 60s): TimeoutError
01:15:35 [heartbeat] started
```

## Test plan

- [x] `pnpm vitest run src/gateway/model-pricing-cache.test.ts` — 33 tests pass
- [x] `pnpm check` — typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)