### PR TITLE
[refactor] Add native AgentHarnessV2 factory registry (RFC #72072 PR 2/7)

### DIFF
--- a/src/agents/harness/builtin-pi.test.ts
+++ b/src/agents/harness/builtin-pi.test.ts
@@ -1,0 +1,106 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import {
+  createPiAgentHarness,
+  createPiAgentHarnessV2,
+  PI_AGENT_HARNESS_ID,
+  PI_AGENT_HARNESS_LABEL,
+} from "./builtin-pi.js";
+import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
+import { getNativeAgentHarnessV2Factory } from "./v2.js";
+
+function createAttemptParams(): AgentHarnessAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "session-key",
+    runId: "run-1",
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    timeoutMs: 5_000,
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: { id: "gpt-5.4", provider: "codex" } as Model<Api>,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+    thinkLevel: "low",
+    messageChannel: "qa",
+    trigger: "manual",
+  } as AgentHarnessAttemptParams;
+}
+
+function createAttemptResult(): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    externalAbort: false,
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    promptError: null,
+    promptErrorSource: null,
+    sessionIdUsed: "session-1",
+    messagesSnapshot: [],
+    assistantTexts: ["pi ok"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+  } as EmbeddedRunAttemptResult;
+}
+
+describe("built-in PI agent harness", () => {
+  it("registers a native AgentHarnessV2 factory under the 'pi' harness id at module load", () => {
+    expect(getNativeAgentHarnessV2Factory(PI_AGENT_HARNESS_ID)).toBeDefined();
+  });
+
+  it("createPiAgentHarness returns the canonical PI V1 harness shape", () => {
+    const harness = createPiAgentHarness();
+    expect(harness.id).toBe(PI_AGENT_HARNESS_ID);
+    expect(harness.label).toBe(PI_AGENT_HARNESS_LABEL);
+    expect(harness.supports({ provider: "codex", requestedRuntime: "auto" })).toEqual({
+      supported: true,
+      priority: 0,
+    });
+  });
+
+  it("createPiAgentHarnessV2 routes send through the V1 harness runAttempt so PR 4 can plumb split lifecycle without breaking parity", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const v1: AgentHarness = {
+      id: PI_AGENT_HARNESS_ID,
+      label: PI_AGENT_HARNESS_LABEL,
+      supports: () => ({ supported: true, priority: 0 }),
+      runAttempt,
+    };
+
+    const v2 = createPiAgentHarnessV2(v1);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+  });
+
+  it("createPiAgentHarnessV2 cleanup is intentionally empty at PR 2 to keep parity with the V1 adapter", async () => {
+    const v1: AgentHarness = {
+      id: PI_AGENT_HARNESS_ID,
+      label: PI_AGENT_HARNESS_LABEL,
+      supports: () => ({ supported: true, priority: 0 }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+    };
+
+    const v2 = createPiAgentHarnessV2(v1);
+    const session = await v2.start(await v2.prepare(createAttemptParams()));
+
+    // No-op cleanup must resolve without throwing for both success and error
+    // shapes. PR 4 will replace this with split-lifecycle teardown.
+    await expect(v2.cleanup({ session, result: createAttemptResult() })).resolves.toBeUndefined();
+    await expect(v2.cleanup({ session, error: new Error("boom") })).resolves.toBeUndefined();
+  });
+});

--- a/src/agents/harness/builtin-pi.ts
+++ b/src/agents/harness/builtin-pi.ts
@@ -1,11 +1,59 @@
 import { runEmbeddedAttempt } from "../pi-embedded-runner/run/attempt.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness } from "./types.js";
+import { registerNativeAgentHarnessV2Factory, type AgentHarnessV2 } from "./v2.js";
+
+export const PI_AGENT_HARNESS_ID = "pi";
+export const PI_AGENT_HARNESS_LABEL = "PI embedded agent";
 
 export function createPiAgentHarness(): AgentHarness {
   return {
-    id: "pi",
-    label: "PI embedded agent",
+    id: PI_AGENT_HARNESS_ID,
+    label: PI_AGENT_HARNESS_LABEL,
     supports: () => ({ supported: true, priority: 0 }),
     runAttempt: runEmbeddedAttempt,
   };
 }
+
+/**
+ * Native AgentHarnessV2 for the built-in PI embedded runner. At PR 2 (RFC 72072)
+ * the lifecycle methods still bottom out in `runEmbeddedAttempt`, so the
+ * visible AgentHarnessAttemptResult must remain identical to the V1-adapter
+ * path. PR 4 is where prepare/start/cleanup will plumb through the split
+ * lifecycle modules.
+ */
+export function createPiAgentHarnessV2(harness: AgentHarness): AgentHarnessV2 {
+  return {
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+    supports: (ctx) => harness.supports(ctx),
+    prepare: async (params) => ({
+      harnessId: harness.id,
+      label: harness.label,
+      pluginId: harness.pluginId,
+      params,
+      lifecycleState: "prepared",
+    }),
+    start: async (prepared) => ({
+      harnessId: prepared.harnessId,
+      label: prepared.label,
+      pluginId: prepared.pluginId,
+      params: prepared.params,
+      lifecycleState: "started",
+    }),
+    send: async (session) => harness.runAttempt(session.params),
+    resolveOutcome: async (session, result) =>
+      applyAgentHarnessResultClassification(harness, result, session.params),
+    cleanup: async (_params) => {
+      // PR 4 will route lifecycle cleanup through
+      // `attempt.subscription-cleanup.ts` here. PR 2 keeps cleanup intentionally
+      // empty so native and V1-adapter paths stay observationally identical.
+    },
+    compact: harness.compact ? (params) => harness.compact!(params) : undefined,
+    reset: harness.reset ? (params) => harness.reset!(params) : undefined,
+    dispose: harness.dispose ? () => harness.dispose!() : undefined,
+  };
+}
+
+registerNativeAgentHarnessV2Factory(PI_AGENT_HARNESS_ID, createPiAgentHarnessV2);

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -22,7 +22,7 @@ import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
-import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
+import { resolveAgentHarnessV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
 
 const log = createSubsystemLogger("agents/harness");
 
@@ -190,7 +190,7 @@ export async function runAgentHarnessAttemptWithFallback(
     sessionKey: params.sessionKey,
     agentId: params.agentId,
   });
-  const v2Harness = adaptAgentHarnessToV2(harness);
+  const v2Harness = resolveAgentHarnessV2(harness);
   if (harness.id === "pi") {
     return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
   }

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -7,9 +7,15 @@ import {
   type DiagnosticEventPayload,
 } from "../../infra/diagnostic-events.js";
 import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
 import type { AgentHarnessV2 } from "./v2.js";
-import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
+import {
+  adaptAgentHarnessToV2,
+  registerNativeAgentHarnessV2Factory,
+  resolveAgentHarnessV2,
+  runAgentHarnessV2LifecycleAttempt,
+} from "./v2.js";
 
 function createAttemptParams(): AgentHarnessAttemptParams {
   return {
@@ -540,5 +546,119 @@ describe("AgentHarness V2 compatibility adapter", () => {
     await v2.cleanup({ session, result: createAttemptResult() });
 
     expect(dispose).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentHarness V2 native factory registry", () => {
+  // Tests in this describe block use unique harness ids so they do not collide
+  // with the module-level "pi" registration in builtin-pi.ts. Vitest isolates
+  // modules per test file, so our registrations stay scoped to this file.
+
+  it("falls back to the V1 adapter when no native factory is registered", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const harness: AgentHarness = {
+      id: "no-native-factory-test",
+      label: "No native factory",
+      supports: () => ({ supported: true }),
+      runAttempt,
+    };
+
+    const resolved = resolveAgentHarnessV2(harness);
+    const prepared = await resolved.prepare(params);
+    const session = await resolved.start(prepared);
+
+    expect(await resolved.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+  });
+
+  it("prefers a registered native factory over the V1 adapter", async () => {
+    const params = createAttemptParams();
+    const adapterResult = createAttemptResult();
+    const nativeResult = { ...createAttemptResult(), assistantTexts: ["native path"] };
+    const runAttempt = vi.fn(async () => adapterResult);
+    const harness: AgentHarness = {
+      id: "native-factory-preference-test",
+      label: "Native factory preference",
+      supports: () => ({ supported: true }),
+      runAttempt,
+    };
+    registerNativeAgentHarnessV2Factory(harness.id, (h) => ({
+      id: h.id,
+      label: h.label,
+      pluginId: h.pluginId,
+      supports: (ctx) => h.supports(ctx),
+      prepare: async (p) => ({
+        harnessId: h.id,
+        label: h.label,
+        params: p,
+        lifecycleState: "prepared",
+      }),
+      start: async (p) => ({ ...p, lifecycleState: "started" }),
+      send: async () => nativeResult,
+      resolveOutcome: async (_session, r) => r,
+      cleanup: async () => {},
+    }));
+
+    const result = await runAgentHarnessV2LifecycleAttempt(resolveAgentHarnessV2(harness), params);
+
+    expect(result).toBe(nativeResult);
+    expect(runAttempt).not.toHaveBeenCalled();
+  });
+
+  it("native AgentHarnessV2 produces the same final attempt result as the V1 adapter for the same V1 harness", async () => {
+    const params = createAttemptParams();
+    const baseResult = createAttemptResult();
+    const adapterRun = vi.fn(async () => baseResult);
+    const nativeRun = vi.fn(async () => baseResult);
+    const adapterV1: AgentHarness = {
+      id: "parity-adapter",
+      label: "Parity",
+      supports: () => ({ supported: true }),
+      runAttempt: adapterRun,
+    };
+    const nativeV1: AgentHarness = {
+      id: "parity-native",
+      label: "Parity",
+      supports: () => ({ supported: true }),
+      runAttempt: nativeRun,
+    };
+
+    // Native factory body mirrors createPiAgentHarnessV2 in builtin-pi.ts so
+    // PR 4 regressions in cleanup ordering surface here as parity drift.
+    const native: AgentHarnessV2 = {
+      id: nativeV1.id,
+      label: nativeV1.label,
+      pluginId: nativeV1.pluginId,
+      supports: (ctx) => nativeV1.supports(ctx),
+      prepare: async (p) => ({
+        harnessId: nativeV1.id,
+        label: nativeV1.label,
+        pluginId: nativeV1.pluginId,
+        params: p,
+        lifecycleState: "prepared",
+      }),
+      start: async (p) => ({
+        harnessId: p.harnessId,
+        label: p.label,
+        pluginId: p.pluginId,
+        params: p.params,
+        lifecycleState: "started",
+      }),
+      send: async (s) => nativeV1.runAttempt(s.params),
+      resolveOutcome: async (s, r) => applyAgentHarnessResultClassification(nativeV1, r, s.params),
+      cleanup: async () => {},
+    };
+
+    const adaptedFinal = await runAgentHarnessV2LifecycleAttempt(
+      adaptAgentHarnessToV2(adapterV1),
+      params,
+    );
+    const nativeFinal = await runAgentHarnessV2LifecycleAttempt(native, params);
+
+    expect(nativeFinal).toEqual({ ...adaptedFinal, agentHarnessId: nativeV1.id });
+    expect(adapterRun).toHaveBeenCalledWith(params);
+    expect(nativeRun).toHaveBeenCalledWith(params);
   });
 });

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -70,6 +70,44 @@ export type AgentHarnessV2 = {
   dispose?(): Promise<void> | void;
 };
 
+/**
+ * Internal-only seam. A native AgentHarnessV2 implementation can register here
+ * so selected harnesses run as a real V2 lifecycle instead of going through
+ * `adaptAgentHarnessToV2`. This is not exposed via `harness/index.ts` or the
+ * plugin SDK; widening it is tracked as optional future work, not RFC 72072 scope.
+ */
+export type NativeAgentHarnessV2Factory = (harness: AgentHarness) => AgentHarnessV2;
+
+const nativeAgentHarnessV2Factories = new Map<string, NativeAgentHarnessV2Factory>();
+
+export function registerNativeAgentHarnessV2Factory(
+  harnessId: string,
+  factory: NativeAgentHarnessV2Factory,
+): void {
+  nativeAgentHarnessV2Factories.set(harnessId, factory);
+}
+
+export function clearNativeAgentHarnessV2Factories(): void {
+  nativeAgentHarnessV2Factories.clear();
+}
+
+export function getNativeAgentHarnessV2Factory(
+  harnessId: string,
+): NativeAgentHarnessV2Factory | undefined {
+  return nativeAgentHarnessV2Factories.get(harnessId);
+}
+
+/**
+ * Prefer a registered native AgentHarnessV2 implementation when available, and
+ * fall back to wrapping the V1 harness with `adaptAgentHarnessToV2`. This is
+ * the single resolution point used by harness selection so the lifecycle
+ * boundary always runs against an `AgentHarnessV2` instance.
+ */
+export function resolveAgentHarnessV2(harness: AgentHarness): AgentHarnessV2 {
+  const factory = nativeAgentHarnessV2Factories.get(harness.id);
+  return factory ? factory(harness) : adaptAgentHarnessToV2(harness);
+}
+
 export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
   return {
     id: harness.id,


### PR DESCRIPTION
Refs #72072 (RFC) — PR 2 of 7.

## Summary

Promotes Harness V2 from "generic V1 adapter" to an internal lifecycle boundary by adding a native AgentHarnessV2 factory registry. The built-in PI harness now ships a native V2 factory; selection prefers it, with a guaranteed fall-back to `adaptAgentHarnessToV2` for any harness without a native factory. A parity test locks the contract that native and adapted paths produce the same final `AgentHarnessAttemptResult` so PR 4 cannot regress cleanup ordering or classification routing without surfacing the drift.

This PR is **scaffolding for PR 4**, not a behavior change. PR 4 (split Pi stream and lifecycle) is what fills the native PI cleanup hook with split-lifecycle teardown. PR 2 keeps native and adapter observationally identical.

## What is being fixed

Today every selected harness goes through `adaptAgentHarnessToV2(harness)` at [src/agents/harness/selection.ts:193](https://github.com/openclaw/openclaw/blob/main/src/agents/harness/selection.ts#L193). That adapter only knows the V1 shape, so the V2 lifecycle (`prepare/start/send/resolveOutcome/cleanup`) has nowhere meaningful to plumb future split-out modules. Until PR 2 lands the seam, PR 4's cleanup work would have to either edit `attempt.ts` directly or widen the public V1 `AgentHarness` shape — both bad outcomes.

Scope of the SDK widening for plugin-supplied native V2 (so Codex can register one too) is explicitly **optional future** per the RFC. PR 2 adds the internal-only registry surface; bundled Codex stays V1 in this PR.

## Architecture diff

```mermaid
flowchart TD
  subgraph Before
    selA[selection.ts] -->|adaptAgentHarnessToV2| adapter[V1 adapter]
    adapter --> v2run[runAgentHarnessV2LifecycleAttempt]
  end
  subgraph After
    selB[selection.ts] -->|resolveAgentHarnessV2| split{native factory registered?}
    split -- yes --> native[native AgentHarnessV2]
    split -- no --> adapter2[adaptAgentHarnessToV2]
    native --> v2run2[runAgentHarnessV2LifecycleAttempt]
    adapter2 --> v2run2
    pi[builtin-pi.ts module load] -->|registerNativeAgentHarnessV2Factory pi| registry[(internal registry)]
    registry -.- split
  end
```

## File map

| Action | Path | Purpose |
|---|---|---|
| modify | `src/agents/harness/v2.ts` | Add `NativeAgentHarnessV2Factory` type, internal registry, `register/clear/getNativeAgentHarnessV2Factory` helpers, and `resolveAgentHarnessV2(harness)` resolution function. None of these are exported via `harness/index.ts` or the plugin SDK. |
| modify | `src/agents/harness/selection.ts` | Replace one call (line 193) from `adaptAgentHarnessToV2(harness)` to `resolveAgentHarnessV2(harness)`. |
| modify | `src/agents/harness/builtin-pi.ts` | Add `createPiAgentHarnessV2(harness)` and register it as the "pi" factory at module load. `send` calls `harness.runAttempt(session.params)` so PR 4 can plumb the split-lifecycle without breaking parity. Export `PI_AGENT_HARNESS_ID` and `PI_AGENT_HARNESS_LABEL` constants. |
| modify | `src/agents/harness/v2.test.ts` | Add tests for `resolveAgentHarnessV2` (registry hit, fallback, parity contract). Existing 14 adapter tests untouched. |
| add | `src/agents/harness/builtin-pi.test.ts` | Native PI factory tests: registration at module load, returned V2 routes `send` through `harness.runAttempt`, cleanup is intentionally empty at PR 2. |

**Do NOT modify (and did not):** `src/agents/harness/index.ts` (public surface), `src/agents/harness/types.ts`, `src/plugin-sdk/agent-harness-runtime.ts`, `extensions/codex/harness.ts`. Plugin shape stays exactly the same.

## Validation

```bash
pnpm check:architecture
# green: 0 runtime value cycles, 0 madge cycles

pnpm check:test-types
# green: tsgo:core:test + tsgo:extensions:test, 0 type errors

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/runtime-plan/build.test.ts \
  src/agents/runtime-plan/types.test.ts \
  src/agents/runtime-plan/types.compat.test.ts \
  src/agents/runtime-plan/tools.test.ts \
  src/agents/runtime-plan/tools.diagnostics.test.ts \
  src/agents/harness/v2.test.ts \
  src/agents/harness/selection.test.ts \
  src/agents/harness/builtin-pi.test.ts
# green: 7 files / 52 tests passed (was 45 baseline; +7 new tests in v2 + builtin-pi)

node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  extensions/codex/src/app-server/event-projector.test.ts \
  extensions/codex/index.test.ts
# green: 3 files / 56 tests passed in 40.6s

pnpm check:changed
# green: lint, import cycles, webhook/pairing guards, agent test lane
```

## What did NOT change

- Public `harness/index.ts` exports: identical (no V2 types or factory functions exposed there).
- Public V1 `AgentHarness` type: identical.
- `registerAgentHarness(...)`, `getAgentHarness(...)`, `listRegisteredAgentHarnesses(...)`, `clearAgentHarnesses(...)`, `disposeRegisteredAgentHarnesses(...)`: identical signatures.
- Plugin SDK at `src/plugin-sdk/agent-harness-runtime.ts`: identical (no V2 surface widening).
- `extensions/codex/harness.ts`: untouched. Codex stays V1, gets V2-adapted as before.
- `src/agents/harness/v2.ts` lifecycle invariants: `runAgentHarnessV2LifecycleAttempt` ordering (`prepare → start → send → resolveOutcome → cleanup`), error-cleanup pairing, and diagnostic emission all unchanged.
- Result classification choke-point: `applyAgentHarnessResultClassification` remains the single source.

## Why this is the right fix

Three alternatives were considered:

1. **Inline the native lifecycle in `adaptAgentHarnessToV2`** — would entangle adapter and native code paths, making PR 4's split-lifecycle work harder to land cleanly.
2. **Add an optional `createV2()` field on the public V1 `AgentHarness`** — widens the plugin SDK contract for a feature that is explicitly *optional future* per the RFC. Reverting later would be breaking.
3. **Special-case Pi inside `selection.ts`** — embeds harness identity into the orchestration layer, which is exactly what the V2 boundary is supposed to avoid.

The internal registry pattern in this PR keeps the V2 lifecycle boundary generic and extensible, leaves the public V1 surface untouched, and makes Codex's eventual native V2 factory a single registration call once the optional SDK widening is approved.

## Notes for reviewers

- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072). Predecessor: PR [#72098](https://github.com/openclaw/openclaw/pull/72098) (PR 1 of 7, baseline doc).
- `selection.test.ts` mocks `./builtin-pi.js`; the mock replaces the entire module so the module-level Pi registration does not run inside that test file. All 25 selection tests still observe the V1-adapter path, which is correct (the mock harness has no real backing).
- Vitest module isolation is what keeps the registry registrations scoped per test file. Tests that need to assert registry behavior register under unique ids ("no-native-factory-test", "native-factory-preference-test", "parity-adapter", "parity-native") so they do not collide with the module-level "pi" registration.
- The native PI cleanup hook is intentionally empty in this PR. PR 4 will replace it with split-lifecycle teardown plumbed through `attempt.subscription-cleanup.ts`. The parity test will surface any drift in cleanup-call signature when that change lands.
