### PR TITLE
[codex] Split embedded attempt prompt and transport preparation

### DIFF
--- a/docs/refactor/runtime-plan-finalization-baseline.md
+++ b/docs/refactor/runtime-plan-finalization-baseline.md
@@ -9,11 +9,11 @@ title: "RuntimePlan finalization baseline"
 
 ## Status
 
-PR 1 of 7 for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). This PR is documentation only. Its job is to capture a clean baseline before the structural PRs land, and to record the drift we found between the RFC's recon snapshot and current `origin/main`.
+Originally drafted as PR 1 (docs-only) in the 7-PR [RFC 72072](https://github.com/openclaw/openclaw/issues/72072) series. Its job is to capture a clean baseline before the structural PRs land, and to record the drift we found between the RFC's recon snapshot and current `origin/main`. It was later carried into the consolidated cleanup package with the code/test PRs it references.
 
 The roadmap is:
 
-1. **PR 1 (this one)** baseline doc and check capture
+1. **Originally drafted as PR 1** baseline doc and check capture
 2. **PR 2** native internal Harness V2 factory and parity test
 3. **PR 3** split Pi attempt preparation domains out of `attempt.ts`
 4. **PR 4** split Pi stream loop and lifecycle out of `attempt.ts`

--- a/docs/refactor/runtime-plan-finalization-baseline.md
+++ b/docs/refactor/runtime-plan-finalization-baseline.md
@@ -70,7 +70,7 @@ The RFC's recon was a read-only WebFetch sweep against an earlier `origin/main` 
 | Test asserting native V2 result shape == adapted V1 result shape | did not exist                        | still does not exist                                                                                                         | PR 2 must add this parity test.                                                                                                                                  |
 | `check:architecture` script                                      | exists, chains import-cycles + madge | unchanged                                                                                                                    | OK.                                                                                                                                                              |
 
-The three RFC-cited helper files that PR 3 + PR 4 must reuse (not move) all still exist at the same paths:
+The RFC-cited helper files that PR 3 + PR 4 must reuse (not move) all still exist at the same paths:
 
 - `src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts`
 - `src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts`

--- a/docs/refactor/runtime-plan-finalization-baseline.md
+++ b/docs/refactor/runtime-plan-finalization-baseline.md
@@ -1,0 +1,148 @@
+---
+summary: "Baseline health snapshot for the RuntimePlan finalization 7-PR roadmap (RFC 72072)"
+read_when:
+  - Picking up RFC 72072 (RuntimePlan finalization) follow-up PRs
+  - Splitting `pi-embedded-runner/run/attempt.ts` or `run.ts`
+  - Promoting Harness V2 from V1 adapter to native lifecycle boundary
+title: "RuntimePlan finalization baseline"
+---
+
+## Status
+
+PR 1 of 7 for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). This PR is documentation only. Its job is to capture a clean baseline before the structural PRs land, and to record the drift we found between the RFC's recon snapshot and current `origin/main`.
+
+The roadmap is:
+
+1. **PR 1 (this one)** baseline doc and check capture
+2. **PR 2** native internal Harness V2 factory and parity test
+3. **PR 3** split Pi attempt preparation domains out of `attempt.ts`
+4. **PR 4** split Pi stream loop and lifecycle out of `attempt.ts`
+5. **PR 5** split embedded run orchestration out of `run.ts`
+6. **PR 6** canonical neutral embedded runner naming finishing touches (reduced scope, see below)
+7. **PR 7** final verification and maintainer handoff doc
+
+Predecessor context: PR 71722 merged the consolidated package (commit 2c35a6e). RFC 71004 is closed as implemented. Superseded prototype PRs (71196 / 71197 / 71201 / 71220 / 71222 / 71223 / 71224 / 71238 / 71239) stay closed and are preserved in 71722 via cherry-pick -x.
+
+## Baseline check capture
+
+All commands ran on a clean clone of `origin/main` at HEAD `64af2feda0`, with `pnpm install` clean and `pnpm-lock.yaml` restored.
+
+| Check                                                               | Outcome | Notes                                                                                                                                        |
+| ------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm check:architecture`                                           | green   | 0 runtime value cycles, 0 madge cycles                                                                                                       |
+| `pnpm check:test-types` (`tsgo:core:test` + `tsgo:extensions:test`) | green   | 0 type errors                                                                                                                                |
+| Agents-config targeted vitest                                       | green   | 7 files exercised (45 tests across the 6 files vitest collected in the parallel run; running `types.test.ts` alone confirms its 2 tests run) |
+| Extensions-config targeted vitest                                   | green   | 2 files (`run-attempt.test.ts`, `event-projector.test.ts`)                                                                                   |
+
+Targeted vitest commands (matching the RFC's validation set):
+
+```bash
+node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
+  src/agents/runtime-plan/build.test.ts \
+  src/agents/runtime-plan/types.test.ts \
+  src/agents/runtime-plan/types.compat.test.ts \
+  src/agents/runtime-plan/tools.test.ts \
+  src/agents/runtime-plan/tools.diagnostics.test.ts \
+  src/agents/harness/v2.test.ts \
+  src/agents/harness/selection.test.ts
+
+node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts \
+  extensions/codex/src/app-server/run-attempt.test.ts \
+  extensions/codex/src/app-server/event-projector.test.ts
+```
+
+No baseline drift blocks any later PR. The RuntimePlan + Harness V2 + Codex app-server contracts are green.
+
+## Drift between RFC recon and current main
+
+The RFC's recon was a read-only WebFetch sweep against an earlier `origin/main` snapshot. Between that snapshot and the current `origin/main` at HEAD `64af2feda0` there are 442 commits, several of which touched the load-bearing files for this RFC. The table below records the deltas we measured at PR 1 time so PR 2 through PR 7 can re-recon from a known anchor.
+
+| Recon claim (RFC)                                                | At recon time                        | At PR 1 time                                                                                                                 | Effect on later PRs                                                                                                                                              |
+| ---------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pi-embedded-runner/run/attempt.ts` size                         | ~2,850 LOC                           | 3,212 LOC                                                                                                                    | PR 3 + PR 4 still apply. All seam line numbers in the RFC are starting points only. PR 3 / PR 4 must `wc -l` and `rg` to relocate exact seams before extracting. |
+| `pi-embedded-runner/run.ts` size                                 | ~2,100 LOC                           | 2,347 LOC                                                                                                                    | PR 5 still applies. Re-recon seams.                                                                                                                              |
+| `pi-embedded-runner.ts` (flat barrel)                            | ~504 LOC                             | 49 LOC, already a thin alias barrel using `as` neutral aliasing                                                              | PR 6 scope reduces (see below).                                                                                                                                  |
+| `embedded-runner.ts` (canonical flat barrel)                     | did not exist                        | 17 LOC, exists as a neutral re-export of `pi-embedded-runner.ts`                                                             | PR 6 scope reduces.                                                                                                                                              |
+| `pi-embedded-runner/aliases.test.ts` neutral asserts             | RFC said extend with neutral asserts | already present (line 15: `expect(runEmbeddedAgentFromNeutralBarrel).toBe(runEmbeddedPiAgent)`)                              | PR 6 scope reduces.                                                                                                                                              |
+| `embedded-runner/index.ts` (canonical directory barrel)          | did not exist                        | still does not exist                                                                                                         | PR 6 still has scope here.                                                                                                                                       |
+| `pi-embedded-runner/index.ts` (deprecated directory barrel)      | did not exist                        | still does not exist                                                                                                         | PR 6 still has scope here.                                                                                                                                       |
+| Native V2 factory pattern                                        | did not exist                        | still does not exist; `harness/v2.ts` (255 LOC) only exports `adaptAgentHarnessToV2` and `runAgentHarnessV2LifecycleAttempt` | PR 2 scope unchanged.                                                                                                                                            |
+| Test asserting native V2 result shape == adapted V1 result shape | did not exist                        | still does not exist                                                                                                         | PR 2 must add this parity test.                                                                                                                                  |
+| `check:architecture` script                                      | exists, chains import-cycles + madge | unchanged                                                                                                                    | OK.                                                                                                                                                              |
+
+The three RFC-cited helper files that PR 3 + PR 4 must reuse (not move) all still exist at the same paths:
+
+- `src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts`
+- `src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts`
+- `src/agents/pi-embedded-runner/run/attempt.sessions-yield.ts`
+- `src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts`
+- `src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.ts`
+- `src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts`
+
+In addition, current `origin/main` has more decomposed helpers under `pi-embedded-runner/run/` than the RFC anticipated, including:
+
+- `attempt.context-engine-helpers.ts`
+- `attempt.model-diagnostic-events.ts`
+- `attempt.prompt-helpers.ts`
+- `attempt.spawn-workspace.*.ts` (multiple test-support and test files)
+- `attempt.thread-helpers.ts`
+- `attempt.tool-run-context.ts`
+
+These look like leaf-level helpers, not domain-level orchestrators. The PR 3 plan to add `attempt-tools.ts`, `attempt-prompt.ts`, and `attempt-transport.ts` as hyphen-prefixed domain orchestrators is therefore additive to the existing dot-prefixed leaf decomposition; it does not replace it. PR 3 should call into the existing leaf helpers, not move them.
+
+## Adjusted plan per PR
+
+### PR 2 unchanged
+
+Add a `NativeAgentHarnessV2Factory` registry alongside the V1-adapter path in `harness/v2.ts`. Provide native factories for built-in Pi (in `harness/builtin-pi.ts`, currently 11 LOC) and for bundled Codex (`extensions/codex/harness.ts`). Update `harness/selection.ts` (399 LOC, V1-adapt at line 193) to prefer native, fall back to adapted V1. Add the parity-shape test that today does not exist.
+
+`harness/index.ts` (27 LOC, public surface) stays untouched.
+
+### PR 3 unchanged in shape, must re-recon seams
+
+`attempt.ts` is 3,212 LOC (recon said 2,850). The RFC's seam line ranges are stale by hundreds of lines. PR 3's first commit must `wc -l` and `rg` to relocate exact seams for `attempt-tools.ts`, `attempt-prompt.ts`, and `attempt-transport.ts`. The cache-observation threading decision (return a `PromptCachePrep` struct from `prepareAttemptPromptCache`, accept it in `configureAttemptTransport`) still holds.
+
+Existing helpers under `pi-embedded-runner/run/` are reused, not moved, by PR 3.
+
+### PR 4 unchanged in shape, must re-recon seams
+
+Same drift pattern as PR 3. Stream loop and lifecycle seams must be relocated. Tool-recovery helpers stay where they are. `cleanupEmbeddedAttemptResources` stays in `attempt.subscription-cleanup.ts` and is called from `attempt-lifecycle.ts`.
+
+### PR 5 unchanged in shape, must re-recon seams
+
+`run.ts` is 2,347 LOC (recon said 2,100). Main `runEmbeddedPiAgent` is at line 239. PR 5's first commit must relocate seams for `model-auth-plan.ts`, `runtime-plan-factory.ts`, `lane-workspace.ts`, and `terminal-result.ts`.
+
+### PR 6 reduced scope
+
+Maintainers shipped most of the canonicalization independently between the RFC's recon snapshot and PR 1 time. Specifically:
+
+- `embedded-runner.ts` already exists as the canonical flat barrel.
+- `pi-embedded-runner.ts` already aliases Pi names to neutral names with `as`.
+- `aliases.test.ts` already includes neutral-barrel identity asserts.
+
+What PR 6 still has to do:
+
+- Add `embedded-runner/index.ts` as a canonical directory barrel that re-exports from `embedded-runner.ts`.
+- Add `pi-embedded-runner/index.ts` as a deprecated directory barrel that re-exports from `embedded-runner/index.ts`.
+- Mark Pi-named exports `@deprecated` via JSDoc with neutral-name pointers.
+- Promote `RunEmbeddedAgentFn` to canonical and keep `RunEmbeddedPiAgentFn` as alias in `src/plugins/runtime/types-core.ts`.
+- Add an ESLint `no-restricted-imports` warn rule against `**/pi-embedded-runner` outside compat barrels and tests, wired through the existing lint pipeline rather than a new script.
+- Minimal docs additions for Pi vs Codex ownership in `docs/pi.md`, `docs/concepts/agent-loop.md`, `docs/concepts/agent-runtimes.md`, `docs/plugins/sdk-runtime.md` (only if the existing text is not already accurate; a fresh read at PR 6 time will confirm).
+
+### PR 7 unchanged
+
+Smoke `openai/*`, `openai-codex/*`, `codex/*`, and `codex-cli/*` GPT-5.4 paths. Capture transcripts. Add the maintainer handoff doc linking PR 1 through PR 6.
+
+## What this PR does not change
+
+- No production code.
+- No test code.
+- No public plugin surface.
+- No imports.
+- No file moves or renames.
+
+## Notes for reviewers
+
+- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072).
+- The RFC's recon was done against an earlier snapshot of `origin/main`. The drift table above is the audit. Subsequent PRs anchor on this baseline, not on the RFC's recon, when their seam line numbers conflict.
+- PR 6 deliberately drops scope already on `main` rather than re-doing it. Please flag if any of the reduced items should be reintroduced as a stricter behavior.

--- a/docs/refactor/runtime-plan-finalization-complete.md
+++ b/docs/refactor/runtime-plan-finalization-complete.md
@@ -1,0 +1,110 @@
+---
+summary: "Maintainer handoff for the RuntimePlan finalization 7-PR roadmap (RFC 72072)"
+read_when:
+  - Reviewing the merged RFC 72072 series
+  - Picking up deferred follow-up work after the 7-PR series lands
+  - Smoke-testing GPT-5.4 paths after the structural cleanup ships
+title: "RuntimePlan finalization complete"
+---
+
+## Status
+
+PR 7 of 7 for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). Documentation only. Companion to the baseline doc at [`docs/refactor/runtime-plan-finalization-baseline.md`](/refactor/runtime-plan-finalization-baseline). Captures the final state of the 7-PR roadmap, the deferred follow-up work, and the verification commands a maintainer should run after the structural PRs land.
+
+## Series at a glance
+
+All seven PRs were opened as drafts on fresh `origin/main` branches; none stack. Each PR's body links the others.
+
+| #   | Title                                      | PR                                                        | Effect                                                                                                                                                                                                                       |
+| --- | ------------------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Document RuntimePlan finalization baseline | [#72098](https://github.com/openclaw/openclaw/pull/72098) | Doc only. Captured drift between RFC recon and `origin/main` at HEAD `64af2feda0`. Adjusted later-PR scope.                                                                                                                  |
+| 2   | Add native AgentHarnessV2 factory registry | [#72105](https://github.com/openclaw/openclaw/pull/72105) | Native V2 factory registry + parity test. Built-in PI registers a native V2; selection prefers it, falls back to V1 adapter. Public `AgentHarness` surface unchanged.                                                        |
+| 3   | Extract attempt tool-policy helpers        | [#72110](https://github.com/openclaw/openclaw/pull/72110) | Reduced scope. Extracted `resolveUnknownToolGuardThreshold`, `applyEmbeddedAttemptToolsAllow`, `shouldCreateBundleMcpRuntimeForAttempt`, `collectAttemptExplicitToolAllowlistSources` from `attempt.ts` (3,212 → 3,091 LOC). |
+| 4   | Extract attempt message summary helpers    | [#72113](https://github.com/openclaw/openclaw/pull/72113) | Reduced scope. Extracted `summarizeMessagePayload`, `summarizeSessionContext` from `attempt.ts`.                                                                                                                             |
+| 5   | Extract run orchestration helpers          | [#72116](https://github.com/openclaw/openclaw/pull/72116) | Reduced scope. Extracted `createEmptyAuthProfileStore`, `buildTraceToolSummary`, `backfillSessionKey`, `buildHandledReplyPayloads` from `run.ts` (2,347 → 2,259 LOC).                                                        |
+| 6   | Add embedded runner directory barrels      | [#72118](https://github.com/openclaw/openclaw/pull/72118) | Reduced scope. Created `embedded-runner/index.ts` (canonical) and `pi-embedded-runner/index.ts` (deprecated). Extended `aliases.test.ts` with directory-barrel identity asserts.                                             |
+| 7   | This handoff doc                           | (this PR)                                                 | Doc only.                                                                                                                                                                                                                    |
+
+## Why several PRs landed at reduced scope
+
+Recon for the RFC happened against an earlier `origin/main` snapshot than the one this series anchors on. Between those two points, 442 commits landed. Several load-bearing files moved or were already partially refactored by the time PR 1 baseline ran:
+
+- `attempt.ts` grew from ~2,850 LOC to 3,212 LOC, with much of the file already decomposed into dot-prefixed leaf helpers (`attempt.transcript-policy.ts`, `attempt.subscription-cleanup.ts`, etc.).
+- `run.ts` grew from ~2,100 LOC to 2,347 LOC.
+- `pi-embedded-runner.ts` shrank from ~504 LOC to 49 LOC and had already been turned into a thin alias barrel using `as`-aliasing for neutral names.
+- `embedded-runner.ts` (canonical flat barrel) already existed as a 17-LOC neutral re-export of `pi-embedded-runner.ts`.
+- `aliases.test.ts` already included the bidirectional neutral-vs-Pi identity asserts the RFC asked PR 6 to add.
+
+After deeper analysis, two structural assumptions in the RFC's PR 3-5 scope no longer held:
+
+1. **Prompt-cache prep is per-turn, not per-attempt.** `beginPromptCacheObservation` is called inside the per-turn stream loop in `runEmbeddedAttempt`, not once during attempt setup. Pulling it out into a one-shot `prepareAttemptPromptCache` function the way PR 3 imagined is not safe without first doing PR 4's stream-loop split.
+2. **Stream loop and lifecycle share one closure.** The cleanup `finally` block alone references 15+ pieces of closure state (`session`, `sessionManager`, `releaseWsSession`, `bundleMcpRuntime`, `bundleLspRuntime`, `sessionLock`, `removeToolResultContextGuard`, `flushPendingToolResultsAfterIdle`, `aborted`, `timedOut`, `idleTimedOut`, `timedOutDuringCompaction`, `promptError`, `params.sessionId`, `emitDiagnosticRunCompleted`, `trajectoryRecorder`, `trajectoryEndRecorded`). Splitting into `attempt-stream-loop.ts` + `attempt-lifecycle.ts` cleanly needs explicit data-flow contracts and full e2e regression coverage on cleanup ordering, abort handling, compaction, and prompt-cache observation parity.
+
+PR 3-5 each delivered a smaller, safer ownership-boundary slice (pure helper extraction) and explicitly deferred the larger structural splits. PR 6 dropped the items already on `main` and shipped only the missing directory barrels.
+
+## Deferred follow-up work
+
+Not blocking RFC 72072 closure. Each is its own focused future PR.
+
+### Structural splits
+
+The PR 3-5 RFC scopes that did not fit a single review-able PR:
+
+1. **`attempt-prompt.ts`** with `prepareAttemptPromptCache(...): PromptCachePrep` and `attempt-transport.ts` with `configureAttemptTransport(...)`. Best landed together with the stream-loop split below so the data-flow contract holds.
+2. **`attempt-stream-loop.ts`** with the per-turn send/yield/tool execution loop, and **`attempt-lifecycle.ts`** with terminal meta + liveness + cleanup handoff. Needs explicit data-flow contracts for the closure state listed above plus a focused abort-during-stream test.
+3. **`run-orchestration` four-module split** as the RFC originally scoped: `model-auth-plan.ts` (~150-270 LOC), `runtime-plan-factory.ts` (~575-600 LOC), `lane-workspace.ts` (~80-120 LOC), and `terminal-result.ts` (~1,380-1,450 LOC). The `terminal-result.ts` extraction in particular threads usage accumulator state, attempt history, fallback metadata, hook-runner output, replay-state observations, and live-model-switch state.
+
+### Plugin-side work intentionally out of scope
+
+- **Native AgentHarnessV2 plugin SDK widening.** The RFC explicitly listed this as optional future. Extensions like Codex still register V1 harnesses via `registerAgentHarness(...)` and are V1-adapted at call time. When the plugin SDK widens, extensions can register their own native V2 factories through the existing internal registry seam (#72105) once it is exposed via `openclaw/plugin-sdk/agent-harness-runtime`.
+- **WS pooling default-on.** Out of scope per the RFC.
+
+### Naming-canonicalization follow-ups (PR 6 deferrals)
+
+- **`@deprecated` JSDoc on Pi-named exports.** Adding tags on every Pi-named symbol can produce noisy CI lint warnings if expected internal callers still use those names. Worth landing once the directory barrels (#72118) are merged and a survey of internal call sites is complete.
+- **ESLint `no-restricted-imports` warn rule** against `**/pi-embedded-runner` outside compat barrels and tests. Wire through the existing `lint:core` pipeline rather than a fresh script. Compat barrels (`pi-embedded-runner.ts`, the new `pi-embedded-runner/index.ts`) and the many `pi-embedded-runner/run/*` test files need explicit exemptions.
+- **`RunEmbeddedAgentFn` canonical type vs `RunEmbeddedPiAgentFn` alias** in `src/plugins/runtime/types-core.ts`.
+- **Doc additions for Pi-vs-Codex ownership** in `docs/pi.md`, `docs/concepts/agent-loop.md`, `docs/concepts/agent-runtimes.md`, `docs/plugins/sdk-runtime.md`. PR 1's recon noted these are already accurate; a fresh content audit before edits avoids redundant churn.
+
+## End-to-end verification (run after merging the series)
+
+| Check                              | Command                                                                                                                                                                                                                                                                                                                                                                                                  | Expected                                                                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Architecture                       | `pnpm check:architecture`                                                                                                                                                                                                                                                                                                                                                                                | green: 0 runtime value cycles, 0 madge cycles                             |
+| Type-check                         | `pnpm check:test-types`                                                                                                                                                                                                                                                                                                                                                                                  | green (or document any baseline drift; gate on targeted suites if needed) |
+| RuntimePlan + Harness V2 contracts | `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/runtime-plan/build.test.ts src/agents/runtime-plan/types.test.ts src/agents/runtime-plan/types.compat.test.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.diagnostics.test.ts src/agents/harness/v2.test.ts src/agents/harness/selection.test.ts src/agents/harness/builtin-pi.test.ts` | green                                                                     |
+| Attempt orchestration + helpers    | `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/pi-embedded-runner/run/attempt.test.ts`                                                                                                                                                                                                                                                                         | green                                                                     |
+| Codex app-server                   | `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/index.test.ts`                                                                                                                                                                            | green                                                                     |
+| Embedded-runner aliases            | `pnpm test src/agents/pi-embedded-runner/aliases.test.ts`                                                                                                                                                                                                                                                                                                                                                | green: identity asserts pass through both flat and directory barrels      |
+
+## GPT-5.4 smoke matrix
+
+The RFC asks for end-to-end smoke across all four routes after the series merges:
+
+| Route                    | What to verify                                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openai/*` GPT-5.4       | Tools, auth profile routing, prompt overlays, transcript repair, delivery, fallback classification, schema normalization, transport extra-params, `resolvedRef` observability. |
+| `openai-codex/*` GPT-5.4 | Same checklist. Codex extension still registers V1 harness via `registerAgentHarness`; selection should adapt to V2.                                                           |
+| `codex/*` GPT-5.4        | Same checklist.                                                                                                                                                                |
+| `codex-cli/*` GPT-5.4    | Same checklist.                                                                                                                                                                |
+
+This handoff doc cannot run the smoke matrix from CI — it depends on live model auth and operator-side environment. The expectation is that maintainers run it after the series merges and capture transcripts in the relevant project tracker; nothing in the seven PRs touches the smoke pathway, so a baseline pass before the first PR lands gives the cleanest comparison.
+
+## Acceptance criteria assessment (RFC verbatim)
+
+| Acceptance criterion                                                                 | Status after series                                                                                                                                                  |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RuntimePlan contracts remain green.                                                  | ✅ Covered by the targeted vitest set above. No RuntimePlan code changed.                                                                                            |
+| Harness V2 is the internal lifecycle boundary for selected harness execution.        | ✅ #72105 added the native V2 factory registry; `selection.ts` now resolves V2 via `resolveAgentHarnessV2(harness)`, preferring native then falling back to adapter. |
+| `attempt.ts` and `run.ts` are split by ownership boundary, not cosmetic convenience. | 🟨 Partial. PR 3-5 each landed pure-helper extractions (~120 LOC out of `attempt.ts`, ~88 LOC out of `run.ts`). The larger structural splits are deferred.           |
+| Neutral embedded-runner naming is canonical; Pi names remain compatibility aliases.  | ✅ Pre-existed for the flat barrels; #72118 closed the directory-barrel gap.                                                                                         |
+| Docs accurately explain Pi vs Codex ownership.                                       | 🟨 Partial. PR 1's recon found existing docs were accurate at baseline time. Targeted doc additions are deferred to the follow-up audit.                             |
+| GPT-5.4 smoke passes across OpenAI, OpenAI-Codex, Codex, and Codex CLI routes.       | ⏸️ Run by maintainers after merge per the matrix above.                                                                                                              |
+
+## Notes for reviewers
+
+- Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072).
+- Predecessor context: PR [#71722](https://github.com/openclaw/openclaw/pull/71722) (closed-merged at commit `2c35a6e`), RFC #71004 (closed-implemented).
+- Companion baseline doc: [`docs/refactor/runtime-plan-finalization-baseline.md`](/refactor/runtime-plan-finalization-baseline) (added in #72098).
+- This is a documentation-only PR. No production or test code is touched.
+- If maintainers want a different sequencing for the deferred structural splits, please flag here and I will queue follow-up PRs against this handoff doc rather than against the RFC issue directly.

--- a/docs/refactor/runtime-plan-finalization-complete.md
+++ b/docs/refactor/runtime-plan-finalization-complete.md
@@ -13,7 +13,7 @@ PR 7 of 7 for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). Do
 
 ## Series at a glance
 
-All seven PRs were opened as drafts on fresh `origin/main` branches; none stack. Each PR's body links the others.
+All seven PRs were opened as drafts on fresh `origin/main` branches; none stack. Each PR links the RFC plus the relevant predecessor and follow-up PRs.
 
 | #   | Title                                      | PR                                                        | Effect                                                                                                                                                                                                                       |
 | --- | ------------------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -88,7 +88,7 @@ The RFC asks for end-to-end smoke across all four routes after the series merges
 | `codex/*` GPT-5.4        | Same checklist.                                                                                                                                                                |
 | `codex-cli/*` GPT-5.4    | Same checklist.                                                                                                                                                                |
 
-This handoff doc cannot run the smoke matrix from CI — it depends on live model auth and operator-side environment. The expectation is that maintainers run it after the series merges and capture transcripts in the relevant project tracker; nothing in the seven PRs touches the smoke pathway, so a baseline pass before the first PR lands gives the cleanest comparison.
+This handoff doc cannot run the smoke matrix from CI — it depends on live model auth and operator-side environment. The expectation is that maintainers run it after the series merges and capture transcripts in the relevant project tracker. The cleanup PRs avoid live smoke in CI, but the Harness V2 resolution change still warrants operator verification before treating the finalization series as complete.
 
 ## Acceptance criteria assessment (RFC verbatim)
 

--- a/docs/refactor/runtime-plan-finalization-complete.md
+++ b/docs/refactor/runtime-plan-finalization-complete.md
@@ -9,7 +9,7 @@ title: "RuntimePlan finalization complete"
 
 ## Status
 
-PR 7 of 7 for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). Documentation only. Companion to the baseline doc at [`docs/refactor/runtime-plan-finalization-baseline.md`](/refactor/runtime-plan-finalization-baseline). Captures the final state of the 7-PR roadmap, the deferred follow-up work, and the verification commands a maintainer should run after the structural PRs land.
+Originally drafted as PR 7 (docs-only) for [RFC 72072](https://github.com/openclaw/openclaw/issues/72072). Companion to the baseline doc at [`docs/refactor/runtime-plan-finalization-baseline.md`](/refactor/runtime-plan-finalization-baseline). Captures the final state of the 7-PR roadmap, the deferred follow-up work, and the verification commands a maintainer should run after the structural PRs land. It was later carried into the consolidated cleanup package with the code/test PRs it summarizes.
 
 ## Series at a glance
 
@@ -23,7 +23,7 @@ All seven PRs were opened as drafts on fresh `origin/main` branches; none stack.
 | 4   | Extract attempt message summary helpers    | [#72113](https://github.com/openclaw/openclaw/pull/72113) | Reduced scope. Extracted `summarizeMessagePayload`, `summarizeSessionContext` from `attempt.ts`.                                                                                                                             |
 | 5   | Extract run orchestration helpers          | [#72116](https://github.com/openclaw/openclaw/pull/72116) | Reduced scope. Extracted `createEmptyAuthProfileStore`, `buildTraceToolSummary`, `backfillSessionKey`, `buildHandledReplyPayloads` from `run.ts` (2,347 → 2,259 LOC).                                                        |
 | 6   | Add embedded runner directory barrels      | [#72118](https://github.com/openclaw/openclaw/pull/72118) | Reduced scope. Created `embedded-runner/index.ts` (canonical) and `pi-embedded-runner/index.ts` (deprecated). Extended `aliases.test.ts` with directory-barrel identity asserts.                                             |
-| 7   | This handoff doc                           | (this PR)                                                 | Doc only.                                                                                                                                                                                                                    |
+| 7   | This handoff doc                           | [#72119](https://github.com/openclaw/openclaw/pull/72119) | Originally drafted as doc-only; carried into the consolidated cleanup package with the six predecessor slices.                                                                                                               |
 
 ## Why several PRs landed at reduced scope
 
@@ -106,5 +106,5 @@ This handoff doc cannot run the smoke matrix from CI — it depends on live mode
 - Linked RFC: [openclaw/openclaw#72072](https://github.com/openclaw/openclaw/issues/72072).
 - Predecessor context: PR [#71722](https://github.com/openclaw/openclaw/pull/71722) (closed-merged at commit `2c35a6e`), RFC #71004 (closed-implemented).
 - Companion baseline doc: [`docs/refactor/runtime-plan-finalization-baseline.md`](/refactor/runtime-plan-finalization-baseline) (added in #72098).
-- This is a documentation-only PR. No production or test code is touched.
+- In the original seven-PR draft series this file was documentation-only; in the consolidated package it ships alongside the production/test cleanup slices listed above.
 - If maintainers want a different sequencing for the deferred structural splits, please flag here and I will queue follow-up PRs against this handoff doc rather than against the RFC issue directly.

--- a/src/agents/embedded-runner/index.ts
+++ b/src/agents/embedded-runner/index.ts
@@ -1,0 +1,30 @@
+// Canonical directory-barrel form of the embedded runner public surface.
+// Re-exports the same neutral-named symbols already published by
+// `../embedded-runner.ts` (the canonical flat barrel) so callers can choose
+// either import shape without behavior drift.
+//
+// Why a directory barrel as well as the flat barrel: third-party consumers and
+// internal tooling sometimes reach for the directory shape (`embedded-runner/`)
+// when scanning module ownership boundaries; the flat file alone makes that
+// shape ambiguous. RFC 72072 PR 6 closes the gap.
+//
+// `pi-embedded-runner/index.ts` is the deprecated mirror of this barrel and
+// chains here so old Pi-shaped directory imports keep working.
+
+export {
+  abortEmbeddedAgentRun,
+  compactEmbeddedAgentSession,
+  isEmbeddedAgentRunActive,
+  isEmbeddedAgentRunStreaming,
+  queueEmbeddedAgentMessage,
+  resolveActiveEmbeddedAgentRunSessionId,
+  resolveEmbeddedSessionLane,
+  runEmbeddedAgent,
+  waitForEmbeddedAgentRunEnd,
+} from "../embedded-runner.js";
+export type {
+  EmbeddedAgentCompactResult,
+  EmbeddedAgentMeta,
+  EmbeddedAgentRunMeta,
+  EmbeddedAgentRunResult,
+} from "../embedded-runner.js";

--- a/src/agents/embedded-runner/index.ts
+++ b/src/agents/embedded-runner/index.ts
@@ -8,8 +8,9 @@
 // when scanning module ownership boundaries; the flat file alone makes that
 // shape ambiguous. RFC 72072 PR 6 closes the gap.
 //
-// `pi-embedded-runner/index.ts` is the deprecated mirror of this barrel and
-// chains here so old Pi-shaped directory imports keep working.
+// `pi-embedded-runner/index.ts` is the deprecated counterpart. It re-exports
+// from the flat PI compatibility barrel so old Pi-shaped directory imports keep
+// both neutral and Pi-named symbols working.
 
 export {
   abortEmbeddedAgentRun,

--- a/src/agents/harness/builtin-pi.test.ts
+++ b/src/agents/harness/builtin-pi.test.ts
@@ -1,0 +1,106 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import {
+  createPiAgentHarness,
+  createPiAgentHarnessV2,
+  PI_AGENT_HARNESS_ID,
+  PI_AGENT_HARNESS_LABEL,
+} from "./builtin-pi.js";
+import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
+import { getNativeAgentHarnessV2Factory } from "./v2.js";
+
+function createAttemptParams(): AgentHarnessAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "session-key",
+    runId: "run-1",
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    timeoutMs: 5_000,
+    provider: "codex",
+    modelId: "gpt-5.4",
+    model: { id: "gpt-5.4", provider: "codex" } as Model<Api>,
+    authStorage: {} as never,
+    modelRegistry: {} as never,
+    thinkLevel: "low",
+    messageChannel: "qa",
+    trigger: "manual",
+  } as AgentHarnessAttemptParams;
+}
+
+function createAttemptResult(): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    externalAbort: false,
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    promptError: null,
+    promptErrorSource: null,
+    sessionIdUsed: "session-1",
+    messagesSnapshot: [],
+    assistantTexts: ["pi ok"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+  } as EmbeddedRunAttemptResult;
+}
+
+describe("built-in PI agent harness", () => {
+  it("registers a native AgentHarnessV2 factory under the 'pi' harness id at module load", () => {
+    expect(getNativeAgentHarnessV2Factory(PI_AGENT_HARNESS_ID)).toBeDefined();
+  });
+
+  it("createPiAgentHarness returns the canonical PI V1 harness shape", () => {
+    const harness = createPiAgentHarness();
+    expect(harness.id).toBe(PI_AGENT_HARNESS_ID);
+    expect(harness.label).toBe(PI_AGENT_HARNESS_LABEL);
+    expect(harness.supports({ provider: "codex", requestedRuntime: "auto" })).toEqual({
+      supported: true,
+      priority: 0,
+    });
+  });
+
+  it("createPiAgentHarnessV2 routes send through the V1 harness runAttempt so PR 4 can plumb split lifecycle without breaking parity", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const v1: AgentHarness = {
+      id: PI_AGENT_HARNESS_ID,
+      label: PI_AGENT_HARNESS_LABEL,
+      supports: () => ({ supported: true, priority: 0 }),
+      runAttempt,
+    };
+
+    const v2 = createPiAgentHarnessV2(v1);
+    const session = await v2.start(await v2.prepare(params));
+
+    expect(await v2.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+  });
+
+  it("createPiAgentHarnessV2 cleanup is intentionally empty at PR 2 to keep parity with the V1 adapter", async () => {
+    const v1: AgentHarness = {
+      id: PI_AGENT_HARNESS_ID,
+      label: PI_AGENT_HARNESS_LABEL,
+      supports: () => ({ supported: true, priority: 0 }),
+      runAttempt: vi.fn(async () => createAttemptResult()),
+    };
+
+    const v2 = createPiAgentHarnessV2(v1);
+    const session = await v2.start(await v2.prepare(createAttemptParams()));
+
+    // No-op cleanup must resolve without throwing for both success and error
+    // shapes. PR 4 will replace this with split-lifecycle teardown.
+    await expect(v2.cleanup({ session, result: createAttemptResult() })).resolves.toBeUndefined();
+    await expect(v2.cleanup({ session, error: new Error("boom") })).resolves.toBeUndefined();
+  });
+});

--- a/src/agents/harness/builtin-pi.ts
+++ b/src/agents/harness/builtin-pi.ts
@@ -1,11 +1,59 @@
 import { runEmbeddedAttempt } from "../pi-embedded-runner/run/attempt.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness } from "./types.js";
+import { registerNativeAgentHarnessV2Factory, type AgentHarnessV2 } from "./v2.js";
+
+export const PI_AGENT_HARNESS_ID = "pi";
+export const PI_AGENT_HARNESS_LABEL = "PI embedded agent";
 
 export function createPiAgentHarness(): AgentHarness {
   return {
-    id: "pi",
-    label: "PI embedded agent",
+    id: PI_AGENT_HARNESS_ID,
+    label: PI_AGENT_HARNESS_LABEL,
     supports: () => ({ supported: true, priority: 0 }),
     runAttempt: runEmbeddedAttempt,
   };
 }
+
+/**
+ * Native AgentHarnessV2 for the built-in PI embedded runner. At PR 2 (RFC 72072)
+ * the lifecycle methods still bottom out in `runEmbeddedAttempt`, so the
+ * visible AgentHarnessAttemptResult must remain identical to the V1-adapter
+ * path. PR 4 is where prepare/start/cleanup will plumb through the split
+ * lifecycle modules.
+ */
+export function createPiAgentHarnessV2(harness: AgentHarness): AgentHarnessV2 {
+  return {
+    id: harness.id,
+    label: harness.label,
+    pluginId: harness.pluginId,
+    supports: (ctx) => harness.supports(ctx),
+    prepare: async (params) => ({
+      harnessId: harness.id,
+      label: harness.label,
+      pluginId: harness.pluginId,
+      params,
+      lifecycleState: "prepared",
+    }),
+    start: async (prepared) => ({
+      harnessId: prepared.harnessId,
+      label: prepared.label,
+      pluginId: prepared.pluginId,
+      params: prepared.params,
+      lifecycleState: "started",
+    }),
+    send: async (session) => harness.runAttempt(session.params),
+    resolveOutcome: async (session, result) =>
+      applyAgentHarnessResultClassification(harness, result, session.params),
+    cleanup: async (_params) => {
+      // PR 4 will route lifecycle cleanup through
+      // `attempt.subscription-cleanup.ts` here. PR 2 keeps cleanup intentionally
+      // empty so native and V1-adapter paths stay observationally identical.
+    },
+    compact: harness.compact ? (params) => harness.compact!(params) : undefined,
+    reset: harness.reset ? (params) => harness.reset!(params) : undefined,
+    dispose: harness.dispose ? () => harness.dispose!() : undefined,
+  };
+}
+
+registerNativeAgentHarnessV2Factory(PI_AGENT_HARNESS_ID, createPiAgentHarnessV2);

--- a/src/agents/harness/builtin-pi.ts
+++ b/src/agents/harness/builtin-pi.ts
@@ -16,11 +16,11 @@ export function createPiAgentHarness(): AgentHarness {
 }
 
 /**
- * Native AgentHarnessV2 for the built-in PI embedded runner. At PR 2 (RFC 72072)
- * the lifecycle methods still bottom out in `runEmbeddedAttempt`, so the
- * visible AgentHarnessAttemptResult must remain identical to the V1-adapter
- * path. PR 4 is where prepare/start/cleanup will plumb through the split
- * lifecycle modules.
+ * Native AgentHarnessV2 for the built-in PI embedded runner. This cleanup
+ * package keeps the lifecycle methods bottoming out in `runEmbeddedAttempt`,
+ * so the visible AgentHarnessAttemptResult remains identical to the V1-adapter
+ * path. Follow-up structural PRs can plumb prepare/start/cleanup through split
+ * lifecycle modules once those seams exist.
  */
 export function createPiAgentHarnessV2(harness: AgentHarness): AgentHarnessV2 {
   return {

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -12,6 +12,7 @@ import {
   selectAgentHarness,
 } from "./selection.js";
 import type { AgentHarness } from "./types.js";
+import { registerNativeAgentHarnessV2Factory } from "./v2.js";
 
 const piRunAttempt = vi.fn(async () => createAttemptResult("pi"));
 
@@ -137,6 +138,37 @@ describe("runAgentHarnessAttemptWithFallback", () => {
 
     expect(result.sessionIdUsed).toBe("pi");
     expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs selected PI attempts through a registered native V2 factory when present", async () => {
+    const nativeResult = createAttemptResult("native-pi");
+    const restoreFactory = registerNativeAgentHarnessV2Factory("pi", (harness) => ({
+      id: harness.id,
+      label: harness.label,
+      pluginId: harness.pluginId,
+      supports: (ctx) => harness.supports(ctx),
+      prepare: async (params) => ({
+        harnessId: harness.id,
+        label: harness.label,
+        pluginId: harness.pluginId,
+        params,
+        lifecycleState: "prepared",
+      }),
+      start: async (prepared) => ({ ...prepared, lifecycleState: "started" }),
+      send: async () => nativeResult,
+      resolveOutcome: async (_session, result) => result,
+      cleanup: async () => {},
+    }));
+    try {
+      const result = await runAgentHarnessAttemptWithFallback(
+        createAttemptParams({ agents: { defaults: { agentRuntime: { id: "auto" } } } }),
+      );
+
+      expect(result.sessionIdUsed).toBe("native-pi");
+      expect(piRunAttempt).not.toHaveBeenCalled();
+    } finally {
+      restoreFactory();
+    }
   });
 
   it("surfaces an auto-selected plugin harness failure instead of replaying through PI", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -22,7 +22,7 @@ import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
-import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
+import { resolveAgentHarnessV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
 
 const log = createSubsystemLogger("agents/harness");
 
@@ -190,7 +190,7 @@ export async function runAgentHarnessAttemptWithFallback(
     sessionKey: params.sessionKey,
     agentId: params.agentId,
   });
-  const v2Harness = adaptAgentHarnessToV2(harness);
+  const v2Harness = resolveAgentHarnessV2(harness);
   if (harness.id === "pi") {
     return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
   }

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -7,9 +7,15 @@ import {
   type DiagnosticEventPayload,
 } from "../../infra/diagnostic-events.js";
 import type { EmbeddedRunAttemptResult } from "../pi-embedded-runner/run/types.js";
+import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type { AgentHarness, AgentHarnessAttemptParams } from "./types.js";
 import type { AgentHarnessV2 } from "./v2.js";
-import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
+import {
+  adaptAgentHarnessToV2,
+  registerNativeAgentHarnessV2Factory,
+  resolveAgentHarnessV2,
+  runAgentHarnessV2LifecycleAttempt,
+} from "./v2.js";
 
 function createAttemptParams(): AgentHarnessAttemptParams {
   return {
@@ -540,5 +546,119 @@ describe("AgentHarness V2 compatibility adapter", () => {
     await v2.cleanup({ session, result: createAttemptResult() });
 
     expect(dispose).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentHarness V2 native factory registry", () => {
+  // Tests in this describe block use unique harness ids so they do not collide
+  // with the module-level "pi" registration in builtin-pi.ts. Vitest isolates
+  // modules per test file, so our registrations stay scoped to this file.
+
+  it("falls back to the V1 adapter when no native factory is registered", async () => {
+    const params = createAttemptParams();
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
+    const harness: AgentHarness = {
+      id: "no-native-factory-test",
+      label: "No native factory",
+      supports: () => ({ supported: true }),
+      runAttempt,
+    };
+
+    const resolved = resolveAgentHarnessV2(harness);
+    const prepared = await resolved.prepare(params);
+    const session = await resolved.start(prepared);
+
+    expect(await resolved.send(session)).toBe(result);
+    expect(runAttempt).toHaveBeenCalledWith(params);
+  });
+
+  it("prefers a registered native factory over the V1 adapter", async () => {
+    const params = createAttemptParams();
+    const adapterResult = createAttemptResult();
+    const nativeResult = { ...createAttemptResult(), assistantTexts: ["native path"] };
+    const runAttempt = vi.fn(async () => adapterResult);
+    const harness: AgentHarness = {
+      id: "native-factory-preference-test",
+      label: "Native factory preference",
+      supports: () => ({ supported: true }),
+      runAttempt,
+    };
+    registerNativeAgentHarnessV2Factory(harness.id, (h) => ({
+      id: h.id,
+      label: h.label,
+      pluginId: h.pluginId,
+      supports: (ctx) => h.supports(ctx),
+      prepare: async (p) => ({
+        harnessId: h.id,
+        label: h.label,
+        params: p,
+        lifecycleState: "prepared",
+      }),
+      start: async (p) => ({ ...p, lifecycleState: "started" }),
+      send: async () => nativeResult,
+      resolveOutcome: async (_session, r) => r,
+      cleanup: async () => {},
+    }));
+
+    const result = await runAgentHarnessV2LifecycleAttempt(resolveAgentHarnessV2(harness), params);
+
+    expect(result).toBe(nativeResult);
+    expect(runAttempt).not.toHaveBeenCalled();
+  });
+
+  it("native AgentHarnessV2 produces the same final attempt result as the V1 adapter for the same V1 harness", async () => {
+    const params = createAttemptParams();
+    const baseResult = createAttemptResult();
+    const adapterRun = vi.fn(async () => baseResult);
+    const nativeRun = vi.fn(async () => baseResult);
+    const adapterV1: AgentHarness = {
+      id: "parity-adapter",
+      label: "Parity",
+      supports: () => ({ supported: true }),
+      runAttempt: adapterRun,
+    };
+    const nativeV1: AgentHarness = {
+      id: "parity-native",
+      label: "Parity",
+      supports: () => ({ supported: true }),
+      runAttempt: nativeRun,
+    };
+
+    // Native factory body mirrors createPiAgentHarnessV2 in builtin-pi.ts so
+    // PR 4 regressions in cleanup ordering surface here as parity drift.
+    const native: AgentHarnessV2 = {
+      id: nativeV1.id,
+      label: nativeV1.label,
+      pluginId: nativeV1.pluginId,
+      supports: (ctx) => nativeV1.supports(ctx),
+      prepare: async (p) => ({
+        harnessId: nativeV1.id,
+        label: nativeV1.label,
+        pluginId: nativeV1.pluginId,
+        params: p,
+        lifecycleState: "prepared",
+      }),
+      start: async (p) => ({
+        harnessId: p.harnessId,
+        label: p.label,
+        pluginId: p.pluginId,
+        params: p.params,
+        lifecycleState: "started",
+      }),
+      send: async (s) => nativeV1.runAttempt(s.params),
+      resolveOutcome: async (s, r) => applyAgentHarnessResultClassification(nativeV1, r, s.params),
+      cleanup: async () => {},
+    };
+
+    const adaptedFinal = await runAgentHarnessV2LifecycleAttempt(
+      adaptAgentHarnessToV2(adapterV1),
+      params,
+    );
+    const nativeFinal = await runAgentHarnessV2LifecycleAttempt(native, params);
+
+    expect(nativeFinal).toEqual({ ...adaptedFinal, agentHarnessId: nativeV1.id });
+    expect(adapterRun).toHaveBeenCalledWith(params);
+    expect(nativeRun).toHaveBeenCalledWith(params);
   });
 });

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -584,7 +584,7 @@ describe("AgentHarness V2 native factory registry", () => {
       supports: () => ({ supported: true }),
       runAttempt,
     };
-    registerNativeAgentHarnessV2Factory(harness.id, (h) => ({
+    const restoreFactory = registerNativeAgentHarnessV2Factory(harness.id, (h) => ({
       id: h.id,
       label: h.label,
       pluginId: h.pluginId,
@@ -600,11 +600,17 @@ describe("AgentHarness V2 native factory registry", () => {
       resolveOutcome: async (_session, r) => r,
       cleanup: async () => {},
     }));
+    try {
+      const result = await runAgentHarnessV2LifecycleAttempt(
+        resolveAgentHarnessV2(harness),
+        params,
+      );
 
-    const result = await runAgentHarnessV2LifecycleAttempt(resolveAgentHarnessV2(harness), params);
-
-    expect(result).toBe(nativeResult);
-    expect(runAttempt).not.toHaveBeenCalled();
+      expect(result).toBe(nativeResult);
+      expect(runAttempt).not.toHaveBeenCalled();
+    } finally {
+      restoreFactory();
+    }
   });
 
   it("native AgentHarnessV2 produces the same final attempt result as the V1 adapter for the same V1 harness", async () => {

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -83,12 +83,16 @@ const nativeAgentHarnessV2Factories = new Map<string, NativeAgentHarnessV2Factor
 export function registerNativeAgentHarnessV2Factory(
   harnessId: string,
   factory: NativeAgentHarnessV2Factory,
-): void {
+): () => void {
+  const previous = nativeAgentHarnessV2Factories.get(harnessId);
   nativeAgentHarnessV2Factories.set(harnessId, factory);
-}
-
-export function clearNativeAgentHarnessV2Factories(): void {
-  nativeAgentHarnessV2Factories.clear();
+  return () => {
+    if (previous) {
+      nativeAgentHarnessV2Factories.set(harnessId, previous);
+      return;
+    }
+    nativeAgentHarnessV2Factories.delete(harnessId);
+  };
 }
 
 export function getNativeAgentHarnessV2Factory(

--- a/src/agents/harness/v2.ts
+++ b/src/agents/harness/v2.ts
@@ -70,6 +70,44 @@ export type AgentHarnessV2 = {
   dispose?(): Promise<void> | void;
 };
 
+/**
+ * Internal-only seam. A native AgentHarnessV2 implementation can register here
+ * so selected harnesses run as a real V2 lifecycle instead of going through
+ * `adaptAgentHarnessToV2`. This is not exposed via `harness/index.ts` or the
+ * plugin SDK; widening it is tracked as optional future work, not RFC 72072 scope.
+ */
+export type NativeAgentHarnessV2Factory = (harness: AgentHarness) => AgentHarnessV2;
+
+const nativeAgentHarnessV2Factories = new Map<string, NativeAgentHarnessV2Factory>();
+
+export function registerNativeAgentHarnessV2Factory(
+  harnessId: string,
+  factory: NativeAgentHarnessV2Factory,
+): void {
+  nativeAgentHarnessV2Factories.set(harnessId, factory);
+}
+
+export function clearNativeAgentHarnessV2Factories(): void {
+  nativeAgentHarnessV2Factories.clear();
+}
+
+export function getNativeAgentHarnessV2Factory(
+  harnessId: string,
+): NativeAgentHarnessV2Factory | undefined {
+  return nativeAgentHarnessV2Factories.get(harnessId);
+}
+
+/**
+ * Prefer a registered native AgentHarnessV2 implementation when available, and
+ * fall back to wrapping the V1 harness with `adaptAgentHarnessToV2`. This is
+ * the single resolution point used by harness selection so the lifecycle
+ * boundary always runs against an `AgentHarnessV2` instance.
+ */
+export function resolveAgentHarnessV2(harness: AgentHarness): AgentHarnessV2 {
+  const factory = nativeAgentHarnessV2Factories.get(harness.id);
+  return factory ? factory(harness) : adaptAgentHarnessToV2(harness);
+}
+
 export function adaptAgentHarnessToV2(harness: AgentHarness): AgentHarnessV2 {
   return {
     id: harness.id,

--- a/src/agents/pi-embedded-runner/aliases.test.ts
+++ b/src/agents/pi-embedded-runner/aliases.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { runEmbeddedAgent as runEmbeddedAgentFromNeutralBarrel } from "../embedded-runner.js";
 import {
+  abortEmbeddedAgentRun as abortEmbeddedAgentRunFromNeutralDirBarrel,
+  compactEmbeddedAgentSession as compactEmbeddedAgentSessionFromNeutralDirBarrel,
+  runEmbeddedAgent as runEmbeddedAgentFromNeutralDirBarrel,
+} from "../embedded-runner/index.js";
+import {
   abortEmbeddedAgentRun,
   abortEmbeddedPiRun,
   compactEmbeddedAgentSession,
@@ -8,6 +13,11 @@ import {
   runEmbeddedAgent,
   runEmbeddedPiAgent,
 } from "../pi-embedded-runner.js";
+import {
+  abortEmbeddedAgentRun as abortEmbeddedAgentRunFromPiDirBarrel,
+  compactEmbeddedAgentSession as compactEmbeddedAgentSessionFromPiDirBarrel,
+  runEmbeddedAgent as runEmbeddedAgentFromPiDirBarrel,
+} from "./index.js";
 
 describe("embedded runner compatibility aliases", () => {
   it("keeps neutral embedded-agent aliases bound to the PI compatibility exports", () => {
@@ -15,5 +25,16 @@ describe("embedded runner compatibility aliases", () => {
     expect(runEmbeddedAgentFromNeutralBarrel).toBe(runEmbeddedPiAgent);
     expect(compactEmbeddedAgentSession).toBe(compactEmbeddedPiSession);
     expect(abortEmbeddedAgentRun).toBe(abortEmbeddedPiRun);
+  });
+
+  it("keeps neutral and PI directory barrels bound to the same canonical exports", () => {
+    // Canonical directory barrel exposes the same neutral functions as the flat barrel.
+    expect(runEmbeddedAgentFromNeutralDirBarrel).toBe(runEmbeddedPiAgent);
+    expect(compactEmbeddedAgentSessionFromNeutralDirBarrel).toBe(compactEmbeddedPiSession);
+    expect(abortEmbeddedAgentRunFromNeutralDirBarrel).toBe(abortEmbeddedPiRun);
+    // Deprecated PI directory barrel chains through the canonical directory barrel.
+    expect(runEmbeddedAgentFromPiDirBarrel).toBe(runEmbeddedPiAgent);
+    expect(compactEmbeddedAgentSessionFromPiDirBarrel).toBe(compactEmbeddedPiSession);
+    expect(abortEmbeddedAgentRunFromPiDirBarrel).toBe(abortEmbeddedPiRun);
   });
 });

--- a/src/agents/pi-embedded-runner/aliases.test.ts
+++ b/src/agents/pi-embedded-runner/aliases.test.ts
@@ -15,8 +15,11 @@ import {
 } from "../pi-embedded-runner.js";
 import {
   abortEmbeddedAgentRun as abortEmbeddedAgentRunFromPiDirBarrel,
+  abortEmbeddedPiRun as abortEmbeddedPiRunFromPiDirBarrel,
   compactEmbeddedAgentSession as compactEmbeddedAgentSessionFromPiDirBarrel,
+  compactEmbeddedPiSession as compactEmbeddedPiSessionFromPiDirBarrel,
   runEmbeddedAgent as runEmbeddedAgentFromPiDirBarrel,
+  runEmbeddedPiAgent as runEmbeddedPiAgentFromPiDirBarrel,
 } from "./index.js";
 
 describe("embedded runner compatibility aliases", () => {
@@ -34,7 +37,10 @@ describe("embedded runner compatibility aliases", () => {
     expect(abortEmbeddedAgentRunFromNeutralDirBarrel).toBe(abortEmbeddedPiRun);
     // Deprecated PI directory barrel chains through the canonical directory barrel.
     expect(runEmbeddedAgentFromPiDirBarrel).toBe(runEmbeddedPiAgent);
+    expect(runEmbeddedPiAgentFromPiDirBarrel).toBe(runEmbeddedPiAgent);
     expect(compactEmbeddedAgentSessionFromPiDirBarrel).toBe(compactEmbeddedPiSession);
+    expect(compactEmbeddedPiSessionFromPiDirBarrel).toBe(compactEmbeddedPiSession);
     expect(abortEmbeddedAgentRunFromPiDirBarrel).toBe(abortEmbeddedPiRun);
+    expect(abortEmbeddedPiRunFromPiDirBarrel).toBe(abortEmbeddedPiRun);
   });
 });

--- a/src/agents/pi-embedded-runner/index.ts
+++ b/src/agents/pi-embedded-runner/index.ts
@@ -1,0 +1,30 @@
+// Deprecated directory-barrel form of the embedded runner public surface.
+// Existed only as a `pi-embedded-runner` historical name. New code must import
+// from the neutral `embedded-runner` barrel (`../embedded-runner.js` for the
+// flat shape or `../embedded-runner/index.js` for the directory shape).
+//
+// Both Pi-named and neutral-named symbols are re-exported here so old
+// `pi-embedded-runner/index.js` imports keep working. The Pi-named
+// `runEmbeddedPiAgent`, `compactEmbeddedPiSession`, etc. continue to work via
+// the existing flat-file barrel `../pi-embedded-runner.ts`.
+//
+// @deprecated Prefer `../embedded-runner/index.js` for new imports; this
+// directory barrel exists only for backward compatibility per RFC 72072 PR 6.
+
+export {
+  abortEmbeddedAgentRun,
+  compactEmbeddedAgentSession,
+  isEmbeddedAgentRunActive,
+  isEmbeddedAgentRunStreaming,
+  queueEmbeddedAgentMessage,
+  resolveActiveEmbeddedAgentRunSessionId,
+  resolveEmbeddedSessionLane,
+  runEmbeddedAgent,
+  waitForEmbeddedAgentRunEnd,
+} from "../embedded-runner/index.js";
+export type {
+  EmbeddedAgentCompactResult,
+  EmbeddedAgentMeta,
+  EmbeddedAgentRunMeta,
+  EmbeddedAgentRunResult,
+} from "../embedded-runner/index.js";

--- a/src/agents/pi-embedded-runner/index.ts
+++ b/src/agents/pi-embedded-runner/index.ts
@@ -13,18 +13,30 @@
 
 export {
   abortEmbeddedAgentRun,
+  abortEmbeddedPiRun,
   compactEmbeddedAgentSession,
+  compactEmbeddedPiSession,
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunStreaming,
+  isEmbeddedPiRunActive,
+  isEmbeddedPiRunStreaming,
   queueEmbeddedAgentMessage,
+  queueEmbeddedPiMessage,
   resolveActiveEmbeddedAgentRunSessionId,
+  resolveActiveEmbeddedRunSessionId,
   resolveEmbeddedSessionLane,
   runEmbeddedAgent,
+  runEmbeddedPiAgent,
   waitForEmbeddedAgentRunEnd,
-} from "../embedded-runner/index.js";
+  waitForEmbeddedPiRunEnd,
+} from "../pi-embedded-runner.js";
 export type {
   EmbeddedAgentCompactResult,
   EmbeddedAgentMeta,
   EmbeddedAgentRunMeta,
   EmbeddedAgentRunResult,
-} from "../embedded-runner/index.js";
+  EmbeddedPiAgentMeta,
+  EmbeddedPiCompactResult,
+  EmbeddedPiRunMeta,
+  EmbeddedPiRunResult,
+} from "../pi-embedded-runner.js";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
@@ -12,7 +11,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
-import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -25,16 +23,11 @@ import {
 } from "../agent-scope.js";
 import {
   type AuthProfileFailureReason,
-  type AuthProfileStore,
   markAuthProfileFailure,
   resolveAuthProfileEligibility,
   markAuthProfileGood,
   markAuthProfileUsed,
 } from "../auth-profiles.js";
-import {
-  resolveSessionKeyForRequest,
-  resolveStoredSessionKeyForSessionId,
-} from "../command/session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { isStrictAgenticExecutionContractActive } from "../execution-contract.js";
 import {
@@ -127,6 +120,12 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import {
+  backfillSessionKey,
+  buildHandledReplyPayloads,
+  buildTraceToolSummary,
+  createEmptyAuthProfileStore,
+} from "./run/run-orchestration-helpers.js";
+import {
   buildBeforeModelResolveAttachments,
   resolveEffectiveRuntimeModel,
   resolveHookModelSelection,
@@ -141,7 +140,6 @@ import type {
   EmbeddedPiAgentMeta,
   EmbeddedPiRunResult,
   TraceAttempt,
-  ToolSummaryTrace,
   EmbeddedRunLivenessState,
 } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
@@ -149,92 +147,6 @@ import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accum
 type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
-
-function createEmptyAuthProfileStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {},
-  };
-}
-
-function buildTraceToolSummary(params: {
-  toolMetas: Array<{ toolName: string; meta?: string }>;
-  hadFailure: boolean;
-}): ToolSummaryTrace | undefined {
-  if (params.toolMetas.length === 0) {
-    return undefined;
-  }
-  const tools: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of params.toolMetas) {
-    const toolName = normalizeOptionalString(entry.toolName);
-    if (!toolName || seen.has(toolName)) {
-      continue;
-    }
-    seen.add(toolName);
-    tools.push(toolName);
-  }
-  return {
-    calls: params.toolMetas.length,
-    tools,
-    failures: params.hadFailure ? 1 : 0,
-  };
-}
-
-/**
- * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
- * The return value is normalized: whitespace-only inputs collapse to undefined, and
- * successful resolution returns a trimmed session key. This is a read-only lookup
- * with no side effects.
- * See: https://github.com/openclaw/openclaw/issues/60552
- */
-function backfillSessionKey(params: {
-  config: RunEmbeddedPiAgentParams["config"];
-  sessionId: string;
-  sessionKey?: string;
-  agentId?: string;
-}): string | undefined {
-  const trimmed = normalizeOptionalString(params.sessionKey);
-  if (trimmed) {
-    return trimmed;
-  }
-  if (!params.config || !params.sessionId) {
-    return undefined;
-  }
-  try {
-    const resolved = normalizeOptionalString(params.agentId)
-      ? resolveStoredSessionKeyForSessionId({
-          cfg: params.config,
-          sessionId: params.sessionId,
-          agentId: params.agentId,
-        })
-      : resolveSessionKeyForRequest({
-          cfg: params.config,
-          sessionId: params.sessionId,
-        });
-    return normalizeOptionalString(resolved.sessionKey);
-  } catch (err) {
-    log.warn(
-      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
-    );
-    return undefined;
-  }
-}
-
-function buildHandledReplyPayloads(reply?: ReplyPayload) {
-  const normalized = reply ?? { text: SILENT_REPLY_TOKEN };
-  return [
-    {
-      text: normalized.text,
-      mediaUrl: normalized.mediaUrl,
-      mediaUrls: normalized.mediaUrls,
-      replyToId: normalized.replyToId,
-      audioAsVoice: normalized.audioAsVoice,
-      isError: normalized.isError,
-      isReasoning: normalized.isReasoning,
-    },
-  ];
-}
 
 export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,

--- a/src/agents/pi-embedded-runner/run/attempt-message-summary.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-message-summary.ts
@@ -1,0 +1,90 @@
+// Pure message-summarization helpers extracted from `attempt.ts` so the
+// embedded attempt orchestrator does not own diagnostic-only payload counting.
+// This is the second ownership-boundary slice for RFC 72072 and the first
+// piece of the lifecycle-domain extraction. The full lifecycle / stream-loop
+// split that the RFC envisioned for PR 4 lands as separate follow-ups because
+// the larger seams (`runEmbeddedAttempt` cleanup `finally` block at lines
+// ~3036-3085, the per-turn stream loop at ~2200-2950) carry deep closure
+// dependencies that need a dedicated focused pass.
+//
+// The exported helpers are pure:
+//   - `summarizeMessagePayload(msg)` returns text/image character counts for
+//     a single AgentMessage payload, normalising string and array content.
+//   - `summarizeSessionContext(messages)` aggregates a session transcript
+//     into role counts, total text chars, total image blocks, and per-message
+//     max text chars. `attempt.ts` uses this once to emit a session-context
+//     diagnostic before each prompt-cache observation.
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export type EmbeddedAttemptMessagePayloadSummary = {
+  textChars: number;
+  imageBlocks: number;
+};
+
+export type EmbeddedAttemptSessionContextSummary = {
+  roleCounts: string;
+  totalTextChars: number;
+  totalImageBlocks: number;
+  maxMessageTextChars: number;
+};
+
+export function summarizeMessagePayload(msg: AgentMessage): EmbeddedAttemptMessagePayloadSummary {
+  const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return { textChars: content.length, imageBlocks: 0 };
+  }
+  if (!Array.isArray(content)) {
+    return { textChars: 0, imageBlocks: 0 };
+  }
+
+  let textChars = 0;
+  let imageBlocks = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typedBlock.type === "image") {
+      imageBlocks++;
+      continue;
+    }
+    if (typeof typedBlock.text === "string") {
+      textChars += typedBlock.text.length;
+    }
+  }
+
+  return { textChars, imageBlocks };
+}
+
+export function summarizeSessionContext(
+  messages: AgentMessage[],
+): EmbeddedAttemptSessionContextSummary {
+  const roleCounts = new Map<string, number>();
+  let totalTextChars = 0;
+  let totalImageBlocks = 0;
+  let maxMessageTextChars = 0;
+
+  for (const msg of messages) {
+    const role = typeof msg.role === "string" ? msg.role : "unknown";
+    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+
+    const payload = summarizeMessagePayload(msg);
+    totalTextChars += payload.textChars;
+    totalImageBlocks += payload.imageBlocks;
+    if (payload.textChars > maxMessageTextChars) {
+      maxMessageTextChars = payload.textChars;
+    }
+  }
+
+  return {
+    roleCounts:
+      [...roleCounts.entries()]
+        .toSorted((a, b) => a[0].localeCompare(b[0]))
+        .map(([role, count]) => `${role}:${count}`)
+        .join(",") || "none",
+    totalTextChars,
+    totalImageBlocks,
+    maxMessageTextChars,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt-prompt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-prompt.ts
@@ -1,0 +1,165 @@
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import {
+  analyzeBootstrapBudget,
+  buildBootstrapInjectionStats,
+  buildBootstrapPromptWarning,
+} from "../../bootstrap-budget.js";
+import {
+  hasCompletedBootstrapTurn,
+  isWorkspaceBootstrapPending,
+  makeBootstrapWarn,
+  resolveBootstrapContextForRun,
+  resolveContextInjectionMode,
+} from "../../bootstrap-files.js";
+import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
+import {
+  resolveBootstrapMaxChars,
+  resolveBootstrapPromptTruncationWarningMode,
+  resolveBootstrapTotalMaxChars,
+} from "../../pi-embedded-helpers.js";
+import { stripToolResultDetails } from "../../session-transcript-repair.js";
+import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
+import { normalizeAssistantReplayContent } from "../replay-history.js";
+import { resolveAttemptWorkspaceBootstrapRouting } from "./attempt-bootstrap-routing.js";
+import { resolveAttemptBootstrapContext } from "./attempt.context-engine-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
+  return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
+}
+
+export function remapInjectedContextFilesToWorkspace(params: {
+  files: EmbeddedContextFile[];
+  sourceWorkspaceDir: string;
+  targetWorkspaceDir: string;
+}): EmbeddedContextFile[] {
+  if (params.sourceWorkspaceDir === params.targetWorkspaceDir) {
+    return params.files;
+  }
+  return params.files.map((file) => {
+    const relative = path.relative(params.sourceWorkspaceDir, file.path);
+    const canRemap = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+    return canRemap
+      ? {
+          ...file,
+          path:
+            relative === ""
+              ? params.targetWorkspaceDir
+              : path.join(params.targetWorkspaceDir, relative),
+        }
+      : file;
+  });
+}
+
+export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
+  return stripToolResultDetails(normalizeAssistantReplayContent(messages));
+}
+
+export async function prepareAttemptBootstrapPromptContext(params: {
+  attempt: EmbeddedRunAttemptParams;
+  sessionLabel: string;
+  resolvedWorkspace: string;
+  effectiveWorkspace: string;
+  toolsEnabled: boolean;
+  toolsRaw: Array<{ name?: string }>;
+  logWarn: (message: string) => void;
+}) {
+  const contextInjectionMode = resolveContextInjectionMode(params.attempt.config);
+  const bootstrapHasFileAccess =
+    params.toolsEnabled && params.toolsRaw.some((tool) => tool.name === "read");
+  const bootstrapRouting = await resolveAttemptWorkspaceBootstrapRouting({
+    isWorkspaceBootstrapPending,
+    bootstrapContextRunKind: params.attempt.bootstrapContextRunKind,
+    trigger: params.attempt.trigger,
+    sessionKey: params.attempt.sessionKey,
+    isPrimaryRun: isPrimaryBootstrapRun(params.attempt.sessionKey),
+    isCanonicalWorkspace: params.attempt.isCanonicalWorkspace,
+    effectiveWorkspace: params.effectiveWorkspace,
+    resolvedWorkspace: params.resolvedWorkspace,
+    hasBootstrapFileAccess: bootstrapHasFileAccess,
+  });
+  const bootstrapMode = bootstrapRouting.bootstrapMode;
+  const shouldStripBootstrapFromContext = bootstrapRouting.shouldStripBootstrapFromContext;
+  const {
+    bootstrapFiles: hookAdjustedBootstrapFiles,
+    contextFiles: resolvedContextFiles,
+    shouldRecordCompletedBootstrapTurn,
+  } = await resolveAttemptBootstrapContext({
+    contextInjectionMode,
+    bootstrapContextMode: params.attempt.bootstrapContextMode,
+    bootstrapContextRunKind: params.attempt.bootstrapContextRunKind ?? "default",
+    bootstrapMode,
+    sessionFile: params.attempt.sessionFile,
+    hasCompletedBootstrapTurn,
+    resolveBootstrapContextForRun: async () =>
+      await resolveBootstrapContextForRun({
+        workspaceDir: params.resolvedWorkspace,
+        config: params.attempt.config,
+        sessionKey: params.attempt.sessionKey,
+        sessionId: params.attempt.sessionId,
+        warn: makeBootstrapWarn({
+          sessionLabel: params.sessionLabel,
+          workspaceDir: params.resolvedWorkspace,
+          warn: params.logWarn,
+        }),
+        contextMode: params.attempt.bootstrapContextMode,
+        runKind: params.attempt.bootstrapContextRunKind,
+      }),
+  });
+  const remappedContextFiles = remapInjectedContextFilesToWorkspace({
+    files: resolvedContextFiles,
+    sourceWorkspaceDir: params.resolvedWorkspace,
+    targetWorkspaceDir: params.effectiveWorkspace,
+  });
+  const contextFiles = shouldStripBootstrapFromContext
+    ? remappedContextFiles.filter((file) => !/(^|[\\/])BOOTSTRAP\.md$/iu.test(file.path.trim()))
+    : remappedContextFiles;
+  const bootstrapFilesForInjectionStats = shouldStripBootstrapFromContext
+    ? hookAdjustedBootstrapFiles.filter((file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME)
+    : hookAdjustedBootstrapFiles;
+  const bootstrapMaxChars = resolveBootstrapMaxChars(params.attempt.config);
+  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.attempt.config);
+  const bootstrapAnalysis = analyzeBootstrapBudget({
+    files: buildBootstrapInjectionStats({
+      bootstrapFiles: bootstrapFilesForInjectionStats,
+      injectedFiles: contextFiles,
+    }),
+    bootstrapMaxChars,
+    bootstrapTotalMaxChars,
+  });
+  const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(
+    params.attempt.config,
+  );
+  const bootstrapPromptWarning = buildBootstrapPromptWarning({
+    analysis: bootstrapAnalysis,
+    mode: bootstrapPromptWarningMode,
+    seenSignatures: params.attempt.bootstrapPromptWarningSignaturesSeen,
+    previousSignature: params.attempt.bootstrapPromptWarningSignature,
+  });
+  const workspaceNotes: string[] = [];
+  if (
+    hookAdjustedBootstrapFiles.some(
+      (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
+    )
+  ) {
+    workspaceNotes.push("Reminder: commit your changes in this workspace after edits.");
+  }
+
+  return {
+    bootstrapMode,
+    shouldStripBootstrapFromContext,
+    hookAdjustedBootstrapFiles,
+    contextFiles,
+    bootstrapFilesForInjectionStats,
+    bootstrapMaxChars,
+    bootstrapTotalMaxChars,
+    bootstrapAnalysis,
+    bootstrapPromptWarningMode,
+    bootstrapPromptWarning,
+    workspaceNotes,
+    shouldRecordCompletedBootstrapTurn,
+    userPromptPrefixText: bootstrapRouting.userPromptPrefixText,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt-tools.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tools.ts
@@ -1,0 +1,151 @@
+// Tool-allowlist and tool-runtime helpers extracted from `attempt.ts` so the
+// embedded attempt orchestrator does not own pure tool policy logic. This is
+// the first ownership-boundary slice for RFC 72072 PR 3. Prompt-cache prep and
+// transport configuration extractions follow as separate PRs because their
+// seams are interleaved with the per-turn stream loop in `attempt.ts` and need
+// dedicated focused passes.
+//
+// The exported helpers are pure or close-to-pure:
+//   - `resolveUnknownToolGuardThreshold` clamps the unknown-tool guard knob.
+//   - `applyEmbeddedAttemptToolsAllow` filters a tool list against an allow set.
+//   - `shouldCreateBundleMcpRuntimeForAttempt` decides whether the bundle MCP
+//     runtime needs to spin up for an attempt based on toolsAllow shape.
+//   - `collectAttemptExplicitToolAllowlistSources` aggregates the layered
+//     tool-allow policy sources (global, agent, group, sandbox, subagent,
+//     runtime override) for the explicit-allowlist guard.
+//
+// `attempt.ts` re-exports the public symbols so the existing import paths
+// (`./attempt.js`) keep working without churn for `attempt.test.ts` or any
+// future caller. PR 3 deliberately keeps consumers unchanged.
+
+import { TOOL_NAME_SEPARATOR } from "../../pi-bundle-mcp-names.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveSubagentToolPolicyForSession,
+} from "../../pi-tools.policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../../subagent-capabilities.js";
+import { collectExplicitToolAllowlistSources } from "../../tool-allowlist-guard.js";
+import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+export function resolveUnknownToolGuardThreshold(loopDetection?: {
+  enabled?: boolean;
+  unknownToolThreshold?: number;
+}): number {
+  // The unknown-tool guard is a safety net against the model hallucinating a
+  // tool name or calling a tool that has since been removed from the allowlist
+  // (for example after a `skills.allowBundled` config change). After `threshold`
+  // consecutive unknown-tool attempts the stream wrapper rewrites the assistant
+  // message content to tell the model to stop, which breaks otherwise-infinite
+  // Tool-not-found loops against the provider. Unlike the genericRepeat /
+  // pingPong / pollNoProgress detectors this guard has no false-positive
+  // surface because the tool is objectively not registered in this run, so it
+  // stays on regardless of `tools.loopDetection.enabled`.
+  const raw = loopDetection?.unknownToolThreshold;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return UNKNOWN_TOOL_THRESHOLD;
+}
+
+export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
+  tools: T[],
+  toolsAllow?: string[],
+): T[] {
+  if (!toolsAllow || toolsAllow.length === 0) {
+    return tools;
+  }
+  const allowSet = new Set(toolsAllow);
+  return tools.filter((tool) => allowSet.has(tool.name));
+}
+
+export function shouldCreateBundleMcpRuntimeForAttempt(params: {
+  toolsEnabled: boolean;
+  disableTools?: boolean;
+  toolsAllow?: string[];
+}): boolean {
+  if (!params.toolsEnabled || params.disableTools === true) {
+    return false;
+  }
+  if (!params.toolsAllow || params.toolsAllow.length === 0) {
+    return true;
+  }
+  return params.toolsAllow.some((toolName) => toolName.includes(TOOL_NAME_SEPARATOR));
+}
+
+export function collectAttemptExplicitToolAllowlistSources(params: {
+  config?: EmbeddedRunAttemptParams["config"];
+  sessionKey?: string;
+  sandboxSessionKey?: string;
+  agentId?: string;
+  modelProvider?: string;
+  modelId?: string;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  toolsAllow?: string[];
+}) {
+  const { agentId, globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
+    resolveEffectiveToolPolicy({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+    });
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider: params.messageProvider,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const subagentStore = resolveSubagentCapabilityStore(params.sandboxSessionKey, {
+    cfg: params.config,
+  });
+  const subagentPolicy =
+    params.sandboxSessionKey &&
+    isSubagentEnvelopeSession(params.sandboxSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, params.sandboxSessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  return collectExplicitToolAllowlistSources([
+    { label: "tools.allow", allow: globalPolicy?.allow },
+    { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
+    {
+      label: agentId ? `agents.${agentId}.tools.allow` : "agent tools.allow",
+      allow: agentPolicy?.allow,
+    },
+    {
+      label: agentId ? `agents.${agentId}.tools.byProvider.allow` : "agent tools.byProvider.allow",
+      allow: agentProviderPolicy?.allow,
+    },
+    { label: "group tools.allow", allow: groupPolicy?.allow },
+    { label: "sandbox tools.allow", allow: params.sandboxToolPolicy?.allow },
+    { label: "subagent tools.allow", allow: subagentPolicy?.allow },
+    { label: "runtime toolsAllow", allow: params.toolsAllow },
+  ]);
+}

--- a/src/agents/pi-embedded-runner/run/attempt-transport.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-transport.ts
@@ -1,0 +1,175 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveProviderTextTransforms } from "../../../plugins/provider-runtime.js";
+import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
+import { registerProviderStreamForModel } from "../../provider-stream.js";
+import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
+import {
+  applyExtraParamsToAgent,
+  resolveAgentTransportOverride,
+  resolveExplicitSettingsTransport,
+} from "../extra-params.js";
+import { resolveCacheRetention } from "../prompt-cache-retention.js";
+import {
+  describeEmbeddedAgentStreamStrategy,
+  resolveEmbeddedAgentApiKey,
+  resolveEmbeddedAgentBaseStreamFn,
+  resolveEmbeddedAgentStreamFn,
+} from "../stream-resolution.js";
+import { shouldUseOpenAIWebSocketTransport } from "./attempt.thread-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptTransportSession = {
+  sessionId: string;
+  agent: {
+    streamFn?: StreamFn;
+    transport?: unknown;
+  };
+};
+
+type AttemptTransportSettingsManager = Parameters<
+  typeof resolveExplicitSettingsTransport
+>[0]["settingsManager"];
+
+export async function configureAttemptTransportRuntime(params: {
+  activeSession: AttemptTransportSession;
+  config?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  model: EmbeddedRunAttemptParams["model"];
+  agentDir: string;
+  effectiveWorkspace: string;
+  sessionId: string;
+  resolvedApiKey?: string;
+  authStorage: EmbeddedRunAttemptParams["authStorage"];
+  runAbortSignal: AbortSignal;
+  settingsManager: AttemptTransportSettingsManager;
+  streamParams?: EmbeddedRunAttemptParams["streamParams"];
+  fastMode?: boolean;
+  thinkLevel: EmbeddedRunAttemptParams["thinkLevel"];
+  sessionAgentId?: string;
+  runtimePlan?: AgentRuntimePlan;
+  logDebug: (message: string) => void;
+  logWarn: (message: string) => void;
+}) {
+  // Rebuild each turn from the session's original stream base so prior-turn
+  // wrappers do not pin us to stale provider/API transport behavior.
+  const defaultSessionStreamFn = resolveEmbeddedAgentBaseStreamFn({
+    session: params.activeSession,
+  });
+  const providerStreamFn = registerProviderStreamForModel({
+    model: params.model,
+    cfg: params.config,
+    agentDir: params.agentDir,
+    workspaceDir: params.effectiveWorkspace,
+  });
+  const shouldUseWebSocketTransport = shouldUseOpenAIWebSocketTransport({
+    provider: params.provider,
+    modelApi: params.model.api,
+    modelBaseUrl: params.model.baseUrl,
+  });
+  const wsApiKey = shouldUseWebSocketTransport
+    ? await resolveEmbeddedAgentApiKey({
+        provider: params.provider,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage: params.authStorage,
+      })
+    : undefined;
+  if (shouldUseWebSocketTransport && !wsApiKey) {
+    params.logWarn(
+      `[ws-stream] no API key for provider=${params.provider}; keeping session-managed HTTP transport`,
+    );
+  }
+  const streamStrategy = describeEmbeddedAgentStreamStrategy({
+    currentStreamFn: defaultSessionStreamFn,
+    providerStreamFn,
+    shouldUseWebSocketTransport,
+    wsApiKey,
+    model: params.model,
+  });
+  params.activeSession.agent.streamFn = resolveEmbeddedAgentStreamFn({
+    currentStreamFn: defaultSessionStreamFn,
+    providerStreamFn,
+    shouldUseWebSocketTransport,
+    wsApiKey,
+    sessionId: params.sessionId,
+    signal: params.runAbortSignal,
+    model: params.model,
+    resolvedApiKey: params.resolvedApiKey,
+    authStorage: params.authStorage,
+  });
+
+  const providerTextTransforms = resolveProviderTextTransforms({
+    provider: params.provider,
+    config: params.config,
+    workspaceDir: params.effectiveWorkspace,
+  });
+  if (providerTextTransforms) {
+    params.activeSession.agent.streamFn = wrapStreamFnTextTransforms({
+      streamFn: params.activeSession.agent.streamFn,
+      input: providerTextTransforms.input,
+      output: providerTextTransforms.output,
+      transformSystemPrompt: false,
+    });
+  }
+
+  const resolvedTransport = resolveExplicitSettingsTransport({
+    settingsManager: params.settingsManager,
+    sessionTransport: params.activeSession.agent.transport,
+  });
+  const streamExtraParamsOverride = {
+    ...params.streamParams,
+    fastMode: params.fastMode,
+  };
+  const preparedRuntimeExtraParams = params.runtimePlan?.transport.resolveExtraParams({
+    extraParamsOverride: streamExtraParamsOverride,
+    thinkingLevel: params.thinkLevel,
+    agentId: params.sessionAgentId,
+    workspaceDir: params.effectiveWorkspace,
+    model: params.model,
+    resolvedTransport,
+  });
+  const { effectiveExtraParams } = applyExtraParamsToAgent(
+    params.activeSession.agent,
+    params.config,
+    params.provider,
+    params.modelId,
+    streamExtraParamsOverride,
+    params.thinkLevel,
+    params.sessionAgentId,
+    params.effectiveWorkspace,
+    params.model,
+    params.agentDir,
+    resolvedTransport,
+    preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
+  );
+  const effectivePromptCacheRetention = resolveCacheRetention(
+    effectiveExtraParams,
+    params.provider,
+    params.model.api,
+    params.modelId,
+  );
+  const agentTransportOverride = resolveAgentTransportOverride({
+    settingsManager: params.settingsManager,
+    effectiveExtraParams,
+  });
+  const sessionTransport =
+    typeof params.activeSession.agent.transport === "string"
+      ? params.activeSession.agent.transport
+      : undefined;
+  const effectiveAgentTransport = agentTransportOverride ?? sessionTransport;
+  if (agentTransportOverride && params.activeSession.agent.transport !== agentTransportOverride) {
+    const previousTransport = params.activeSession.agent.transport;
+    params.logDebug(
+      `embedded agent transport override: ${previousTransport} -> ${agentTransportOverride} ` +
+        `(${params.provider}/${params.modelId})`,
+    );
+  }
+
+  return {
+    effectiveExtraParams,
+    effectivePromptCacheRetention,
+    effectiveAgentTransport,
+    streamStrategy,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -219,6 +219,13 @@ import {
 } from "./attempt-bootstrap-routing.js";
 export { shouldStripBootstrapFromEmbeddedContext } from "./attempt-bootstrap-routing.js";
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
+import { summarizeSessionContext } from "./attempt-message-summary.js";
+import {
+  applyEmbeddedAttemptToolsAllow,
+  collectAttemptExplicitToolAllowlistSources,
+  resolveUnknownToolGuardThreshold,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tools.js";
 import {
   assembleAttemptContextEngine,
   buildLoopPromptCacheInfo,
@@ -340,13 +347,6 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
-import {
-  applyEmbeddedAttemptToolsAllow,
-  collectAttemptExplicitToolAllowlistSources,
-  resolveUnknownToolGuardThreshold,
-  shouldCreateBundleMcpRuntimeForAttempt,
-} from "./attempt-tools.js";
-
 export {
   applyEmbeddedAttemptToolsAllow,
   resolveUnknownToolGuardThreshold,
@@ -379,8 +379,6 @@ export function remapInjectedContextFilesToWorkspace(params: {
       : file;
   });
 }
-
-import { summarizeSessionContext } from "./attempt-message-summary.js";
 
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   return stripToolResultDetails(normalizeAssistantReplayContent(messages));

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -380,68 +380,7 @@ export function remapInjectedContextFilesToWorkspace(params: {
   });
 }
 
-function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
-  const content = (msg as { content?: unknown }).content;
-  if (typeof content === "string") {
-    return { textChars: content.length, imageBlocks: 0 };
-  }
-  if (!Array.isArray(content)) {
-    return { textChars: 0, imageBlocks: 0 };
-  }
-
-  let textChars = 0;
-  let imageBlocks = 0;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; text?: unknown };
-    if (typedBlock.type === "image") {
-      imageBlocks++;
-      continue;
-    }
-    if (typeof typedBlock.text === "string") {
-      textChars += typedBlock.text.length;
-    }
-  }
-
-  return { textChars, imageBlocks };
-}
-
-function summarizeSessionContext(messages: AgentMessage[]): {
-  roleCounts: string;
-  totalTextChars: number;
-  totalImageBlocks: number;
-  maxMessageTextChars: number;
-} {
-  const roleCounts = new Map<string, number>();
-  let totalTextChars = 0;
-  let totalImageBlocks = 0;
-  let maxMessageTextChars = 0;
-
-  for (const msg of messages) {
-    const role = typeof msg.role === "string" ? msg.role : "unknown";
-    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
-
-    const payload = summarizeMessagePayload(msg);
-    totalTextChars += payload.textChars;
-    totalImageBlocks += payload.imageBlocks;
-    if (payload.textChars > maxMessageTextChars) {
-      maxMessageTextChars = payload.textChars;
-    }
-  }
-
-  return {
-    roleCounts:
-      [...roleCounts.entries()]
-        .toSorted((a, b) => a[0].localeCompare(b[0]))
-        .map(([role, count]) => `${role}:${count}`)
-        .join(",") || "none",
-    totalTextChars,
-    totalImageBlocks,
-    maxMessageTextChars,
-  };
-}
+import { summarizeSessionContext } from "./attempt-message-summary.js";
 
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   return stripToolResultDetails(normalizeAssistantReplayContent(messages));

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -85,7 +85,6 @@ import { supportsModelTools } from "../../model-tool-support.js";
 import { releaseWsSession } from "../../openai-ws-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import { createBundleLspToolRuntime } from "../../pi-bundle-lsp-runtime.js";
-import { TOOL_NAME_SEPARATOR } from "../../pi-bundle-mcp-names.js";
 import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
@@ -111,11 +110,6 @@ import {
   toClientToolDefinitions,
 } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveSubagentToolPolicyForSession,
-} from "../../pi-tools.policy.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
@@ -141,19 +135,11 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../../subagent-capabilities.js";
 import { resolveSystemPromptOverride } from "../../system-prompt-override.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
-import {
-  buildEmptyExplicitToolAllowlistError,
-  collectExplicitToolAllowlistSources,
-} from "../../tool-allowlist-guard.js";
-import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
+import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
@@ -354,25 +340,18 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
-export function resolveUnknownToolGuardThreshold(loopDetection?: {
-  enabled?: boolean;
-  unknownToolThreshold?: number;
-}): number {
-  // The unknown-tool guard is a safety net against the model hallucinating a
-  // tool name or calling a tool that has since been removed from the allowlist
-  // (for example after a `skills.allowBundled` config change). After `threshold`
-  // consecutive unknown-tool attempts the stream wrapper rewrites the assistant
-  // message content to tell the model to stop, which breaks otherwise-infinite
-  // Tool-not-found loops against the provider. Unlike the genericRepeat /
-  // pingPong / pollNoProgress detectors this guard has no false-positive
-  // surface because the tool is objectively not registered in this run, so it
-  // stays on regardless of `tools.loopDetection.enabled`.
-  const raw = loopDetection?.unknownToolThreshold;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
-  }
-  return UNKNOWN_TOOL_THRESHOLD;
-}
+import {
+  applyEmbeddedAttemptToolsAllow,
+  collectAttemptExplicitToolAllowlistSources,
+  resolveUnknownToolGuardThreshold,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tools.js";
+
+export {
+  applyEmbeddedAttemptToolsAllow,
+  resolveUnknownToolGuardThreshold,
+  shouldCreateBundleMcpRuntimeForAttempt,
+} from "./attempt-tools.js";
 
 export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
   return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
@@ -464,106 +443,8 @@ function summarizeSessionContext(messages: AgentMessage[]): {
   };
 }
 
-export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
-  tools: T[],
-  toolsAllow?: string[],
-): T[] {
-  if (!toolsAllow || toolsAllow.length === 0) {
-    return tools;
-  }
-  const allowSet = new Set(toolsAllow);
-  return tools.filter((tool) => allowSet.has(tool.name));
-}
-
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   return stripToolResultDetails(normalizeAssistantReplayContent(messages));
-}
-
-export function shouldCreateBundleMcpRuntimeForAttempt(params: {
-  toolsEnabled: boolean;
-  disableTools?: boolean;
-  toolsAllow?: string[];
-}): boolean {
-  if (!params.toolsEnabled || params.disableTools === true) {
-    return false;
-  }
-  if (!params.toolsAllow || params.toolsAllow.length === 0) {
-    return true;
-  }
-  return params.toolsAllow.some((toolName) => toolName.includes(TOOL_NAME_SEPARATOR));
-}
-
-function collectAttemptExplicitToolAllowlistSources(params: {
-  config?: EmbeddedRunAttemptParams["config"];
-  sessionKey?: string;
-  sandboxSessionKey?: string;
-  agentId?: string;
-  modelProvider?: string;
-  modelId?: string;
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
-  toolsAllow?: string[];
-}) {
-  const { agentId, globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
-    resolveEffectiveToolPolicy({
-      config: params.config,
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-    });
-  const groupPolicy = resolveGroupToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    spawnedBy: params.spawnedBy,
-    messageProvider: params.messageProvider,
-    groupId: params.groupId,
-    groupChannel: params.groupChannel,
-    groupSpace: params.groupSpace,
-    accountId: params.agentAccountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const subagentStore = resolveSubagentCapabilityStore(params.sandboxSessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    params.sandboxSessionKey &&
-    isSubagentEnvelopeSession(params.sandboxSessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sandboxSessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  return collectExplicitToolAllowlistSources([
-    { label: "tools.allow", allow: globalPolicy?.allow },
-    { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
-    {
-      label: agentId ? `agents.${agentId}.tools.allow` : "agent tools.allow",
-      allow: agentPolicy?.allow,
-    },
-    {
-      label: agentId ? `agents.${agentId}.tools.byProvider.allow` : "agent tools.byProvider.allow",
-      allow: agentProviderPolicy?.allow,
-    },
-    { label: "group tools.allow", allow: groupPolicy?.allow },
-    { label: "sandbox tools.allow", allow: params.sandboxToolPolicy?.allow },
-    { label: "subagent tools.allow", allow: subagentPolicy?.allow },
-    { label: "runtime toolsAllow", allow: params.toolsAllow },
-  ]);
 }
 
 export async function runEmbeddedAttempt(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
@@ -29,11 +28,10 @@ import {
 } from "../../../plugins/provider-model-compat.js";
 import {
   resolveProviderSystemPromptContribution,
-  resolveProviderTextTransforms,
   transformProviderSystemPrompt,
 } from "../../../plugins/provider-runtime.js";
 import { getPluginToolMeta } from "../../../plugins/tools.js";
-import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import {
@@ -52,20 +50,10 @@ import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import {
-  analyzeBootstrapBudget,
-  buildBootstrapPromptWarning,
   buildBootstrapTruncationReportMeta,
-  buildBootstrapInjectionStats,
   prependBootstrapPromptWarning,
 } from "../../bootstrap-budget.js";
-import {
-  FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
-  hasCompletedBootstrapTurn,
-  isWorkspaceBootstrapPending,
-  makeBootstrapWarn,
-  resolveBootstrapContextForRun,
-  resolveContextInjectionMode,
-} from "../../bootstrap-files.js";
+import { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
   listChannelSupportedActions,
@@ -89,14 +77,10 @@ import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "../../pi-bundle-mcp-tools.js";
-import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
   isCloudCodeAssistFormatError,
-  resolveBootstrapMaxChars,
-  resolveBootstrapPromptTruncationWarningMode,
-  resolveBootstrapTotalMaxChars,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
@@ -110,9 +94,7 @@ import {
   toClientToolDefinitions,
 } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
-import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
-import { registerProviderStreamForModel } from "../../provider-stream.js";
 import {
   logAgentRuntimeToolDiagnostics,
   normalizeAgentRuntimeTools,
@@ -121,10 +103,7 @@ import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
-import {
-  sanitizeToolUseResultPairing,
-  stripToolResultDetails,
-} from "../../session-transcript-repair.js";
+import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import {
   acquireSessionWriteLock,
   resolveSessionLockMaxHoldFromTimeout,
@@ -142,18 +121,12 @@ import { resolveAgentTimeoutMs } from "../../timeout.js";
 import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
-import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
-import {
-  applyExtraParamsToAgent,
-  resolveAgentTransportOverride,
-  resolveExplicitSettingsTransport,
-} from "../extra-params.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
@@ -164,7 +137,6 @@ import {
   completePromptCacheObservation,
   type PromptCacheChange,
 } from "../prompt-cache-observability.js";
-import { resolveCacheRetention } from "../prompt-cache-retention.js";
 import {
   normalizeAssistantReplayContent,
   sanitizeSessionHistory,
@@ -182,7 +154,6 @@ import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manage
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
-  describeEmbeddedAgentStreamStrategy,
   resetEmbeddedAgentBaseStreamFnCacheForTest,
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
@@ -213,19 +184,28 @@ import { mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
-import {
-  resolveAttemptWorkspaceBootstrapRouting,
-  shouldStripBootstrapFromEmbeddedContext,
-} from "./attempt-bootstrap-routing.js";
+import { shouldStripBootstrapFromEmbeddedContext } from "./attempt-bootstrap-routing.js";
 export { shouldStripBootstrapFromEmbeddedContext } from "./attempt-bootstrap-routing.js";
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
 import { summarizeSessionContext } from "./attempt-message-summary.js";
+import {
+  isPrimaryBootstrapRun,
+  normalizeMessagesForLlmBoundary,
+  prepareAttemptBootstrapPromptContext,
+  remapInjectedContextFilesToWorkspace,
+} from "./attempt-prompt.js";
+export {
+  isPrimaryBootstrapRun,
+  normalizeMessagesForLlmBoundary,
+  remapInjectedContextFilesToWorkspace,
+} from "./attempt-prompt.js";
 import {
   applyEmbeddedAttemptToolsAllow,
   collectAttemptExplicitToolAllowlistSources,
   resolveUnknownToolGuardThreshold,
   shouldCreateBundleMcpRuntimeForAttempt,
 } from "./attempt-tools.js";
+import { configureAttemptTransportRuntime } from "./attempt-transport.js";
 import {
   assembleAttemptContextEngine,
   buildLoopPromptCacheInfo,
@@ -233,7 +213,6 @@ import {
   findCurrentAttemptAssistantMessage,
   finalizeAttemptContextEngineTurn,
   resolvePromptCacheTouchTimestamp,
-  resolveAttemptBootstrapContext,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
 import {
@@ -269,7 +248,6 @@ import {
   composeSystemPromptWithHookContext,
   resolveAttemptSpawnWorkspaceDir,
   shouldPersistCompletedBootstrapTurn,
-  shouldUseOpenAIWebSocketTransport,
 } from "./attempt.thread-helpers.js";
 import {
   shouldRepairMalformedToolCallArguments,
@@ -353,37 +331,6 @@ export {
   shouldCreateBundleMcpRuntimeForAttempt,
 } from "./attempt-tools.js";
 
-export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
-  return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
-}
-
-export function remapInjectedContextFilesToWorkspace(params: {
-  files: EmbeddedContextFile[];
-  sourceWorkspaceDir: string;
-  targetWorkspaceDir: string;
-}): EmbeddedContextFile[] {
-  if (params.sourceWorkspaceDir === params.targetWorkspaceDir) {
-    return params.files;
-  }
-  return params.files.map((file) => {
-    const relative = path.relative(params.sourceWorkspaceDir, file.path);
-    const canRemap = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-    return canRemap
-      ? {
-          ...file,
-          path:
-            relative === ""
-              ? params.targetWorkspaceDir
-              : path.join(params.targetWorkspaceDir, relative),
-        }
-      : file;
-  });
-}
-
-export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
-  return stripToolResultDetails(normalizeAssistantReplayContent(messages));
-}
-
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
@@ -462,7 +409,6 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const contextInjectionMode = resolveContextInjectionMode(params.config);
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
     const diagnosticTrace = freezeDiagnosticTraceContext(createDiagnosticTraceContext());
     const runTrace = freezeDiagnosticTraceContext(
@@ -566,82 +512,26 @@ export async function runEmbeddedAttempt(
             return applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow);
           })();
     const toolsEnabled = supportsModelTools(params.model);
-    const bootstrapHasFileAccess = toolsEnabled && toolsRaw.some((tool) => tool.name === "read");
-    const bootstrapRouting = await resolveAttemptWorkspaceBootstrapRouting({
-      isWorkspaceBootstrapPending,
-      bootstrapContextRunKind: params.bootstrapContextRunKind,
-      trigger: params.trigger,
-      sessionKey: params.sessionKey,
-      isPrimaryRun: isPrimaryBootstrapRun(params.sessionKey),
-      isCanonicalWorkspace: params.isCanonicalWorkspace,
-      effectiveWorkspace,
-      resolvedWorkspace,
-      hasBootstrapFileAccess: bootstrapHasFileAccess,
-    });
-    const bootstrapMode = bootstrapRouting.bootstrapMode;
-    const shouldStripBootstrapFromContext = bootstrapRouting.shouldStripBootstrapFromContext;
     const {
-      bootstrapFiles: hookAdjustedBootstrapFiles,
-      contextFiles: resolvedContextFiles,
-      shouldRecordCompletedBootstrapTurn,
-    } = await resolveAttemptBootstrapContext({
-      contextInjectionMode,
-      bootstrapContextMode: params.bootstrapContextMode,
-      bootstrapContextRunKind: params.bootstrapContextRunKind ?? "default",
-      bootstrapMode,
-      sessionFile: params.sessionFile,
-      hasCompletedBootstrapTurn,
-      resolveBootstrapContextForRun: async () =>
-        await resolveBootstrapContextForRun({
-          workspaceDir: resolvedWorkspace,
-          config: params.config,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          warn: makeBootstrapWarn({
-            sessionLabel,
-            workspaceDir: resolvedWorkspace,
-            warn: (message) => log.warn(message),
-          }),
-          contextMode: params.bootstrapContextMode,
-          runKind: params.bootstrapContextRunKind,
-        }),
-    });
-    const remappedContextFiles = remapInjectedContextFilesToWorkspace({
-      files: resolvedContextFiles,
-      sourceWorkspaceDir: resolvedWorkspace,
-      targetWorkspaceDir: effectiveWorkspace,
-    });
-    const contextFiles = shouldStripBootstrapFromContext
-      ? remappedContextFiles.filter((file) => !/(^|[\\/])BOOTSTRAP\.md$/iu.test(file.path.trim()))
-      : remappedContextFiles;
-    const bootstrapFilesForInjectionStats = shouldStripBootstrapFromContext
-      ? hookAdjustedBootstrapFiles.filter((file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME)
-      : hookAdjustedBootstrapFiles;
-    const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
-    const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
-    const bootstrapAnalysis = analyzeBootstrapBudget({
-      files: buildBootstrapInjectionStats({
-        bootstrapFiles: bootstrapFilesForInjectionStats,
-        injectedFiles: contextFiles,
-      }),
+      hookAdjustedBootstrapFiles,
+      contextFiles,
       bootstrapMaxChars,
       bootstrapTotalMaxChars,
+      bootstrapAnalysis,
+      bootstrapPromptWarningMode,
+      bootstrapPromptWarning,
+      workspaceNotes,
+      shouldRecordCompletedBootstrapTurn,
+      userPromptPrefixText,
+    } = await prepareAttemptBootstrapPromptContext({
+      attempt: params,
+      sessionLabel,
+      resolvedWorkspace,
+      effectiveWorkspace,
+      toolsEnabled,
+      toolsRaw,
+      logWarn: (message) => log.warn(message),
     });
-    const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(params.config);
-    const bootstrapPromptWarning = buildBootstrapPromptWarning({
-      analysis: bootstrapAnalysis,
-      mode: bootstrapPromptWarningMode,
-      seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
-      previousSignature: params.bootstrapPromptWarningSignature,
-    });
-    const workspaceNotes: string[] = [];
-    if (
-      hookAdjustedBootstrapFiles.some(
-        (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
-      )
-    ) {
-      workspaceNotes.push("Reminder: commit your changes in this workspace after edits.");
-    }
     if (isEmbeddedMode()) {
       workspaceNotes.push(
         "Running in local embedded mode (no gateway). Most tools work locally. Gateway-dependent tools (canvas, nodes, cron, message, sessions_send, sessions_spawn, gateway) are unavailable. Subagent kill/steer require a gateway. Do not attempt to read gateway-specific files such as sessions.json, gateway.log, or gateway.pid.",
@@ -1013,7 +903,6 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
-    const userPromptPrefixText = bootstrapRouting.userPromptPrefixText;
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
@@ -1353,116 +1242,32 @@ export async function runEmbeddedAttempt(
         }),
       );
 
-      // Rebuild each turn from the session's original stream base so prior-turn
-      // wrappers do not pin us to stale provider/API transport behavior.
-      const defaultSessionStreamFn = resolveEmbeddedAgentBaseStreamFn({
-        session: activeSession,
-      });
-      const providerStreamFn = registerProviderStreamForModel({
-        model: params.model,
-        cfg: params.config,
-        agentDir,
-        workspaceDir: effectiveWorkspace,
-      });
-      const shouldUseWebSocketTransport = shouldUseOpenAIWebSocketTransport({
+      const {
+        effectiveExtraParams,
+        effectivePromptCacheRetention,
+        effectiveAgentTransport,
+        streamStrategy,
+      } = await configureAttemptTransportRuntime({
+        activeSession,
+        config: params.config,
         provider: params.provider,
-        modelApi: params.model.api,
-        modelBaseUrl: params.model.baseUrl,
-      });
-      const wsApiKey = shouldUseWebSocketTransport
-        ? await resolveEmbeddedAgentApiKey({
-            provider: params.provider,
-            resolvedApiKey: params.resolvedApiKey,
-            authStorage: params.authStorage,
-          })
-        : undefined;
-      if (shouldUseWebSocketTransport && !wsApiKey) {
-        log.warn(
-          `[ws-stream] no API key for provider=${params.provider}; keeping session-managed HTTP transport`,
-        );
-      }
-      const streamStrategy = describeEmbeddedAgentStreamStrategy({
-        currentStreamFn: defaultSessionStreamFn,
-        providerStreamFn,
-        shouldUseWebSocketTransport,
-        wsApiKey,
+        modelId: params.modelId,
         model: params.model,
-      });
-      activeSession.agent.streamFn = resolveEmbeddedAgentStreamFn({
-        currentStreamFn: defaultSessionStreamFn,
-        providerStreamFn,
-        shouldUseWebSocketTransport,
-        wsApiKey,
+        agentDir,
+        effectiveWorkspace,
         sessionId: params.sessionId,
-        signal: runAbortController.signal,
-        model: params.model,
         resolvedApiKey: params.resolvedApiKey,
         authStorage: params.authStorage,
-      });
-      const providerTextTransforms = resolveProviderTextTransforms({
-        provider: params.provider,
-        config: params.config,
-        workspaceDir: effectiveWorkspace,
-      });
-      if (providerTextTransforms) {
-        activeSession.agent.streamFn = wrapStreamFnTextTransforms({
-          streamFn: activeSession.agent.streamFn,
-          input: providerTextTransforms.input,
-          output: providerTextTransforms.output,
-          transformSystemPrompt: false,
-        });
-      }
-
-      const resolvedTransport = resolveExplicitSettingsTransport({
+        runAbortSignal: runAbortController.signal,
         settingsManager,
-        sessionTransport: activeSession.agent.transport,
-      });
-      const streamExtraParamsOverride = {
-        ...params.streamParams,
+        streamParams: params.streamParams,
         fastMode: params.fastMode,
-      };
-      const preparedRuntimeExtraParams = params.runtimePlan?.transport.resolveExtraParams({
-        extraParamsOverride: streamExtraParamsOverride,
-        thinkingLevel: params.thinkLevel,
-        agentId: sessionAgentId,
-        workspaceDir: effectiveWorkspace,
-        model: params.model,
-        resolvedTransport,
-      });
-      const { effectiveExtraParams } = applyExtraParamsToAgent(
-        activeSession.agent,
-        params.config,
-        params.provider,
-        params.modelId,
-        streamExtraParamsOverride,
-        params.thinkLevel,
+        thinkLevel: params.thinkLevel,
         sessionAgentId,
-        effectiveWorkspace,
-        params.model,
-        agentDir,
-        resolvedTransport,
-        preparedRuntimeExtraParams
-          ? { preparedExtraParams: preparedRuntimeExtraParams }
-          : undefined,
-      );
-      const effectivePromptCacheRetention = resolveCacheRetention(
-        effectiveExtraParams,
-        params.provider,
-        params.model.api,
-        params.modelId,
-      );
-      const agentTransportOverride = resolveAgentTransportOverride({
-        settingsManager,
-        effectiveExtraParams,
+        runtimePlan: params.runtimePlan,
+        logDebug: (message) => log.debug(message),
+        logWarn: (message) => log.warn(message),
       });
-      const effectiveAgentTransport = agentTransportOverride ?? activeSession.agent.transport;
-      if (agentTransportOverride && activeSession.agent.transport !== agentTransportOverride) {
-        const previousTransport = activeSession.agent.transport;
-        log.debug(
-          `embedded agent transport override: ${previousTransport} -> ${agentTransportOverride} ` +
-            `(${params.provider}/${params.modelId})`,
-        );
-      }
 
       const cacheObservabilityEnabled = Boolean(cacheTrace) || log.isEnabled("debug");
       const promptCacheToolNames = collectPromptCacheToolNames(

--- a/src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/run-orchestration-helpers.ts
@@ -1,0 +1,123 @@
+// Pure orchestration helpers extracted from `run.ts` so the embedded run
+// orchestrator does not own auth-store seeding, trace-summary shaping,
+// session-key backfill, or handled-reply payload normalization.
+//
+// This is the third ownership-boundary slice for RFC 72072 and the first
+// piece of the run-orchestration extraction. The full split that the RFC
+// envisioned for PR 5 (`model-auth-plan.ts`, `runtime-plan-factory.ts`,
+// `lane-workspace.ts`, `terminal-result.ts`) lands as separate follow-ups
+// because the larger seams sit inside `runEmbeddedPiAgent`'s closure with
+// deep state dependencies. PR 5 keeps that pattern conservative, matching
+// the reduced scope used in PR 3 (#72110) and PR 4 (#72113).
+//
+// The exported helpers are pure or close-to-pure:
+//   - `createEmptyAuthProfileStore` returns a fresh AuthProfileStore.
+//   - `buildTraceToolSummary` aggregates a tool-call slice into the trace
+//     summary shape used by the run-attempt observability pipeline.
+//   - `backfillSessionKey` does the read-only sessionId→sessionKey lookup
+//     that runs at the top of `runEmbeddedPiAgent`. It logs a warning on
+//     failure but otherwise has no side effects.
+//   - `buildHandledReplyPayloads` normalises an optional ReplyPayload into
+//     the array shape downstream delivery expects, defaulting to a silent
+//     reply token when the caller did not provide one.
+
+import type { ReplyPayload } from "../../../auto-reply/reply-payload.js";
+import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
+import { normalizeOptionalString } from "../../../shared/string-coerce.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import {
+  resolveSessionKeyForRequest,
+  resolveStoredSessionKeyForSessionId,
+} from "../../command/session.js";
+import { redactRunIdentifier } from "../../workspace-run.js";
+import { log } from "../logger.js";
+import type { ToolSummaryTrace } from "../types.js";
+import type { RunEmbeddedPiAgentParams } from "./params.js";
+
+export function createEmptyAuthProfileStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {},
+  };
+}
+
+export function buildTraceToolSummary(params: {
+  toolMetas: Array<{ toolName: string; meta?: string }>;
+  hadFailure: boolean;
+}): ToolSummaryTrace | undefined {
+  if (params.toolMetas.length === 0) {
+    return undefined;
+  }
+  const tools: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of params.toolMetas) {
+    const toolName = normalizeOptionalString(entry.toolName);
+    if (!toolName || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+    tools.push(toolName);
+  }
+  return {
+    calls: params.toolMetas.length,
+    tools,
+    failures: params.hadFailure ? 1 : 0,
+  };
+}
+
+/**
+ * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
+ * The return value is normalized: whitespace-only inputs collapse to undefined, and
+ * successful resolution returns a trimmed session key. This is a read-only lookup
+ * with no side effects.
+ * See: https://github.com/openclaw/openclaw/issues/60552
+ */
+export function backfillSessionKey(params: {
+  config: RunEmbeddedPiAgentParams["config"];
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+}): string | undefined {
+  const trimmed = normalizeOptionalString(params.sessionKey);
+  if (trimmed) {
+    return trimmed;
+  }
+  if (!params.config || !params.sessionId) {
+    return undefined;
+  }
+  try {
+    const resolved = normalizeOptionalString(params.agentId)
+      ? resolveStoredSessionKeyForSessionId({
+          cfg: params.config,
+          sessionId: params.sessionId,
+          agentId: params.agentId,
+        })
+      : resolveSessionKeyForRequest({
+          cfg: params.config,
+          sessionId: params.sessionId,
+        });
+    return normalizeOptionalString(resolved.sessionKey);
+  } catch (err) {
+    log.warn(
+      `[backfillSessionKey] Failed to resolve sessionKey for sessionId=${redactRunIdentifier(sanitizeForLog(params.sessionId))}: ${formatErrorMessage(err)}`,
+    );
+    return undefined;
+  }
+}
+
+export function buildHandledReplyPayloads(reply?: ReplyPayload) {
+  const normalized = reply ?? { text: SILENT_REPLY_TOKEN };
+  return [
+    {
+      text: normalized.text,
+      mediaUrl: normalized.mediaUrl,
+      mediaUrls: normalized.mediaUrls,
+      replyToId: normalized.replyToId,
+      audioAsVoice: normalized.audioAsVoice,
+      isError: normalized.isError,
+      isReasoning: normalized.isReasoning,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

@steipete @pashpashpash this is the first **real structural split** after the consolidated RuntimePlan cleanup package.

This PR is stacked after #72134 and implements the next slice from RFC #72072: move prompt/bootstrap preparation and transport/session-stream setup out of `run/attempt.ts` without changing runtime behavior.

> Review note: until #72134 lands, this PR includes that cleanup package in the base diff. The unique diff after #72134 is one commit: `1cdfd2c5be refactor: split attempt prompt and transport preparation`.

## Diagram

```mermaid
flowchart TD
  A["runEmbeddedAttempt"] --> B["attempt-prompt.ts"]
  A --> C["attempt-transport.ts"]
  A --> D["remaining stream loop + lifecycle"]

  B --> B1["bootstrap routing"]
  B --> B2["context-file remap"]
  B --> B3["bootstrap budget + warning"]
  B --> B4["LLM-boundary message normalization"]

  C --> C1["provider stream selection"]
  C --> C2["OpenAI websocket decision"]
  C --> C3["provider text transforms"]
  C --> C4["RuntimePlan transport extra params"]
  C --> C5["effective cache retention + transport"]

  D --> E["future PR: stream-loop/lifecycle split"]
```

## What Changed

| File | Change |
|---|---|
| `src/agents/pi-embedded-runner/run/attempt-prompt.ts` | New prompt/bootstrap helper module for primary-bootstrap detection, injected-context remapping, LLM-boundary message normalization, bootstrap routing, context loading, budget analysis, and warning preparation. |
| `src/agents/pi-embedded-runner/run/attempt-transport.ts` | New transport helper module for provider stream selection, OpenAI WS selection, provider text transforms, RuntimePlan transport extra params, cache-retention resolution, and effective transport reporting. |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Delegates the two extracted policy clusters while preserving existing exports and behavior-compatible fallback paths. |

## What Did Not Change

- No Harness V2 public API change.
- No Codex adapter behavior change.
- No `pi-embedded-runner` rename.
- No stream-loop/lifecycle extraction yet.
- No terminal-result/failover extraction yet.
- No WS pooling behavior change.

## Why This Slice

The previous reduced drafts intentionally avoided the closure-heavy portions of `attempt.ts`. This PR starts the actual split with two seams that are high-value but still reviewable:

- Prompt/bootstrap preparation is a coherent ownership boundary and already has focused bootstrap/context tests.
- Transport setup is a coherent ownership boundary and keeps wrapper ordering intact by mutating `activeSession.agent.streamFn` in the same sequence before the remaining stream wrappers run.

## Validation

Passed locally:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/run/attempt.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/pi-embedded-runner/stream-resolution.test.ts \
  src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts \
  src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.test.ts \
  src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts \
  src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts \
  src/agents/pi-embedded-runner/prompt-cache-retention.test.ts \
  src/agents/pi-embedded-runner/prompt-cache-observability.test.ts

./node_modules/.bin/oxlint --tsconfig tsconfig.oxlint.core.json \
  src/agents/pi-embedded-runner/run/attempt.ts \
  src/agents/pi-embedded-runner/run/attempt-prompt.ts \
  src/agents/pi-embedded-runner/run/attempt-transport.ts

git diff --check
pnpm check:architecture
```

Known baseline/staked caveat:

```bash
pnpm check:test-types
pnpm check:changed
```

Both still fail on existing repo-baseline `ModelCompatConfig` / `@vincentkoc/qrcode-tui` drift in files outside this PR's unique diff, matching the current cleanup-package caveat. This PR no longer has attempt-specific type errors after the transport return narrowing.

## Related Work

- RFC: #72072
- Consolidated cleanup package: #72134
- Superseded draft sources carried by #72134: #72098, #72105, #72110, #72113, #72116, #72118, #72119

## Follow-Up Structural PRs

- Split the remaining stream loop and lifecycle cleanup state from `attempt.ts`.
- Split `run.ts` by runtime-plan factory, lane/workspace, model/auth, and terminal-result helpers.
- Add canonical embedded-runner import guard/docs after structural seams are stable.
