### PR TITLE
fix(macos): keep attach-only from stopping gateway launchd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
+- macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.
 - Bonjour/Gateway: cap flapping advertiser restarts in a sliding window, so mDNS probing/name-conflict loops disable discovery instead of churning indefinitely on constrained hosts. Refs #74209 and #74242. Thanks @ndj888 and @Sanjays2402.
 - Plugins/runtime-deps: verify staged package entry files before reusing mirrored runtime roots, so browser-control repairs incomplete `ajv`/MCP SDK installs after update instead of failing after restart on a missing `ajv/dist/ajv.js`. Refs #74630. Thanks @spickeringlr.
 - Heartbeat: resolve `responsePrefix` template variables with the selected provider, model, and thinking context before delivering alerts or suppressing prefixed `HEARTBEAT_OK` replies. Fixes #43064; repairs #43065; supersedes #46858. Thanks @yweiii and @JunJD.

--- a/apps/macos/Sources/OpenClaw/DebugSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DebugSettings.swift
@@ -92,14 +92,6 @@ struct DebugSettings: View {
                             self.launchAgentWriteDisabled = GatewayLaunchAgentManager.isLaunchAgentWriteDisabled()
                             return
                         }
-                        if newValue {
-                            Task {
-                                _ = await GatewayLaunchAgentManager.set(
-                                    enabled: false,
-                                    bundlePath: Bundle.main.bundlePath,
-                                    port: GatewayEnvironment.gatewayPort())
-                            }
-                        }
                     }
 
                 Text(

--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -207,9 +207,9 @@ extension GatewayLaunchAgentManager {
     }
 
     #if DEBUG
-    nonisolated(unsafe) private static var testingDisableLaunchAgentMarkerURL: URL?
-    nonisolated(unsafe) private static var testingInterceptDaemonCommands = false
-    nonisolated(unsafe) private static var testingDaemonCommandCalls: [[String]] = []
+    private nonisolated(unsafe) static var testingDisableLaunchAgentMarkerURL: URL?
+    private nonisolated(unsafe) static var testingInterceptDaemonCommands = false
+    private nonisolated(unsafe) static var testingDaemonCommandCalls: [[String]] = []
 
     static func setTestingDisableLaunchAgentMarkerURL(_ url: URL?) {
         self.testingDisableLaunchAgentMarkerURL = url

--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -5,7 +5,12 @@ enum GatewayLaunchAgentManager {
     private static let disableLaunchAgentMarker = ".openclaw/disable-launchagent"
 
     private static var disableLaunchAgentMarkerURL: URL {
-        FileManager().homeDirectoryForCurrentUser
+        #if DEBUG
+        if let testingDisableLaunchAgentMarkerURL {
+            return testingDisableLaunchAgentMarkerURL
+        }
+        #endif
+        return FileManager().homeDirectoryForCurrentUser
             .appendingPathComponent(self.disableLaunchAgentMarker)
     }
 
@@ -17,6 +22,10 @@ enum GatewayLaunchAgentManager {
     static func isLaunchAgentWriteDisabled() -> Bool {
         if FileManager().fileExists(atPath: self.disableLaunchAgentMarkerURL.path) { return true }
         return false
+    }
+
+    static func applyAttachOnlyRuntimeOverride() -> String? {
+        self.setLaunchAgentWriteDisabled(true)
     }
 
     static func setLaunchAgentWriteDisabled(_ disabled: Bool) -> String? {
@@ -144,6 +153,15 @@ extension GatewayLaunchAgentManager {
         timeout: Double,
         quiet: Bool) async -> CommandResult
     {
+        #if DEBUG
+        if self.testingInterceptDaemonCommands {
+            self.testingDaemonCommandCalls.append(args)
+            return CommandResult(
+                success: true,
+                payload: Data("{\"ok\":true}".utf8),
+                message: nil)
+        }
+        #endif
         let command = CommandResolver.openclawCommand(
             subcommand: "gateway",
             extraArgs: self.withJsonFlag(args),
@@ -187,4 +205,26 @@ extension GatewayLaunchAgentManager {
     private static func summarize(_ text: String) -> String? {
         TextSummarySupport.summarizeLastLine(text)
     }
+
+    #if DEBUG
+    nonisolated(unsafe) private static var testingDisableLaunchAgentMarkerURL: URL?
+    nonisolated(unsafe) private static var testingInterceptDaemonCommands = false
+    nonisolated(unsafe) private static var testingDaemonCommandCalls: [[String]] = []
+
+    static func setTestingDisableLaunchAgentMarkerURL(_ url: URL?) {
+        self.testingDisableLaunchAgentMarkerURL = url
+    }
+
+    static func setTestingInterceptDaemonCommands(_ intercept: Bool) {
+        self.testingInterceptDaemonCommands = intercept
+    }
+
+    static func clearTestingDaemonCommandCalls() {
+        self.testingDaemonCommandCalls.removeAll(keepingCapacity: false)
+    }
+
+    static func testingDaemonCommandCallsSnapshot() -> [[String]] {
+        self.testingDaemonCommandCalls
+    }
+    #endif
 }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -98,15 +98,9 @@ struct OpenClawApp: App {
     private static func applyAttachOnlyOverrideIfNeeded() {
         let args = CommandLine.arguments
         guard args.contains("--attach-only") || args.contains("--no-launchd") else { return }
-        if let error = GatewayLaunchAgentManager.setLaunchAgentWriteDisabled(true) {
+        if let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride() {
             Self.logger.error("attach-only flag failed: \(error, privacy: .public)")
             return
-        }
-        Task {
-            _ = await GatewayLaunchAgentManager.set(
-                enabled: false,
-                bundlePath: Bundle.main.bundlePath,
-                port: GatewayEnvironment.gatewayPort())
         }
         Self.logger.info("attach-only flag enabled")
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -3,6 +3,29 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayLaunchAgentManagerTests {
+    @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
+        let dir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)
+        let marker = dir.appendingPathComponent("disable-launchagent")
+        try FileManager().createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager().removeItem(at: dir) }
+        defer {
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+        }
+
+        GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+        GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+        GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+
+        let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride()
+
+        #expect(error == nil)
+        #expect(FileManager().fileExists(atPath: marker.path))
+        #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+    }
+
     @Test func `launch agent plist snapshot parses args and env`() throws {
         let url = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-launchd-\(UUID().uuidString).plist")


### PR DESCRIPTION
## Summary

- keep macOS attach-only mode from disabling/uninstalling the Gateway LaunchAgent
- make the `--attach-only` / `--no-launchd` launch path and Debug Settings toggle only persist the disable marker
- add a focused regression test proving attach-only writes the marker without issuing daemon commands

## Related reports / duplicate review

- Related: #42530 (`Mac app kills running gateway on launch despite disable-launchagent sentinel`)
- Reviewed related launchd/LaunchAgent PRs/issues before opening: #44, #20379, #64447, #43660, #48455, #24123, #51811, #56035, #71929.
- I did not find an open PR that narrowly fixes this attach-only/UI path; the nearest exact report is #42530, which is closed/locked but matches the behavior this patch prevents.

## Behavior change

Attach-only should mean “attach to an existing Gateway; do not manage launchd”. Previously both the CLI flag path and Debug Settings toggle could still call `GatewayLaunchAgentManager.set(enabled: false, ...)`, which can stop/disable/uninstall the Gateway LaunchAgent and drop active sessions. This patch routes attach-only through a marker-only helper instead.

## Security / secrets check

- No new permissions/capabilities.
- No secrets/tokens/credentials added.
- Secret-pattern scan of added diff lines found no matches.
- Full changed-file scan only matched pre-existing dummy test literals (`" secret "`, `"pw"`) in `GatewayLaunchAgentManagerTests.swift`, not real credentials.

## Testing

- `swift test --filter GatewayLaunchAgentManagerTests`
- `swift test --filter GatewayProcessManagerTests`
- `git diff --check`
- Manual controlled canary from the packet: patched app launched with `--attach-only`; Gateway PID stayed stable; no new Gateway SIGTERM during the canary window; app node reconnected.
