### PR TITLE
fix: preserve cron telegram topic delivery after timeout

### DIFF
--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -363,6 +363,18 @@ describe("runCronIsolatedAgentTurn telegram forum-topic direct delivery", () => 
     });
   });
 
+  it("preserves explicit supergroup topic targets for cron announce delivery", async () => {
+    await expectTelegramAnnounceDelivery({
+      to: "-1003774691294:topic:47",
+      payloads: [{ text: "topic 47 completion" }],
+      expected: {
+        chatId: "-1003774691294",
+        text: "topic 47 completion",
+        messageThreadId: 47,
+      },
+    });
+  });
+
   it("delivers only the final assistant-visible text to forum-topic telegram targets", async () => {
     await expectTelegramAnnounceDelivery({
       to: "123:topic:42",

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -142,6 +142,7 @@ export function createCronPromptExecutor(params: {
             cliSessionId,
             skillsSnapshot: params.skillsSnapshot,
             messageChannel: params.messageChannel,
+            abortSignal: params.abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
             senderIsOwner: true,

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./run.suite-helpers.js";
 import {
   buildWorkspaceSkillSnapshotMock,
+  dispatchCronDeliveryMock,
   getCliSessionIdMock,
   isCliProviderMock,
   lookupContextTokensMock,
@@ -257,6 +258,40 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
   });
 
   describe("CLI session handoff (issue #29774)", () => {
+    it("passes the cron abort signal to CLI runs and drops late CLI results", async () => {
+      const abortController = new AbortController();
+      let markCliStarted!: () => void;
+      const cliStarted = new Promise<void>((resolve) => {
+        markCliStarted = resolve;
+      });
+
+      isCliProviderMock.mockReturnValue(true);
+      runCliAgentMock.mockImplementationOnce(async (params: { abortSignal?: AbortSignal }) => {
+        expect(params.abortSignal).toBe(abortController.signal);
+        markCliStarted();
+        await new Promise<void>((resolve) => {
+          params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {
+          payloads: [{ text: "late cli output" }],
+          meta: { agentMeta: { sessionId: "late-cli-session", usage: { input: 5, output: 10 } } },
+        };
+      });
+      mockCliFallbackInvocation();
+
+      const runPromise = runCronIsolatedAgentTurn(
+        makeSkillParams({ abortSignal: abortController.signal }),
+      );
+      await cliStarted;
+      abortController.abort("cron: job execution timed out");
+
+      const result = await runPromise;
+
+      expect(result.status).toBe("error");
+      expect(result.error).toBe("cron: job execution timed out");
+      expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    });
+
     it("does not pass stored cliSessionId on fresh isolated runs (isNewSession=true)", async () => {
       // Simulate a persisted CLI session ID from a previous run.
       getCliSessionIdMock.mockReturnValue("prev-cli-session-abc");


### PR DESCRIPTION
## What
Adds regression coverage for explicit Telegram forum topic cron announce delivery and forwards cron timeout abort signals into CLI-backed isolated cron agent runs so late CLI completions are discarded before announce dispatch.

## Why
A cron configured to announce to `telegram:-1003774691294:topic:47` must preserve `messageThreadId: 47`. A timed-out isolated cron run could continue producing a late final answer after the job was marked timed out, risking fallback to the active/default Telegram topic.

## Changes
- Cover explicit Telegram topic delivery
- Forward abort signal to CLI cron runs
- Drop late CLI timeout results before delivery

## Testing
- `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts`
- `pnpm test src/cron/isolated-agent/run.skill-filter.test.ts`
- `pnpm check:changed`