### PR TITLE
docs: document avatar image 2MB size limit

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -202,6 +202,8 @@ Override fields explicitly:
 openclaw agents set-identity --agent main --name "OpenClaw" --emoji "🦞" --avatar avatars/openclaw.png
 ```
 
+> **Note:** Avatar image files must be under 2 MB. Larger files are silently ignored.
+
 Config sample:
 
 ```json5

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -974,7 +974,7 @@ for provider examples and precedence.
 - `fastModeDefault`: optional per-agent default for fast mode (`true | false`). Applies when no per-message or session fast-mode override is set.
 - `agentRuntime`: optional per-agent low-level runtime policy override. Use `{ id: "codex" }` to make one agent Codex-only while other agents keep the default PI fallback in `auto` mode.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
-- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI. **Image files must be under 2 MB**; larger files are silently ignored with no error message.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.


### PR DESCRIPTION
Avatar image files must be under 2 MB, but exceeding this limit produces no error — the avatar is silently ignored. This adds a note about the size limit in both:

- `docs/gateway/config-agents.md` (identity.avatar field reference)
- `docs/cli/agents.md` (set-identity command)

Fixes #65312