### PR TITLE
fix(kimi): allow user to override api field in provider config [AI-assisted]

### DIFF
--- a/extensions/kimi-coding/index.test.ts
+++ b/extensions/kimi-coding/index.test.ts
@@ -1,3 +1,4 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import plugin from "./index.js";
@@ -19,5 +20,87 @@ describe("kimi provider plugin", () => {
       ],
       defaultLevel: "off",
     });
+  });
+
+  it("allows user to override api field from provider config", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run({
+      config: {
+        models: {
+          providers: {
+            kimi: {
+              baseUrl: "https://api.kimi.com/coding/v1",
+              api: "openai-completions",
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as unknown as ProviderCatalogContext);
+
+    expect(result).toBeTruthy();
+    const catalogProvider = (result as { provider: Record<string, unknown> }).provider;
+    expect(catalogProvider.api).toBe("openai-completions");
+    expect(catalogProvider.baseUrl).toBe("https://api.kimi.com/coding/v1");
+  });
+
+  it("allows user to override api field without overriding baseUrl", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run({
+      config: {
+        models: {
+          providers: {
+            kimi: {
+              api: "openai-completions",
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as unknown as ProviderCatalogContext);
+
+    expect(result).toBeTruthy();
+    const catalogProvider = (result as { provider: Record<string, unknown> }).provider;
+    expect(catalogProvider.api).toBe("openai-completions");
+    // baseUrl should remain the built-in default
+    expect(catalogProvider.baseUrl).toBe("https://api.kimi.com/coding/");
+  });
+
+  it("uses built-in api when user does not override", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run({
+      config: {
+        models: {
+          providers: {
+            kimi: {
+              baseUrl: "https://api.kimi.com/coding/",
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as unknown as ProviderCatalogContext);
+
+    expect(result).toBeTruthy();
+    const catalogProvider = (result as { provider: Record<string, unknown> }).provider;
+    expect(catalogProvider.api).toBe("anthropic-messages");
   });
 });

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import type { ModelApi } from "openclaw/plugin-sdk/provider-model-shared";
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { applyKimiCodeConfig, KIMI_CODING_MODEL_REF } from "./onboard.js";
@@ -75,6 +76,9 @@ export default definePluginEntry({
           );
           const builtInProvider = buildKimiCodingProvider();
           const explicitBaseUrl = normalizeOptionalString(explicitProvider?.baseUrl) ?? "";
+          const explicitApi = (normalizeOptionalString(explicitProvider?.api) ?? "") as
+            | ModelApi
+            | "";
           const explicitHeaders = isRecord(explicitProvider?.headers)
             ? (explicitProvider.headers as Record<string, SecretInput>)
             : undefined;
@@ -82,6 +86,7 @@ export default definePluginEntry({
             provider: {
               ...builtInProvider,
               ...(explicitBaseUrl ? { baseUrl: explicitBaseUrl } : {}),
+              ...(explicitApi ? { api: explicitApi } : {}),
               ...(explicitHeaders
                 ? {
                     headers: {


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: The Kimi Code provider hardcodes `api: "anthropic-messages"` and ignores the user's explicit `api` config, causing tool call protocol mismatches when users switch to OpenAI-compatible endpoints.
- Why it matters: Users cannot use Kimi's OpenAI-compatible endpoint (`/coding/v1`) because the `api` field is silently overridden.
- What changed: Forward `explicitApi` from user provider config alongside `baseUrl` and `headers` in `extensions/kimi/src/index.ts`.
- What did NOT change (scope boundary): No changes to the built-in provider defaults, other provider catalogs, or any shared infrastructure.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions / Plugins

## Linked Issue/PR
- Closes #72156
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: In `extensions/kimi/src/index.ts`, `builtInProvider` is spread first, then only `baseUrl` and `headers` are explicitly overridden from user config. The `api` field from `explicitProvider` is never forwarded.
- Missing detection / guardrail: No test verified that user-provided `api` config is respected.
- Contributing context (if known): The pattern was copied from providers that only need `baseUrl`/`headers` overrides; `api` was overlooked.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/kimi/src/index.test.ts`
- Scenario the test should lock in: When user config includes `api: "openai-completions"`, the resolved provider must use that value instead of the hardcoded `"anthropic-messages"`.
- Why this is the smallest reliable guardrail: Unit test on the catalog `run` function directly exercises the config merge logic.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — 3 new tests added.

## User-visible / Behavior Changes
Users can now override the `api` field in their Kimi provider config (e.g., setting `api: "openai-completions"` for the `/coding/v1` endpoint).

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only forwards an existing user config field that was previously silently ignored. No new attack surface or permission escalation.
