### PR TITLE
fix(cron): omit misleading resolved error in run record when delivery.mode is none

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -731,6 +731,19 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(result.delivered).toBe(false);
     expect(result.deliveryAttempted).toBe(false);
   });
+
+  it("omits resolved delivery trace when delivery.mode is none", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "none",
+      channel: "last",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.delivery).not.toHaveProperty("resolved");
+  });
 });
 
 describe("runCronIsolatedAgentTurn delivery instruction", () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -216,28 +216,31 @@ function buildCronDeliveryTrace(params: {
     source:
       params.deliveryPlan.channel === "last" || !params.deliveryPlan.channel ? "last" : "explicit",
   });
-  const resolved = params.resolvedDelivery.ok
-    ? {
-        ok: true,
-        ...normalizeCronTraceTarget({
-          channel: params.resolvedDelivery.channel,
-          to: params.resolvedDelivery.to,
-          accountId: params.resolvedDelivery.accountId,
-          threadId: params.resolvedDelivery.threadId,
-          source: params.resolvedDelivery.mode === "implicit" ? "last" : "explicit",
-        }),
-      }
-    : {
-        ok: false,
-        ...normalizeCronTraceTarget({
-          channel: params.resolvedDelivery.channel,
-          to: params.resolvedDelivery.to ?? null,
-          accountId: params.resolvedDelivery.accountId,
-          threadId: params.resolvedDelivery.threadId,
-          source: params.resolvedDelivery.mode === "implicit" ? "last" : "explicit",
-        }),
-        error: params.resolvedDelivery.error.message,
-      };
+  const resolved =
+    params.deliveryPlan.mode === "none"
+      ? undefined
+      : params.resolvedDelivery.ok
+        ? {
+            ok: true,
+            ...normalizeCronTraceTarget({
+              channel: params.resolvedDelivery.channel,
+              to: params.resolvedDelivery.to,
+              accountId: params.resolvedDelivery.accountId,
+              threadId: params.resolvedDelivery.threadId,
+              source: params.resolvedDelivery.mode === "implicit" ? "last" : "explicit",
+            }),
+          }
+        : {
+            ok: false,
+            ...normalizeCronTraceTarget({
+              channel: params.resolvedDelivery.channel,
+              to: params.resolvedDelivery.to ?? null,
+              accountId: params.resolvedDelivery.accountId,
+              threadId: params.resolvedDelivery.threadId,
+              source: params.resolvedDelivery.mode === "implicit" ? "last" : "explicit",
+            }),
+            error: params.resolvedDelivery.error.message,
+          };
   const messageToolSentTo = params.messagingToolSentTargets
     .map((target) =>
       normalizeMessagingToolTarget(
@@ -249,7 +252,7 @@ function buildCronDeliveryTrace(params: {
     .filter((target): target is CronDeliveryTraceMessageTarget => Boolean(target));
   return {
     ...(intended ? { intended } : {}),
-    resolved,
+    ...(resolved ? { resolved } : {}),
     ...(messageToolSentTo.length > 0 ? { messageToolSentTo } : {}),
     fallbackUsed: params.fallbackUsed,
     delivered: params.delivered,


### PR DESCRIPTION
## Summary

- Problem: When a cron job has `delivery.mode: "none"` (set via `openclaw cron edit --no-deliver`), the run record still contains a `delivery.resolved` object with `ok: false` and an error message like `"delivery is disabled"`. This is misleading because delivery was intentionally disabled, not failing.
- Why it matters: Operators and LLM agents inspecting run records mistakenly conclude the cron is broken when it is working as intended.
- What changed: In `buildCronDeliveryTrace`, when `deliveryPlan.mode === "none"`, the `resolved` field is now omitted from the delivery trace instead of being populated with a faux-failure error.
- What did NOT change: Behavior for `announce` and `webhook` delivery modes is unchanged. The `deliveryStatus: "not-requested"` signal remains intact.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #72210

## Root Cause

- Root cause: `resolveCronDeliveryContext` creates a `resolvedDelivery` with `ok: false` and `error: new Error("delivery is disabled")` when `mode === "none"`. `buildCronDeliveryTrace` then unconditionally serializes this error into the run record, creating a false-negative signal that contradicts the correct `deliveryStatus: "not-requested"`.
- Missing detection / guardrail: No gate existed to skip or neutralize the `resolved` block when delivery was explicitly disabled.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cron/isolated-agent/run.message-tool-policy.test.ts`
- Scenario the test should lock in: A cron run with `delivery.mode: "none"` must not produce a `delivery.resolved` field in the result.
- Existing test that already covers this: None; added a new test case.

## User-visible / Behavior Changes

- Cron run records for `delivery.mode=none` jobs no longer contain a misleading `delivery.resolved.error` field.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime: Node 22

### Steps

1. Configure a cron job with `delivery.mode: "none"`.
2. Trigger a manual run.
3. Inspect the run record in `~/.openclaw/cron/runs/<job-id>.jsonl`.

### Expected

- The run record does not contain a `delivery.resolved` block (or contains neutral metadata).

### Actual (before fix)

- The run record contains `delivery.resolved.ok: false` with `error: "delivery is disabled"`.

## Evidence

- [x] Failing test/log before + passing after: Added `omits resolved delivery trace when delivery.mode is none` test; passes after the fix.

## Human Verification

- Verified scenarios: Local unit tests (`pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts`) pass (28/28). Lint (`pnpm lint`) and typecheck (`pnpm tsgo`) pass.
- Edge cases checked: `announce` and `webhook` modes still produce `resolved` traces as before.
- What I did not verify: Full integration test with a live gateway instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Downstream consumers might expect `delivery.resolved` to always exist.
  - Mitigation: The `CronDeliveryTrace` type already marks `resolved` as optional (`resolved?: ...`), so consumers should already handle its absence. Existing tests confirm no breakage.
