### PR TITLE
feat: auto-inject agent personality from workspace root (PERSONALITY.md)

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -16,6 +16,8 @@ import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
+import * as fs from 'fs';
+import * as path from 'path';
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -146,11 +148,22 @@ export async function resolveCommandsSystemPromptBundle(
     : { enabled: false };
   const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
 
+  let rootPersonality: string | undefined = undefined;
+  try {
+    const personalityPath = path.join(workspaceDir, 'PERSONALITY.md');
+    if (fs.existsSync(personalityPath)) {
+      rootPersonality = fs.readFileSync(personalityPath, 'utf-8');
+      console.log('Root personality loaded from PERSONALITY.md');
+    }
+  } catch (err) {
+    console.error('Failed to read root personality file:', err);
+  }
+
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,
     defaultThinkLevel: params.resolvedThinkLevel,
     reasoningLevel: params.resolvedReasoningLevel,
-    extraSystemPrompt: undefined,
+    extraSystemPrompt: rootPersonality,
     ownerNumbers: undefined,
     reasoningTagHint: false,
     toolNames,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -16,8 +16,6 @@ import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
-import fs from "node:fs/promises";
-import path from "node:path";
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -148,30 +146,11 @@ export async function resolveCommandsSystemPromptBundle(
     : { enabled: false };
   const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
 
-  let rootPersonality: string | undefined = undefined;
-  try {
-    const personalityPath = path.join(workspaceDir, "PERSONALITY.md");
-
-    const content = await fs.readFile(personalityPath, "utf-8");
-    
-    if (content.length > 8192) {
-      console.warn("PERSONALITY.md is too large, truncating to 8KB");
-      rootPersonality = content.slice(0, 8192);
-    } else {
-      rootPersonality = content;
-    }
-    console.log("Root personality loaded from PERSONALITY.md");
-  } catch (err: unknown) {
-    if (err.code !== "ENOENT") {
-      console.error("Failed to read root personality file:", err);
-    }
-  }
-
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,
     defaultThinkLevel: params.resolvedThinkLevel,
     reasoningLevel: params.resolvedReasoningLevel,
-    extraSystemPrompt: rootPersonality,
+    extraSystemPrompt: undefined,
     ownerNumbers: undefined,
     reasoningTagHint: false,
     toolNames,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -16,8 +16,8 @@ import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from "node:fs/promises";
+import path from "node:path";
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -150,13 +150,21 @@ export async function resolveCommandsSystemPromptBundle(
 
   let rootPersonality: string | undefined = undefined;
   try {
-    const personalityPath = path.join(workspaceDir, 'PERSONALITY.md');
-    if (fs.existsSync(personalityPath)) {
-      rootPersonality = fs.readFileSync(personalityPath, 'utf-8');
-      console.log('Root personality loaded from PERSONALITY.md');
+    const personalityPath = path.join(workspaceDir, "PERSONALITY.md");
+
+    const content = await fs.readFile(personalityPath, "utf-8");
+    
+    if (content.length > 8192) {
+      console.warn("PERSONALITY.md is too large, truncating to 8KB");
+      rootPersonality = content.substring(0, 8192);
+    } else {
+      rootPersonality = content;
     }
-  } catch (err) {
-    console.error('Failed to read root personality file:', err);
+    console.log("Root personality loaded from PERSONALITY.md");
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      console.error("Failed to read root personality file:", err);
+    }
   }
 
   const systemPrompt = buildAgentSystemPrompt({

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -156,12 +156,12 @@ export async function resolveCommandsSystemPromptBundle(
     
     if (content.length > 8192) {
       console.warn("PERSONALITY.md is too large, truncating to 8KB");
-      rootPersonality = content.substring(0, 8192);
+      rootPersonality = content.slice(0, 8192);
     } else {
       rootPersonality = content;
     }
     console.log("Root personality loaded from PERSONALITY.md");
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (err.code !== "ENOENT") {
       console.error("Failed to read root personality file:", err);
     }

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -275,11 +275,11 @@ export async function runPreparedReply(
     const content = await fs.readFile(personalityPath, "utf-8");
     if (content.length > 8192) {
       console.warn("PERSONALITY.md is too large, truncating to 8KB");
-      rootPersonality = content.substring(0, 8192);
+      rootPersonality = content.slice(0, 8192);
     } else {
       rootPersonality = content;
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (err.code !== "ENOENT") {
       console.error("Failed to read root personality file:", err);
     }

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -280,7 +280,7 @@ export async function runPreparedReply(
       rootPersonality = content;
     }
   } catch (err: unknown) {
-    if (err.code !== "ENOENT") {
+    if (err && typeof err === "object" && "code" in err && err.code !== "ENOENT") {
       console.error("Failed to read root personality file:", err);
     }
   }

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -61,6 +61,8 @@ import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
@@ -266,6 +268,23 @@ export async function runPreparedReply(
     workspaceDir,
     sessionStore,
   } = params;
+
+  let rootPersonality: string | undefined = undefined;
+  try {
+    const personalityPath = path.join(workspaceDir, "PERSONALITY.md");
+    const content = await fs.readFile(personalityPath, "utf-8");
+    if (content.length > 8192) {
+      console.warn("PERSONALITY.md is too large, truncating to 8KB");
+      rootPersonality = content.substring(0, 8192);
+    } else {
+      rootPersonality = content;
+    }
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      console.error("Failed to read root personality file:", err);
+    }
+  }
+
   const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
     cfg,
     ctx,
@@ -357,6 +376,7 @@ export async function runPreparedReply(
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
+    rootPersonality,
     buildExecOverridePromptHint({
       execOverrides,
       elevatedLevel: resolvedElevatedLevel,
@@ -370,6 +390,7 @@ export async function runPreparedReply(
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
+    rootPersonality,
     buildExecOverridePromptHint({
       execOverrides,
       elevatedLevel: resolvedElevatedLevel,


### PR DESCRIPTION
## Overview
This Pull Request implements the feature to simplify agent personality management. It enables the system to automatically detect and load a `PERSONALITY.md` file if it exists at the workspace root, making agent configuration more intuitive for developers.

## Key Changes
* **Module Integration:** Added `fs` and `path` imports to handle workspace file system operations.
* **Dynamic Resolution:** Updated the `resolveCommandsSystemPromptBundle` function in `src/auto-reply/reply/commands-system-prompt.ts` to perform a shallow scan of the `workspaceDir`.
* **Prompt Injection:** Mapped the content of `PERSONALITY.md` to the `extraSystemPrompt` parameter within the `buildAgentSystemPrompt` lifecycle.
* **Error Handling:** Implemented `try-catch` blocks to ensure that the absence of the file does not break the agent's startup sequence.

## Why this is important?
Previously, defining an agent's "identity" required navigating through complex configurations. This change introduces a **"Plug-and-Play"** approach—allowing users to steer agent behavior by simply editing a Markdown file in their project's main directory.

## How to Test?
1. **With File:** Create `PERSONALITY.md` in the project root with the text: *"You are a helpful assistant that speaks in rhymes."* Start the agent and verify the behavior.
2. **Without File:** Delete the file and ensure the agent starts normally with default system prompts.
3. **Stability:** Verified that the system correctly logs when the personality is loaded and handles missing files gracefully.

## Checklist
- [x] Code follows the project's TypeScript/Node.js style guidelines.
- [x] Self-review performed.
- [x] No breaking changes introduced for existing configurations.

Fixes #71581 
**Labels:** `enhancement`, `feat`