### PR TITLE
fix(discord): deduplicate tool progress entries in block streaming mode [AI-assisted]

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1054,4 +1054,26 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(draftStream.update).not.toHaveBeenCalled();
   });
+
+  it("deduplicates tool progress entries with matching bare names in block mode", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "session_status" });
+      await params?.replyOptions?.onItemEvent?.({ name: "session_status" });
+      await params?.replyOptions?.onToolStart?.({ name: "session_status" });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createBlockModeContext();
+
+    await processDiscordMessage(ctx as any);
+
+    const updates = draftStream.update.mock.calls.map((call) => call[0]);
+    for (const text of updates) {
+      const lines = text.split("\n").filter((line: string) => line.startsWith("•"));
+      const uniqueLines = new Set(lines);
+      expect(lines.length).toBe(uniqueLines.size);
+    }
+  });
 });

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -645,7 +645,13 @@ export async function processDiscordMessage(
       return;
     }
     const previous = previewToolProgressLines.at(-1);
-    if (previous === normalized) {
+    const bareNormalized = normalized.replace(/^tool:\s*/, "");
+    if (
+      previous === normalized ||
+      previewToolProgressLines.some(
+        (entry) => entry === normalized || entry.replace(/^tool:\s*/, "") === bareNormalized,
+      )
+    ) {
       return;
     }
     previewToolProgressLines = [...previewToolProgressLines, normalized].slice(-8);


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: In Discord block streaming mode, tool progress lines show duplicate entries for the same tool (e.g., `session_status` appearing multiple times).
- Why it matters: Duplicate progress lines clutter the streaming preview and confuse users about actual tool activity.
- What changed: Extended the dedup check in `pushPreviewToolProgress` to compare against all existing entries (not just the last one), with bare name normalization (stripping the `"tool: "` prefix).
- What did NOT change (scope boundary): No changes to tool execution logic, event dispatching, or any other streaming mode.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions (Discord)

## Linked Issue/PR
- Closes #72205
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `pushPreviewToolProgress` only compared the new entry against the *last* entry in the array (`lines[lines.length - 1] !== line`). When `onToolStart` emits `"tool: session_status"` and `onItemEvent` later emits `"session_status"`, they differ in the `"tool: "` prefix and both pass the dedup check, resulting in duplicate entries for the same tool.
- Missing detection / guardrail: No test for duplicate tool progress entries across different event sources (onToolStart vs onItemEvent).
- Contributing context: The two code paths (`onToolStart` at line ~990 and `onItemEvent` at line ~997) independently push tool names with different formatting conventions.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/discord/src/monitor/message-handler.process.test.ts`
- Scenario the test should lock in: When `pushPreviewToolProgress` is called with entries that differ only by the `"tool: "` prefix (e.g., `"tool: session_status"` then `"session_status"`), only one entry should remain.
- Why this is the smallest reliable guardrail: Directly tests the dedup function with the exact input pattern that caused the bug.
- Existing test that already covers this: N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Discord block streaming mode no longer shows duplicate tool names in the "Working…" progress section.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only affects display-layer dedup logic for tool progress previews. No security-sensitive data flows are touched.
