### PR TITLE
fix: shortcut live session model redirects during fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Auto-reply: poison inbound message dedupe after replay-unsafe provider/runtime failures so retries stay safe before visible progress but cannot duplicate messages after block output, tool side effects, or session progress. Fixes #69303; keeps #58549 and #64606 as duplicate validation. Thanks @martingarramon, @NikolaFC, and @zeroth-blip.
+- Agents/model fallback: jump directly to a known later live-session model redirect instead of walking unrelated fallback candidates, while preserving the already-landed live-session/fallback loop guard. Fixes #57471; related loop family already closed via #58496. Thanks @yuxiaoyang2007-prog.
 - Gateway/Bonjour: keep @homebridge/ciao cancellation handlers registered across advertiser restarts so late probing cancellations cannot crash Linux and other mDNS-churned gateways. Thanks @codex.
 - Plugins/startup: load the default `memory-core` slot during Gateway startup when permitted so active-memory recall can call `memory_search` and `memory_get` without requiring an explicit `plugins.slots.memory` entry, while preserving `plugins.slots.memory: "none"`. Thanks @codex.
 - Plugins/CLI: prefer native require for compiled bundled plugin JavaScript before jiti so read-only config, status, device, and node commands avoid unnecessary transform overhead on slow hosts. Fixes #62842. Thanks @Effet.

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -707,6 +707,55 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
   });
 
+  it("jumps directly to a later live-session model switch candidate (#57471)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [
+              "anthropic/claude-haiku-3-5",
+              "anthropic/claude-sonnet-4-6",
+              "openrouter/deepseek-chat",
+            ],
+          },
+        },
+      },
+    });
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const run = vi.fn(async (provider: string, model: string) => {
+      if (provider === "openai" && model === "gpt-4.1-mini") {
+        throw switchError;
+      }
+      if (provider === "anthropic" && model === "claude-sonnet-4-6") {
+        return "ok";
+      }
+      throw new Error(`unexpected fallback candidate: ${provider}/${model}`);
+    });
+    const onError = vi.fn();
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+      onError,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-sonnet-4-6");
+    expect(result.attempts).toEqual([]);
+    expect(onError).not.toHaveBeenCalled();
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-4.1-mini"],
+      ["anthropic", "claude-sonnet-4-6"],
+    ]);
+  });
+
   it("falls back on auth errors", async () => {
     await expectFallsBackToHaiku({
       provider: "openai",

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -326,6 +326,18 @@ function recordFailedCandidateAttempt(params: {
   });
 }
 
+function findLaterLiveSessionModelSwitchCandidateIndex(params: {
+  error: LiveSessionModelSwitchError;
+  candidates: ModelCandidate[];
+  currentIndex: number;
+}): number | null {
+  const targetKey = modelKey(params.error.provider, params.error.model);
+  const targetIndex = params.candidates.findIndex(
+    (candidate) => modelKey(candidate.provider, candidate.model) === targetKey,
+  );
+  return targetIndex > params.currentIndex ? targetIndex : null;
+}
+
 function throwFallbackFailureSummary(params: {
   attempts: FallbackAttempt[];
   candidates: ModelCandidate[];
@@ -924,6 +936,16 @@ export async function runWithModelFallback<T>(params: {
       // instead of re-throwing and triggering infinite retry loops in the
       // outer runner.  (#58466)
       if (err instanceof LiveSessionModelSwitchError) {
+        const liveSwitchTargetIndex = findLaterLiveSessionModelSwitchCandidateIndex({
+          error: err,
+          candidates,
+          currentIndex: i,
+        });
+        if (liveSwitchTargetIndex !== null) {
+          i = liveSwitchTargetIndex - 1;
+          continue;
+        }
+
         const switchMsg = err.message;
         const switchNormalized = new FailoverError(switchMsg, {
           reason: "overloaded",


### PR DESCRIPTION
## Summary
- Handle LiveSessionModelSwitchError as a redirect to the active live-session model when the target is known and allowed, instead of recording each non-target fallback candidate as failed.
- Preserve the existing failover behavior that prevents fallback/live-session infinite loops.
- Add regression coverage for #57471 where a session locked to one model receives a request for another model and should not walk the full fallback chain before reaching the locked model.

## Credit
Reported by @yuxiaoyang2007-prog in #57471. This builds on the already-landed live-session/fallback fixes tracked through #58496 and related closed reports.

## Validation
- pnpm check:changed

ProjectClownfish replacement details:
- Cluster: ghcrawl-165983-agentic-merge
- Source PRs: none
- Credit: Credit yuxiaoyang2007-prog for #57471's report of the remaining wasted fallback-chain behavior.; Mention that the broader live-session/fallback loop family was already closed against current main; this follow-up is only for the redirect/candidate-walk inefficiency.
- Validation: pnpm check:changed
