### PR TITLE
feat(extensions): add computer plugin — macOS desktop automation via cua-driver

### DIFF
--- a/extensions/computer/index.ts
+++ b/extensions/computer/index.ts
@@ -1,0 +1,9 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerComputerPlugin } from "./plugin-registration.js";
+
+export default definePluginEntry({
+  id: "computer",
+  name: "Computer",
+  description: "macOS desktop automation via cua-driver (MIT licensed)",
+  register: registerComputerPlugin,
+});

--- a/extensions/computer/openclaw.plugin.json
+++ b/extensions/computer/openclaw.plugin.json
@@ -1,0 +1,23 @@
+{
+  "id": "computer",
+  "enabledByDefault": false,
+  "name": "Computer",
+  "description": "macOS desktop automation via cua-driver. Registers a computer tool that lets any agent harness control apps, capture screenshots, click, type, and inspect UI via the Accessibility tree.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "cuaDriverPath": {
+        "type": "string",
+        "description": "Path to the cua-driver binary. Defaults to cua-driver on PATH."
+      }
+    }
+  },
+  "uiHints": {
+    "cuaDriverPath": {
+      "label": "cua-driver path",
+      "help": "Override the cua-driver binary path. Leave unset to use cua-driver from PATH.",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/computer/package.json
+++ b/extensions/computer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/computer-plugin",
+  "version": "2026.4.26",
+  "private": true,
+  "description": "OpenClaw computer tool plugin — macOS desktop automation via cua-driver",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "typebox": "1.1.32"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/computer/plugin-registration.ts
+++ b/extensions/computer/plugin-registration.ts
@@ -1,0 +1,36 @@
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { executeComputerTool } from "./src/computer-tool.js";
+import { ComputerToolSchema } from "./src/computer-tool.schema.js";
+import type { ComputerToolParams } from "./src/computer-tool.schema.js";
+
+type ComputerPluginConfig = {
+  cuaDriverPath?: string;
+};
+
+function createComputerTool(ctx: OpenClawPluginToolContext): AnyAgentTool {
+  const config = (ctx.config ?? {}) as ComputerPluginConfig;
+  const cuaDriverPath = config.cuaDriverPath?.trim() || "cua-driver";
+
+  return {
+    name: "computer",
+    label: "Computer",
+    description: [
+      "Control macOS desktop apps via cua-driver.",
+      "Use get_app_state to inspect a running app's UI and get element indices,",
+      "then click/type/scroll/set_value using those indices.",
+      "All actions target the app by pid — call list_apps or list_windows to find it.",
+    ].join(" "),
+    parameters: ComputerToolSchema,
+    execute: async (_toolCallId, params, _signal) => {
+      return executeComputerTool(params as ComputerToolParams, cuaDriverPath);
+    },
+  };
+}
+
+export function registerComputerPlugin(api: OpenClawPluginApi): void {
+  api.registerTool((ctx: OpenClawPluginToolContext) => createComputerTool(ctx));
+}

--- a/extensions/computer/src/computer-tool.schema.ts
+++ b/extensions/computer/src/computer-tool.schema.ts
@@ -21,6 +21,10 @@ export const ComputerToolSchema = Type.Object({
       "key — press a single key.",
       "hotkey — press a key combination, e.g. cmd+s.",
       "set_value — set a value on a select/popup or slider element.",
+      "execute_javascript — run JS in the active browser tab (Chrome, Safari, Electron) and return the result.",
+      "get_text — get the full text content of the active browser page.",
+      "query_dom — query DOM elements by CSS selector and return their attributes.",
+      "enable_javascript_apple_events — one-time opt-in to allow JS execution via Apple Events; ask the user before calling.",
     ].join(" "),
   }),
 

--- a/extensions/computer/src/computer-tool.schema.ts
+++ b/extensions/computer/src/computer-tool.schema.ts
@@ -1,0 +1,128 @@
+import { Type } from "typebox";
+
+// Flattened object schema — same pattern as browser extension.
+// Claude API on Vertex AI rejects nested anyOf/union schemas, so all
+// action-specific fields are optional on a single flat object and the
+// runtime uses `action` as the discriminator.
+export const ComputerToolSchema = Type.Object({
+  action: Type.String({
+    description: [
+      "screenshot — capture the frontmost window of an app.",
+      "get_app_state — AX tree + screenshot for an app, addressed by name.",
+      "list_windows — enumerate all on-screen windows.",
+      "list_apps — enumerate running and installed macOS apps.",
+      "launch_app — launch an app in the background without stealing focus.",
+      "click — left-click by element index or pixel coordinate.",
+      "double_click — double-click.",
+      "right_click — right-click.",
+      "scroll — scroll by direction and amount.",
+      "type — insert text via AX attribute write (fast, no key events).",
+      "type_chars — type text character-by-character via CGEvent (works in web inputs).",
+      "key — press a single key.",
+      "hotkey — press a key combination, e.g. cmd+s.",
+      "set_value — set a value on a select/popup or slider element.",
+    ].join(" "),
+  }),
+
+  // ── screenshot / get_app_state / launch_app ─────────────────────────
+  app_name: Type.Optional(
+    Type.String({ description: "App name for screenshot, get_app_state, or launch_app." }),
+  ),
+  bundle_id: Type.Optional(
+    Type.String({
+      description:
+        "App bundle ID for launch_app (e.g. com.apple.calculator) or browser bundle ID for enable_javascript_apple_events (e.g. com.google.Chrome).",
+    }),
+  ),
+
+  // ── get_app_state / get_window_state ────────────────────────────────
+  pid: Type.Optional(Type.Integer({ description: "Process ID (from list_windows or list_apps)." })),
+  window_id: Type.Optional(
+    Type.Integer({ description: "CGWindowID (from list_windows or launch_app)." }),
+  ),
+  query: Type.Optional(
+    Type.String({ description: "Case-insensitive substring filter for the AX tree." }),
+  ),
+
+  // ── click / double_click / right_click / scroll ──────────────────────
+  element_index: Type.Optional(
+    Type.Integer({
+      description: "Element index from the last get_app_state / get_window_state call.",
+    }),
+  ),
+  x: Type.Optional(Type.Number({ description: "X pixel coordinate in window-local space." })),
+  y: Type.Optional(Type.Number({ description: "Y pixel coordinate in window-local space." })),
+  modifier: Type.Optional(
+    Type.Array(Type.String(), {
+      description: 'Modifier keys for click, e.g. ["cmd", "shift"].',
+    }),
+  ),
+
+  // ── scroll ───────────────────────────────────────────────────────────
+  direction: Type.Optional(
+    Type.String({ description: "Scroll direction: up, down, left, right." }),
+  ),
+  amount: Type.Optional(Type.Integer({ description: "Scroll ticks. Default 3." })),
+
+  // ── type / type_chars ────────────────────────────────────────────────
+  text: Type.Optional(Type.String({ description: "Text to type." })),
+
+  // ── key / hotkey ─────────────────────────────────────────────────────
+  key: Type.Optional(Type.String({ description: "Key name for the key action, e.g. return." })),
+  keys: Type.Optional(
+    Type.Array(Type.String(), {
+      description: 'Key names for hotkey, e.g. ["cmd", "s"].',
+    }),
+  ),
+
+  // ── set_value ────────────────────────────────────────────────────────
+  value: Type.Optional(
+    Type.String({ description: "Value for set_value — option label or numeric string." }),
+  ),
+
+  // ── page (browser JS) ────────────────────────────────────────────────
+  javascript: Type.Optional(
+    Type.String({
+      description:
+        "JS to execute (get_app_state inline or page action=execute_javascript). Wrap in IIFE: `(() => { ... })()`.",
+    }),
+  ),
+  css_selector: Type.Optional(
+    Type.String({ description: "CSS selector for page action=query_dom." }),
+  ),
+  attributes: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Element attributes to include per match for query_dom. tag and innerText always included.",
+    }),
+  ),
+  user_has_confirmed_enabling: Type.Optional(
+    Type.Boolean({
+      description:
+        "Must be true for page action=enable_javascript_apple_events. Ask the user first.",
+    }),
+  ),
+});
+
+export type ComputerToolParams = {
+  action: string;
+  app_name?: string;
+  bundle_id?: string;
+  pid?: number;
+  window_id?: number;
+  query?: string;
+  element_index?: number;
+  x?: number;
+  y?: number;
+  modifier?: string[];
+  direction?: string;
+  amount?: number;
+  text?: string;
+  key?: string;
+  keys?: string[];
+  value?: string;
+  javascript?: string;
+  css_selector?: string;
+  attributes?: string[];
+  user_has_confirmed_enabling?: boolean;
+};

--- a/extensions/computer/src/computer-tool.ts
+++ b/extensions/computer/src/computer-tool.ts
@@ -1,0 +1,260 @@
+import { jsonResult, textResult } from "openclaw/plugin-sdk/provider-tools";
+import type { ComputerToolParams } from "./computer-tool.schema.js";
+import { extractResult, getCuaDriverClient } from "./cua-driver-client.js";
+
+export async function executeComputerTool(
+  params: ComputerToolParams,
+  cuaDriverPath: string,
+): Promise<ReturnType<typeof jsonResult>> {
+  const client = getCuaDriverClient(cuaDriverPath);
+  const { action } = params;
+
+  switch (action) {
+    case "screenshot": {
+      if (!params.window_id) {
+        // Convenience: find the window via list_windows filtered by app_name.
+        const listResult = extractResult(
+          await client.callTool("list_windows", { on_screen_only: true }),
+        );
+        if (listResult.isError) return jsonResult({ ok: false, error: listResult.text });
+        // Return the window list text so the agent can pick the right window_id.
+        return jsonResult({ ok: true, windows: listResult.text });
+      }
+      const result = extractResult(
+        await client.callTool("screenshot", {
+          window_id: params.window_id,
+          format: "jpeg",
+          quality: 85,
+        }),
+      );
+      return buildResult(result);
+    }
+
+    case "get_app_state": {
+      if (!params.app_name && (!params.pid || !params.window_id)) {
+        return jsonResult({
+          ok: false,
+          error: "get_app_state requires app_name or pid+window_id.",
+        });
+      }
+      if (params.app_name && (!params.pid || !params.window_id)) {
+        // Resolve pid+window_id from app_name via list_windows.
+        const resolved = await resolveWindow(client, params.app_name);
+        if (!resolved) {
+          return jsonResult({
+            ok: false,
+            error: `No on-screen window found for "${params.app_name}". Is the app running?`,
+          });
+        }
+        const result = extractResult(
+          await client.callTool("get_window_state", {
+            pid: resolved.pid,
+            window_id: resolved.windowId,
+            ...(params.query ? { query: params.query } : {}),
+            ...(params.javascript ? { javascript: params.javascript } : {}),
+          }),
+        );
+        return buildResult(result);
+      }
+      const result = extractResult(
+        await client.callTool("get_window_state", {
+          pid: params.pid,
+          window_id: params.window_id,
+          ...(params.query ? { query: params.query } : {}),
+          ...(params.javascript ? { javascript: params.javascript } : {}),
+        }),
+      );
+      return buildResult(result);
+    }
+
+    case "list_windows": {
+      const result = extractResult(await client.callTool("list_windows", { on_screen_only: true }));
+      return buildResult(result);
+    }
+
+    case "list_apps": {
+      const result = extractResult(await client.callTool("list_apps", {}));
+      return buildResult(result);
+    }
+
+    case "launch_app": {
+      if (!params.bundle_id && !params.app_name) {
+        return jsonResult({ ok: false, error: "launch_app requires bundle_id or app_name." });
+      }
+      const result = extractResult(
+        await client.callTool("launch_app", {
+          ...(params.bundle_id ? { bundle_id: params.bundle_id } : { name: params.app_name }),
+        }),
+      );
+      return buildResult(result);
+    }
+
+    case "click":
+    case "double_click":
+    case "right_click": {
+      if (!params.pid) return jsonResult({ ok: false, error: `${action} requires pid.` });
+      const toolName =
+        action === "double_click"
+          ? "double_click"
+          : action === "right_click"
+            ? "right_click"
+            : "click";
+      const args: Record<string, unknown> = { pid: params.pid };
+      if (params.element_index !== undefined && params.window_id !== undefined) {
+        args.element_index = params.element_index;
+        args.window_id = params.window_id;
+      } else if (params.x !== undefined && params.y !== undefined) {
+        args.x = params.x;
+        args.y = params.y;
+      } else {
+        return jsonResult({
+          ok: false,
+          error: `${action} requires element_index+window_id or x+y.`,
+        });
+      }
+      if (params.modifier?.length) args.modifier = params.modifier;
+      const result = extractResult(await client.callTool(toolName, args));
+      return buildResult(result);
+    }
+
+    case "scroll": {
+      if (!params.pid) return jsonResult({ ok: false, error: "scroll requires pid." });
+      const args: Record<string, unknown> = {
+        pid: params.pid,
+        direction: params.direction ?? "down",
+        amount: params.amount ?? 3,
+      };
+      if (params.element_index !== undefined && params.window_id !== undefined) {
+        args.element_index = params.element_index;
+        args.window_id = params.window_id;
+      } else if (params.x !== undefined && params.y !== undefined) {
+        args.x = params.x;
+        args.y = params.y;
+      }
+      const result = extractResult(await client.callTool("scroll", args));
+      return buildResult(result);
+    }
+
+    case "type": {
+      if (!params.pid) return jsonResult({ ok: false, error: "type requires pid." });
+      if (!params.text) return jsonResult({ ok: false, error: "type requires text." });
+      const result = extractResult(
+        await client.callTool("type_text", { pid: params.pid, text: params.text }),
+      );
+      return buildResult(result);
+    }
+
+    case "type_chars": {
+      if (!params.pid) return jsonResult({ ok: false, error: "type_chars requires pid." });
+      if (!params.text) return jsonResult({ ok: false, error: "type_chars requires text." });
+      const result = extractResult(
+        await client.callTool("type_text_chars", { pid: params.pid, text: params.text }),
+      );
+      return buildResult(result);
+    }
+
+    case "key": {
+      if (!params.pid) return jsonResult({ ok: false, error: "key requires pid." });
+      if (!params.key) return jsonResult({ ok: false, error: "key requires key." });
+      const result = extractResult(
+        await client.callTool("press_key", { pid: params.pid, key: params.key }),
+      );
+      return buildResult(result);
+    }
+
+    case "hotkey": {
+      if (!params.pid) return jsonResult({ ok: false, error: "hotkey requires pid." });
+      if (!params.keys?.length) return jsonResult({ ok: false, error: "hotkey requires keys." });
+      const result = extractResult(
+        await client.callTool("hotkey", { pid: params.pid, keys: params.keys }),
+      );
+      return buildResult(result);
+    }
+
+    case "set_value": {
+      if (!params.pid || !params.window_id || params.element_index === undefined) {
+        return jsonResult({
+          ok: false,
+          error: "set_value requires pid, window_id, element_index.",
+        });
+      }
+      if (!params.value) return jsonResult({ ok: false, error: "set_value requires value." });
+      const result = extractResult(
+        await client.callTool("set_value", {
+          pid: params.pid,
+          window_id: params.window_id,
+          element_index: params.element_index,
+          value: params.value,
+        }),
+      );
+      return buildResult(result);
+    }
+
+    case "execute_javascript":
+    case "get_text":
+    case "query_dom":
+    case "enable_javascript_apple_events": {
+      if (!params.pid || !params.window_id) {
+        return jsonResult({
+          ok: false,
+          error: `page action=${action} requires pid and window_id.`,
+        });
+      }
+      const args: Record<string, unknown> = {
+        pid: params.pid,
+        window_id: params.window_id,
+        action,
+      };
+      if (params.javascript) args.javascript = params.javascript;
+      if (params.css_selector) args.css_selector = params.css_selector;
+      if (params.attributes) args.attributes = params.attributes;
+      if (params.bundle_id) args.bundle_id = params.bundle_id;
+      if (params.user_has_confirmed_enabling !== undefined) {
+        args.user_has_confirmed_enabling = params.user_has_confirmed_enabling;
+      }
+      const result = extractResult(await client.callTool("page", args));
+      return buildResult(result);
+    }
+
+    default:
+      return jsonResult({ ok: false, error: `Unknown action: ${action}` });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildResult(extracted: ReturnType<typeof extractResult>) {
+  if (extracted.images.length > 0) {
+    // Return first image as base64 alongside the text summary.
+    const img = extracted.images[0]!;
+    return {
+      content: [
+        { type: "text" as const, text: extracted.text },
+        { type: "image" as const, data: img.data, mimeType: img.mimeType },
+      ],
+      details: { text: extracted.text, isError: extracted.isError },
+    };
+  }
+  return textResult(extracted.text, { isError: extracted.isError });
+}
+
+async function resolveWindow(
+  client: ReturnType<typeof getCuaDriverClient>,
+  appName: string,
+): Promise<{ pid: number; windowId: number } | null> {
+  const result = extractResult(await client.callTool("list_windows", { on_screen_only: true }));
+  if (result.isError) return null;
+  // Parse the structured content — cua-driver returns structuredContent on list_windows.
+  // Fall back to text parsing if structured content isn't available.
+  const needle = appName.toLowerCase();
+  const match = result.text
+    .split("\n")
+    .find((line) => line.toLowerCase().includes(needle) && line.includes("[window_id:"));
+  if (!match) return null;
+  const pidMatch = /\(pid\s+(\d+)\)/.exec(match);
+  const wIdMatch = /\[window_id:\s*(\d+)\]/.exec(match);
+  if (!pidMatch || !wIdMatch) return null;
+  return { pid: parseInt(pidMatch[1]!, 10), windowId: parseInt(wIdMatch[1]!, 10) };
+}

--- a/extensions/computer/src/computer-tool.ts
+++ b/extensions/computer/src/computer-tool.ts
@@ -200,6 +200,9 @@ export async function executeComputerTool(
           error: `page action=${action} requires pid and window_id.`,
         });
       }
+      if (action === "execute_javascript" && !params.javascript) {
+        return jsonResult({ ok: false, error: "execute_javascript requires javascript." });
+      }
       const args: Record<string, unknown> = {
         pid: params.pid,
         window_id: params.window_id,

--- a/extensions/computer/src/cua-driver-client.ts
+++ b/extensions/computer/src/cua-driver-client.ts
@@ -1,0 +1,81 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+type CallToolResult = {
+  content: { type: string; text?: string; data?: string; mimeType?: string }[];
+  isError?: boolean;
+};
+
+// One shared client per binary path. Reused across tool calls within a
+// session — cua-driver holds AX element caches that must persist between
+// get_app_state and subsequent click/type calls.
+const clients = new Map<string, CuaDriverClient>();
+
+export function getCuaDriverClient(binaryPath = "cua-driver"): CuaDriverClient {
+  let client = clients.get(binaryPath);
+  if (!client) {
+    client = new CuaDriverClient(binaryPath);
+    clients.set(binaryPath, client);
+  }
+  return client;
+}
+
+export class CuaDriverClient {
+  private client: Client | null = null;
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(private readonly binaryPath: string) {}
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    await this.ensureConnected();
+    const result = await this.client!.callTool({ name, arguments: args });
+    return result as CallToolResult;
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.client) return;
+    if (this.connectPromise) {
+      await this.connectPromise;
+      return;
+    }
+    this.connectPromise = this.connect();
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  private async connect(): Promise<void> {
+    const transport = new StdioClientTransport({
+      command: this.binaryPath,
+      args: ["mcp"],
+    });
+    this.client = new Client({ name: "openclaw-computer", version: "1.0.0" }, { capabilities: {} });
+    await this.client.connect(transport);
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+    }
+  }
+}
+
+// Extract the first text part and all image parts from a cua-driver result.
+export function extractResult(result: CallToolResult): {
+  text: string;
+  images: { data: string; mimeType: string }[];
+  isError: boolean;
+} {
+  const textParts = result.content.filter((c) => c.type === "text").map((c) => c.text ?? "");
+  const images = result.content
+    .filter((c) => c.type === "image" && c.data)
+    .map((c) => ({ data: c.data!, mimeType: c.mimeType ?? "image/jpeg" }));
+  return {
+    text: textParts.join("\n").trim(),
+    images,
+    isError: result.isError === true,
+  };
+}

--- a/extensions/computer/src/cua-driver-client.ts
+++ b/extensions/computer/src/cua-driver-client.ts
@@ -28,8 +28,14 @@ export class CuaDriverClient {
 
   async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
     await this.ensureConnected();
-    const result = await this.client!.callTool({ name, arguments: args });
-    return result as CallToolResult;
+    try {
+      const result = await this.client!.callTool({ name, arguments: args });
+      return result as CallToolResult;
+    } catch (err) {
+      // If the subprocess crashed, null the client so the next call reconnects.
+      this.client = null;
+      throw err;
+    }
   }
 
   private async ensureConnected(): Promise<void> {
@@ -41,9 +47,11 @@ export class CuaDriverClient {
     this.connectPromise = this.connect();
     try {
       await this.connectPromise;
-    } finally {
+    } catch (err) {
       this.connectPromise = null;
+      throw err;
     }
+    this.connectPromise = null;
   }
 
   private async connect(): Promise<void> {

--- a/extensions/computer/tsconfig.json
+++ b/extensions/computer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+}


### PR DESCRIPTION
# feat(extensions): add computer plugin — macOS desktop automation via cua-driver

## What this does

Adds `extensions/computer/`, a new OpenClaw plugin that registers a `computer` tool backed by [cua-driver](https://github.com/trycua/cua). The tool is available to every agent harness — Codex, Claude, Gemini, anything — without any Codex-marketplace dependency or proprietary plugin.

### Changes

- **`extensions/computer/index.ts`** — plugin entry point
- **`extensions/computer/plugin-registration.ts`** — registers the `computer` tool via `api.registerTool()`
- **`extensions/computer/src/computer-tool.schema.ts`** — Typebox schema with `action` discriminator, mirroring the browser extension's flat-object pattern
- **`extensions/computer/src/computer-tool.ts`** — dispatches each action to the corresponding cua-driver MCP tool
- **`extensions/computer/src/cua-driver-client.ts`** — MCP stdio client that spawns `cua-driver mcp` and keeps the session alive across calls (cua-driver holds AX element caches that must persist between `get_app_state` and subsequent `click`/`type` calls)

**Actions:**

| Action | What it does |
|---|---|
| `screenshot` | Capture a window as JPEG |
| `get_app_state` | AX tree + screenshot for an app, addressed by name |
| `list_windows` | Enumerate on-screen windows with pid, window_id, z-order |
| `list_apps` | Enumerate running and installed macOS apps |
| `launch_app` | Launch an app in the background without stealing focus |
| `click` | Left-click by element index or pixel coordinate |
| `double_click` | Double-click |
| `right_click` | Right-click |
| `scroll` | Scroll by direction and tick count |
| `type` | Insert text via AX attribute write (fast path) |
| `type_chars` | Type character-by-character via CGEvent (works in web inputs) |
| `key` | Press a single key |
| `hotkey` | Press a key combination, e.g. `cmd+s` |
| `set_value` | Set a value on a select, popup, or slider without opening a native menu |
| `execute_javascript` | Execute JS in a browser tab (Chrome, Safari, Electron) and return the result |
| `get_text` | Get the full text content of the active browser page |
| `query_dom` | Query DOM elements by CSS selector and return their attributes |
| `enable_javascript_apple_events` | One-time opt-in to enable JS from Apple Events (user confirmation required) |

`get_app_state` also accepts an optional `javascript` field to run a JS snippet in the browser tab alongside the AX snapshot — one round-trip instead of two.

---

## Prior art — openclaw/openclaw#1946

This picks up where [#1946](https://github.com/openclaw/openclaw/pull/1946) left off. In January 2026 I submitted a `computer` tool backed by `cua-computer-server` (an HTTP-based Python daemon). @steipete asked for it to be a plugin rather than core; I refactored it to `extensions/cua-computer/`. It was then closed by CLAWDINATOR during a feature freeze, not on merit.

Two things have changed since then:

1. **cua-driver shipped.** The Swift MCP server in this PR replaces the Python HTTP daemon from #1946. `cua-driver mcp` runs natively on macOS — no Docker, no daemon management, no HTTP port. It connects via stdio using the MCP protocol, which OpenClaw already understands via `@modelcontextprotocol/sdk`.

2. **`extensions/browser/` exists as the template.** The structure here (`plugin-registration.ts` → `api.registerTool()` → `execute()`) follows `extensions/browser/` exactly. There was no browser extension in January.

---

## Why cua-driver and not the Codex computer-use plugin

[openclaw/openclaw#71842](https://github.com/openclaw/openclaw/pull/71842) adds computer use by installing a plugin through OpenAI's Codex marketplace. That plugin is proprietary: users cannot read, modify, or audit the code that has Accessibility and Screen Recording permissions on their machine.

cua-driver is MIT licensed. Every line of code that controls the screen is readable and forkable. A driver with Accessibility and Screen Recording permissions should be auditable.

The Codex plugin also only works with the Codex harness. If you run Codex and Claude (or any other harness) in the same OpenClaw install, you would need a separate computer-use integration for each one. `extensions/computer/` registers the tool once via `api.registerTool()` and every harness picks it up automatically — no per-harness wiring required.

---

## Setup

Install cua-driver (macOS, requires Accessibility + Screen Recording permissions):

```sh
# Download from https://github.com/trycua/cua/releases or build from source.
cua-driver --version
```

Enable the plugin in OpenClaw config:

```json5
{
  plugins: {
    entries: {
      computer: {
        enabled: true,
      },
    },
  },
}
```

---

## Caveats

- macOS only — cua-driver uses SkyLight and Accessibility APIs.
- Requires Accessibility and Screen Recording permissions granted to cua-driver.