### PR TITLE
postinstall: reinstall stale bundled runtime deps after npm updates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/diagnostics-prometheus:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/diffs:
     dependencies:
       '@pierre/diffs':

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -22,6 +22,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveNpmRunner } from "./npm-runner.mjs";
@@ -29,6 +30,8 @@ import { resolveNpmRunner } from "./npm-runner.mjs";
 export const BUNDLED_PLUGIN_INSTALL_TARGETS = [];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const semver = require("semver");
 const DEFAULT_EXTENSIONS_DIR = join(__dirname, "..", "dist", "extensions");
 const DEFAULT_PACKAGE_ROOT = join(__dirname, "..");
 const DISABLE_POSTINSTALL_ENV = "OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL";
@@ -356,101 +359,17 @@ function dependencySentinelPath(depName) {
   return join("node_modules", ...depName.split("/"), "package.json");
 }
 
-function parseComparableVersion(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u.exec(version.trim());
-  if (!match) {
-    return null;
-  }
-
-  return {
-    major: Number.parseInt(match[1], 10),
-    minor: Number.parseInt(match[2], 10),
-    patch: Number.parseInt(match[3], 10),
-    prerelease: match[4] ?? "",
-  };
-}
-
-function comparePrereleaseIdentifiers(left, right) {
-  const leftNumeric = /^\d+$/u.test(left);
-  const rightNumeric = /^\d+$/u.test(right);
-  if (leftNumeric && rightNumeric) {
-    return Number.parseInt(left, 10) - Number.parseInt(right, 10);
-  }
-  if (leftNumeric) {
-    return -1;
-  }
-  if (rightNumeric) {
-    return 1;
-  }
-  return left.localeCompare(right);
-}
-
-function compareComparableVersions(left, right) {
-  if (left.major !== right.major) {
-    return left.major - right.major;
-  }
-  if (left.minor !== right.minor) {
-    return left.minor - right.minor;
-  }
-  if (left.patch !== right.patch) {
-    return left.patch - right.patch;
-  }
-  if (left.prerelease === right.prerelease) {
-    return 0;
-  }
-  if (!left.prerelease) {
-    return 1;
-  }
-  if (!right.prerelease) {
-    return -1;
-  }
-
-  const leftParts = left.prerelease.split(".");
-  const rightParts = right.prerelease.split(".");
-  const maxLength = Math.max(leftParts.length, rightParts.length);
-  for (let index = 0; index < maxLength; index += 1) {
-    const leftPart = leftParts[index];
-    const rightPart = rightParts[index];
-    if (leftPart === undefined) {
-      return -1;
-    }
-    if (rightPart === undefined) {
-      return 1;
-    }
-    const result = comparePrereleaseIdentifiers(leftPart, rightPart);
-    if (result !== 0) {
-      return result;
-    }
-  }
-  return 0;
-}
-
 function isInstalledDependencyVersionSatisfied(installedVersion, spec) {
-  if (installedVersion === spec) {
-    return true;
+  const normalizedInstalledVersion = semver.valid(installedVersion);
+  const normalizedRange = semver.validRange(spec);
+  if (normalizedInstalledVersion && normalizedRange) {
+    // Keep postinstall aligned with bundled-runtime-deps.ts so eager install
+    // and runtime repair agree on whether an installed dep already satisfies the spec.
+    return semver.satisfies(normalizedInstalledVersion, normalizedRange, {
+      includePrerelease: true,
+    });
   }
-  if (!spec.startsWith("^")) {
-    return false;
-  }
-
-  const installed = parseComparableVersion(installedVersion);
-  const minimum = parseComparableVersion(spec.slice(1));
-  if (!installed || !minimum) {
-    return false;
-  }
-
-  const minimumSatisfied = compareComparableVersions(installed, minimum) >= 0;
-  if (!minimumSatisfied) {
-    return false;
-  }
-
-  if (minimum.major > 0) {
-    return installed.major === minimum.major;
-  }
-  if (minimum.minor > 0) {
-    return installed.major === 0 && installed.minor === minimum.minor;
-  }
-  return installed.major === 0 && installed.minor === 0 && installed.patch === minimum.patch;
+  return installedVersion === spec;
 }
 
 const KNOWN_NATIVE_PLATFORMS = new Set([

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -356,6 +356,103 @@ function dependencySentinelPath(depName) {
   return join("node_modules", ...depName.split("/"), "package.json");
 }
 
+function parseComparableVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u.exec(version.trim());
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] ?? "",
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftNumeric = /^\d+$/u.test(left);
+  const rightNumeric = /^\d+$/u.test(right);
+  if (leftNumeric && rightNumeric) {
+    return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+  }
+  if (leftNumeric) {
+    return -1;
+  }
+  if (rightNumeric) {
+    return 1;
+  }
+  return left.localeCompare(right);
+}
+
+function compareComparableVersions(left, right) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  if (left.patch !== right.patch) {
+    return left.patch - right.patch;
+  }
+  if (left.prerelease === right.prerelease) {
+    return 0;
+  }
+  if (!left.prerelease) {
+    return 1;
+  }
+  if (!right.prerelease) {
+    return -1;
+  }
+
+  const leftParts = left.prerelease.split(".");
+  const rightParts = right.prerelease.split(".");
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    const result = comparePrereleaseIdentifiers(leftPart, rightPart);
+    if (result !== 0) {
+      return result;
+    }
+  }
+  return 0;
+}
+
+function isInstalledDependencyVersionSatisfied(installedVersion, spec) {
+  if (installedVersion === spec) {
+    return true;
+  }
+  if (!spec.startsWith("^")) {
+    return false;
+  }
+
+  const installed = parseComparableVersion(installedVersion);
+  const minimum = parseComparableVersion(spec.slice(1));
+  if (!installed || !minimum) {
+    return false;
+  }
+
+  const minimumSatisfied = compareComparableVersions(installed, minimum) >= 0;
+  if (!minimumSatisfied) {
+    return false;
+  }
+
+  if (minimum.major > 0) {
+    return installed.major === minimum.major;
+  }
+  if (minimum.minor > 0) {
+    return installed.major === 0 && installed.minor === minimum.minor;
+  }
+  return installed.major === 0 && installed.minor === 0 && installed.patch === minimum.patch;
+}
+
 const KNOWN_NATIVE_PLATFORMS = new Set([
   "aix",
   "android",
@@ -392,6 +489,14 @@ function runtimeDepNeedsInstall(params) {
 
   try {
     const packageJson = params.readJson(packageJsonPath);
+    const installedVersion =
+      typeof packageJson.version === "string" ? packageJson.version.trim() : "";
+    if (
+      !installedVersion ||
+      !isInstalledDependencyVersionSatisfied(installedVersion, params.dep.version)
+    ) {
+      return true;
+    }
     return Object.keys(packageJson.optionalDependencies ?? {}).some(
       (childName) =>
         optionalDependencyTargetsRuntime(childName, {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -114,6 +114,8 @@ describe("bundled plugin postinstall", () => {
     await fs.writeFile(
       path.join(packageRoot, "node_modules", "@snazzah", "davey", "package.json"),
       JSON.stringify({
+        name: "@snazzah/davey",
+        version: "0.1.11",
         optionalDependencies: {
           "@snazzah/davey-win32-arm64-msvc": "0.1.11",
         },
@@ -710,6 +712,35 @@ describe("bundled plugin postinstall", () => {
     });
 
     expectNpmInstallSpawn(spawnSync, packageRoot, ["acpx@0.4.1"]);
+  });
+
+  it("skips reinstall when the installed version satisfies a semver range", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-packaged-install-range-ok-");
+    await fs.mkdir(path.join(packageRoot, "dist", "extensions"), { recursive: true });
+    await fs.mkdir(path.join(packageRoot, "node_modules", "acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "node_modules", "acpx", "package.json"),
+      JSON.stringify({ name: "acpx", version: "1.2.3" }),
+      "utf8",
+    );
+    const spawnSync = vi.fn();
+
+    runBundledPluginPostinstall({
+      env: { OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "1", HOME: "/tmp/home" },
+      packageRoot,
+      runtimeDeps: [
+        {
+          name: "acpx",
+          pluginIds: ["acpx"],
+          sentinelPath: path.join("node_modules", "acpx", "package.json"),
+          version: "~1.2.0",
+        },
+      ],
+      spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("reinstalls bundled runtime deps when optional native children are missing", async () => {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -669,7 +669,7 @@ describe("bundled plugin postinstall", () => {
     await fs.mkdir(path.join(packageRoot, "node_modules", "acpx"), { recursive: true });
     await fs.writeFile(
       path.join(packageRoot, "node_modules", "acpx", "package.json"),
-      "{}\n",
+      JSON.stringify({ name: "acpx", version: "0.4.1" }),
       "utf8",
     );
     const spawnSync = vi.fn();
@@ -682,6 +682,34 @@ describe("bundled plugin postinstall", () => {
     });
 
     expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("reinstalls bundled plugin deps when the installed version is stale", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "acpx", {
+      dependencies: {
+        acpx: "0.4.1",
+      },
+    });
+    await fs.mkdir(path.join(packageRoot, "node_modules", "acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "node_modules", "acpx", "package.json"),
+      JSON.stringify({ name: "acpx", version: "0.3.0" }),
+      "utf8",
+    );
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+
+    runBundledPluginPostinstall({
+      env: { OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS: "1", HOME: "/tmp/home" },
+      extensionsDir,
+      packageRoot,
+      npmRunner: createBareNpmRunner(["acpx@0.4.1"]),
+      spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expectNpmInstallSpawn(spawnSync, packageRoot, ["acpx@0.4.1"]);
   });
 
   it("reinstalls bundled runtime deps when optional native children are missing", async () => {
@@ -830,7 +858,7 @@ describe("bundled plugin postinstall", () => {
     });
     await fs.writeFile(
       path.join(packageRoot, "node_modules", "@slack", "web-api", "package.json"),
-      "{}\n",
+      JSON.stringify({ name: "@slack/web-api", version: "7.11.0" }),
     );
     const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 


### PR DESCRIPTION
## Summary
- treat stale bundled runtime dep versions as missing during postinstall eager installs
- evaluate installed runtime dep versions with the same semver contract used by bundled runtime repair instead of the earlier exact-or-caret-only check
- restore the optional native-child regression path by writing a real `@snazzah/davey` version into the test fixture
- keep the minimal `pnpm-lock.yaml` importer sync needed for the current `extensions/diagnostics-prometheus` workspace graph so frozen-lockfile CI reflects the checked-in package graph

## Testing
- pnpm test -- test/scripts/postinstall-bundled-plugins.test.ts -t "installed version is stale|optional native children are missing|installed version satisfies a semver range|sentinel package already exists|installs only missing bundled plugin runtime deps"
- pnpm exec oxlint scripts/postinstall-bundled-plugins.mjs test/scripts/postinstall-bundled-plugins.test.ts && pnpm exec oxfmt --check scripts/postinstall-bundled-plugins.mjs test/scripts/postinstall-bundled-plugins.test.ts
- manual stale-version repro through runBundledPluginPostinstall confirmed the reinstall path for an outdated installed dependency version
- pnpm check currently stops in pre-existing unrelated agents/typebox baseline failures in this worktree

## Linked Issue
Closes #72058