### PR TITLE
fix(agents): omit temperature for anthropic opus 4.7 requests

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -902,4 +902,25 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("omits temperature for Claude Opus 4.7 requests", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Be concise." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        temperature: 0.2,
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).not.toHaveProperty("temperature");
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -109,7 +109,8 @@ type MutableAssistantOutput = {
 };
 
 function isClaudeOpus47Model(modelId: string): boolean {
-  return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  return normalizedModelId.includes("opus-4-7") || normalizedModelId.includes("opus-4.7");
 }
 
 function isClaudeOpus46Model(modelId: string): boolean {
@@ -765,7 +766,11 @@ function buildAnthropicParams(
       },
     ];
   }
-  if (options?.temperature !== undefined && !options.thinkingEnabled) {
+  if (
+    options?.temperature !== undefined &&
+    !options.thinkingEnabled &&
+    !isClaudeOpus47Model(model.id)
+  ) {
     params.temperature = options.temperature;
   }
   if (context.tools) {


### PR DESCRIPTION
# fix(agents): omit Opus 4.7 temperature in Anthropic transport

## Summary

Fixes repeated compaction first-attempt failures for Anthropic `claude-opus-4-7` by preventing `temperature` from being sent on that model.

Fixes #72123.

## Root Cause

- OpenClaw can inherit `temperature` from merged runtime/model extra params.
- Anthropic transport forwarded that `temperature` when thinking was not enabled.
- Anthropic Opus 4.7 rejects sampling parameters in this shape, causing first-attempt `400` errors and fallback retries.

## Official Evidence (Anthropic docs)

From Anthropic's migration guide:

> "Sampling parameters removed: Setting `temperature`, `top_p`, or `top_k` to any non-default value on Claude Opus 4.7 returns a 400 error. The safest migration path is to omit these parameters entirely from request payloads."

Reference: [Anthropic migration guide](https://docs.anthropic.com/en/docs/about-claude/models/migrating-to-claude-4)

## What Changed

- Updated `src/agents/anthropic-transport-stream.ts`:
  - normalized Opus 4.7 model-id matching;
  - skipped `params.temperature` injection for Opus 4.7 even if `options.temperature` is present.
- Updated `src/agents/anthropic-transport-stream.test.ts`:
  - added regression test to assert Opus 4.7 payload omits `temperature`.

## Validation

- `pnpm test src/agents/anthropic-transport-stream.test.ts` (pass, 9/9)
- `pnpm check:changed` was attempted; 
## Risk / Follow-up

- Scope is narrow to Anthropic Opus 4.7 request shaping.
- Other Anthropic models keep existing behavior.

## AI-assisted

- [x] AI-assisted and manually reviewed.
