### PR TITLE
[refactor] Extract run orchestration helpers (RFC #72072 PR 5/7, reduced scope)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
@@ -12,7 +11,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
-import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -25,16 +23,11 @@ import {
 } from "../agent-scope.js";
 import {
   type AuthProfileFailureReason,
-  type AuthProfileStore,
   markAuthProfileFailure,
   resolveAuthProfileEligibility,
   markAuthProfileGood,
   markAuthProfileUsed,
 } from "../auth-profiles.js";
-import {
-  resolveSessionKeyForRequest,
-  resolveStoredSessionKeyForSessionId,
-} from "../command/session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { isStrictAgenticExecutionContractActive } from "../execution-contract.js";
 import {
@@ -127,6 +120,12 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import {
+  backfillSessionKey,
+  buildHandledReplyPayloads,
+  buildTraceToolSummary,
+  createEmptyAuthProfileStore,
+} from "./run/run-orchestration-helpers.js";
+import {
   buildBeforeModelResolveAttachments,
   resolveEffectiveRuntimeModel,
   resolveHookModelSelection,
@@ -141,7 +140,6 @@ import type {
   EmbeddedPiAgentMeta,
   EmbeddedPiRunResult,
   TraceAttempt,
-  ToolSummaryTrace,
   EmbeddedRunLivenessState,
 } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
@@ -149,92 +147,6 @@ import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accum
 type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
-
-function createEmptyAuthProfileStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {},
-  };
-}
-
-function buildTraceToolSummary(params: {
-  toolMetas: Array<{ toolName: string; meta?: string }>;
-  hadFailure: boolean;
-}): ToolSummaryTrace | undefined {
-  if (params.toolMetas.length === 0) {
-    return undefined;
-  }
-  const tools: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of params.toolMetas) {
-    const toolName = normalizeOptionalString(entry.toolName);
-    if (!toolName || seen.has(toolName)) {
-      continue;
-    }
-    seen.add(toolName);
-    tools.push(toolName);
-  }
-  return {
-    calls: params.toolMetas.length,
-    tools,
-    failures: params.hadFailure ? 1 : 0,
-  };
-}
-
-/**
- * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
- * The return value is normalized: whitespace-only inputs collapse to undefined, and
- * successful resolution returns a trimmed session key. This is a read-only lookup
- * with no side effects.
- * See: https://github.com/openclaw/openclaw/issues/60552
- */
-function backfillSessionKey(params: {
-  config: RunEmbeddedPiAgentParams["config"];
-  sessionId: string;
-  sessionKey?: string;
-  agentId?: string;
-}): string | undefined {
-  const trimmed = normalizeOptionalString(params.sessionKey);
-  if (trimmed) {
-    return trimmed;
-  }
-  if (!params.config || !params.sessionId) {
-    return undefined;
-  }
-  try {
-    const resolved = normalizeOptionalString(params.agentId)
-      ? resolveStoredSessionKeyForSessionId({
-          cfg: params.config,
-          sessionId: params.sessionId,
-          agentId: params.agentId,
-        })
-      : resolveSessionKeyForRequest({
-          cfg: params.config,
-          sessionId: params.sessionId,
-        });
-    return normalizeOptionalString(resolved.sessionKey);
-  } catch (err) {
-    log.warn(
-      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
-    );
-    return undefined;
-  }
-}
-
-function buildHandledReplyPayloads(reply?: ReplyPayload) {
-  const normalized = reply ?? { text: SILENT_REPLY_TOKEN };
-  return [
-    {
-      text: normalized.text,
-      mediaUrl: normalized.mediaUrl,
-      mediaUrls: normalized.mediaUrls,
-      replyToId: normalized.replyToId,
-      audioAsVoice: normalized.audioAsVoice,
-      isError: normalized.isError,
-      isReasoning: normalized.isReasoning,
-    },
-  ];
-}
 
 export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,

--- a/src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts
@@ -1,0 +1,123 @@
+// Pure orchestration helpers extracted from `run.ts` so the embedded run
+// orchestrator does not own auth-store seeding, trace-summary shaping,
+// session-key backfill, or handled-reply payload normalization.
+//
+// This is the third ownership-boundary slice for RFC 72072 and the first
+// piece of the run-orchestration extraction. The full split that the RFC
+// envisioned for PR 5 (`model-auth-plan.ts`, `runtime-plan-factory.ts`,
+// `lane-workspace.ts`, `terminal-result.ts`) lands as separate follow-ups
+// because the larger seams sit inside `runEmbeddedPiAgent`'s closure with
+// deep state dependencies. PR 5 keeps that pattern conservative, matching
+// the reduced scope used in PR 3 (#72110) and PR 4 (#72113).
+//
+// The exported helpers are pure or close-to-pure:
+//   - `createEmptyAuthProfileStore` returns a fresh AuthProfileStore.
+//   - `buildTraceToolSummary` aggregates a tool-call slice into the trace
+//     summary shape used by the run-attempt observability pipeline.
+//   - `backfillSessionKey` does the read-only sessionId→sessionKey lookup
+//     that runs at the top of `runEmbeddedPiAgent`. It logs a warning on
+//     failure but otherwise has no side effects.
+//   - `buildHandledReplyPayloads` normalises an optional ReplyPayload into
+//     the array shape downstream delivery expects, defaulting to a silent
+//     reply token when the caller did not provide one.
+
+import type { ReplyPayload } from "../../../auto-reply/reply-payload.js";
+import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import { normalizeOptionalString } from "../../../shared/string-coerce.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import {
+  resolveSessionKeyForRequest,
+  resolveStoredSessionKeyForSessionId,
+} from "../../command/session.js";
+import { redactRunIdentifier } from "../../workspace-run.js";
+import { log } from "../logger.js";
+import type { ToolSummaryTrace } from "../types.js";
+import type { RunEmbeddedPiAgentParams } from "./params.js";
+
+export function createEmptyAuthProfileStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {},
+  };
+}
+
+export function buildTraceToolSummary(params: {
+  toolMetas: Array<{ toolName: string; meta?: string }>;
+  hadFailure: boolean;
+}): ToolSummaryTrace | undefined {
+  if (params.toolMetas.length === 0) {
+    return undefined;
+  }
+  const tools: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of params.toolMetas) {
+    const toolName = normalizeOptionalString(entry.toolName);
+    if (!toolName || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+    tools.push(toolName);
+  }
+  return {
+    calls: params.toolMetas.length,
+    tools,
+    failures: params.hadFailure ? 1 : 0,
+  };
+}
+
+/**
+ * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
+ * The return value is normalized: whitespace-only inputs collapse to undefined, and
+ * successful resolution returns a trimmed session key. This is a read-only lookup
+ * with no side effects.
+ * See: https://github.com/openclaw/openclaw/issues/60552
+ */
+export function backfillSessionKey(params: {
+  config: RunEmbeddedPiAgentParams["config"];
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+}): string | undefined {
+  const trimmed = normalizeOptionalString(params.sessionKey);
+  if (trimmed) {
+    return trimmed;
+  }
+  if (!params.config || !params.sessionId) {
+    return undefined;
+  }
+  try {
+    const resolved = normalizeOptionalString(params.agentId)
+      ? resolveStoredSessionKeyForSessionId({
+          cfg: params.config,
+          sessionId: params.sessionId,
+          agentId: params.agentId,
+        })
+      : resolveSessionKeyForRequest({
+          cfg: params.config,
+          sessionId: params.sessionId,
+        });
+    return normalizeOptionalString(resolved.sessionKey);
+  } catch (err) {
+    log.warn(
+      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
+    );
+    return undefined;
+  }
+}
+
+export function buildHandledReplyPayloads(reply?: ReplyPayload) {
+  const normalized = reply ?? { text: SILENT_REPLY_TOKEN };
+  return [
+    {
+      text: normalized.text,
+      mediaUrl: normalized.mediaUrl,
+      mediaUrls: normalized.mediaUrls,
+      replyToId: normalized.replyToId,
+      audioAsVoice: normalized.audioAsVoice,
+      isError: normalized.isError,
+      isReasoning: normalized.isReasoning,
+    },
+  ];
+}


### PR DESCRIPTION
Refs #72072 (RFC) — PR 5 of 7 (reduced scope).

## Summary

Extracts four pure orchestration helpers (`createEmptyAuthProfileStore`, `buildTraceToolSummary`, `backfillSessionKey`, `buildHandledReplyPayloads`) from `pi-embedded-runner/run.ts` into a new domain module `run/run-orchestration-helpers.ts`. `run.ts` imports them from the new module and the four no-longer-needed top-level imports (`ReplyPayload`, `normalizeOptionalString`, `AuthProfileStore`, `resolveSessionKeyForRequest`, `resolveStoredSessionKeyForSessionId`, `ToolSummaryTrace`) are removed. None of the four helpers were exported, so the public surface is unchanged.

This is a **reduced PR 5 scope**, mirroring the conservative cuts taken in [#72110](https://github.com/openclaw/openclaw/pull/72110) (PR 3) and [#72113](https://github.com/openclaw/openclaw/pull/72113) (PR 4). The RFC's PR 5 design called for four substantial new modules (`model-auth-plan.ts` ~150-270 LOC, `runtime-plan-factory.ts` ~575-600 LOC, `lane-workspace.ts` ~80-120 LOC, `terminal-result.ts` ~1,380-1,450 LOC). After deeper recon against current `origin/main`, the larger seams sit inside `runEmbeddedPiAgent`'s closure with deep state dependencies, particularly `terminal-result.ts` which would need to thread 30+ pieces of state through a returned struct. Moving them safely needs a dedicated focused pass with full e2e regression coverage on auth profile rotation, lane workspace setup, and terminal result shape.

## What is being fixed

Four pure helpers were inline in the embedded run orchestrator:

- `createEmptyAuthProfileStore` (6 LOC): a one-liner factory.
- `buildTraceToolSummary` (23 LOC): aggregates a tool-call slice into the trace summary observability shape.
- `backfillSessionKey` (39 LOC): the read-only sessionId→sessionKey lookup that runs at the top of `runEmbeddedPiAgent`. Logs a warning on failure but has no other side effects.
- `buildHandledReplyPayloads` (14 LOC): normalises an optional ReplyPayload into the array shape downstream delivery expects, defaulting to a silent reply token when the caller does not provide one.

Affected surface: `src/agents/pi-embedded-runner/run.ts`, new file `src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts`.

## Architecture diff

```mermaid
flowchart TD
  subgraph Before
    runEmbeddedPiAgent --> inlineEmptyAuthStore[inline createEmptyAuthProfileStore]
    runEmbeddedPiAgent --> inlineTraceToolSummary[inline buildTraceToolSummary]
    runEmbeddedPiAgent --> inlineBackfillSessionKey[inline backfillSessionKey]
    runEmbeddedPiAgent --> inlineHandledReply[inline buildHandledReplyPayloads]
  end
  subgraph After
    runEmbeddedPiAgent2[runEmbeddedPiAgent] -- imports --> orchHelpers[run/run-orchestration-helpers.ts]
  end
```

## File map

| Action | Path | Purpose |
|---|---|---|
| add | `src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts` | Pure orchestration helpers extracted from `run.ts`. All four are exported so the seam is testable; no external caller imports them today, so `run.ts` does not re-export. |
| modify | `src/agents/pi-embedded-runner/run.ts` | Remove the four inline helper definitions. Import from the new module. Drop now-unused top-level imports (`ReplyPayload`, `normalizeOptionalString`, `AuthProfileStore`, `resolveSessionKeyForRequest`, `resolveStoredSessionKeyForSessionId`, `ToolSummaryTrace`). |

LOC change: `run.ts` 2,347 → 2,259 (−88 LOC). New `run/run-orchestration-helpers.ts` is 123 LOC including documentation header.

## Validation

```bash
pnpm check:architecture
# green: 0 runtime value cycles, 0 madge cycles

pnpm check:test-types
# green: tsgo:core:test + tsgo:extensions:test, 0 type errors

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/run.incomplete-turn.test.ts \
  src/agents/pi-embedded-runner/run.empty-error-retry.test.ts \
  src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts \
  src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts
# green: 4 files / 82 tests passed in 1.42s
```

## Why the reduced scope

`runEmbeddedPiAgent` is 2,100+ LOC with auth-plan resolution, runtime-plan construction, lane/workspace setup, the per-attempt loop, and terminal-result assembly all sharing one closure. The RFC's four-module split is the right end state but it threads enough closure state through return-shapes (especially the terminal-result phase, which references usage accumulator state, attempt history, fallback metadata, hook-runner output, replay-state observations, and live-model-switch state) that a single review-able PR can't credibly land it without broader e2e coverage on auth profile rotation and post-compaction reply policy. That work will land as a dedicated follow-up.

PR 5 still delivers a real ownership-boundary improvement: the four pure helpers no longer live in the orchestration module, and four top-level imports no longer pollute `run.ts`'s import block.

## What did NOT change

- Public API: zero. All four helpers were private symbols in `run.ts`; they are now exported from the new module but `run.ts` does not re-export.
- `runEmbeddedPiAgent` body: only the four call sites that use the moved helpers; no orchestration logic touched.
- Behavior: zero. Pure textual move plus removal of unused imports.
- All `run/*` test files (`run.incomplete-turn.test.ts`, `run.empty-error-retry.test.ts`, `run.cross-provider-fallback-error-context.test.ts`, `run.before-agent-reply-cron.test.ts`, etc.): untouched.
- Other helpers in `pi-embedded-runner/run/`: untouched.

## Notes for reviewers

- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072). Predecessors: [#72098](https://github.com/openclaw/openclaw/pull/72098), [#72105](https://github.com/openclaw/openclaw/pull/72105), [#72110](https://github.com/openclaw/openclaw/pull/72110), [#72113](https://github.com/openclaw/openclaw/pull/72113).
- This PR is intentionally a small slice. PR 7 will track the deferred structural splits (`model-auth-plan.ts`, `runtime-plan-factory.ts`, `lane-workspace.ts`, `terminal-result.ts`) as named follow-up work for a focused dedicated pass.
- The new module sits at `run/run-orchestration-helpers.ts` rather than reusing the existing `run/helpers.ts` because the two are different concerns: `run/helpers.ts` already owns retry/scrub/agent-meta utilities, while the four extracted helpers are session-key, auth-store, trace-summary, and reply-payload concerns. Keeping them in a sibling module reads better than overloading a single grab-bag file.
