### PR TITLE
docs(start): use provider-neutral model in getting-started example

### DIFF
--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -121,7 +121,7 @@ Example:
 {
   logging: { level: "info" },
   agent: {
-    model: "anthropic/claude-opus-4-6",
+    model: "<provider>/<model-id>", // e.g. openai/gpt-4.1, anthropic/claude-sonnet-4-6
     workspace: "~/.openclaw/workspace",
     thinkingDefault: "high",
     timeoutSeconds: 1800,


### PR DESCRIPTION
The getting-started config snippet in `docs/start/openclaw.md` hardcoded `anthropic/claude-opus-4-6` as the default model. Since OpenClaw is model-agnostic, this replaces it with `openai/gpt-4.1` as a more neutral default.

Fixes #62529