### PR TITLE
fix(onboard): detect vision-capable models for custom providers

### DIFF
--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -311,6 +311,69 @@ describe("applyCustomApiConfig", () => {
     ).toBeUndefined();
   });
 
+  it("detects vision-capable models for non-azure custom providers", () => {
+    for (const modelId of ["claude-sonnet-4-6", "gpt-4o-mini", "gemini-2.5-pro", "qwen-vl-max"]) {
+      const result = applyCustomApiConfig({
+        config: {},
+        baseUrl: "https://llm.example.com/v1",
+        modelId,
+        compatibility: "openai",
+        apiKey: "key123",
+        providerId: "custom",
+      });
+      const provider = result.config.models?.providers?.custom;
+      expect(provider?.models?.[0]?.input).toEqual(["text", "image"]);
+    }
+  });
+
+  it("does not add image input for non-vision non-azure models", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "llama-3.1-70b",
+      compatibility: "openai",
+      apiKey: "key123",
+      providerId: "custom",
+    });
+    const provider = result.config.models?.providers?.custom;
+    expect(provider?.models?.[0]?.input).toEqual(["text"]);
+  });
+
+  it("re-onboard updates input for existing non-azure vision models", () => {
+    const result = applyCustomApiConfig({
+      config: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://llm.example.com/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "claude-sonnet-4-6",
+                  name: "My Claude",
+                  contextWindow: 200000,
+                  maxTokens: 8192,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  reasoning: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "claude-sonnet-4-6",
+      compatibility: "openai",
+      apiKey: "key123",
+      providerId: "custom",
+    });
+    const provider = result.config.models?.providers?.custom;
+    const model = provider?.models?.find((m) => m.id === "claude-sonnet-4-6");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.name).toBe("My Claude");
+  });
+
   it("re-onboard preserves user-customized fields for non-azure models", () => {
     const result = applyCustomApiConfig({
       config: {

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -195,7 +195,9 @@ describe("applyCustomApiConfig", () => {
 
     const model = provider?.models?.find((m) => m.id === "gpt-4.1");
     expect(model?.reasoning).toBe(false);
-    expect(model?.input).toEqual(["text"]);
+    // gpt-4.1 is a vision-capable model; isLikelyVisionModel must apply on the
+    // Azure path too, not just the non-Azure one.
+    expect(model?.input).toEqual(["text", "image"]);
     expect(model?.compat).toEqual({ supportsStore: false });
 
     const modelRef = `${providerId}/gpt-4.1`;
@@ -312,7 +314,17 @@ describe("applyCustomApiConfig", () => {
   });
 
   it("detects vision-capable models for non-azure custom providers", () => {
-    for (const modelId of ["claude-sonnet-4-6", "gpt-4o-mini", "gemini-2.5-pro", "qwen-vl-max"]) {
+    for (const modelId of [
+      "claude-sonnet-4-6",
+      "gpt-4o-mini",
+      "gpt-4-turbo-2024-04-09",
+      "gpt-4-vision-preview",
+      "gemini-2.5-pro",
+      "qwen-vl-max",
+      "llava-13b",
+      "moondream2",
+      "phi-3.5-vision-instruct",
+    ]) {
       const result = applyCustomApiConfig({
         config: {},
         baseUrl: "https://llm.example.com/v1",
@@ -323,6 +335,22 @@ describe("applyCustomApiConfig", () => {
       });
       const provider = result.config.models?.providers?.custom;
       expect(provider?.models?.[0]?.input).toEqual(["text", "image"]);
+    }
+  });
+
+  it("detects vision-capable models for azure custom providers", () => {
+    for (const modelId of ["gpt-4o", "gpt-4.1", "gemini-2.5-pro"]) {
+      const result = applyCustomApiConfig({
+        config: {},
+        baseUrl: "https://my-resource.openai.azure.com",
+        modelId,
+        compatibility: "openai",
+        apiKey: "key123",
+      });
+      const providerId = result.providerId!;
+      const provider = result.config.models?.providers?.[providerId];
+      const model = provider?.models?.find((m) => m.id === modelId);
+      expect(model?.input).toEqual(["text", "image"]);
     }
   });
 

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -487,6 +487,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   const hasModel = existingModels.some((model) => model.id === modelId);
   const isLikelyReasoningModel = isAzure && /\b(o[134]|gpt-([5-9]|\d{2,}))\b/i.test(modelId);
+  const isLikelyVisionModel =
+    /\b(claude|gpt-4o|gpt-4\.1|gpt-5|gemini|qwen-vl|qwen2-vl|glm-4v|pixtral)\b/i.test(modelId);
   const nextModel = isAzure
     ? {
         id: modelId,
@@ -505,7 +507,9 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
         name: `${modelId} (Custom Provider)`,
         contextWindow: DEFAULT_CONTEXT_WINDOW,
         maxTokens: DEFAULT_MAX_TOKENS,
-        input: ["text"] as ["text"],
+        input: isLikelyVisionModel
+          ? (["text", "image"] as Array<"text" | "image">)
+          : (["text"] as ["text"]),
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         reasoning: false,
       };
@@ -517,6 +521,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
               ...(isAzure ? nextModel : {}),
               name: model.name ?? nextModel.name,
               cost: model.cost ?? nextModel.cost,
+              input:
+                nextModel.input.length > (model.input?.length ?? 0) ? nextModel.input : model.input,
               contextWindow: normalizeContextWindowForCustomModel(model.contextWindow),
               maxTokens: model.maxTokens ?? nextModel.maxTokens,
             }

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -488,14 +488,17 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const hasModel = existingModels.some((model) => model.id === modelId);
   const isLikelyReasoningModel = isAzure && /\b(o[134]|gpt-([5-9]|\d{2,}))\b/i.test(modelId);
   const isLikelyVisionModel =
-    /\b(claude|gpt-4o|gpt-4\.1|gpt-5|gemini|qwen-vl|qwen2-vl|glm-4v|pixtral)\b/i.test(modelId);
+    /\b(claude|gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-4-vision|gpt-5|gemini|qwen-vl|qwen2-vl|glm-4v|pixtral|llava|moondream\d*|phi-.*vision)\b/i.test(
+      modelId,
+    );
+  const supportsImageInput = isLikelyVisionModel || (isAzure && isLikelyReasoningModel);
   const nextModel = isAzure
     ? {
         id: modelId,
         name: `${modelId} (Custom Provider)`,
         contextWindow: AZURE_DEFAULT_CONTEXT_WINDOW,
         maxTokens: AZURE_DEFAULT_MAX_TOKENS,
-        input: isLikelyReasoningModel
+        input: supportsImageInput
           ? (["text", "image"] as Array<"text" | "image">)
           : (["text"] as ["text"]),
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },


### PR DESCRIPTION
Non-Azure custom providers hardcoded `input: ["text"]` for all models, silently disabling image/vision support even when the underlying model (Claude, GPT-4o, Gemini, Qwen-VL, etc.) fully supports it. Users had no way to fix this through the wizard and had to manually edit `openclaw.json`.

This adds a name-pattern check (similar to the existing Azure reasoning-model detection) that auto-sets `input: ["text", "image"]` for common vision-capable model families: Claude, GPT-4o, GPT-4.1, GPT-5, Gemini, Qwen-VL, GLM-4V, and Pixtral.

Fixes #51869