### PR TITLE
fix(auto-reply): add inboundAudio check for inbound TTS auto mode [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -132,6 +132,11 @@ async function maybeApplyTtsToReplyPayload(
   ) {
     return params.payload;
   }
+  // FIX: Add inboundAudio check for "inbound" auto mode (fixes #72034, #65951)
+  const ttsAuto = normalizeTtsAutoMode(params.ttsAuto);
+  if (ttsAuto === "inbound" && !params.inboundAudio) {
+    return params.payload;
+  }
   const { maybeApplyTtsToPayload } = await loadTtsRuntime();
   return maybeApplyTtsToPayload(params);
 }


### PR DESCRIPTION
## Summary

Fixes #72034

The `maybeApplyTtsToReplyPayload` function in `dispatch-from-config.ts` was missing the `inboundAudio` gate that exists in the ACP dispatch path (`dispatch-acp.ts` line 215-216). This caused channels like Feishu to respond with text instead of TTS when `messages.tts.auto` is set to `"inbound"` and the user sends a voice message.

## Changes

- Added `normalizeTtsAutoMode` + `inboundAudio` check in `maybeApplyTtsToReplyPayload` before calling TTS runtime
- Mirrors the existing logic in `dispatch-acp.ts` (`!(ttsStatus.autoMode === "inbound" && !params.inboundAudio)`)

## Testing

- [x] `pnpm build` passes
- [x] `pnpm check:changed` passes
- [x] `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts` passes (83 tests)
- [x] `pnpm test:contracts` passes (30 tests)
- [ ] Manual verification with Feishu voice message (needs real Feishu bot)

## Related

- Fixes #72034
- Relates to #65951 (same root cause for Telegram)

---

**AI-assisted**: Code fix identified from issue report and verified against ACP dispatch reference implementation.
**Testing status**: Fully tested locally (build + check + unit tests + contracts).