### PR TITLE
fix(media-understanding): allow aws-sdk auth mode in image tool [AI-assisted]

### DIFF
--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -32,3 +32,10 @@ export function requireApiKey(auth: ResolvedProviderAuth, provider: string): str
   }
   throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
 }
+
+export function requireApiKeyAllowAwsSdk(auth: ResolvedProviderAuth, provider: string): string {
+  if (auth.mode === "aws-sdk") {
+    return normalizeSecretInput(auth.apiKey) ?? "";
+  }
+  return requireApiKey(auth, provider);
+}

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -88,6 +88,7 @@ let applyAuthHeaderOverride: typeof import("./model-auth.js").applyAuthHeaderOve
 let applyLocalNoAuthHeaderOverride: typeof import("./model-auth.js").applyLocalNoAuthHeaderOverride;
 let hasUsableCustomProviderApiKey: typeof import("./model-auth.js").hasUsableCustomProviderApiKey;
 let requireApiKey: typeof import("./model-auth.js").requireApiKey;
+let requireApiKeyAllowAwsSdk: typeof import("./model-auth.js").requireApiKeyAllowAwsSdk;
 let resolveApiKeyForProvider: typeof import("./model-auth.js").resolveApiKeyForProvider;
 let resolveAwsSdkEnvVarName: typeof import("./model-auth.js").resolveAwsSdkEnvVarName;
 let resolveModelAuthMode: typeof import("./model-auth.js").resolveModelAuthMode;
@@ -105,6 +106,7 @@ beforeAll(async () => {
     applyLocalNoAuthHeaderOverride,
     hasUsableCustomProviderApiKey,
     requireApiKey,
+    requireApiKeyAllowAwsSdk,
     resolveApiKeyForProvider,
     resolveAwsSdkEnvVarName,
     resolveModelAuthMode,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -43,7 +43,11 @@ import {
 import { normalizeProviderId } from "./model-selection.js";
 
 export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
-export { requireApiKey, resolveAwsSdkEnvVarName } from "./model-auth-runtime-shared.js";
+export {
+  requireApiKey,
+  requireApiKeyAllowAwsSdk,
+  resolveAwsSdkEnvVarName,
+} from "./model-auth-runtime-shared.js";
 export type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 export type ProviderCredentialPrecedence = "profile-first" | "env-first";
 

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -14,6 +14,7 @@ const hoisted = vi.hoisted(() => ({
     mode: "oauth",
   })),
   requireApiKeyMock: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
+  requireApiKeyAllowAwsSdkMock: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
   setRuntimeApiKeyMock: vi.fn(),
   discoverModelsMock: vi.fn(),
   fetchMock: vi.fn(),
@@ -27,6 +28,7 @@ const {
   getApiKeyForModelMock,
   resolveApiKeyForProviderMock,
   requireApiKeyMock,
+  requireApiKeyAllowAwsSdkMock,
   setRuntimeApiKeyMock,
   discoverModelsMock,
   fetchMock,
@@ -60,6 +62,7 @@ vi.mock("../agents/model-auth.js", () => ({
   getApiKeyForModel: getApiKeyForModelMock,
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
   requireApiKey: requireApiKeyMock,
+  requireApiKeyAllowAwsSdk: requireApiKeyAllowAwsSdkMock,
 }));
 
 vi.mock("../agents/provider-stream.js", () => ({
@@ -145,7 +148,7 @@ describe("describeImageWithModel", () => {
     expect(getApiKeyForModelMock).toHaveBeenCalledWith(
       expect.objectContaining({ store: authStore }),
     );
-    expect(requireApiKeyMock).toHaveBeenCalled();
+    expect(requireApiKeyAllowAwsSdkMock).toHaveBeenCalled();
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("minimax-portal", "oauth-test");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.minimax.io/v1/coding_plan/vlm",
@@ -612,5 +615,52 @@ describe("describeImageWithModel", () => {
       }),
     );
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
+  });
+
+  it("does not throw for amazon-bedrock aws-sdk auth mode without an API key", async () => {
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "",
+      source: "aws-sdk",
+      mode: "aws-sdk",
+    });
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "amazon-bedrock",
+        id: "anthropic.claude-sonnet-4-6",
+        api: "anthropic-messages",
+        input: ["text", "image"],
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "amazon-bedrock",
+      model: "anthropic.claude-sonnet-4-6",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "bedrock ok" }],
+    });
+    requireApiKeyAllowAwsSdkMock.mockReturnValueOnce("");
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "amazon-bedrock",
+      model: "anthropic.claude-sonnet-4-6",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "bedrock ok",
+      model: "anthropic.claude-sonnet-4-6",
+    });
+    expect(requireApiKeyAllowAwsSdkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "aws-sdk" }),
+      "amazon-bedrock",
+    );
   });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -3,7 +3,7 @@ import { complete } from "@mariozechner/pi-ai";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm.js";
 import {
   getApiKeyForModel,
-  requireApiKey,
+  requireApiKeyAllowAwsSdk,
   resolveApiKeyForProvider,
 } from "../agents/model-auth.js";
 import { findNormalizedProviderValue, normalizeModelRef } from "../agents/model-selection.js";
@@ -202,7 +202,7 @@ async function resolveImageRuntime(params: {
     preferredProfile: params.preferredProfile,
     store: params.authStore,
   });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
+  const apiKey = requireApiKeyAllowAwsSdk(apiKeyInfo, model.provider);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
   return { apiKey, model };
 }
@@ -304,7 +304,7 @@ async function resolveMinimaxVlmFallbackRuntime(params: {
     agentDir: params.agentDir,
   });
   return {
-    apiKey: requireApiKey(auth, params.provider),
+    apiKey: requireApiKeyAllowAwsSdk(auth, params.provider),
     modelBaseUrl: resolveConfiguredProviderBaseUrl(params.cfg, params.provider),
   };
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -4,7 +4,7 @@ import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
 } from "../agents/api-key-rotation.js";
-import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { requireApiKeyAllowAwsSdk, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import {
   mergeModelProviderRequestOverrides,
   sanitizeConfiguredModelProviderRequest,
@@ -404,7 +404,7 @@ async function resolveProviderExecutionAuth(params: {
   return {
     apiKeys: collectProviderApiKeysForExecution({
       provider: params.providerId,
-      primaryApiKey: requireApiKey(auth, params.providerId),
+      primaryApiKey: requireApiKeyAllowAwsSdk(auth, params.providerId),
     }),
     providerConfig: params.cfg.models?.providers?.[params.providerId],
   };


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: The `image` tool fails for all Bedrock models when using AWS SDK credential resolution (IAM role, instance profile, `AWS_PROFILE`). `requireApiKey` throws `No API key resolved for provider "amazon-bedrock" (auth mode: aws-sdk)` even though chat/completion with the same model works fine.
- Why it matters: Any user relying on AWS SDK credential chains (the standard for IAM roles, EC2 instances, ECS tasks) cannot use image analysis with Bedrock models at all.
- What changed: Added `requireApiKeyAllowAwsSdk` helper in `model-auth-runtime-shared.ts` that returns an empty string for `aws-sdk` mode instead of throwing. Replaced `requireApiKey` calls in `image.ts` (2 sites) and `runner.entries.ts` (1 site) with the new helper.
- What did NOT change (scope boundary): `requireApiKey` itself is unchanged — all non-aws-sdk auth modes still throw on missing keys. The chat/completion path's existing `allowMissingApiKeyModes` mechanism is untouched.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Media understanding (`src/media-understanding/`)
- [x] Agent auth (`src/agents/model-auth*`)

## Linked Issue/PR
- Closes #72031
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `resolveImageRuntime` in `image.ts` unconditionally called `requireApiKey`, which throws when `auth.apiKey` is empty regardless of `auth.mode`. For `amazon-bedrock` with `aws-sdk` mode, no static API key exists — the AWS SDK resolves credentials at call time. The chat path already handled this via `allowMissingApiKeyModes: ["aws-sdk"]`, but the image path did not.
- Missing detection / guardrail: No test covered the aws-sdk auth mode path in the image tool.
- Contributing context: The image tool auth was written before Bedrock's aws-sdk credential mode was widely used, and the escape hatch was only added to the chat path.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/media-understanding/image.test.ts`
- Scenario the test should lock in: `describeImageWithModel` with `auth.mode === "aws-sdk"` and no API key must succeed without throwing.
- Why this is the smallest reliable guardrail: Direct unit test on the image description function with mocked aws-sdk auth — no AWS credentials needed.
- Existing test that already covers this: N/A

## User-visible / Behavior Changes
Image analysis with Bedrock models using AWS SDK credentials now works (previously always failed).

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- `requireApiKeyAllowAwsSdk` only relaxes the API key requirement for `aws-sdk` mode, which by definition uses the AWS SDK credential chain instead of static keys. All other auth modes still require an explicit API key. The empty string passed as `apiKey` is not used by the Bedrock SDK path — it resolves credentials independently.
