### PR TITLE
fix(gateway): default-allow safe Windows companion node commands (#71876)

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeDeclaredNodeCommands } from "./node-command-policy.js";
+import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
+  normalizeDeclaredNodeCommands,
+  resolveNodeCommandAllowlist,
+} from "./node-command-policy.js";
 
 describe("gateway/node-command-policy", () => {
   it("normalizes declared node commands against the allowlist", () => {
@@ -10,5 +14,23 @@ describe("gateway/node-command-policy", () => {
         allowlist,
       }),
     ).toEqual(["canvas.snapshot", "system.run"]);
+  });
+
+  it("includes safe Windows companion command defaults (not only system.run)", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {},
+      { platform: "win32 10.0.17763", deviceFamily: "Windows" },
+    );
+
+    expect(allow.has("canvas.present")).toBe(true);
+    expect(allow.has("camera.list")).toBe(true);
+    expect(allow.has("location.get")).toBe(true);
+    expect(allow.has("screen.snapshot")).toBe(true);
+    expect(allow.has("device.info")).toBe(true);
+    expect(allow.has("device.status")).toBe(true);
+    expect(allow.has("system.run")).toBe(true);
+    for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+      expect(allow.has(cmd)).toBe(false);
+    }
   });
 });

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -115,7 +115,17 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...SCREEN_COMMANDS,
   ],
   linux: [...SYSTEM_COMMANDS],
-  windows: [...SYSTEM_COMMANDS],
+  // Windows tray companion can declare the same "safe" canvas/camera/location/screen
+  // surface as other desktop companions; it still must list commands on the node and
+  // pass the declared-command gate. See #71876.
+  windows: [
+    ...CANVAS_COMMANDS,
+    ...CAMERA_COMMANDS,
+    ...LOCATION_COMMANDS,
+    ...SCREEN_COMMANDS,
+    ...DEVICE_COMMANDS,
+    ...SYSTEM_COMMANDS,
+  ],
   // Fail-safe: unknown metadata should not receive host exec defaults.
   unknown: [...UNKNOWN_PLATFORM_COMMANDS],
 };


### PR DESCRIPTION
## Summary

- **Problem:** On Windows, the gateway platform default allowlist for paired nodes was effectively a **minimal** `system.*`-centric surface, while a tray companion that **declared** the same safe commands as other desktop hosts (e.g. `canvas.present`, `camera.list`) could still be **rejected** at policy resolution. Tracked in [#71876](https://github.com/openclaw/openclaw/issues/71876) (Expand Windows node default allowlist for safe declared companion commands).
- **Why it matters:** Windows companions should be able to use the same **documented, low-risk** node command families as macOS (canvas, list-only camera, location, screen snapshot, device info) without extra `gateway.nodes.allowCommands` wiring, when the node has already **declared** those commands and passes existing gates.
- **What changed:** `PLATFORM_DEFAULTS.windows` in `src/gateway/node-command-policy.ts` now includes the same **safe** bundles as the desktop pattern: `CANVAS_COMMANDS`, `CAMERA_COMMANDS`, `LOCATION_COMMANDS`, `SCREEN_COMMANDS`, `DEVICE_COMMANDS`, plus existing `SYSTEM_COMMANDS`. A regression in `node-command-policy.test.ts` locks in the expanded defaults and that `DEFAULT_DANGEROUS_NODE_COMMANDS` stay **excluded** from the default allow set.
- **What did NOT change (scope boundary):** `DEFAULT_DANGEROUS_NODE_COMMANDS` and opt-in high-risk behavior (`camera.snap`, `screen.record`, etc.) still require explicit `gateway.nodes.allowCommands` and remain blocked from defaults. Declared-command normalization, `denyCommands`, and the security model of declare + allowlist + deny are unchanged in intent.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes [#71876](https://github.com/openclaw/openclaw/issues/71876)
- Related: none
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `PLATFORM_DEFAULTS` for `windows` was a narrow set compared to `macos`, so policy-consistent, declared companion commands for canvas/camera/location/screen/device were missing from the default allow surface even when they are safe and mirrored on other platforms.
- **Missing detection / guardrail:** No unit test asserted the Windows default set included those families while excluding `DEFAULT_DANGEROUS_NODE_COMMANDS`.
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/gateway/node-command-policy.test.ts` (`includes safe Windows companion command defaults (not only system.run)`)
- **Scenario the test should lock in:** For Windows metadata, `resolveNodeCommandAllowlist` includes `canvas.present`, `camera.list`, `location.get`, `screen.snapshot`, `device.info`, `device.status`, and `system.run`, and does **not** include any `DEFAULT_DANGEROUS_NODE_COMMANDS` entry.
- **Why this is the smallest reliable guardrail:** Pure allowlist resolution and dangerous-set exclusion; no I/O.
- **Existing test that already covers this (if any):** N/A
- **If no new test is added, why not:** N/A

## User-visible / Behavior Changes

- **Default behavior:** A paired **Windows** node (with `gateway.nodes.enabled` and normal pairing) can have declared safe commands like `canvas.present` **accepted** when they are on the widened default allowlist, without extra `allowCommands` for those same families, subject to the existing declared-command and deny rules.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No** (config keys unchanged; this adjusts default allowlist content for a platform, not a new API).
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **Yes** -- the **default** allowlist for the Windows platform now includes the same **safe** command *names* as the macOS desktop default pattern (see Summary). `DEFAULT_DANGEROUS_NODE_COMMANDS` are still excluded; explicit opt-in and `denyCommands` still apply.
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: Wider default allow for Windows; mitigated by parity with macOS safe set, unit test excluding dangerous commands, and unchanged high-risk opt-in.

## Repro + Verification

### Environment

- **OS:** Windows (companion) / any for unit tests
- **Runtime/container:** N/A
- **Model/provider:** N/A
- **Integration/channel (if any):** N/A
- **Relevant config (redacted):** `gateway.nodes` as documented

### Steps

1. `pnpm test src/gateway/node-command-policy.test.ts`
2. (Optional) Pair a Windows node declaring e.g. `canvas.present` and confirm policy allows it with defaults.

### Expected

- Tests pass; Windows defaults include the safe set and exclude dangerous defaults.

### Actual

- `pnpm test src/gateway/node-command-policy.test.ts` passes after rebase on latest `main`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Parity/QA: A previous workflow run failed only the **OpenAI / Opus 4.6 parity** (qa-lab) gate, which is **not** specific to this gateway change; this branch was **rebased onto the latest `main`** to re-trigger CI.

## Human Verification (required)

- **Verified scenarios:** Unit tests for Windows default allowlist and dangerous exclusion.
- **Edge cases checked:** `DEFAULT_DANGEROUS_NODE_COMMANDS` are absent from the resolved set for the sample Windows profile.
- **What I did not verify:** Full end-to-end tray app against a live gateway (only policy unit coverage here).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- **Backward compatible?** **Yes** (broader default allow; does not remove prior explicit `allowCommands` or deny behavior)
- **Config/env changes?** **No** (same config keys; defaults broaden for Windows)
- **Migration needed?** **No**
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** Broader default allow on Windows could surprise operators who relied on the old implicit Windows-minimal behavior. **Mitigation:** Aligns with macOS safe surface; dangerous commands off defaults; `denyCommands` unchanged; test proves dangerous list excluded.
