### PR TITLE
test(plugin-sdk): backfill DeepSeek V4 tool-call reasoning on large transcript (#71915)

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -2,6 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   buildCopilotDynamicHeaders,
+  createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createHtmlEntityToolCallArgumentDecodingWrapper,
   createPayloadPatchStreamWrapper,
   defaultToolStreamExtraParams,
@@ -263,5 +264,48 @@ describe("createPayloadPatchStreamWrapper", () => {
     void wrapped({ id: "model" } as never, { messages: [] } as never, {});
 
     expect(onPayloadWasInstalled).toBe(false);
+  });
+});
+
+/**
+ * DeepSeek V4: the thinking wrapper's onPayload pass must set `reasoning_content` on
+ * every assistant row that carries `tool_calls` (single forward scan). Structural check
+ * only (no wall-clock) so CI is deterministic. Refs #71915.
+ */
+describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
+  it("adds empty reasoning_content to V4 tool-call assistant messages for a large message list", () => {
+    const toolTurns = 2000;
+    const messages: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < toolTurns; i++) {
+      messages.push({ role: "user", content: "x" });
+      messages.push({
+        role: "assistant",
+        tool_calls: [
+          { id: `call_${i}`, type: "function", function: { name: "t", arguments: "{}" } },
+        ],
+      });
+    }
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = { messages };
+      void options?.onPayload?.(payload as never, model as never);
+      return createFakeStream({ events: [], resultMessage: {} }) as never;
+    };
+    const wrap = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: (model) =>
+        (model as { provider?: string }).provider === "deepseek" &&
+        (model as { id?: string }).id === "deepseek-v4-flash",
+    });
+    expect(wrap).toBeDefined();
+    void wrap!({ provider: "deepseek", id: "deepseek-v4-flash" } as never, {} as never, {});
+
+    const toolAssistants = messages.filter(
+      (m) => m.role === "assistant" && Array.isArray(m.tool_calls),
+    );
+    expect(toolAssistants).toHaveLength(toolTurns);
+    for (const m of toolAssistants) {
+      expect(m).toHaveProperty("reasoning_content", "");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** [#71915](https://github.com/openclaw/openclaw/issues/71915) reports potential gateway high CPU / pathological behavior with DeepSeek V4; this PR adds a **deterministic** `plugin-sdk` regression for the V4 OpenAI-compatible “thinking” wrapper’s `onPayload` pass. Greptile/Codex previously flagged a **wall-clock** assertion as flaky in CI, so the test is **structural only** (no `expect(ms)`).
- **Why it matters:** A large in-memory `messages` array (many assistant rows with `tool_calls`) plus assertions on `reasoning_content` backfill catches regressions in that request-patch path without depending on machine load.
- **What changed:** `src/plugin-sdk/provider-stream-shared.test.ts` — `describe("createDeepSeekV4OpenAICompatibleThinkingWrapper")` builds a ~2000-assistant–tool turn transcript, invokes the wrapped `StreamFn`, and asserts every matching assistant message has `reasoning_content: ""`. The fake `baseStreamFn` now calls `onPayload` as `(payload, model)`; the stream invocation is prefixed with `void` for the floating-promise lint rule.
- **What did NOT change (scope boundary):** No production, gateway, or default-provider behavior—**tests only**.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related [#71915](https://github.com/openclaw/openclaw/issues/71915)
- [ ] This PR fixes a bug or regression

> **Note:** This PR **refs** #71915. Keep the issue **open** until a maintainer confirms the original production symptom with logs/profile, if it still reproduces. This test is a **structural guard**, not a substitute for that confirmation.

## Root Cause (if applicable)

- **Root cause:** N/A to this test-only change; the production report in #71915 may be multi-factor.
- **Missing detection / guardrail:** No large-transcript regression for V4 `reasoning_content` backfill on tool-call assistant rows before this.
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/plugin-sdk/provider-stream-shared.test.ts`
- **Scenario the test should lock in:** With thinking enabled, after `onPayload` runs, every assistant message with `tool_calls` in a long list has `reasoning_content: ""`.
- **Why this is the smallest reliable guardrail:** In-memory only; no network; no wall-clock.
- **Existing test that already covers this (if any):** N/A
- **If no new test is added, why not:** N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- **OS:** any
- **Runtime/container:** Node 22+ (repo default)
- **Model/provider:** N/A (mock stream)
- **Integration/channel (if any):** N/A
- **Relevant config (redacted):** N/A

### Steps

1. `pnpm test src/plugin-sdk/provider-stream-shared.test.ts`

### Expected

- All tests pass; the V4 block asserts `reasoning_content` on every tool-call assistant message.

### Actual

- `pnpm test src/plugin-sdk/provider-stream-shared.test.ts` passes locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

CI (prior head): `check-test-types` failed on `onPayload` arity (`TS2554` at `provider-stream-shared.test.ts`); `check-lint` (oxlint) required `void` on the floating stream promise. Current commit addresses both.

## Human Verification (required)

- **Verified scenarios:** The test file above passes; `onPayload` matches `StreamFn` (two-argument) usage used elsewhere in `src/plugin-sdk/provider-stream.test.ts`.
- **Edge cases checked:** Long transcript; no absolute timing.
- **What I did not verify:** Live DeepSeek V4 gateway CPU on a real deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- **Backward compatible?** **Yes**
- **Config/env changes?** **No**
- **Migration needed?** **No**

## Risks and Mitigations

- **Risk:** Slightly more work in a single test case — **Mitigation:** in-memory only; no I/O; typical runtime remains small.
