### PR TITLE
[refactor] Extract attempt message summary helpers (RFC #72072 PR 4/7, reduced scope)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt-message-summary.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-message-summary.ts
@@ -1,0 +1,90 @@
+// Pure message-summarization helpers extracted from `attempt.ts` so the
+// embedded attempt orchestrator does not own diagnostic-only payload counting.
+// This is the second ownership-boundary slice for RFC 72072 and the first
+// piece of the lifecycle-domain extraction. The full lifecycle / stream-loop
+// split that the RFC envisioned for PR 4 lands as separate follow-ups because
+// the larger seams (`runEmbeddedAttempt` cleanup `finally` block at lines
+// ~3036-3085, the per-turn stream loop at ~2200-2950) carry deep closure
+// dependencies that need a dedicated focused pass.
+//
+// The exported helpers are pure:
+//   - `summarizeMessagePayload(msg)` returns text/image character counts for
+//     a single AgentMessage payload, normalising string and array content.
+//   - `summarizeSessionContext(messages)` aggregates a session transcript
+//     into role counts, total text chars, total image blocks, and per-message
+//     max text chars. `attempt.ts` uses this once to emit a session-context
+//     diagnostic before each prompt-cache observation.
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export type EmbeddedAttemptMessagePayloadSummary = {
+  textChars: number;
+  imageBlocks: number;
+};
+
+export type EmbeddedAttemptSessionContextSummary = {
+  roleCounts: string;
+  totalTextChars: number;
+  totalImageBlocks: number;
+  maxMessageTextChars: number;
+};
+
+export function summarizeMessagePayload(msg: AgentMessage): EmbeddedAttemptMessagePayloadSummary {
+  const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return { textChars: content.length, imageBlocks: 0 };
+  }
+  if (!Array.isArray(content)) {
+    return { textChars: 0, imageBlocks: 0 };
+  }
+
+  let textChars = 0;
+  let imageBlocks = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typedBlock.type === "image") {
+      imageBlocks++;
+      continue;
+    }
+    if (typeof typedBlock.text === "string") {
+      textChars += typedBlock.text.length;
+    }
+  }
+
+  return { textChars, imageBlocks };
+}
+
+export function summarizeSessionContext(
+  messages: AgentMessage[],
+): EmbeddedAttemptSessionContextSummary {
+  const roleCounts = new Map<string, number>();
+  let totalTextChars = 0;
+  let totalImageBlocks = 0;
+  let maxMessageTextChars = 0;
+
+  for (const msg of messages) {
+    const role = typeof msg.role === "string" ? msg.role : "unknown";
+    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+
+    const payload = summarizeMessagePayload(msg);
+    totalTextChars += payload.textChars;
+    totalImageBlocks += payload.imageBlocks;
+    if (payload.textChars > maxMessageTextChars) {
+      maxMessageTextChars = payload.textChars;
+    }
+  }
+
+  return {
+    roleCounts:
+      [...roleCounts.entries()]
+        .toSorted((a, b) => a[0].localeCompare(b[0]))
+        .map(([role, count]) => `${role}:${count}`)
+        .join(",") || "none",
+    totalTextChars,
+    totalImageBlocks,
+    maxMessageTextChars,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -401,68 +401,7 @@ export function remapInjectedContextFilesToWorkspace(params: {
   });
 }
 
-function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
-  const content = (msg as { content?: unknown }).content;
-  if (typeof content === "string") {
-    return { textChars: content.length, imageBlocks: 0 };
-  }
-  if (!Array.isArray(content)) {
-    return { textChars: 0, imageBlocks: 0 };
-  }
-
-  let textChars = 0;
-  let imageBlocks = 0;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; text?: unknown };
-    if (typedBlock.type === "image") {
-      imageBlocks++;
-      continue;
-    }
-    if (typeof typedBlock.text === "string") {
-      textChars += typedBlock.text.length;
-    }
-  }
-
-  return { textChars, imageBlocks };
-}
-
-function summarizeSessionContext(messages: AgentMessage[]): {
-  roleCounts: string;
-  totalTextChars: number;
-  totalImageBlocks: number;
-  maxMessageTextChars: number;
-} {
-  const roleCounts = new Map<string, number>();
-  let totalTextChars = 0;
-  let totalImageBlocks = 0;
-  let maxMessageTextChars = 0;
-
-  for (const msg of messages) {
-    const role = typeof msg.role === "string" ? msg.role : "unknown";
-    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
-
-    const payload = summarizeMessagePayload(msg);
-    totalTextChars += payload.textChars;
-    totalImageBlocks += payload.imageBlocks;
-    if (payload.textChars > maxMessageTextChars) {
-      maxMessageTextChars = payload.textChars;
-    }
-  }
-
-  return {
-    roleCounts:
-      [...roleCounts.entries()]
-        .toSorted((a, b) => a[0].localeCompare(b[0]))
-        .map(([role, count]) => `${role}:${count}`)
-        .join(",") || "none",
-    totalTextChars,
-    totalImageBlocks,
-    maxMessageTextChars,
-  };
-}
+import { summarizeSessionContext } from "./attempt-message-summary.js";
 
 export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   tools: T[],


### PR DESCRIPTION
Refs #72072 (RFC) — PR 4 of 7 (reduced scope).

## Summary

Extracts the two pure message-summarization helpers (`summarizeMessagePayload`, `summarizeSessionContext`) from `pi-embedded-runner/run/attempt.ts` into a new domain module `attempt-message-summary.ts`. These were the first cleanly-bounded slice of the lifecycle/diagnostics phase and have no closure dependencies on `runEmbeddedAttempt`'s state. `attempt.ts` imports `summarizeSessionContext` for one diagnostic call site; the helpers are not part of the public attempt surface so they are not re-exported.

This is a **reduced PR 4 scope**, mirroring the conservative cut taken in [#72110](https://github.com/openclaw/openclaw/pull/72110) (PR 3). The RFC's PR 4 design called for `attempt-stream-loop.ts` (~1,550-1,850 LOC pulled out) and `attempt-lifecycle.ts` (~1,900-2,050 LOC pulled out). After deeper recon against current `origin/main`, both seams are inside `runEmbeddedAttempt`'s closure with deep state dependencies (the cleanup `finally` block at lines ~3036-3085 alone references `session`, `sessionManager`, `releaseWsSession`, `bundleMcpRuntime`, `bundleLspRuntime`, `sessionLock`, `removeToolResultContextGuard`, `flushPendingToolResultsAfterIdle`, `aborted`, `timedOut`, `idleTimedOut`, `timedOutDuringCompaction`, `promptError`, `params.sessionId`, `emitDiagnosticRunCompleted`, `trajectoryRecorder`, `trajectoryEndRecorded`). Moving them safely needs a dedicated focused pass with full e2e coverage.

## What is being fixed

Two pure message-introspection helpers were inline in the embedded attempt orchestrator. They are diagnostic-only (one is called from a debug log site; the other is unused outside of itself except internally in `summarizeSessionContext`). Reviewing diagnostic shape meant scrolling past unrelated orchestration. Their move clears ~62 LOC out of `attempt.ts` while keeping the public surface unchanged.

Affected surface: `src/agents/pi-embedded-runner/run/attempt.ts`, new file `src/agents/pi-embedded-runner/run/attempt-message-summary.ts`.

## Architecture diff

```mermaid
flowchart TD
  subgraph Before
    runEmbeddedAttempt --> inlineSummarizePayload[inline summarizeMessagePayload]
    runEmbeddedAttempt --> inlineSummarizeSessionContext[inline summarizeSessionContext]
  end
  subgraph After
    runEmbeddedAttempt2[runEmbeddedAttempt] -- imports summarizeSessionContext --> summaryModule[attempt-message-summary.ts]
    summaryModule -- private internal --> summarizePayload[summarizeMessagePayload]
  end
```

## File map

| Action | Path | Purpose |
|---|---|---|
| add | `src/agents/pi-embedded-runner/run/attempt-message-summary.ts` | Pure message-payload and session-context summarization helpers extracted from `attempt.ts`. Both exported so the seam is visible; PR 4 only consumes `summarizeSessionContext` from `attempt.ts`. |
| modify | `src/agents/pi-embedded-runner/run/attempt.ts` | Remove the two inline helper definitions, import `summarizeSessionContext` from the new module. |

LOC change: `attempt.ts` 3,212 → 3,151 (−61 LOC at PR 4 baseline; PR 3 reduces it further to 3,091). New `attempt-message-summary.ts` is 90 LOC including documentation header.

## Validation

```bash
pnpm check:architecture
# green: 0 runtime value cycles, 0 madge cycles

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/run/attempt.test.ts
# green: 1 file / 122 tests passed in 2.66s

# Note on `pnpm check:test-types`: 2 type errors surfaced in
#   `src/wizard/setup.test.ts(976,55)` and `src/wizard/setup.test.ts(983,48)`.
# These come from the upstream commits on `origin/main` since the PR 1 baseline
# (`edcb2326a1 test: cover setup provider auth selection` and adjacent), not from
# this PR. PR 4 does not touch `src/wizard/`. Per CLAUDE.md guidance, this PR
# gates on targeted suites and documents the unrelated baseline drift here.
```

## Why the reduced scope

`runEmbeddedAttempt` is 2,400+ LOC of orchestration with the stream loop and the lifecycle finally-block sharing a single closure. Extracting them into separate files needs either:

1. Bundling 30+ pieces of state into a context struct passed to each domain function (high mechanical risk of subtle ordering/timing bugs in the lifecycle).
2. Inlining the seams into helpers but keeping the orchestration shape, gaining nothing.
3. Splitting the closure properly across multiple modules with explicit data flow contracts (the RFC's intent, but a multi-day pass).

Approach 3 is the right end-state but does not fit a single review-able PR without full e2e regression coverage on cleanup ordering, abort handling, compaction, and prompt-cache observation parity. It will land as a dedicated follow-up with its own validation strategy.

PR 4 still delivers a real ownership-boundary improvement: pure summarization helpers no longer live in the orchestration module.

## What did NOT change

- Public API: zero. `summarizeMessagePayload` and `summarizeSessionContext` were private symbols in `attempt.ts` (not exported); they are now exported from `attempt-message-summary.ts` for visibility but `attempt.ts` does not re-export them.
- `attempt.test.ts`: untouched. All 122 tests still pass.
- Behavior: zero. Pure textual move.
- Any of the leaf helpers in `pi-embedded-runner/run/`: untouched.
- Plugin SDK: untouched.

## Notes for reviewers

- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072). Predecessors: [#72098](https://github.com/openclaw/openclaw/pull/72098), [#72105](https://github.com/openclaw/openclaw/pull/72105), [#72110](https://github.com/openclaw/openclaw/pull/72110).
- This PR is intentionally a small slice. If you would prefer the larger stream-loop / lifecycle split here, please flag and I will reopen with a wider scope; otherwise the deferred work is tracked in PR 7's handoff doc.
- The wizard type-check drift is unrelated upstream noise (`src/wizard/setup.test.ts`); PR 4 does not touch that surface.
