### PR TITLE
fix(agents): avoid duplicating subagent task prompts

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -171,6 +171,40 @@ describe("spawnSubagentDirect seam flow", () => {
     );
   });
 
+  it("sends the concrete task in the child message payload", async () => {
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        calls.push(request);
+        if (request.method === "agent") {
+          return { runId: "run-1" };
+        }
+        if (request.method?.startsWith("sessions.")) {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const task = "TRACE-72019 inspect duplicated subagent task payload";
+    const result = await spawnSubagentDirect(
+      {
+        task,
+        model: "openai-codex/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall?.params?.message).toContain(`[Subagent Task]: ${task}`);
+    expect(agentCall?.params?.extraSystemPrompt).toBe("system-prompt");
+  });
+
   it("omits requesterOrigin threadId when no requester thread is provided", async () => {
     hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent") {

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -34,7 +34,7 @@ export function buildSubagentSystemPrompt(params: {
     `You are a **subagent** spawned by the ${parentLabel} for a specific task.`,
     "",
     "## Your Role",
-    "- You were created to handle the task provided in the first user message.",
+    "- You were created to handle the task in the `[Subagent Task]` section of the current subagent kickoff message. Treat that section as authoritative over earlier or forked transcript messages.",
     "- Complete this task. That's your entire purpose.",
     `- You are NOT the ${parentLabel}. Don't try to be.`,
     "",

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -16,10 +16,6 @@ export function buildSubagentSystemPrompt(params: {
   /** Config value: max allowed spawn depth. */
   maxSpawnDepth?: number;
 }) {
-  const taskText =
-    typeof params.task === "string" && params.task.trim()
-      ? params.task.replace(/\s+/g, " ").trim()
-      : "{{TASK_DESCRIPTION}}";
   const childDepth = typeof params.childDepth === "number" ? params.childDepth : 1;
   const maxSpawnDepth =
     typeof params.maxSpawnDepth === "number"
@@ -38,7 +34,7 @@ export function buildSubagentSystemPrompt(params: {
     `You are a **subagent** spawned by the ${parentLabel} for a specific task.`,
     "",
     "## Your Role",
-    `- You were created to handle: ${taskText}`,
+    "- You were created to handle the task provided in the first user message.",
     "- Complete this task. That's your entire purpose.",
     `- You are NOT the ${parentLabel}. Don't try to be.`,
     "",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -997,7 +997,9 @@ describe("buildSubagentSystemPrompt", () => {
       maxSpawnDepth: 2,
     });
 
-    expect(prompt).toContain("task provided in the first user message");
+    expect(prompt).toContain("`[Subagent Task]` section");
+    expect(prompt).toContain("earlier or forked transcript messages");
+    expect(prompt).not.toContain("first user message");
     expect(prompt).not.toContain(task);
     expect(prompt).not.toContain("TRACE-72019");
   });

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -988,6 +988,20 @@ describe("buildSubagentSystemPrompt", () => {
     expect(prompt).toContain("instead of full-file `cat`");
   });
 
+  it("keeps the concrete task out of standing system instructions", () => {
+    const task = "TRACE-72019 investigate duplicated subagent task payload";
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc",
+      task,
+      childDepth: 1,
+      maxSpawnDepth: 2,
+    });
+
+    expect(prompt).toContain("task provided in the first user message");
+    expect(prompt).not.toContain(task);
+    expect(prompt).not.toContain("TRACE-72019");
+  });
+
   it("omits ACP spawning guidance when ACP is disabled", () => {
     const prompt = buildSubagentSystemPrompt({
       childSessionKey: "agent:main:subagent:abc",


### PR DESCRIPTION
## Summary

Fixes #72019.

- Keep the concrete `sessions_spawn` task in the child user message only.
- Replace the duplicated task text in the subagent system prompt with a stable reference to the first user message.
- Add regressions that the system prompt omits the task while the child agent payload still receives it.

## Validation

- `pnpm test src/agents/system-prompt.test.ts src/agents/subagent-spawn.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`

Note: plain `pnpm check:changed` hit `ERR_WORKER_OUT_OF_MEMORY` in the broad agents Vitest lane after 375/376 files passed; the serial-worker retry passed.
