### PR TITLE
fix install.ps1 Main return handling in CI

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -30,7 +30,7 @@ function Write-Host {
         "error" { "$ERROR✗$NC $Message" }
         default { "$MUTED·$NC $Message" }
     }
-    Microsoft.PowerShell.Utility\Write-Host $msg
+    [void](Microsoft.PowerShell.Utility\Write-Host $msg)
 }
 
 function Write-Banner {


### PR DESCRIPTION
Closes #72250

## Summary
- make the PowerShell installer's `Write-Host` wrapper side-effect-only
- prevent host chatter from leaking into `Main` return values during Windows installer fixtures
- fix the `core-support-boundary` CI failure seen in https://github.com/openclaw/openclaw/actions/runs/24960081278

## Testing
- `pnpm test test/scripts/install-ps1.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts`
- `pnpm build`
