### PR TITLE
feat(creel-context): bundled plugin for sender classification + envelope

### DIFF
--- a/extensions/creel-context/index.ts
+++ b/extensions/creel-context/index.ts
@@ -1,0 +1,10 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerCreelContextPlugin } from "./src/plugin.js";
+
+export default definePluginEntry({
+  id: "creel-context",
+  name: "Creel Context",
+  description:
+    "Classifies inbound senders against the Creel control plane and threads the resulting envelope through the prompt and chat-history scope filter.",
+  register: registerCreelContextPlugin,
+});

--- a/extensions/creel-context/openclaw.plugin.json
+++ b/extensions/creel-context/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "creel-context",
+  "name": "Creel Context",
+  "description": "Classifies inbound senders against the Creel control plane (owner / contact / stranger / public visitor) and threads the resulting envelope through the prompt and chat-history scope filter so a single agent feels coherent across messaging channels.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "daemonBaseUrl": {
+        "type": "string",
+        "description": "Override the auto-detected http://127.0.0.1:DAEMON_PORT base URL the plugin uses to call the local daemon."
+      },
+      "envelopeSummaryPath": {
+        "type": "string",
+        "description": "Override the workspace-relative envelope summary JSON path. Defaults to <workspace>/state/envelope-summary.json so the chat-history scope filter can read it."
+      },
+      "requestTimeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 30000,
+        "description": "Per-request timeout in ms when calling the daemon's /sender/whoami and /verify-channel-token endpoints."
+      },
+      "logging": {
+        "type": "boolean",
+        "description": "Emit per-turn classification timing + outcome logs."
+      }
+    }
+  },
+  "uiHints": {
+    "enabled": {
+      "label": "Creel Context Classifier",
+      "help": "Globally enable or pause Creel sender classification + envelope injection."
+    },
+    "daemonBaseUrl": {
+      "label": "Daemon Base URL",
+      "help": "Advanced: override the local daemon URL the plugin calls. Defaults to http://127.0.0.1:${DAEMON_PORT} from the daemon-injected env var."
+    },
+    "envelopeSummaryPath": {
+      "label": "Envelope Summary Path",
+      "help": "Advanced: override where the per-turn envelope summary is written. Must match what chat-history's search_context.py reads."
+    },
+    "requestTimeoutMs": {
+      "label": "Request Timeout (ms)",
+      "help": "How long the plugin waits for the local daemon before falling back to a stranger classification."
+    },
+    "logging": {
+      "label": "Enable Logging",
+      "help": "Log per-turn classification decisions for debugging."
+    }
+  }
+}

--- a/extensions/creel-context/src/daemon-client.test.ts
+++ b/extensions/creel-context/src/daemon-client.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import { DaemonClient, resolveDaemonBaseUrl } from "./daemon-client.js";
+
+const mkResp = (init: { ok: boolean; status: number; body?: string }): Response =>
+  ({
+    ok: init.ok,
+    status: init.status,
+    text: () => Promise.resolve(init.body ?? ""),
+  }) as unknown as Response;
+
+describe("DaemonClient.whoami", () => {
+  it("calls GET /sender/whoami with channel + handle + optional session/group keys", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        mkResp({ ok: true, status: 200, body: JSON.stringify({ role: "owner", is_owner: true }) }),
+      ),
+    );
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090", fetchImpl });
+    const resp = await client.whoami({
+      channel: "whatsapp",
+      handle: "+15551234",
+      sessionKey: "agent:main:main",
+      groupKey: "g-1",
+    });
+    expect(resp.is_owner).toBe(true);
+    const url = String(fetchImpl.mock.calls[0]?.[0]);
+    expect(url.startsWith("http://127.0.0.1:8090/sender/whoami?")).toBe(true);
+    expect(url).toContain("channel=whatsapp");
+    expect(url).toContain("handle=%2B15551234"); // URL-encoded "+"
+    expect(url).toContain("session_key=agent%3Amain%3Amain");
+    expect(url).toContain("group_key=g-1");
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("GET");
+  });
+
+  it("returns degraded stranger envelope when the daemon errors", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(mkResp({ ok: false, status: 502 })));
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090", fetchImpl });
+    const resp = await client.whoami({ channel: "whatsapp", handle: "+1" });
+    expect(resp).toEqual({ role: "stranger", is_owner: false });
+  });
+
+  it("returns degraded stranger envelope when fetch itself throws", async () => {
+    const fetchImpl = vi.fn(() => Promise.reject(new Error("ECONNREFUSED")));
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090", fetchImpl });
+    const resp = await client.whoami({ channel: "whatsapp", handle: "+1" });
+    expect(resp.role).toBe("stranger");
+    expect(resp.is_owner).toBe(false);
+  });
+
+  it("strips trailing slashes in baseUrl so URL doesn't get double-//", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(mkResp({ ok: true, status: 200, body: "{}" })));
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090////", fetchImpl });
+    await client.whoami({ channel: "x", handle: "y" });
+    const url = String(fetchImpl.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:8090\/sender\/whoami\?/u);
+  });
+});
+
+describe("DaemonClient.verifyChannelToken", () => {
+  it("posts JSON body and returns parsed result", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        mkResp({
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            handle_id: "h-1",
+            user_id: "u-1",
+            channel: "telegram",
+            handle_normalized: "12345",
+            handle_display: "Alice",
+            status: "verified",
+          }),
+        }),
+      ),
+    );
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090", fetchImpl });
+    const resp = await client.verifyChannelToken({
+      channel: "telegram",
+      handle: "12345",
+      handleDisplay: "Alice",
+      token: "abcdefghijklmnop",
+    });
+    expect(resp.handle_id).toBe("h-1");
+    expect(resp.status).toBe("verified");
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      channel: "telegram",
+      handle: "12345",
+      handle_display: "Alice",
+      token: "abcdefghijklmnop",
+    });
+  });
+
+  it("throws on non-2xx so the caller can distinguish failure modes", async () => {
+    const fetchImpl = vi.fn(() => Promise.resolve(mkResp({ ok: false, status: 401 })));
+    const client = new DaemonClient({ baseUrl: "http://127.0.0.1:8090", fetchImpl });
+    await expect(
+      client.verifyChannelToken({
+        channel: "telegram",
+        handle: "12345",
+        token: "abcdefghijklmnop",
+      }),
+    ).rejects.toThrow(/401/u);
+  });
+});
+
+describe("resolveDaemonBaseUrl", () => {
+  it("prefers an explicit override", () => {
+    const orig = process.env.DAEMON_PORT;
+    process.env.DAEMON_PORT = "9999";
+    try {
+      expect(resolveDaemonBaseUrl("http://override:1")).toBe("http://override:1");
+    } finally {
+      if (orig === undefined) {
+        delete process.env.DAEMON_PORT;
+      } else {
+        process.env.DAEMON_PORT = orig;
+      }
+    }
+  });
+
+  it("falls back to DAEMON_PORT env when no override", () => {
+    const orig = process.env.DAEMON_PORT;
+    process.env.DAEMON_PORT = "8090";
+    try {
+      expect(resolveDaemonBaseUrl(undefined)).toBe("http://127.0.0.1:8090");
+    } finally {
+      if (orig === undefined) {
+        delete process.env.DAEMON_PORT;
+      } else {
+        process.env.DAEMON_PORT = orig;
+      }
+    }
+  });
+
+  it("returns null when neither override nor env is set", () => {
+    const orig = process.env.DAEMON_PORT;
+    delete process.env.DAEMON_PORT;
+    try {
+      expect(resolveDaemonBaseUrl(undefined)).toBeNull();
+      expect(resolveDaemonBaseUrl("   ")).toBeNull();
+    } finally {
+      if (orig !== undefined) {
+        process.env.DAEMON_PORT = orig;
+      }
+    }
+  });
+});

--- a/extensions/creel-context/src/daemon-client.ts
+++ b/extensions/creel-context/src/daemon-client.ts
@@ -1,0 +1,136 @@
+// HTTP client for the creel daemon's local sender-classifier endpoints.
+// The daemon binds 127.0.0.1:${DAEMON_PORT} so this client never reaches
+// outside the agent pod. The daemon itself authenticates with the control
+// plane on our behalf using its per-claw bearer token.
+
+export type SenderResolution = {
+  role: string;
+  is_owner: boolean;
+  user_id?: string;
+  handle_display?: string;
+  handle_status?: string;
+  conversation_id?: string;
+};
+
+export type WhoamiQuery = {
+  channel: string;
+  handle: string;
+  sessionKey?: string;
+  groupKey?: string;
+};
+
+export type VerifyChannelTokenInput = {
+  channel: string;
+  handle: string;
+  handleDisplay?: string;
+  token: string;
+};
+
+export type VerifyChannelTokenResult = {
+  handle_id: string;
+  user_id: string;
+  channel: string;
+  handle_normalized: string;
+  handle_display: string;
+  status: string;
+};
+
+export type DaemonClientOptions = {
+  baseUrl: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+};
+
+const DEFAULT_TIMEOUT_MS = 1500;
+
+export class DaemonClient {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: DaemonClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/u, "");
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  // Resolves a (channel, handle) to its envelope. On any failure (timeout,
+  // network, daemon down, control-plane down) we return the conservative
+  // fail-closed answer (role=stranger) rather than throwing — the calling
+  // hook must NEVER block the agent reply, so degraded mode beats hard fail.
+  async whoami(query: WhoamiQuery): Promise<SenderResolution> {
+    const url = new URL(`${this.baseUrl}/sender/whoami`);
+    url.searchParams.set("channel", query.channel);
+    url.searchParams.set("handle", query.handle);
+    if (query.sessionKey) {
+      url.searchParams.set("session_key", query.sessionKey);
+    }
+    if (query.groupKey) {
+      url.searchParams.set("group_key", query.groupKey);
+    }
+    return this.requestJSON<SenderResolution>("GET", url.toString()).catch(() => ({
+      role: "stranger",
+      is_owner: false,
+    }));
+  }
+
+  // Telegram /start <token> verification proxy. Returns the freshly created
+  // OwnerChannelHandle on success; throws on failure so the caller can
+  // distinguish "verification failed" from "control plane unreachable" and
+  // surface the right operator-facing message.
+  async verifyChannelToken(input: VerifyChannelTokenInput): Promise<VerifyChannelTokenResult> {
+    return this.requestJSON<VerifyChannelTokenResult>(
+      "POST",
+      `${this.baseUrl}/verify-channel-token`,
+      {
+        channel: input.channel,
+        handle: input.handle,
+        handle_display: input.handleDisplay ?? "",
+        token: input.token,
+      },
+    );
+  }
+
+  private async requestJSON<T>(
+    method: "GET" | "POST",
+    url: string,
+    body?: Record<string, unknown>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const init: RequestInit = {
+        method,
+        signal: controller.signal,
+        headers: body ? { "content-type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      };
+      const resp = await this.fetchImpl(url, init);
+      if (!resp.ok) {
+        throw new Error(`daemon ${method} ${url} returned ${resp.status}`);
+      }
+      const text = await resp.text();
+      if (!text) {
+        return {} as T;
+      }
+      return JSON.parse(text) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// Resolves the daemon base URL from the runtime env. Returns null when
+// neither override nor the env var is set so the plugin can degrade
+// gracefully rather than fire requests at a nonsense URL.
+export function resolveDaemonBaseUrl(override?: string): string | null {
+  const trimmedOverride = override?.trim();
+  if (trimmedOverride) {
+    return trimmedOverride;
+  }
+  const port = process.env.DAEMON_PORT?.trim();
+  if (!port) {
+    return null;
+  }
+  return `http://127.0.0.1:${port}`;
+}

--- a/extensions/creel-context/src/envelope-writer.test.ts
+++ b/extensions/creel-context/src/envelope-writer.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeEnvelopeSummary } from "./envelope-writer.js";
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "creel-context-test-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("writeEnvelopeSummary", () => {
+  it("writes the consumer-facing fields the Python scope filter reads", async () => {
+    const path = join(workDir, "state", "envelope-summary.json");
+    await writeEnvelopeSummary({
+      path,
+      envelope: {
+        sender_role: "owner",
+        is_owner: true,
+        context_type: "dm",
+        channel: "whatsapp",
+        handle: "+15551234",
+        session_key: "agent:main:main",
+        user_id: "u-1",
+        handle_display: "+15551234",
+        resolved_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    // Required surface for search_context.py:allowed_scopes:
+    expect(parsed.sender_role).toBe("owner");
+    expect(parsed.is_owner).toBe(true);
+    expect(parsed.context_type).toBe("dm");
+    expect(parsed.owner_dm_unlock_for_turn).toBe(false);
+    // Diagnostic _meta block — useful on-call but ignored by the consumer.
+    expect(parsed._meta.channel).toBe("whatsapp");
+    expect(parsed._meta.handle).toBe("+15551234");
+    expect(parsed._meta.session_key).toBe("agent:main:main");
+    expect(parsed._meta.user_id).toBe("u-1");
+    expect(parsed._meta.resolved_at).toBe("2026-04-26T00:00:00.000Z");
+  });
+
+  it("creates the parent directory if it does not exist", async () => {
+    const path = join(workDir, "deeply", "nested", "envelope-summary.json");
+    await writeEnvelopeSummary({
+      path,
+      envelope: {
+        sender_role: "stranger",
+        is_owner: false,
+        context_type: "dm",
+        resolved_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    expect(parsed.sender_role).toBe("stranger");
+  });
+
+  it("propagates owner_dm_unlock_for_turn=true when set", async () => {
+    const path = join(workDir, "envelope-summary.json");
+    await writeEnvelopeSummary({
+      path,
+      envelope: {
+        sender_role: "owner",
+        is_owner: true,
+        context_type: "group",
+        owner_dm_unlock_for_turn: true,
+        resolved_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    expect(parsed.owner_dm_unlock_for_turn).toBe(true);
+  });
+});

--- a/extensions/creel-context/src/envelope-writer.ts
+++ b/extensions/creel-context/src/envelope-writer.ts
@@ -1,0 +1,36 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { Envelope } from "./envelope.js";
+
+// Writes the per-turn envelope summary to disk in the location
+// bisque/skills/chat-history/scripts/search_context.py reads
+// (`<workspaceDir>/state/envelope-summary.json` by default — overridable
+// via the plugin config so operators can re-target during local debugging).
+//
+// File contents intentionally include only the fields the Python
+// consumer touches, NOT the full envelope. Any extra debug fields we
+// want to inspect should land in a sibling file (envelope-debug.json),
+// not pollute the contract surface that the scope filter trusts.
+export async function writeEnvelopeSummary(args: {
+  path: string;
+  envelope: Envelope;
+}): Promise<void> {
+  const summary = {
+    sender_role: args.envelope.sender_role,
+    is_owner: args.envelope.is_owner,
+    context_type: args.envelope.context_type,
+    owner_dm_unlock_for_turn: args.envelope.owner_dm_unlock_for_turn ?? false,
+    // Optional metadata block the consumer ignores but that helps on-call
+    // diagnose stale envelopes via `cat envelope-summary.json`.
+    _meta: {
+      channel: args.envelope.channel,
+      handle: args.envelope.handle,
+      session_key: args.envelope.session_key,
+      user_id: args.envelope.user_id,
+      handle_display: args.envelope.handle_display,
+      resolved_at: args.envelope.resolved_at,
+    },
+  };
+  await mkdir(dirname(args.path), { recursive: true });
+  await writeFile(args.path, JSON.stringify(summary, null, 2), "utf8");
+}

--- a/extensions/creel-context/src/envelope.test.ts
+++ b/extensions/creel-context/src/envelope.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { buildEnvelope, EnvelopeCache, type Envelope } from "./envelope.js";
+
+describe("buildEnvelope", () => {
+  it("propagates resolution fields and derives context_type from sessionKey", () => {
+    const env = buildEnvelope({
+      resolution: {
+        role: "owner",
+        is_owner: true,
+        user_id: "u-1",
+        handle_display: "+15551234",
+        conversation_id: "conv-1",
+      },
+      channel: "whatsapp",
+      handle: "+15551234",
+      sessionKey: "agent:main:main",
+    });
+    expect(env.sender_role).toBe("owner");
+    expect(env.is_owner).toBe(true);
+    expect(env.user_id).toBe("u-1");
+    expect(env.handle_display).toBe("+15551234");
+    expect(env.conversation_id).toBe("conv-1");
+    expect(env.context_type).toBe("dm");
+    expect(env.channel).toBe("whatsapp");
+    expect(env.handle).toBe("+15551234");
+    expect(env.session_key).toBe("agent:main:main");
+    // resolved_at is ISO-8601 + parseable.
+    expect(() => new Date(env.resolved_at).toISOString()).not.toThrow();
+  });
+
+  it("flips context_type to group for group session keys", () => {
+    const env = buildEnvelope({
+      resolution: { role: "group_member", is_owner: false },
+      channel: "discord",
+      handle: "user-7",
+      sessionKey: "agent:main:discord:group:server-9",
+    });
+    expect(env.context_type).toBe("group");
+  });
+
+  it("falls back to stranger when role is empty (defense-in-depth)", () => {
+    const env = buildEnvelope({
+      resolution: { role: "", is_owner: false },
+      channel: "x",
+      handle: "y",
+    });
+    expect(env.sender_role).toBe("stranger");
+  });
+});
+
+describe("EnvelopeCache", () => {
+  const sample = (sessionKey: string): Envelope => ({
+    sender_role: "owner",
+    is_owner: true,
+    context_type: "dm",
+    channel: "whatsapp",
+    handle: `+1${sessionKey.slice(0, 4)}`,
+    session_key: sessionKey,
+    resolved_at: new Date().toISOString(),
+  });
+
+  it("returns undefined for missing keys", () => {
+    expect(new EnvelopeCache().get("none")).toBeUndefined();
+  });
+
+  it("round-trips a stored envelope", () => {
+    const c = new EnvelopeCache();
+    c.set("k1", sample("k1"));
+    expect(c.get("k1")?.session_key).toBe("k1");
+  });
+
+  it("expires entries past the TTL", async () => {
+    const c = new EnvelopeCache({ ttlMs: 5 });
+    c.set("k1", sample("k1"));
+    await new Promise((r) => setTimeout(r, 15));
+    expect(c.get("k1")).toBeUndefined();
+  });
+
+  it("evicts oldest entry when over the size cap (LRU)", () => {
+    const c = new EnvelopeCache({ maxEntries: 2 });
+    c.set("a", sample("a"));
+    c.set("b", sample("b"));
+    c.set("c", sample("c")); // should evict "a"
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBeDefined();
+    expect(c.get("c")).toBeDefined();
+    expect(c.size()).toBe(2);
+  });
+
+  it("a get() promotes the entry so it survives the next eviction", () => {
+    const c = new EnvelopeCache({ maxEntries: 2 });
+    c.set("a", sample("a"));
+    c.set("b", sample("b"));
+    c.get("a"); // promote a → b is now LRU
+    c.set("c", sample("c")); // should evict "b" (the new LRU)
+    expect(c.get("b")).toBeUndefined();
+    expect(c.get("a")).toBeDefined();
+    expect(c.get("c")).toBeDefined();
+  });
+
+  it("delete and clear behave as expected", () => {
+    const c = new EnvelopeCache();
+    c.set("a", sample("a"));
+    c.delete("a");
+    expect(c.get("a")).toBeUndefined();
+    c.set("a", sample("a"));
+    c.set("b", sample("b"));
+    c.clear();
+    expect(c.size()).toBe(0);
+  });
+});

--- a/extensions/creel-context/src/envelope.ts
+++ b/extensions/creel-context/src/envelope.ts
@@ -1,0 +1,106 @@
+import type { SenderResolution } from "./daemon-client.js";
+import { contextTypeFromSessionKey } from "./scope.js";
+
+// Envelope shape — MUST match what bisque/skills/chat-history/scripts/
+// search_context.py:allowed_scopes consumes. Drift here silently breaks
+// recall scoping.
+export type Envelope = {
+  sender_role: string;
+  is_owner: boolean;
+  context_type: "dm" | "group";
+  channel?: string;
+  handle?: string;
+  session_key?: string;
+  user_id?: string;
+  handle_display?: string;
+  conversation_id?: string;
+  resolved_at: string; // ISO-8601 — for debugging stale envelopes
+  // Reserved for v7 §Pillar 1 owner-DM-unlock-in-group flow — surfaces
+  // owner_dm rows in a group session when the owner explicitly asks.
+  // Slice B leaves it unset; Phase 2 wires it up via a keyword trigger.
+  owner_dm_unlock_for_turn?: boolean;
+};
+
+export function buildEnvelope(args: {
+  resolution: SenderResolution;
+  channel: string;
+  handle: string;
+  sessionKey?: string;
+}): Envelope {
+  return {
+    sender_role: args.resolution.role || "stranger",
+    is_owner: args.resolution.is_owner,
+    context_type: contextTypeFromSessionKey(args.sessionKey),
+    channel: args.channel,
+    handle: args.handle,
+    session_key: args.sessionKey,
+    user_id: args.resolution.user_id || undefined,
+    handle_display: args.resolution.handle_display || undefined,
+    conversation_id: args.resolution.conversation_id || undefined,
+    resolved_at: new Date().toISOString(),
+  };
+}
+
+// Bounded LRU keyed by sessionKey. Per-session is the right grain —
+// before_prompt_build fires per agent run within a session, and the
+// session_key is the same across turns of one logical conversation.
+// We keep the cap small because each agent pod typically handles a
+// handful of concurrent sessions; the cap is defensive against leaks
+// from sessions that never receive an explicit session_end.
+const DEFAULT_MAX_ENTRIES = 128;
+const DEFAULT_TTL_MS = 60_000;
+
+type CacheEntry = {
+  envelope: Envelope;
+  deadline: number;
+};
+
+export class EnvelopeCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly max: number;
+  private readonly ttlMs: number;
+
+  constructor(opts?: { maxEntries?: number; ttlMs?: number }) {
+    this.max = opts?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  get(sessionKey: string): Envelope | undefined {
+    const entry = this.entries.get(sessionKey);
+    if (!entry) {
+      return undefined;
+    }
+    if (Date.now() > entry.deadline) {
+      this.entries.delete(sessionKey);
+      return undefined;
+    }
+    // Promote to MRU position by re-insertion.
+    this.entries.delete(sessionKey);
+    this.entries.set(sessionKey, entry);
+    return entry.envelope;
+  }
+
+  set(sessionKey: string, envelope: Envelope): void {
+    this.entries.delete(sessionKey);
+    this.entries.set(sessionKey, { envelope, deadline: Date.now() + this.ttlMs });
+    while (this.entries.size > this.max) {
+      const oldest = this.entries.keys().next().value;
+      if (!oldest) {
+        break;
+      }
+      this.entries.delete(oldest);
+    }
+  }
+
+  delete(sessionKey: string): void {
+    this.entries.delete(sessionKey);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/extensions/creel-context/src/plugin.ts
+++ b/extensions/creel-context/src/plugin.ts
@@ -1,0 +1,247 @@
+import { join } from "node:path";
+import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { DaemonClient, resolveDaemonBaseUrl, type SenderResolution } from "./daemon-client.js";
+import { writeEnvelopeSummary } from "./envelope-writer.js";
+import { buildEnvelope, EnvelopeCache, type Envelope } from "./envelope.js";
+import { deriveSessionKeyForInbound } from "./session-key.js";
+import { detectStartToken } from "./start-token.js";
+
+// Plugin config shape — mirrors openclaw.plugin.json:configSchema. Kept
+// internal because the only consumer is this file.
+type CreelContextConfig = {
+  enabled?: boolean;
+  daemonBaseUrl?: string;
+  envelopeSummaryPath?: string;
+  requestTimeoutMs?: number;
+  logging?: boolean;
+};
+
+const DEFAULT_AGENT_ID = "main";
+
+export function registerCreelContextPlugin(api: OpenClawPluginApi): void {
+  const cfg = normalizeConfig(api.pluginConfig);
+
+  if (cfg.enabled === false) {
+    api.logger.info?.("creel-context: disabled via plugin config");
+    return;
+  }
+
+  const baseUrl = resolveDaemonBaseUrl(cfg.daemonBaseUrl);
+  if (!baseUrl) {
+    api.logger.warn?.(
+      "creel-context: no daemon base URL — DAEMON_PORT env not set and no override; plugin will no-op until configured",
+    );
+    return;
+  }
+
+  const client = new DaemonClient({
+    baseUrl,
+    timeoutMs: cfg.requestTimeoutMs,
+  });
+
+  // EnvelopeCache keyed by sessionKey — message_received computes it via
+  // deriveSessionKeyForInbound, before_prompt_build reads it directly from
+  // ctx.sessionKey. Both produce identical keys (canonical openclaw shape:
+  // "agent:main:main" for DMs, "agent:main:<channel>:group:<convId>" for
+  // groups), so the bridge between the two hooks is the session-key
+  // contract — not a fragile (channel, conversationId) tuple.
+  //
+  // Multi-conversation collisions on agent:main:main are intentional:
+  // openclaw collapses all DM channels into one bucket and the chat-history
+  // scope filter expects exactly that. Groups stay isolated per
+  // (channel, convId).
+  const cache = new EnvelopeCache();
+
+  api.on("message_received", async (event, ctx) => {
+    const channel = ctx.channelId?.trim();
+    if (!channel) {
+      return;
+    }
+
+    // Prefer E.164 when the channel adapter has it (WhatsApp, iMessage,
+    // BlueBubbles, etc. populate metadata.senderE164). Fall back to
+    // event.from for non-phone channels (Telegram numeric ID, Discord
+    // snowflake, Slack U-id). The control plane normalizes again before
+    // lookup, so either form survives — but senderE164 is friendlier to
+    // log and matches what most insert paths persist.
+    const senderE164 = readMetaString(event.metadata, "senderE164");
+    const handle = (senderE164 || event.from || "").trim();
+    if (!handle) {
+      return;
+    }
+
+    const { sessionKey, groupKey } = deriveSessionKeyForInbound(channel, ctx.conversationId);
+
+    // Telegram /start <token> magic-link verification. Fire before
+    // classification because /start typically arrives before the user's
+    // handle is known to the control plane.
+    const tokenMatch = detectStartToken(event.content);
+    if (tokenMatch) {
+      try {
+        await client.verifyChannelToken({
+          channel,
+          handle,
+          handleDisplay:
+            readMetaString(event.metadata, "senderUsername") ||
+            readMetaString(event.metadata, "senderName") ||
+            handle,
+          token: tokenMatch.token,
+        });
+        if (cfg.logging) {
+          api.logger.info?.(
+            `creel-context: verified channel token channel=${channel} handle=${handle}`,
+          );
+        }
+      } catch (err) {
+        api.logger.warn?.(
+          `creel-context: verify channel token failed channel=${channel} handle=${handle} error=${stringifyErr(err)}`,
+        );
+      }
+    }
+
+    let resolution: SenderResolution;
+    try {
+      resolution = await client.whoami({ channel, handle, sessionKey, groupKey });
+    } catch (err) {
+      // whoami() already returns degraded-mode on failure, so an actual
+      // throw here is unexpected. Fail closed.
+      api.logger.warn?.(`creel-context: whoami threw error=${stringifyErr(err)}`);
+      resolution = { role: "stranger", is_owner: false };
+    }
+
+    const envelope = buildEnvelope({
+      resolution,
+      channel,
+      handle,
+      sessionKey,
+    });
+    cache.set(sessionKey, envelope);
+
+    const path = resolveEnvelopePath(api, cfg);
+    try {
+      await writeEnvelopeSummary({ path, envelope });
+    } catch (err) {
+      api.logger.warn?.(
+        `creel-context: write envelope summary failed path=${path} error=${stringifyErr(err)}`,
+      );
+    }
+
+    if (cfg.logging) {
+      api.logger.info?.(
+        `creel-context: classified channel=${channel} handle=${handle} role=${envelope.sender_role} is_owner=${envelope.is_owner} session_key=${sessionKey}`,
+      );
+    }
+  });
+
+  api.on("before_prompt_build", (_event, ctx) => {
+    const sessionKey = ctx.sessionKey?.trim();
+    const envelope = sessionKey ? cache.get(sessionKey) : undefined;
+    if (!envelope) {
+      return undefined;
+    }
+
+    const note = renderPromptNote(envelope);
+    if (!note) {
+      return undefined;
+    }
+
+    // prependSystemContext (not prependContext) so prompt caching stays
+    // intact across turns of the same conversation. The note text is
+    // deterministic for a given (role, channel).
+    return { prependSystemContext: note };
+  });
+
+  api.on("session_end", (_event, ctx) => {
+    if (ctx.sessionKey) {
+      cache.delete(ctx.sessionKey);
+    }
+  });
+}
+
+function normalizeConfig(raw: Record<string, unknown> | undefined): CreelContextConfig {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+  const out: CreelContextConfig = {};
+  if (typeof raw.enabled === "boolean") {
+    out.enabled = raw.enabled;
+  }
+  if (typeof raw.daemonBaseUrl === "string") {
+    out.daemonBaseUrl = raw.daemonBaseUrl;
+  }
+  if (typeof raw.envelopeSummaryPath === "string") {
+    out.envelopeSummaryPath = raw.envelopeSummaryPath;
+  }
+  if (typeof raw.requestTimeoutMs === "number") {
+    out.requestTimeoutMs = raw.requestTimeoutMs;
+  }
+  if (typeof raw.logging === "boolean") {
+    out.logging = raw.logging;
+  }
+  return out;
+}
+
+function resolveEnvelopePath(api: OpenClawPluginApi, cfg: CreelContextConfig): string {
+  const override = cfg.envelopeSummaryPath?.trim();
+  if (override) {
+    return override;
+  }
+  const workspaceDir = resolveAgentWorkspaceDir(api.config, DEFAULT_AGENT_ID);
+  return join(workspaceDir, "state", "envelope-summary.json");
+}
+
+function readMetaString(meta: Record<string, unknown> | undefined, key: string): string {
+  if (!meta) {
+    return "";
+  }
+  const v = meta[key];
+  return typeof v === "string" ? v : "";
+}
+
+function renderPromptNote(envelope: Envelope): string | null {
+  const role = envelope.sender_role;
+  const channel = envelope.channel || "this channel";
+  switch (role) {
+    case "owner":
+      return [
+        "## Sender envelope",
+        `You are talking to your **owner** (verified on ${channel}). Speak openly and treat their requests as authoritative.`,
+        "",
+      ].join("\n");
+    case "known_contact":
+    case "approved_stranger":
+      return [
+        "## Sender envelope",
+        `You are talking to an approved contact on ${channel}, NOT the owner. Be helpful but do not disclose owner-private memory.`,
+        "",
+      ].join("\n");
+    case "group_member":
+      return [
+        "## Sender envelope",
+        `You are speaking in a group on ${channel}. Treat all participants as non-owner unless stated otherwise.`,
+        "",
+      ].join("\n");
+    case "public_visitor":
+      return [
+        "## Sender envelope",
+        `You are talking to a public visitor on ${channel} (not the owner, not a verified contact). Be polite and information-only; never reveal owner-private memory.`,
+        "",
+      ].join("\n");
+    case "stranger":
+      return [
+        "## Sender envelope",
+        `Sender on ${channel} is unverified. Be helpful but never disclose owner-private memory.`,
+        "",
+      ].join("\n");
+    default:
+      return null;
+  }
+}
+
+function stringifyErr(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/extensions/creel-context/src/scope.test.ts
+++ b/extensions/creel-context/src/scope.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { contextTypeFromSessionKey, scopeFromSessionKey } from "./scope.js";
+
+describe("scopeFromSessionKey", () => {
+  it("classifies the canonical owner-DM key", () => {
+    expect(scopeFromSessionKey("agent:main:main")).toBe("owner_dm");
+  });
+
+  it("classifies public visitor sessions by prefix", () => {
+    expect(scopeFromSessionKey("agent:main:public:visitor-abc")).toBe("public_dm");
+  });
+
+  it("classifies group sessions when key contains :group:", () => {
+    expect(scopeFromSessionKey("agent:main:whatsapp:group:1234@g.us")).toBe("group");
+  });
+
+  it("classifies contact-DM sessions for both :dm: and :direct: markers", () => {
+    expect(scopeFromSessionKey("agent:main:telegram:dm:user-123")).toBe("contact_dm");
+    expect(scopeFromSessionKey("agent:main:slack:direct:user-456")).toBe("contact_dm");
+  });
+
+  it("returns 'unknown' for empty / null input (fail-closed)", () => {
+    expect(scopeFromSessionKey(undefined)).toBe("unknown");
+    expect(scopeFromSessionKey(null)).toBe("unknown");
+    expect(scopeFromSessionKey("")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for keys that don't match any rule", () => {
+    expect(scopeFromSessionKey("foo")).toBe("unknown");
+    expect(scopeFromSessionKey("agent:main:misc:weird")).toBe("unknown");
+  });
+
+  // Group classification must take priority over the generic :dm: marker so a
+  // hypothetical "...:group:dm:..." key doesn't get mis-scoped — guards against
+  // a foot-gun if a channel ever encodes dm-in-group routing.
+  it("prefers group over dm/direct markers when both appear", () => {
+    expect(scopeFromSessionKey("agent:main:foo:group:bar:dm:baz")).toBe("group");
+  });
+});
+
+describe("contextTypeFromSessionKey", () => {
+  it("returns group only for group-scoped session keys", () => {
+    expect(contextTypeFromSessionKey("agent:main:whatsapp:group:1@g")).toBe("group");
+  });
+
+  it("returns dm for owner_dm, contact_dm, public_dm, and unknown", () => {
+    expect(contextTypeFromSessionKey("agent:main:main")).toBe("dm");
+    expect(contextTypeFromSessionKey("agent:main:telegram:dm:u")).toBe("dm");
+    expect(contextTypeFromSessionKey("agent:main:public:v")).toBe("dm");
+    expect(contextTypeFromSessionKey(undefined)).toBe("dm");
+  });
+});

--- a/extensions/creel-context/src/scope.ts
+++ b/extensions/creel-context/src/scope.ts
@@ -1,0 +1,36 @@
+// Mirrors bisque/skills/chat-history/scripts/index_sessions.py:scope_from_session_key.
+// Both files MUST stay in sync — drift would silently break recall scoping.
+//
+// Scope labels:
+//   owner_dm    — agent:main:main (owner converged DM across channels)
+//   contact_dm  — session_key contains :dm: or :direct: (per-handle non-owner DM)
+//   group       — session_key contains :group:
+//   public_dm   — session_key starts with agent:main:public: (Globster discovery visitors)
+//   unknown     — anything else (recall fail-closes for unknown shapes)
+
+export type MemoryScope = "owner_dm" | "contact_dm" | "group" | "public_dm" | "unknown";
+
+export function scopeFromSessionKey(sessionKey: string | undefined | null): MemoryScope {
+  if (!sessionKey) {
+    return "unknown";
+  }
+  if (sessionKey === "agent:main:main") {
+    return "owner_dm";
+  }
+  if (sessionKey.startsWith("agent:main:public:")) {
+    return "public_dm";
+  }
+  if (sessionKey.includes(":group:")) {
+    return "group";
+  }
+  if (sessionKey.includes(":dm:") || sessionKey.includes(":direct:")) {
+    return "contact_dm";
+  }
+  return "unknown";
+}
+
+// Derives a stable context_type for the envelope — consumed by
+// search_context.py:allowed_scopes. group → group, everything else → dm.
+export function contextTypeFromSessionKey(sessionKey: string | undefined | null): "dm" | "group" {
+  return scopeFromSessionKey(sessionKey) === "group" ? "group" : "dm";
+}

--- a/extensions/creel-context/src/session-key.test.ts
+++ b/extensions/creel-context/src/session-key.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveSessionKeyForInbound, isGroupConversationId } from "./session-key.js";
+
+describe("deriveSessionKeyForInbound", () => {
+  it("collapses non-group DMs into the canonical agent:main:main bucket", () => {
+    expect(deriveSessionKeyForInbound("whatsapp", "+15551234@s.whatsapp.net")).toEqual({
+      sessionKey: "agent:main:main",
+    });
+    expect(deriveSessionKeyForInbound("telegram", "12345")).toEqual({
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("returns a group-shaped key + groupKey for group conversations", () => {
+    expect(deriveSessionKeyForInbound("whatsapp", "1234567890-1234567890@g.us")).toEqual({
+      sessionKey: "agent:main:whatsapp:group:1234567890-1234567890@g.us",
+      groupKey: "1234567890-1234567890@g.us",
+    });
+    expect(deriveSessionKeyForInbound("telegram", "-1001234567890")).toEqual({
+      sessionKey: "agent:main:telegram:group:-1001234567890",
+      groupKey: "-1001234567890",
+    });
+  });
+
+  it("falls back to DM bucket when conversationId is missing", () => {
+    expect(deriveSessionKeyForInbound("whatsapp", undefined)).toEqual({
+      sessionKey: "agent:main:main",
+    });
+  });
+});
+
+describe("isGroupConversationId", () => {
+  it("flags WhatsApp groups by @g.us suffix", () => {
+    expect(isGroupConversationId("whatsapp", "12-34@g.us")).toBe(true);
+    expect(isGroupConversationId("whatsapp", "12@s.whatsapp.net")).toBe(false);
+    expect(isGroupConversationId("whatsapp", "12@c.us")).toBe(false);
+  });
+
+  it("flags Telegram groups by leading minus (chat_id<0 convention)", () => {
+    expect(isGroupConversationId("telegram", "-12345")).toBe(true);
+    expect(isGroupConversationId("telegram", "-1001234567890")).toBe(true);
+    expect(isGroupConversationId("telegram", "12345")).toBe(false);
+  });
+
+  it("flags Slack non-DM channels by prefix", () => {
+    expect(isGroupConversationId("slack", "C12345")).toBe(true); // public
+    expect(isGroupConversationId("slack", "G12345")).toBe(true); // legacy private
+    expect(isGroupConversationId("slack", "MPDM-abc")).toBe(true); // multi-party DM
+    expect(isGroupConversationId("slack", "D12345")).toBe(false); // DM
+  });
+
+  it("conservatively treats unknown / signal-poor channels as DM", () => {
+    for (const ch of ["discord", "matrix", "imessage", "icloud", "signal", "webchat", "unknown"]) {
+      expect(isGroupConversationId(ch, "anything")).toBe(false);
+    }
+  });
+
+  it("returns false for missing conversationId regardless of channel", () => {
+    expect(isGroupConversationId("whatsapp", undefined)).toBe(false);
+    expect(isGroupConversationId("telegram", undefined)).toBe(false);
+    expect(isGroupConversationId("slack", undefined)).toBe(false);
+  });
+});

--- a/extensions/creel-context/src/session-key.ts
+++ b/extensions/creel-context/src/session-key.ts
@@ -1,0 +1,74 @@
+// Per-inbound session-key derivation, mirroring openclaw's canonical
+// scheme (src/config/sessions/session-key.ts) so the conversations table
+// the control plane upserts is keyed identically to the agent runtime's
+// own session bucket.
+//
+// Canonical shapes:
+//   agent:main:main                       — owner DM converged across channels
+//   agent:main:<channel>:group:<groupId>  — group / channel
+//
+// Slice B does NOT distinguish owner-DM from contact-DM at the
+// session-key level (matches openclaw — the differentiation lives in
+// the envelope.sender_role written to envelope-summary.json). All
+// non-group direct chats collapse into agent:main:main.
+
+export type DerivedSessionKey = {
+  sessionKey: string;
+  groupKey?: string;
+};
+
+export function deriveSessionKeyForInbound(
+  channel: string,
+  conversationId: string | undefined,
+): DerivedSessionKey {
+  if (isGroupConversationId(channel, conversationId)) {
+    return {
+      sessionKey: `agent:main:${channel}:group:${conversationId}`,
+      groupKey: conversationId,
+    };
+  }
+  // Canonical owner-DM bucket. Non-owner DMs end up here too, but the
+  // envelope's sender_role tells the agent + scope filter who is talking.
+  return { sessionKey: "agent:main:main" };
+}
+
+// Per-channel "is this a group conversation?" heuristic. Channels can
+// disambiguate via different signals — the safe default for unknown
+// shapes is treat-as-DM, since the worst case is a missed group upsert
+// (still gets classification + envelope; just no group row in
+// conversations table). Phase 2 plumbs proper isGroup from
+// inbound_claim's richer event context.
+export function isGroupConversationId(
+  channel: string,
+  conversationId: string | undefined,
+): conversationId is string {
+  if (!conversationId) {
+    return false;
+  }
+  switch (channel) {
+    case "whatsapp":
+      // WhatsApp JIDs: groups end in @g.us, DMs end in @s.whatsapp.net /
+      // @c.us.
+      return conversationId.endsWith("@g.us");
+    case "telegram":
+      // Telegram chat IDs are negative for groups/supergroups, positive
+      // for DMs. Also cover the "-100..." supergroup form.
+      return conversationId.startsWith("-");
+    case "slack":
+      // Slack channel IDs are prefixed: D=DM, G=private group (legacy),
+      // C=public channel, MPDM=multi-party DM.
+      return /^[CG]/u.test(conversationId) || conversationId.startsWith("MPDM");
+    case "discord":
+    case "matrix":
+    case "imessage":
+    case "icloud":
+    case "signal":
+    case "webchat":
+      // We don't get a reliable group/dm signal from message_received
+      // ctx alone for these channels. Be conservative: treat as DM.
+      // Phase 2 will swap this for inbound_claim's isGroup.
+      return false;
+    default:
+      return false;
+  }
+}

--- a/extensions/creel-context/src/start-token.test.ts
+++ b/extensions/creel-context/src/start-token.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { detectStartToken } from "./start-token.js";
+
+describe("detectStartToken", () => {
+  it("extracts the token from a Telegram /start payload", () => {
+    expect(detectStartToken("/start abc123def456ghi789jkl")).toEqual({
+      token: "abc123def456ghi789jkl",
+    });
+  });
+
+  it("strips the @BotName suffix Telegram appends in groups", () => {
+    expect(detectStartToken("/start@MyBot abc123def456ghi789jkl")).toEqual({
+      token: "abc123def456ghi789jkl",
+    });
+  });
+
+  it("ignores trailing arguments — Telegram contract only uses the first", () => {
+    expect(detectStartToken("/start abc123def456ghi789jkl extra noise")).toEqual({
+      token: "abc123def456ghi789jkl",
+    });
+  });
+
+  it("returns null when /start has no payload", () => {
+    expect(detectStartToken("/start")).toBeNull();
+    expect(detectStartToken("/start ")).toBeNull();
+  });
+
+  it("returns null when payload is too short (anti-bruteforce sanity)", () => {
+    expect(detectStartToken("/start short")).toBeNull();
+  });
+
+  it("returns null for unrelated bodies", () => {
+    expect(detectStartToken("hi there")).toBeNull();
+    expect(detectStartToken("")).toBeNull();
+    expect(detectStartToken(null)).toBeNull();
+    expect(detectStartToken(undefined)).toBeNull();
+  });
+
+  it("rejects payloads containing characters outside Telegram's start alphabet", () => {
+    expect(detectStartToken("/start abc!@#$ short")).toBeNull();
+    // Telegram's `start` parameter strips +, /, =, . — none of these tokens
+    // could ever be delivered, so we reject to avoid mistakenly accepting
+    // a forged or smuggled value.
+    expect(detectStartToken("/start AAAA+BBBB_CCCC=DDDD")).toBeNull();
+    expect(detectStartToken("/start abcd.efgh.ijkl.mnop")).toBeNull();
+  });
+
+  it("accepts base64url-no-padding tokens (Telegram's real shape)", () => {
+    expect(detectStartToken("/start AAAA-BBBB_CCCC-DDDD")).toEqual({
+      token: "AAAA-BBBB_CCCC-DDDD",
+    });
+  });
+});

--- a/extensions/creel-context/src/start-token.ts
+++ b/extensions/creel-context/src/start-token.ts
@@ -1,0 +1,30 @@
+// Detects Telegram-style /start <token> deep-link payloads in inbound
+// message bodies.
+//
+// Background: Telegram bots can be reached via `t.me/<bot>?start=<token>`
+// links. When the user clicks the link, Telegram sends `/start <token>` as
+// the first message. We use that as the magic-link verification token —
+// the token is single-use and is matched against
+// challenge_verifications.token_hash on the control plane.
+//
+// The pattern matches Telegram's real `start` parameter alphabet
+// ([A-Za-z0-9_-], no padding — see Telegram Bot API "Deep Linking" docs),
+// length 16-256, and must be the FIRST whitespace-separated argument so
+// "/start foo bar" treats only "foo" as the token (Telegram's contract).
+
+const START_TOKEN_RE = /^\s*\/start(?:@\S+)?\s+([A-Za-z0-9_-]{16,256})(?:\s|$)/u;
+
+export type StartTokenMatch = {
+  token: string;
+};
+
+export function detectStartToken(body: string | undefined | null): StartTokenMatch | null {
+  if (!body) {
+    return null;
+  }
+  const match = body.match(START_TOKEN_RE);
+  if (!match || !match[1]) {
+    return null;
+  }
+  return { token: match[1] };
+}

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -1,6 +1,7 @@
 import "./test-helpers.js";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import * as infraRuntime from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { withEnvAsync } from "openclaw/plugin-sdk/testing";
@@ -19,6 +20,17 @@ import {
   setLoadConfigMock,
   startWebAutoReplyMonitor,
 } from "./auto-reply.test-harness.js";
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/infra-runtime")>(
+    "openclaw/plugin-sdk/infra-runtime",
+  );
+  return {
+    ...actual,
+    drainPendingDeliveries: vi.fn(async () => undefined),
+    enqueueSystemEvent: vi.fn(),
+  };
+});
 
 installWebAutoReplyTestHomeHooks();
 
@@ -356,6 +368,48 @@ describe("web auto-reply connection", () => {
     expect(content).toMatch(/web-heartbeat/);
     expect(content).toMatch(/connectionId/);
     expect(content).toMatch(/messagesHandled/);
+  });
+
+  it("does not expose the connected WhatsApp phone in agent-visible system events", async () => {
+    const authDir = `/tmp/openclaw-wa-system-event-${crypto.randomUUID()}`;
+    await fs.mkdir(authDir, { recursive: true });
+    await fs.writeFile(
+      `${authDir}/creds.json`,
+      JSON.stringify({ me: { id: "15551234567@s.whatsapp.net" } }),
+    );
+
+    setLoadConfigMock({
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+          accounts: {
+            default: {
+              authDir,
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const enqueueSystemEvent = vi.mocked(infraRuntime.enqueueSystemEvent);
+      await monitorWebChannel(
+        false,
+        async () => createMockWebListener(),
+        false,
+        async () => ({ text: "ok" }),
+      );
+
+      const messages = enqueueSystemEvent.mock.calls.map(([message]) => String(message));
+      expect(messages).toContain("WhatsApp gateway connected.");
+      expect(messages.join("\n")).not.toContain("15551234567");
+      expect(messages.join("\n")).not.toContain("+15551234567");
+      expect(messages).not.toContain("WhatsApp gateway connected as +15551234567.");
+    } finally {
+      resetLoadConfigMock();
+      await fs.rm(authDir, { recursive: true, force: true });
+    }
   });
 
   it("logs outbound replies to file", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -25,7 +25,7 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
+import { formatError, getWebAuthAgeMs } from "../session.js";
 import { loadConfig } from "./config.runtime.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
@@ -284,13 +284,12 @@ export async function monitorWebChannel(
         }),
       );
 
-      const { e164: selfE164 } = readWebSelfId(account.authDir);
       const connectRoute = resolveAgentRoute({
         cfg,
         channel: "whatsapp",
         accountId: account.accountId,
       });
-      enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
+      enqueueSystemEvent("WhatsApp gateway connected.", {
         sessionKey: connectRoute.sessionKey,
       });
 


### PR DESCRIPTION
## Summary
Adds the `creel-context` bundled plugin that classifies inbound senders against the Creel control plane (owner / known_contact / approved_stranger / group_member / public_visitor / stranger) and writes the resulting envelope to `~/.openclaw/workspace/state/envelope-summary.json` for the chat-history scope filter to consume.

- `message_received` hook: derives canonical sessionKey + groupKey, calls daemon `/sender/whoami`, writes envelope summary, opportunistically detects Telegram `/start <token>` and proxies to daemon `/verify-channel-token`.
- `before_prompt_build` hook: looks up the per-sessionKey envelope and prepends a small system note (cache-friendly via `prependSystemContext`).
- `session_end` hook: per-session envelope cleanup.
- 46 vitest tests across 6 files: scope rules, daemon client URL/error mapping, envelope LRU/TTL, envelope file format (consumer contract), Telegram start-token alphabet rejection, sessionKey derivation per channel.

Daemon counterpart ships in `project-creel/bisque#TBD` (PR linked when created); control-plane counterpart in `project-creel/creel#TBD`.

## Test plan
- [x] `pnpm test extensions/creel-context` — 46/46 passing
- [x] `pnpm tsgo` — clean
- [x] `oxlint --type-aware extensions/creel-context/src/` — 0 warnings, 0 errors
- [x] `pnpm build` — `dist/extensions/creel-context/{index.js, openclaw.plugin.json}` produced
- [ ] End-to-end on a real claw with the bisque + creel counterparts deployed (verification on maorei@monday.com's claws first, then fleet rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)