### PR TITLE
fix(browser): resolve playwright-core through runtime shim

### DIFF
--- a/extensions/browser/src/browser/playwright-core.runtime.ts
+++ b/extensions/browser/src/browser/playwright-core.runtime.ts
@@ -1,0 +1,6 @@
+import { createRequire } from "node:module";
+import type * as PlaywrightCore from "playwright-core";
+
+const require = createRequire(import.meta.url);
+
+export const playwrightCore = require("playwright-core") as typeof PlaywrightCore;

--- a/extensions/browser/src/browser/pw-ai.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-ai.e2e.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-
-vi.mock("playwright-core", () => ({
-  chromium: {
-    connectOverCDP: vi.fn(),
-  },
-}));
+import { connectOverCdpMock, getChromeWebSocketUrlMock } from "./pw-session.mock-setup.js";
 
 type FakeSession = {
   send: ReturnType<typeof vi.fn>;
@@ -55,14 +50,12 @@ function createBrowser(pages: unknown[]) {
   } as unknown as import("playwright-core").Browser;
 }
 
-let chromiumMock: typeof import("playwright-core").chromium;
 let snapshotAiViaPlaywright: typeof import("./pw-tools-core.snapshot.js").snapshotAiViaPlaywright;
 let clickViaPlaywright: typeof import("./pw-tools-core.interactions.js").clickViaPlaywright;
 let closePlaywrightBrowserConnection: typeof import("./pw-session.js").closePlaywrightBrowserConnection;
 
 beforeAll(async () => {
-  const pw = await import("playwright-core");
-  chromiumMock = pw.chromium;
+  getChromeWebSocketUrlMock.mockResolvedValue(null);
   ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
   ({ clickViaPlaywright } = await import("./pw-tools-core.interactions.js"));
   ({ closePlaywrightBrowserConnection } = await import("./pw-session.js"));
@@ -79,7 +72,7 @@ describe("pw-ai", () => {
     const p2 = createPage({ targetId: "T2", snapshotFull: "TWO" });
     const browser = createBrowser([p1.page, p2.page]);
 
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     const res = await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -96,7 +89,7 @@ describe("pw-ai", () => {
     const p1 = createPage({ targetId: "T1", snapshotFull: snapshot });
     const browser = createBrowser([p1.page]);
 
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     const res = await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -123,7 +116,7 @@ describe("pw-ai", () => {
     const p1 = createPage({ targetId: "T1", snapshotFull: longSnapshot });
     const browser = createBrowser([p1.page]);
 
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     const res = await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -140,7 +133,7 @@ describe("pw-ai", () => {
     const snapshot = ['- button "OK" [ref=1]', '- link "Docs" [ref=2]'].join("\n");
     const p1 = createPage({ targetId: "T1", snapshotFull: snapshot });
     const browser = createBrowser([p1.page]);
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     const res = await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -167,7 +160,7 @@ describe("pw-ai", () => {
   it("clicks a ref using aria-ref locator", async () => {
     const p1 = createPage({ targetId: "T1" });
     const browser = createBrowser([p1.page]);
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     await clickViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -182,7 +175,7 @@ describe("pw-ai", () => {
   it("uses Playwright's public AI aria snapshot API", async () => {
     const p1 = createPage({ targetId: "T1", snapshotFull: "ONE" });
     const browser = createBrowser([p1.page]);
-    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -199,8 +192,7 @@ describe("pw-ai", () => {
   it("reuses the CDP connection for repeated calls", async () => {
     const p1 = createPage({ targetId: "T1", snapshotFull: "ONE" });
     const browser = createBrowser([p1.page]);
-    const connect = vi.spyOn(chromiumMock, "connectOverCDP");
-    connect.mockResolvedValue(browser);
+    connectOverCdpMock.mockResolvedValue(browser);
 
     await snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -212,6 +204,6 @@ describe("pw-ai", () => {
       ref: "1",
     });
 
-    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connectOverCdpMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/pw-session.mock-setup.ts
+++ b/extensions/browser/src/browser/pw-session.mock-setup.ts
@@ -4,9 +4,12 @@ import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 export const connectOverCdpMock: MockFn = vi.fn();
 export const getChromeWebSocketUrlMock: MockFn = vi.fn();
 
-vi.mock("playwright-core", () => ({
-  chromium: {
-    connectOverCDP: (...args: unknown[]) => connectOverCdpMock(...args),
+vi.mock("./playwright-core.runtime.js", () => ({
+  playwrightCore: {
+    chromium: {
+      connectOverCDP: (...args: unknown[]) => connectOverCdpMock(...args),
+    },
+    devices: {},
   },
 }));
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -11,7 +11,6 @@ import type {
   Response,
   Route,
 } from "playwright-core";
-import { chromium } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
 import { SsrFBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
 import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
@@ -36,8 +35,11 @@ import {
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
+import { playwrightCore } from "./playwright-core.runtime.js";
 import { BROWSER_REF_MARKER_ATTRIBUTE, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
 import { sanitizeUntrustedFileName } from "./safe-filename.js";
+
+const { chromium } = playwrightCore;
 
 export type BrowserConsoleMessage = {
   type: string;

--- a/extensions/browser/src/browser/pw-tools-core.state.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.ts
@@ -1,7 +1,9 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { devices as playwrightDevices } from "playwright-core";
+import { playwrightCore } from "./playwright-core.runtime.js";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import { withPageScopedCdpClient } from "./pw-session.page-cdp.js";
+
+const { devices: playwrightDevices } = playwrightCore;
 
 export async function setOfflineViaPlaywright(opts: {
   cdpUrl: string;

--- a/scripts/test-built-bundled-runtime-deps.mjs
+++ b/scripts/test-built-bundled-runtime-deps.mjs
@@ -112,6 +112,20 @@ function stageBrowserRuntimeDependencyStub(stageNodeModulesDir, packageName) {
   );
 }
 
+function findBuiltBrowserEntryPath(distDir) {
+  const candidates = fs
+    .readdirSync(distDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^pw-ai-(?!state-).*\.js$/u.test(entry.name))
+    .map((entry) => path.join(distDir, entry.name))
+    .toSorted((left, right) => left.localeCompare(right));
+  if (candidates.length === 0) {
+    throw new assert.AssertionError({
+      message: `missing built pw-ai entry under ${distDir}`,
+    });
+  }
+  return candidates[0];
+}
+
 function createBuiltBrowserImportSmokeFixture(packageRoot) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-built-browser-smoke-"));
   const tempDistDir = path.join(tempRoot, "dist");
@@ -168,7 +182,7 @@ function createBuiltBrowserImportSmokeFixture(packageRoot) {
   }
 
   return {
-    entryPath: path.join(tempDistDir, "pw-ai.js"),
+    entryPath: findBuiltBrowserEntryPath(tempDistDir),
     stageNodeModulesDir,
     tempRoot,
   };

--- a/scripts/test-built-bundled-runtime-deps.mjs
+++ b/scripts/test-built-bundled-runtime-deps.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   collectBuiltBundledPluginStagedRuntimeDependencyErrors,
   collectBundledPluginRootRuntimeMirrorErrors,
@@ -39,6 +42,188 @@ const errors = [
 ];
 
 assert.deepEqual(errors, [], errors.join("\n"));
+
+function packageNodeModulesPath(nodeModulesDir, packageName) {
+  return path.join(nodeModulesDir, ...packageName.split("/"));
+}
+
+function stageBrowserRuntimeDependencyStub(stageNodeModulesDir, packageName) {
+  const packageDir = packageNodeModulesPath(stageNodeModulesDir, packageName);
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: packageName,
+        version: "0.0.0",
+        main: "./index.cjs",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  if (packageName === "playwright-core") {
+    fs.writeFileSync(
+      path.join(packageDir, "index.cjs"),
+      [
+        "module.exports = {",
+        "  chromium: {",
+        "    marker: 'stub-chromium',",
+        "  },",
+        "  devices: {",
+        "    'Stub Device': { marker: 'stub-device' },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    return;
+  }
+
+  if (packageName === "typebox") {
+    fs.writeFileSync(
+      path.join(packageDir, "index.cjs"),
+      [
+        "const createSchema = (kind, value = {}) => ({ kind, ...value });",
+        "const Type = new Proxy(function Type() {}, {",
+        "  get(_target, prop) {",
+        "    if (prop === Symbol.toStringTag) {",
+        "      return 'Type';",
+        "    }",
+        "    return (...args) => createSchema(String(prop), { args });",
+        "  },",
+        "});",
+        "",
+        "module.exports = { Type };",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    return;
+  }
+
+  fs.writeFileSync(
+    path.join(packageDir, "index.cjs"),
+    ["module.exports = {};", ""].join("\n"),
+    "utf8",
+  );
+}
+
+function createBuiltBrowserImportSmokeFixture(packageRoot) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-built-browser-smoke-"));
+  const tempDistDir = path.join(tempRoot, "dist");
+  const tempNodeModulesDir = path.join(tempRoot, "node_modules");
+  const stageNodeModulesDir = path.join(
+    tempRoot,
+    ".openclaw",
+    "plugin-runtime-deps",
+    "browser",
+    "node_modules",
+  );
+
+  fs.cpSync(path.join(packageRoot, "dist"), tempDistDir, {
+    recursive: true,
+    dereference: true,
+  });
+  fs.copyFileSync(path.join(packageRoot, "package.json"), path.join(tempRoot, "package.json"));
+  fs.cpSync(path.join(packageRoot, "node_modules"), tempNodeModulesDir, {
+    recursive: true,
+    dereference: true,
+  });
+  fs.rmSync(path.join(tempNodeModulesDir, "playwright-core"), {
+    force: true,
+    recursive: true,
+  });
+
+  assert.ok(!fs.existsSync(path.join(tempNodeModulesDir, "playwright-core")));
+  fs.mkdirSync(stageNodeModulesDir, { recursive: true });
+  assert.deepEqual(fs.readdirSync(stageNodeModulesDir), []);
+
+  const browserPackageJson = JSON.parse(
+    fs.readFileSync(path.join(tempDistDir, "extensions", "browser", "package.json"), "utf8"),
+  );
+  const browserRuntimeDeps = new Map(
+    [
+      ...Object.entries(browserPackageJson.dependencies ?? {}),
+      ...Object.entries(browserPackageJson.optionalDependencies ?? {}),
+    ].filter((entry) => typeof entry[1] === "string" && entry[1].length > 0),
+  );
+  const missingBrowserRuntimeDeps = [...browserRuntimeDeps.keys()]
+    .filter((packageName) => {
+      const rootSentinel = path.join(tempNodeModulesDir, ...packageName.split("/"), "package.json");
+      const stagedSentinel = path.join(
+        stageNodeModulesDir,
+        ...packageName.split("/"),
+        "package.json",
+      );
+      return !fs.existsSync(rootSentinel) && !fs.existsSync(stagedSentinel);
+    })
+    .toSorted((left, right) => left.localeCompare(right));
+
+  for (const packageName of missingBrowserRuntimeDeps) {
+    stageBrowserRuntimeDependencyStub(stageNodeModulesDir, packageName);
+  }
+
+  return {
+    entryPath: path.join(tempDistDir, "pw-ai.js"),
+    stageNodeModulesDir,
+    tempRoot,
+  };
+}
+
+function runBuiltBrowserImportSmoke(packageRoot) {
+  const fixture = createBuiltBrowserImportSmokeFixture(packageRoot);
+  try {
+    assert.ok(fs.existsSync(fixture.entryPath), `missing built pw-ai entry: ${fixture.entryPath}`);
+    assert.ok(
+      !fs.existsSync(path.join(fixture.tempRoot, "node_modules", "playwright-core")),
+      "package-root playwright-core should be absent in the smoke fixture",
+    );
+    assert.ok(
+      fs.existsSync(path.join(fixture.stageNodeModulesDir, "playwright-core", "package.json")),
+      "staged playwright-core should be present in the repair fixture",
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `await import(${JSON.stringify(pathToFileURL(fixture.entryPath).href)});`,
+      ],
+      {
+        cwd: fixture.tempRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_PATH: fixture.stageNodeModulesDir,
+        },
+      },
+    );
+
+    assert.equal(
+      result.status,
+      0,
+      [
+        "[build-smoke] built browser pw-ai import failed",
+        `status=${String(result.status)}`,
+        `signal=${String(result.signal)}`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  } finally {
+    fs.rmSync(fixture.tempRoot, { recursive: true, force: true });
+  }
+}
+
+runBuiltBrowserImportSmoke(packageRoot);
+
 process.stdout.write(
   `[build-smoke] bundled runtime dependency smoke passed packageRoot=${packageRoot}\n`,
 );


### PR DESCRIPTION
## Summary

Fix browser Playwright actions failing in packaged builds by resolving `playwright-core` through a browser-local runtime shim.

## Linked Issue/PR

Closes #72168

## Verification

- Confirmed `playwright-core` resolves through `createRequire`.
- Full browser e2e lane was blocked here by an unrelated missing `typebox` dependency.
