### PR TITLE
fix(gateway): suppress Windows console flicker and prevent Bonjour fatal crashes (#70238, #72344, #72339)

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -611,6 +611,38 @@ describe("gateway bonjour advertiser", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("disables advertiser on EADDRINUSE instead of crashing", async () => {
+    enableAdvertiserUnitMode();
+    vi.useFakeTimers();
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("listen EADDRINUSE: address already in use :::5353"))
+      .mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    // Advance timers to let the floating disableAdvertiser() complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("mDNS conflict detected (possibly Avahi)"),
+    );
+    expect(createService).toHaveBeenCalledTimes(1);
+    expect(advertise).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+
+    // After disable, subsequent stop should be a no-op (shutdown already ran)
+    await started.stop();
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes hostnames with domains for service names", async () => {
     // Allow advertiser to run in unit tests.
     delete process.env.VITEST;

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -139,6 +139,16 @@ function isAnnouncedState(state: string) {
   return state === BONJOUR_ANNOUNCED_STATE;
 }
 
+function isCancellationError(err: unknown): boolean {
+  const msg = formatBonjourError(err).toUpperCase();
+  return msg.includes("CANCELLED") || msg.includes("CANCELED");
+}
+
+function isEaddrInUse(err: unknown): boolean {
+  const msg = formatBonjourError(err).toLowerCase();
+  return msg.includes("eaddrinuse") || msg.includes("address already in use");
+}
+
 function shouldSuppressCiaoConsoleLog(args: unknown[]): boolean {
   return args.some(
     (arg) => typeof arg === "string" && arg.includes(CIAO_SELF_PROBE_RETRY_FRAGMENT),
@@ -324,14 +334,32 @@ export async function startGatewayBonjourAdvertiser(
               logger.info(`bonjour: advertised ${serviceSummary(label, svc)}`);
             })
             .catch((err) => {
-              logger.warn(
-                `bonjour: advertise failed (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-              );
+              const msg = formatBonjourError(err);
+              if (isCancellationError(err)) {
+                logger.debug(
+                  `bonjour: advertise cancelled (${serviceSummary(label, svc)}): ${msg}`,
+                );
+              } else if (isEaddrInUse(err)) {
+                void disableAdvertiser(
+                  "mDNS conflict detected (possibly Avahi); Bonjour discovery may be limited.",
+                );
+              } else {
+                logger.warn(`bonjour: advertise failed (${serviceSummary(label, svc)}): ${msg}`);
+              }
             });
         } catch (err) {
-          logger.warn(
-            `bonjour: advertise threw (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-          );
+          const msg = formatBonjourError(err);
+          if (isCancellationError(err)) {
+            logger.debug(
+              `bonjour: advertise threw cancellation (${serviceSummary(label, svc)}): ${msg}`,
+            );
+          } else if (isEaddrInUse(err)) {
+            void disableAdvertiser(
+              "mDNS conflict detected (possibly Avahi); Bonjour discovery may be limited.",
+            );
+          } else {
+            logger.warn(`bonjour: advertise threw (${serviceSummary(label, svc)}): ${msg}`);
+          }
         }
       }
     }
@@ -366,6 +394,19 @@ export async function startGatewayBonjourAdvertiser(
       }
     };
 
+    const disableAdvertiser = async (reason: string) => {
+      if (stopped || disabled) {
+        return;
+      }
+      disabled = true;
+      logger.warn(reason);
+      const previous = cycle;
+      cycle = null;
+      stateTracker.clear();
+      await stopCycle(previous, { shutdownResponder: true });
+      restoreConsoleLog();
+    };
+
     const recreateAdvertiser = async (reason: string) => {
       if (stopped || disabled) {
         return;
@@ -376,15 +417,9 @@ export async function startGatewayBonjourAdvertiser(
       recreatePromise = (async () => {
         consecutiveRestarts += 1;
         if (consecutiveRestarts > MAX_CONSECUTIVE_RESTARTS) {
-          disabled = true;
-          logger.warn(
+          await disableAdvertiser(
             `bonjour: disabling advertiser after ${MAX_CONSECUTIVE_RESTARTS} failed restarts (${reason}); set discovery.mdns.mode="off" or OPENCLAW_DISABLE_BONJOUR=1 to disable mDNS discovery`,
           );
-          const previous = cycle;
-          cycle = null;
-          stateTracker.clear();
-          await stopCycle(previous, { shutdownResponder: true });
-          restoreConsoleLog();
           return;
         }
         logger.warn(`bonjour: restarting advertiser (${reason})`);
@@ -459,14 +494,36 @@ export async function startGatewayBonjourAdvertiser(
         );
         try {
           void svc.advertise().catch((err) => {
-            logger.warn(
-              `bonjour: watchdog re-advertise failed (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-            );
+            const msg = formatBonjourError(err);
+            if (isCancellationError(err)) {
+              logger.debug(
+                `bonjour: watchdog re-advertise cancelled (${serviceSummary(label, svc)}): ${msg}`,
+              );
+            } else if (isEaddrInUse(err)) {
+              void disableAdvertiser(
+                "mDNS conflict detected (possibly Avahi); Bonjour discovery may be limited.",
+              );
+            } else {
+              logger.warn(
+                `bonjour: watchdog re-advertise failed (${serviceSummary(label, svc)}): ${msg}`,
+              );
+            }
           });
         } catch (err) {
-          logger.warn(
-            `bonjour: watchdog re-advertise threw (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-          );
+          const msg = formatBonjourError(err);
+          if (isCancellationError(err)) {
+            logger.debug(
+              `bonjour: watchdog re-advertise threw cancellation (${serviceSummary(label, svc)}): ${msg}`,
+            );
+          } else if (isEaddrInUse(err)) {
+            void disableAdvertiser(
+              "mDNS conflict detected (possibly Avahi); Bonjour discovery may be limited.",
+            );
+          } else {
+            logger.warn(
+              `bonjour: watchdog re-advertise threw (${serviceSummary(label, svc)}): ${msg}`,
+            );
+          }
         }
       }
     }, WATCHDOG_INTERVAL_MS);
@@ -481,7 +538,16 @@ export async function startGatewayBonjourAdvertiser(
         } catch {
           // ignore
         }
-        await stopCycle(cycle, { shutdownResponder: true });
+        try {
+          await stopCycle(cycle, { shutdownResponder: true });
+        } catch (err) {
+          const msg = formatBonjourError(err);
+          if (isCancellationError(err)) {
+            logger.debug(`bonjour: stop cancellation: ${msg}`);
+          } else {
+            logger.warn(`bonjour: stop cleanup error: ${msg}`);
+          }
+        }
         restoreConsoleLog();
         cleanupProcessHandlers();
       },

--- a/package.json
+++ b/package.json
@@ -1752,7 +1752,8 @@
       }
     },
     "patchedDependencies": {
-      "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch"
+      "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch",
+      "@homebridge/ciao@1.3.6": "patches/@homebridge__ciao@1.3.6.patch"
     }
   }
 }

--- a/patches/@homebridge__ciao@1.3.6.patch
+++ b/patches/@homebridge__ciao@1.3.6.patch
@@ -1,0 +1,94 @@
+diff --git a/lib/CiaoService.js b/lib/CiaoService.js
+index a70f9b4906ccd9bd5d3d475eeef9d9ae076dacec..552123f291f7dc3ba2231636ff35dcc91ab31ea2 100644
+--- a/lib/CiaoService.js
++++ b/lib/CiaoService.js
+@@ -473,11 +473,8 @@ class CiaoService extends events_1.EventEmitter {
+             // thus, when sending the first request, the socket will be bound, and we don't need to wait here
+             this.emit("republish" /* InternalServiceEvent.REPUBLISH */, error => {
+                 if (error) {
+-                    console.log("FATAL Error occurred trying to re-announce service " + this.fqdn + "! We can't recover from this!");
+-                    console.log(error.stack);
+-                    process.exit(1); // we have a service which should be announced, though we failed to re-announce.
+-                    // if this should ever happen in reality, whe might want to introduce a more sophisticated recovery
+-                    // for situations where it makes sense
++                    console.warn("FATAL Error occurred trying to re-announce service " + this.fqdn + "! We can't recover from this!");
++                    console.warn(error.stack);
+                 }
+             });
+         }
+diff --git a/lib/NetworkManager.js b/lib/NetworkManager.js
+index d13c3f249d8f3a55bec35a7af663db56a8df8772..8c3fdd026562f48ce852d609fdecc3c6214f7c39 100644
+--- a/lib/NetworkManager.js
++++ b/lib/NetworkManager.js
+@@ -425,7 +425,7 @@ class NetworkManager extends events_1.EventEmitter {
+     static getWindowsNetworkInterfaces() {
+         // does not return loopback interface
+         return new Promise((resolve, reject) => {
+-            child_process_1.default.exec("arp -a | findstr /C:\"---\"", (error, stdout) => {
++            child_process_1.default.exec("arp -a | findstr /C:\"---\"", { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     reject(error);
+                     return;
+@@ -472,7 +472,7 @@ class NetworkManager extends events_1.EventEmitter {
+         // does not return loopback interface
+         return new Promise((resolve, reject) => {
+             // for ipv6 "ndp -a -n |grep -v permanent" with filtering for "expired"
+-            child_process_1.default.exec("arp -a -n -l", async (error, stdout) => {
++            child_process_1.default.exec("arp -a -n -l", { windowsHide: true }, async (error, stdout) => {
+                 if (error) {
+                     reject(error);
+                     return;
+@@ -517,7 +517,7 @@ class NetworkManager extends events_1.EventEmitter {
+         return new Promise((resolve, reject) => {
+             // we use "ip neigh" here instead of the aliases like "ip neighbour" or "ip neighbor"
+             // as those were only added like 5 years ago https://github.com/shemminger/iproute2/commit/ede723964a065992bf9d0dbe3f780e65ca917872
+-            child_process_1.default.exec("ip neigh show", (error, stdout) => {
++            child_process_1.default.exec("ip neigh show", { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     if (error.message.includes("ip: not found")) {
+                         debug("LINUX: ip was not found on the system. Falling back to assuming network interfaces!");
+@@ -563,7 +563,7 @@ class NetworkManager extends events_1.EventEmitter {
+     static getFreeBSDNetworkInterfaces() {
+         // does not return loopback interface
+         return new Promise((resolve, reject) => {
+-            child_process_1.default.exec("arp -a -n", (error, stdout) => {
++            child_process_1.default.exec("arp -a -n", { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     reject(error);
+                     return;
+@@ -593,7 +593,7 @@ class NetworkManager extends events_1.EventEmitter {
+         // does not return loopback interface
+         return new Promise((resolve, reject) => {
+             // for ipv6 something like "ndp -a -n | grep R" (grep for reachable; maybe exclude permanent?)
+-            child_process_1.default.exec("arp -a -n", (error, stdout) => {
++            child_process_1.default.exec("arp -a -n", { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     reject(error);
+                     return;
+@@ -642,7 +642,7 @@ class NetworkManager extends events_1.EventEmitter {
+                * Other messages handled here.
+                * "All Wi-Fi network services are disabled": encountered on macOS VM machines
+                */
+-            child_process_1.default.exec("networksetup -getairportnetwork " + name, (error, stdout) => {
++            child_process_1.default.exec("networksetup -getairportnetwork " + name, { windowsHide: true }, (error, stdout) => {
+                 if (error) {
+                     if (stdout.includes("not a Wi-Fi interface")) {
+                         resolve(1 /* WifiState.NOT_A_WIFI_INTERFACE */);
+diff --git a/lib/Responder.js b/lib/Responder.js
+index 7df617c848b386a19ef3155355187a8879d24b72..5490708e598e80f2847d034b456902760e82f8b1 100644
+--- a/lib/Responder.js
++++ b/lib/Responder.js
+@@ -624,11 +624,8 @@ class Responder {
+                 // noinspection JSIgnoredPromiseFromCall
+                 this.republishService(service, error => {
+                     if (error) {
+-                        console.log(`FATAL Error occurred trying to resolve conflict for service ${service.getFQDN()}! We can't recover from this!`);
+-                        console.log(error.stack);
+-                        process.exit(1); // we have a service which should be announced, though we failed to reannounce.
+-                        // if this should ever happen in reality, whe might want to introduce a more sophisticated recovery
+-                        // for situations where it makes sense
++                        console.warn(`FATAL Error occurred trying to resolve conflict for service ${service.getFQDN()}! We can't recover from this!`);
++                        console.warn(error.stack);
+                     }
+                 }, true);
+             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ overrides:
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
 patchedDependencies:
+  '@homebridge/ciao@1.3.6':
+    hash: c0836cb408866d6a6c76d61b04532f3d8d6428e02738e77bdb00b5b7e72ead61
+    path: patches/@homebridge__ciao@1.3.6.patch
   '@whiskeysockets/baileys@7.0.0-rc.9':
     hash: 23ec8efe1484afa57c51b96955ba331d1467521a8e676a18c2690da7e70a6201
     path: patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
@@ -311,7 +314,7 @@ importers:
     dependencies:
       '@homebridge/ciao':
         specifier: ^1.3.6
-        version: 1.3.6
+        version: 1.3.6(patch_hash=c0836cb408866d6a6c76d61b04532f3d8d6428e02738e77bdb00b5b7e72ead61)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -8706,7 +8709,7 @@ snapshots:
 
   '@hapi/hoek@9.3.0': {}
 
-  '@homebridge/ciao@1.3.6':
+  '@homebridge/ciao@1.3.6(patch_hash=c0836cb408866d6a6c76d61b04532f3d8d6428e02738e77bdb00b5b7e72ead61)':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3

--- a/src/tui/tui-launch.ts
+++ b/src/tui/tui-launch.ts
@@ -101,6 +101,7 @@ export async function launchTuiCli(
     const child = spawn(process.execPath, args, {
       stdio: "inherit",
       env,
+      windowsHide: true,
     });
     const { detach } = attachChildProcessBridge(child);
 


### PR DESCRIPTION
# fix(gateway): suppress Windows console flicker and prevent Bonjour fatal crashes (#70238, #72344, #72339)

## Summary

- **Problem:** On Windows, launching the gateway causes jarring command prompt flickers. More critically, on both Linux and Windows, the Bonjour plugin causes fatal gateway crashes due to unhandled `CIAO PROBING CANCELLED` rejections and hard `process.exit(1)` calls in the `@homebridge/ciao` dependency when mDNS conflicts (like Avahi) occur.
- **Why it matters:** This range of issues makes the gateway appear unstable on Windows and entirely unusable on many headless Linux VPS environments where mDNS stacks often conflict.
- **What changed:** - **Windows Flicker Fix:** Added `windowsHide: true` to the TUI spawn and patched 6 `exec` calls within `@homebridge/ciao`.
    - **Plugin Shielding:** Updated `advertiser.ts` with error helpers to catch and suppress `CANCELLED` errors, logging them as debug instead of allowing them to crash the process.
    - **Dependency Hardening:** Patched `@homebridge/ciao@1.3.6` to replace `process.exit(1)` with `console.warn()` in `CiaoService.js` and `Responder.js` recovery paths.
    - **Conflict Resilience:** Added detection for `EADDRINUSE`. If a conflict (e.g., Avahi) is detected, the plugin now logs a warning and disables itself gracefully rather than crashing the core service.
- **What did NOT change:** No changes were made to core networking logic or discovery protocols.

---

## Change Type

- [x] Bug fix
- [x] Security hardening (Stability)
- [x] Refactor required for the fix (Dependency patch)

---

## Scope

- [x] Gateway / orchestration
- [x] Integrations (Bonjour/mDNS)
- [x] UI / DX

---

## Linked Issues

- Closes #70238
- Closes #72344
- Closes #72339
- [x] This PR fixes a bug or regression

---

## Root Cause

1. **Visual Flicker:** Missing `windowsHide` flags on child process spawns in both internal code and dependencies.
2. **Fatal Crashes:** Probing cancellations from `ciao` were leaking as unhandled promise rejections during watchdog restarts.
3. **Hard Exits:** The `@homebridge/ciao` library utilized `process.exit(1)` for internal network interface update failures, which is inappropriate for a plugin-level dependency.

---

## User-visible / Behavior Changes

- **Windows:** Silent startup without flashing `cmd.exe` windows.
- **Linux:** Resilience against existing Avahi/mDNS stacks; the gateway logs a conflict warning and continues to run.
- **General:** Improved reliability; Bonjour failures are no longer fatal to the core gateway process.

---

## Repro + Verification

### Environment
- OS: Windows 11 / Ubuntu 24.04 (Headless VPS)
- Runtime: Node v22+
- Tooling: pnpm

### Steps
1. Start gateway on Windows -> **Verified:** No visible console flickers.
2. Start gateway on Linux with `avahi-daemon` active -> **Verified:** Logs `mDNS conflict detected`, gateway remains stable.
3. Trigger watchdog re-advertise cycle -> **Verified:** `CANCELLED` errors caught, process stays alive.

---

## Evidence

- [x] All 29 `bonjour` extension tests pass.
- [x] Verified `pnpm patch-commit` for `@homebridge/ciao@1.3.6` contains both visibility flags and exit-trap removals.
- [x] Confidence Score: 5/5 (Greptile)

---

## Human Verification

- **Verified scenarios:** Local Windows 11 build; Headless Linux VPS (Contabo) with Avahi conflict.
- **Edge cases checked:** Relaunching the gateway multiple times; manual watchdog triggers.