### PR TITLE
fix(agents): dedupe subagent task in first user turn (#72019)

### DIFF
--- a/src/agents/subagent-initial-user-message.test.ts
+++ b/src/agents/subagent-initial-user-message.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
+
+describe("buildSubagentInitialUserMessage", () => {
+  it("does not embed a task string (avoids duplicating the system **Your Role** block)", () => {
+    const msg = buildSubagentInitialUserMessage({
+      childDepth: 1,
+      maxSpawnDepth: 3,
+      persistentSession: false,
+    });
+    const secret = "Xy9_UNIQUE_TASK_PLACEHOLDER_FOR_TEST";
+    expect(msg).not.toContain(secret);
+    expect(msg).not.toContain("[Subagent Task]:");
+    expect(msg).toContain("**Your Role**");
+    expect(msg).toContain("depth 1/3");
+  });
+
+  it("includes the persistent session note when requested", () => {
+    const msg = buildSubagentInitialUserMessage({
+      childDepth: 2,
+      maxSpawnDepth: 4,
+      persistentSession: true,
+    });
+    expect(msg).toContain("persistent and remains available");
+  });
+});

--- a/src/agents/subagent-initial-user-message.ts
+++ b/src/agents/subagent-initial-user-message.ts
@@ -1,0 +1,24 @@
+/**
+ * First user turn for a native `sessions_spawn` / subagent run. The full task
+ * string must not be repeated here: it already appears under **Your Role** in
+ * the subagent system prompt. Duplicating it doubled input tokens (#72019).
+ */
+export function buildSubagentInitialUserMessage(params: {
+  childDepth: number;
+  maxSpawnDepth: number;
+  /** When true, this subagent uses a persistent session for follow-up messages. */
+  persistentSession: boolean;
+}): string {
+  const lines: string[] = [
+    `[Subagent Context] You are running as a subagent (depth ${params.childDepth}/${params.maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
+  ];
+  if (params.persistentSession) {
+    lines.push(
+      "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages.",
+    );
+  }
+  lines.push(
+    "Begin. Your assigned task is in the system prompt under **Your Role**; execute it to completion.",
+  );
+  return lines.join("\n\n");
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -24,6 +24,7 @@ import {
   materializeSubagentAttachments,
   type SubagentAttachmentReceiptFile,
 } from "./subagent-attachments.js";
+import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
@@ -974,15 +975,11 @@ export async function spawnSubagentDirect(
     ? "lightweight"
     : undefined;
 
-  const childTaskMessage = [
-    `[Subagent Context] You are running as a subagent (depth ${childDepth}/${maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
-    spawnMode === "session"
-      ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
-      : undefined,
-    `[Subagent Task]: ${task}`,
-  ]
-    .filter((line): line is string => Boolean(line))
-    .join("\n\n");
+  const childTaskMessage = buildSubagentInitialUserMessage({
+    childDepth,
+    maxSpawnDepth,
+    persistentSession: spawnMode === "session",
+  });
 
   const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
     agentGroupId: ctx.agentGroupId,

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -16,10 +16,9 @@ export function buildSubagentSystemPrompt(params: {
   /** Config value: max allowed spawn depth. */
   maxSpawnDepth?: number;
 }) {
-  const taskText =
-    typeof params.task === "string" && params.task.trim()
-      ? params.task.replace(/\s+/g, " ").trim()
-      : "{{TASK_DESCRIPTION}}";
+  const taskRaw = typeof params.task === "string" ? params.task : "";
+  const hasTask = taskRaw.trim() !== "";
+  const taskBody = hasTask ? taskRaw.trim() : "";
   const childDepth = typeof params.childDepth === "number" ? params.childDepth : 1;
   const maxSpawnDepth =
     typeof params.maxSpawnDepth === "number"
@@ -32,16 +31,33 @@ export function buildSubagentSystemPrompt(params: {
   const canSpawn = childDepth < maxSpawnDepth;
   const parentLabel = childDepth >= 2 ? "parent orchestrator" : "main agent";
 
+  const yourRole: string[] =
+    hasTask && taskBody.includes("\n")
+      ? [
+          "## Your Role",
+          "- You were created to handle the following task (verbatim; line breaks preserved):",
+          "",
+          "```",
+          taskBody,
+          "```",
+          "- Complete this task. That's your entire purpose.",
+          `- You are NOT the ${parentLabel}. Don't try to be.`,
+          "",
+        ]
+      : [
+          "## Your Role",
+          `- You were created to handle: ${hasTask ? taskBody : "{{TASK_DESCRIPTION}}"}`,
+          "- Complete this task. That's your entire purpose.",
+          `- You are NOT the ${parentLabel}. Don't try to be.`,
+          "",
+        ];
+
   const lines = [
     "# Subagent Context",
     "",
     `You are a **subagent** spawned by the ${parentLabel} for a specific task.`,
     "",
-    "## Your Role",
-    `- You were created to handle: ${taskText}`,
-    "- Complete this task. That's your entire purpose.",
-    `- You are NOT the ${parentLabel}. Don't try to be.`,
-    "",
+    ...yourRole,
     "## Rules",
     "1. **Stay focused** - Do your assigned task, nothing else",
     `2. **Complete the task** - Your final message will be automatically reported to the ${parentLabel}`,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -988,6 +988,21 @@ describe("buildSubagentSystemPrompt", () => {
     expect(prompt).toContain("instead of full-file `cat`");
   });
 
+  it("keeps multiline and indented task text verbatim in the system prompt (regression: #72019 review)", () => {
+    const task = "line one\n  line two\n  line three";
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc",
+      task,
+      childDepth: 1,
+      maxSpawnDepth: 1,
+    });
+    expect(prompt).toContain("```");
+    expect(prompt).toContain("line one");
+    expect(prompt).toContain("  line two");
+    expect(prompt).toContain("  line three");
+    expect(prompt).not.toContain("line one  line two");
+  });
+
   it("omits ACP spawning guidance when ACP is disabled", () => {
     const prompt = buildSubagentSystemPrompt({
       childSessionKey: "agent:main:subagent:abc",


### PR DESCRIPTION
## Summary

- **Problem:** For native `sessions_spawn` / subagent runs, the long task string was present both in the subagent **system** prompt (under `## Your Role`) and again in the **first user** turn as `[Subagent Task]: ...`, roughly doubling input tokens for that portion of the first request (#72019).
- **Why it matters:** Subagent spawns are on the hot path; duplicate task text is pure overhead and can push large tasks over context limits faster.
- **What changed:** New helper `buildSubagentInitialUserMessage` (`src/agents/subagent-initial-user-message.ts`) produces a short bootstrap user message that points the model to `## Your Role` only. `spawnSubagentDirect` (`src/agents/subagent-spawn.ts`) uses it instead of inlining the full task in the first user turn.
- **Second commit (review follow-up):** `buildSubagentSystemPrompt` no longer replaced all whitespace in `task` with a single line (which could mangle multiline/JSON/shell). Multiline `task` is shown verbatim inside a fenced block under `## Your Role`; single-line tasks stay a single bullet (`src/agents/subagent-system-prompt.ts`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72019
- Related: N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The spawn path built both the subagent system prompt and the first user message from the same `task` string.
- **Missing guardrail:** No single source-of-truth for “long task in system, short kickoff in user” for the first turn.
- **Additional finding (after deduping the user turn):** The system prompt had normalized `task` to one line, which is wrong for multiline/shell/JSON; fixed in the second commit.
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/subagent-initial-user-message.test.ts`, `src/agents/system-prompt.test.ts`
- **Scenario the test should lock in:** (1) First user text does not repeat the full `task` or `[Subagent Task]:`. (2) Multiline `task` appears with line breaks preserved in the system prompt (fenced + verbatim) after the `buildSubagentSystemPrompt` follow-up.
- **Why this is the smallest reliable guardrail:** The bug is entirely prompt assembly; unit tests on the two builders catch regressions without needing a full gateway.
- **Existing test that already covers this (if any):** N/A
- **If no new test is added, why not:** N/A (new tests are included)

## User-visible / Behavior Changes

- **Subagent runs:** The first user turn is a short pointer to `## Your Role`; the full `task` remains in the subagent system prompt, with **verbatim** handling for multiline `task` (see above).
- **No** change to `sessions_spawn` routing, tool surface, or registry of subagent runs.

## Diagram (if applicable)

N/A (prompt string assembly only)

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- N/A (unit-test verified)

### Steps

1. Run: `pnpm test src/agents/subagent-initial-user-message.test.ts`
2. Run: `pnpm test src/agents/system-prompt.test.ts`

### Expected

- All tests pass.

### Actual

- All tests pass locally after the `task` narrowing fix for `buildSubagentSystemPrompt` (TypeScript / CI).

## Evidence

- [x] Failing test/log before + passing after: CI previously failed with `TS18048` in `subagent-system-prompt.ts` after the verbatim-task change; fixed by narrowing with `taskRaw: string` before `trim()`.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Unit behavior for no duplicated task in first user turn; multiline task not collapsed to a single line in the system prompt.
- **Edge cases checked:** multiline (new test); single-line (existing cases).
- **What you did not verify:** Not measured token counts end-to-end in a live subagent run (out of scope for this PR; QC asked optional integration).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- **Backward compatible?** Yes (first user text shape only; no protocol change)
- **Config/env changes?** No
- **Migration needed?** No

## Risks and Mitigations

- **Risk:** A provider that ignored system content and only read the user turn might miss the task — **Mitigation:** the system prompt is unchanged in intent; the first user line explicitly points to `## Your Role` where the full `task` lives, matching #72019 option (1).
- **Risk (addressed in follow-up commit):** Losing newlines/indentation in `task` when the user turn no longer included a verbatim copy — **Mitigation:** `buildSubagentSystemPrompt` no longer flattens whitespace; multiline tasks use a fenced code block.

## Changelog

- Omitted in-branch to limit merge noise on `CHANGELOG.md`; can be added at land time if release policy requires a user-facing line for #72019.
