### PR TITLE
fix(sessions): check sessionId fallback path before pruning in cleanup [AI-assisted]

### DIFF
--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import type { RuntimeEnv } from "../runtime.js";
 
@@ -287,5 +288,81 @@ describe("sessionsCleanupCommand", () => {
     expect(payload.allAgents).toBe(true);
     expect(Array.isArray(payload.stores)).toBe(true);
     expect((payload.stores as unknown[]).length).toBe(2);
+  });
+
+  describe("stale sessionFile fallback", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("does not prune entry with stale sessionFile when sessionId transcript exists", async () => {
+      const stalePath = "/stale/old-name.jsonl";
+      const fallbackPath = "/resolved/sessions/stale-id.jsonl";
+      mocks.resolveSessionFilePath.mockImplementation(
+        (_sessionId: string, entry?: { sessionFile?: string }) =>
+          entry?.sessionFile ? stalePath : fallbackPath,
+      );
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => String(p) === fallbackPath);
+      mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+      mocks.loadSessionStore.mockReturnValue({
+        staleEntry: {
+          sessionId: "stale-id",
+          sessionFile: "old-name.jsonl",
+          updatedAt: Date.now(),
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand({ json: true, dryRun: true, fixMissing: true }, runtime);
+
+      const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+      expect(payload.missing).toBe(0);
+      expect(payload.beforeCount).toBe(1);
+      expect(payload.afterCount).toBe(1);
+    });
+
+    it("prunes entry with stale sessionFile when sessionId transcript is also missing", async () => {
+      mocks.resolveSessionFilePath.mockImplementation(
+        (sessionId: string, entry?: { sessionFile?: string }) =>
+          entry?.sessionFile ? `/stale/${sessionId}.jsonl` : `/also-missing/${sessionId}.jsonl`,
+      );
+      mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+      mocks.loadSessionStore.mockReturnValue({
+        gone: {
+          sessionId: "gone-id",
+          sessionFile: "old-name.jsonl",
+          updatedAt: Date.now(),
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand({ json: true, dryRun: true, fixMissing: true }, runtime);
+
+      const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+      expect(payload.missing).toBe(1);
+      expect(payload.afterCount).toBe(0);
+    });
+
+    it("keeps entry when sessionFile path is valid and file exists", async () => {
+      const validPath = "/resolved/sessions/valid-id.jsonl";
+      mocks.resolveSessionFilePath.mockImplementation(() => validPath);
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => String(p) === validPath);
+      mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+      mocks.loadSessionStore.mockReturnValue({
+        valid: {
+          sessionId: "valid-id",
+          sessionFile: "valid-id.jsonl",
+          updatedAt: Date.now(),
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand({ json: true, dryRun: true, fixMissing: true }, runtime);
+
+      const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+      expect(payload.missing).toBe(0);
+      expect(payload.beforeCount).toBe(1);
+      expect(payload.afterCount).toBe(1);
+    });
   });
 });

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -151,6 +151,10 @@ function pruneMissingTranscriptEntries(params: {
     }
     const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
     if (!fs.existsSync(transcriptPath)) {
+      const fallbackPath = resolveSessionFilePath(entry.sessionId, undefined, sessionPathOpts);
+      if (fallbackPath !== transcriptPath && fs.existsSync(fallbackPath)) {
+        continue;
+      }
       delete params.store[key];
       removed += 1;
       params.onPruned?.(key);


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `openclaw sessions cleanup --fix-missing` incorrectly prunes valid session entries when the stored `sessionFile` path is stale but a transcript file named after the `sessionId` still exists on disk.
- Why it matters: Users running cleanup lose valid session data; the reporter observed 63 of 75 entries marked for pruning despite transcripts existing.
- What changed: `pruneMissingTranscriptEntries()` now checks the sessionId-based fallback path before marking an entry as missing.
- What did NOT change (scope boundary): `resolveSessionFilePath()` in `src/config/sessions/paths.ts` is untouched. No changes to session lifecycle, store format, or other cleanup actions.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] CLI / Commands

## Linked Issue/PR
- Closes #63897
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `pruneMissingTranscriptEntries()` calls `resolveSessionFilePath(sessionId, entry, opts)` which prefers `entry.sessionFile`. When that stored path is stale (renamed/moved file), it passes path validation but points to a nonexistent file. The function does not fall back to the sessionId-based path, so the entry is pruned even though `<sessionId>.jsonl` exists on disk.
- Missing detection / guardrail: No fallback check for the sessionId-based transcript path when the sessionFile-based path fails.
- Contributing context: Session file paths can drift from the stored `sessionFile` field over time due to session resets, migrations, or internal renames.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/commands/sessions-cleanup.test.ts`
- Scenario the test should lock in: Entry with stale `sessionFile` but valid `<sessionId>.jsonl` transcript is not pruned; entry where both paths are missing is still pruned; entry with valid `sessionFile` is kept.
- Why this is the smallest reliable guardrail: The three test cases cover the exact branching logic added to `pruneMissingTranscriptEntries()`.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — three new tests added.

## User-visible / Behavior Changes
- `openclaw sessions cleanup --fix-missing` no longer incorrectly prunes sessions whose transcript exists under the sessionId filename but whose stored `sessionFile` path is stale.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only changes the pruning logic to check an additional local filesystem path before deleting a session store entry. No new permissions, no network access changes, no credential handling changes.
