### PR TITLE
fix(plugins): jiti file URL for Windows ESM import (#72040)

### DIFF
--- a/src/plugins/jiti-file-specifier.test.ts
+++ b/src/plugins/jiti-file-specifier.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeJitiFileSpecifier } from "./jiti-file-specifier.js";
+
+describe("normalizeJitiFileSpecifier", () => {
+  it("leaves specifiers unchanged on non-Windows platforms", () => {
+    const abs = "C:/openclaw/extensions/telegram/index.ts";
+    expect(normalizeJitiFileSpecifier(abs, "linux")).toBe(abs);
+  });
+
+  it("converts a Windows drive-letter path to a file: URL (native import() safe)", () => {
+    const p = "C:/openclaw/dist/extensions/telegram/api.js";
+    const out = normalizeJitiFileSpecifier(p, "win32");
+    expect(out).toBe("file:///C:/openclaw/dist/extensions/telegram/api.js");
+  });
+
+  it("preserves an existing file: URL on Windows", () => {
+    const f = "file:///C:/openclaw/entry.mjs";
+    expect(normalizeJitiFileSpecifier(f, "win32")).toBe(f);
+  });
+});

--- a/src/plugins/jiti-file-specifier.ts
+++ b/src/plugins/jiti-file-specifier.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Node's ESM `import()` treats some Windows absolute paths (notably `C:\...`) as
+ * having a `c:` URL scheme. jiti's native import path must use `file:` URLs for
+ * those paths instead (see #72040).
+ */
+export function normalizeJitiFileSpecifier(
+  specifier: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32" || specifier.length === 0) {
+    return specifier;
+  }
+  if (
+    specifier.startsWith("file:") ||
+    specifier.startsWith("node:") ||
+    specifier.startsWith("data:")
+  ) {
+    return specifier;
+  }
+  if (path.isAbsolute(specifier) && shouldCoerceWin32FileUrl(specifier)) {
+    return pathToFileURL(specifier).href;
+  }
+  return specifier;
+}
+
+function shouldCoerceWin32FileUrl(filePath: string): boolean {
+  if (filePath.startsWith("\\\\")) {
+    return true;
+  }
+  return /^[A-Za-z]:/u.test(filePath);
+}

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -1,4 +1,5 @@
 import { createJiti } from "jiti";
+import { normalizeJitiFileSpecifier } from "./jiti-file-specifier.js";
 import {
   buildPluginLoaderJitiOptions,
   createPluginLoaderJitiCacheKey,
@@ -24,8 +25,9 @@ export function getCachedPluginJitiLoader(params: {
   cacheScopeKey?: string;
 }): PluginJitiLoader {
   const jitiFilename = params.jitiFilename ?? params.modulePath;
+  const jitiRootSpecifier = normalizeJitiFileSpecifier(jitiFilename);
   if (params.cacheScopeKey) {
-    const scopedCacheKey = `${jitiFilename}::${params.cacheScopeKey}`;
+    const scopedCacheKey = `${jitiRootSpecifier}::${params.cacheScopeKey}`;
     const cached = params.cache.get(scopedCacheKey);
     if (cached) {
       return cached;
@@ -69,15 +71,28 @@ export function getCachedPluginJitiLoader(params: {
       tryNative,
       aliasMap,
     });
-  const scopedCacheKey = `${jitiFilename}::${params.cacheScopeKey ?? cacheKey}`;
+  const scopedCacheKey = `${jitiRootSpecifier}::${params.cacheScopeKey ?? cacheKey}`;
   const cached = params.cache.get(scopedCacheKey);
   if (cached) {
     return cached;
   }
-  const loader = (params.createLoader ?? createJiti)(jitiFilename, {
+  const rawLoader = (params.createLoader ?? createJiti)(jitiRootSpecifier, {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });
+  const loader = new Proxy(rawLoader, {
+    apply(target, thisArg, argArray) {
+      const [first, ...rest] = argArray as [unknown, ...unknown[]];
+      if (typeof first === "string") {
+        return Reflect.apply(
+          target,
+          thisArg,
+          [normalizeJitiFileSpecifier(first), ...rest] as never,
+        ) as never;
+      }
+      return Reflect.apply(target, thisArg, argArray as never) as never;
+    },
+  }) as PluginJitiLoader;
   params.cache.set(scopedCacheKey, loader);
   return loader;
 }


### PR DESCRIPTION
## Summary

- **Problem:** On **Windows**, bundled channel/plugin loading via jiti can hit `ERR_UNSUPPORTED_ESM_URL_SCHEME` / `Received protocol 'c:'` when Node’s native ESM `import` receives a drive-letter path. Reported for Telegram in #72040.
- **Why it matters:** Channel can fail to start on Windows even when the install is otherwise valid.
- **What changed:** `normalizeJitiFileSpecifier` in `src/plugins/jiti-file-specifier.ts` converts `win32` **absolute** drive/UNC paths to `file:` URLs. `getCachedPluginJitiLoader` passes a normalized jiti “filename” and wraps the returned jiti instance with a **`Proxy`**, so the callable still satisfies the full `Jiti` type (fix for TS2740) while normalizing the request path on each invocation. Unit tests in `jiti-file-specifier.test.ts`; existing `jiti-loader-cache.test.ts` kept green.
- **What did NOT change:** Non-Windows platforms, specifiers that are already `file:`, and plugin manifest / discovery.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] API / contracts (jiti load seam only, internal)
- [x] Integrations (bundled plugins load path)

## Linked issues

- Closes #72040
- [x] Regression/bug

## Root cause

- **Root cause:** jiti’s `nativeImport` uses `import()`. On Windows, bare `C:\...` strings are not valid ESM specifiers; they must be `file:` URLs.
- **CI lesson:** A thin arrow wrapper for `Jiti` breaks `tsc` because `Jiti` is a callable with extra properties — the fix is a **Proxy** preserving the real object.

## Regression test plan

- [x] Unit — `jiti-file-specifier.test.ts` (win32 + linux behavior)
- [x] Existing — `jiti-loader-cache.test.ts` (caching, aliasing, overrides)

## User-visible

- Windows: bundled channels (e.g. Telegram) that load through this jiti path should no longer fail immediately on that ESM error (subject to any separate packaging/dependency issues).

**Diagram — N/A**

## Security

- All “No” (path normalization to `file:` only).

## Changelog

- **Omitted** in this PR to keep `CHANGELOG.md` conflict-free. Maintainers can add a line at merge if required.

## Compatibility

- **Yes** — only affects how absolute paths are passed to jiti/Node on Windows.

## Risks

- **Risk:** Proxy edge cases on exotic jiti call patterns — **mitigation:** `apply` trap only rewrites a leading string argument; all other `Reflect.apply` pass-through. Tests + prior loader tests.

## Review conversations (bots)

- [x] Addressed: **TypeScript** — wrapper must preserve `Jiti` shape; fixed with `Proxy` (CI `build:ci-artifacts` previously failed on TS2740).  
- [x] **Changelog** — removed from the PR diff to reduce merge pain per contributor request.

## CI

- Failing `build-artifacts` on the pre-fix commit was **directly** due to the arrow-wrapper type error; the Proxy fix is targeted at that. A full `pnpm build:ci-artifacts` run may still require a complete trusted workspace `pnpm install` (local/CI), unrelated to the diff’s logic.
