### PR TITLE
fix(tasks): add jitter tolerance to audit timestamp checks

### DIFF
--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -90,8 +90,15 @@ function hasBlockingMetadata(flow: TaskFlowRecord): boolean {
   );
 }
 
+/**
+ * Small tolerance for timestamp ordering checks.  Timestamps may originate
+ * from separate `Date.now()` calls, so inversions of a few milliseconds are
+ * expected jitter — not real bugs.  Only flag inversions that exceed this.
+ */
+const TIMESTAMP_JITTER_MS = 100;
+
 function findTimestampInconsistency(flow: TaskFlowRecord): TaskFlowAuditFinding | null {
-  if (flow.updatedAt < flow.createdAt) {
+  if (flow.createdAt - flow.updatedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -99,7 +106,7 @@ function findTimestampInconsistency(flow: TaskFlowRecord): TaskFlowAuditFinding 
       detail: "updatedAt is earlier than createdAt",
     });
   }
-  if (flow.endedAt && flow.endedAt < flow.createdAt) {
+  if (flow.endedAt && flow.createdAt - flow.endedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -107,7 +114,7 @@ function findTimestampInconsistency(flow: TaskFlowRecord): TaskFlowAuditFinding 
       detail: "endedAt is earlier than createdAt",
     });
   }
-  if (flow.endedAt && flow.endedAt < flow.updatedAt) {
+  if (flow.endedAt && flow.updatedAt - flow.endedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -115,6 +115,68 @@ describe("task-registry audit", () => {
     ]);
   });
 
+  it("ignores startedAt < createdAt inversions within jitter tolerance", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = now - 60_000;
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "tiny-jitter",
+          status: "succeeded",
+          createdAt: base,
+          startedAt: base - 24, // 24 ms jitter — well within tolerance
+          endedAt: base + 1000,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings.filter((f) => f.code === "inconsistent_timestamps")).toEqual([]);
+  });
+
+  it("flags startedAt < createdAt inversions exceeding jitter tolerance", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = now - 60_000;
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "big-inversion",
+          status: "succeeded",
+          createdAt: base,
+          startedAt: base - 500, // 500 ms — exceeds tolerance
+          endedAt: base + 1000,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+
+    const timestamps = findings.filter((f) => f.code === "inconsistent_timestamps");
+    expect(timestamps).toHaveLength(1);
+    expect(timestamps[0].detail).toBe("startedAt is earlier than createdAt");
+  });
+
+  it("ignores endedAt < startedAt inversions within jitter tolerance", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = now - 60_000;
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "ended-jitter",
+          status: "succeeded",
+          createdAt: base,
+          startedAt: base + 100,
+          endedAt: base + 90, // 10 ms jitter
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings.filter((f) => f.code === "inconsistent_timestamps")).toEqual([]);
+  });
+
   it("does not double-report lost tasks as missing cleanup", () => {
     const now = Date.parse("2026-03-30T01:00:00.000Z");
     const findings = listTaskAuditFindings({

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -17,6 +17,14 @@ export type TaskAuditOptions = {
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
+
+/**
+ * Small tolerance for timestamp ordering checks.  `startedAt` and `createdAt`
+ * may originate from separate `Date.now()` calls (or even different runtimes),
+ * so inversions of a few milliseconds are expected jitter — not real bugs.
+ * Only flag inversions that exceed this threshold.
+ */
+const TIMESTAMP_JITTER_MS = 100;
 export { createEmptyTaskAuditSummary };
 export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
 
@@ -47,7 +55,7 @@ function taskReferenceAt(task: TaskRecord): number {
 }
 
 function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
-  if (task.startedAt && task.startedAt < task.createdAt) {
+  if (task.startedAt && task.createdAt - task.startedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -55,7 +63,7 @@ function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
       detail: "startedAt is earlier than createdAt",
     });
   }
-  if (task.endedAt && task.startedAt && task.endedAt < task.startedAt) {
+  if (task.endedAt && task.startedAt && task.startedAt - task.endedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",


### PR DESCRIPTION
## Summary

`openclaw tasks audit` emits large numbers of false `inconsistent_timestamps` warnings when `startedAt` precedes `createdAt` by only a few milliseconds (5–24 ms observed). These inversions are harmless timestamp jitter from separate `Date.now()` calls during task creation/start transitions.

## Changes

- **`task-registry.audit.ts`**: Add a `TIMESTAMP_JITTER_MS = 100` tolerance constant. Timestamp ordering checks now compare the *delta* against the tolerance rather than using strict `<` — inversions under 100 ms are silently ignored.
- **`task-flow-registry.audit.ts`**: Apply the same tolerance to the flow-level timestamp checks for consistency.
- **`task-registry.audit.test.ts`**: Three new unit tests:
  - Within-tolerance jitter (24 ms) → no warning
  - Beyond-tolerance inversion (500 ms) → warning fires
  - `endedAt` vs `startedAt` jitter → no warning

## Why 100 ms?

Reported deltas range from 5–24 ms. A 100 ms threshold gives ~4× headroom over observed jitter while still catching genuine timestamp corruption (which would typically be seconds/minutes off). The constant is named and documented for easy adjustment.

## Before / After

| Host with 954 tasks | Before | After |
|---------------------|--------|-------|
| `inconsistent_timestamps` warnings | 954 | 0 (all deltas < 100 ms) |

Closes #72035