### PR TITLE
Fix Discord explicit DM target normalization

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -119,6 +119,30 @@ describe("discordPlugin outbound", () => {
     expect(discordPlugin.outbound?.preferFinalAssistantVisibleText).toBe(true);
   });
 
+  it("preserves explicit user and channel target prefixes", () => {
+    const parseExplicitTarget = discordPlugin.messaging?.parseExplicitTarget;
+    if (!parseExplicitTarget) {
+      throw new Error("Expected discordPlugin.messaging.parseExplicitTarget to be defined");
+    }
+
+    expect(parseExplicitTarget({ raw: "user:123456789012345678" })).toEqual({
+      to: "user:123456789012345678",
+      chatType: "direct",
+    });
+    expect(parseExplicitTarget({ raw: "<@123456789012345678>" })).toEqual({
+      to: "user:123456789012345678",
+      chatType: "direct",
+    });
+    expect(parseExplicitTarget({ raw: "channel:987654321098765432" })).toEqual({
+      to: "channel:987654321098765432",
+      chatType: "channel",
+    });
+    expect(parseExplicitTarget({ raw: "987654321098765432" })).toEqual({
+      to: "channel:987654321098765432",
+      chatType: "channel",
+    });
+  });
+
   it("honors per-account replyToMode overrides", () => {
     const resolveReplyToMode = discordPlugin.threading?.resolveReplyToMode;
     if (!resolveReplyToMode) {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -353,7 +353,7 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
## Summary
- preserve normalized Discord explicit targets from `parseDiscordExplicitTarget`
- prevent `user:<id>` and mentions from collapsing to bare IDs that later default to `channel:<id>`
- add regression coverage for user, mention, channel, and bare numeric target handling

## Why
Cron delivery previews and failure alerts can pass explicit Discord DM targets such as `user:<id>`. Returning only `target.id` strips the `user:` prefix, and later routing treats the bare snowflake as a channel target. That causes Discord DM alerts to fail with `Unknown Channel`.

## Testing
- Not run locally, fresh checkout has no dependencies available in this environment.
- Patch was validated against the installed runtime behavior and reviewed statically.
