### PR TITLE
fix: only include existing service path fallbacks

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -13,25 +13,43 @@ import {
 } from "./service-env.js";
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
-  it("includes user bin directories when HOME is set on Linux", () => {
+  it("includes common user bin directories but skips missing version-manager fallbacks on Linux", () => {
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
+      pathExists: () => false,
     });
 
-    // Should include all common user bin directories
+    // Stable user bin conventions remain available.
     expect(result).toContain("/home/testuser/.local/bin");
     expect(result).toContain("/home/testuser/.npm-global/bin");
     expect(result).toContain("/home/testuser/bin");
-    expect(result).toContain("/home/testuser/.nvm/current/bin");
-    expect(result).toContain("/home/testuser/.local/share/fnm/aliases/default/bin");
-    expect(result).toContain("/home/testuser/.local/share/fnm/current/bin");
-    expect(result).toContain("/home/testuser/.fnm/aliases/default/bin");
-    expect(result).toContain("/home/testuser/.fnm/current/bin");
+
+    // Version/package-manager fallbacks should not be written unless present on disk.
+    expect(result).not.toContain("/home/testuser/.nvm/current/bin");
+    expect(result).not.toContain("/home/testuser/.local/share/fnm/aliases/default/bin");
+    expect(result).not.toContain("/home/testuser/.local/share/fnm/current/bin");
+    expect(result).not.toContain("/home/testuser/.fnm/aliases/default/bin");
+    expect(result).not.toContain("/home/testuser/.fnm/current/bin");
+    expect(result).not.toContain("/home/testuser/.volta/bin");
+    expect(result).not.toContain("/home/testuser/.asdf/shims");
+    expect(result).not.toContain("/home/testuser/.local/share/pnpm");
+    expect(result).not.toContain("/home/testuser/.bun/bin");
+  });
+
+  it("includes Linux version-manager fallback dirs that exist on disk", () => {
+    const existing = new Set(["/home/testuser/.volta/bin", "/home/testuser/.local/share/pnpm"]);
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+      pathExists: (dir) => existing.has(dir),
+    });
+
     expect(result).toContain("/home/testuser/.volta/bin");
-    expect(result).toContain("/home/testuser/.asdf/shims");
     expect(result).toContain("/home/testuser/.local/share/pnpm");
-    expect(result).toContain("/home/testuser/.bun/bin");
+    expect(result).not.toContain("/home/testuser/.asdf/shims");
+    expect(result).not.toContain("/home/testuser/.bun/bin");
+    expect(result).not.toContain("/home/testuser/.local/share/fnm/aliases/default/bin");
   });
 
   it("excludes user bin directories when HOME is undefined on Linux", () => {
@@ -81,6 +99,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   it("includes env-configured bin roots when HOME is set on Linux", () => {
     const result = getMinimalServicePathPartsFromEnv({
       platform: "linux",
+      pathExists: () => false,
       env: {
         HOME: "/home/testuser",
         PNPM_HOME: "/opt/pnpm",
@@ -103,35 +122,56 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/opt/fnm/current/bin");
   });
 
-  it("includes version manager directories on macOS when HOME is set", () => {
+  it("includes common user bin directories but skips missing version-manager fallbacks on macOS", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
+      pathExists: () => false,
     });
 
-    // Should include common user bin directories
+    // Stable user bin conventions remain available.
     expect(result).toContain("/Users/testuser/.local/bin");
     expect(result).toContain("/Users/testuser/.npm-global/bin");
     expect(result).toContain("/Users/testuser/bin");
 
-    // Should include version manager paths (macOS specific)
-    // Note: nvm has no stable default path, relies on user's shell config
-    expect(result).toContain("/Users/testuser/Library/Application Support/fnm/aliases/default/bin"); // fnm default on macOS
-    expect(result).toContain("/Users/testuser/.fnm/aliases/default/bin"); // fnm if customized to ~/.fnm
-    expect(result).toContain("/Users/testuser/.volta/bin");
-    expect(result).toContain("/Users/testuser/.asdf/shims");
-    expect(result).toContain("/Users/testuser/Library/pnpm"); // pnpm default on macOS
-    expect(result).toContain("/Users/testuser/.local/share/pnpm"); // pnpm XDG fallback
-    expect(result).toContain("/Users/testuser/.bun/bin");
+    // Version/package-manager fallbacks should not be written unless present on disk.
+    expect(result).not.toContain(
+      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
+    );
+    expect(result).not.toContain("/Users/testuser/.fnm/aliases/default/bin");
+    expect(result).not.toContain("/Users/testuser/.volta/bin");
+    expect(result).not.toContain("/Users/testuser/.asdf/shims");
+    expect(result).not.toContain("/Users/testuser/Library/pnpm");
+    expect(result).not.toContain("/Users/testuser/.local/share/pnpm");
+    expect(result).not.toContain("/Users/testuser/.bun/bin");
 
     // Should also include macOS system directories
     expect(result).toContain("/opt/homebrew/bin");
     expect(result).toContain("/usr/local/bin");
   });
 
+  it("includes macOS version-manager fallback dirs that exist on disk", () => {
+    const existing = new Set([
+      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
+      "/Users/testuser/Library/pnpm",
+    ]);
+    const result = getMinimalServicePathParts({
+      platform: "darwin",
+      home: "/Users/testuser",
+      pathExists: (dir) => existing.has(dir),
+    });
+
+    expect(result).toContain("/Users/testuser/Library/Application Support/fnm/aliases/default/bin");
+    expect(result).toContain("/Users/testuser/Library/pnpm");
+    expect(result).not.toContain("/Users/testuser/.fnm/aliases/default/bin");
+    expect(result).not.toContain("/Users/testuser/.volta/bin");
+    expect(result).not.toContain("/Users/testuser/.asdf/shims");
+  });
+
   it("includes env-configured version manager dirs on macOS", () => {
     const result = getMinimalServicePathPartsFromEnv({
       platform: "darwin",
+      pathExists: () => false,
       env: {
         HOME: "/Users/testuser",
         FNM_DIR: "/Users/testuser/Library/Application Support/fnm",
@@ -148,10 +188,12 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/Users/testuser/Library/pnpm");
   });
 
-  it("places version manager dirs before system dirs on macOS", () => {
+  it("places existing version manager dirs before system dirs on macOS", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
+      pathExists: (dir) =>
+        dir === "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
     });
 
     // fnm on macOS defaults to ~/Library/Application Support/fnm
@@ -295,18 +337,22 @@ describe("buildMinimalServicePath", () => {
     expect(result).toBe("C:\\\\Windows\\\\System32");
   });
 
-  it("includes Linux user directories when HOME is set in env", () => {
+  it("includes stable Linux user directories when HOME is set in env", () => {
     const result = buildMinimalServicePath({
       platform: "linux",
       env: { HOME: "/home/alice" },
+      pathExists: () => false,
     });
     const parts = splitPath(result, "linux");
 
-    // Verify user directories are included
+    // Verify stable user directories are included
     expect(parts).toContain("/home/alice/.local/bin");
     expect(parts).toContain("/home/alice/.npm-global/bin");
-    expect(parts).toContain("/home/alice/.nvm/current/bin");
-    expect(parts).toContain("/home/alice/.local/share/fnm/aliases/default/bin");
+    expect(parts).toContain("/home/alice/bin");
+
+    // Missing version-manager fallbacks are not frozen into the service PATH.
+    expect(parts).not.toContain("/home/alice/.nvm/current/bin");
+    expect(parts).not.toContain("/home/alice/.local/share/fnm/aliases/default/bin");
 
     // Verify system directories are also included
     expect(parts).toContain("/usr/local/bin");
@@ -366,11 +412,12 @@ describe("buildMinimalServicePath", () => {
       platform: "linux",
       extraDirs: ["/home/alice/.nvm/versions/node/v22.22.0/bin"],
       env: { HOME: "/home/alice" },
+      pathExists: () => false,
     });
     const parts = splitPath(result, "linux");
 
     expect(parts[0]).toBe("/home/alice/.nvm/versions/node/v22.22.0/bin");
-    expect(parts).toContain("/home/alice/.nvm/current/bin");
+    expect(parts).not.toContain("/home/alice/.nvm/current/bin");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -28,6 +29,7 @@ export type MinimalServicePathOptions = {
   extraDirs?: string[];
   home?: string;
   env?: Record<string, string | undefined>;
+  pathExists?: (dir: string) => boolean;
 };
 
 type BuildServicePathOptions = MinimalServicePathOptions & {
@@ -79,6 +81,24 @@ function addNonEmptyDir(dirs: string[], dir: string | undefined): void {
   }
 }
 
+function defaultPathExists(dir: string): boolean {
+  try {
+    return fs.existsSync(dir);
+  } catch {
+    return false;
+  }
+}
+
+function addExistingDir(
+  dirs: string[],
+  dir: string | undefined,
+  pathExists: (dir: string) => boolean,
+): void {
+  if (dir && pathExists(dir)) {
+    dirs.push(dir);
+  }
+}
+
 function appendSubdir(base: string | undefined, subdir: string): string | undefined {
   if (!base) {
     return undefined;
@@ -90,9 +110,16 @@ function addCommonUserBinDirs(dirs: string[], home: string): void {
   dirs.push(`${home}/.local/bin`);
   dirs.push(`${home}/.npm-global/bin`);
   dirs.push(`${home}/bin`);
-  dirs.push(`${home}/.volta/bin`);
-  dirs.push(`${home}/.asdf/shims`);
-  dirs.push(`${home}/.bun/bin`);
+}
+
+function addCommonVersionManagerFallbackDirs(
+  dirs: string[],
+  home: string,
+  pathExists: (dir: string) => boolean,
+): void {
+  addExistingDir(dirs, `${home}/.volta/bin`, pathExists);
+  addExistingDir(dirs, `${home}/.asdf/shims`, pathExists);
+  addExistingDir(dirs, `${home}/.bun/bin`, pathExists);
 }
 
 function addCommonEnvConfiguredBinDirs(
@@ -144,6 +171,7 @@ function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
 export function resolveDarwinUserBinDirs(
   home: string | undefined,
   env?: Record<string, string | undefined>,
+  pathExists: (dir: string) => boolean = defaultPathExists,
 ): string[] {
   if (!home) {
     return [];
@@ -164,6 +192,7 @@ export function resolveDarwinUserBinDirs(
 
   // Common user bin directories
   addCommonUserBinDirs(dirs, home);
+  addCommonVersionManagerFallbackDirs(dirs, home, pathExists);
 
   // Nix Home Manager (cross-platform)
   addNixProfileBinDirs(dirs, home, env);
@@ -171,11 +200,11 @@ export function resolveDarwinUserBinDirs(
   // Node version managers - macOS specific paths
   // nvm: no stable default path, depends on user's shell configuration
   // fnm: macOS default is ~/Library/Application Support/fnm, not ~/.fnm
-  dirs.push(`${home}/Library/Application Support/fnm/aliases/default/bin`); // fnm default
-  dirs.push(`${home}/.fnm/aliases/default/bin`); // fnm if customized to ~/.fnm
+  addExistingDir(dirs, `${home}/Library/Application Support/fnm/aliases/default/bin`, pathExists); // fnm default
+  addExistingDir(dirs, `${home}/.fnm/aliases/default/bin`, pathExists); // fnm if customized to ~/.fnm
   // pnpm: macOS default is ~/Library/pnpm, not ~/.local/share/pnpm
-  dirs.push(`${home}/Library/pnpm`); // pnpm default
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm XDG fallback
+  addExistingDir(dirs, `${home}/Library/pnpm`, pathExists); // pnpm default
+  addExistingDir(dirs, `${home}/.local/share/pnpm`, pathExists); // pnpm XDG fallback
 
   return dirs;
 }
@@ -187,6 +216,7 @@ export function resolveDarwinUserBinDirs(
 export function resolveLinuxUserBinDirs(
   home: string | undefined,
   env?: Record<string, string | undefined>,
+  pathExists: (dir: string) => boolean = defaultPathExists,
 ): string[] {
   if (!home) {
     return [];
@@ -202,23 +232,25 @@ export function resolveLinuxUserBinDirs(
 
   // Common user bin directories
   addCommonUserBinDirs(dirs, home);
+  addCommonVersionManagerFallbackDirs(dirs, home, pathExists);
 
   // Nix Home Manager (cross-platform)
   addNixProfileBinDirs(dirs, home, env);
 
   // Node version managers
-  dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink
-  dirs.push(`${home}/.local/share/fnm/aliases/default/bin`); // fnm default
-  dirs.push(`${home}/.local/share/fnm/current/bin`); // fnm legacy current symlink
-  dirs.push(`${home}/.fnm/aliases/default/bin`); // fnm if customized to ~/.fnm
-  dirs.push(`${home}/.fnm/current/bin`); // fnm legacy current symlink
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm global bin
+  addExistingDir(dirs, `${home}/.nvm/current/bin`, pathExists); // nvm with current symlink
+  addExistingDir(dirs, `${home}/.local/share/fnm/aliases/default/bin`, pathExists); // fnm default
+  addExistingDir(dirs, `${home}/.local/share/fnm/current/bin`, pathExists); // fnm legacy current symlink
+  addExistingDir(dirs, `${home}/.fnm/aliases/default/bin`, pathExists); // fnm if customized to ~/.fnm
+  addExistingDir(dirs, `${home}/.fnm/current/bin`, pathExists); // fnm legacy current symlink
+  addExistingDir(dirs, `${home}/.local/share/pnpm`, pathExists); // pnpm global bin
 
   return dirs;
 }
 
 export function getMinimalServicePathParts(options: MinimalServicePathOptions = {}): string[] {
   const platform = options.platform ?? process.platform;
+  const pathExists = options.pathExists ?? defaultPathExists;
   if (platform === "win32") {
     return [];
   }
@@ -230,9 +262,9 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   // Add user bin directories for version managers (npm global, nvm, fnm, volta, etc.)
   const userDirs =
     platform === "linux"
-      ? resolveLinuxUserBinDirs(options.home, options.env)
+      ? resolveLinuxUserBinDirs(options.home, options.env, pathExists)
       : platform === "darwin"
-        ? resolveDarwinUserBinDirs(options.home, options.env)
+        ? resolveDarwinUserBinDirs(options.home, options.env, pathExists)
         : [];
 
   const add = (dir: string) => {


### PR DESCRIPTION
## Summary
- keep explicit env-configured PATH roots unchanged
- stop adding hard-coded Node/package-manager fallback dirs unless they exist on disk
- add deterministic tests for missing vs existing fallback dirs on Linux and macOS

Fixes #71944

## Verification
- node scripts/run-vitest.mjs run --config test/vitest/vitest.daemon.config.ts
- corepack pnpm format:check -- src/daemon/service-env.ts src/daemon/service-env.test.ts
- corepack pnpm tsgo:core