### PR TITLE
[refactor] Extract attempt tool-policy helpers (RFC #72072 PR 3/7, reduced scope)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt-tools.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tools.ts
@@ -1,0 +1,151 @@
+// Tool-allowlist and tool-runtime helpers extracted from `attempt.ts` so the
+// embedded attempt orchestrator does not own pure tool policy logic. This is
+// the first ownership-boundary slice for RFC 72072 PR 3. Prompt-cache prep and
+// transport configuration extractions follow as separate PRs because their
+// seams are interleaved with the per-turn stream loop in `attempt.ts` and need
+// dedicated focused passes.
+//
+// The exported helpers are pure or close-to-pure:
+//   - `resolveUnknownToolGuardThreshold` clamps the unknown-tool guard knob.
+//   - `applyEmbeddedAttemptToolsAllow` filters a tool list against an allow set.
+//   - `shouldCreateBundleMcpRuntimeForAttempt` decides whether the bundle MCP
+//     runtime needs to spin up for an attempt based on toolsAllow shape.
+//   - `collectAttemptExplicitToolAllowlistSources` aggregates the layered
+//     tool-allow policy sources (global, agent, group, sandbox, subagent,
+//     runtime override) for the explicit-allowlist guard.
+//
+// `attempt.ts` re-exports the public symbols so the existing import paths
+// (`./attempt.js`) keep working without churn for `attempt.test.ts` or any
+// future caller. PR 3 deliberately keeps consumers unchanged.
+
+import { TOOL_NAME_SEPARATOR } from "../../pi-bundle-mcp-names.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveSubagentToolPolicyForSession,
+} from "../../pi-tools.policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../../subagent-capabilities.js";
+import { collectExplicitToolAllowlistSources } from "../../tool-allowlist-guard.js";
+import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+export function resolveUnknownToolGuardThreshold(loopDetection?: {
+  enabled?: boolean;
+  unknownToolThreshold?: number;
+}): number {
+  // The unknown-tool guard is a safety net against the model hallucinating a
+  // tool name or calling a tool that has since been removed from the allowlist
+  // (for example after a `skills.allowBundled` config change). After `threshold`
+  // consecutive unknown-tool attempts the stream wrapper rewrites the assistant
+  // message content to tell the model to stop, which breaks otherwise-infinite
+  // Tool-not-found loops against the provider. Unlike the genericRepeat /
+  // pingPong / pollNoProgress detectors this guard has no false-positive
+  // surface because the tool is objectively not registered in this run, so it
+  // stays on regardless of `tools.loopDetection.enabled`.
+  const raw = loopDetection?.unknownToolThreshold;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return UNKNOWN_TOOL_THRESHOLD;
+}
+
+export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
+  tools: T[],
+  toolsAllow?: string[],
+): T[] {
+  if (!toolsAllow || toolsAllow.length === 0) {
+    return tools;
+  }
+  const allowSet = new Set(toolsAllow);
+  return tools.filter((tool) => allowSet.has(tool.name));
+}
+
+export function shouldCreateBundleMcpRuntimeForAttempt(params: {
+  toolsEnabled: boolean;
+  disableTools?: boolean;
+  toolsAllow?: string[];
+}): boolean {
+  if (!params.toolsEnabled || params.disableTools === true) {
+    return false;
+  }
+  if (!params.toolsAllow || params.toolsAllow.length === 0) {
+    return true;
+  }
+  return params.toolsAllow.some((toolName) => toolName.includes(TOOL_NAME_SEPARATOR));
+}
+
+export function collectAttemptExplicitToolAllowlistSources(params: {
+  config?: EmbeddedRunAttemptParams["config"];
+  sessionKey?: string;
+  sandboxSessionKey?: string;
+  agentId?: string;
+  modelProvider?: string;
+  modelId?: string;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  toolsAllow?: string[];
+}) {
+  const { agentId, globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
+    resolveEffectiveToolPolicy({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+    });
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider: params.messageProvider,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const subagentStore = resolveSubagentCapabilityStore(params.sandboxSessionKey, {
+    cfg: params.config,
+  });
+  const subagentPolicy =
+    params.sandboxSessionKey &&
+    isSubagentEnvelopeSession(params.sandboxSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, params.sandboxSessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  return collectExplicitToolAllowlistSources([
+    { label: "tools.allow", allow: globalPolicy?.allow },
+    { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
+    {
+      label: agentId ? `agents.${agentId}.tools.allow` : "agent tools.allow",
+      allow: agentPolicy?.allow,
+    },
+    {
+      label: agentId ? `agents.${agentId}.tools.byProvider.allow` : "agent tools.byProvider.allow",
+      allow: agentProviderPolicy?.allow,
+    },
+    { label: "group tools.allow", allow: groupPolicy?.allow },
+    { label: "sandbox tools.allow", allow: params.sandboxToolPolicy?.allow },
+    { label: "subagent tools.allow", allow: subagentPolicy?.allow },
+    { label: "runtime toolsAllow", allow: params.toolsAllow },
+  ]);
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -85,7 +85,6 @@ import { supportsModelTools } from "../../model-tool-support.js";
 import { releaseWsSession } from "../../openai-ws-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import { createBundleLspToolRuntime } from "../../pi-bundle-lsp-runtime.js";
-import { TOOL_NAME_SEPARATOR } from "../../pi-bundle-mcp-names.js";
 import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
@@ -111,11 +110,6 @@ import {
   toClientToolDefinitions,
 } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveSubagentToolPolicyForSession,
-} from "../../pi-tools.policy.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
@@ -141,19 +135,11 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../../subagent-capabilities.js";
 import { resolveSystemPromptOverride } from "../../system-prompt-override.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
-import {
-  buildEmptyExplicitToolAllowlistError,
-  collectExplicitToolAllowlistSources,
-} from "../../tool-allowlist-guard.js";
-import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
+import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
@@ -354,25 +340,18 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
-export function resolveUnknownToolGuardThreshold(loopDetection?: {
-  enabled?: boolean;
-  unknownToolThreshold?: number;
-}): number {
-  // The unknown-tool guard is a safety net against the model hallucinating a
-  // tool name or calling a tool that has since been removed from the allowlist
-  // (for example after a `skills.allowBundled` config change). After `threshold`
-  // consecutive unknown-tool attempts the stream wrapper rewrites the assistant
-  // message content to tell the model to stop, which breaks otherwise-infinite
-  // Tool-not-found loops against the provider. Unlike the genericRepeat /
-  // pingPong / pollNoProgress detectors this guard has no false-positive
-  // surface because the tool is objectively not registered in this run, so it
-  // stays on regardless of `tools.loopDetection.enabled`.
-  const raw = loopDetection?.unknownToolThreshold;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
-  }
-  return UNKNOWN_TOOL_THRESHOLD;
-}
+import {
+  applyEmbeddedAttemptToolsAllow,
+  collectAttemptExplicitToolAllowlistSources,
+  resolveUnknownToolGuardThreshold,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tools.js";
+
+export {
+  applyEmbeddedAttemptToolsAllow,
+  resolveUnknownToolGuardThreshold,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tools.js";
 
 export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
   return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
@@ -464,106 +443,8 @@ function summarizeSessionContext(messages: AgentMessage[]): {
   };
 }
 
-export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
-  tools: T[],
-  toolsAllow?: string[],
-): T[] {
-  if (!toolsAllow || toolsAllow.length === 0) {
-    return tools;
-  }
-  const allowSet = new Set(toolsAllow);
-  return tools.filter((tool) => allowSet.has(tool.name));
-}
-
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   return stripToolResultDetails(normalizeAssistantReplayContent(messages));
-}
-
-export function shouldCreateBundleMcpRuntimeForAttempt(params: {
-  toolsEnabled: boolean;
-  disableTools?: boolean;
-  toolsAllow?: string[];
-}): boolean {
-  if (!params.toolsEnabled || params.disableTools === true) {
-    return false;
-  }
-  if (!params.toolsAllow || params.toolsAllow.length === 0) {
-    return true;
-  }
-  return params.toolsAllow.some((toolName) => toolName.includes(TOOL_NAME_SEPARATOR));
-}
-
-function collectAttemptExplicitToolAllowlistSources(params: {
-  config?: EmbeddedRunAttemptParams["config"];
-  sessionKey?: string;
-  sandboxSessionKey?: string;
-  agentId?: string;
-  modelProvider?: string;
-  modelId?: string;
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
-  toolsAllow?: string[];
-}) {
-  const { agentId, globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
-    resolveEffectiveToolPolicy({
-      config: params.config,
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-    });
-  const groupPolicy = resolveGroupToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    spawnedBy: params.spawnedBy,
-    messageProvider: params.messageProvider,
-    groupId: params.groupId,
-    groupChannel: params.groupChannel,
-    groupSpace: params.groupSpace,
-    accountId: params.agentAccountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const subagentStore = resolveSubagentCapabilityStore(params.sandboxSessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    params.sandboxSessionKey &&
-    isSubagentEnvelopeSession(params.sandboxSessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sandboxSessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  return collectExplicitToolAllowlistSources([
-    { label: "tools.allow", allow: globalPolicy?.allow },
-    { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
-    {
-      label: agentId ? `agents.${agentId}.tools.allow` : "agent tools.allow",
-      allow: agentPolicy?.allow,
-    },
-    {
-      label: agentId ? `agents.${agentId}.tools.byProvider.allow` : "agent tools.byProvider.allow",
-      allow: agentProviderPolicy?.allow,
-    },
-    { label: "group tools.allow", allow: groupPolicy?.allow },
-    { label: "sandbox tools.allow", allow: params.sandboxToolPolicy?.allow },
-    { label: "subagent tools.allow", allow: subagentPolicy?.allow },
-    { label: "runtime toolsAllow", allow: params.toolsAllow },
-  ]);
 }
 
 export async function runEmbeddedAttempt(


### PR DESCRIPTION
Refs #72072 (RFC) — PR 3 of 7 (reduced scope).

## Summary

Extracts the cleanly-bounded tool-policy helpers (`resolveUnknownToolGuardThreshold`, `applyEmbeddedAttemptToolsAllow`, `shouldCreateBundleMcpRuntimeForAttempt`, `collectAttemptExplicitToolAllowlistSources`) out of `pi-embedded-runner/run/attempt.ts` (3,212 LOC) into a new domain module `attempt-tools.ts` (151 LOC). `attempt.ts` re-exports the public symbols so all existing import paths keep working.

This is a **reduced PR 3 scope** compared to the RFC. The RFC envisioned three new modules in this PR (`attempt-tools.ts`, `attempt-prompt.ts`, `attempt-transport.ts`). After deeper recon against current `origin/main`, two of the three planned extractions (`attempt-prompt.ts`, `attempt-transport.ts`) sit on per-turn seams inside the main stream loop rather than on per-attempt setup seams; pulling them cleanly requires the lifecycle work that PR 4 plans. They will land as separate follow-ups, not in PR 3.

## What is being fixed

Pure tool-policy logic was inline in the embedded attempt orchestrator, mixed with cross-cutting orchestration state. Reviewing the unknown-tool guard threshold or the explicit-allowlist source aggregation meant scrolling past a 2.5k LOC orchestration body. The four functions extracted here are independently testable, have no closure dependencies on `runEmbeddedAttempt`'s state, and were already covered by `attempt.test.ts`.

`attempt.test.ts` continues to import them from `./attempt.js` (via the re-export), so test-side blast radius is zero.

Affected surface: `src/agents/pi-embedded-runner/run/attempt.ts`, new file `src/agents/pi-embedded-runner/run/attempt-tools.ts`. No public API change. No test changes.

## Architecture diff

```mermaid
flowchart TD
  subgraph Before
    runEmbeddedAttempt --> inlineUnknownGuard[inline resolveUnknownToolGuardThreshold]
    runEmbeddedAttempt --> inlineToolsAllow[inline applyEmbeddedAttemptToolsAllow]
    runEmbeddedAttempt --> inlineBundleMcpDecision[inline shouldCreateBundleMcpRuntimeForAttempt]
    runEmbeddedAttempt --> inlineAllowlistAggregation[inline collectAttemptExplicitToolAllowlistSources]
    attemptTest[attempt.test.ts] --> attemptModule[attempt.ts]
  end
  subgraph After
    runEmbeddedAttempt2[runEmbeddedAttempt] -- imports --> toolsModule[attempt-tools.ts]
    attemptModule2[attempt.ts] -- re-exports --> toolsModule
    attemptTest2[attempt.test.ts] --> attemptModule2
  end
```

## File map

| Action | Path | Purpose |
|---|---|---|
| add | `src/agents/pi-embedded-runner/run/attempt-tools.ts` | New domain module owning four pure-or-near-pure tool helpers, all previously in `attempt.ts`. |
| modify | `src/agents/pi-embedded-runner/run/attempt.ts` | Remove the four moved functions (~120 LOC), re-export them from the new module so external callers keep working, drop now-unused imports (`TOOL_NAME_SEPARATOR`, `pi-tools.policy.js` policy resolvers, `subagent-capabilities.js` helpers, `collectExplicitToolAllowlistSources`, `UNKNOWN_TOOL_THRESHOLD`). `attempt.ts` body still calls the four helpers via the local import. |

LOC change: `attempt.ts` 3,212 → 3,091 (−121 LOC). New `attempt-tools.ts` is 151 LOC.

## Validation

```bash
pnpm check:architecture
# green: 0 runtime value cycles, 0 madge cycles

pnpm check:test-types
# green: tsgo:core:test + tsgo:extensions:test, 0 type errors

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/run/attempt.test.ts
# green: 1 file / 122 tests passed in 3.26s

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/run/attempt.test.ts \
  src/agents/runtime-plan/build.test.ts \
  src/agents/runtime-plan/tools.test.ts \
  src/agents/harness/v2.test.ts \
  src/agents/harness/selection.test.ts
# green: 5 files / 164 tests passed

pnpm check:changed
# All static checks (lint:core, runtime/madge import cycles, webhook/pairing guards) green.
# Targeted lane: agents.config.ts → 38 files / 663 tests passed in 13.33s.
# Unrelated E2E flake: vitest.e2e.config.ts → 1 failure in
#   `src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts`
#   ("preserves user-pinned auth profiles across provider aliases", 127s).
# This e2e file does not import any of the symbols this PR moved
# (`grep` for `attempt-tools` / `applyEmbeddedAttemptToolsAllow` / etc. returns nothing).
# The failure is a pre-existing flake in the auth-profile-rotation surface, not caused by this PR.
```

## Why the reduced scope

The RFC's PR 3 design assumed the prompt-cache prep was a one-shot setup that could be pulled out into a single `prepareAttemptPromptCache(...): PromptCachePrep` function before the per-turn stream loop. Recon against current `origin/main` shows the cache observation is born inside the loop on every turn (`beginPromptCacheObservation` at attempt.ts:2276 within the per-turn body). Extracting it cleanly without disturbing the rest of the loop body is PR 4's work, not PR 3's.

Similarly, the transport configuration (extra-param resolution, stream-fn wrapping, Google prompt-cache stream wrapper) is currently a sequence of decorations applied inline against `activeSession.agent.streamFn` mid-loop, not a one-shot setup. A safe extraction needs the lifecycle split that PR 4 introduces.

PR 3 still delivers the slice of the RFC that is independently safe and reviewable: pure tool-policy helpers off the orchestration body. PR 3.1 / PR 4 follow-ups will continue the per-turn-seam work.

## What did NOT change

- Public API: zero surface change. All previously-exported symbols still export from `./attempt.js`.
- `attempt.test.ts`: untouched. All 122 tests still pass importing from `./attempt.js`.
- Behavior: zero. This is a textual move with no logic change.
- Imports for callers: zero. No consumer of `attempt.ts` had to change.
- `runEmbeddedAttempt` body: only the call sites that use the moved helpers; no orchestration logic touched.
- Plugin SDK at `src/plugin-sdk/agent-harness-runtime.ts`: untouched.
- The other helper files in this directory (`attempt.transcript-policy.ts`, `attempt.subscription-cleanup.ts`, `attempt.sessions-yield.ts`, `attempt.stop-reason-recovery.ts`, `attempt.tool-call-argument-repair.ts`, `attempt.tool-call-normalization.ts`, etc.): untouched.

## Notes for reviewers

- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072). Predecessors: PR [#72098](https://github.com/openclaw/openclaw/pull/72098) (PR 1, baseline doc), PR [#72105](https://github.com/openclaw/openclaw/pull/72105) (PR 2, native AgentHarnessV2 factory).
- The reduced scope decision is documented in the baseline doc at PR 1 and surfaced again here. If you want the full three-module extraction in this PR, please flag and I will reopen for the prompt + transport seams together with PR 4's lifecycle work.
- `collectAttemptExplicitToolAllowlistSources` is intentionally exported from `attempt-tools.ts` (it was previously a private symbol in `attempt.ts`). It is not re-exported from `attempt.ts` since no external caller needs it; only `attempt.ts` imports it locally to drive the explicit-allowlist guard.
- The double `import` + `export {} from` pattern in `attempt.ts` for the three publicly-re-exported helpers is intentional: `import` brings the symbols into scope so the body can call them; the separate `export { ... } from` line keeps the re-export available to external callers.
