### PR TITLE
fix(tasks): harden taskflow timestamps and control runtime packaging

### DIFF
--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -334,6 +334,43 @@ describe("task-flow-registry", () => {
     });
   });
 
+  it("keeps mirrored terminal flow timestamps monotonic when the terminal event lands after endedAt", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const mirrored = createTaskFlowForTask({
+        task: {
+          ownerKey: "agent:main:main",
+          taskId: "task-running",
+          notifyPolicy: "done_only",
+          status: "running",
+          task: "Fix permissions",
+          createdAt: 100,
+          lastEventAt: 100,
+        },
+      });
+
+      const terminal = syncFlowFromTask({
+        taskId: "task-done",
+        parentFlowId: mirrored.flowId,
+        status: "succeeded",
+        terminalOutcome: "succeeded",
+        notifyPolicy: "done_only",
+        task: "Fix permissions",
+        lastEventAt: 205,
+        endedAt: 200,
+      });
+
+      expect(terminal).toMatchObject({
+        flowId: mirrored.flowId,
+        status: "succeeded",
+        updatedAt: 205,
+        endedAt: 205,
+      });
+    });
+  });
+
   it("preserves explicit json null in state and wait payloads", async () => {
     await withFlowRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -190,6 +190,16 @@ function resolveFlowBlockedSummary(
   );
 }
 
+function resolveTaskFlowTerminalTimestamps(params: {
+  createdAt: number;
+  updatedAt?: number;
+  endedAt?: number;
+}) {
+  const updatedAt = params.updatedAt ?? params.endedAt ?? params.createdAt;
+  const endedAt = Math.max(params.endedAt ?? updatedAt, updatedAt);
+  return { updatedAt, endedAt };
+}
+
 export function deriveTaskFlowStatusFromTask(
   task: Pick<TaskRecord, "status" | "terminalOutcome">,
 ): TaskFlowStatus {
@@ -389,9 +399,13 @@ export function createTaskFlowForTask(params: {
     terminalFlowStatus === "failed" ||
     terminalFlowStatus === "cancelled" ||
     terminalFlowStatus === "lost";
-  const endedAt = isTerminal
-    ? (params.task.endedAt ?? params.task.lastEventAt ?? params.task.createdAt)
-    : undefined;
+  const terminalTimestamps = isTerminal
+    ? resolveTaskFlowTerminalTimestamps({
+        createdAt: params.task.createdAt,
+        updatedAt: params.task.lastEventAt,
+        endedAt: params.task.endedAt,
+      })
+    : null;
   return createFlowRecord({
     syncMode: "task_mirrored",
     ownerKey: params.task.ownerKey,
@@ -404,8 +418,8 @@ export function createTaskFlowForTask(params: {
       terminalFlowStatus === "blocked" ? normalizeOptionalString(params.task.taskId) : undefined,
     blockedSummary: resolveFlowBlockedSummary(params.task),
     createdAt: params.task.createdAt,
-    updatedAt: params.task.lastEventAt ?? params.task.createdAt,
-    ...(endedAt !== undefined ? { endedAt } : {}),
+    updatedAt: terminalTimestamps?.updatedAt ?? params.task.lastEventAt ?? params.task.createdAt,
+    ...(terminalTimestamps ? { endedAt: terminalTimestamps.endedAt } : {}),
   });
 }
 
@@ -603,6 +617,14 @@ export function syncFlowFromTask(
     terminalFlowStatus === "failed" ||
     terminalFlowStatus === "cancelled" ||
     terminalFlowStatus === "lost";
+  const now = Date.now();
+  const terminalTimestamps = isTerminal
+    ? resolveTaskFlowTerminalTimestamps({
+        createdAt: flow.createdAt,
+        updatedAt: task.lastEventAt ?? now,
+        endedAt: task.endedAt,
+      })
+    : null;
   return updateFlowRecordByIdUnchecked(flowId, {
     status: terminalFlowStatus,
     notifyPolicy: task.notifyPolicy,
@@ -611,12 +633,8 @@ export function syncFlowFromTask(
     blockedSummary:
       terminalFlowStatus === "blocked" ? (resolveFlowBlockedSummary(task) ?? null) : null,
     waitJson: null,
-    updatedAt: task.lastEventAt ?? Date.now(),
-    ...(isTerminal
-      ? {
-          endedAt: task.endedAt ?? task.lastEventAt ?? Date.now(),
-        }
-      : { endedAt: null }),
+    updatedAt: terminalTimestamps?.updatedAt ?? task.lastEventAt ?? now,
+    ...(terminalTimestamps ? { endedAt: terminalTimestamps.endedAt } : { endedAt: null }),
   });
 }
 

--- a/src/tasks/task-registry-control-runtime-build.test.ts
+++ b/src/tasks/task-registry-control-runtime-build.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import config from "../../tsdown.config.ts";
+
+describe("tsdown core dist entries", () => {
+  it("emits the task-registry control runtime on a stable dist path", () => {
+    const build = Array.isArray(config) ? config[0] : config;
+    const entry = build.entry as Record<string, string>;
+
+    expect(entry).toMatchObject({
+      "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",
+    });
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -218,6 +218,9 @@ function buildCoreDistEntries(): Record<string, string> {
       "src/commands/doctor/shared/plugin-registry-migration.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
+    // Keep the ACP task-control shim on a stable root filename so task-registry
+    // cancel paths can always resolve it from the shipped dist artifact.
+    "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",
     "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",
     "plugins/public-surface-runtime": "src/plugins/public-surface-runtime.ts",


### PR DESCRIPTION
## Summary
- normalize mirrored TaskFlow terminal timestamps so terminal `endedAt` cannot lag behind `updatedAt`
- add regression coverage for terminal task-flow timestamp normalization
- emit `task-registry-control.runtime` as a stable root dist entry so task cancel/control paths can resolve it from packaged builds
- add a build-entry regression test for the stable runtime artifact

## Validation
- `node scripts/run-vitest.mjs run src/tasks/task-flow-registry.test.ts src/tasks/task-registry-control-runtime-build.test.ts`
- `node scripts/tsdown-build.mjs` + verified `dist/task-registry-control.runtime.js` exists

## Notes
- This targets the native OpenClaw task/taskflow registry warning pile: mostly `inconsistent_timestamps` noise from task/flow lifecycle bookkeeping.
- Current `main` already includes broader task timestamp normalization; this PR keeps the remaining mirrored TaskFlow and packaged runtime hardening.
