### PR TITLE
fix(mattermost): prevent DM replies from creating threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory-core: respect configured memory-search embedding concurrency during non-batch indexing so local Ollama embedding backends can serialize indexing instead of flooding the server. Fixes #66822. (#66931) Thanks @oliviareid-svg and @LyraInTheFlesh.
 - Docker/update smoke: keep the package-derived update-channel fixture on package-shipped files and make its UI build stub create the asset the updater verifies. Thanks @vincentkoc.
 - Gateway/models: repair legacy `models.providers.*.api = "openai"` config values to `openai-completions`, and skip providers with future stale API enum values during startup instead of bricking the gateway. Fixes #72477. (#72542) Thanks @JooyoungChoi14 and @obviyus.
+- Mattermost/thread replies: use the Mattermost thread root for delivery when replying to an existing thread without turning `replyToMode: "off"` conversations into thread-scoped sessions, preventing invalid non-root reply delivery. (#55151, #55186, #57565) Thanks @dlindegaard, @hnykda, and @dave.
 
 ## 2026.4.26
 

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateMattermostMentionGate,
   MattermostRetryableInboundError,
   processMattermostReplayGuardedPost,
+  resolveMattermostDeliveryReplyToId,
   resolveMattermostReactionChannelId,
   resolveMattermostEffectiveReplyToId,
   resolveMattermostReplyRootId,
@@ -162,6 +163,7 @@ describe("resolveMattermostReplyRootId with block streaming payloads", () => {
     // mode, the deliver callback should still use the existing threadRootId.
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         threadRootId: "thread-root-1",
         replyToId: "streamed-reply-id",
       }),
@@ -173,9 +175,19 @@ describe("resolveMattermostReplyRootId with block streaming payloads", () => {
     // inbound post id as replyToId from the "all" threading mode.
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         replyToId: "inbound-post-for-threading",
       }),
     ).toBe("inbound-post-for-threading");
+  });
+
+  it("uses the existing thread root only when a delivery reply target exists", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        kind: "channel",
+        threadRootId: "thread-root-1",
+      }),
+    ).toBeUndefined();
   });
 });
 
@@ -183,6 +195,7 @@ describe("resolveMattermostReplyRootId", () => {
   it("uses replyToId for top-level replies", () => {
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         replyToId: "inbound-post-123",
       }),
     ).toBe("inbound-post-123");
@@ -191,14 +204,76 @@ describe("resolveMattermostReplyRootId", () => {
   it("keeps the thread root when replying inside an existing thread", () => {
     expect(
       resolveMattermostReplyRootId({
+        kind: "group",
         threadRootId: "thread-root-456",
         replyToId: "child-post-789",
       }),
     ).toBe("thread-root-456");
   });
 
+  it("drops payload replyToId for direct messages", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        kind: "direct",
+        replyToId: "dm-post-123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps direct messages non-threaded even when a thread root is present", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        kind: "direct",
+        threadRootId: "thread-root-456",
+        replyToId: "child-post-789",
+      }),
+    ).toBeUndefined();
+  });
+
   it("falls back to undefined when neither reply target is available", () => {
     expect(resolveMattermostReplyRootId({})).toBeUndefined();
+  });
+});
+
+describe("resolveMattermostDeliveryReplyToId", () => {
+  it("uses the session reply id when replyToMode routes to a thread", () => {
+    expect(
+      resolveMattermostDeliveryReplyToId({
+        kind: "channel",
+        effectiveReplyToId: "thread-root-456",
+        postId: "child-post-789",
+        threadRootId: "thread-root-456",
+      }),
+    ).toBe("thread-root-456");
+  });
+
+  it("keeps replyToMode off sessions top-level while preserving threaded delivery targets", () => {
+    expect(
+      resolveMattermostDeliveryReplyToId({
+        kind: "channel",
+        postId: "child-post-789",
+        threadRootId: "thread-root-456",
+      }),
+    ).toBe("child-post-789");
+  });
+
+  it("does not create a delivery reply target for top-level posts without session threading", () => {
+    expect(
+      resolveMattermostDeliveryReplyToId({
+        kind: "channel",
+        postId: "top-level-post-123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not create delivery reply targets for direct messages", () => {
+    expect(
+      resolveMattermostDeliveryReplyToId({
+        kind: "direct",
+        postId: "dm-post-123",
+        threadRootId: "thread-root-456",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -231,14 +231,22 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
 }
 
 export function resolveMattermostReplyRootId(params: {
+  kind?: ChatType;
   threadRootId?: string;
   replyToId?: string;
 }): string | undefined {
+  if (params.kind === "direct") {
+    return undefined;
+  }
+  const replyToId = normalizeOptionalString(params.replyToId);
+  if (!replyToId) {
+    return undefined;
+  }
   const threadRootId = normalizeOptionalString(params.threadRootId);
   if (threadRootId) {
     return threadRootId;
   }
-  return normalizeOptionalString(params.replyToId);
+  return replyToId;
 }
 
 export function canFinalizeMattermostPreviewInPlace(params: {
@@ -360,6 +368,24 @@ export function resolveMattermostEffectiveReplyToId(params: {
     params.replyToMode === "first" ||
     params.replyToMode === "batched"
     ? postId
+    : undefined;
+}
+
+export function resolveMattermostDeliveryReplyToId(params: {
+  kind?: ChatType;
+  effectiveReplyToId?: string;
+  postId?: string | null;
+  threadRootId?: string | null;
+}): string | undefined {
+  if (params.kind === "direct") {
+    return undefined;
+  }
+  const effectiveReplyToId = normalizeOptionalString(params.effectiveReplyToId);
+  if (effectiveReplyToId) {
+    return effectiveReplyToId;
+  }
+  return normalizeOptionalString(params.threadRootId)
+    ? normalizeOptionalString(params.postId)
     : undefined;
 }
 
@@ -631,6 +657,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           replyToMode,
           threadRootId: opts.post.root_id,
         });
+        const deliveryReplyToId = resolveMattermostDeliveryReplyToId({
+          kind,
+          effectiveReplyToId: threadContext.effectiveReplyToId,
+          postId: opts.post.id || opts.postId,
+          threadRootId: opts.post.root_id,
+        });
+        const deliveryReplyRootId = resolveMattermostReplyRootId({
+          kind,
+          threadRootId: opts.post.root_id ?? undefined,
+          replyToId: deliveryReplyToId,
+        });
         const to = kind === "direct" ? `user:${opts.userId}` : `channel:${opts.channelId}`;
         const bodyText = `[Button click: user @${opts.userName} selected "${opts.actionName}"]`;
         const ctxPayload = core.channel.reply.finalizeInboundContext({
@@ -658,7 +695,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           Provider: "mattermost" as const,
           Surface: "mattermost" as const,
           MessageSid: `interaction:${opts.postId}:${opts.actionId}`,
-          ReplyToId: threadContext.effectiveReplyToId,
+          ReplyToId: deliveryReplyToId,
           MessageThreadId: threadContext.effectiveReplyToId,
           WasMentioned: true,
           CommandAuthorized: false,
@@ -683,7 +720,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           channel: "mattermost",
           accountId: account.accountId,
           typing: {
-            start: () => sendTypingIndicator(opts.channelId, threadContext.effectiveReplyToId),
+            start: () => sendTypingIndicator(opts.channelId, deliveryReplyRootId),
             onStartError: (err) => {
               logTypingFailure({
                 log: (message) => logger.debug?.(message),
@@ -707,7 +744,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 accountId: account.accountId,
                 agentId: route.agentId,
                 replyToId: resolveMattermostReplyRootId({
-                  threadRootId: threadContext.effectiveReplyToId,
+                  kind,
+                  threadRootId: opts.post.root_id ?? undefined,
                   replyToId: payload.replyToId,
                 }),
                 textLimit,
@@ -813,9 +851,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     postId: string;
     messageSid?: string;
     effectiveReplyToId?: string;
+    deliveryReplyToId?: string;
+    threadRootId?: string;
     deliverReplies?: boolean;
   }): Promise<string> => {
     const to = params.kind === "direct" ? `user:${params.senderId}` : `channel:${params.channelId}`;
+    const deliveryReplyRootId = resolveMattermostReplyRootId({
+      kind: params.kind,
+      threadRootId: params.threadRootId,
+      replyToId: params.deliveryReplyToId ?? params.effectiveReplyToId,
+    });
     const fromLabel =
       params.kind === "direct"
         ? `Mattermost DM from ${params.senderName}`
@@ -846,7 +891,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       Provider: "mattermost" as const,
       Surface: "mattermost" as const,
       MessageSid: params.messageSid ?? `interaction:${params.postId}:${Date.now()}`,
-      ReplyToId: params.effectiveReplyToId,
+      ReplyToId: params.deliveryReplyToId ?? params.effectiveReplyToId,
       MessageThreadId: params.effectiveReplyToId,
       Timestamp: Date.now(),
       WasMentioned: true,
@@ -877,7 +922,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       accountId: account.accountId,
       typing: shouldDeliverReplies
         ? {
-            start: () => sendTypingIndicator(params.channelId, params.effectiveReplyToId),
+            start: () => sendTypingIndicator(params.channelId, deliveryReplyRootId),
             onStartError: (err) => {
               logTypingFailure({
                 log: (message) => logger.debug?.(message),
@@ -915,7 +960,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             accountId: account.accountId,
             agentId: params.route.agentId,
             replyToId: resolveMattermostReplyRootId({
-              threadRootId: params.effectiveReplyToId,
+              kind: params.kind,
+              threadRootId: params.threadRootId,
               replyToId: trimmedPayload.replyToId,
             }),
             textLimit,
@@ -1058,6 +1104,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       replyToMode,
       threadRootId: params.post.root_id,
     });
+    const deliveryReplyToId = resolveMattermostDeliveryReplyToId({
+      kind,
+      effectiveReplyToId: threadContext.effectiveReplyToId,
+      postId: params.post.id || params.payload.post_id,
+      threadRootId: params.post.root_id,
+    });
     const modelSessionRoute = {
       agentId: route.agentId,
       sessionKey: threadContext.sessionKey,
@@ -1143,6 +1195,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             model: pickerState.model,
           }),
           effectiveReplyToId: threadContext.effectiveReplyToId,
+          deliveryReplyToId,
+          threadRootId: params.post.root_id ?? undefined,
           deliverReplies: true,
         });
         const updatedModel = resolveMattermostModelPickerCurrentModel({
@@ -1374,6 +1428,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           threadRootId,
         });
         const { effectiveReplyToId, sessionKey, parentSessionKey } = threadContext;
+        const deliveryReplyToId = resolveMattermostDeliveryReplyToId({
+          kind,
+          effectiveReplyToId,
+          postId: post.id,
+          threadRootId,
+        });
+        const deliveryReplyRootId = resolveMattermostReplyRootId({
+          kind,
+          threadRootId,
+          replyToId: deliveryReplyToId,
+        });
         const historyKey = kind === "direct" ? null : sessionKey;
 
         const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
@@ -1557,7 +1622,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           MessageSidFirst: allMessageIds.length > 1 ? allMessageIds[0] : undefined,
           MessageSidLast:
             allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
-          ReplyToId: effectiveReplyToId,
+          ReplyToId: deliveryReplyToId,
           MessageThreadId: effectiveReplyToId,
           Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
           WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
@@ -1608,7 +1673,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           channel: "mattermost",
           accountId: account.accountId,
           typing: {
-            start: () => sendTypingIndicator(channelId, effectiveReplyToId),
+            start: () => sendTypingIndicator(channelId, deliveryReplyRootId),
             onStartError: (err) => {
               logTypingFailure({
                 log: (message) => logger.debug?.(message),
@@ -1622,7 +1687,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const draftStream = createMattermostDraftStream({
           client,
           channelId,
-          rootId: effectiveReplyToId,
+          rootId: deliveryReplyRootId,
           throttleMs: 1200,
           log: logVerboseMessage,
           warn: logVerboseMessage,
@@ -1697,7 +1762,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 info,
                 client,
                 draftStream,
-                effectiveReplyToId,
+                effectiveReplyToId: deliveryReplyRootId,
                 resolvePreviewFinalText,
                 previewState,
                 logVerboseMessage,
@@ -1710,7 +1775,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     accountId: account.accountId,
                     agentId: route.agentId,
                     replyToId: resolveMattermostReplyRootId({
-                      threadRootId: effectiveReplyToId,
+                      kind,
+                      threadRootId,
                       replyToId: payload.replyToId,
                     }),
                     textLimit,


### PR DESCRIPTION
## Summary
- Repair and validate the narrow Mattermost DM reply-root fix from #60115.
- Direct-message replies should not send a Mattermost root_id, while non-DM thread replies must keep using the correct thread root.
- Keep the patch scoped to monitor routing and focused tests.

## Credit
This carries forward the useful fix path from @jwchmodx in https://github.com/openclaw/openclaw/pull/60115, with related context from #59758, #59981, #59791, #55186, and #57565.

## Validation
- pnpm -s vitest run extensions/mattermost/src/mattermost/monitor.test.ts
- pnpm check:changed
- Codex /review must pass cleanly before merge.

ProjectClownfish replacement details:
- Cluster: ghcrawl-166016-agentic-merge
- Source PRs: https://github.com/openclaw/openclaw/pull/60115
- Credit: Credit @jwchmodx for the narrow #60115 fix path: https://github.com/openclaw/openclaw/pull/60115.; Mention related prior reports/attempts from #59758, #59981, #59791, #55186, and #57565 in the PR body without treating those broader branches as merged.
- Validation: pnpm -s vitest run extensions/mattermost/src/mattermost/monitor.test.ts; pnpm check:changed
- Repair fallback: validation command failed (pnpm check:changed): undefined ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "check:changed" not found Did you mean "pnpm test:changed"?
