### PR TITLE
Add continuity diagnostics and restore guardrails

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -52,7 +52,6 @@ describe("Codex app-server approval bridge", () => {
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
       "plugin.approval.waitDecision",
-      "plugin.approval.list",
     ]);
     expect(mockCallGatewayTool).toHaveBeenCalledWith(
       "plugin.approval.request",
@@ -447,8 +446,6 @@ describe("Codex app-server approval bridge", () => {
     expect(result).toEqual({ decision: "decline" });
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
-      "plugin.approval.list",
-      "plugin.approval.list",
     ]);
     expect(params.onAgentEvent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -52,6 +52,7 @@ describe("Codex app-server approval bridge", () => {
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
       "plugin.approval.waitDecision",
+      "plugin.approval.list",
     ]);
     expect(mockCallGatewayTool).toHaveBeenCalledWith(
       "plugin.approval.request",
@@ -444,7 +445,11 @@ describe("Codex app-server approval bridge", () => {
     });
 
     expect(result).toEqual({ decision: "decline" });
-    expect(mockCallGatewayTool).toHaveBeenCalledTimes(1);
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.list",
+      "plugin.approval.list",
+    ]);
     expect(params.onAgentEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: "approval",

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -7,8 +7,8 @@ import {
   approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
   requestPluginApproval,
+  resolveCodexPluginApprovalDecision,
   type AppServerApprovalOutcome,
-  waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
@@ -101,9 +101,14 @@ export async function handleCodexAppServerApprovalRequest(params: {
       message: "Codex app-server approval requested.",
     });
 
-    const decision = approvalRequestExplicitlyUnavailable(requestResult)
-      ? null
-      : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
+    const decision = await resolveCodexPluginApprovalDecision({
+      approvalId,
+      requestResult,
+      paramsForRun: params.paramsForRun,
+      toolName: context.toolName,
+      toolCallId: context.itemId,
+      signal: params.signal,
+    });
     const outcome = mapExecDecisionToOutcome(decision);
 
     emitApprovalEvent(params.paramsForRun, {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -1,5 +1,6 @@
 import {
   callGatewayTool,
+  emitContinuityDiagnostic,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 
@@ -25,6 +26,104 @@ type ApprovalWaitResult = {
   id?: string;
   decision?: ExecApprovalDecision | null;
 };
+
+type LivePluginApprovalState =
+  | {
+      ok: true;
+      pending: boolean;
+      request?: unknown;
+    }
+  | {
+      ok: false;
+      pending?: undefined;
+      error: string;
+    };
+
+async function resolveLiveCodexPluginApprovalState(
+  approvalId: string,
+): Promise<LivePluginApprovalState> {
+  try {
+    const requests = await callGatewayTool<unknown[]>(
+      "plugin.approval.list",
+      { timeoutMs: 3_000 },
+      {},
+      { expectFinal: false },
+    );
+    const list = Array.isArray(requests) ? requests : [];
+    const request = list.find(
+      (entry) =>
+        Boolean(entry) &&
+        typeof entry === "object" &&
+        (entry as { id?: unknown }).id === approvalId,
+    );
+    return {
+      ok: true,
+      pending: Boolean(request),
+      request,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function describeCodexPluginCarriedApprovalState(
+  decision: ExecApprovalDecision | null | undefined,
+): string {
+  if (decision === undefined) {
+    return "wait-for-live-decision";
+  }
+  if (decision === null) {
+    return "resolved:null";
+  }
+  return `resolved:${decision}`;
+}
+
+function describeCodexPluginLiveApprovalState(live: LivePluginApprovalState): string {
+  if (!live.ok) {
+    return "unknown";
+  }
+  return live.pending ? "pending" : "not-pending";
+}
+
+function readRunId(paramsForRun: EmbeddedRunAttemptParams): string | undefined {
+  const runId = (paramsForRun as { runId?: unknown }).runId;
+  return typeof runId === "string" && runId.trim() ? runId.trim() : undefined;
+}
+
+function emitCodexPluginApprovalCarryMismatch(params: {
+  approvalId: string;
+  paramsForRun: EmbeddedRunAttemptParams;
+  toolName: string;
+  toolCallId?: string;
+  phase: string;
+  severity?: "info" | "warn" | "error";
+  carriedState: string;
+  liveState: string;
+  error?: string;
+}): void {
+  emitContinuityDiagnostic({
+    type: "diag.approval.carry_mismatch",
+    severity: params.severity ?? "warn",
+    runId: readRunId(params.paramsForRun) ?? params.approvalId,
+    sessionKey: params.paramsForRun.sessionKey,
+    phase: params.phase,
+    correlation: {
+      approvalKind: "plugin",
+      approvalId: params.approvalId,
+      pluginId: "openclaw-codex-app-server",
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+    },
+    details: {
+      carriedState: params.carriedState,
+      liveState: params.liveState,
+      error: params.error,
+    },
+  });
+}
 
 export async function requestPluginApproval(params: {
   paramsForRun: EmbeddedRunAttemptParams;
@@ -100,6 +199,67 @@ export async function waitForPluginApprovalDecision(params: {
       params.signal.removeEventListener("abort", onAbort);
     }
   }
+}
+
+export async function resolveCodexPluginApprovalDecision(params: {
+  approvalId: string;
+  requestResult?: ApprovalRequestResult;
+  paramsForRun: EmbeddedRunAttemptParams;
+  toolName: string;
+  toolCallId?: string;
+  signal?: AbortSignal;
+}): Promise<ExecApprovalDecision | null | undefined> {
+  const hasImmediateDecision = Object.prototype.hasOwnProperty.call(
+    params.requestResult ?? {},
+    "decision",
+  );
+  const preResolvedDecision = hasImmediateDecision ? params.requestResult?.decision : undefined;
+  const carriedState = describeCodexPluginCarriedApprovalState(preResolvedDecision);
+  if (hasImmediateDecision) {
+    const liveBefore = await resolveLiveCodexPluginApprovalState(params.approvalId);
+    if (liveBefore.ok && liveBefore.pending) {
+      emitCodexPluginApprovalCarryMismatch({
+        approvalId: params.approvalId,
+        paramsForRun: params.paramsForRun,
+        toolName: params.toolName,
+        toolCallId: params.toolCallId,
+        phase: "before_plugin_decision_use",
+        carriedState,
+        liveState: describeCodexPluginLiveApprovalState(liveBefore),
+      });
+    } else if (!liveBefore.ok) {
+      emitCodexPluginApprovalCarryMismatch({
+        approvalId: params.approvalId,
+        paramsForRun: params.paramsForRun,
+        toolName: params.toolName,
+        toolCallId: params.toolCallId,
+        phase: "before_plugin_decision_use",
+        severity: "info",
+        carriedState,
+        liveState: "unknown",
+        error: liveBefore.error,
+      });
+    }
+  }
+  const decision = hasImmediateDecision
+    ? preResolvedDecision
+    : await waitForPluginApprovalDecision({
+        approvalId: params.approvalId,
+        signal: params.signal,
+      });
+  const liveAfter = await resolveLiveCodexPluginApprovalState(params.approvalId);
+  if (liveAfter.ok && liveAfter.pending && decision !== undefined) {
+    emitCodexPluginApprovalCarryMismatch({
+      approvalId: params.approvalId,
+      paramsForRun: params.paramsForRun,
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+      phase: "after_plugin_decision_resolve",
+      carriedState: `decision:${decision ?? "null"}`,
+      liveState: describeCodexPluginLiveApprovalState(liveAfter),
+    });
+  }
+  return decision;
 }
 
 export function mapExecDecisionToOutcome(

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -209,57 +209,23 @@ export async function resolveCodexPluginApprovalDecision(params: {
   toolCallId?: string;
   signal?: AbortSignal;
 }): Promise<ExecApprovalDecision | null | undefined> {
-  const hasImmediateDecision = Object.prototype.hasOwnProperty.call(
-    params.requestResult ?? {},
-    "decision",
-  );
-  const preResolvedDecision = hasImmediateDecision ? params.requestResult?.decision : undefined;
-  const carriedState = describeCodexPluginCarriedApprovalState(preResolvedDecision);
-  if (hasImmediateDecision) {
-    const liveBefore = await resolveLiveCodexPluginApprovalState(params.approvalId);
-    if (liveBefore.ok && liveBefore.pending) {
-      emitCodexPluginApprovalCarryMismatch({
-        approvalId: params.approvalId,
-        paramsForRun: params.paramsForRun,
-        toolName: params.toolName,
-        toolCallId: params.toolCallId,
-        phase: "before_plugin_decision_use",
-        carriedState,
-        liveState: describeCodexPluginLiveApprovalState(liveBefore),
-      });
-    } else if (!liveBefore.ok) {
-      emitCodexPluginApprovalCarryMismatch({
-        approvalId: params.approvalId,
-        paramsForRun: params.paramsForRun,
-        toolName: params.toolName,
-        toolCallId: params.toolCallId,
-        phase: "before_plugin_decision_use",
-        severity: "info",
-        carriedState,
-        liveState: "unknown",
-        error: liveBefore.error,
-      });
-    }
-  }
-  const decision = hasImmediateDecision
-    ? preResolvedDecision
-    : await waitForPluginApprovalDecision({
-        approvalId: params.approvalId,
-        signal: params.signal,
-      });
-  const liveAfter = await resolveLiveCodexPluginApprovalState(params.approvalId);
-  if (liveAfter.ok && liveAfter.pending && decision !== undefined) {
+  if (approvalRequestExplicitlyUnavailable(params.requestResult)) {
     emitCodexPluginApprovalCarryMismatch({
       approvalId: params.approvalId,
       paramsForRun: params.paramsForRun,
       toolName: params.toolName,
       toolCallId: params.toolCallId,
-      phase: "after_plugin_decision_resolve",
-      carriedState: `decision:${decision ?? "null"}`,
-      liveState: describeCodexPluginLiveApprovalState(liveAfter),
+      phase: "plugin_approval_route_unavailable",
+      severity: "info",
+      carriedState: "resolved:null",
+      liveState: "not-queried",
     });
+    return null;
   }
-  return decision;
+  return await waitForPluginApprovalDecision({
+    approvalId: params.approvalId,
+    signal: params.signal,
+  });
 }
 
 export function mapExecDecisionToOutcome(

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -59,6 +59,7 @@ import {
 import {
   canonicalizeAcpSessionKey,
   createUnsupportedControlError,
+  emitAcpHandleDiagnostic,
   hasLegacyAcpIdentityProjection,
   normalizeAcpErrorCode,
   normalizeActorKey,
@@ -1862,9 +1863,26 @@ export class AcpSessionManager {
         if (!cached) {
           return;
         }
+        const idleMs = Math.max(0, now - lastTouchedAt);
         this.runtimeCache.clear(candidate.actorKey);
         this.evictedRuntimeCount += 1;
         this.lastEvictedAt = Date.now();
+        emitAcpHandleDiagnostic({
+          type: "diag.acp.handle_evicted",
+          phase: "idle_eviction",
+          sessionKey: candidate.state.handle.sessionKey,
+          actorKey: candidate.actorKey,
+          backend: cached.backend,
+          agent: cached.agent,
+          details: {
+            idleMs,
+            idleTtlMs,
+            mode: cached.mode,
+            cwd: cached.cwd,
+            evictedTotal: this.evictedRuntimeCount,
+            reason: "idle-evicted",
+          },
+        });
         try {
           await cached.runtime.close({
             handle: cached.handle,
@@ -1874,6 +1892,21 @@ export class AcpSessionManager {
           logVerbose(
             `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
           );
+          emitAcpHandleDiagnostic({
+            type: "diag.acp.handle_eviction_close_failed",
+            severity: "warn",
+            phase: "idle_eviction_close",
+            sessionKey: candidate.state.handle.sessionKey,
+            actorKey: candidate.actorKey,
+            backend: cached.backend,
+            agent: cached.agent,
+            details: {
+              idleMs,
+              idleTtlMs,
+              mode: cached.mode,
+              error: formatErrorMessage(error),
+            },
+          });
         }
       });
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -13,14 +13,20 @@ const hoisted = vi.hoisted(() => {
   const upsertAcpSessionMetaMock = vi.fn();
   const getAcpRuntimeBackendMock = vi.fn();
   const requireAcpRuntimeBackendMock = vi.fn();
+  const emitContinuityDiagnosticMock = vi.fn();
   return {
     listAcpSessionEntriesMock,
     readAcpSessionEntryMock,
     upsertAcpSessionMetaMock,
     getAcpRuntimeBackendMock,
     requireAcpRuntimeBackendMock,
+    emitContinuityDiagnosticMock,
   };
 });
+
+vi.mock("../../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: hoisted.emitContinuityDiagnosticMock,
+}));
 
 vi.mock("../runtime/session-meta.js", () => ({
   listAcpSessionEntries: (params: unknown) => hoisted.listAcpSessionEntriesMock(params),
@@ -229,6 +235,7 @@ describe("AcpSessionManager", () => {
     hoisted.readAcpSessionEntryMock.mockReset();
     hoisted.upsertAcpSessionMetaMock.mockReset().mockResolvedValue(null);
     hoisted.requireAcpRuntimeBackendMock.mockReset();
+    hoisted.emitContinuityDiagnosticMock.mockReset();
     hoisted.getAcpRuntimeBackendMock.mockReset().mockImplementation((backendId?: string) => {
       try {
         return hoisted.requireAcpRuntimeBackendMock(backendId);
@@ -1823,6 +1830,16 @@ describe("AcpSessionManager", () => {
           handle: expect.objectContaining({
             sessionKey: "agent:codex:acp:session-a",
           }),
+        }),
+      );
+      expect(hoisted.emitContinuityDiagnosticMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "diag.acp.handle_evicted",
+          severity: "info",
+          phase: "idle_eviction",
+          sessionKey: "agent:codex:acp:session-a",
+          correlation: expect.objectContaining({ backend: "acpx", agent: "codex" }),
+          details: expect.objectContaining({ idleTtlMs: 600, reason: "idle-evicted" }),
         }),
       );
     } finally {

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -4,6 +4,7 @@ import {
 } from "../../config/sessions/main-session.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitContinuityDiagnostic } from "../../infra/continuity-diagnostics.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -111,6 +112,30 @@ export function resolveRuntimeIdleTtlMs(cfg: OpenClawConfig): number {
     return 0;
   }
   return Math.round(ttlMinutes * 60 * 1000);
+}
+
+export function emitAcpHandleDiagnostic(params: {
+  type: string;
+  severity?: "info" | "warn" | "error";
+  phase?: string;
+  sessionKey?: string;
+  actorKey?: string;
+  backend?: string;
+  agent?: string;
+  details?: Record<string, unknown>;
+}): void {
+  emitContinuityDiagnostic({
+    type: params.type,
+    severity: params.severity ?? "info",
+    phase: params.phase,
+    sessionKey: params.sessionKey,
+    correlation: {
+      actorKey: params.actorKey,
+      backend: params.backend,
+      agent: params.agent,
+    },
+    details: params.details,
+  });
 }
 
 export function hasLegacyAcpIdentityProjection(meta: SessionAcpMeta): boolean {

--- a/src/agents/agent-command.continuity-boundary.test.ts
+++ b/src/agents/agent-command.continuity-boundary.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+
+const emittedDiagnostics = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const pendingState = vi.hoisted(() => ({ value: false }));
+
+vi.mock("../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: vi.fn((params: Record<string, unknown>) => {
+    emittedDiagnostics.push(params);
+    return params;
+  }),
+}));
+
+vi.mock("../infra/outbound/pending-spawn-query.js", () => ({
+  resolvePendingSpawnedChildren: vi.fn(() => pendingState.value),
+}));
+
+import { __testing } from "./agent-command.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+beforeEach(() => {
+  emittedDiagnostics.length = 0;
+  pendingState.value = false;
+});
+
+describe("agent-command continuity boundary freshen", () => {
+  test("records next-turn freshen marker and emits stale-risk diagnostics once", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-boundary-freshen-"));
+    tempDirs.push(dir);
+    const storePath = path.join(dir, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const boundaryMetadata = {
+      version: 1,
+      type: "compact.boundary",
+      boundaryId: "compact-boundary:test",
+      createdAt: 123,
+      state: {
+        sessionBinding: {
+          sessionKey,
+          sessionId: "session-live",
+          agentId: "main",
+          channel: "discord",
+          accountId: "account-1",
+          threadId: "thread-1",
+        },
+        approval: {
+          captured: false,
+          reason: "approval live state is captured by the dedicated approval mismatch guard",
+        },
+        outbound: { channel: "discord", targetId: "user-1", threadId: "thread-1" },
+        children: { pendingDescendantState: "live-query-required", livePendingDescendants: false },
+        policy: { provider: "openai", model: "gpt-test", thinkingLevel: "high" },
+      },
+    } as const;
+    const entry: SessionEntry = {
+      sessionId: "session-live",
+      updatedAt: Date.now(),
+      channel: "discord",
+      lastAccountId: "account-1",
+      lastThreadId: "thread-1",
+      providerOverride: "openai",
+      modelOverride: "gpt-test",
+      thinkingLevel: "high",
+      continuityRestore: {
+        usedBoundary: {
+          type: "continuity.restore.used_boundary",
+          checkpointId: "checkpoint-1",
+          boundaryId: boundaryMetadata.boundaryId,
+          restoredAt: 456,
+          boundaryMetadata,
+        },
+      },
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf8");
+
+    const next = await __testing.freshenRestoredBoundaryForNextTurn({
+      sessionEntry: entry,
+      sessionStore,
+      storePath,
+      sessionKey,
+      sessionId: "session-live",
+      sessionAgentId: "main",
+      runId: "run-1",
+      configuredProvider: "openai",
+      configuredModel: "gpt-test",
+      persistedThinking: "high",
+    });
+
+    expect(next?.continuityRestore?.nextTurnFreshened).toMatchObject({
+      boundaryId: boundaryMetadata.boundaryId,
+      checkpointId: "checkpoint-1",
+      mismatchCount: 0,
+      fallbackKeys: [],
+      livePendingDescendants: false,
+      pendingDescendantCount: 0,
+      staleRiskCount: 3,
+    });
+    expect(emittedDiagnostics.map((event) => event.type)).toEqual([
+      "continuity.restore.boundary_freshened",
+      "continuity.restore.boundary_stale_risk",
+    ]);
+    expect(emittedDiagnostics[0]).toMatchObject({
+      severity: "info",
+      phase: "next_turn_freshen",
+      sessionKey,
+      correlation: { boundaryId: boundaryMetadata.boundaryId, checkpointId: "checkpoint-1" },
+    });
+    expect(emittedDiagnostics[1]).toMatchObject({
+      severity: "info",
+      details: {
+        risks: [
+          { slot: "approval", status: "not-captured" },
+          { slot: "acp", status: "missing-seed" },
+          { slot: "wake", status: "missing-seed" },
+        ],
+      },
+    });
+
+    emittedDiagnostics.length = 0;
+    const second = await __testing.freshenRestoredBoundaryForNextTurn({
+      sessionEntry: next,
+      sessionStore,
+      storePath,
+      sessionKey,
+      sessionId: "session-live",
+      sessionAgentId: "main",
+    });
+
+    expect(second).toBe(next);
+    expect(emittedDiagnostics).toEqual([]);
+  });
+
+  test("detects boundary/live mismatches", () => {
+    const result = __testing.collectContinuityMismatches(
+      { channel: "discord", accountId: "account-1", threadId: "thread-1" },
+      { channel: "slack", accountId: "account-1" },
+      "sessionBinding",
+    );
+
+    expect(result).toEqual({
+      mismatches: [{ key: "sessionBinding.channel", boundary: "discord", live: "slack" }],
+      fallbackKeys: ["sessionBinding.threadId"],
+    });
+  });
+});

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -8,13 +8,18 @@ import {
 } from "../auto-reply/thinking.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import type {
+  SessionContinuityRestoreBoundaryMarker,
+  SessionEntry,
+} from "../config/sessions/types.js";
 import {
   clearAgentRunContext,
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { resolvePendingSpawnedChildren } from "../infra/outbound/pending-spawn-query.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -248,6 +253,279 @@ function normalizeExplicitOverrideInput(raw: string, kind: "provider" | "model")
   return trimmed;
 }
 
+type ContinuityMismatch = {
+  key: string;
+  boundary: unknown;
+  live: unknown;
+};
+
+type BoundaryFreshenCandidate = {
+  marker: SessionContinuityRestoreBoundaryMarker;
+  state: Record<string, unknown>;
+  boundaryId: string;
+};
+
+function isContinuityPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function compactContinuityValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() ? value.trim() : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function valuesEqualForContinuity(boundaryValue: unknown, liveValue: unknown): boolean {
+  if (boundaryValue === undefined || boundaryValue === null || boundaryValue === "") {
+    return true;
+  }
+  return String(boundaryValue) === String(liveValue ?? "");
+}
+
+function collectContinuityMismatches(
+  boundary: Record<string, unknown>,
+  live: Record<string, unknown>,
+  prefix = "",
+): { mismatches: ContinuityMismatch[]; fallbackKeys: string[] } {
+  const mismatches: ContinuityMismatch[] = [];
+  const fallbackKeys: string[] = [];
+  for (const [key, boundaryValue] of Object.entries(boundary)) {
+    if (boundaryValue === undefined || boundaryValue === null || boundaryValue === "") {
+      continue;
+    }
+    const liveValue = live[key];
+    const qualifiedKey = prefix ? `${prefix}.${key}` : key;
+    if (liveValue === undefined || liveValue === null || liveValue === "") {
+      fallbackKeys.push(qualifiedKey);
+      continue;
+    }
+    if (!valuesEqualForContinuity(boundaryValue, liveValue)) {
+      mismatches.push({
+        key: qualifiedKey,
+        boundary: boundaryValue,
+        live: liveValue,
+      });
+    }
+  }
+  return { mismatches, fallbackKeys };
+}
+
+function resolveBoundaryStaleRiskDiagnostics(state: Record<string, unknown>): Array<{
+  slot: string;
+  status: "missing-seed" | "not-captured";
+  reason?: string;
+}> {
+  const risks: Array<{
+    slot: string;
+    status: "missing-seed" | "not-captured";
+    reason?: string;
+  }> = [];
+  const approval = isContinuityPlainObject(state.approval) ? state.approval : undefined;
+  if (!approval) {
+    risks.push({ slot: "approval", status: "missing-seed" });
+  } else if (approval.captured === false) {
+    risks.push({
+      slot: "approval",
+      status: "not-captured",
+      reason: compactContinuityValue(approval.reason),
+    });
+  }
+  for (const slot of ["acp", "wake"]) {
+    if (!isContinuityPlainObject(state[slot])) {
+      risks.push({ slot, status: "missing-seed" });
+    }
+  }
+  return risks;
+}
+
+function resolveLiveBoundaryPolicy(params: {
+  sessionEntry?: SessionEntry;
+  configuredProvider?: string;
+  configuredModel?: string;
+  thinkOverride?: string;
+  persistedThinking?: string;
+}): Record<string, string | undefined> {
+  return {
+    provider:
+      compactContinuityValue(params.sessionEntry?.providerOverride) ??
+      compactContinuityValue(params.configuredProvider),
+    model:
+      compactContinuityValue(params.sessionEntry?.modelOverride) ??
+      compactContinuityValue(params.configuredModel),
+    thinkingLevel:
+      compactContinuityValue(params.thinkOverride) ??
+      compactContinuityValue(params.sessionEntry?.thinkingLevel) ??
+      compactContinuityValue(params.persistedThinking),
+  };
+}
+
+function resolveBoundaryFreshenMarker(
+  sessionEntry: SessionEntry | undefined,
+): BoundaryFreshenCandidate | undefined {
+  const restore = isContinuityPlainObject(sessionEntry?.continuityRestore)
+    ? sessionEntry.continuityRestore
+    : undefined;
+  const marker = isContinuityPlainObject(restore?.usedBoundary)
+    ? (restore.usedBoundary as SessionContinuityRestoreBoundaryMarker)
+    : undefined;
+  const metadata = isContinuityPlainObject(marker?.boundaryMetadata)
+    ? marker.boundaryMetadata
+    : undefined;
+  const state = isContinuityPlainObject(metadata?.state) ? metadata.state : undefined;
+  if (!marker || !metadata || !state) {
+    return undefined;
+  }
+  const boundaryId =
+    compactContinuityValue(marker.boundaryId) ??
+    compactContinuityValue(metadata.boundaryId) ??
+    compactContinuityValue(marker.checkpointId);
+  if (!boundaryId) {
+    return undefined;
+  }
+  const freshened = isContinuityPlainObject(restore?.nextTurnFreshened)
+    ? restore.nextTurnFreshened
+    : undefined;
+  if (compactContinuityValue(freshened?.boundaryId) === boundaryId) {
+    return undefined;
+  }
+  return {
+    marker,
+    state,
+    boundaryId,
+  };
+}
+
+async function freshenRestoredBoundaryForNextTurn(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionKey?: string;
+  sessionId: string;
+  sessionAgentId: string;
+  runId?: string;
+  configuredProvider?: string;
+  configuredModel?: string;
+  thinkOverride?: string;
+  persistedThinking?: string;
+}): Promise<SessionEntry | undefined> {
+  const restoreMarker = resolveBoundaryFreshenMarker(params.sessionEntry);
+  if (!restoreMarker || !params.sessionKey || !params.sessionStore || !params.storePath) {
+    return params.sessionEntry;
+  }
+  const { state, boundaryId, marker } = restoreMarker;
+  const liveSessionBinding: Record<string, unknown> = {
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    agentId: params.sessionAgentId,
+    channel:
+      compactContinuityValue(params.sessionEntry?.channel) ??
+      compactContinuityValue(params.sessionEntry?.lastChannel),
+    accountId: compactContinuityValue(params.sessionEntry?.lastAccountId),
+    threadId: compactContinuityValue(params.sessionEntry?.lastThreadId),
+  };
+  const sessionBindingResult = collectContinuityMismatches(
+    isContinuityPlainObject(state.sessionBinding) ? state.sessionBinding : {},
+    liveSessionBinding,
+  );
+  const livePendingDescendants = resolvePendingSpawnedChildren(params.sessionKey);
+  const pendingDescendantCount = livePendingDescendants ? 1 : 0;
+  const childMismatches: ContinuityMismatch[] = [];
+  const boundaryChildren = isContinuityPlainObject(state.children) ? state.children : {};
+  if (
+    typeof boundaryChildren.livePendingDescendants === "boolean" &&
+    boundaryChildren.livePendingDescendants !== livePendingDescendants
+  ) {
+    childMismatches.push({
+      key: "children.livePendingDescendants",
+      boundary: boundaryChildren.livePendingDescendants,
+      live: livePendingDescendants,
+    });
+  }
+  const boundaryPolicy = isContinuityPlainObject(state.policy) ? state.policy : {};
+  const livePolicy = resolveLiveBoundaryPolicy(params);
+  const policyResult = collectContinuityMismatches(boundaryPolicy, livePolicy, "policy");
+  const staleRiskDiagnostics = resolveBoundaryStaleRiskDiagnostics(state);
+  const mismatches = [
+    ...sessionBindingResult.mismatches,
+    ...childMismatches,
+    ...policyResult.mismatches,
+  ];
+  const fallbackKeys = [...sessionBindingResult.fallbackKeys, ...policyResult.fallbackKeys];
+  const policyLiveKeys = Object.keys(livePolicy).filter((key) => livePolicy[key] !== undefined);
+  const freshenedAt = Date.now();
+
+  emitContinuityDiagnostic({
+    type: "continuity.restore.boundary_freshened",
+    severity: mismatches.length > 0 ? "warn" : "info",
+    runId: params.runId ?? boundaryId,
+    sessionKey: params.sessionKey,
+    phase: "next_turn_freshen",
+    correlation: {
+      boundaryId,
+      checkpointId: marker.checkpointId,
+    },
+    details: {
+      stateKeys: Object.keys(state),
+      mismatchCount: mismatches.length,
+      mismatches: mismatches.slice(0, 12),
+      fallbackKeys,
+      livePendingDescendants,
+      pendingDescendantCount,
+      policyLiveKeys,
+      staleRiskCount: staleRiskDiagnostics.length,
+    },
+  });
+  if (staleRiskDiagnostics.length > 0) {
+    emitContinuityDiagnostic({
+      type: "continuity.restore.boundary_stale_risk",
+      severity: "info",
+      runId: params.runId ?? boundaryId,
+      sessionKey: params.sessionKey,
+      phase: "next_turn_freshen",
+      correlation: {
+        boundaryId,
+        checkpointId: marker.checkpointId,
+      },
+      details: {
+        risks: staleRiskDiagnostics,
+        stateKeys: Object.keys(state),
+        policyLiveKeys,
+      },
+    });
+  }
+
+  const next: SessionEntry = {
+    ...(params.sessionEntry ?? { sessionId: params.sessionId }),
+    updatedAt: freshenedAt,
+    continuityRestore: {
+      ...(isContinuityPlainObject(params.sessionEntry?.continuityRestore)
+        ? params.sessionEntry.continuityRestore
+        : {}),
+      nextTurnFreshened: {
+        boundaryId,
+        checkpointId: marker.checkpointId,
+        freshenedAt,
+        mismatchCount: mismatches.length,
+        fallbackKeys,
+        livePendingDescendants,
+        pendingDescendantCount,
+        staleRiskCount: staleRiskDiagnostics.length,
+      },
+    },
+  };
+  await persistSessionEntry({
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    entry: next,
+  });
+  return next;
+}
+
 async function prepareAgentCommandExecution(
   opts: AgentCommandOpts & { senderIsOwner: boolean },
   runtime: RuntimeEnv,
@@ -404,6 +682,8 @@ async function prepareAgentCommandExecution(
     agentDir,
     runId,
     acpManager,
+    configuredProvider: configuredModel.provider,
+    configuredModel: configuredModel.model,
     acpResolution,
   };
 }
@@ -438,6 +718,8 @@ async function agentCommandInternal(
     agentDir,
     runId,
     acpManager,
+    configuredProvider,
+    configuredModel,
     acpResolution,
   } = prepared;
   let sessionEntry = prepared.sessionEntry;
@@ -459,6 +741,20 @@ async function agentCommandInternal(
     if (acpResolution?.kind === "stale") {
       throw acpResolution.error;
     }
+
+    sessionEntry = await freshenRestoredBoundaryForNextTurn({
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionKey,
+      sessionId,
+      sessionAgentId,
+      runId,
+      configuredProvider,
+      configuredModel,
+      thinkOverride,
+      persistedThinking,
+    });
 
     if (acpResolution?.kind === "ready" && sessionKey) {
       const attemptExecutionRuntime = await loadAttemptExecutionRuntime();
@@ -1198,4 +1494,8 @@ export async function agentCommandFromIngress(
 export const __testing = {
   resolveAgentRuntimeConfig,
   prepareAgentCommandExecution,
+  collectContinuityMismatches,
+  freshenRestoredBoundaryForNextTurn,
+  resolveBoundaryFreshenMarker,
+  resolveBoundaryStaleRiskDiagnostics,
 };

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -292,6 +292,7 @@ export async function processGatewayAllowlist(
       const decision = await resolveApprovalDecisionOrUndefined({
         approvalId,
         preResolvedDecision,
+        sessionKey: params.notifySessionKey ?? params.sessionKey,
         onFailure: () =>
           void sendExecApprovalFollowupResult(
             followupTarget,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -321,6 +321,7 @@ export async function executeNodeHostCommand(
         const decision = await execHostShared.resolveApprovalDecisionOrUndefined({
           approvalId,
           preResolvedDecision,
+          sessionKey: params.notifySessionKey ?? params.sessionKey,
           onFailure: () =>
             void execHostShared.sendExecApprovalFollowupResult(
               followupTarget,

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  callGatewayTool: vi.fn(),
+  emitContinuityDiagnostic: vi.fn(),
+  resolveRegisteredExecApprovalDecision: vi.fn(),
   resolveExecApprovals: vi.fn(() => ({
     defaults: {
       security: "allowlist",
@@ -19,6 +22,10 @@ const mocks = vi.hoisted(() => ({
   })),
 }));
 
+vi.mock("../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: mocks.emitContinuityDiagnostic,
+}));
+
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
   return {
@@ -27,12 +34,25 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./bash-tools.exec-approval-request.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./bash-tools.exec-approval-request.js")>();
+  return {
+    ...mod,
+    resolveRegisteredExecApprovalDecision: mocks.resolveRegisteredExecApprovalDecision,
+  };
+});
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: mocks.callGatewayTool,
+}));
+
 let sendExecApprovalFollowupResult: typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
 let maxExecApprovalFollowupFailureLogKeys: typeof import("./bash-tools.exec-host-shared.js").MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS;
 let enforceStrictInlineEvalApprovalBoundary: typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
 let resolveExecHostApprovalContext: typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext;
 let resolveExecApprovalUnavailableState: typeof import("./bash-tools.exec-host-shared.js").resolveExecApprovalUnavailableState;
 let buildExecApprovalPendingToolResult: typeof import("./bash-tools.exec-host-shared.js").buildExecApprovalPendingToolResult;
+let resolveApprovalDecisionOrUndefined: typeof import("./bash-tools.exec-host-shared.js").resolveApprovalDecisionOrUndefined;
 
 beforeAll(async () => {
   ({
@@ -42,7 +62,16 @@ beforeAll(async () => {
     resolveExecHostApprovalContext,
     resolveExecApprovalUnavailableState,
     buildExecApprovalPendingToolResult,
+    resolveApprovalDecisionOrUndefined,
   } = await import("./bash-tools.exec-host-shared.js"));
+});
+
+beforeEach(() => {
+  mocks.callGatewayTool.mockReset();
+  mocks.callGatewayTool.mockResolvedValue([]);
+  mocks.emitContinuityDiagnostic.mockReset();
+  mocks.resolveRegisteredExecApprovalDecision.mockReset();
+  mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue(null);
 });
 
 describe("sendExecApprovalFollowupResult", () => {
@@ -201,6 +230,79 @@ describe("resolveExecHostApprovalContext", () => {
     });
 
     expect(result.askFallback).toBe("allowlist");
+  });
+});
+
+describe("resolveApprovalDecisionOrUndefined", () => {
+  it("emits an exec approval carry-mismatch diagnostic when a carried decision still has live pending state", async () => {
+    mocks.callGatewayTool.mockResolvedValue([{ id: "approval-1" }]);
+    mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue("allow-once");
+    const onFailure = vi.fn();
+
+    await expect(
+      resolveApprovalDecisionOrUndefined({
+        approvalId: "approval-1",
+        preResolvedDecision: "allow-once",
+        sessionKey: "agent:main:discord:direct:alice",
+        onFailure,
+      }),
+    ).resolves.toBe("allow-once");
+
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.list",
+      { timeoutMs: 3_000 },
+      {},
+      { expectFinal: false },
+    );
+    expect(mocks.emitContinuityDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.approval.carry_mismatch",
+        severity: "warn",
+        runId: "approval-1",
+        sessionKey: "agent:main:discord:direct:alice",
+        phase: "before_decision_use",
+        correlation: {
+          approvalKind: "exec",
+          approvalId: "approval-1",
+        },
+        details: expect.objectContaining({
+          carriedState: "resolved:allow-once",
+          liveState: "pending",
+        }),
+      }),
+    );
+  });
+
+  it("emits an info diagnostic when live approval lookup fails but still resolves the registered decision", async () => {
+    mocks.callGatewayTool.mockRejectedValue(new Error("gateway offline"));
+    mocks.resolveRegisteredExecApprovalDecision.mockResolvedValue(null);
+    const onFailure = vi.fn();
+
+    await expect(
+      resolveApprovalDecisionOrUndefined({
+        approvalId: "approval-2",
+        preResolvedDecision: undefined,
+        sessionKey: "session-main",
+        onFailure,
+      }),
+    ).resolves.toBeNull();
+
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(mocks.emitContinuityDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.approval.carry_mismatch",
+        severity: "info",
+        runId: "approval-2",
+        sessionKey: "session-main",
+        phase: "before_decision_use",
+        details: expect.objectContaining({
+          carriedState: "wait-for-live-decision",
+          liveState: "unknown",
+          error: "gateway offline",
+        }),
+      }),
+    );
   });
 });
 

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildExecApprovalUnavailableReplyPayload } from "../infra/exec-approval-reply.js";
 import {
@@ -24,6 +25,7 @@ import {
 import { buildApprovalPendingMessage } from "./bash-tools.exec-runtime.js";
 import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import { callGatewayTool } from "./tools/gateway.js";
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
 export const MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS = 256;
@@ -94,6 +96,18 @@ export type ExecApprovalFollowupResultDeps = {
   sendExecApprovalFollowup?: typeof sendExecApprovalFollowup;
   logWarn?: typeof logWarn;
 };
+
+type LiveExecApprovalState =
+  | {
+      ok: true;
+      pending: boolean;
+      request?: unknown;
+    }
+  | {
+      ok: false;
+      pending?: undefined;
+      error: string;
+    };
 
 export type DefaultExecApprovalRequestArgs = {
   warnings: string[];
@@ -213,17 +227,122 @@ export function resolveExecHostApprovalContext(params: {
 export async function resolveApprovalDecisionOrUndefined(params: {
   approvalId: string;
   preResolvedDecision: string | null | undefined;
+  sessionKey?: string;
   onFailure: () => void;
 }): Promise<string | null | undefined> {
+  const carriedState = describeCarriedApprovalState(params.preResolvedDecision);
+  const liveBefore = await resolveLiveExecApprovalState(params.approvalId);
+  if (params.preResolvedDecision !== undefined && liveBefore.ok && liveBefore.pending) {
+    emitApprovalCarryMismatch({
+      approvalId: params.approvalId,
+      sessionKey: params.sessionKey,
+      phase: "before_decision_use",
+      carriedState,
+      liveState: describeLiveApprovalState(liveBefore),
+    });
+  } else if (!liveBefore.ok) {
+    emitApprovalCarryMismatch({
+      approvalId: params.approvalId,
+      sessionKey: params.sessionKey,
+      phase: "before_decision_use",
+      severity: "info",
+      carriedState,
+      liveState: "unknown",
+      error: liveBefore.error,
+    });
+  }
   try {
-    return await resolveRegisteredExecApprovalDecision({
+    const decision = await resolveRegisteredExecApprovalDecision({
       approvalId: params.approvalId,
       preResolvedDecision: params.preResolvedDecision,
     });
+    const liveAfter = await resolveLiveExecApprovalState(params.approvalId);
+    if (liveAfter.ok && liveAfter.pending && decision !== undefined) {
+      emitApprovalCarryMismatch({
+        approvalId: params.approvalId,
+        sessionKey: params.sessionKey,
+        phase: "after_decision_resolve",
+        carriedState: `decision:${decision ?? "null"}`,
+        liveState: describeLiveApprovalState(liveAfter),
+      });
+    }
+    return decision;
   } catch {
     params.onFailure();
     return undefined;
   }
+}
+
+async function resolveLiveExecApprovalState(approvalId: string): Promise<LiveExecApprovalState> {
+  try {
+    const requests = await callGatewayTool<unknown[]>(
+      "exec.approval.list",
+      { timeoutMs: 3_000 },
+      {},
+      { expectFinal: false },
+    );
+    const list = Array.isArray(requests) ? requests : [];
+    const request = list.find(
+      (entry) =>
+        Boolean(entry) &&
+        typeof entry === "object" &&
+        (entry as { id?: unknown }).id === approvalId,
+    );
+    return {
+      ok: true,
+      pending: Boolean(request),
+      request,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: formatErrorMessage(err),
+    };
+  }
+}
+
+function emitApprovalCarryMismatch(params: {
+  approvalId: string;
+  sessionKey?: string;
+  phase: string;
+  severity?: "info" | "warn" | "error";
+  carriedState: string;
+  liveState: string;
+  error?: string;
+}): void {
+  emitContinuityDiagnostic({
+    type: "diag.approval.carry_mismatch",
+    severity: params.severity ?? "warn",
+    runId: params.approvalId,
+    sessionKey: params.sessionKey,
+    phase: params.phase,
+    correlation: {
+      approvalKind: "exec",
+      approvalId: params.approvalId,
+    },
+    details: {
+      carriedState: params.carriedState,
+      liveState: params.liveState,
+      error: params.error,
+    },
+  });
+}
+
+function describeCarriedApprovalState(decision: string | null | undefined): string {
+  if (decision === undefined) {
+    return "wait-for-live-decision";
+  }
+  if (decision === null) {
+    return "resolved:null";
+  }
+  return `resolved:${decision}`;
+}
+
+function describeLiveApprovalState(live: LiveExecApprovalState): string {
+  if (!live.ok) {
+    return "unknown";
+  }
+  return live.pending ? "pending" : "not-pending";
 }
 
 export function resolveExecApprovalUnavailableState(params: {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1,12 +1,25 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
+
+const emittedDiagnostics = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock("../../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: vi.fn((params: Record<string, unknown>) => {
+    emittedDiagnostics.push(params);
+    return params;
+  }),
+}));
 
 const deliverOutboundPayloadsMock = vi.hoisted(() =>
   vi.fn(async (..._args: unknown[]) => [] as unknown[]),
@@ -55,6 +68,27 @@ const slackRegistry = createTestRegistry([
   },
 ]);
 
+const tempDirs: string[] = [];
+
+async function createSessionStoreForTest(entries: Record<string, SessionEntry>): Promise<{
+  dir: string;
+  storePath: string;
+  cfg: OpenClawConfig;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-delivery-store-"));
+  tempDirs.push(dir);
+  const storePath = path.join(dir, "sessions.json");
+  await fs.writeFile(storePath, JSON.stringify(entries), "utf8");
+  return {
+    dir,
+    storePath,
+    cfg: {
+      session: { scope: "global", mainKey: "main", store: storePath },
+      agents: { list: [{ id: "tester", workspace: "/tmp/agent-workspace" }] },
+    } as OpenClawConfig,
+  };
+}
+
 function createResult(overrides: Partial<RunResult> = {}): RunResult {
   return {
     meta: {
@@ -90,11 +124,15 @@ async function deliverMediaReplyForTest(outboundSession: DeliverParams["outbound
 
 describe("normalizeAgentCommandReplyPayloads", () => {
   beforeEach(() => {
+    emittedDiagnostics.length = 0;
+    deliverOutboundPayloadsMock.mockClear();
+    createReplyMediaPathNormalizerMock.mockClear();
     setActivePluginRegistry(slackRegistry);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     setActivePluginRegistry(emptyRegistry);
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
   });
 
   it("keeps Slack directives in text for direct agent deliveries", () => {
@@ -262,5 +300,109 @@ describe("normalizeAgentCommandReplyPayloads", () => {
         text: "[[buttons: Release menu | Choose an action | Retry:retry, Ignore:ignore]]",
       },
     ]);
+  });
+
+  it("re-resolves outbound target from the live session entry before delivery", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    const now = Date.now();
+    const { cfg } = await createSessionStoreForTest({
+      global: {
+        sessionId: "session-live",
+        updatedAt: now,
+        lastChannel: "slack",
+        lastTo: "#live",
+      } as SessionEntry,
+    });
+
+    await deliverAgentCommandResult({
+      cfg,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "test",
+        deliver: true,
+      } as AgentCommandOpts,
+      outboundSession: { key: "main", agentId: "tester" } as never,
+      sessionEntry: {
+        sessionId: "session-live",
+        updatedAt: now - 1,
+        lastChannel: "slack",
+        lastTo: "#carried",
+      } as SessionEntry,
+      payloads: [{ text: "Ready." }],
+      result: createResult(),
+    });
+
+    const [deliverArgs] = deliverOutboundPayloadsMock.mock.calls[0] ?? [];
+    expect(deliverArgs).toMatchObject({ channel: "slack", to: "#live" });
+    expect(emittedDiagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "diag.outbound.target_reresolved",
+        severity: "warn",
+        phase: "before_delivery",
+      }),
+    );
+  });
+
+  it("uses restored boundary delivery metadata as a transient fallback", async () => {
+    const runtime = { log: vi.fn() };
+    const entry = {
+      sessionId: "session-restored",
+      updatedAt: Date.now(),
+      continuityRestore: {
+        usedBoundary: {
+          type: "continuity.restore.used_boundary",
+          checkpointId: "checkpoint-1",
+          boundaryId: "compact-boundary:test",
+          restoredAt: Date.now(),
+          boundaryMetadata: {
+            version: 1,
+            type: "compact.boundary",
+            boundaryId: "compact-boundary:test",
+            createdAt: Date.now(),
+            state: {
+              sessionBinding: { channel: "slack", accountId: "account-1", threadId: "thread-1" },
+              approval: { captured: false, reason: "captured elsewhere" },
+              outbound: { channel: "slack", targetId: "#restored", threadId: "thread-1" },
+              children: { pendingDescendantState: "live-query-required" },
+              policy: {},
+            },
+          },
+        },
+      },
+    } as SessionEntry;
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "test",
+      } as AgentCommandOpts,
+      outboundSession: { key: "main", agentId: "tester" } as never,
+      sessionEntry: entry,
+      payloads: [{ text: "Preview." }],
+      result: createResult(),
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith("Preview.");
+    expect(delivered.payloads).toMatchObject([{ text: "Preview." }]);
+    expect(entry.lastChannel).toBeUndefined();
+    expect(emittedDiagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "continuity.restore.boundary_fallback_applied",
+        severity: "info",
+        phase: "before_delivery",
+        correlation: expect.objectContaining({
+          boundaryId: "compact-boundary:test",
+          checkpointId: "checkpoint-1",
+          planSource: "carried",
+        }),
+        details: expect.objectContaining({
+          appliedFields: ["channel", "to", "accountId", "threadId"],
+        }),
+      }),
+    );
   });
 });

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -317,7 +317,7 @@ function readBoundaryDeliverySeed(entry: SessionEntry | undefined): BoundaryDeli
   const outbound = isPlainBoundaryObject(state.outbound) ? state.outbound : {};
   const binding = isPlainBoundaryObject(state.sessionBinding) ? state.sessionBinding : {};
   const channel = nonEmptyString(outbound.channel) ?? nonEmptyString(binding.channel);
-  const to = nonEmptyString(outbound.targetId) ?? nonEmptyString(binding.targetId);
+  const to = nonEmptyString(outbound.targetId);
   const accountId = nonEmptyString(binding.accountId);
   const threadId = nonEmptyString(outbound.threadId) ?? nonEmptyString(binding.threadId);
   if (!channel && !to && !accountId && !threadId) {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -6,9 +6,11 @@ import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-med
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
-import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitContinuityDiagnostic } from "../../infra/continuity-diagnostics.js";
 import {
+  type AgentDeliveryPlan,
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
@@ -25,6 +27,7 @@ import {
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { resolveGatewaySessionStoreTarget } from "../../gateway/session-utils.js";
 import { isNestedAgentLane } from "../lanes.js";
 import type { AgentCommandOpts } from "./types.js";
 
@@ -173,6 +176,258 @@ export function normalizeAgentCommandReplyPayloads(params: {
   return normalizedPayloads;
 }
 
+type LiveOutboundSessionEntry = {
+  entry: SessionEntry;
+  storeKey: string;
+  canonicalKey: string;
+};
+
+type DeliveryPlanArgs = Parameters<typeof resolveAgentDeliveryPlan>[0];
+
+type BoundaryDeliverySeed = {
+  boundaryId?: string;
+  checkpointId?: string;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  threadId?: string;
+};
+
+function loadLiveOutboundSessionEntry(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+}): LiveOutboundSessionEntry | null {
+  const sessionKey = typeof params.sessionKey === "string" && params.sessionKey.trim()
+    ? params.sessionKey.trim()
+    : "";
+  if (!sessionKey) {
+    return null;
+  }
+  try {
+    const target = resolveGatewaySessionStoreTarget({
+      cfg: params.cfg,
+      key: sessionKey,
+    });
+    const store = loadSessionStore(target.storePath);
+    for (const key of target.storeKeys ?? []) {
+      const entry = store[key];
+      if (entry) {
+        return {
+          entry,
+          storeKey: key,
+          canonicalKey: target.canonicalKey,
+        };
+      }
+    }
+    const entry = store[target.canonicalKey];
+    return entry
+      ? {
+          entry,
+          storeKey: target.canonicalKey,
+          canonicalKey: target.canonicalKey,
+        }
+      : null;
+  } catch (err) {
+    emitContinuityDiagnostic({
+      type: "diag.outbound.live_lookup_failed",
+      severity: "info",
+      sessionKey,
+      phase: "before_delivery",
+      correlation: { sessionKey },
+      details: { error: err instanceof Error ? err.message : String(err) },
+    });
+    return null;
+  }
+}
+
+function snapshotDeliveryPlan(plan: AgentDeliveryPlan): Record<string, unknown> {
+  return {
+    channel: plan.resolvedChannel,
+    to: plan.resolvedTo,
+    accountId: plan.resolvedAccountId,
+    threadId: plan.resolvedThreadId,
+    targetMode: plan.deliveryTargetMode,
+  };
+}
+
+function stableJson(value: Record<string, unknown>): string {
+  return JSON.stringify(value, Object.keys(value).sort());
+}
+
+function maybeEmitOutboundReresolveDiagnostic(params: {
+  sessionKey?: string;
+  carriedPlan: AgentDeliveryPlan;
+  livePlan: AgentDeliveryPlan | null;
+  carriedEntry?: SessionEntry;
+  liveEntry?: SessionEntry;
+  liveStoreKey?: string;
+}): void {
+  if (!params.livePlan) {
+    return;
+  }
+  const carried = snapshotDeliveryPlan(params.carriedPlan);
+  const live = snapshotDeliveryPlan(params.livePlan);
+  if (stableJson(carried) === stableJson(live)) {
+    return;
+  }
+  emitContinuityDiagnostic({
+    type: "diag.outbound.target_reresolved",
+    severity: "warn",
+    sessionKey: params.sessionKey,
+    phase: "before_delivery",
+    correlation: {
+      sessionKey: params.sessionKey,
+      storeKey: params.liveStoreKey,
+    },
+    details: {
+      carried,
+      live,
+      carriedUpdatedAt: params.carriedEntry?.updatedAt,
+      liveUpdatedAt: params.liveEntry?.updatedAt,
+    },
+  });
+}
+
+function isPlainBoundaryObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() ? value.trim() : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readBoundaryDeliverySeed(entry: SessionEntry | undefined): BoundaryDeliverySeed | null {
+  const restore = isPlainBoundaryObject(entry?.continuityRestore)
+    ? entry.continuityRestore
+    : undefined;
+  const marker = isPlainBoundaryObject(restore?.usedBoundary) ? restore.usedBoundary : undefined;
+  const metadata = isPlainBoundaryObject(marker?.boundaryMetadata)
+    ? marker.boundaryMetadata
+    : undefined;
+  const state = isPlainBoundaryObject(metadata?.state) ? metadata.state : undefined;
+  if (!marker || !metadata || !state) {
+    return null;
+  }
+  const outbound = isPlainBoundaryObject(state.outbound) ? state.outbound : {};
+  const binding = isPlainBoundaryObject(state.sessionBinding) ? state.sessionBinding : {};
+  const channel = nonEmptyString(outbound.channel) ?? nonEmptyString(binding.channel);
+  const to = nonEmptyString(outbound.targetId) ?? nonEmptyString(binding.targetId);
+  const accountId = nonEmptyString(binding.accountId);
+  const threadId = nonEmptyString(outbound.threadId) ?? nonEmptyString(binding.threadId);
+  if (!channel && !to && !accountId && !threadId) {
+    return null;
+  }
+  return {
+    boundaryId:
+      nonEmptyString(marker.boundaryId) ??
+      nonEmptyString(metadata.boundaryId) ??
+      nonEmptyString(marker.checkpointId),
+    checkpointId: nonEmptyString(marker.checkpointId),
+    channel,
+    to,
+    accountId,
+    threadId,
+  };
+}
+
+function missingDeliveryField(entry: SessionEntry | undefined, field: keyof SessionEntry): boolean {
+  if (!entry) {
+    return true;
+  }
+  const value = entry[field];
+  return value === undefined || value === null || value === "";
+}
+
+function applyBoundaryDeliveryFallback(entry: SessionEntry | undefined): {
+  entry: SessionEntry | undefined;
+  appliedFields: string[];
+  seed: BoundaryDeliverySeed | null;
+} {
+  const seed = readBoundaryDeliverySeed(entry);
+  if (!seed) {
+    return { entry, appliedFields: [], seed: null };
+  }
+  const next: SessionEntry = entry ? { ...entry } : ({ sessionId: "" } as SessionEntry);
+  const appliedFields: string[] = [];
+  const context = isPlainBoundaryObject(next.deliveryContext) ? { ...next.deliveryContext } : {};
+  if (
+    seed.channel &&
+    missingDeliveryField(next, "lastChannel") &&
+    missingDeliveryField(next, "channel") &&
+    !nonEmptyString(context.channel)
+  ) {
+    next.lastChannel = seed.channel as SessionEntry["lastChannel"];
+    context.channel = seed.channel;
+    appliedFields.push("channel");
+  }
+  if (seed.to && missingDeliveryField(next, "lastTo") && !nonEmptyString(context.to)) {
+    next.lastTo = seed.to;
+    context.to = seed.to;
+    appliedFields.push("to");
+  }
+  if (
+    seed.accountId &&
+    missingDeliveryField(next, "lastAccountId") &&
+    !nonEmptyString(context.accountId)
+  ) {
+    next.lastAccountId = seed.accountId;
+    context.accountId = seed.accountId;
+    appliedFields.push("accountId");
+  }
+  if (
+    seed.threadId &&
+    missingDeliveryField(next, "lastThreadId") &&
+    !nonEmptyString(context.threadId)
+  ) {
+    next.lastThreadId = seed.threadId;
+    context.threadId = seed.threadId;
+    appliedFields.push("threadId");
+  }
+  if (appliedFields.length > 0) {
+    next.deliveryContext = context as SessionEntry["deliveryContext"];
+  }
+  return {
+    entry: appliedFields.length > 0 ? next : entry,
+    appliedFields,
+    seed,
+  };
+}
+
+function maybeEmitBoundaryDeliveryFallbackDiagnostic(params: {
+  sessionKey?: string;
+  planSource: "live" | "carried";
+  appliedFields?: string[];
+  seed?: BoundaryDeliverySeed | null;
+  plan?: AgentDeliveryPlan;
+}): void {
+  if (!params.appliedFields?.length || !params.seed) {
+    return;
+  }
+  emitContinuityDiagnostic({
+    type: "continuity.restore.boundary_fallback_applied",
+    severity: "info",
+    sessionKey: params.sessionKey,
+    phase: "before_delivery",
+    correlation: {
+      boundaryId: params.seed.boundaryId,
+      checkpointId: params.seed.checkpointId,
+      sessionKey: params.sessionKey,
+      planSource: params.planSource,
+    },
+    details: {
+      appliedFields: params.appliedFields,
+      seed: params.seed,
+      plan: params.plan ? snapshotDeliveryPlan(params.plan) : undefined,
+    },
+  });
+}
+
 export async function deliverAgentCommandResult(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
@@ -182,6 +437,7 @@ export async function deliverAgentCommandResult(params: {
   sessionEntry: SessionEntry | undefined;
   result: RunResult;
   payloads: RunResult["payloads"];
+  hasPendingSpawnedChildren?: boolean;
 }) {
   const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
   const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
@@ -191,8 +447,7 @@ export async function deliverAgentCommandResult(params: {
   const turnSourceTo = opts.runContext?.currentChannelId ?? opts.to;
   const turnSourceAccountId = opts.runContext?.accountId ?? opts.accountId;
   const turnSourceThreadId = opts.runContext?.currentThreadTs ?? opts.threadId;
-  const deliveryPlan = resolveAgentDeliveryPlan({
-    sessionEntry,
+  const deliveryPlanArgs: Omit<DeliveryPlanArgs, "sessionEntry"> = {
     requestedChannel: opts.replyChannel ?? opts.channel,
     explicitTo: opts.replyTo ?? opts.to,
     explicitThreadId: opts.threadId,
@@ -202,6 +457,43 @@ export async function deliverAgentCommandResult(params: {
     turnSourceTo,
     turnSourceAccountId,
     turnSourceThreadId,
+  };
+  const carriedBoundaryFallback = applyBoundaryDeliveryFallback(sessionEntry);
+  const carriedDeliveryPlan = resolveAgentDeliveryPlan({
+    sessionEntry: carriedBoundaryFallback.entry,
+    ...deliveryPlanArgs,
+  });
+  const liveOutboundSession = deliver
+    ? loadLiveOutboundSessionEntry({
+        cfg,
+        sessionKey: effectiveSessionKey,
+      })
+    : null;
+  const liveBoundaryFallback = liveOutboundSession?.entry
+    ? applyBoundaryDeliveryFallback(liveOutboundSession.entry)
+    : null;
+  const liveDeliveryPlan = liveBoundaryFallback?.entry
+    ? resolveAgentDeliveryPlan({
+        sessionEntry: liveBoundaryFallback.entry,
+        ...deliveryPlanArgs,
+      })
+    : null;
+  maybeEmitOutboundReresolveDiagnostic({
+    sessionKey: effectiveSessionKey,
+    carriedPlan: carriedDeliveryPlan,
+    livePlan: liveDeliveryPlan,
+    carriedEntry: sessionEntry,
+    liveEntry: liveOutboundSession?.entry,
+    liveStoreKey: liveOutboundSession?.storeKey,
+  });
+  const deliveryPlan = liveDeliveryPlan ?? carriedDeliveryPlan;
+  const selectedFallback = liveDeliveryPlan ? liveBoundaryFallback : carriedBoundaryFallback;
+  maybeEmitBoundaryDeliveryFallbackDiagnostic({
+    sessionKey: effectiveSessionKey,
+    planSource: liveDeliveryPlan ? "live" : "carried",
+    appliedFields: selectedFallback?.appliedFields,
+    seed: selectedFallback?.seed,
+    plan: deliveryPlan,
   });
   let deliveryChannel = deliveryPlan.resolvedChannel;
   const explicitChannelHint = (opts.replyChannel ?? opts.channel)?.trim();
@@ -319,7 +611,12 @@ export async function deliverAgentCommandResult(params: {
           accountId: resolvedAccountId,
         })
       : normalizedReplyPayloads;
-  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
+  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads, {
+    cfg,
+    sessionKey: effectiveSessionKey,
+    surface: deliveryChannel,
+    hasPendingSpawnedChildren: params.hasPendingSpawnedChildren,
+  });
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   if (opts.json) {
     runtime.log(

--- a/src/agents/pi-embedded-runner/compact-boundary-metadata.test.ts
+++ b/src/agents/pi-embedded-runner/compact-boundary-metadata.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { __testing, buildCompactBoundaryMetadata } from "./compact-boundary-metadata.js";
+
+describe("compact-boundary-metadata", () => {
+  test("builds the minimal compact boundary metadata state", () => {
+    const metadata = buildCompactBoundaryMetadata({
+      diagId: "diag-1",
+      createdAt: 123,
+      sessionKey: " session-main ",
+      sessionId: "session-id",
+      sessionAgentId: "agent-main",
+      channel: "discord",
+      accountId: "account-1",
+      targetId: "user-1",
+      threadId: 42,
+      messageId: " msg-1 ",
+      sandboxEnabled: true,
+      sandboxWorkspaceAccess: "read-write",
+      bashElevated: false,
+      provider: "openai",
+      model: "gpt-test",
+      thinkLevel: "high",
+      trigger: "manual",
+    });
+
+    expect(metadata).toEqual({
+      version: 1,
+      type: "compact.boundary",
+      boundaryId: "compact-boundary:diag-1",
+      createdAt: 123,
+      state: {
+        sessionBinding: {
+          sessionKey: "session-main",
+          sessionId: "session-id",
+          agentId: "agent-main",
+          channel: "discord",
+          accountId: "account-1",
+          threadId: "42",
+          messageId: "msg-1",
+        },
+        approval: {
+          captured: false,
+          reason: "approval live state is captured by the dedicated approval mismatch guard",
+        },
+        outbound: {
+          channel: "discord",
+          targetId: "user-1",
+          threadId: "42",
+          replyToMessageId: "msg-1",
+        },
+        children: {
+          pendingDescendantState: "live-query-required",
+          livePendingDescendants: undefined,
+        },
+        policy: {
+          sandboxEnabled: true,
+          sandboxWorkspaceAccess: "read-write",
+          bashElevated: false,
+          provider: "openai",
+          model: "gpt-test",
+          thinkingLevel: "high",
+          trigger: "manual",
+        },
+      },
+    });
+  });
+
+  test("normalizes only compact boundary primitives", () => {
+    expect(__testing.compactBoundaryString(" value ")).toBe("value");
+    expect(__testing.compactBoundaryString(123)).toBe("123");
+    expect(__testing.compactBoundaryString("   ")).toBeUndefined();
+    expect(__testing.compactBoundaryString(Number.NaN)).toBeUndefined();
+    expect(__testing.compactBoundaryBoolean(true)).toBe(true);
+    expect(__testing.compactBoundaryBoolean("true")).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/compact-boundary-metadata.ts
+++ b/src/agents/pi-embedded-runner/compact-boundary-metadata.ts
@@ -1,0 +1,87 @@
+import type { SessionCompactionBoundaryMetadata } from "../../config/sessions/types.js";
+
+export type BuildCompactBoundaryMetadataParams = {
+  diagId: string;
+  createdAt: number;
+  sessionKey?: string;
+  sessionId?: string;
+  sessionAgentId?: string;
+  channel?: string;
+  accountId?: string;
+  targetId?: string;
+  threadId?: string | number;
+  messageId?: string | number;
+  livePendingDescendants?: boolean;
+  sandboxEnabled?: boolean;
+  sandboxWorkspaceAccess?: string;
+  bashElevated?: unknown;
+  provider?: string;
+  model?: string;
+  thinkLevel?: string;
+  trigger?: string;
+};
+
+function compactBoundaryString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() ? value.trim() : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function compactBoundaryBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function buildCompactBoundaryMetadata(
+  params: BuildCompactBoundaryMetadataParams,
+): SessionCompactionBoundaryMetadata {
+  const boundaryId = `compact-boundary:${params.diagId}`;
+  return {
+    version: 1,
+    type: "compact.boundary",
+    boundaryId,
+    createdAt: params.createdAt,
+    state: {
+      sessionBinding: {
+        sessionKey: compactBoundaryString(params.sessionKey),
+        sessionId: compactBoundaryString(params.sessionId),
+        agentId: compactBoundaryString(params.sessionAgentId),
+        channel: compactBoundaryString(params.channel),
+        accountId: compactBoundaryString(params.accountId),
+        threadId: compactBoundaryString(params.threadId),
+        messageId: compactBoundaryString(params.messageId),
+      },
+      approval: {
+        captured: false,
+        reason: "approval live state is captured by the dedicated approval mismatch guard",
+      },
+      outbound: {
+        channel: compactBoundaryString(params.channel),
+        targetId: compactBoundaryString(params.targetId),
+        threadId: compactBoundaryString(params.threadId),
+        replyToMessageId: compactBoundaryString(params.messageId),
+      },
+      children: {
+        pendingDescendantState: "live-query-required",
+        livePendingDescendants: compactBoundaryBoolean(params.livePendingDescendants),
+      },
+      policy: {
+        sandboxEnabled: compactBoundaryBoolean(params.sandboxEnabled),
+        sandboxWorkspaceAccess: compactBoundaryString(params.sandboxWorkspaceAccess),
+        bashElevated: compactBoundaryBoolean(params.bashElevated),
+        provider: compactBoundaryString(params.provider),
+        model: compactBoundaryString(params.model),
+        thinkingLevel: compactBoundaryString(params.thinkLevel),
+        trigger: compactBoundaryString(params.trigger),
+      },
+    },
+  };
+}
+
+export const __testing = {
+  compactBoundaryBoolean,
+  compactBoundaryString,
+};

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -20,6 +20,7 @@ import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { maybeCompactAgentHarnessSession } from "../harness/selection.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
+import { buildCompactBoundaryMetadata } from "./compact-boundary-metadata.js";
 import type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";
 import {
@@ -178,6 +179,22 @@ export async function compactEmbeddedPiSession(
                 postSessionFile: params.sessionFile,
                 postLeafId,
                 postEntryId: postLeafId,
+                boundaryMetadata: buildCompactBoundaryMetadata({
+                  diagId: params.diagId ?? params.runId ?? params.sessionId,
+                  createdAt: Date.now(),
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  sessionAgentId,
+                  channel: params.messageChannel ?? params.messageProvider,
+                  accountId: params.agentAccountId,
+                  targetId: params.currentChannelId,
+                  threadId: params.currentThreadTs,
+                  messageId: params.currentMessageId,
+                  provider: ceProvider,
+                  model: ceModelId,
+                  thinkLevel: params.thinkLevel,
+                  trigger: params.trigger,
+                }),
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;
             } catch (err) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -99,6 +99,7 @@ import {
 } from "../skills.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
 import { classifyCompactionReason, resolveCompactionFailureReason } from "./compact-reasons.js";
+import { buildCompactBoundaryMetadata } from "./compact-boundary-metadata.js";
 import type { CompactEmbeddedPiSessionParams, CompactionMessageMetrics } from "./compact.types.js";
 import {
   asCompactionHookRunner,
@@ -1126,6 +1127,25 @@ export async function compactEmbeddedPiSessionDirect(
                 postLeafId: postCompactionLeafId,
                 postEntryId: postCompactionLeafId,
                 createdAt: compactStartedAt,
+                boundaryMetadata: buildCompactBoundaryMetadata({
+                  diagId,
+                  createdAt: compactStartedAt,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  sessionAgentId,
+                  channel: runtimeChannel,
+                  accountId: params.agentAccountId,
+                  targetId: params.currentChannelId,
+                  threadId: params.currentThreadTs,
+                  messageId: params.currentMessageId,
+                  sandboxEnabled: sandbox?.enabled === true,
+                  sandboxWorkspaceAccess: sandbox?.workspaceAccess,
+                  bashElevated: params.bashElevated,
+                  provider,
+                  model: modelId,
+                  thinkLevel,
+                  trigger,
+                }),
               });
               checkpointSnapshotRetained = storedCheckpoint !== null;
             } catch (err) {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -679,7 +679,7 @@ describe("before_tool_call requireApproval handling", () => {
     });
 
     expect(result.blocked).toBe(false);
-    expect(mockCallGateway).toHaveBeenCalledTimes(2);
+    expect(mockCallGateway).toHaveBeenCalledTimes(3);
     expect(mockCallGateway).toHaveBeenCalledWith(
       "plugin.approval.request",
       expect.any(Object),
@@ -825,6 +825,7 @@ describe("before_tool_call requireApproval handling", () => {
     expect(onResolution).toHaveBeenCalledWith("cancelled");
     expect(mockCallGateway.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
+      "plugin.approval.list",
     ]);
   });
 

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,4 +1,5 @@
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 import {
   diagnosticErrorCategory,
   diagnosticHttpStatusCode,
@@ -45,6 +46,18 @@ const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
 
+type LivePluginApprovalState =
+  | {
+      ok: true;
+      pending: boolean;
+      request?: unknown;
+    }
+  | {
+      ok: false;
+      pending?: undefined;
+      error: string;
+    };
+
 const loadBeforeToolCallRuntime = createLazyRuntimeSurface(
   () => import("./pi-tools.before-tool-call.runtime.js"),
   ({ beforeToolCallRuntime }) => beforeToolCallRuntime,
@@ -55,6 +68,85 @@ function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }):
     return `${params.runId}:${params.toolCallId}`;
   }
   return params.toolCallId;
+}
+
+async function resolveLivePluginApprovalState(
+  approvalId: string,
+): Promise<LivePluginApprovalState> {
+  try {
+    const requests = await callGatewayTool<unknown[]>(
+      "plugin.approval.list",
+      { timeoutMs: 3_000 },
+      {},
+      { expectFinal: false },
+    );
+    const list = Array.isArray(requests) ? requests : [];
+    const request = list.find(
+      (entry) =>
+        Boolean(entry) &&
+        typeof entry === "object" &&
+        (entry as { id?: unknown }).id === approvalId,
+    );
+    return {
+      ok: true,
+      pending: Boolean(request),
+      request,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function describePluginCarriedApprovalState(decision: string | null | undefined): string {
+  if (decision === undefined) {
+    return "wait-for-live-decision";
+  }
+  if (decision === null) {
+    return "resolved:null";
+  }
+  return `resolved:${decision}`;
+}
+
+function describePluginLiveApprovalState(live: LivePluginApprovalState): string {
+  if (!live.ok) {
+    return "unknown";
+  }
+  return live.pending ? "pending" : "not-pending";
+}
+
+function emitPluginApprovalCarryMismatch(params: {
+  approvalId: string;
+  sessionKey?: string;
+  runId?: string;
+  toolName: string;
+  toolCallId?: string;
+  phase: string;
+  severity?: "info" | "warn" | "error";
+  carriedState: string;
+  liveState: string;
+  error?: string;
+}): void {
+  emitContinuityDiagnostic({
+    type: "diag.approval.carry_mismatch",
+    severity: params.severity ?? "warn",
+    runId: params.runId ?? params.approvalId,
+    sessionKey: params.sessionKey,
+    phase: params.phase,
+    correlation: {
+      approvalKind: "plugin",
+      approvalId: params.approvalId,
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+    },
+    details: {
+      carriedState: params.carriedState,
+      liveState: params.liveState,
+      error: params.error,
+    },
+  });
 }
 
 function mergeParamsWithApprovalOverrides(
@@ -315,9 +407,39 @@ export async function runBeforeToolCallHook(args: {
           requestResult ?? {},
           "decision",
         );
+        const preResolvedDecision = hasImmediateDecision ? requestResult?.decision : undefined;
+        const carriedState = describePluginCarriedApprovalState(preResolvedDecision);
+        if (hasImmediateDecision) {
+          const liveBefore = await resolveLivePluginApprovalState(id);
+          if (liveBefore.ok && liveBefore.pending) {
+            emitPluginApprovalCarryMismatch({
+              approvalId: id,
+              sessionKey: args.ctx?.sessionKey,
+              runId: args.ctx?.runId,
+              toolName,
+              toolCallId: args.toolCallId,
+              phase: "before_plugin_decision_use",
+              carriedState,
+              liveState: describePluginLiveApprovalState(liveBefore),
+            });
+          } else if (!liveBefore.ok) {
+            emitPluginApprovalCarryMismatch({
+              approvalId: id,
+              sessionKey: args.ctx?.sessionKey,
+              runId: args.ctx?.runId,
+              toolName,
+              toolCallId: args.toolCallId,
+              phase: "before_plugin_decision_use",
+              severity: "info",
+              carriedState,
+              liveState: "unknown",
+              error: liveBefore.error,
+            });
+          }
+        }
         let decision: string | null | undefined;
         if (hasImmediateDecision) {
-          decision = requestResult?.decision;
+          decision = preResolvedDecision;
           if (decision === null) {
             safeOnResolution(PluginApprovalResolutions.CANCELLED);
             return {
@@ -360,6 +482,19 @@ export async function runBeforeToolCallHook(args: {
             waitResult = await waitPromise;
           }
           decision = waitResult?.decision;
+        }
+        const liveAfter = await resolveLivePluginApprovalState(id);
+        if (liveAfter.ok && liveAfter.pending && decision !== undefined) {
+          emitPluginApprovalCarryMismatch({
+            approvalId: id,
+            sessionKey: args.ctx?.sessionKey,
+            runId: args.ctx?.runId,
+            toolName,
+            toolCallId: args.toolCallId,
+            phase: "after_plugin_decision_resolve",
+            carriedState: `decision:${decision ?? "null"}`,
+            liveState: describePluginLiveApprovalState(liveAfter),
+          });
         }
         const resolution: PluginApprovalResolution =
           decision === PluginApprovalResolutions.ALLOW_ONCE ||

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -16,6 +16,7 @@ const readLatestAssistantReplyMock = vi.fn(async (_params?: unknown) => "raw sub
 const isEmbeddedPiRunActiveMock = vi.fn((_sessionId: string) => false);
 const queueEmbeddedPiMessageMock = vi.fn((_sessionId: string, _text: string) => false);
 const waitForEmbeddedPiRunEndMock = vi.fn(async (_sessionId: string, _timeoutMs?: number) => true);
+const emitContinuityDiagnosticMock = vi.hoisted(() => vi.fn());
 let mockConfig: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
   session: {
     mainKey: "main",
@@ -34,6 +35,10 @@ const { subagentRegistryRuntimeMock } = vi.hoisted(() => ({
     replaceSubagentRunAfterSteer: vi.fn(() => true),
     resolveRequesterForChildSession: vi.fn(() => null),
   },
+}));
+
+vi.mock("../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: emitContinuityDiagnosticMock,
 }));
 
 vi.mock("./subagent-announce.runtime.js", () => ({
@@ -228,6 +233,7 @@ describe("subagent announce seam flow", () => {
     isEmbeddedPiRunActiveMock.mockReset().mockReturnValue(false);
     queueEmbeddedPiMessageMock.mockReset().mockReturnValue(false);
     waitForEmbeddedPiRunEndMock.mockReset().mockResolvedValue(true);
+    emitContinuityDiagnosticMock.mockClear();
     mockConfig = {
       session: {
         mainKey: "main",
@@ -250,6 +256,32 @@ describe("subagent announce seam flow", () => {
     subagentRegistryRuntimeMock.replaceSubagentRunAfterSteer.mockReturnValue(true);
     subagentRegistryRuntimeMock.resolveRequesterForChildSession.mockReset();
     subagentRegistryRuntimeMock.resolveRequesterForChildSession.mockReturnValue(null);
+  });
+
+  it("emits announce delivery outcome diagnostics", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:child",
+      childRunId: "run-child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "summarize results",
+      timeoutMs: 100,
+      cleanup: "keep",
+      roundOneReply: "done",
+      waitForCompletion: false,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(emitContinuityDiagnosticMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.subagent.announce_delivery_outcome",
+        severity: "info",
+        sessionKey: "agent:main:subagent:child",
+        runId: "run-child",
+        phase: "announce_delivery",
+        details: expect.objectContaining({ delivered: true, path: "direct" }),
+      }),
+    );
   });
 
   it("suppresses ANNOUNCE_SKIP delivery while still deleting the child session", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -6,6 +6,7 @@ import {
   stripSilentToken,
 } from "../auto-reply/tokens.js";
 import { defaultRuntime } from "../runtime.js";
+import { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
@@ -566,12 +567,51 @@ export async function runSubagentAnnounceFlow(params: {
     });
     params.onDeliveryResult?.(delivery);
     didAnnounce = delivery.delivered;
+    emitContinuityDiagnostic({
+      type: "diag.subagent.announce_delivery_outcome",
+      severity: delivery.delivered ? "info" : "warn",
+      sessionKey: params.childSessionKey,
+      runId: params.childRunId,
+      phase: "announce_delivery",
+      correlation: {
+        runId: params.childRunId,
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: targetRequesterSessionKey,
+        announceId,
+        path: delivery.path,
+      },
+      details: {
+        delivered: delivery.delivered,
+        path: delivery.path,
+        error: delivery.error,
+        announceType,
+        requesterIsSubagent,
+        expectsCompletionMessage,
+        targetRequesterSessionKey,
+      },
+    });
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.error?.(
         `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
       );
     }
   } catch (err) {
+    emitContinuityDiagnostic({
+      type: "diag.subagent.announce_flow_error",
+      severity: "warn",
+      sessionKey: params.childSessionKey,
+      runId: params.childRunId,
+      phase: "announce_delivery",
+      correlation: {
+        runId: params.childRunId,
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: params.requesterSessionKey,
+      },
+      details: {
+        error: err instanceof Error ? err.message : String(err),
+        announceType,
+      },
+    });
     defaultRuntime.error?.(`Subagent announce failed: ${String(err)}`);
     // Best-effort follow-ups; ignore failures to avoid breaking the caller response.
   } finally {

--- a/src/agents/subagent-registry-completion.test.ts
+++ b/src/agents/subagent-registry-completion.test.ts
@@ -5,6 +5,11 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 const lifecycleMocks = vi.hoisted(() => ({
   getGlobalHookRunner: vi.fn(),
   runSubagentEnded: vi.fn(async () => {}),
+  emitContinuityDiagnostic: vi.fn(),
+}));
+
+vi.mock("../infra/continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: lifecycleMocks.emitContinuityDiagnostic,
 }));
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
@@ -47,6 +52,7 @@ describe("emitSubagentEndedHookOnce", () => {
   beforeEach(() => {
     lifecycleMocks.getGlobalHookRunner.mockClear();
     lifecycleMocks.runSubagentEnded.mockClear();
+    lifecycleMocks.emitContinuityDiagnostic.mockClear();
   });
 
   it("treats timing differences as different only after both outcomes have timing", () => {
@@ -80,6 +86,47 @@ describe("emitSubagentEndedHookOnce", () => {
         { status: "ok" },
       ),
     ).toBe(false);
+  });
+
+  it("records child terminal state separately from announce outcome", () => {
+    const entry = createRunEntry();
+
+    expect(
+      mod.recordSubagentTerminalState(entry, {
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        outcome: { status: "ok", startedAt: 10, endedAt: 20, elapsedMs: 10 },
+        endedAt: 20,
+      }),
+    ).toBe(true);
+    expect(entry.childTerminalState).toMatchObject({
+      type: "subagent.child.terminal_state",
+      status: "ok",
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      runId: entry.runId,
+      childSessionKey: entry.childSessionKey,
+    });
+
+    expect(
+      mod.recordSubagentAnnounceOutcome(entry, {
+        status: "delivered",
+        reason: "announce-delivered",
+        delivered: true,
+        cleanup: "keep",
+      }),
+    ).toBe(true);
+    expect(entry.announceOutcome).toMatchObject({
+      type: "subagent.announce_outcome",
+      status: "delivered",
+      delivered: true,
+      cleanup: "keep",
+    });
+    expect(entry.childTerminalState?.status).toBe("ok");
+    expect(lifecycleMocks.emitContinuityDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "diag.subagent.child_terminal_state" }),
+    );
+    expect(lifecycleMocks.emitContinuityDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "diag.subagent.announce_outcome" }),
+    );
   });
 
   it("records ended hook marker even when no subagent_ended hooks are registered", async () => {

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
@@ -9,6 +10,22 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+function sameShallowRecord(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  if (!a) {
+    return false;
+  }
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 export function runOutcomesEqual(
   a: SubagentRunOutcome | undefined,
@@ -61,6 +78,112 @@ export function resolveLifecycleOutcomeFromRunOutcome(
     return SUBAGENT_ENDED_OUTCOME_TIMEOUT;
   }
   return SUBAGENT_ENDED_OUTCOME_OK;
+}
+
+export function recordSubagentTerminalState(
+  entry: SubagentRunRecord,
+  params: {
+    reason: SubagentLifecycleEndedReason;
+    outcome?: SubagentRunOutcome;
+    endedAt?: number;
+  },
+): boolean {
+  const outcome = params.outcome ?? { status: "unknown" };
+  const next = {
+    type: "subagent.child.terminal_state" as const,
+    status: typeof outcome.status === "string" ? outcome.status : "unknown",
+    reason: params.reason,
+    runId: entry.runId,
+    childSessionKey: entry.childSessionKey,
+    requesterSessionKey: entry.requesterSessionKey,
+    startedAt: typeof outcome.startedAt === "number" ? outcome.startedAt : entry.startedAt,
+    endedAt: params.endedAt,
+    elapsedMs: typeof outcome.elapsedMs === "number" ? outcome.elapsedMs : undefined,
+    error: typeof outcome.error === "string" ? outcome.error : undefined,
+    recordedAt: Date.now(),
+  };
+  const comparableKeys = ["status", "reason", "startedAt", "endedAt", "elapsedMs", "error"];
+  if (sameShallowRecord(entry.childTerminalState, next, comparableKeys)) {
+    return false;
+  }
+  const previous = entry.childTerminalState;
+  entry.childTerminalState = next;
+  emitContinuityDiagnostic({
+    type: "diag.subagent.child_terminal_state",
+    severity: next.status === "error" || next.status === "timeout" ? "warn" : "info",
+    sessionKey: entry.childSessionKey,
+    runId: entry.runId,
+    phase: "subagent_terminal",
+    correlation: {
+      runId: entry.runId,
+      childSessionKey: entry.childSessionKey,
+      requesterSessionKey: entry.requesterSessionKey,
+    },
+    details: {
+      terminalState: next,
+      previousStatus: previous?.status,
+      previousReason: previous?.reason,
+    },
+  });
+  return true;
+}
+
+export function recordSubagentAnnounceOutcome(
+  entry: SubagentRunRecord,
+  params: {
+    status: "delivered" | "deferred" | "failed" | "skipped";
+    reason: string;
+    delivered: boolean;
+    cleanup: "delete" | "keep";
+    nextDelayMs?: number;
+  },
+): boolean {
+  const next = {
+    type: "subagent.announce_outcome" as const,
+    status: params.status,
+    reason: params.reason,
+    delivered: params.delivered,
+    cleanup: params.cleanup,
+    runId: entry.runId,
+    childSessionKey: entry.childSessionKey,
+    requesterSessionKey: entry.requesterSessionKey,
+    completionAnnouncedAt: entry.completionAnnouncedAt,
+    retryCount: entry.announceRetryCount,
+    nextDelayMs: params.nextDelayMs,
+    recordedAt: Date.now(),
+  };
+  const comparableKeys = [
+    "status",
+    "reason",
+    "delivered",
+    "cleanup",
+    "completionAnnouncedAt",
+    "retryCount",
+    "nextDelayMs",
+  ];
+  if (sameShallowRecord(entry.announceOutcome, next, comparableKeys)) {
+    return false;
+  }
+  const previous = entry.announceOutcome;
+  entry.announceOutcome = next;
+  emitContinuityDiagnostic({
+    type: "diag.subagent.announce_outcome",
+    severity: params.status === "failed" ? "warn" : "info",
+    sessionKey: entry.childSessionKey,
+    runId: entry.runId,
+    phase: "subagent_announce",
+    correlation: {
+      runId: entry.runId,
+      childSessionKey: entry.childSessionKey,
+      requesterSessionKey: entry.requesterSessionKey,
+    },
+    details: {
+      announceOutcome: next,
+      previousStatus: previous?.status,
+      previousReason: previous?.reason,
+    },
+  });
+  return true;
 }
 
 export async function emitSubagentEndedHookOnce(params: {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -20,7 +20,11 @@ import {
   resolveCleanupCompletionReason,
   resolveDeferredCleanupDecision,
 } from "./subagent-registry-cleanup.js";
-import { shouldUpdateRunOutcome } from "./subagent-registry-completion.js";
+import {
+  recordSubagentAnnounceOutcome,
+  recordSubagentTerminalState,
+  shouldUpdateRunOutcome,
+} from "./subagent-registry-completion.js";
 import {
   ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
   ANNOUNCE_EXPIRY_MS,
@@ -475,6 +479,16 @@ export function createSubagentRegistryLifecycleController(params: {
     if (didAnnounce) {
       if (!options?.skipAnnounce) {
         entry.completionAnnouncedAt = Date.now();
+      }
+      if (
+        recordSubagentAnnounceOutcome(entry, {
+          status: options?.skipAnnounce ? "skipped" : "delivered",
+          reason: options?.skipAnnounce ? "already-announced" : "announce-delivered",
+          delivered: true,
+          cleanup,
+        }) ||
+        !options?.skipAnnounce
+      ) {
         params.persist();
       }
       safeSetSubagentTaskDeliveryStatus({
@@ -521,6 +535,13 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.lastAnnounceRetryAt = now;
       entry.wakeOnDescendantSettle = true;
       entry.cleanupHandled = false;
+      recordSubagentAnnounceOutcome(entry, {
+        status: "deferred",
+        reason: "pending-descendants",
+        delivered: false,
+        cleanup,
+        nextDelayMs: deferredDecision.delayMs,
+      });
       params.resumedRuns.delete(runId);
       params.persist();
       scheduleResumeSubagentRun(runId, entry, deferredDecision.delayMs);
@@ -533,6 +554,12 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     if (deferredDecision.kind === "give-up") {
+      recordSubagentAnnounceOutcome(entry, {
+        status: "failed",
+        reason: deferredDecision.reason,
+        delivered: false,
+        cleanup,
+      });
       safeSetSubagentTaskDeliveryStatus({
         runId,
         childSessionKey: entry.childSessionKey,
@@ -560,6 +587,13 @@ export function createSubagentRegistryLifecycleController(params: {
       return;
     }
 
+    recordSubagentAnnounceOutcome(entry, {
+      status: "deferred",
+      reason: deferredDecision.kind,
+      delivered: false,
+      cleanup,
+      nextDelayMs: deferredDecision.resumeDelayMs,
+    });
     entry.cleanupHandled = false;
     params.resumedRuns.delete(runId);
     params.persist();
@@ -703,6 +737,15 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     if (await freezeRunResultAtCompletion(entry, outcome)) {
+      mutated = true;
+    }
+    if (
+      recordSubagentTerminalState(entry, {
+        reason: completeParams.reason,
+        outcome,
+        endedAt,
+      })
+    ) {
       mutated = true;
     }
 

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -3,6 +3,35 @@ import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
+export type SubagentChildTerminalState = {
+  type: "subagent.child.terminal_state";
+  status: string;
+  reason: SubagentLifecycleEndedReason;
+  runId: string;
+  childSessionKey: string;
+  requesterSessionKey: string;
+  startedAt?: number;
+  endedAt?: number;
+  elapsedMs?: number;
+  error?: string;
+  recordedAt: number;
+};
+
+export type SubagentAnnounceOutcomeRecord = {
+  type: "subagent.announce_outcome";
+  status: "delivered" | "deferred" | "failed" | "skipped";
+  reason: string;
+  delivered: boolean;
+  cleanup: "delete" | "keep";
+  runId: string;
+  childSessionKey: string;
+  requesterSessionKey: string;
+  completionAnnouncedAt?: number;
+  retryCount?: number;
+  nextDelayMs?: number;
+  recordedAt: number;
+};
+
 export type SubagentRunRecord = {
   runId: string;
   childSessionKey: string;
@@ -23,6 +52,8 @@ export type SubagentRunRecord = {
   accumulatedRuntimeMs?: number;
   endedAt?: number;
   outcome?: SubagentRunOutcome;
+  childTerminalState?: SubagentChildTerminalState;
+  announceOutcome?: SubagentAnnounceOutcomeRecord;
   archiveAtMs?: number;
   cleanupCompletedAt?: number;
   cleanupHandled?: boolean;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -150,6 +150,18 @@ export type SessionCompactionCheckpoint = {
   boundaryMetadata?: SessionCompactionBoundaryMetadata;
 };
 
+export type SessionContinuityRestoreBoundaryMarker = {
+  type: "continuity.restore.used_boundary";
+  checkpointId: string;
+  boundaryId?: string;
+  restoredAt: number;
+  boundaryMetadata: SessionCompactionBoundaryMetadata;
+};
+
+export type SessionContinuityRestoreState = {
+  usedBoundary?: SessionContinuityRestoreBoundaryMarker;
+};
+
 export type SessionPluginDebugEntry = {
   pluginId: string;
   lines: string[];
@@ -292,6 +304,7 @@ export type SessionEntry = {
   contextTokens?: number;
   compactionCount?: number;
   compactionCheckpoints?: SessionCompactionCheckpoint[];
+  continuityRestore?: SessionContinuityRestoreState;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   memoryFlushContextHash?: string;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -158,8 +158,20 @@ export type SessionContinuityRestoreBoundaryMarker = {
   boundaryMetadata: SessionCompactionBoundaryMetadata;
 };
 
+export type SessionContinuityNextTurnFreshenedMarker = {
+  boundaryId: string;
+  checkpointId?: string;
+  freshenedAt: number;
+  mismatchCount: number;
+  fallbackKeys?: string[];
+  livePendingDescendants?: boolean;
+  pendingDescendantCount?: number;
+  staleRiskCount?: number;
+};
+
 export type SessionContinuityRestoreState = {
   usedBoundary?: SessionContinuityRestoreBoundaryMarker;
+  nextTurnFreshened?: SessionContinuityNextTurnFreshenedMarker;
 };
 
 export type SessionPluginDebugEntry = {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -93,8 +93,50 @@ export type SessionCompactionTranscriptReference = {
   entryId?: string;
 };
 
+export type SessionCompactionBoundaryMetadata = {
+  version: 1;
+  type: "compact.boundary";
+  boundaryId: string;
+  createdAt: number;
+  state: {
+    sessionBinding: {
+      sessionKey?: string;
+      sessionId?: string;
+      agentId?: string;
+      channel?: string;
+      accountId?: string;
+      threadId?: string;
+      messageId?: string;
+    };
+    approval: {
+      captured: false;
+      reason: string;
+    };
+    outbound: {
+      channel?: string;
+      targetId?: string;
+      threadId?: string;
+      replyToMessageId?: string;
+    };
+    children: {
+      pendingDescendantState: "live-query-required";
+      livePendingDescendants?: boolean;
+    };
+    policy: {
+      sandboxEnabled?: boolean;
+      sandboxWorkspaceAccess?: string;
+      bashElevated?: boolean;
+      provider?: string;
+      model?: string;
+      thinkingLevel?: string;
+      trigger?: string;
+    };
+  };
+};
+
 export type SessionCompactionCheckpoint = {
   checkpointId: string;
+  boundaryId?: string;
   sessionKey: string;
   sessionId: string;
   createdAt: number;
@@ -105,6 +147,7 @@ export type SessionCompactionCheckpoint = {
   firstKeptEntryId?: string;
   preCompaction: SessionCompactionTranscriptReference;
   postCompaction: SessionCompactionTranscriptReference;
+  boundaryMetadata?: SessionCompactionBoundaryMetadata;
 };
 
 export type SessionPluginDebugEntry = {

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -21,6 +21,7 @@ export const SessionCompactionTranscriptReferenceSchema = Type.Object(
 export const SessionCompactionCheckpointSchema = Type.Object(
   {
     checkpointId: NonEmptyString,
+    boundaryId: Type.Optional(NonEmptyString),
     sessionKey: NonEmptyString,
     sessionId: NonEmptyString,
     createdAt: Type.Integer({ minimum: 0 }),
@@ -31,6 +32,7 @@ export const SessionCompactionCheckpointSchema = Type.Object(
     firstKeptEntryId: Type.Optional(NonEmptyString),
     preCompaction: SessionCompactionTranscriptReferenceSchema,
     postCompaction: SessionCompactionTranscriptReferenceSchema,
+    boundaryMetadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -17,6 +17,8 @@ import {
   resolveMainSessionKey,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  type SessionCompactionCheckpoint,
+  type SessionContinuityRestoreBoundaryMarker,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -27,6 +29,7 @@ import {
   type SessionPatchHookEvent,
 } from "../../hooks/internal-hooks.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { emitContinuityDiagnostic } from "../../infra/continuity-diagnostics.js";
 import {
   normalizeAgentId,
   parseAgentSessionKey,
@@ -249,6 +252,62 @@ function buildDashboardSessionKey(agentId: string): string {
   return `agent:${agentId}:dashboard:${randomUUID()}`;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function buildContinuityRestoreBoundaryMarker(params: {
+  checkpoint: SessionCompactionCheckpoint;
+  restoredAt: number;
+}): SessionContinuityRestoreBoundaryMarker | undefined {
+  const boundaryMetadata = params.checkpoint.boundaryMetadata;
+  if (!isPlainObject(boundaryMetadata)) {
+    return undefined;
+  }
+  const boundaryId =
+    typeof boundaryMetadata.boundaryId === "string" && boundaryMetadata.boundaryId.trim()
+      ? boundaryMetadata.boundaryId.trim()
+      : typeof params.checkpoint.boundaryId === "string" && params.checkpoint.boundaryId.trim()
+        ? params.checkpoint.boundaryId.trim()
+        : undefined;
+  return {
+    type: "continuity.restore.used_boundary",
+    checkpointId: params.checkpoint.checkpointId,
+    ...(boundaryId ? { boundaryId } : {}),
+    restoredAt: params.restoredAt,
+    boundaryMetadata,
+  };
+}
+
+function emitRestoreUsedBoundaryDiagnostic(params: {
+  marker?: SessionContinuityRestoreBoundaryMarker;
+  sessionKey: string;
+  sessionId: string;
+  phase: "checkpoint_branch" | "checkpoint_restore";
+}): void {
+  const marker = params.marker;
+  if (!marker) {
+    return;
+  }
+  emitContinuityDiagnostic({
+    type: "continuity.restore.used_boundary",
+    severity: "info",
+    runId: marker.boundaryId ?? marker.checkpointId,
+    sessionKey: params.sessionKey,
+    phase: params.phase,
+    correlation: {
+      checkpointId: marker.checkpointId,
+      boundaryId: marker.boundaryId,
+    },
+    details: {
+      sessionId: params.sessionId,
+      stateKeys: isPlainObject(marker.boundaryMetadata.state)
+        ? Object.keys(marker.boundaryMetadata.state)
+        : undefined,
+    },
+  });
+}
+
 function cloneCheckpointSessionEntry(params: {
   currentEntry: SessionEntry;
   nextSessionId: string;
@@ -257,12 +316,20 @@ function cloneCheckpointSessionEntry(params: {
   parentSessionKey?: string;
   totalTokens?: number;
   preserveCompactionCheckpoints?: boolean;
+  checkpoint?: SessionCompactionCheckpoint;
 }): SessionEntry {
+  const restoredAt = Date.now();
+  const restoreBoundaryMarker = params.checkpoint
+    ? buildContinuityRestoreBoundaryMarker({
+        checkpoint: params.checkpoint,
+        restoredAt,
+      })
+    : undefined;
   return {
     ...params.currentEntry,
     sessionId: params.nextSessionId,
     sessionFile: params.nextSessionFile,
-    updatedAt: Date.now(),
+    updatedAt: restoredAt,
     systemSent: false,
     abortedLastRun: false,
     startedAt: undefined,
@@ -287,6 +354,7 @@ function cloneCheckpointSessionEntry(params: {
     compactionCheckpoints: params.preserveCompactionCheckpoints
       ? params.currentEntry.compactionCheckpoints
       : undefined,
+    ...(restoreBoundaryMarker ? { continuityRestore: { usedBoundary: restoreBoundaryMarker } } : {}),
   };
 }
 
@@ -1051,10 +1119,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       label,
       parentSessionKey: canonicalKey,
       totalTokens: checkpoint.tokensBefore,
+      checkpoint,
     });
 
     await updateSessionStore(target.storePath, (store) => {
       store[nextKey] = nextEntry;
+    });
+    emitRestoreUsedBoundaryDiagnostic({
+      marker: nextEntry.continuityRestore?.usedBoundary,
+      sessionKey: nextKey,
+      sessionId: nextEntry.sessionId,
+      phase: "checkpoint_branch",
     });
 
     respond(
@@ -1176,10 +1251,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       nextSessionFile: restoredSessionFile,
       totalTokens: checkpoint.tokensBefore,
       preserveCompactionCheckpoints: true,
+      checkpoint,
     });
 
     await updateSessionStore(storePath, (store) => {
       store[canonicalKey] = nextEntry;
+    });
+    emitRestoreUsedBoundaryDiagnostic({
+      marker: nextEntry.continuityRestore?.usedBoundary,
+      sessionKey: canonicalKey,
+      sessionId: nextEntry.sessionId,
+      phase: "checkpoint_restore",
     });
 
     respond(

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1414,6 +1414,19 @@ describe("gateway server sessions", () => {
     const { dir, storePath } = await createSessionStoreDir();
     const fixture = await createCheckpointFixture(dir);
     const { SessionManager } = await getSessionManagerModule();
+    const boundaryMetadata = {
+      version: 1,
+      type: "compact.boundary",
+      boundaryId: "compact-boundary:test-1",
+      createdAt: Date.now(),
+      state: {
+        sessionBinding: { sessionKey: "agent:main:main", sessionId: fixture.sessionId },
+        approval: { captured: false, reason: "captured elsewhere" },
+        outbound: { channel: "discord", targetId: "user-1" },
+        children: { pendingDescendantState: "live-query-required" },
+        policy: { provider: "openai", model: "gpt-test", thinkingLevel: "high" },
+      },
+    } as const;
     await writeSessionStore({
       entries: {
         main: {
@@ -1423,6 +1436,7 @@ describe("gateway server sessions", () => {
           compactionCheckpoints: [
             {
               checkpointId: "checkpoint-1",
+              boundaryId: boundaryMetadata.boundaryId,
               sessionKey: "agent:main:main",
               sessionId: fixture.sessionId,
               createdAt: Date.now(),
@@ -1442,6 +1456,7 @@ describe("gateway server sessions", () => {
                 leafId: fixture.postCompactionLeafId,
                 entryId: fixture.postCompactionLeafId,
               },
+              boundaryMetadata,
             },
           ],
         },
@@ -1502,7 +1517,12 @@ describe("gateway server sessions", () => {
       ok: true;
       sourceKey: string;
       key: string;
-      entry: { sessionId: string; sessionFile?: string; parentSessionKey?: string };
+      entry: {
+        sessionId: string;
+        sessionFile?: string;
+        parentSessionKey?: string;
+        continuityRestore?: { usedBoundary?: { checkpointId?: string; boundaryId?: string } };
+      };
     }>(ws, "sessions.compaction.branch", {
       key: "main",
       checkpointId: "checkpoint-1",
@@ -1510,6 +1530,10 @@ describe("gateway server sessions", () => {
     expect(branched.ok).toBe(true);
     expect(branched.payload?.sourceKey).toBe("agent:main:main");
     expect(branched.payload?.entry.parentSessionKey).toBe("agent:main:main");
+    expect(branched.payload?.entry.continuityRestore?.usedBoundary).toMatchObject({
+      checkpointId: "checkpoint-1",
+      boundaryId: boundaryMetadata.boundaryId,
+    });
     const branchedSessionFile = branched.payload?.entry.sessionFile;
     expect(branchedSessionFile).toBeTruthy();
     const branchedSession = SessionManager.open(branchedSessionFile!, dir);
@@ -1523,17 +1547,27 @@ describe("gateway server sessions", () => {
         parentSessionKey?: string;
         compactionCheckpoints?: unknown[];
         sessionId?: string;
+        continuityRestore?: { usedBoundary?: { checkpointId?: string; boundaryId?: string } };
       }
     >;
     const branchedEntry = storeAfterBranch[branched.payload!.key];
     expect(branchedEntry?.parentSessionKey).toBe("agent:main:main");
     expect(branchedEntry?.compactionCheckpoints).toBeUndefined();
+    expect(branchedEntry?.continuityRestore?.usedBoundary).toMatchObject({
+      checkpointId: "checkpoint-1",
+      boundaryId: boundaryMetadata.boundaryId,
+    });
 
     const restored = await rpcReq<{
       ok: true;
       key: string;
       sessionId: string;
-      entry: { sessionId: string; sessionFile?: string; compactionCheckpoints?: unknown[] };
+      entry: {
+        sessionId: string;
+        sessionFile?: string;
+        compactionCheckpoints?: unknown[];
+        continuityRestore?: { usedBoundary?: { checkpointId?: string; boundaryId?: string } };
+      };
     }>(ws, "sessions.compaction.restore", {
       key: "main",
       checkpointId: "checkpoint-1",
@@ -1542,6 +1576,10 @@ describe("gateway server sessions", () => {
     expect(restored.payload?.key).toBe("agent:main:main");
     expect(restored.payload?.sessionId).not.toBe(fixture.sessionId);
     expect(restored.payload?.entry.compactionCheckpoints).toHaveLength(1);
+    expect(restored.payload?.entry.continuityRestore?.usedBoundary).toMatchObject({
+      checkpointId: "checkpoint-1",
+      boundaryId: boundaryMetadata.boundaryId,
+    });
     const restoredSessionFile = restored.payload?.entry.sessionFile;
     expect(restoredSessionFile).toBeTruthy();
     const restoredSession = SessionManager.open(restoredSessionFile!, dir);
@@ -1551,10 +1589,18 @@ describe("gateway server sessions", () => {
 
     const storeAfterRestore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
-      { compactionCheckpoints?: unknown[]; sessionId?: string }
+      {
+        compactionCheckpoints?: unknown[];
+        sessionId?: string;
+        continuityRestore?: { usedBoundary?: { checkpointId?: string; boundaryId?: string } };
+      }
     >;
     expect(storeAfterRestore["agent:main:main"]?.sessionId).toBe(restored.payload?.sessionId);
     expect(storeAfterRestore["agent:main:main"]?.compactionCheckpoints).toHaveLength(1);
+    expect(storeAfterRestore["agent:main:main"]?.continuityRestore?.usedBoundary).toMatchObject({
+      checkpointId: "checkpoint-1",
+      boundaryId: boundaryMetadata.boundaryId,
+    });
 
     ws.close();
   });

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -11,6 +11,7 @@ import {
   cleanupCompactionCheckpointSnapshot,
   persistSessionCompactionCheckpoint,
 } from "./session-compaction-checkpoints.js";
+import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
 
 const tempDirs: string[] = [];
 
@@ -161,5 +162,69 @@ describe("session-compaction-checkpoints", () => {
     expect(
       Object.values(nextStore).find((entry) => entry.compactionCheckpoints)?.compactionCheckpoints,
     ).toHaveLength(25);
+
+test("persist stores boundary id and metadata with the checkpoint", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-store-"));
+    tempDirs.push(dir);
+    const storePath = path.join(dir, "sessions.json");
+    const cfg = {
+      session: { scope: "global", mainKey: "main", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: "main" });
+    await fs.mkdir(path.dirname(target.storePath), { recursive: true });
+    const checkpointCreatedAt = Date.now();
+    await fs.writeFile(
+      target.storePath,
+      JSON.stringify({
+        [target.canonicalKey]: { sessionId: "session-live", updatedAt: checkpointCreatedAt },
+      }),
+      "utf8",
+    );
+    const boundaryMetadata = {
+      version: 1,
+      type: "compact.boundary",
+      boundaryId: "compact-boundary:diag-1",
+      createdAt: 123,
+      state: {
+        sessionBinding: { sessionKey: "main", sessionId: "session-live" },
+        approval: { captured: false, reason: "captured elsewhere" },
+        outbound: { channel: "discord", targetId: "user-1" },
+        children: { pendingDescendantState: "live-query-required" },
+        policy: { provider: "openai", model: "gpt-test", thinkingLevel: "high" },
+      },
+    } as const;
+
+    const checkpoint = await persistSessionCompactionCheckpoint({
+      cfg,
+      sessionKey: "main",
+      sessionId: "session-live",
+      reason: "manual",
+      snapshot: {
+        sessionId: "session-pre",
+        sessionFile: path.join(dir, "pre.jsonl"),
+        leafId: "leaf-pre",
+      },
+      postSessionFile: path.join(dir, "post.jsonl"),
+      postLeafId: "leaf-post",
+      postEntryId: "leaf-post",
+      createdAt: checkpointCreatedAt,
+      boundaryMetadata,
+    });
+
+    expect(checkpoint?.boundaryId).toBe("compact-boundary:diag-1");
+    expect(checkpoint?.boundaryMetadata).toEqual(boundaryMetadata);
+
+    const stored = JSON.parse(await fs.readFile(target.storePath, "utf8")) as Record<
+      string,
+      { compactionCheckpoints?: Array<Record<string, unknown>> }
+    >;
+    const storedEntry = stored[checkpoint!.sessionKey];
+    expect(storedEntry.compactionCheckpoints).toHaveLength(1);
+    expect(storedEntry.compactionCheckpoints?.[0]).toMatchObject({
+      boundaryId: "compact-boundary:diag-1",
+      boundaryMetadata,
+    });
+
   });
 });

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -162,8 +162,9 @@ describe("session-compaction-checkpoints", () => {
     expect(
       Object.values(nextStore).find((entry) => entry.compactionCheckpoints)?.compactionCheckpoints,
     ).toHaveLength(25);
+  });
 
-test("persist stores boundary id and metadata with the checkpoint", async () => {
+  test("persist stores boundary id and metadata with the checkpoint", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-store-"));
     tempDirs.push(dir);
     const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { updateSessionStore } from "../config/sessions.js";
 import type {
+  SessionCompactionBoundaryMetadata,
   SessionCompactionCheckpoint,
   SessionCompactionCheckpointReason,
   SessionEntry,
@@ -170,6 +171,7 @@ export async function persistSessionCompactionCheckpoint(params: {
   postSessionFile?: string;
   postLeafId?: string;
   postEntryId?: string;
+  boundaryMetadata?: SessionCompactionBoundaryMetadata;
   createdAt?: number;
 }): Promise<SessionCompactionCheckpoint | null> {
   const target = resolveGatewaySessionStoreTarget({
@@ -179,6 +181,7 @@ export async function persistSessionCompactionCheckpoint(params: {
   const createdAt = params.createdAt ?? Date.now();
   const checkpoint: SessionCompactionCheckpoint = {
     checkpointId: randomUUID(),
+    ...(params.boundaryMetadata?.boundaryId ? { boundaryId: params.boundaryMetadata.boundaryId } : {}),
     sessionKey: target.canonicalKey,
     sessionId: params.sessionId,
     createdAt,
@@ -200,6 +203,7 @@ export async function persistSessionCompactionCheckpoint(params: {
       ...(params.postLeafId?.trim() ? { leafId: params.postLeafId.trim() } : {}),
       ...(params.postEntryId?.trim() ? { entryId: params.postEntryId.trim() } : {}),
     },
+    ...(params.boundaryMetadata ? { boundaryMetadata: params.boundaryMetadata } : {}),
   };
 
   let stored = false;

--- a/src/infra/continuity-diagnostics.test.ts
+++ b/src/infra/continuity-diagnostics.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logger = vi.hoisted(() => ({
+  subsystem: "continuity/diagnostics",
+  isEnabled: vi.fn(() => true),
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  raw: vi.fn(),
+  child: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => logger),
+}));
+
+import { onAgentEvent, resetAgentEventsForTest } from "./agent-events.js";
+import { __testing, emitContinuityDiagnostic } from "./continuity-diagnostics.js";
+
+describe("continuity-diagnostics", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+    vi.clearAllMocks();
+  });
+
+  it("normalizes, logs, returns, and emits diagnostic data", () => {
+    const events: Array<{ runId: string; stream: string; sessionKey?: string; data: unknown }> = [];
+    const stop = onAgentEvent((event) => {
+      events.push({
+        runId: event.runId,
+        stream: event.stream,
+        sessionKey: event.sessionKey,
+        data: event.data,
+      });
+    });
+
+    const data = emitContinuityDiagnostic({
+      type: " diag.approval.carry_mismatch ",
+      severity: "error",
+      phase: " before_decision_use ",
+      sessionKey: " session-main ",
+      correlation: {
+        approvalId: " approval-1 ",
+        ignored: undefined,
+        approvalKind: "exec",
+      },
+      details: {
+        reason: "live_pending_missing",
+        skipped: undefined,
+      },
+    });
+
+    stop();
+
+    expect(data).toEqual({
+      type: "diag.approval.carry_mismatch",
+      severity: "error",
+      phase: "before_decision_use",
+      sessionKey: "session-main",
+      correlation: {
+        approvalId: " approval-1 ",
+        approvalKind: "exec",
+      },
+      details: {
+        reason: "live_pending_missing",
+      },
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[diagnostic] diag.approval.carry_mismatch phase=before_decision_use sessionKey=session-main",
+      data,
+    );
+    expect(events).toEqual([
+      {
+        runId: "approval-1",
+        stream: "diagnostic",
+        sessionKey: "session-main",
+        data,
+      },
+    ]);
+  });
+
+  it("defaults to warn severity and uses session/type fallback run ids", () => {
+    const events: Array<{ runId: string; data: unknown }> = [];
+    const stop = onAgentEvent((event) => {
+      events.push({ runId: event.runId, data: event.data });
+    });
+
+    const withSession = emitContinuityDiagnostic({
+      type: "diag.outbound.target_reresolved",
+      sessionKey: "session-delivery",
+    });
+    const withoutSession = emitContinuityDiagnostic({
+      type: "   ",
+    });
+
+    stop();
+
+    expect(withSession).toEqual({
+      type: "diag.outbound.target_reresolved",
+      severity: "warn",
+      sessionKey: "session-delivery",
+    });
+    expect(withoutSession).toEqual({
+      type: "diag.unknown",
+      severity: "warn",
+    });
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.runId)).toEqual([
+      "session-delivery",
+      "diag.unknown",
+    ]);
+  });
+
+  it("logs info diagnostics through the info logger", () => {
+    const data = emitContinuityDiagnostic({
+      type: "continuity.restore.boundary_freshened",
+      severity: "info",
+      runId: "run-1",
+      correlation: { boundaryId: "boundary-1" },
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[diagnostic] continuity.restore.boundary_freshened",
+      data,
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps helper normalizers small and predictable", () => {
+    expect(__testing.cleanString(" value ")).toBe("value");
+    expect(__testing.cleanString("   ")).toBeUndefined();
+    expect(__testing.normalizeSeverity("debug")).toBe("warn");
+    expect(__testing.compactObject({ a: 1, b: undefined, c: null })).toEqual({ a: 1, c: null });
+    expect(__testing.compactObject(["nope"])).toBeUndefined();
+  });
+});

--- a/src/infra/continuity-diagnostics.ts
+++ b/src/infra/continuity-diagnostics.ts
@@ -1,0 +1,103 @@
+import { emitAgentEvent } from "./agent-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+export type ContinuityDiagnosticSeverity = "info" | "warn" | "error";
+
+export type ContinuityDiagnosticRecord = Record<string, unknown>;
+
+export type ContinuityDiagnosticData = {
+  type: string;
+  severity: ContinuityDiagnosticSeverity;
+  phase?: string;
+  sessionKey?: string;
+  correlation?: ContinuityDiagnosticRecord;
+  details?: ContinuityDiagnosticRecord;
+};
+
+export type EmitContinuityDiagnosticParams = {
+  type: string;
+  severity?: ContinuityDiagnosticSeverity;
+  phase?: string;
+  sessionKey?: string;
+  runId?: string;
+  correlation?: ContinuityDiagnosticRecord;
+  details?: ContinuityDiagnosticRecord;
+};
+
+const log = createSubsystemLogger("continuity/diagnostics");
+
+function cleanString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeSeverity(value: unknown): ContinuityDiagnosticSeverity {
+  return value === "info" || value === "warn" || value === "error" ? value : "warn";
+}
+
+function compactObject(value: unknown): ContinuityDiagnosticRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const out: ContinuityDiagnosticRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) {
+      out[key] = entry;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function readStringField(record: ContinuityDiagnosticRecord | undefined, key: string): string | undefined {
+  return cleanString(record?.[key]);
+}
+
+export function emitContinuityDiagnostic(
+  params: EmitContinuityDiagnosticParams,
+): ContinuityDiagnosticData {
+  const type = cleanString(params.type) ?? "diag.unknown";
+  const severity = normalizeSeverity(params.severity);
+  const phase = cleanString(params.phase);
+  const sessionKey = cleanString(params.sessionKey);
+  const correlation = compactObject(params.correlation);
+  const details = compactObject(params.details);
+  const data: ContinuityDiagnosticData = {
+    type,
+    severity,
+    ...(phase ? { phase } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(correlation ? { correlation } : {}),
+    ...(details ? { details } : {}),
+  };
+  const message = `[diagnostic] ${type}${phase ? ` phase=${phase}` : ""}${
+    sessionKey ? ` sessionKey=${sessionKey}` : ""
+  }`;
+
+  if (severity === "error") {
+    log.error(message, data);
+  } else if (severity === "warn") {
+    log.warn(message, data);
+  } else {
+    log.info(message, data);
+  }
+
+  emitAgentEvent({
+    runId:
+      cleanString(params.runId) ??
+      readStringField(correlation, "approvalId") ??
+      readStringField(correlation, "boundaryId") ??
+      readStringField(correlation, "childSessionKey") ??
+      sessionKey ??
+      type,
+    stream: "diagnostic",
+    ...(sessionKey ? { sessionKey } : {}),
+    data,
+  });
+
+  return data;
+}
+
+export const __testing = {
+  cleanString,
+  compactObject,
+  normalizeSeverity,
+};

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const emitContinuityDiagnosticMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./continuity-diagnostics.js", () => ({
+  emitContinuityDiagnostic: emitContinuityDiagnosticMock,
+}));
+
 import {
   hasHeartbeatWakeHandler,
   hasPendingHeartbeatWake,
@@ -40,6 +47,7 @@ describe("heartbeat-wake", () => {
 
   beforeEach(() => {
     resetHeartbeatWakeStateForTests();
+    emitContinuityDiagnosticMock.mockClear();
   });
 
   afterEach(() => {
@@ -110,6 +118,39 @@ describe("heartbeat-wake", () => {
       initialReason: "exec-event",
       expectedRetryReason: "exec-event",
     });
+    expect(emitContinuityDiagnosticMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.heartbeat.wake_orphaned",
+        severity: "warn",
+        phase: "handler_error_requeued",
+        details: expect.objectContaining({ count: 1 }),
+      }),
+    );
+  });
+
+  it("emits an orphan diagnostic when a queued wake fires without a handler", async () => {
+    vi.useFakeTimers();
+
+    requestHeartbeatNow({
+      reason: "manual",
+      agentId: "main",
+      sessionKey: "agent:main:discord:direct:alice",
+      coalesceMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(hasPendingHeartbeatWake()).toBe(false);
+    expect(emitContinuityDiagnosticMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.heartbeat.wake_orphaned",
+        severity: "warn",
+        phase: "handler_missing",
+        sessionKey: "agent:main:discord:direct:alice",
+        correlation: expect.objectContaining({ agentId: "main", wakeReason: "manual" }),
+        details: expect.objectContaining({ count: 1 }),
+      }),
+    );
   });
 
   it("stale disposer does not clear a newer handler", async () => {
@@ -236,23 +277,25 @@ describe("heartbeat-wake", () => {
     expect(handlerB).toHaveBeenCalledWith({ reason: "manual" });
   });
 
-  it("drains pending wake once a handler is registered", async () => {
+  it("clears orphaned pending wake when no handler is registered at fire time", async () => {
     vi.useFakeTimers();
 
     requestHeartbeatNow({ reason: "manual", coalesceMs: 0 });
     await vi.advanceTimersByTimeAsync(1);
-    expect(hasPendingHeartbeatWake()).toBe(true);
+    expect(hasPendingHeartbeatWake()).toBe(false);
+    expect(emitContinuityDiagnosticMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "diag.heartbeat.wake_orphaned",
+        phase: "handler_missing",
+        details: expect.objectContaining({ count: 1 }),
+      }),
+    );
 
     const handler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
     setHeartbeatWakeHandler(handler);
 
-    await vi.advanceTimersByTimeAsync(249);
+    await vi.advanceTimersByTimeAsync(250);
     expect(handler).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith({ reason: "manual" });
-    expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
   it("forwards wake target fields and preserves them across retries", async () => {

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { emitContinuityDiagnostic } from "./continuity-diagnostics.js";
 import {
   isHeartbeatActionWakeReason,
   normalizeHeartbeatWakeReason,
@@ -86,6 +87,45 @@ function getWakeTargetKey(params: { agentId?: string; sessionKey?: string }) {
   return `${agentId ?? ""}::${sessionKey ?? ""}`;
 }
 
+function summarizeWakeBatch(batch: PendingWakeReason[]): Record<string, unknown> {
+  const reasons = Array.from(new Set(batch.map((wake) => wake.reason).filter(Boolean))).slice(
+    0,
+    8,
+  );
+  const targets = Array.from(
+    new Set(
+      batch.map((wake) =>
+        getWakeTargetKey({ agentId: wake.agentId, sessionKey: wake.sessionKey }),
+      ),
+    ),
+  ).slice(0, 8);
+  return {
+    count: batch.length,
+    reasons,
+    targets,
+  };
+}
+
+function emitHeartbeatWakeOrphanDiagnostic(params: {
+  phase: string;
+  agentId?: string;
+  sessionKey?: string;
+  reason?: string;
+  details?: Record<string, unknown>;
+}): void {
+  emitContinuityDiagnostic({
+    type: "diag.heartbeat.wake_orphaned",
+    severity: "warn",
+    phase: params.phase,
+    sessionKey: params.sessionKey,
+    correlation: {
+      agentId: params.agentId,
+      wakeReason: params.reason,
+    },
+    details: params.details,
+  });
+}
+
 function queuePendingWakeReason(params?: {
   reason?: string;
   requestedAt?: number;
@@ -153,10 +193,6 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
     timerDueAt = null;
     timerKind = null;
     scheduled = false;
-    const active = handler;
-    if (!active) {
-      return;
-    }
     if (running) {
       scheduled = true;
       schedule(delay, kind);
@@ -165,6 +201,21 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
 
     const pendingBatch = Array.from(pendingWakes.values());
     pendingWakes.clear();
+    const active = handler;
+    if (!active) {
+      const summary = summarizeWakeBatch(pendingBatch);
+      emitHeartbeatWakeOrphanDiagnostic({
+        phase: "handler_missing",
+        agentId: pendingBatch[0]?.agentId,
+        sessionKey: pendingBatch[0]?.sessionKey,
+        reason: pendingBatch[0]?.reason,
+        details: {
+          ...summary,
+          handlerGeneration,
+        },
+      });
+      return;
+    }
     running = true;
     try {
       for (const pendingWake of pendingBatch) {
@@ -187,6 +238,17 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
         }
       }
     } catch {
+      const summary = summarizeWakeBatch(pendingBatch);
+      emitHeartbeatWakeOrphanDiagnostic({
+        phase: "handler_error_requeued",
+        agentId: pendingBatch[0]?.agentId,
+        sessionKey: pendingBatch[0]?.sessionKey,
+        reason: pendingBatch[0]?.reason,
+        details: {
+          ...summary,
+          handlerGeneration,
+        },
+      });
       // Error is already logged by the heartbeat runner; schedule a retry.
       for (const pendingWake of pendingBatch) {
         queuePendingWakeReason({

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -63,6 +63,7 @@ export { resolveEmbeddedAgentRuntime } from "../agents/pi-embedded-runner/runtim
 export { resolveUserPath } from "../utils.js";
 export { callGatewayTool } from "../agents/tools/gateway.js";
 export { formatToolAggregate } from "../auto-reply/tool-meta.js";
+export { emitContinuityDiagnostic } from "../infra/continuity-diagnostics.js";
 export { isMessagingTool, isMessagingToolSendAction } from "../agents/pi-embedded-messaging.js";
 export {
   extractToolResultMediaArtifact,


### PR DESCRIPTION
## Summary

Adds continuity diagnostics and guardrails around compaction/restore, outbound delivery, approval carry-over, subagent completion/announce flows, heartbeat wake handling, and ACP runtime-handle eviction.

The goal is to make continuity-sensitive state transitions observable and safer when a session is compacted/restored or when long-running work crosses turns.

## Main changes

- Add `src/infra/continuity-diagnostics.ts` helper for diagnostic events/logging.
- Persist compact boundary metadata on compaction checkpoints.
- Record restore/branch boundary markers and validate/freshen them on the next turn.
- Re-resolve outbound delivery targets from live session state before delivery.
- Add boundary fallback diagnostics for restored outbound/session binding data.
- Add exec/plugin approval mismatch diagnostics before using carried decisions.
- Track subagent terminal state separately from announce delivery outcome.
- Add announce delivery diagnostics.
- Add heartbeat wake orphan diagnostics.
- Add ACP idle handle eviction/close-failure diagnostics.

## Current branch status

- Rebased onto current `openclaw/openclaw:main`.
- Mergeable status after rebase: `MERGEABLE`.
- Opened as a draft because this touches several continuity-sensitive paths and may need maintainer guidance on diagnostic names/surface area.

## Verification

Original full-checkout source-port verification after dependency install with `pnpm install --frozen-lockfile --ignore-scripts`:

- `git diff --check`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- Targeted source-port vitest batch: 18 files / 251 tests passed

After rebasing onto current `main`, targeted regression batch passed locally:

```bash
./node_modules/.bin/vitest run \
  src/infra/continuity-diagnostics.test.ts \
  src/agents/pi-embedded-runner/compact-boundary-metadata.test.ts \
  src/gateway/session-compaction-checkpoints.test.ts \
  src/agents/command/delivery.test.ts \
  src/agents/bash-tools.exec-host-shared.test.ts \
  extensions/codex/src/app-server/approval-bridge.test.ts \
  src/agents/subagent-registry-completion.test.ts \
  src/agents/subagent-registry-lifecycle.test.ts \
  src/agents/subagent-announce.test.ts \
  src/acp/control-plane/manager.test.ts \
  src/infra/heartbeat-wake.test.ts
```

Result: 14 test files / 213 tests passed.

## Notes

- The branch is intentionally split into reviewable commits by concern area, plus one final rebase-conflict resolution commit for current `main` compatibility.
- The Codex app-server approval bridge resolution was adjusted during rebase to preserve current `main` behavior that does not trust request-time approval decisions for two-phase approvals.
