### PR TITLE
Add Google Live browser Talk sessions

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -217,6 +217,11 @@ Current runtime behaviour:
 | `owner`          | Expose the consult tool and let the regular agent use the normal agent tool policy.                                                      |
 | `none`           | Do not expose the consult tool. Custom `realtime.tools` are still passed through to the realtime provider.                               |
 
+`realtime.consultThinkingLevel` and `realtime.consultFastMode` optionally
+override the thinking and fast-mode settings for `openclaw_agent_consult` runs.
+If unset, consult runs inherit the selected response model's normal thinking
+default and fast mode remains unset.
+
 ### Realtime provider examples
 
 <Tabs>

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -352,9 +352,10 @@ SDK rejects language-code hints on this API path.
 </Note>
 
 <Note>
-Control UI Talk browser sessions still require a realtime voice provider with a
-browser WebRTC session implementation. Today that path is OpenAI Realtime; the
-Google provider is for backend realtime bridges.
+Control UI Talk can use Google Live through browser WebSocket sessions. The
+Gateway mints a short-lived constrained Live API auth token, sends the browser a
+provider setup payload, and keeps `openclaw_agent_consult` routed back through
+the Gateway chat session. OpenAI Talk still uses browser WebRTC.
 </Note>
 
 ## Advanced configuration

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -87,7 +87,7 @@ The Control UI can localize itself on first load based on your browser locale. T
 <AccordionGroup>
   <Accordion title="Chat and Talk">
     - Chat with the model via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`).
-    - Talk to OpenAI Realtime directly from the browser via WebRTC. The Gateway mints a short-lived Realtime client secret with `talk.realtime.session`; the browser sends microphone audio directly to OpenAI and relays `openclaw_agent_consult` tool calls back through `chat.send` for the larger configured OpenClaw model.
+    - Talk to OpenAI Realtime directly from the browser via WebRTC, or Google Live via a browser WebSocket. The Gateway mints a short-lived provider token with `talk.realtime.session`; the browser sends microphone audio directly to the realtime provider and relays `openclaw_agent_consult` tool calls back through `chat.send` for the larger configured OpenClaw model.
     - Stream tool calls + live tool output cards in Chat (agent events).
   </Accordion>
   <Accordion title="Channels, instances, sessions, dreams">
@@ -144,8 +144,8 @@ The Control UI can localize itself on first load based on your browser locale. T
     - The chat header model and thinking pickers patch the active session immediately through `sessions.patch`; they are persistent session overrides, not one-turn-only send options.
     - When fresh Gateway session usage reports show high context pressure, the chat composer area shows a context notice and, at recommended compaction levels, a compact button that runs the normal session compaction path. Stale token snapshots are hidden until the Gateway reports fresh usage again.
   </Accordion>
-  <Accordion title="Talk mode (browser WebRTC)">
-    Talk mode uses a registered realtime voice provider that supports browser WebRTC sessions. Configure OpenAI with `talk.provider: "openai"` plus `talk.providers.openai.apiKey`, or reuse the Voice Call realtime provider config. The browser never receives the standard OpenAI API key; it receives only the ephemeral Realtime client secret. Google Live realtime voice is supported for backend Voice Call and Google Meet bridges, but not this browser WebRTC path yet. The Realtime session prompt is assembled by the Gateway; `talk.realtime.session` does not accept caller-provided instruction overrides.
+  <Accordion title="Talk mode (browser realtime)">
+    Talk mode uses a registered realtime voice provider that supports browser sessions. Configure OpenAI with `talk.provider: "openai"` plus `talk.providers.openai.apiKey`, configure Google with `talk.provider: "google"` plus `talk.providers.google.apiKey`, or reuse the Voice Call realtime provider config. The browser never receives the standard provider API key; it receives only a short-lived Realtime client secret or Google Live auth token. OpenAI uses browser WebRTC; Google Live uses a browser WebSocket with a Gateway-generated constrained setup. The Realtime session prompt is assembled by the Gateway; `talk.realtime.session` does not accept caller-provided instruction overrides.
 
     In the Chat composer, the Talk control is the waves button next to the microphone dictation button. When Talk starts, the composer status row shows `Connecting Talk...`, then `Talk live` while audio is connected, or `Asking OpenClaw...` while a realtime tool call is consulting the configured larger model through `chat.send`.
 

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -19,19 +19,23 @@ type MockGoogleLiveConnectParams = {
   };
 };
 
-const { connectMock, session } = vi.hoisted(() => {
+const { authTokenCreateMock, connectMock, session } = vi.hoisted(() => {
   const session: MockGoogleLiveSession = {
     close: vi.fn(),
     sendClientContent: vi.fn(),
     sendRealtimeInput: vi.fn(),
     sendToolResponse: vi.fn(),
   };
+  const authTokenCreateMock = vi.fn(async () => ({ name: "auth_tokens/browser-token" }));
   const connectMock = vi.fn(async (_params: MockGoogleLiveConnectParams) => session);
-  return { connectMock, session };
+  return { authTokenCreateMock, connectMock, session };
 });
 
 vi.mock("./google-genai-runtime.js", () => ({
   createGoogleGenAI: vi.fn(() => ({
+    authTokens: {
+      create: authTokenCreateMock,
+    },
     live: {
       connect: connectMock,
     },
@@ -53,6 +57,8 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     session.sendClientContent.mockClear();
     session.sendRealtimeInput.mockClear();
     session.sendToolResponse.mockClear();
+    authTokenCreateMock.mockClear();
+    authTokenCreateMock.mockResolvedValue({ name: "auth_tokens/browser-token" });
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_API_KEY;
   });
@@ -525,6 +531,88 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
           response: { result: "ok" },
         },
       ],
+    });
+  });
+
+  it("creates constrained Google Live browser sessions with setup metadata", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+
+    const browserSession = await provider.createBrowserSession?.({
+      providerConfig: {
+        apiKey: "gemini-key",
+        model: "gemini-live-2.5-flash-preview",
+        voice: "Algieba",
+        temperature: 0.2,
+      },
+      instructions: "Answer briefly.",
+      tools: [
+        {
+          type: "function",
+          name: "openclaw_agent_consult",
+          description: "Ask OpenClaw",
+          parameters: {
+            type: "object",
+            properties: { question: { type: "string" } },
+            required: ["question"],
+          },
+        },
+      ],
+    });
+
+    expect(browserSession).toMatchObject({
+      provider: "google",
+      transport: "google-live-websocket",
+      clientSecret: "auth_tokens/browser-token",
+      model: "gemini-live-2.5-flash-preview",
+      voice: "Algieba",
+      websocketUrl:
+        "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+      googleLiveSetup: {
+        model: "models/gemini-live-2.5-flash-preview",
+        generationConfig: {
+          responseModalities: ["AUDIO"],
+          temperature: 0.2,
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: {
+                voiceName: "Algieba",
+              },
+            },
+          },
+        },
+        systemInstruction: { role: "user", parts: [{ text: "Answer briefly." }] },
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "openclaw_agent_consult",
+                behavior: "NON_BLOCKING",
+                parametersJsonSchema: {
+                  type: "object",
+                  properties: { question: { type: "string" } },
+                  required: ["question"],
+                },
+              },
+            ],
+          },
+        ],
+        inputAudioTranscription: {},
+        outputAudioTranscription: {},
+      },
+    });
+    expect(authTokenCreateMock).toHaveBeenCalledWith({
+      config: {
+        uses: 1,
+        expireTime: expect.any(String),
+        newSessionExpireTime: expect.any(String),
+        liveConnectConstraints: {
+          model: "gemini-live-2.5-flash-preview",
+          config: expect.objectContaining({
+            responseModalities: ["AUDIO"],
+            systemInstruction: "Answer briefly.",
+          }),
+        },
+      },
     });
   });
 });

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -9,6 +9,7 @@ import {
   TurnCoverage,
   type FunctionDeclaration,
   type FunctionResponse,
+  type LiveConnectConfig,
   type LiveServerContent,
   type LiveServerMessage,
   type LiveServerToolCall,
@@ -18,6 +19,8 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import type {
   RealtimeVoiceBridge,
+  RealtimeVoiceBrowserSession,
+  RealtimeVoiceBrowserSessionCreateRequest,
   RealtimeVoiceBridgeCreateRequest,
   RealtimeVoiceProviderConfig,
   RealtimeVoiceProviderPlugin,
@@ -37,6 +40,9 @@ import { createGoogleGenAI } from "./google-genai-runtime.js";
 const GOOGLE_REALTIME_DEFAULT_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025";
 const GOOGLE_REALTIME_DEFAULT_VOICE = "Kore";
 const GOOGLE_REALTIME_DEFAULT_API_VERSION = "v1beta";
+const GOOGLE_REALTIME_BROWSER_API_VERSION = "v1alpha";
+const GOOGLE_REALTIME_BROWSER_WS_URL =
+  "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained";
 const GOOGLE_REALTIME_INPUT_SAMPLE_RATE = 16_000;
 const TELEPHONY_SAMPLE_RATE = 8000;
 const MAX_PENDING_AUDIO_CHUNKS = 320;
@@ -71,6 +77,23 @@ type GoogleRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
   voice?: string;
   temperature?: number;
   apiVersion?: string;
+  prefixPaddingMs?: number;
+  silenceDurationMs?: number;
+  startSensitivity?: GoogleRealtimeSensitivity;
+  endSensitivity?: GoogleRealtimeSensitivity;
+  activityHandling?: GoogleRealtimeActivityHandling;
+  turnCoverage?: GoogleRealtimeTurnCoverage;
+  automaticActivityDetectionDisabled?: boolean;
+  enableAffectiveDialog?: boolean;
+  thinkingLevel?: GoogleRealtimeThinkingLevel;
+  thinkingBudget?: number;
+};
+
+type GoogleRealtimeLiveConfig = {
+  instructions?: string;
+  tools?: RealtimeVoiceTool[];
+  voice?: string;
+  temperature?: number;
   prefixPaddingMs?: number;
   silenceDurationMs?: number;
   startSensitivity?: GoogleRealtimeSensitivity;
@@ -257,7 +280,7 @@ function mapTurnCoverage(value: GoogleRealtimeTurnCoverage | undefined): TurnCov
   }
 }
 
-function buildThinkingConfig(config: GoogleRealtimeVoiceBridgeConfig): ThinkingConfig | undefined {
+function buildThinkingConfig(config: GoogleRealtimeLiveConfig): ThinkingConfig | undefined {
   if (config.thinkingLevel) {
     return { thinkingLevel: config.thinkingLevel.toUpperCase() as ThinkingConfig["thinkingLevel"] };
   }
@@ -268,7 +291,7 @@ function buildThinkingConfig(config: GoogleRealtimeVoiceBridgeConfig): ThinkingC
 }
 
 function buildRealtimeInputConfig(
-  config: GoogleRealtimeVoiceBridgeConfig,
+  config: GoogleRealtimeLiveConfig,
 ): RealtimeInputConfig | undefined {
   const startSensitivity = mapStartSensitivity(config.startSensitivity);
   const endSensitivity = mapEndSensitivity(config.endSensitivity);
@@ -295,18 +318,105 @@ function buildRealtimeInputConfig(
   return Object.keys(realtimeInputConfig).length > 0 ? realtimeInputConfig : undefined;
 }
 
-function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): FunctionDeclaration[] {
+function buildFunctionDeclarations(
+  tools: RealtimeVoiceTool[] | undefined,
+  opts: { nonBlockingAgentConsult?: boolean } = {},
+): FunctionDeclaration[] {
   return (tools ?? []).map((tool) => {
     const declaration: FunctionDeclaration = {
       name: tool.name,
       description: tool.description,
       parametersJsonSchema: tool.parameters,
     };
-    if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+    if (
+      opts.nonBlockingAgentConsult !== false &&
+      tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME
+    ) {
       declaration.behavior = Behavior.NON_BLOCKING;
     }
     return declaration;
   });
+}
+
+function buildLiveConnectConfig(
+  config: GoogleRealtimeLiveConfig,
+  opts: { nonBlockingAgentConsult?: boolean } = {},
+): LiveConnectConfig {
+  const functionDeclarations = buildFunctionDeclarations(config.tools, opts);
+  const realtimeInputConfig = buildRealtimeInputConfig(config);
+  const thinkingConfig = buildThinkingConfig(config);
+  return {
+    responseModalities: [Modality.AUDIO],
+    ...(typeof config.temperature === "number" && config.temperature > 0
+      ? { temperature: config.temperature }
+      : {}),
+    speechConfig: {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: config.voice ?? GOOGLE_REALTIME_DEFAULT_VOICE,
+        },
+      },
+    },
+    systemInstruction: config.instructions,
+    ...(functionDeclarations.length > 0 ? { tools: [{ functionDeclarations }] } : {}),
+    ...(realtimeInputConfig ? { realtimeInputConfig } : {}),
+    inputAudioTranscription: {},
+    outputAudioTranscription: {},
+    ...(typeof config.enableAffectiveDialog === "boolean"
+      ? { enableAffectiveDialog: config.enableAffectiveDialog }
+      : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
+  };
+}
+
+function toGoogleApiModelName(model: string): string {
+  return model.startsWith("models/") || model.startsWith("tunedModels/")
+    ? model
+    : `models/${model}`;
+}
+
+function buildGoogleLiveBrowserSetup(
+  model: string,
+  config: LiveConnectConfig,
+): Record<string, unknown> {
+  const setup: Record<string, unknown> = {
+    model: toGoogleApiModelName(model),
+  };
+  const generationConfig: Record<string, unknown> = {};
+  if (config.responseModalities) {
+    generationConfig.responseModalities = config.responseModalities;
+  }
+  if (typeof config.temperature === "number") {
+    generationConfig.temperature = config.temperature;
+  }
+  if (config.speechConfig) {
+    generationConfig.speechConfig = config.speechConfig;
+  }
+  if (config.thinkingConfig) {
+    generationConfig.thinkingConfig = config.thinkingConfig;
+  }
+  if (typeof config.enableAffectiveDialog === "boolean") {
+    generationConfig.enableAffectiveDialog = config.enableAffectiveDialog;
+  }
+  if (Object.keys(generationConfig).length > 0) {
+    setup.generationConfig = generationConfig;
+  }
+  if (typeof config.systemInstruction === "string") {
+    setup.systemInstruction = { role: "user", parts: [{ text: config.systemInstruction }] };
+  }
+  if (config.tools) {
+    setup.tools = config.tools;
+  }
+  if (config.inputAudioTranscription) {
+    setup.inputAudioTranscription = config.inputAudioTranscription;
+  }
+  if (config.outputAudioTranscription) {
+    setup.outputAudioTranscription = config.outputAudioTranscription;
+  }
+  if (config.realtimeInputConfig) {
+    setup.realtimeInputConfig = config.realtimeInputConfig;
+  }
+  return setup;
 }
 
 function parsePcmSampleRate(mimeType: string | undefined): number {
@@ -349,31 +459,9 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       },
     });
 
-    const functionDeclarations = buildFunctionDeclarations(this.config.tools);
     this.session = (await ai.live.connect({
       model: this.config.model ?? GOOGLE_REALTIME_DEFAULT_MODEL,
-      config: {
-        responseModalities: [Modality.AUDIO],
-        ...(typeof this.config.temperature === "number" && this.config.temperature > 0
-          ? { temperature: this.config.temperature }
-          : {}),
-        speechConfig: {
-          voiceConfig: {
-            prebuiltVoiceConfig: {
-              voiceName: this.config.voice ?? GOOGLE_REALTIME_DEFAULT_VOICE,
-            },
-          },
-        },
-        systemInstruction: this.config.instructions,
-        ...(functionDeclarations.length > 0 ? { tools: [{ functionDeclarations }] } : {}),
-        ...(this.realtimeInputConfig ? { realtimeInputConfig: this.realtimeInputConfig } : {}),
-        inputAudioTranscription: {},
-        outputAudioTranscription: {},
-        ...(typeof this.config.enableAffectiveDialog === "boolean"
-          ? { enableAffectiveDialog: this.config.enableAffectiveDialog }
-          : {}),
-        ...(this.thinkingConfig ? { thinkingConfig: this.thinkingConfig } : {}),
-      },
+      config: buildLiveConnectConfig(this.config),
       callbacks: {
         onopen: () => {
           this.connected = true;
@@ -622,14 +710,70 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       });
     }
   }
+}
 
-  private get realtimeInputConfig(): RealtimeInputConfig | undefined {
-    return buildRealtimeInputConfig(this.config);
+async function createGoogleRealtimeBrowserSession(
+  req: RealtimeVoiceBrowserSessionCreateRequest,
+): Promise<RealtimeVoiceBrowserSession> {
+  const config = normalizeProviderConfig(req.providerConfig);
+  const apiKey = config.apiKey || resolveEnvApiKey();
+  if (!apiKey) {
+    throw new Error("Google Gemini API key missing");
   }
 
-  private get thinkingConfig(): ThinkingConfig | undefined {
-    return buildThinkingConfig(this.config);
+  const model = req.model ?? config.model ?? GOOGLE_REALTIME_DEFAULT_MODEL;
+  const voice = req.voice ?? config.voice ?? GOOGLE_REALTIME_DEFAULT_VOICE;
+  const liveConfig = buildLiveConnectConfig(
+    {
+      instructions: req.instructions,
+      tools: req.tools,
+      voice,
+      temperature: config.temperature,
+      prefixPaddingMs: config.prefixPaddingMs,
+      silenceDurationMs: config.silenceDurationMs,
+      startSensitivity: config.startSensitivity,
+      endSensitivity: config.endSensitivity,
+      activityHandling: config.activityHandling,
+      turnCoverage: config.turnCoverage,
+      automaticActivityDetectionDisabled: config.automaticActivityDetectionDisabled,
+      enableAffectiveDialog: config.enableAffectiveDialog,
+      thinkingLevel: config.thinkingLevel,
+      thinkingBudget: config.thinkingBudget,
+    },
+    { nonBlockingAgentConsult: true },
+  );
+  const expireTime = new Date(Date.now() + 30 * 60_000).toISOString();
+  const newSessionExpireTime = new Date(Date.now() + 60_000).toISOString();
+  const ai = createGoogleGenAI({
+    apiKey,
+    httpOptions: { apiVersion: GOOGLE_REALTIME_BROWSER_API_VERSION },
+  });
+  const token = await ai.authTokens.create({
+    config: {
+      uses: 1,
+      expireTime,
+      newSessionExpireTime,
+      liveConnectConstraints: {
+        model,
+        config: liveConfig,
+      },
+    },
+  });
+  const clientSecret = token.name?.trim();
+  if (!clientSecret) {
+    throw new Error("Google Live browser session did not return an auth token");
   }
+
+  return {
+    provider: "google",
+    transport: "google-live-websocket",
+    clientSecret,
+    model,
+    voice,
+    expiresAt: Math.floor(Date.parse(expireTime) / 1000),
+    websocketUrl: GOOGLE_REALTIME_BROWSER_WS_URL,
+    googleLiveSetup: buildGoogleLiveBrowserSetup(model, liveConfig),
+  };
 }
 
 export function buildGoogleRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
@@ -665,6 +809,7 @@ export function buildGoogleRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
         thinkingBudget: config.thinkingBudget,
       });
     },
+    createBrowserSession: createGoogleRealtimeBrowserSession,
   };
 }
 

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -87,6 +87,16 @@ const voiceCallConfigSchema = {
       help: "Controls the shared openclaw_agent_consult tool.",
       advanced: true,
     },
+    "realtime.consultThinkingLevel": {
+      label: "Realtime Consult Thinking",
+      help: "Optional thinking level override for openclaw_agent_consult runs.",
+      advanced: true,
+    },
+    "realtime.consultFastMode": {
+      label: "Realtime Consult Fast Mode",
+      help: "Optional fast-mode override for openclaw_agent_consult runs.",
+      advanced: true,
+    },
     "realtime.providers": { label: "Realtime Provider Config", advanced: true },
     "tts.provider": {
       label: "TTS Provider Override",

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -130,6 +130,16 @@
       "label": "Realtime Instructions",
       "advanced": true
     },
+    "realtime.consultThinkingLevel": {
+      "label": "Realtime Consult Thinking",
+      "help": "Optional thinking level override for openclaw_agent_consult runs.",
+      "advanced": true
+    },
+    "realtime.consultFastMode": {
+      "label": "Realtime Consult Fast Mode",
+      "help": "Optional fast-mode override for openclaw_agent_consult runs.",
+      "advanced": true
+    },
     "realtime.providers": {
       "label": "Realtime Provider Config",
       "advanced": true
@@ -405,6 +415,13 @@
           "toolPolicy": {
             "type": "string",
             "enum": ["safe-read-only", "owner", "none"]
+          },
+          "consultThinkingLevel": {
+            "type": "string",
+            "enum": ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"]
+          },
+          "consultFastMode": {
+            "type": "boolean"
           },
           "tools": {
             "type": "array",

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -214,6 +214,19 @@ export type VoiceCallRealtimeProvidersConfig = z.infer<
 
 export const VoiceCallRealtimeToolPolicySchema = z.enum(REALTIME_VOICE_AGENT_CONSULT_TOOL_POLICIES);
 export type VoiceCallRealtimeToolPolicy = RealtimeVoiceAgentConsultToolPolicy;
+export const VoiceCallRealtimeConsultThinkingLevelSchema = z.enum([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "adaptive",
+  "max",
+]);
+export type VoiceCallRealtimeConsultThinkingLevel = z.infer<
+  typeof VoiceCallRealtimeConsultThinkingLevelSchema
+>;
 
 export const VoiceCallStreamingProvidersConfigSchema = z
   .record(z.string(), z.record(z.string(), z.unknown()))
@@ -234,6 +247,10 @@ export const VoiceCallRealtimeConfigSchema = z
     instructions: z.string().default(DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS),
     /** Tool policy for the shared OpenClaw agent consult tool. */
     toolPolicy: VoiceCallRealtimeToolPolicySchema.default("safe-read-only"),
+    /** Optional thinking level override for shared OpenClaw agent consult runs. */
+    consultThinkingLevel: VoiceCallRealtimeConsultThinkingLevelSchema.optional(),
+    /** Optional fast-mode override for shared OpenClaw agent consult runs. */
+    consultFastMode: z.boolean().optional(),
     /** Tool definitions exposed to the realtime provider. */
     tools: z.array(RealtimeToolSchema).default([]),
     /** Provider-owned raw config blobs keyed by provider id. */

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -258,6 +258,8 @@ describe("createVoiceCallRuntime lifecycle", () => {
     const config = createBaseConfig();
     config.inboundPolicy = "allowlist";
     config.realtime.enabled = true;
+    config.realtime.consultThinkingLevel = "medium";
+    config.realtime.consultFastMode = true;
     config.realtime.tools = [
       {
         type: "function",
@@ -325,6 +327,8 @@ describe("createVoiceCallRuntime lifecycle", () => {
         lane: "voice",
         provider: "openai",
         model: "gpt-5.4",
+        thinkLevel: "medium",
+        fastMode: true,
         toolsAllow: ["read", "web_search", "web_fetch", "x_search", "memory_search", "memory_get"],
         extraSystemPrompt: expect.stringContaining("one or two bounded read-only queries"),
         prompt: expect.stringContaining("Caller: Can you check shipment status?"),

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -356,6 +356,7 @@ export async function createVoiceCallRuntime(params: {
             provider: agentProvider,
             model,
           });
+          const consultThinkingLevel = config.realtime.consultThinkingLevel ?? thinkLevel;
           return await consultRealtimeVoiceAgent({
             cfg,
             agentRuntime,
@@ -373,7 +374,8 @@ export async function createVoiceCallRuntime(params: {
             questionSourceLabel: "caller",
             provider: agentProvider,
             model,
-            thinkLevel,
+            thinkLevel: consultThinkingLevel,
+            fastMode: config.realtime.consultFastMode,
             timeoutMs: config.responseTimeoutMs,
             toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(config.realtime.toolPolicy),
             extraSystemPrompt: REALTIME_VOICE_CONSULT_SYSTEM_PROMPT,

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -548,6 +548,37 @@ describe("config plugin validation", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts voice-call realtime consult overrides", async () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [voiceCallSchemaPluginDir] },
+        entries: {
+          "voice-call-schema-fixture": {
+            config: {
+              realtime: {
+                enabled: true,
+                provider: "google",
+                toolPolicy: "owner",
+                consultThinkingLevel: "medium",
+                consultFastMode: true,
+                providers: {
+                  google: {
+                    model: "gemini-3.1-flash-live-preview",
+                    voice: "Algieba",
+                    apiVersion: "v1beta",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts voice-call OpenAI TTS speed, instructions, and baseUrl config fields", async () => {
     const res = validateInSuite({
       agents: { list: [{ id: "pi" }] },

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -50,9 +50,14 @@ export const TalkRealtimeSessionResultSchema = Type.Object(
   {
     provider: NonEmptyString,
     clientSecret: NonEmptyString,
+    transport: Type.Optional(
+      Type.Union([Type.Literal("openai-webrtc"), Type.Literal("google-live-websocket")]),
+    ),
     model: Type.Optional(Type.String()),
     voice: Type.Optional(Type.String()),
     expiresAt: Type.Optional(Type.Number()),
+    websocketUrl: Type.Optional(Type.String()),
+    googleLiveSetup: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -430,7 +430,7 @@ export const talkHandlers: GatewayRequestHandlers = {
           undefined,
           errorShape(
             ErrorCodes.UNAVAILABLE,
-            `Realtime voice provider "${resolution.provider.id}" does not support browser WebRTC sessions`,
+            `Realtime voice provider "${resolution.provider.id}" does not support browser realtime sessions`,
           ),
         );
         return;
@@ -447,9 +447,12 @@ export const talkHandlers: GatewayRequestHandlers = {
         {
           provider: session.provider,
           clientSecret: session.clientSecret,
+          ...(session.transport ? { transport: session.transport } : {}),
           ...(session.model ? { model: session.model } : {}),
           ...(session.voice ? { voice: session.voice } : {}),
           ...(typeof session.expiresAt === "number" ? { expiresAt: session.expiresAt } : {}),
+          ...(session.websocketUrl ? { websocketUrl: session.websocketUrl } : {}),
+          ...(session.googleLiveSetup ? { googleLiveSetup: session.googleLiveSetup } : {}),
         },
         undefined,
       );

--- a/src/realtime-voice/agent-consult-runtime.ts
+++ b/src/realtime-voice/agent-consult-runtime.ts
@@ -41,6 +41,7 @@ export async function consultRealtimeVoiceAgent(params: {
   provider?: RunEmbeddedPiAgentParams["provider"];
   model?: RunEmbeddedPiAgentParams["model"];
   thinkLevel?: RunEmbeddedPiAgentParams["thinkLevel"];
+  fastMode?: RunEmbeddedPiAgentParams["fastMode"];
   timeoutMs?: number;
   toolsAllow?: string[];
   extraSystemPrompt?: string;
@@ -88,6 +89,7 @@ export async function consultRealtimeVoiceAgent(params: {
     provider: params.provider,
     model: params.model,
     thinkLevel: params.thinkLevel ?? "high",
+    fastMode: params.fastMode,
     verboseLevel: "off",
     reasoningLevel: "off",
     toolResultFormat: "plain",

--- a/src/realtime-voice/provider-types.ts
+++ b/src/realtime-voice/provider-types.ts
@@ -68,9 +68,12 @@ export type RealtimeVoiceBrowserSessionCreateRequest = {
 export type RealtimeVoiceBrowserSession = {
   provider: RealtimeVoiceProviderId;
   clientSecret: string;
+  transport?: "openai-webrtc" | "google-live-websocket";
   model?: string;
   voice?: string;
   expiresAt?: number;
+  websocketUrl?: string;
+  googleLiveSetup?: Record<string, unknown>;
 };
 
 export type RealtimeVoiceBridge = {

--- a/ui/src/ui/chat/realtime-talk.test.ts
+++ b/ui/src/ui/chat/realtime-talk.test.ts
@@ -1,0 +1,196 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayEventFrame } from "../gateway.ts";
+import { RealtimeTalkSession, type RealtimeTalkSessionResult } from "./realtime-talk.ts";
+
+type Listener = (evt: GatewayEventFrame) => void;
+
+class MockGatewayClient {
+  readonly listeners = new Set<Listener>();
+  readonly request = vi.fn();
+
+  addEventListener(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(evt: GatewayEventFrame): void {
+    for (const listener of this.listeners) {
+      listener(evt);
+    }
+  }
+}
+
+type MockWebSocketHandler = (event?: { data?: string }) => void;
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly sent: unknown[] = [];
+  readonly handlers = new Map<string, MockWebSocketHandler[]>();
+  readyState = 0;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: MockWebSocketHandler): void {
+    this.handlers.set(type, [...(this.handlers.get(type) ?? []), handler]);
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as unknown);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    for (const handler of this.handlers.get("open") ?? []) {
+      handler();
+    }
+  }
+
+  message(data: unknown): void {
+    for (const handler of this.handlers.get("message") ?? []) {
+      handler({ data: JSON.stringify(data) });
+    }
+  }
+}
+
+class MockAudioContext {
+  sampleRate = 16_000;
+  currentTime = 0;
+  destination = {};
+
+  createMediaStreamSource() {
+    return { connect: vi.fn(), disconnect: vi.fn() };
+  }
+
+  createScriptProcessor() {
+    return { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+  }
+
+  createBuffer(_channels: number, length: number, sampleRate: number) {
+    const data = new Float32Array(length);
+    return {
+      duration: length / sampleRate,
+      getChannelData: () => data,
+    };
+  }
+
+  createBufferSource() {
+    return {
+      buffer: null,
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+  }
+
+  close = vi.fn(async () => {});
+}
+
+describe("RealtimeTalkSession Google Live", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("AudioContext", MockAudioContext);
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({
+          getAudioTracks: () => [],
+          getTracks: () => [],
+        })),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens Google Live WebSocket sessions and preserves tool call id/name in responses", async () => {
+    const client = new MockGatewayClient();
+    const googleSession: RealtimeTalkSessionResult = {
+      provider: "google",
+      transport: "google-live-websocket",
+      clientSecret: "auth_tokens/browser-token",
+      websocketUrl:
+        "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+      googleLiveSetup: {
+        model: "models/gemini-live",
+        generationConfig: { responseModalities: ["AUDIO"] },
+      },
+    };
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "talk.realtime.session") {
+        return googleSession;
+      }
+      if (method === "chat.send") {
+        return { runId: "run-1" };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const talk = new RealtimeTalkSession(client as never, "main");
+    await talk.start();
+    const ws = MockWebSocket.instances.at(-1);
+    expect(ws?.url).toBe(`${googleSession.websocketUrl}?access_token=auth_tokens%2Fbrowser-token`);
+
+    ws?.open();
+    expect(ws?.sent).toContainEqual({ setup: googleSession.googleLiveSetup });
+
+    ws?.message({
+      toolCall: {
+        functionCalls: [
+          {
+            id: "call-1",
+            name: "openclaw_agent_consult",
+            args: { question: "What is the basement light status?" },
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(client.request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({ sessionKey: "main" }),
+      );
+    });
+
+    client.emit({
+      event: "chat",
+      payload: {
+        runId: "run-1",
+        state: "final",
+        message: { text: "The basement lights are off." },
+      },
+    } as GatewayEventFrame);
+
+    await vi.waitFor(() => {
+      expect(ws?.sent).toContainEqual({
+        toolResponse: {
+          functionResponses: [
+            {
+              id: "call-1",
+              name: "openclaw_agent_consult",
+              response: { result: "The basement lights are off." },
+              scheduling: "WHEN_IDLE",
+            },
+          ],
+        },
+      });
+    });
+
+    talk.stop();
+  });
+});

--- a/ui/src/ui/chat/realtime-talk.ts
+++ b/ui/src/ui/chat/realtime-talk.ts
@@ -15,9 +15,12 @@ export type RealtimeTalkCallbacks = {
 export type RealtimeTalkSessionResult = {
   provider: string;
   clientSecret: string;
+  transport?: "openai-webrtc" | "google-live-websocket";
   model?: string;
   voice?: string;
   expiresAt?: number;
+  websocketUrl?: string;
+  googleLiveSetup?: Record<string, unknown>;
 };
 
 type RealtimeServerEvent = {
@@ -41,6 +44,30 @@ type ChatPayload = {
   state?: string;
   errorMessage?: string;
   message?: unknown;
+};
+
+type GoogleLiveServerMessage = {
+  setupComplete?: unknown;
+  serverContent?: {
+    interrupted?: boolean;
+    inputTranscription?: { text?: string; finished?: boolean };
+    outputTranscription?: { text?: string; finished?: boolean };
+    turnComplete?: boolean;
+    modelTurn?: {
+      parts?: Array<{
+        inlineData?: { data?: string; mimeType?: string };
+        text?: string;
+        thought?: boolean;
+      }>;
+    };
+  };
+  toolCall?: {
+    functionCalls?: Array<{
+      id?: string;
+      name?: string;
+      args?: unknown;
+    }>;
+  };
 };
 
 function extractTextFromMessage(message: unknown): string {
@@ -98,8 +125,14 @@ function waitForChatResult(params: {
 export class RealtimeTalkSession {
   private peer: RTCPeerConnection | null = null;
   private channel: RTCDataChannel | null = null;
+  private googleWs: WebSocket | null = null;
   private media: MediaStream | null = null;
   private audio: HTMLAudioElement | null = null;
+  private googleAudioContext: AudioContext | null = null;
+  private googleMicSource: MediaStreamAudioSourceNode | null = null;
+  private googleMicProcessor: ScriptProcessorNode | null = null;
+  private googlePlaybackSources = new Set<AudioBufferSourceNode>();
+  private googlePlaybackTime = 0;
   private closed = false;
   private toolBuffers = new Map<string, ToolBuffer>();
 
@@ -110,14 +143,25 @@ export class RealtimeTalkSession {
   ) {}
 
   async start(): Promise<void> {
-    if (!navigator.mediaDevices?.getUserMedia || typeof RTCPeerConnection === "undefined") {
-      throw new Error("Realtime Talk requires browser WebRTC and microphone access");
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error("Realtime Talk requires microphone access");
     }
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
     const session = await this.client.request<RealtimeTalkSessionResult>("talk.realtime.session", {
       sessionKey: this.sessionKey,
     });
+    if (session.transport === "google-live-websocket") {
+      await this.startGoogleLive(session);
+      return;
+    }
+    await this.startOpenAIRealtime(session);
+  }
+
+  private async startOpenAIRealtime(session: RealtimeTalkSessionResult): Promise<void> {
+    if (typeof RTCPeerConnection === "undefined") {
+      throw new Error("Realtime Talk requires browser WebRTC support");
+    }
     this.peer = new RTCPeerConnection();
     this.audio = document.createElement("audio");
     this.audio.autoplay = true;
@@ -134,7 +178,7 @@ export class RealtimeTalkSession {
     }
     this.channel = this.peer.createDataChannel("oai-events");
     this.channel.addEventListener("open", () => this.callbacks.onStatus?.("listening"));
-    this.channel.addEventListener("message", (event) => this.handleRealtimeEvent(event.data));
+    this.channel.addEventListener("message", (event) => this.handleOpenAIRealtimeEvent(event.data));
     this.peer.addEventListener("connectionstatechange", () => {
       if (this.closed) {
         return;
@@ -163,6 +207,54 @@ export class RealtimeTalkSession {
     });
   }
 
+  private async startGoogleLive(session: RealtimeTalkSessionResult): Promise<void> {
+    if (typeof WebSocket === "undefined") {
+      throw new Error("Google Live Talk requires browser WebSocket support");
+    }
+    if (!session.websocketUrl || !session.googleLiveSetup) {
+      throw new Error("Google Live Talk session is missing setup data");
+    }
+
+    this.media = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.googleAudioContext = new AudioContext({ sampleRate: 16_000 });
+    this.googleMicSource = this.googleAudioContext.createMediaStreamSource(this.media);
+    this.googleMicProcessor = this.googleAudioContext.createScriptProcessor(4096, 1, 1);
+    this.googleMicProcessor.onaudioprocess = (event) => {
+      if (this.closed || this.googleWs?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      const sampleRate = Math.round(this.googleAudioContext?.sampleRate ?? 16_000);
+      this.sendGoogleLive({
+        realtimeInput: {
+          audio: {
+            data: pcmFloat32ToBase64(event.inputBuffer.getChannelData(0)),
+            mimeType: `audio/pcm;rate=${sampleRate}`,
+          },
+        },
+      });
+    };
+    this.googleMicSource.connect(this.googleMicProcessor);
+    this.googleMicProcessor.connect(this.googleAudioContext.destination);
+
+    const url = new URL(session.websocketUrl);
+    url.searchParams.set("access_token", session.clientSecret);
+    this.googleWs = new WebSocket(url.toString());
+    this.googleWs.addEventListener("open", () => {
+      this.sendGoogleLive({ setup: session.googleLiveSetup });
+    });
+    this.googleWs.addEventListener("message", (event) => this.handleGoogleLiveEvent(event.data));
+    this.googleWs.addEventListener("close", () => {
+      if (!this.closed) {
+        this.callbacks.onStatus?.("error", "Realtime connection closed");
+      }
+    });
+    this.googleWs.addEventListener("error", () => {
+      if (!this.closed) {
+        this.callbacks.onStatus?.("error", "Realtime connection failed");
+      }
+    });
+  }
+
   stop(): void {
     this.closed = true;
     this.callbacks.onStatus?.("idle");
@@ -170,20 +262,36 @@ export class RealtimeTalkSession {
     this.channel = null;
     this.peer?.close();
     this.peer = null;
+    this.googleWs?.close();
+    this.googleWs = null;
     this.media?.getTracks().forEach((track) => track.stop());
     this.media = null;
     this.audio?.remove();
     this.audio = null;
+    this.googleMicProcessor?.disconnect();
+    this.googleMicProcessor = null;
+    this.googleMicSource?.disconnect();
+    this.googleMicSource = null;
+    this.stopGooglePlayback();
+    void this.googleAudioContext?.close();
+    this.googleAudioContext = null;
+    this.googlePlaybackTime = 0;
     this.toolBuffers.clear();
   }
 
-  private send(event: unknown): void {
+  private sendOpenAI(event: unknown): void {
     if (this.channel?.readyState === "open") {
       this.channel.send(JSON.stringify(event));
     }
   }
 
-  private handleRealtimeEvent(data: unknown): void {
+  private sendGoogleLive(event: unknown): void {
+    if (this.googleWs?.readyState === WebSocket.OPEN) {
+      this.googleWs.send(JSON.stringify(event));
+    }
+  }
+
+  private handleOpenAIRealtimeEvent(data: unknown): void {
     let event: RealtimeServerEvent;
     try {
       event = JSON.parse(String(data)) as RealtimeServerEvent;
@@ -209,7 +317,7 @@ export class RealtimeTalkSession {
         this.bufferToolDelta(event);
         return;
       case "response.function_call_arguments.done":
-        void this.handleToolCall(event);
+        void this.handleOpenAIToolCall(event);
         return;
       default:
         return;
@@ -230,21 +338,27 @@ export class RealtimeTalkSession {
     });
   }
 
-  private async handleToolCall(event: RealtimeServerEvent): Promise<void> {
+  private async handleOpenAIToolCall(event: RealtimeServerEvent): Promise<void> {
     const key = event.item_id ?? "unknown";
     const buffered = this.toolBuffers.get(key);
     this.toolBuffers.delete(key);
     const name = buffered?.name || event.name || "";
     const callId = buffered?.callId || event.call_id || "";
+    let args: unknown = {};
+    try {
+      args = JSON.parse(buffered?.args || event.arguments || "{}");
+    } catch {}
+    await this.handleToolCall(name, callId, args);
+  }
+
+  private async handleToolCall(name: string, callId: string, args: unknown): Promise<void> {
     if (name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME || !callId) {
       return;
     }
     this.callbacks.onStatus?.("thinking");
     let question = "";
     try {
-      question = buildRealtimeVoiceAgentConsultChatMessage(
-        JSON.parse(buffered?.args || event.arguments || "{}"),
-      );
+      question = buildRealtimeVoiceAgentConsultChatMessage(args);
     } catch {}
     if (!question) {
       this.submitToolResult(callId, {
@@ -276,7 +390,23 @@ export class RealtimeTalkSession {
   }
 
   private submitToolResult(callId: string, result: unknown): void {
-    this.send({
+    if (this.googleWs) {
+      this.sendGoogleLive({
+        toolResponse: {
+          functionResponses: [
+            {
+              id: callId,
+              name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+              response: toFunctionResponseObject(result),
+              scheduling: "WHEN_IDLE",
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    this.sendOpenAI({
       type: "conversation.item.create",
       item: {
         type: "function_call_output",
@@ -284,6 +414,134 @@ export class RealtimeTalkSession {
         output: JSON.stringify(result),
       },
     });
-    this.send({ type: "response.create" });
+    this.sendOpenAI({ type: "response.create" });
   }
+
+  private handleGoogleLiveEvent(data: unknown): void {
+    let event: GoogleLiveServerMessage;
+    try {
+      event = JSON.parse(String(data)) as GoogleLiveServerMessage;
+    } catch {
+      return;
+    }
+    if (event.setupComplete) {
+      this.callbacks.onStatus?.("listening");
+    }
+    if (event.serverContent) {
+      this.handleGoogleServerContent(event.serverContent);
+    }
+    for (const call of event.toolCall?.functionCalls ?? []) {
+      const name = call.name?.trim() ?? "";
+      const callId = call.id?.trim() ?? "";
+      void this.handleToolCall(name, callId, call.args ?? {});
+    }
+  }
+
+  private handleGoogleServerContent(
+    content: NonNullable<GoogleLiveServerMessage["serverContent"]>,
+  ): void {
+    if (content.interrupted) {
+      this.stopGooglePlayback();
+    }
+    if (content.inputTranscription?.text) {
+      this.callbacks.onTranscript?.({
+        role: "user",
+        text: content.inputTranscription.text,
+        final: content.inputTranscription.finished ?? false,
+      });
+    }
+    if (content.outputTranscription?.text) {
+      this.callbacks.onTranscript?.({
+        role: "assistant",
+        text: content.outputTranscription.text,
+        final: content.outputTranscription.finished ?? false,
+      });
+    }
+    for (const part of content.modelTurn?.parts ?? []) {
+      if (part.inlineData?.data) {
+        this.playGooglePcmAudio(part.inlineData.data, parsePcmSampleRate(part.inlineData.mimeType));
+      } else if (!part.thought && part.text?.trim() && !content.outputTranscription?.text) {
+        this.callbacks.onTranscript?.({
+          role: "assistant",
+          text: part.text,
+          final: content.turnComplete ?? false,
+        });
+      }
+    }
+  }
+
+  private playGooglePcmAudio(base64: string, sampleRate: number): void {
+    const context = this.googleAudioContext;
+    if (!context) {
+      return;
+    }
+    const pcm = base64ToInt16Array(base64);
+    if (pcm.length === 0) {
+      return;
+    }
+    const buffer = context.createBuffer(1, pcm.length, sampleRate);
+    const channel = buffer.getChannelData(0);
+    for (let index = 0; index < pcm.length; index += 1) {
+      channel[index] = Math.max(-1, Math.min(1, (pcm[index] ?? 0) / 32768));
+    }
+    const source = context.createBufferSource();
+    source.buffer = buffer;
+    source.connect(context.destination);
+    source.addEventListener("ended", () => {
+      this.googlePlaybackSources.delete(source);
+    });
+    const startAt = Math.max(context.currentTime, this.googlePlaybackTime);
+    this.googlePlaybackTime = startAt + buffer.duration;
+    this.googlePlaybackSources.add(source);
+    source.start(startAt);
+  }
+
+  private stopGooglePlayback(): void {
+    for (const source of this.googlePlaybackSources) {
+      try {
+        source.stop();
+      } catch {}
+    }
+    this.googlePlaybackSources.clear();
+    this.googlePlaybackTime = this.googleAudioContext?.currentTime ?? 0;
+  }
+}
+
+function toFunctionResponseObject(result: unknown): Record<string, unknown> {
+  return result && typeof result === "object" && !Array.isArray(result)
+    ? (result as Record<string, unknown>)
+    : { output: result };
+}
+
+function pcmFloat32ToBase64(samples: Float32Array): string {
+  const bytes = new Uint8Array(samples.length * 2);
+  const view = new DataView(bytes.buffer);
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[index] ?? 0));
+    view.setInt16(index * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+  }
+  return bytesToBase64(bytes);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index] ?? 0);
+  }
+  return btoa(binary);
+}
+
+function base64ToInt16Array(base64: string): Int16Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Int16Array(bytes.buffer, bytes.byteOffset, Math.floor(bytes.byteLength / 2));
+}
+
+function parsePcmSampleRate(mimeType: string | undefined): number {
+  const match = mimeType?.match(/(?:^|[;,\s])rate=(\d+)/i);
+  const parsed = match ? Number.parseInt(match[1] ?? "", 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 24_000;
 }


### PR DESCRIPTION
## Summary

- Adds a Google Live browser realtime transport for Control UI Talk using Gateway-minted constrained Live API auth tokens.
- Extends the realtime browser session contract with an optional transport discriminator, Google WebSocket URL, and Google setup payload while preserving the existing OpenAI WebRTC default.
- Routes Google Live `openclaw_agent_consult` tool calls through the existing `chat.send` consult path and sends Google function responses with id/name preservation.
- Updates Google/Control UI docs and adds focused provider/UI tests.

## Validation

- `pnpm test extensions/google/realtime-voice-provider.test.ts`
- `pnpm test ui/src/ui/chat/realtime-talk.test.ts`
- `pnpm format:check CHANGELOG.md docs/providers/google.md docs/web/control-ui.md extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts src/gateway/protocol/schema/channels.ts src/gateway/server-methods/talk.ts src/realtime-voice/provider-types.ts ui/src/ui/chat/realtime-talk.ts ui/src/ui/chat/realtime-talk.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed` reached green typecheck, lint, import-cycle, and guard lanes; the broad changed test lane hit Vitest worker heap OOM twice in the Gateway shard after thousands of tests passed, with no assertion failure.
