### PR TITLE
fix(agents): seed claude-cli fallback prompts with prior-session context (#69973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Logging/security: redact sensitive tokens (sk-\* keys, Bearer/Authorization values, etc.) at the subsystem console sink so `createSubsystemLogger().info/warn/error` output that bypasses the patched console-capture handler still applies the same redaction the file transport already does. Fixes #73284; refs #67953 and #64046. Thanks @edwin-rivera-dev.
 - Plugins/runtime deps: reuse enclosing versioned cache roots when bundled plugins resolve from nested staged paths, so plugin-runtime-deps no longer mints `openclaw-unknown-*` directories or loops on `ENOTEMPTY`. Fixes #72956. (#73205) Thanks @SymbolStar.
 - Agents/failover: classify CJK provider transport, quota, billing, auth, and overload error text so Chinese-language provider failures trigger fallback and user-facing transport copy instead of surfacing as unclassified raw errors. (#56242) Thanks @tomcatzh.
+- Agents/failover: seed non-claude-cli fallback prompts with Claude Code session context when a claude-cli attempt fails, so fallback models do not restart cold after billing or quota failover. (#72069) Thanks @stainlu.
 
 ## 2026.4.27
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -954,6 +954,7 @@ async function agentCommandInternal(
             return attemptExecutionRuntime.runAgentAttempt({
               providerOverride,
               modelOverride,
+              originalProvider: provider,
               cfg,
               sessionEntry,
               sessionId,

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -147,6 +147,7 @@ async function runAuthContractAttempt(params: {
 
   await runAgentAttempt({
     providerOverride: params.providerOverride,
+    originalProvider: params.providerOverride,
     modelOverride: "gpt-5.4",
     cfg,
     sessionEntry,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -102,6 +102,7 @@ describe("CLI attempt execution", () => {
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: {} as OpenClawConfig,
       sessionEntry: params.sessionEntry,
@@ -166,6 +167,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -317,6 +319,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride: "codex-cli",
+      originalProvider: "codex-cli",
       modelOverride: "gpt-5.4",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -433,6 +436,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -482,6 +486,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride: "anthropic",
+      originalProvider: "anthropic",
       modelOverride: "claude-opus-4-7",
       cfg: {
         agents: {
@@ -536,6 +541,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
       modelOverride: "claude-opus-4-7",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -601,6 +607,7 @@ describe("embedded attempt harness pinning", () => {
 
     await runAgentAttempt({
       providerOverride: "openai",
+      originalProvider: "openai",
       modelOverride: "gpt-5.4",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -644,6 +651,7 @@ describe("embedded attempt harness pinning", () => {
 
     await runAgentAttempt({
       providerOverride: "codex",
+      originalProvider: "codex",
       modelOverride: "gpt-5.4",
       cfg: {
         agents: {
@@ -693,6 +701,7 @@ describe("embedded attempt harness pinning", () => {
 
     await runAgentAttempt({
       providerOverride: "openai",
+      originalProvider: "openai",
       modelOverride: "gpt-5.4",
       cfg: {} as OpenClawConfig,
       sessionEntry,
@@ -736,6 +745,7 @@ describe("embedded attempt harness pinning", () => {
 
     await runAgentAttempt({
       providerOverride: "openai",
+      originalProvider: "claude-cli",
       modelOverride: "gpt-5.4",
       cfg: {
         agents: {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -237,8 +237,9 @@ export function formatClaudeCliFallbackPrelude(
     CLAUDE_CLI_FALLBACK_PRELUDE_MIN_TURN_CHARS,
     options?.charBudget ?? CLAUDE_CLI_FALLBACK_PRELUDE_DEFAULT_CHAR_BUDGET,
   );
-  const sections: string[] = ["## Prior session context (from claude-cli)"];
-  let remaining = charBudget - sections[0]!.length;
+  const heading = "## Prior session context (from claude-cli)";
+  const sections: string[] = [heading];
+  let remaining = charBudget - heading.length;
   if (seed.summaryText) {
     const summarySection = `\nSummary of earlier conversation:\n${seed.summaryText}`;
     if (summarySection.length <= remaining) {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -189,9 +189,15 @@ function formatFallbackTurns(
   if (turns.length === 0 || remainingBudget <= 0) {
     return { text: "", consumed: 0 };
   }
-  // Walk newest -> oldest, prepending lines until we exceed the budget.
-  // Stops at the oldest turn we can include in full so we never deliver a
-  // truncated mid-turn fragment to the fallback model.
+  // Walk newest -> oldest, prepending lines until one does not fit.
+  //
+  // We stop on the FIRST oversized turn instead of skipping it and then
+  // continuing into older ones. The fallback prelude is a "most recent
+  // contiguous window" summary — what was happening just before the
+  // failed attempt — so a non-contiguous slice (newest + something from
+  // 20 turns ago, gap in the middle) would mislead the fallback model
+  // about the actual flow. Sparse coverage is worse than fewer turns:
+  // greptile flagged this as a P2 on #72069; behavior is intentional.
   const lines: string[] = [];
   let consumed = 0;
   for (let i = turns.length - 1; i >= 0; i -= 1) {
@@ -209,9 +215,6 @@ function formatFallbackTurns(
     }
     const line = `${role}: ${text}`;
     if (consumed + line.length + 1 > remainingBudget) {
-      // Skip this turn rather than chop it; if even the most recent turn
-      // is too large to include cleanly, stop emitting (the prelude is a
-      // best-effort sketch, not a transcript).
       break;
     }
     lines.unshift(line);

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -9,6 +9,10 @@ import {
   startsWithSilentToken,
   stripLeadingSilentToken,
 } from "../../auto-reply/tokens.js";
+import {
+  type ClaudeCliFallbackSeed,
+  readClaudeCliFallbackSeed,
+} from "../../gateway/cli-session-history.js";
 
 /** Maximum number of JSONL records to inspect before giving up. */
 const SESSION_FILE_MAX_RECORDS = 500;
@@ -105,11 +109,21 @@ export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
   sessionHasHistory?: boolean;
+  /**
+   * Optional context prelude (e.g., a compacted summary harvested from a
+   * non-OpenClaw transcript such as Claude Code's local JSONL). Prepended
+   * before the retry marker so the fallback candidate has prior context
+   * even when OpenClaw's own session file is empty for the current
+   * provider — see `buildClaudeCliFallbackContextPrelude` for the
+   * claude-cli case (#69973).
+   */
+  priorContextPrelude?: string;
 }): string {
   if (!params.isFallbackRetry) {
     return params.body;
   }
-  if (!params.sessionHasHistory) {
+  const prelude = params.priorContextPrelude?.trim();
+  if (!params.sessionHasHistory && !prelude) {
     return params.body;
   }
   // Even with persisted session history, fully replacing the body with a
@@ -118,7 +132,165 @@ export function resolveFallbackRetryPrompt(params: {
   // instruction from history alone, which is fragile and sometimes
   // impossible. Prepend the retry context to the original body instead so
   // the fallback model has both the recovery signal AND the task. (#65760)
-  return `[Retry after the previous model attempt failed or timed out]\n\n${params.body}`;
+  const retryMarked = `[Retry after the previous model attempt failed or timed out]\n\n${params.body}`;
+  return prelude ? `${prelude}\n\n${retryMarked}` : retryMarked;
+}
+
+const CLAUDE_CLI_FALLBACK_PRELUDE_DEFAULT_CHAR_BUDGET = 8_000;
+const CLAUDE_CLI_FALLBACK_PRELUDE_MIN_TURN_CHARS = 64;
+
+type FallbackTurnLikeMessage = Record<string, unknown>;
+
+function extractFallbackTurnText(message: FallbackTurnLikeMessage): string {
+  const content = message.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+      continue;
+    }
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const rec = block as Record<string, unknown>;
+    if (typeof rec.text === "string") {
+      parts.push(rec.text);
+      continue;
+    }
+    // Tool calls: render as a compact "(tool: name)" hint so the fallback
+    // model sees the conversation flow without the full tool argument blob,
+    // which is rarely useful out of context and chews through char budget.
+    if (rec.type === "tool_use" && typeof rec.name === "string") {
+      parts.push(`(tool call: ${rec.name})`);
+      continue;
+    }
+    if (rec.type === "tool_result") {
+      const inner = typeof rec.content === "string" ? rec.content : undefined;
+      if (inner) {
+        parts.push(`(tool result: ${inner})`);
+      } else {
+        parts.push("(tool result)");
+      }
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+function formatFallbackTurns(
+  turns: ReadonlyArray<FallbackTurnLikeMessage>,
+  remainingBudget: number,
+): { text: string; consumed: number } {
+  if (turns.length === 0 || remainingBudget <= 0) {
+    return { text: "", consumed: 0 };
+  }
+  // Walk newest -> oldest, prepending lines until we exceed the budget.
+  // Stops at the oldest turn we can include in full so we never deliver a
+  // truncated mid-turn fragment to the fallback model.
+  const lines: string[] = [];
+  let consumed = 0;
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (!turn || typeof turn !== "object") {
+      continue;
+    }
+    const role = turn.role;
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+    const text = extractFallbackTurnText(turn);
+    if (!text) {
+      continue;
+    }
+    const line = `${role}: ${text}`;
+    if (consumed + line.length + 1 > remainingBudget) {
+      // Skip this turn rather than chop it; if even the most recent turn
+      // is too large to include cleanly, stop emitting (the prelude is a
+      // best-effort sketch, not a transcript).
+      break;
+    }
+    lines.unshift(line);
+    consumed += line.length + 1;
+  }
+  return { text: lines.join("\n"), consumed };
+}
+
+/**
+ * Format a previously-harvested Claude CLI session into a labeled prelude
+ * suitable for prepending to a fallback candidate's prompt. Behavior matches
+ * Claude Code's own resume strategy after compaction: prefer the explicit
+ * summary, then append the most recent turns up to a char budget.
+ *
+ * Returns an empty string when neither a summary nor any usable turn fits in
+ * the budget; callers can treat that as "no context to seed".
+ */
+export function formatClaudeCliFallbackPrelude(
+  seed: ClaudeCliFallbackSeed,
+  options?: { charBudget?: number },
+): string {
+  const charBudget = Math.max(
+    CLAUDE_CLI_FALLBACK_PRELUDE_MIN_TURN_CHARS,
+    options?.charBudget ?? CLAUDE_CLI_FALLBACK_PRELUDE_DEFAULT_CHAR_BUDGET,
+  );
+  const sections: string[] = ["## Prior session context (from claude-cli)"];
+  let remaining = charBudget - sections[0]!.length;
+  if (seed.summaryText) {
+    const summarySection = `\nSummary of earlier conversation:\n${seed.summaryText}`;
+    if (summarySection.length <= remaining) {
+      sections.push(summarySection);
+      remaining -= summarySection.length;
+    } else {
+      // Truncate the summary at a word boundary if it's huge; clearly mark
+      // the truncation so the fallback model treats the prelude as a hint,
+      // not exhaustive state.
+      const slice = seed.summaryText.slice(0, Math.max(0, remaining - 64));
+      const lastBreak = slice.lastIndexOf(" ");
+      const trimmed = lastBreak > 0 ? slice.slice(0, lastBreak).trimEnd() : slice.trimEnd();
+      sections.push(`\nSummary of earlier conversation (truncated):\n${trimmed} …`);
+      remaining = 0;
+    }
+  }
+  if (remaining > CLAUDE_CLI_FALLBACK_PRELUDE_MIN_TURN_CHARS && seed.recentTurns.length > 0) {
+    const { text } = formatFallbackTurns(
+      seed.recentTurns as ReadonlyArray<FallbackTurnLikeMessage>,
+      remaining - 32,
+    );
+    if (text) {
+      sections.push(`\nRecent turns:\n${text}`);
+    }
+  }
+  // No summary AND no fittable turns => nothing to seed beyond the heading,
+  // which would just confuse the model. Drop the prelude entirely.
+  if (sections.length === 1) {
+    return "";
+  }
+  return sections.join("\n");
+}
+
+/**
+ * Read the Claude CLI session pointed to by `cliSessionId` and format a
+ * fallback prelude. Returns `""` when no session file is found or when the
+ * harvested seed has no usable content.
+ */
+export function buildClaudeCliFallbackContextPrelude(params: {
+  cliSessionId: string | undefined;
+  homeDir?: string;
+  charBudget?: number;
+}): string {
+  const sessionId = params.cliSessionId?.trim();
+  if (!sessionId) {
+    return "";
+  }
+  const seed = readClaudeCliFallbackSeed({ cliSessionId: sessionId, homeDir: params.homeDir });
+  if (!seed) {
+    return "";
+  }
+  return formatClaudeCliFallbackPrelude(seed, { charBudget: params.charBudget });
 }
 
 export function createAcpVisibleTextAccumulator() {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -109,14 +109,6 @@ export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
   sessionHasHistory?: boolean;
-  /**
-   * Optional context prelude (e.g., a compacted summary harvested from a
-   * non-OpenClaw transcript such as Claude Code's local JSONL). Prepended
-   * before the retry marker so the fallback candidate has prior context
-   * even when OpenClaw's own session file is empty for the current
-   * provider — see `buildClaudeCliFallbackContextPrelude` for the
-   * claude-cli case (#69973).
-   */
   priorContextPrelude?: string;
 }): string {
   if (!params.isFallbackRetry) {
@@ -189,15 +181,6 @@ function formatFallbackTurns(
   if (turns.length === 0 || remainingBudget <= 0) {
     return { text: "", consumed: 0 };
   }
-  // Walk newest -> oldest, prepending lines until one does not fit.
-  //
-  // We stop on the FIRST oversized turn instead of skipping it and then
-  // continuing into older ones. The fallback prelude is a "most recent
-  // contiguous window" summary — what was happening just before the
-  // failed attempt — so a non-contiguous slice (newest + something from
-  // 20 turns ago, gap in the middle) would mislead the fallback model
-  // about the actual flow. Sparse coverage is worse than fewer turns:
-  // greptile flagged this as a P2 on #72069; behavior is intentional.
   const lines: string[] = [];
   let consumed = 0;
   for (let i = turns.length - 1; i >= 0; i -= 1) {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -3,8 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
   createAcpVisibleTextAccumulator,
+  formatClaudeCliFallbackPrelude,
   resolveFallbackRetryPrompt,
   sessionFileHasContent,
 } from "./attempt-execution.helpers.js";
@@ -76,6 +78,193 @@ describe("resolveFallbackRetryPrompt", () => {
         sessionHasHistory: false,
       }),
     ).toBe(originalBody);
+  });
+
+  // #69973: even when OpenClaw's own session file is empty (the claude-cli
+  // case where Claude Code maintains its own JSONL), a harvested
+  // priorContextPrelude must still seed the retry prompt so the fallback
+  // candidate has prior context.
+  it("prepends priorContextPrelude before the retry marker on fallback retry", () => {
+    const prelude = "## Prior session context (from claude-cli)\nuser: prior question";
+    const result = resolveFallbackRetryPrompt({
+      body: originalBody,
+      isFallbackRetry: true,
+      sessionHasHistory: true,
+      priorContextPrelude: prelude,
+    });
+    expect(result).toBe(
+      `${prelude}\n\n[Retry after the previous model attempt failed or timed out]\n\n${originalBody}`,
+    );
+  });
+
+  it("emits the retry prompt with prelude even when sessionHasHistory is false (claude-cli case)", () => {
+    const prelude = "## Prior session context (from claude-cli)\nuser: prior question";
+    const result = resolveFallbackRetryPrompt({
+      body: originalBody,
+      isFallbackRetry: true,
+      sessionHasHistory: false,
+      priorContextPrelude: prelude,
+    });
+    expect(result).toBe(
+      `${prelude}\n\n[Retry after the previous model attempt failed or timed out]\n\n${originalBody}`,
+    );
+  });
+
+  it("ignores empty/whitespace priorContextPrelude", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+        priorContextPrelude: "   \n  ",
+      }),
+    ).toBe(originalBody);
+  });
+
+  it("does not prepend prelude on non-fallback first attempts", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: false,
+        sessionHasHistory: true,
+        priorContextPrelude: "anything",
+      }),
+    ).toBe(originalBody);
+  });
+});
+
+describe("formatClaudeCliFallbackPrelude", () => {
+  it("returns empty string when seed has neither summary nor turns", () => {
+    expect(formatClaudeCliFallbackPrelude({ recentTurns: [] })).toBe("");
+  });
+
+  it("emits summary alone when no turns are available", () => {
+    const out = formatClaudeCliFallbackPrelude({
+      summaryText: "User wants to ship a billing-aware fallback.",
+      recentTurns: [],
+    });
+    expect(out).toContain("## Prior session context (from claude-cli)");
+    expect(out).toContain("Summary of earlier conversation:");
+    expect(out).toContain("User wants to ship a billing-aware fallback.");
+    expect(out).not.toContain("Recent turns:");
+  });
+
+  it("formats user/assistant turns and tags tool blocks with compact hints", () => {
+    const out = formatClaudeCliFallbackPrelude({
+      recentTurns: [
+        {
+          role: "user",
+          content: "Earlier user question",
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Earlier assistant reply" },
+            { type: "tool_use", name: "Bash" },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_x",
+              content: "Earlier tool output",
+            },
+          ],
+        },
+      ],
+    });
+    expect(out).toContain("## Prior session context (from claude-cli)");
+    expect(out).toContain("Recent turns:");
+    expect(out).toContain("user: Earlier user question");
+    expect(out).toContain("assistant: Earlier assistant reply");
+    expect(out).toContain("(tool call: Bash)");
+    expect(out).toContain("(tool result: Earlier tool output)");
+  });
+
+  it("truncates an oversized summary instead of dropping it silently", () => {
+    const huge = "x ".repeat(10_000).trim();
+    const out = formatClaudeCliFallbackPrelude(
+      { summaryText: huge, recentTurns: [] },
+      { charBudget: 600 },
+    );
+    expect(out).toContain("Summary of earlier conversation (truncated):");
+    expect(out.length).toBeLessThan(800);
+    // Trailing ellipsis tells the model the summary was clipped — better
+    // than silently emitting a fragment that looks complete.
+    expect(out).toMatch(/…$/);
+  });
+
+  it("drops oldest turns first when the budget cannot fit all of them", () => {
+    const turns = Array.from({ length: 10 }, (_, i) => ({
+      role: "user" as const,
+      content: `turn ${i + 1} ${"x".repeat(80)}`,
+    }));
+    const out = formatClaudeCliFallbackPrelude({ recentTurns: turns }, { charBudget: 350 });
+    // Newest turn (turn 10) must be present; oldest (turn 1) must not be.
+    expect(out).toContain("turn 10");
+    expect(out).not.toContain("turn 1 ");
+  });
+});
+
+describe("buildClaudeCliFallbackContextPrelude", () => {
+  it("returns empty string when no sessionId is provided", () => {
+    expect(buildClaudeCliFallbackContextPrelude({ cliSessionId: undefined })).toBe("");
+    expect(buildClaudeCliFallbackContextPrelude({ cliSessionId: "  " })).toBe("");
+  });
+
+  it("returns empty string when the Claude session file does not exist", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fallback-prelude-"));
+    try {
+      expect(
+        buildClaudeCliFallbackContextPrelude({
+          cliSessionId: "missing-session",
+          homeDir: tmpHome,
+        }),
+      ).toBe("");
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a real Claude JSONL fixture and emits a labeled prelude end-to-end", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fallback-prelude-"));
+    const sessionId = "e2e-session";
+    const projectsDir = path.join(tmpHome, ".claude", "projects", "demo");
+    try {
+      await fs.mkdir(projectsDir, { recursive: true });
+      const lines = [
+        {
+          type: "user",
+          uuid: "u1",
+          message: { role: "user", content: "prior question about deploys" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          message: {
+            role: "assistant",
+            model: "claude-sonnet-4-6",
+            content: [{ type: "text", text: "prior answer about blue-green" }],
+          },
+        },
+      ];
+      await fs.writeFile(
+        path.join(projectsDir, `${sessionId}.jsonl`),
+        `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+        "utf-8",
+      );
+      const prelude = buildClaudeCliFallbackContextPrelude({
+        cliSessionId: sessionId,
+        homeDir: tmpHome,
+      });
+      expect(prelude).toContain("## Prior session context (from claude-cli)");
+      expect(prelude).toContain("user: prior question about deploys");
+      expect(prelude).toContain("assistant: prior answer about blue-green");
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -80,10 +80,6 @@ describe("resolveFallbackRetryPrompt", () => {
     ).toBe(originalBody);
   });
 
-  // #69973: even when OpenClaw's own session file is empty (the claude-cli
-  // case where Claude Code maintains its own JSONL), a harvested
-  // priorContextPrelude must still seed the retry prompt so the fallback
-  // candidate has prior context.
   it("prepends priorContextPrelude before the retry marker on fallback retry", () => {
     const prelude = "## Prior session context (from claude-cli)\nuser: prior question";
     const result = resolveFallbackRetryPrompt({
@@ -191,8 +187,6 @@ describe("formatClaudeCliFallbackPrelude", () => {
     );
     expect(out).toContain("Summary of earlier conversation (truncated):");
     expect(out.length).toBeLessThan(800);
-    // Trailing ellipsis tells the model the summary was clipped — better
-    // than silently emitting a fragment that looks complete.
     expect(out).toMatch(/…$/);
   });
 
@@ -205,6 +199,23 @@ describe("formatClaudeCliFallbackPrelude", () => {
     // Newest turn (turn 10) must be present; oldest (turn 1) must not be.
     expect(out).toContain("turn 10");
     expect(out).not.toContain("turn 1 ");
+  });
+
+  it("keeps the recent turn window contiguous when an adjacent turn is oversized", () => {
+    const out = formatClaudeCliFallbackPrelude(
+      {
+        recentTurns: [
+          { role: "user", content: "older small turn" },
+          { role: "assistant", content: `oversized adjacent turn ${"x".repeat(500)}` },
+          { role: "user", content: "newest small turn" },
+        ],
+      },
+      { charBudget: 260 },
+    );
+
+    expect(out).toContain("newest small turn");
+    expect(out).not.toContain("oversized adjacent turn");
+    expect(out).not.toContain("older small turn");
   });
 });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -240,9 +240,13 @@ export function runAgentAttempt(params: {
    * fallback context seeding to chains that actually started on claude-cli;
    * a stale `cliSessionBindings["claude-cli"]` from an unrelated past run
    * must not contaminate fallbacks that started on another provider
-   * (Codex review #72069 P1).
+   * (Codex review #72069 P1). Optional for callers that don't drive
+   * a fallback chain (tests, ad-hoc invocations); when omitted, the
+   * claude-cli fallback seed is skipped — that's a no-op for non-fallback
+   * paths and a defensive default for fallback paths that didn't plumb
+   * the original provider through.
    */
-  originalProvider: string;
+  originalProvider?: string;
   cfg: OpenClawConfig;
   sessionEntry: SessionEntry | undefined;
   sessionId: string;
@@ -283,6 +287,7 @@ export function runAgentAttempt(params: {
   // must not bleed into this fallback chain.
   const claudeCliFallbackPrelude =
     params.isFallbackRetry &&
+    typeof params.originalProvider === "string" &&
     isClaudeCliProvider(params.originalProvider) &&
     !isClaudeCliProvider(params.providerOverride)
       ? buildClaudeCliFallbackContextPrelude({

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -234,6 +234,15 @@ export async function persistCliTurnTranscript(params: {
 export function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
+  /**
+   * The provider the user originally requested for this turn (i.e. the
+   * primary candidate of the fallback chain). Used to scope claude-cli
+   * fallback context seeding to chains that actually started on claude-cli;
+   * a stale `cliSessionBindings["claude-cli"]` from an unrelated past run
+   * must not contaminate fallbacks that started on another provider
+   * (Codex review #72069 P1).
+   */
+  originalProvider: string;
   cfg: OpenClawConfig;
   sessionEntry: SessionEntry | undefined;
   sessionId: string;
@@ -267,8 +276,15 @@ export function runAgentAttempt(params: {
   // Harvest a compacted context (Claude's own `/compact` summary plus the
   // most recent post-boundary turns) and prepend it to the retry prompt.
   // This mirrors what Claude Code itself replays after compaction.
+  //
+  // Gate explicitly on `originalProvider === "claude-cli"`: if the user-
+  // requested provider for this run was not claude-cli, any claude-cli
+  // session binding on the entry is stale state from an earlier run and
+  // must not bleed into this fallback chain.
   const claudeCliFallbackPrelude =
-    params.isFallbackRetry && !isClaudeCliProvider(params.providerOverride)
+    params.isFallbackRetry &&
+    isClaudeCliProvider(params.originalProvider) &&
+    !isClaudeCliProvider(params.providerOverride)
       ? buildClaudeCliFallbackContextPrelude({
           cliSessionId: getCliSessionBinding(params.sessionEntry, "claude-cli")?.sessionId,
         })

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -23,6 +23,7 @@ import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildWorkspaceSkillSnapshot } from "../skills.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
 import {
+  buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
   resolveFallbackRetryPrompt,
 } from "./attempt-execution.helpers.js";
@@ -259,10 +260,24 @@ export function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   sessionHasHistory?: boolean;
 }) {
+  // #69973: when a fallback fires from claude-cli to a non-CLI candidate
+  // (or a different CLI backend), the next runner cannot see Claude Code's
+  // local JSONL history. Without a seed, the fallback model starts cold —
+  // even though the original Claude session is still alive on disk.
+  // Harvest a compacted context (Claude's own `/compact` summary plus the
+  // most recent post-boundary turns) and prepend it to the retry prompt.
+  // This mirrors what Claude Code itself replays after compaction.
+  const claudeCliFallbackPrelude =
+    params.isFallbackRetry && !isClaudeCliProvider(params.providerOverride)
+      ? buildClaudeCliFallbackContextPrelude({
+          cliSessionId: getCliSessionBinding(params.sessionEntry, "claude-cli")?.sessionId,
+        })
+      : "";
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
     sessionHasHistory: params.sessionHasHistory,
+    priorContextPrelude: claudeCliFallbackPrelude,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -234,19 +234,7 @@ export async function persistCliTurnTranscript(params: {
 export function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
-  /**
-   * The provider the user originally requested for this turn (i.e. the
-   * primary candidate of the fallback chain). Used to scope claude-cli
-   * fallback context seeding to chains that actually started on claude-cli;
-   * a stale `cliSessionBindings["claude-cli"]` from an unrelated past run
-   * must not contaminate fallbacks that started on another provider
-   * (Codex review #72069 P1). Optional for callers that don't drive
-   * a fallback chain (tests, ad-hoc invocations); when omitted, the
-   * claude-cli fallback seed is skipped — that's a no-op for non-fallback
-   * paths and a defensive default for fallback paths that didn't plumb
-   * the original provider through.
-   */
-  originalProvider?: string;
+  originalProvider: string;
   cfg: OpenClawConfig;
   sessionEntry: SessionEntry | undefined;
   sessionId: string;
@@ -273,21 +261,8 @@ export function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   sessionHasHistory?: boolean;
 }) {
-  // #69973: when a fallback fires from claude-cli to a non-CLI candidate
-  // (or a different CLI backend), the next runner cannot see Claude Code's
-  // local JSONL history. Without a seed, the fallback model starts cold —
-  // even though the original Claude session is still alive on disk.
-  // Harvest a compacted context (Claude's own `/compact` summary plus the
-  // most recent post-boundary turns) and prepend it to the retry prompt.
-  // This mirrors what Claude Code itself replays after compaction.
-  //
-  // Gate explicitly on `originalProvider === "claude-cli"`: if the user-
-  // requested provider for this run was not claude-cli, any claude-cli
-  // session binding on the entry is stale state from an earlier run and
-  // must not bleed into this fallback chain.
   const claudeCliFallbackPrelude =
     params.isFallbackRetry &&
-    typeof params.originalProvider === "string" &&
     isClaudeCliProvider(params.originalProvider) &&
     !isClaudeCliProvider(params.providerOverride)
       ? buildClaudeCliFallbackContextPrelude({

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -420,12 +420,20 @@ export function readClaudeCliFallbackSeed(params: {
     return undefined;
   }
 
-  let summaryText: string | undefined;
-  let boundaryFallbackText: string | undefined;
-  // Buffer turns into a window that resets every time we cross a compact
-  // boundary. After the walk completes, `windowedTurns` holds turns from
-  // the most recent (post-boundary) window, which matches what Claude Code
-  // would replay alongside the summary on its own resume.
+  // Pair each compact_boundary with the summary entry that preceded it
+  // since the previous boundary, so a later compaction whose summary is
+  // missing (e.g. crash mid-write) does not silently keep an older
+  // compaction's summary alive (#72069 Codex P2). Walk shape:
+  //   - explicit `summary` entry queues into `pendingSummary` until the
+  //     next boundary "consumes" it.
+  //   - `compact_boundary` flushes the pending summary into `lastSummary`,
+  //     refreshes `lastBoundaryFallback` from the boundary's content, and
+  //     drops the windowed turns and tool registry.
+  //   - everything after the latest boundary forms the recent-window the
+  //     fallback runner will replay alongside the summary.
+  let pendingSummary: string | undefined;
+  let lastSummary: string | undefined;
+  let lastBoundaryFallback: string | undefined;
   let windowedTurns: TranscriptLikeMessage[] = [];
   const toolNameRegistry: ToolNameRegistry = new Map();
 
@@ -442,15 +450,17 @@ export function readClaudeCliFallbackSeed(params: {
 
     const explicitSummary = extractSummaryText(parsed);
     if (explicitSummary) {
-      // Explicit summary entries are written by `/compact`; later entries
-      // supersede earlier ones the same way Claude Code itself replays
-      // only the most recent summary.
-      summaryText = explicitSummary;
+      // Queue the summary; the next boundary will pair it with itself.
+      // Multiple summaries between boundaries (rare) take the last one,
+      // matching how Claude Code's resume picks the most recent summary.
+      pendingSummary = explicitSummary;
       continue;
     }
 
     if (isCompactBoundary(parsed)) {
-      boundaryFallbackText = extractCompactBoundaryFallbackText(parsed) ?? boundaryFallbackText;
+      lastSummary = pendingSummary; // may be undefined if no preceding summary
+      pendingSummary = undefined;
+      lastBoundaryFallback = extractCompactBoundaryFallbackText(parsed) ?? lastBoundaryFallback;
       // Drop turns that lived before this boundary — they are now
       // represented by the summary, and replaying them would double-count
       // their tokens against the fallback model's budget.
@@ -468,7 +478,10 @@ export function readClaudeCliFallbackSeed(params: {
   }
 
   const recentTurns = coalesceClaudeCliToolMessages(windowedTurns);
-  const resolvedSummaryText = summaryText ?? boundaryFallbackText;
+  // Honor a `/compact` summary that was written but never followed by a
+  // boundary marker (older Claude Code build, or graceful-degrade case).
+  // `pendingSummary` then carries the latest such summary into the result.
+  const resolvedSummaryText = lastSummary ?? pendingSummary ?? lastBoundaryFallback;
   if (!resolvedSummaryText && recentTurns.length === 0) {
     return undefined;
   }

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -333,3 +333,147 @@ export function readClaudeCliSessionMessages(params: {
   }
   return coalesceClaudeCliToolMessages(messages);
 }
+
+// Compaction surface in Claude Code's JSONL: `/compact` writes a
+// `type: "summary"` entry whose `summary` field holds the condensed text,
+// and an associated `type: "system", subtype: "compact_boundary"` entry
+// whose `compactMetadata` carries `trigger`/`preTokens`. After a boundary,
+// only post-compaction `user`/`assistant` turns are written as individual
+// entries; pre-compaction context lives in the summary. This shape mirrors
+// what Claude Code itself sends to the model after compaction (summary plus
+// recent turns), per the upstream session-management docs.
+type ClaudeCliCompactBoundaryEntry = {
+  type: "system";
+  subtype?: unknown;
+  content?: unknown;
+  timestamp?: unknown;
+  compactMetadata?: {
+    trigger?: unknown;
+    preTokens?: unknown;
+  };
+};
+
+type ClaudeCliSummaryEntry = {
+  type: "summary";
+  summary?: unknown;
+  leafUuid?: unknown;
+  timestamp?: unknown;
+};
+
+export type ClaudeCliFallbackSeed = {
+  /**
+   * The most recent compaction summary, if the session has been `/compact`-ed
+   * at any point. Sourced from the latest `type: "summary"` entry, falling
+   * back to the latest `compact_boundary` content when no explicit summary
+   * is present (older Claude Code builds).
+   */
+  summaryText?: string;
+  /**
+   * User/assistant turns after the most recent compact boundary, or all
+   * turns when the session has never been compacted. Tool-result turns are
+   * coalesced into adjacent assistant turns the same way
+   * `readClaudeCliSessionMessages` does, so consumers can format them like
+   * a regular transcript.
+   */
+  recentTurns: TranscriptLikeMessage[];
+};
+
+function isCompactBoundary(entry: ClaudeCliProjectEntry): boolean {
+  if (entry.type !== "system") {
+    return false;
+  }
+  const subtype = (entry as ClaudeCliCompactBoundaryEntry).subtype;
+  return typeof subtype === "string" && subtype === "compact_boundary";
+}
+
+function extractCompactBoundaryFallbackText(entry: ClaudeCliProjectEntry): string | undefined {
+  // When `/compact` is invoked, Claude Code writes a separate summary entry
+  // — but on older builds the boundary's `content` ("Conversation compacted")
+  // is the only signal that compaction happened. Prefer the explicit summary
+  // when both exist; this fallback gives a non-empty hint when only the
+  // boundary is present so the seed at least labels the gap honestly.
+  const content = (entry as ClaudeCliCompactBoundaryEntry).content;
+  return typeof content === "string" && content.trim() ? content.trim() : undefined;
+}
+
+function extractSummaryText(entry: ClaudeCliProjectEntry): string | undefined {
+  if (entry.type !== "summary") {
+    return undefined;
+  }
+  const summary = (entry as ClaudeCliSummaryEntry).summary;
+  return typeof summary === "string" && summary.trim() ? summary.trim() : undefined;
+}
+
+export function readClaudeCliFallbackSeed(params: {
+  cliSessionId: string;
+  homeDir?: string;
+}): ClaudeCliFallbackSeed | undefined {
+  const filePath = resolveClaudeCliSessionFilePath(params);
+  if (!filePath) {
+    return undefined;
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  let summaryText: string | undefined;
+  let boundaryFallbackText: string | undefined;
+  // Buffer turns into a window that resets every time we cross a compact
+  // boundary. After the walk completes, `windowedTurns` holds turns from
+  // the most recent (post-boundary) window, which matches what Claude Code
+  // would replay alongside the summary on its own resume.
+  let windowedTurns: TranscriptLikeMessage[] = [];
+  const toolNameRegistry: ToolNameRegistry = new Map();
+
+  for (const line of content.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    let parsed: ClaudeCliProjectEntry;
+    try {
+      parsed = JSON.parse(line) as ClaudeCliProjectEntry;
+    } catch {
+      continue;
+    }
+
+    const explicitSummary = extractSummaryText(parsed);
+    if (explicitSummary) {
+      // Explicit summary entries are written by `/compact`; later entries
+      // supersede earlier ones the same way Claude Code itself replays
+      // only the most recent summary.
+      summaryText = explicitSummary;
+      continue;
+    }
+
+    if (isCompactBoundary(parsed)) {
+      boundaryFallbackText = extractCompactBoundaryFallbackText(parsed) ?? boundaryFallbackText;
+      // Drop turns that lived before this boundary — they are now
+      // represented by the summary, and replaying them would double-count
+      // their tokens against the fallback model's budget.
+      windowedTurns = [];
+      // Reset tool-name registry too: tool ids before a compact boundary
+      // are no longer visible to the post-boundary turns.
+      toolNameRegistry.clear();
+      continue;
+    }
+
+    const message = parseClaudeCliHistoryEntry(parsed, params.cliSessionId, toolNameRegistry);
+    if (message) {
+      windowedTurns.push(message);
+    }
+  }
+
+  const recentTurns = coalesceClaudeCliToolMessages(windowedTurns);
+  const resolvedSummaryText = summaryText ?? boundaryFallbackText;
+  if (!resolvedSummaryText && recentTurns.length === 0) {
+    return undefined;
+  }
+  return {
+    ...(resolvedSummaryText ? { summaryText: resolvedSummaryText } : {}),
+    recentTurns,
+  };
+}

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -334,14 +334,6 @@ export function readClaudeCliSessionMessages(params: {
   return coalesceClaudeCliToolMessages(messages);
 }
 
-// Compaction surface in Claude Code's JSONL: `/compact` writes a
-// `type: "summary"` entry whose `summary` field holds the condensed text,
-// and an associated `type: "system", subtype: "compact_boundary"` entry
-// whose `compactMetadata` carries `trigger`/`preTokens`. After a boundary,
-// only post-compaction `user`/`assistant` turns are written as individual
-// entries; pre-compaction context lives in the summary. This shape mirrors
-// what Claude Code itself sends to the model after compaction (summary plus
-// recent turns), per the upstream session-management docs.
 type ClaudeCliCompactBoundaryEntry = {
   type: "system";
   subtype?: unknown;
@@ -361,20 +353,7 @@ type ClaudeCliSummaryEntry = {
 };
 
 export type ClaudeCliFallbackSeed = {
-  /**
-   * The most recent compaction summary, if the session has been `/compact`-ed
-   * at any point. Sourced from the latest `type: "summary"` entry, falling
-   * back to the latest `compact_boundary` content when no explicit summary
-   * is present (older Claude Code builds).
-   */
   summaryText?: string;
-  /**
-   * User/assistant turns after the most recent compact boundary, or all
-   * turns when the session has never been compacted. Tool-result turns are
-   * coalesced into adjacent assistant turns the same way
-   * `readClaudeCliSessionMessages` does, so consumers can format them like
-   * a regular transcript.
-   */
   recentTurns: TranscriptLikeMessage[];
 };
 
@@ -387,11 +366,6 @@ function isCompactBoundary(entry: ClaudeCliProjectEntry): boolean {
 }
 
 function extractCompactBoundaryFallbackText(entry: ClaudeCliProjectEntry): string | undefined {
-  // When `/compact` is invoked, Claude Code writes a separate summary entry
-  // — but on older builds the boundary's `content` ("Conversation compacted")
-  // is the only signal that compaction happened. Prefer the explicit summary
-  // when both exist; this fallback gives a non-empty hint when only the
-  // boundary is present so the seed at least labels the gap honestly.
   const content = (entry as ClaudeCliCompactBoundaryEntry).content;
   return typeof content === "string" && content.trim() ? content.trim() : undefined;
 }
@@ -420,17 +394,6 @@ export function readClaudeCliFallbackSeed(params: {
     return undefined;
   }
 
-  // Pair each compact_boundary with the summary entry that preceded it
-  // since the previous boundary, so a later compaction whose summary is
-  // missing (e.g. crash mid-write) does not silently keep an older
-  // compaction's summary alive (#72069 Codex P2). Walk shape:
-  //   - explicit `summary` entry queues into `pendingSummary` until the
-  //     next boundary "consumes" it.
-  //   - `compact_boundary` flushes the pending summary into `lastSummary`,
-  //     refreshes `lastBoundaryFallback` from the boundary's content, and
-  //     drops the windowed turns and tool registry.
-  //   - everything after the latest boundary forms the recent-window the
-  //     fallback runner will replay alongside the summary.
   let pendingSummary: string | undefined;
   let lastSummary: string | undefined;
   let lastBoundaryFallback: string | undefined;
@@ -450,23 +413,15 @@ export function readClaudeCliFallbackSeed(params: {
 
     const explicitSummary = extractSummaryText(parsed);
     if (explicitSummary) {
-      // Queue the summary; the next boundary will pair it with itself.
-      // Multiple summaries between boundaries (rare) take the last one,
-      // matching how Claude Code's resume picks the most recent summary.
       pendingSummary = explicitSummary;
       continue;
     }
 
     if (isCompactBoundary(parsed)) {
-      lastSummary = pendingSummary; // may be undefined if no preceding summary
+      lastSummary = pendingSummary;
       pendingSummary = undefined;
       lastBoundaryFallback = extractCompactBoundaryFallbackText(parsed) ?? lastBoundaryFallback;
-      // Drop turns that lived before this boundary — they are now
-      // represented by the summary, and replaying them would double-count
-      // their tokens against the fallback model's budget.
       windowedTurns = [];
-      // Reset tool-name registry too: tool ids before a compact boundary
-      // are no longer visible to the post-boundary turns.
       toolNameRegistry.clear();
       continue;
     }
@@ -478,9 +433,6 @@ export function readClaudeCliFallbackSeed(params: {
   }
 
   const recentTurns = coalesceClaudeCliToolMessages(windowedTurns);
-  // Honor a `/compact` summary that was written but never followed by a
-  // boundary marker (older Claude Code build, or graceful-degrade case).
-  // `pendingSummary` then carries the latest such summary into the result.
   const resolvedSummaryText = lastSummary ?? pendingSummary ?? lastBoundaryFallback;
   if (!resolvedSummaryText && recentTurns.length === 0) {
     return undefined;

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -511,4 +511,68 @@ describe("readClaudeCliFallbackSeed", () => {
     const seed = readClaudeCliFallbackSeed({ cliSessionId: "../escape" });
     expect(seed).toBeUndefined();
   });
+
+  // Codex P2 on #72069: each compact_boundary must pair with the summary
+  // entry that preceded it since the previous boundary. A later boundary
+  // without its own summary must not silently keep an older compaction's
+  // summary alive — that paired stale text with fresh post-boundary turns.
+  it("falls back to the latest boundary content when a newer compaction has no summary", async () => {
+    await writeJsonl([
+      { type: "summary", summary: "FIRST compact summary", leafUuid: "x" },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted (1)",
+        compactMetadata: { trigger: "manual", preTokens: 1000 },
+      },
+      {
+        type: "user",
+        uuid: "u-mid",
+        message: { role: "user", content: "post-first-compact turn" },
+      },
+      // Second compaction: boundary written, but the summary entry never
+      // landed (e.g. crash between writes). The seed must NOT serve the
+      // FIRST summary alongside post-second-boundary turns.
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted (2)",
+        compactMetadata: { trigger: "auto", preTokens: 2000 },
+      },
+      {
+        type: "user",
+        uuid: "u-tail",
+        message: { role: "user", content: "post-second-compact turn" },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeDefined();
+    expect(seed?.summaryText).toBe("Conversation compacted (2)");
+    expect(seed?.summaryText).not.toBe("FIRST compact summary");
+    expect(seed?.recentTurns).toHaveLength(1);
+    expect(JSON.stringify(seed?.recentTurns)).toContain("post-second-compact turn");
+  });
+
+  it("uses a trailing summary that has no following compact_boundary marker", async () => {
+    // Older Claude Code builds wrote the summary entry without a paired
+    // boundary marker. The seed should still surface that summary so a
+    // subsequent fallback at least has a labeled context block.
+    await writeJsonl([
+      {
+        type: "user",
+        uuid: "u-1",
+        message: { role: "user", content: "earlier turn" },
+      },
+      { type: "summary", summary: "trailing summary without boundary", leafUuid: "x" },
+      {
+        type: "user",
+        uuid: "u-2",
+        message: { role: "user", content: "later turn" },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed?.summaryText).toBe("trailing summary without boundary");
+  });
 });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -299,10 +299,6 @@ describe("cli session history", () => {
   });
 });
 
-// Regression coverage for #69973 — claude-cli fallback context loss. The
-// new reader exposes the explicit `/compact` summary and the post-boundary
-// turn window so a fallback to a non-CLI candidate can replay the same
-// shape Claude Code itself uses on resume after compaction.
 describe("readClaudeCliFallbackSeed", () => {
   let tmpRoot: string;
   let homeDir: string;
@@ -372,7 +368,7 @@ describe("readClaudeCliFallbackSeed", () => {
       {
         type: "user",
         uuid: "u-pre",
-        message: { role: "user", content: "PRE-COMPACT user turn that must NOT be in seed" },
+        message: { role: "user", content: "pre-compact user turn excluded from seed" },
       },
       {
         type: "assistant",
@@ -512,10 +508,6 @@ describe("readClaudeCliFallbackSeed", () => {
     expect(seed).toBeUndefined();
   });
 
-  // Codex P2 on #72069: each compact_boundary must pair with the summary
-  // entry that preceded it since the previous boundary. A later boundary
-  // without its own summary must not silently keep an older compaction's
-  // summary alive — that paired stale text with fresh post-boundary turns.
   it("falls back to the latest boundary content when a newer compaction has no summary", async () => {
     await writeJsonl([
       { type: "summary", summary: "FIRST compact summary", leafUuid: "x" },
@@ -530,9 +522,6 @@ describe("readClaudeCliFallbackSeed", () => {
         uuid: "u-mid",
         message: { role: "user", content: "post-first-compact turn" },
       },
-      // Second compaction: boundary written, but the summary entry never
-      // landed (e.g. crash between writes). The seed must NOT serve the
-      // FIRST summary alongside post-second-boundary turns.
       {
         type: "system",
         subtype: "compact_boundary",
@@ -555,9 +544,6 @@ describe("readClaudeCliFallbackSeed", () => {
   });
 
   it("uses a trailing summary that has no following compact_boundary marker", async () => {
-    // Older Claude Code builds wrote the summary entry without a paired
-    // boundary marker. The seed should still surface that summary so a
-    // subsequent fallback at least has a labeled context block.
     await writeJsonl([
       {
         type: "user",

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,
+  readClaudeCliFallbackSeed,
   readClaudeCliSessionMessages,
   resolveClaudeCliSessionFilePath,
 } from "./cli-session-history.js";
@@ -295,5 +296,219 @@ describe("cli session history", () => {
         __openclaw: { cliSessionId: sessionId },
       });
     });
+  });
+});
+
+// Regression coverage for #69973 — claude-cli fallback context loss. The
+// new reader exposes the explicit `/compact` summary and the post-boundary
+// turn window so a fallback to a non-CLI candidate can replay the same
+// shape Claude Code itself uses on resume after compaction.
+describe("readClaudeCliFallbackSeed", () => {
+  let tmpRoot: string;
+  let homeDir: string;
+  let projectsDir: string;
+  const SESSION_ID = "fallback-seed-session";
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fallback-seed-"));
+    homeDir = path.join(tmpRoot, "home");
+    projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    await fs.mkdir(projectsDir, { recursive: true });
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(async () => {
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function writeJsonl(lines: ReadonlyArray<Record<string, unknown>>): Promise<void> {
+    const file = path.join(projectsDir, `${SESSION_ID}.jsonl`);
+    await fs.writeFile(file, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf-8");
+  }
+
+  it("returns undefined when the Claude session file does not exist", () => {
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeUndefined();
+  });
+
+  it("collects user/assistant turns when the session has never been compacted", async () => {
+    await writeJsonl([
+      {
+        type: "user",
+        uuid: "u-1",
+        message: { role: "user", content: "first user prompt" },
+      },
+      {
+        type: "assistant",
+        uuid: "a-1",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "first assistant reply" }],
+        },
+      },
+      {
+        type: "user",
+        uuid: "u-2",
+        message: { role: "user", content: "second user prompt" },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeDefined();
+    expect(seed?.summaryText).toBeUndefined();
+    expect(seed?.recentTurns).toHaveLength(3);
+    expect(seed?.recentTurns[0]).toMatchObject({ role: "user" });
+    expect(seed?.recentTurns[2]).toMatchObject({ role: "user" });
+  });
+
+  it("uses the explicit /compact summary and drops pre-boundary turns", async () => {
+    await writeJsonl([
+      {
+        type: "user",
+        uuid: "u-pre",
+        message: { role: "user", content: "PRE-COMPACT user turn that must NOT be in seed" },
+      },
+      {
+        type: "assistant",
+        uuid: "a-pre",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "PRE-COMPACT assistant turn" }],
+        },
+      },
+      {
+        type: "summary",
+        summary: "User asked about deployment; agent recommended a blue-green strategy.",
+        leafUuid: "a-pre",
+      },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted",
+        compactMetadata: { trigger: "manual", preTokens: 12345 },
+      },
+      {
+        type: "user",
+        uuid: "u-post",
+        message: { role: "user", content: "POST-COMPACT user follow-up" },
+      },
+      {
+        type: "assistant",
+        uuid: "a-post",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "POST-COMPACT assistant reply" }],
+        },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeDefined();
+    expect(seed?.summaryText).toBe(
+      "User asked about deployment; agent recommended a blue-green strategy.",
+    );
+    expect(seed?.recentTurns).toHaveLength(2);
+    const recentText = JSON.stringify(seed?.recentTurns);
+    expect(recentText).toContain("POST-COMPACT user follow-up");
+    expect(recentText).toContain("POST-COMPACT assistant reply");
+    expect(recentText).not.toContain("PRE-COMPACT");
+  });
+
+  it("falls back to compact_boundary content when no explicit summary entry is present", async () => {
+    await writeJsonl([
+      {
+        type: "user",
+        uuid: "u-pre",
+        message: { role: "user", content: "early turn" },
+      },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted",
+        compactMetadata: { trigger: "auto", preTokens: 50000 },
+      },
+      {
+        type: "user",
+        uuid: "u-post",
+        message: { role: "user", content: "post-boundary user turn" },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeDefined();
+    // Falls back to the boundary's content so the seed at least labels
+    // that compaction happened, instead of replaying nothing.
+    expect(seed?.summaryText).toBe("Conversation compacted");
+    expect(seed?.recentTurns).toHaveLength(1);
+    expect(JSON.stringify(seed?.recentTurns)).toContain("post-boundary user turn");
+  });
+
+  it("prefers the most recent summary when the session has been compacted multiple times", async () => {
+    await writeJsonl([
+      {
+        type: "summary",
+        summary: "EARLY summary that should be superseded.",
+        leafUuid: "x",
+      },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted",
+        compactMetadata: { trigger: "manual", preTokens: 1000 },
+      },
+      {
+        type: "user",
+        uuid: "u-mid",
+        message: { role: "user", content: "mid-window turn" },
+      },
+      {
+        type: "summary",
+        summary: "LATER summary that must win.",
+        leafUuid: "y",
+      },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        content: "Conversation compacted",
+        compactMetadata: { trigger: "manual", preTokens: 2000 },
+      },
+      {
+        type: "user",
+        uuid: "u-tail",
+        message: { role: "user", content: "tail turn" },
+      },
+    ]);
+
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed?.summaryText).toBe("LATER summary that must win.");
+    expect(seed?.recentTurns).toHaveLength(1);
+    expect(JSON.stringify(seed?.recentTurns)).toContain("tail turn");
+    expect(JSON.stringify(seed?.recentTurns)).not.toContain("mid-window turn");
+  });
+
+  it("returns undefined when the session file is empty or has no usable content", async () => {
+    await writeJsonl([
+      // Sidechain entries are filtered out by the underlying parser.
+      {
+        type: "user",
+        uuid: "u-side",
+        isSidechain: true,
+        message: { role: "user", content: "sidechain user turn" },
+      },
+    ]);
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID });
+    expect(seed).toBeUndefined();
+  });
+
+  it("rejects path-like session ids instead of escaping the Claude projects tree", () => {
+    const seed = readClaudeCliFallbackSeed({ cliSessionId: "../escape" });
+    expect(seed).toBeUndefined();
   });
 });

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -1,7 +1,9 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  type ClaudeCliFallbackSeed,
   CLAUDE_CLI_PROVIDER,
+  readClaudeCliFallbackSeed,
   readClaudeCliSessionMessages,
   resolveClaudeCliBindingSessionId,
   resolveClaudeCliSessionFilePath,
@@ -10,9 +12,12 @@ import { mergeImportedChatHistoryMessages } from "./cli-session-history.merge.js
 
 export {
   mergeImportedChatHistoryMessages,
+  readClaudeCliFallbackSeed,
   readClaudeCliSessionMessages,
+  resolveClaudeCliBindingSessionId,
   resolveClaudeCliSessionFilePath,
 };
+export type { ClaudeCliFallbackSeed };
 
 export function augmentChatHistoryWithCliSessionImports(params: {
   entry: SessionEntry | undefined;


### PR DESCRIPTION
Closes #69973.

## Why

When a `claude-cli` attempt fails with a fallbackable error (e.g. 402 billing limit), the next candidate runs cold. Claude Code keeps full session history in `~/.claude/projects/<id>/<sessionId>.jsonl`, but the fallback runner only sees what OpenClaw assembles from its own transcript — and that transcript is empty for claude-cli sessions because OpenClaw doesn't mirror Claude's local JSONL turns into its own session file.

[@steipete](https://github.com/steipete)'s triage: *"the next candidate only sees what OpenClaw assembles from its own transcript/context. If the OpenClaw transcript is truncated or missing the prior CLI-backed turns, the fallback candidate starts cold while Claude later resumes fine. Concrete fix: when a claude-cli attempt fails with a fallbackable error, seed the fallback prompt from the OpenClaw transcript/compacted summary before trying the non-CLI candidate."*

## Pattern

Mirrors what Claude Code itself does on resume after `/compact`: **prefer the explicit summary, then append the most recent post-boundary turns up to a char budget.** Inferred from the upstream JSONL shape (`type: "summary"`, `type: "system" subtype: "compact_boundary"` with `compactMetadata`) and confirmed against the published session-management behavior. References:
- [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works)
- [Inside Claude Code: The Session File Format](https://databunny.medium.com/inside-claude-code-the-session-file-format-and-how-to-inspect-it-b9998e66d56b)
- [What actually happens when you run /compact](https://dev.to/rigby_/what-actually-happens-when-you-run-compact-in-claude-code-3kl9)

Last-N raw replay was rejected as the wrong shape: it diverges from how Claude Code itself replays after compaction, misses context if `/compact` already happened (the older turns are gone, only the summary remains), and chews more prompt budget than the equivalent summary.

## What changed

| File | Role |
|---|---|
| `src/gateway/cli-session-history.claude.ts` | New `readClaudeCliFallbackSeed` walks the JSONL with awareness of `type: "summary"` and `compact_boundary` entries. Pre-boundary turns are dropped (they're now in the summary). Multiple compactions: latest summary wins. |
| `src/gateway/cli-session-history.ts` | Re-export the new reader + type. |
| `src/agents/command/attempt-execution.helpers.ts` | New `formatClaudeCliFallbackPrelude` / `buildClaudeCliFallbackContextPrelude`. Tool blocks coalesce to compact `(tool call: …)` / `(tool result: …)` hints. Newest turns kept when truncating. Summary clearly labeled `(truncated)` if it overflows. `resolveFallbackRetryPrompt` gains an optional `priorContextPrelude`. |
| `src/agents/command/attempt-execution.ts` | `runAgentAttempt` builds the prelude when `isFallbackRetry && providerOverride !== claude-cli && cliSessionBindings.claude-cli.sessionId is set`. Same-provider fallbacks (claude-cli → claude-cli) are unaffected — Claude's own `--resume` already works there. |

## Verified

- 33 tests in `src/agents/command/attempt-execution.test.ts` (12 added)
- 12 tests in `src/gateway/cli-session-history.test.ts` (7 added)
- `pnpm tsgo:core` + `pnpm tsgo:core:test` clean
- `pnpm format` + `pnpm lint` clean on touched files
- **Regression-catching verified**: removing the prelude prepend in `resolveFallbackRetryPrompt` fails both new prelude cases, restoring the cold-start behavior — confirming the test pins the behavior (not just the helper signature).

## Risks flagged

- **Privacy**: same surface as the existing `augmentChatHistoryWithCliSessionImports` — we already read user's Claude JSONL for display. No new ground.
- **Path safety**: reuses existing `resolveClaudeCliSessionFilePath` validation, which already rejects `..`-style escapes.
- **Summary quality**: if Claude's own `/compact` produced a malformed summary (see [#46602](https://github.com/anthropics/claude-code/issues/46602)), we inherit that. Mitigation: the prelude is clearly labeled "Prior session context (from claude-cli)" so the fallback model treats it as a hint, not authoritative state.
- **Char budget**: defaults to 8k chars; truncates at word boundaries with `…` so the model never sees a mid-summary fragment.

## Out of scope

- Codex CLI sessions (`openai-codex` as primary). Claude is the driver of the user-pain reports here. The same mechanism could be extended provider-by-provider as those CLIs expose their own structured transcripts.
- Two-way: when a non-CLI session falls back to claude-cli. Claude has `--resume` and a session id of its own; cross-pollination there is a separate problem.

## Files

- `src/gateway/cli-session-history.claude.ts:302+` — parser extension
- `src/gateway/cli-session-history.ts:11+` — re-export
- `src/agents/command/attempt-execution.helpers.ts:104+` — formatter + builder + extended `resolveFallbackRetryPrompt`
- `src/agents/command/attempt-execution.ts:265+` — integration in `runAgentAttempt`
