### PR TITLE
fix runtime deps temp cleanup race

### DIFF
--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -8,6 +8,7 @@ import { resolveNpmRunner } from "./npm-runner.mjs";
 
 const TRANSIENT_TEMP_REMOVE_ERROR_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
 const TEMP_REMOVE_RETRY_DELAYS_MS = [10, 25, 50];
+const TEMP_OWNER_FILE = "owner.json";
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
@@ -48,13 +49,26 @@ function makeTempDir(parentDir, prefix) {
   return fs.mkdtempSync(path.join(parentDir, prefix));
 }
 
+function writeRuntimeDepsTempOwner(tempDir) {
+  writeJson(path.join(tempDir, TEMP_OWNER_FILE), {
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+function makeOwnedTempDir(parentDir, prefix) {
+  const tempDir = makeTempDir(parentDir, prefix);
+  writeRuntimeDepsTempOwner(tempDir);
+  return tempDir;
+}
+
 function sanitizeTempPrefixSegment(value) {
   const normalized = value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/-+/g, "-");
   return normalized.length > 0 ? normalized : "plugin";
 }
 
 function makePluginOwnedTempDir(pluginDir, label) {
-  return makeTempDir(pluginDir, `.openclaw-runtime-deps-${label}-`);
+  return makeOwnedTempDir(pluginDir, `.openclaw-runtime-deps-${label}-`);
 }
 
 function assertPathIsNotSymlink(targetPath, label) {
@@ -74,7 +88,7 @@ function replaceDirAtomically(targetPath, sourcePath) {
   assertPathIsNotSymlink(targetPath, "replace runtime deps");
   const targetParentDir = path.dirname(targetPath);
   fs.mkdirSync(targetParentDir, { recursive: true });
-  const backupPath = makeTempDir(
+  const backupPath = makeOwnedTempDir(
     targetParentDir,
     `.openclaw-runtime-deps-backup-${sanitizeTempPrefixSegment(path.basename(targetPath))}-`,
   );
@@ -100,7 +114,7 @@ function writeJsonAtomically(targetPath, value) {
   assertPathIsNotSymlink(targetPath, "write runtime deps stamp");
   const targetParentDir = path.dirname(targetPath);
   fs.mkdirSync(targetParentDir, { recursive: true });
-  const tempDir = makeTempDir(
+  const tempDir = makeOwnedTempDir(
     targetParentDir,
     `.openclaw-runtime-deps-stamp-${sanitizeTempPrefixSegment(path.basename(targetPath))}-`,
   );
@@ -952,6 +966,35 @@ function readRuntimeDepsStamp(stampPath) {
   }
 }
 
+function readRuntimeDepsTempOwner(tempDir) {
+  try {
+    const owner = readJson(path.join(tempDir, TEMP_OWNER_FILE));
+    return owner && typeof owner === "object" ? owner : null;
+  } catch {
+    return null;
+  }
+}
+
+function isLiveProcess(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function shouldRemoveRuntimeDepsTempDir(tempDir) {
+  const owner = readRuntimeDepsTempOwner(tempDir);
+  if (!owner || typeof owner.pid !== "number") {
+    return true;
+  }
+  return !isLiveProcess(owner.pid);
+}
+
 function removeStaleRuntimeDepsTempDirs(pluginDir) {
   if (!fs.existsSync(pluginDir)) {
     return;
@@ -959,6 +1002,9 @@ function removeStaleRuntimeDepsTempDirs(pluginDir) {
   for (const entry of fs.readdirSync(pluginDir, { withFileTypes: true })) {
     if (entry.name.startsWith(".openclaw-runtime-deps-")) {
       const targetPath = path.join(pluginDir, entry.name);
+      if (!shouldRemoveRuntimeDepsTempDir(targetPath)) {
+        continue;
+      }
       for (let attempt = 0; attempt <= TEMP_REMOVE_RETRY_DELAYS_MS.length; attempt += 1) {
         try {
           removePathIfExists(targetPath);

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -301,6 +301,40 @@ describe("stageBundledPluginRuntimeDeps", () => {
     );
   });
 
+  it("keeps runtime deps temp dirs owned by a live build process", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { "left-pad": "1.3.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const activeTempDir = path.join(pluginDir, ".openclaw-runtime-deps-stage-active");
+    fs.mkdirSync(activeTempDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(activeTempDir, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+    fs.writeFileSync(path.join(activeTempDir, "marker.txt"), "active\n", "utf8");
+
+    stageBundledPluginRuntimeDeps({
+      cwd: repoRoot,
+      installPluginRuntimeDepsImpl: ({ fingerprint, stampPath }: RuntimeDepsStampParams) => {
+        const nodeModulesDir = path.join(pluginDir, "node_modules");
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(path.join(nodeModulesDir, "marker.txt"), "installed\n", "utf8");
+        writeRuntimeDepsStamp(stampPath, fingerprint);
+      },
+    });
+
+    expect(fs.readFileSync(path.join(activeTempDir, "marker.txt"), "utf8")).toBe("active\n");
+    expect(fs.readFileSync(path.join(pluginDir, "node_modules", "marker.txt"), "utf8")).toBe(
+      "installed\n",
+    );
+  });
+
   it("restages when installed root runtime dependency contents change", () => {
     const { pluginDir, repoRoot } = createBundledPluginFixture({
       packageJson: {


### PR DESCRIPTION
## Summary

- Mark runtime dependency staging temp directories with an owner pid.
- Skip cleanup of staging temp directories owned by a live build process.
- Add regression coverage for concurrent runtime-deps cleanup preserving an active staging directory.

## Root Cause

`runtime-postbuild` removes stale `.openclaw-runtime-deps-*` directories before staging each bundled plugin's runtime dependencies. When two build/postbuild processes overlap in the same checkout, one process can delete another process's active staging directory while the first process is still pruning dependency files. That can make the prune walker hit `ENOENT` mid-walk, matching the observed `scandir dist/extensions/discord/.openclaw-runtime-deps-stage-.../node_modules/typebox/...` failure during `pnpm build`.

## Validation

- `pnpm test test/scripts/stage-bundled-plugin-runtime-deps.test.ts`
- `pnpm build`
