### PR TITLE
fix(msteams): use federated token exchange for managed identity auth

### DIFF
--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -211,13 +211,42 @@ function createManagedIdentityApp(
 
   const tokenProvider = async (scope: string | string[]): Promise<string> => {
     const credential = await getCredential();
-    const token = await credential.getToken(scope);
 
-    if (!token?.token) {
-      throw new Error("Failed to acquire token via managed identity.");
+    // When using User-Assigned Managed Identity with a federated identity
+    // credential, we must perform a token exchange:
+    // 1. Get an MI token for the federated exchange audience
+    // 2. Use it as a client_assertion to acquire a token for the Bot App ID
+    // This is necessary because the MI token's appid (the UAMI client ID)
+    // differs from the Bot App ID that the Bot Framework expects.
+    const miToken = await credential.getToken("api://AzureADTokenExchange");
+    if (!miToken?.token) {
+      throw new Error("Failed to acquire MI token for federated token exchange.");
     }
 
-    return token.token;
+    const targetScope = Array.isArray(scope) ? scope.join(" ") : scope;
+    const params = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: creds.appId,
+      client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: miToken.token,
+      scope: targetScope || "https://api.botframework.com/.default",
+    });
+
+    const url = `https://login.microsoftonline.com/${creds.tenantId}/oauth2/v2.0/token`;
+    const resp = await fetch(url, {
+      method: "POST",
+      body: params,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    const data = (await resp.json()) as { access_token?: string; error?: string; error_description?: string };
+
+    if (!data.access_token) {
+      throw new Error(
+        `Federated token exchange failed: ${data.error ?? "unknown"} - ${data.error_description ?? JSON.stringify(data)}`,
+      );
+    }
+
+    return data.access_token;
   };
 
   return new sdk.App({


### PR DESCRIPTION
## Problem

When `useManagedIdentity: true` is configured for the MS Teams channel, `createManagedIdentityApp` passes the raw managed identity token directly to the Teams SDK via the `token` provider callback.

This causes authentication failures because:
- The MI token's `appid` claim is the **UAMI client ID** (e.g., `c4049fe9-...`)
- But Bot Framework expects tokens issued for the **Bot App Registration ID** (e.g., `67fb1acc-...`)
- The token provider is called with scopes like `https://api.botframework.com/.default`, but ManagedIdentityCredential cannot directly acquire tokens for this scope

## Root Cause

`ManagedIdentityCredential.getToken(scope)` returns a token where the `appid` is the managed identity's client ID, not the Bot App ID. The Teams SDK's `App` constructor accepts `clientId: creds.appId` but the actual token doesn't match, causing Bot Framework to reject the authentication.

## Fix

Perform a proper **federated token exchange** (client_credentials + client_assertion):

1. Acquire an MI token for `api://AzureADTokenExchange` (the standard federated exchange audience)
2. Use it as a `client_assertion` to exchange for a token scoped to the Bot App ID via OAuth2 `client_credentials` grant against `login.microsoftonline.com`

This matches how Azure Workload Identity works in AKS and other federated identity credential flows.

## Environment

- Azure Container App with User-Assigned Managed Identity
- Bot Service with `msaAppType: UserAssignedMSI`
- Federated Identity Credential linking UAMI to the App Registration

## Config

```json5
{
  channels: {
    msteams: {
      authType: "federated",
      useManagedIdentity: true,
      managedIdentityClientId: "<UAMI_CLIENT_ID>",
      appId: "<BOT_APP_ID>",
      tenantId: "<TENANT_ID>",
    }
  }
}
```
