### PR TITLE
fix(doctor): exclude trajectory sidecar files from orphan transcript detection [AI-assisted]

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -302,6 +302,20 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
   });
 
+  it("does not flag trajectory sidecar files as orphan transcripts", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(
+      path.join(sessionsDir, "active-session.trajectory.jsonl"),
+      '{"type":"trajectory"}\n',
+    );
+    const confirmRuntimeRepair = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+    expect(stateIntegrityText()).not.toContain("orphan transcript");
+    expect(stateIntegrityText()).not.toContain("trajectory");
+  });
+
   it.skipIf(process.platform === "win32")(
     "does not archive referenced transcripts when the state dir path resolves through a symlink",
     async () => {

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -4,6 +4,7 @@ import {
   isCompactionCheckpointTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
+  isTrajectoryJournalFileName,
   isUsageCountedSessionTranscriptFileName,
   parseCompactionCheckpointTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
@@ -32,6 +33,15 @@ describe("session artifact helpers", () => {
       false,
     );
     expect(isPrimarySessionTranscriptFileName("sessions.json")).toBe(false);
+    expect(isPrimarySessionTranscriptFileName("abc.trajectory.jsonl")).toBe(false);
+  });
+
+  it("classifies trajectory journal files", () => {
+    expect(isTrajectoryJournalFileName("abc.trajectory.jsonl")).toBe(true);
+    expect(isTrajectoryJournalFileName("some-session-id.trajectory.jsonl")).toBe(true);
+    expect(isTrajectoryJournalFileName("abc.jsonl")).toBe(false);
+    expect(isTrajectoryJournalFileName("abc.trajectory.json")).toBe(false);
+    expect(isTrajectoryJournalFileName("trajectory.jsonl")).toBe(false);
   });
 
   it("classifies usage-counted transcript files", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -40,11 +40,18 @@ export function isCompactionCheckpointTranscriptFileName(fileName: string): bool
   return parseCompactionCheckpointTranscriptFileName(fileName) !== null;
 }
 
+export function isTrajectoryJournalFileName(fileName: string): boolean {
+  return fileName.endsWith(".trajectory.jsonl");
+}
+
 export function isPrimarySessionTranscriptFileName(fileName: string): boolean {
   if (fileName === "sessions.json") {
     return false;
   }
   if (!fileName.endsWith(".jsonl")) {
+    return false;
+  }
+  if (isTrajectoryJournalFileName(fileName)) {
     return false;
   }
   if (isCompactionCheckpointTranscriptFileName(fileName)) {


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `openclaw doctor` state-integrity check falsely flags active `*.trajectory.jsonl` sidecar files as orphan transcripts, suggesting they can be safely archived while the session is still active.
- Why it matters: Users may archive active trajectory data, potentially losing session trajectory history for a running session.
- What changed: Added `isTrajectoryJournalFileName()` helper in `artifacts.ts` and excluded trajectory journal files from `isPrimarySessionTranscriptFileName()`, so they are never considered primary transcripts and never enter the orphan detection path.
- What did NOT change (scope boundary): The orphan transcript detection logic itself is unchanged. Only the file classification predicate was tightened. No changes to trajectory recording, session management, or other doctor checks.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] CLI commands (`src/commands/`)
- [x] Session config (`src/config/sessions/`)

## Linked Issue/PR
- Closes #71960
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `isPrimarySessionTranscriptFileName()` matched any `*.jsonl` file that wasn't a compaction checkpoint or archive artifact. Trajectory sidecar files (`*.trajectory.jsonl`) are a distinct artifact type but were not excluded, so they passed the primary transcript filter. Meanwhile, `referencedTranscriptPaths` only contained paths from `sessions.json` entries — not trajectory sidecar paths referenced via `*.trajectory-path.json`.
- Missing detection / guardrail: No test verified that trajectory sidecar files would not be classified as primary transcripts.
- Contributing context: Trajectory sidecars were added after the orphan transcript detection, and the classification predicate was not updated to account for the new file type.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/commands/doctor-state-integrity.test.ts`, `src/config/sessions/artifacts.test.ts`
- Scenario the test should lock in: A `*.trajectory.jsonl` file in the sessions directory must NOT be reported as an orphan transcript by doctor state-integrity.
- Why this is the smallest reliable guardrail: Direct unit test on the classification helper + integration test on the doctor check — no runtime dependencies needed.
- Existing test that already covers this: N/A

## User-visible / Behavior Changes
`openclaw doctor` no longer warns about active trajectory sidecar files as orphan transcripts.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix tightens file classification to exclude trajectory sidecars from orphan detection. No new data exposure, no security-sensitive paths touched.
