### PR TITLE
fix(qqbot): improve error messages with actionable guidance

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -113,7 +113,7 @@ export class ApiClient {
         throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
       }
       this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
-      throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
+      throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}. Check network connectivity and QQ API endpoint access. See: https://docs.openclaw.ai/channels/qqbot`, 0, path);
     } finally {
       clearTimeout(timeoutId);
     }

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -241,7 +241,7 @@ export class TokenManager {
     }
 
     if (!data.access_token) {
-      throw new Error(`Failed to get access_token: ${JSON.stringify(data)}`);
+      throw new Error(`Failed to get access_token (check QQBOT_APP_ID and QQBOT_CLIENT_SECRET). API response: ${JSON.stringify(data)}. See: https://docs.openclaw.ai/channels/qqbot`);
     }
 
     const expiresAt = Date.now() + (data.expires_in ?? 7200) * 1000;

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -74,7 +74,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
 
   // ---- 2. Validate ----
   if (!account.appId || !account.clientSecret) {
-    throw new Error("QQBot not configured (missing appId or clientSecret)");
+    throw new Error("QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET env vars, or run `openclaw configure`. See: https://docs.openclaw.ai/channels/qqbot");
   }
 
   // ---- 3. Diagnostics ----

--- a/extensions/qqbot/src/engine/messaging/outbound.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound.ts
@@ -1024,7 +1024,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
   }
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return { channel: "qqbot", error: "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET env vars, or run `openclaw configure`. See: https://docs.openclaw.ai/channels/qqbot" };
   }
 
   try {
@@ -1061,7 +1061,7 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
   initApiConfig(account.appId, { markdownSupport: account.markdownSupport });
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return { channel: "qqbot", error: "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET env vars, or run `openclaw configure`. See: https://docs.openclaw.ai/channels/qqbot" };
   }
   if (!ctx.mediaUrl) {
     return { channel: "qqbot", error: "mediaUrl is required for sendMedia" };


### PR DESCRIPTION
QQBot error messages were overly technical — dumping raw JSON and lacking actionable hints. This improves:

1. **"not configured" errors** → now mention `QQBOT_APP_ID` and `QQBOT_CLIENT_SECRET` env var names + docs link
2. **access_token failures** → include credential check hints + docs link
3. **Network errors** → include troubleshooting guidance + docs link

Fixes #65868